### PR TITLE
LPS-18499

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -132,7 +132,6 @@ public abstract class BaseIndexer implements Indexer {
 		BooleanQuery facetQuery = BooleanQueryFactoryUtil.create();
 
 		facetQuery.addExactTerm(Field.ENTRY_CLASS_NAME, className);
-		facetQuery.addExactTerm(Field.PORTLET_ID, getPortletId(searchContext));
 
 		if (searchContext.getUserId() > 0) {
 			SearchPermissionChecker searchPermissionChecker =


### PR DESCRIPTION
LPS-18499 Searching on className is sufficient. Adding portletId to search query messes up things when portlet has multiple objects with indexer attached
