### PR TITLE
LPS-18440 Fix broken cache enable logic

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/Entity.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/Entity.java
@@ -415,6 +415,20 @@ public class Entity {
 		return false;
 	}
 
+	public boolean hasNonLazyBlobColumn() {
+		if ((_blobList == null) || _blobList.isEmpty()) {
+			return false;
+		}
+
+		for (EntityColumn col : _blobList) {
+			if (!col.isLazy()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public boolean hasLocalService() {
 		return _localService;
 	}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
@@ -152,7 +152,7 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 
 	public static final String TX_MANAGER = "${entity.getTXManager()}";
 
-	<#if entity.hasLazyBlobColumn()>
+	<#if entity.hasNonLazyBlobColumn()>
 		public static final boolean ENTITY_CACHE_ENABLED = false;
 
 		public static final boolean FINDER_CACHE_ENABLED = false;

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -551,6 +551,10 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 		EntityCacheUtil.putResult(${entity.name}ModelImpl.ENTITY_CACHE_ENABLED, ${entity.name}Impl.class, ${entity.varName}.getPrimaryKey(), ${entity.varName});
 
+		<#if entity.hasLazyBlobColumn()>
+			${entity.varName}.resetOriginalValues();
+		</#if>
+
 		<#list uniqueFinderList as finder>
 			<#assign finderColsList = finder.getColumns()>
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLContentModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLContentModelImpl.java
@@ -72,8 +72,12 @@ public class DLContentModelImpl extends BaseModelImpl<DLContent>
 	public static final String DATA_SOURCE = "liferayDataSource";
 	public static final String SESSION_FACTORY = "liferaySessionFactory";
 	public static final String TX_MANAGER = "liferayTransactionManager";
-	public static final boolean ENTITY_CACHE_ENABLED = false;
-	public static final boolean FINDER_CACHE_ENABLED = false;
+	public static final boolean ENTITY_CACHE_ENABLED = GetterUtil.getBoolean(com.liferay.portal.util.PropsUtil.get(
+				"value.object.entity.cache.enabled.com.liferay.portlet.documentlibrary.model.DLContent"),
+			true);
+	public static final boolean FINDER_CACHE_ENABLED = GetterUtil.getBoolean(com.liferay.portal.util.PropsUtil.get(
+				"value.object.finder.cache.enabled.com.liferay.portlet.documentlibrary.model.DLContent"),
+			true);
 
 	public Class<?> getModelClass() {
 		return DLContent.class;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLContentPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLContentPersistenceImpl.java
@@ -346,6 +346,8 @@ public class DLContentPersistenceImpl extends BasePersistenceImpl<DLContent>
 		EntityCacheUtil.putResult(DLContentModelImpl.ENTITY_CACHE_ENABLED,
 			DLContentImpl.class, dlContent.getPrimaryKey(), dlContent);
 
+		dlContent.resetOriginalValues();
+
 		if (!isNew &&
 				((dlContent.getCompanyId() != dlContentModelImpl.getOriginalCompanyId()) ||
 				!Validator.equals(dlContent.getPortletId(),


### PR DESCRIPTION
Hey Brian,

Your formatting at git 1d3e0ed92c3ff9ee29af41ecb41c6d24db92751f, svn rev84303 broke the cache enable logic for blob entity.

I changed it back and also add a convenient reset in persistence, so at service level user don't have to manually reset their blob entity, the reason is blob object is transient, after update hibernate already consumes it. To reuse the entity, it has to null out its blob to force a reload.

Shuyang
