### PR TITLE
LPS-17039 The message for the user should be "Go to Control Panel" 

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -373,7 +373,7 @@ action.UPDATE_THREAD_PRIORITY=Update Thread Priority
 action.UPDATE_USER=Update User
 action.VIEW=View
 action.VIEW_ALL_TASKS=View All Tasks
-action.VIEW_CONTROL_PANEL=View Control Panel
+action.VIEW_CONTROL_PANEL=Go to Control Panel
 action.VIEW_USER=View User
 
 ##


### PR DESCRIPTION
LPS-17039 The message for the user should be "Go to Control Panel" to match the terminology of the Dockbar
