### PR TITLE
Rollback LPS-17916

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -667,10 +667,10 @@ set JAVA_OPTS=-Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -Djonas.felix
 					<replacevalue><![CDATA[redirectPort="8443" URIEncoding="UTF-8" />]]></replacevalue>
 				</replace>
 
-				<!--<replace file="${app.server.dir}/conf/server.xml">
+				<replace file="${app.server.dir}/conf/server.xml">
 					<replacetoken><![CDATA[xmlValidation="false" xmlNamespaceAware="false">]]></replacetoken>
 					<replacevalue><![CDATA[xmlValidation="false" xmlNamespaceAware="false" deployXML="false">]]></replacevalue>
-				</replace>-->
+				</replace>
 
 				<if>
 					<and>


### PR DESCRIPTION
Breaks plugin loading on restart with context names before "ROOT"
