### PR TITLE
LPS-18675 Javadoc formatter crashes on non-javadoc block comments adjacen

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
+++ b/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
@@ -933,7 +933,13 @@ public class JavadocFormatter {
 
 			int pos = lineNumber - 2;
 
-			String line = lines[pos].trim();
+			String line = lines[pos];
+
+			if (line == null) {
+				continue;
+			}
+
+			line = line.trim();
 
 			if (line.endsWith("*/")) {
 				while (true) {


### PR DESCRIPTION
LPS-18675 Javadoc formatter crashes on non-javadoc block comments adjacent to methods
