### PR TITLE
LPS-18643 Usability improvements in the admin user process

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -11,7 +11,7 @@ lang.line.end=right
 ##
 
 javax.portlet.description.104=Update Manager shows you all user installed plugins as well as their version number, whether it is from the Liferay repository, and whether it can be upgraded.
-javax.portlet.description.125=Users are individuals who performs tasks using the portal. Administrators can create new users or deactivate existing users. Users can be organized in a hierarchy of organizations and delegate its administration.
+javax.portlet.description.125=Users are individuals who performs tasks using the portal. Administrators can create new users or deactivate existing users. Users can be organized in a hierarchy of organizations and delegate its administration. It is also possible to create transversal user groups to allow assignment of all of its users to sites or roles, to set personal site templates, etc.
 javax.portlet.description.128=Roles are groupings of users that share a particular function within the portal, according to a particular scope. Administrators can add roles which can be granted permissions to various functions within portlet applications.
 javax.portlet.description.129=Password policies define enterprise level security measures which include user lockout and password expiration. Administrators can define policies or delegate to an LDAP server.
 javax.portlet.description.130=Settings is where most of the global portal settings are including names, authentication, default user associations, and mail host names.


### PR DESCRIPTION
I had doubts regarding whether to remove this key from the other Language files. The drawback is that we would force translators to translate from scratch. I'll let you decide what you think is best.
