### PR TITLE
LPS-17584

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/pop/MessageListenerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/pop/MessageListenerImpl.java
@@ -271,23 +271,24 @@ public class MessageListenerImpl implements MessageListener {
 
 		int pos = recipient.indexOf(CharPool.AT);
 
-		String target = recipient.substring(
-			MBUtil.MESSAGE_POP_PORTLET_PREFIX.length(), pos);
+		if (pos >= 0) {
+			long parentMessageId = 0;
 
-		String[] parts = StringUtil.split(target, StringPool.PERIOD);
+			String target = recipient.substring(
+				MBUtil.MESSAGE_POP_PORTLET_PREFIX.length(), pos);
 
-		long parentMessageId = 0;
+			String[] parts = StringUtil.split(target, StringPool.PERIOD);
 
-		if (parts.length == 2) {
-			parentMessageId = GetterUtil.getLong(parts[1]);
+			if (parts.length == 2) {
+				parentMessageId = GetterUtil.getLong(parts[1]);
+			}
+
+			if (parentMessageId > 0) {
+				return parentMessageId;
+			}
 		}
 
-		if (parentMessageId > 0) {
-			return parentMessageId;
-		}
-		else {
-			return MBUtil.getParentMessageId(message);
-		}
+		return MBUtil.getParentMessageId(message);
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(MessageListenerImpl.class);


### PR DESCRIPTION
Mike already checked through it

This is basically a quick fix. The code needs some cleaning up. Processing of the messageId (message id containing category and parent messageId, not the MBMessage.messageId) is too haphazard. For example, the messageId is extracted multiple times using functionally equivalent logic. I've started some of the cleaning but it's too risky to introduce right now with the next 6.0 SP coming out.
