### PR TITLE
LPS-17584

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/pop/MessageListenerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/pop/MessageListenerImpl.java
@@ -268,8 +268,10 @@ public class MessageListenerImpl implements MessageListener {
 		throws Exception {
 
 		int pos = recipient.indexOf(CharPool.AT);
+		boolean hasPrefix =
+			StringUtil.startsWith(recipient, MBUtil.MESSAGE_POP_PORTLET_PREFIX);
 
-		if (pos < 0) {
+		if (pos < 0 || !hasPrefix) {
 			return MBUtil.getParentMessageId(message);
 		}
 


### PR DESCRIPTION
Patched string parsing error. Temporary fix, exception was being tossed by duplicate logic that attempted to extract the messageId even though the messageId was already extracted.
