### PR TITLE
LPS-18951 The aui:input tag should read the value from the bean if it has not been specified

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -230,7 +230,10 @@ String labelTag = AUIUtil.buildLabel(inlineLabel, showForLabel, forLabel);
 			valueString = value.toString();
 		}
 
-		if (!ignoreRequestValue && (type.equals("text") || type.equals("textarea"))) {
+		if (type.equals("hidden") && (value == null)) {
+			valueString = BeanPropertiesUtil.getStringSilent(bean, name);
+		}
+		else if (!ignoreRequestValue && (type.equals("text") || type.equals("textarea"))) {
 			valueString = BeanParamUtil.getStringSilent(bean, request, name, valueString);
 
 			if (Validator.isNotNull(fieldParam)) {


### PR DESCRIPTION
LPS-18951 The aui:input tag should read the value from the bean if it has not been specified with a value="" (Also solves LPS-18952)
