### PR TITLE
LPS-17841 Permissions inconsistent in certain portlets when upgrading fro

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradePermission.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.upgrade.v6_1_0;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.RoleConstants;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.ResourceActionsUtil;
@@ -86,22 +87,23 @@ public class UpgradePermission extends UpgradeProcess {
 
 		ResourceActionLocalServiceUtil.checkResourceActions(name, modelActions);
 
+		int scope = ResourceConstants.SCOPE_INDIVIDUAL;
 		long actionIdsLong = 1;
 
 		if (community) {
-			ResourcePermissionLocalServiceUtil.setContainerResourcePermissions(
-				name, RoleConstants.ORGANIZATION_USER, actionIdsLong);
-			ResourcePermissionLocalServiceUtil.setContainerResourcePermissions(
-				name, RoleConstants.SITE_MEMBER, actionIdsLong);
+			ResourcePermissionLocalServiceUtil.addResourcePermissions(
+				name, RoleConstants.ORGANIZATION_USER, scope, actionIdsLong);
+			ResourcePermissionLocalServiceUtil.addResourcePermissions(
+				name, RoleConstants.SITE_MEMBER, scope, actionIdsLong);
 		}
 
 		if (guest) {
-			ResourcePermissionLocalServiceUtil.setContainerResourcePermissions(
-				name, RoleConstants.GUEST, actionIdsLong);
+			ResourcePermissionLocalServiceUtil.addResourcePermissions(
+				name, RoleConstants.GUEST, scope, actionIdsLong);
 		}
 
-		ResourcePermissionLocalServiceUtil.setContainerResourcePermissions(
-			name, RoleConstants.OWNER, actionIdsLong);
+		ResourcePermissionLocalServiceUtil.addResourcePermissions(
+			name, RoleConstants.OWNER, scope, actionIdsLong);
 	}
 
 }

--- a/portal-service/src/com/liferay/portal/service/ResourcePermissionLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/ResourcePermissionLocalService.java
@@ -520,21 +520,6 @@ public interface ResourcePermissionLocalService
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* Only to be used during the upgrade process, not part of the public API.
-	* Grants the role individual scope permissions to perform the actions on
-	* all resources of the type.
-	*
-	* @param name the resource's name, which can be either a class name or a
-	portlet ID
-	* @param roleName the role's name
-	* @param actionIdsLong the bitwise IDs of the actions
-	* @throws SystemException if a system exception occurred
-	*/
-	public void setContainerResourcePermissions(java.lang.String name,
-		java.lang.String roleName, long actionIdsLong)
-		throws com.liferay.portal.kernel.exception.SystemException;
-
-	/**
 	* Updates the role's permissions at the scope, setting the actions that can
 	* be performed on resources of the type, also setting the owner of any
 	* newly created resource permissions. Existing actions are replaced.

--- a/portal-service/src/com/liferay/portal/service/ResourcePermissionLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/ResourcePermissionLocalServiceUtil.java
@@ -588,24 +588,6 @@ public class ResourcePermissionLocalServiceUtil {
 	}
 
 	/**
-	* Only to be used during the upgrade process, not part of the public API.
-	* Grants the role individual scope permissions to perform the actions on
-	* all resources of the type.
-	*
-	* @param name the resource's name, which can be either a class name or a
-	portlet ID
-	* @param roleName the role's name
-	* @param actionIdsLong the bitwise IDs of the actions
-	* @throws SystemException if a system exception occurred
-	*/
-	public static void setContainerResourcePermissions(java.lang.String name,
-		java.lang.String roleName, long actionIdsLong)
-		throws com.liferay.portal.kernel.exception.SystemException {
-		getService()
-			.setContainerResourcePermissions(name, roleName, actionIdsLong);
-	}
-
-	/**
 	* Updates the role's permissions at the scope, setting the actions that can
 	* be performed on resources of the type, also setting the owner of any
 	* newly created resource permissions. Existing actions are replaced.

--- a/portal-service/src/com/liferay/portal/service/ResourcePermissionLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/ResourcePermissionLocalServiceWrapper.java
@@ -578,24 +578,6 @@ public class ResourcePermissionLocalServiceWrapper
 	}
 
 	/**
-	* Only to be used during the upgrade process, not part of the public API.
-	* Grants the role individual scope permissions to perform the actions on
-	* all resources of the type.
-	*
-	* @param name the resource's name, which can be either a class name or a
-	portlet ID
-	* @param roleName the role's name
-	* @param actionIdsLong the bitwise IDs of the actions
-	* @throws SystemException if a system exception occurred
-	*/
-	public void setContainerResourcePermissions(java.lang.String name,
-		java.lang.String roleName, long actionIdsLong)
-		throws com.liferay.portal.kernel.exception.SystemException {
-		_resourcePermissionLocalService.setContainerResourcePermissions(name,
-			roleName, actionIdsLong);
-	}
-
-	/**
 	* Updates the role's permissions at the scope, setting the actions that can
 	* be performed on resources of the type, also setting the owner of any
 	* newly created resource permissions. Existing actions are replaced.


### PR DESCRIPTION
LPS-17841 Permissions inconsistent in certain portlets when upgrading from 6.0 to 6.0.12

Remove setContainerResourcePermissions() from ResourcePermissionLocalSer
vice in lieu of addResourcePermission().
