### PR TITLE
LPS 18762

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java
@@ -428,7 +428,8 @@ public class CacheFilter extends BasePortalFilter {
 			// twice because the user could have been authenticated after the
 			// initial test.
 
-			if (isCacheableRequest(request) &&
+			if ((byteBufferResponse.getStatus() == HttpServletResponse.SC_OK) &&
+				isCacheableRequest(request) &&
 				isCacheableResponse(byteBufferResponse)) {
 
 				CacheUtil.putCacheResponseData(

--- a/portal-impl/src/com/liferay/portal/util/DynamicCSSUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/DynamicCSSUtil.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-2011 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.scripting.ScriptingException;
+import com.liferay.portal.kernel.servlet.WebDirDetector;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
+import com.liferay.portal.kernel.util.UnsyncPrintWriterPool;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.scripting.ruby.RubyExecutor;
+
+import java.io.File;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Raymond Augé
+ */
+public class DynamicCSSUtil {
+
+	public static void init() {
+		String rootDir = WebDirDetector.getRootDir(
+			PortalClassLoaderUtil.getClassLoader());
+
+		_rubyScriptFile = new File(rootDir + "WEB-INF/sass/main.rb");
+
+		try {
+
+			// Ruby executor needs to warm up when requiring Sass. Always breaks
+			// the first time without this block.
+
+			_rubyExecutor.eval(
+				null, new HashMap<String, Object>(), null,
+				"require 'rubygems'\nrequire 'sass'");
+		}
+		catch (ScriptingException se) {
+			_log.error(se, se);
+		}
+	}
+
+	public static String parseSass(String cssRealPath, String content)
+		throws ScriptingException {
+
+		Map<String, Object> inputObjects = new HashMap<String, Object>();
+
+		inputObjects.put("content", content);
+
+		inputObjects.put("cssRealPath", cssRealPath);
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+
+		UnsyncPrintWriter unsyncPrintWriter = UnsyncPrintWriterPool.borrow(
+			unsyncByteArrayOutputStream);
+
+		inputObjects.put("out", unsyncPrintWriter);
+
+		_rubyExecutor.eval(null, inputObjects, null, _rubyScriptFile);
+
+		unsyncPrintWriter.flush();
+
+		String parsedContent = unsyncByteArrayOutputStream.toString();
+
+		if (Validator.isNotNull(parsedContent)) {
+			return parsedContent;
+		}
+
+		return content;
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(DynamicCSSUtil.class);
+
+	private static RubyExecutor _rubyExecutor = new RubyExecutor();
+	private static File _rubyScriptFile;
+
+}

--- a/portal-impl/test/com/liferay/portal/servlet/filters/strip/StripFilterTest.java
+++ b/portal-impl/test/com/liferay/portal/servlet/filters/strip/StripFilterTest.java
@@ -76,7 +76,7 @@ public class StripFilterTest extends TestCase {
 
 		StringWriter stringWriter = new StringWriter();
 
-		stripFilter.processCSS(charBuffer, stringWriter);
+		stripFilter.processCSS(null, charBuffer, stringWriter);
 
 		assertEquals("style type=\"text/css\">", stringWriter.toString());
 		assertEquals(22, charBuffer.position());
@@ -86,7 +86,7 @@ public class StripFilterTest extends TestCase {
 		charBuffer = CharBuffer.wrap("style type=\"text/css\"></style>");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(charBuffer, stringWriter);
+		stripFilter.processCSS(null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\"></style>", stringWriter.toString());
@@ -97,7 +97,7 @@ public class StripFilterTest extends TestCase {
 		charBuffer = CharBuffer.wrap("style type=\"text/css\"> \r\t\n</style>");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(charBuffer, stringWriter);
+		stripFilter.processCSS(null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\"></style>", stringWriter.toString());
@@ -114,7 +114,7 @@ public class StripFilterTest extends TestCase {
 			"style type=\"text/css\">" + code + "</style>");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(charBuffer, stringWriter);
+		stripFilter.processCSS(null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\">" + minifiedCode + "</style>",
@@ -127,7 +127,7 @@ public class StripFilterTest extends TestCase {
 			"style type=\"text/css\">" + code + "</style> \r\t\n");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(charBuffer, stringWriter);
+		stripFilter.processCSS(null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\">" + minifiedCode + "</style> ",

--- a/portal-web/docroot/WEB-INF/sass/main.rb
+++ b/portal-web/docroot/WEB-INF/sass/main.rb
@@ -7,27 +7,16 @@ java_import com.liferay.portal.servlet.filters.dynamiccss.DynamicCSSFilter
 
 log = LogFactoryUtil.getLog(DynamicCSSFilter.java_class)
 
-begin
-	engine = Sass::Engine.new(
-		$content,
-		{
-			:debug_info => log.isDebugEnabled,
-			:filename => $cssRealPath,
-			:full_exception => log.isDebugEnabled,
-			:syntax => :scss,
-			:load_paths => ['html/'],
-			:ugly => true
-		}
-	)
+engine = Sass::Engine.new(
+	$content,
+	{
+		:debug_info => log.isDebugEnabled,
+		:filename => $cssRealPath,
+		:full_exception => log.isDebugEnabled,
+		:syntax => :scss,
+		:load_paths => ['html/'],
+		:ugly => true
+	}
+)
 
-	$out.println engine.render
-rescue
-	log.error "Error on #$cssRealPath"
-	log.error $!
-
-	if log.isDebugEnabled
-		log.debug $content
-	end
-
-	$out.println $content
-end
+$out.println engine.render


### PR DESCRIPTION
Ok, so I'd like to highlight some small changes in behavior.
- css that fails dynamic(sass) parsing will result in the HTTP status changing to 500 so that it is never cached by CacheFilter or browsers (the 500 also makes it easier to find the culprit on the client side). 
- The full error stack will appear in the log (we're not trapping any errors in the ruby script anymore since it makes it harder to handle the errors properly on the java side).

Besides that, there should no longer be logged errors unless there is truly an error in the syntax.
