### PR TITLE
LPS-19099 LPS-19228 Source formatting

### DIFF
--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -17,7 +17,7 @@
 							OR [$OWNER_CHECK$]
 						)
 				)
-			AS InlineSQLResourcePermission ON
+			InlineSQLResourcePermission ON
 				[$PRIM_KEYS$]
 		]]>
 	</sql>


### PR DESCRIPTION
QA oracle testing caused an exception.  Aliasing a temp table with "AS" threw the exception in Oracle.  Followed the same pattern found in the temp tables created in journal.xml and blogs.xml and removed the AS clause.
