### PR TITLE
LPS-19351 Replace all usages of the word "Community" in portal.properties 

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7482,8 +7482,8 @@
     sites.email.membership.reply.subject=com/liferay/portlet/sites/dependencies/email_membership_reply_subject.tmpl
     sites.email.membership.reply.body=com/liferay/portlet/sites/dependencies/email_membership_reply_body.tmpl
 
-    communities.email.membership.request.subject=com/liferay/portlet/sites/dependencies/email_membership_request_subject.tmpl
-    communities.email.membership.request.body=com/liferay/portlet/sites/dependencies/email_membership_request_body.tmpl
+    sites.email.membership.request.subject=com/liferay/portlet/sites/dependencies/email_membership_request_subject.tmpl
+    sites.email.membership.request.body=com/liferay/portlet/sites/dependencies/email_membership_request_body.tmpl
 
 ##
 ## Shopping Portlet


### PR DESCRIPTION
Brian, this two properties has been forgotten in a previous commit
