### PR TITLE
LPS-19355 Metadata fields do not appear when adding a document type in Ro

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
@@ -267,7 +267,7 @@ else if (dlFileEntryType != null) {
 		<div class='<%= ((folder == null) || folder.isSupportsMetadata()) ? StringPool.BLANK : "aui-helper-hidden" %>' id="<portlet:namespace />metadata">
 			<aui:input name="description" />
 
-			<c:if test="<%= (folder != null) && (folder.getModel() instanceof DLFolder) %>">
+			<c:if test="<%= (folder == null) || (folder.getModel() instanceof DLFolder) %>">
 
 				<%
 				List<DLFileEntryType> dlFileEntryTypes = DLFileEntryTypeLocalServiceUtil.getFolderFileEntryTypes(scopeGroupId, folderId, true);


### PR DESCRIPTION
LPS-19355 Metadata fields do not appear when adding a document type in Root Folder
