### PR TITLE
LPS-19612 Migrate all the preferences to CamelCase

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
+++ b/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
@@ -166,17 +166,17 @@ public class AddDefaultLayoutSetPrototypesAction extends SimpleAction {
 
 		Map<String, String> preferences = new HashMap<String, String>();
 
-		preferences.put("any-asset-type", Boolean.FALSE.toString());
+		preferences.put("anyAssetType", Boolean.FALSE.toString());
 
 		long classNameId = PortalUtil.getClassNameId(CalEvent.class);
 
-		preferences.put("class-name-ids", String.valueOf(classNameId));
+		preferences.put("classNameIds", String.valueOf(classNameId));
 
 		preferences.put(
-			"portlet-setup-title-" + LocaleUtil.getDefault(),
+			"portletSetupTitle" + LocaleUtil.getDefault(),
 			"Upcoming Events");
 		preferences.put(
-			"portlet-setup-use-custom-title", Boolean.TRUE.toString());
+			"portletSetupUseCustomTitle", Boolean.TRUE.toString());
 
 		updatePortletSetup(layout, portletId, preferences);
 

--- a/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
+++ b/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
@@ -173,7 +173,7 @@ public class AddDefaultLayoutSetPrototypesAction extends SimpleAction {
 		preferences.put("classNameIds", String.valueOf(classNameId));
 
 		preferences.put(
-			"portletSetupTitle" + LocaleUtil.getDefault(),
+			"portletSetupTitle_" + LocaleUtil.getDefault(),
 			"Upcoming Events");
 		preferences.put(
 			"portletSetupUseCustomTitle", Boolean.TRUE.toString());

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1216,9 +1216,9 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 				try {
 					preferences.setValue(
-						"portlet-setup-title-" + languageId, newPortletTitle);
+						"portletSetupTitle" + languageId, newPortletTitle);
 					preferences.setValue(
-						"portlet-setup-use-custom-title",
+						"portletSetupUseCustomTitle",
 						Boolean.TRUE.toString());
 
 					preferences.store();

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1216,7 +1216,7 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 				try {
 					preferences.setValue(
-						"portletSetupTitle" + languageId, newPortletTitle);
+						"portletSetupTitle_" + languageId, newPortletTitle);
 					preferences.setValue(
 						"portletSetupUseCustomTitle",
 						Boolean.TRUE.toString());

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_0.java
@@ -28,6 +28,7 @@ import com.liferay.portal.upgrade.v6_1_0.UpgradeLock;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeMessageBoards;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeNavigation;
 import com.liferay.portal.upgrade.v6_1_0.UpgradePermission;
+import com.liferay.portal.upgrade.v6_1_0.UpgradePortletLookAndFeelPreferences;
 import com.liferay.portal.upgrade.v6_1_0.UpgradePortletPreferences;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeResourcePermission;
 import com.liferay.portal.upgrade.v6_1_0.UpgradeScheduler;
@@ -64,6 +65,7 @@ public class UpgradeProcess_6_1_0 extends UpgradeProcess {
 		upgrade(UpgradeMessageBoards.class);
 		upgrade(UpgradeNavigation.class);
 		upgrade(UpgradePermission.class);
+		upgrade(UpgradePortletLookAndFeelPreferences.class);
 		upgrade(UpgradePortletPreferences.class);
 		upgrade(UpgradeResourcePermission.class);
 		upgrade(UpgradeScheduler.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradePortletLookAndFeelPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradePortletLookAndFeelPreferences.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-2010 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v6_1_0;
+
+import com.liferay.portal.kernel.upgrade.BaseUpgradePortletPreferences;
+import com.liferay.portlet.PortletPreferencesFactoryUtil;
+
+import javax.portlet.PortletPreferences;
+import java.util.Map;
+
+/**
+ *
+ * @author Eudaldo Alonso
+ */
+public class UpgradePortletLookAndFeelPreferences
+	extends BaseUpgradePortletPreferences {
+
+	@Override
+	protected String getUpdatePortletPreferencesWhereClause() {
+		return "preferences like '%portlet-setup-title-%'";
+	}
+
+	@Override
+	protected String upgradePreferences(
+			long companyId, long ownerId, int ownerType, long plid,
+			String portletId, String xml)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.fromXML(
+				companyId, ownerId, ownerType, plid, portletId, xml);
+
+		Map<String, String[]> preferencesMap = portletPreferences.getMap();
+
+		for (String oldName : preferencesMap.keySet()) {
+			if (oldName.startsWith("portlet-setup-title-")) {
+				String newName = oldName.replaceFirst(
+					"portlet-setup-title-", "portlet-setup-title_");
+
+				String[] values = preferencesMap.get(oldName);
+
+				portletPreferences.reset(oldName);
+
+				portletPreferences.setValues(newName, values);
+			}
+		}
+
+		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+	}
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradePortletPreferences.java
@@ -118,11 +118,6 @@ public class UpgradePortletPreferences
 		return 0;
 	}
 
-	@Override
-	protected String[] getPortletIds() {
-		return _CAMEL_CASE_UPGRADE_PORTLET_IDS;
-	}
-
 	protected long getPortletPreferencesId(
 			long ownerId, int ownerType, long plid, String portletId)
 		throws Exception {
@@ -155,6 +150,11 @@ public class UpgradePortletPreferences
 		}
 
 		return 0;
+	}
+
+	@Override
+	protected String getUpdatePortletPreferencesWhereClause() {
+		return "true";
 	}
 
 	protected void updatePortalPreferences() throws Exception {

--- a/portal-impl/src/com/liferay/portlet/PortletResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletResponseImpl.java
@@ -257,7 +257,7 @@ public abstract class PortletResponseImpl implements LiferayPortletResponse {
 
 			String linkToLayoutUuid = GetterUtil.getString(
 				portletSetup.getValue(
-					"portlet-setup-link-to-layout-uuid", null));
+					"portletSetupLinkToLayoutUuid", null));
 
 			if (Validator.isNotNull(linkToLayoutUuid)) {
 				try {

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherUtil.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherUtil.java
@@ -82,7 +82,7 @@ public class AssetPublisherUtil {
 				referringPortletResource, null);
 
 		String selectionStyle = portletPreferences.getValue(
-			"selection-style", "dynamic");
+			"selectionStyle", "dynamic");
 
 		if (selectionStyle.equals("dynamic")) {
 			return;

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditScopeAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditScopeAction.java
@@ -285,10 +285,10 @@ public class EditScopeAction extends EditConfigurationAction {
 
 		if (!newPortletTitle.equals(portletTitle)) {
 			preferences.setValue(
-				"portlet-setup-title-" + themeDisplay.getLanguageId(),
+				"portletSetupTitle" + themeDisplay.getLanguageId(),
 				newPortletTitle);
 			preferences.setValue(
-				"portlet-setup-use-custom-title", Boolean.TRUE.toString());
+				"portletSetupUseCustomTitle", Boolean.TRUE.toString());
 		}
 
 		preferences.store();

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditScopeAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditScopeAction.java
@@ -285,7 +285,7 @@ public class EditScopeAction extends EditConfigurationAction {
 
 		if (!newPortletTitle.equals(portletTitle)) {
 			preferences.setValue(
-				"portletSetupTitle" + themeDisplay.getLanguageId(),
+				"portletSetupTitle_" + themeDisplay.getLanguageId(),
 				newPortletTitle);
 			preferences.setValue(
 				"portletSetupUseCustomTitle", Boolean.TRUE.toString());

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSharingAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSharingAction.java
@@ -135,7 +135,7 @@ public class EditSharingAction extends EditConfigurationAction {
 			actionRequest, "widgetShowAddAppLink");
 
 		preferences.setValue(
-			"lfr-widget-show-add-app-link",
+			"lfrWidgetShowAddAppLink",
 			String.valueOf(widgetShowAddAppLink));
 	}
 
@@ -150,12 +150,12 @@ public class EditSharingAction extends EditConfigurationAction {
 		boolean facebookShowAddAppLink = ParamUtil.getBoolean(
 			actionRequest, "facebookShowAddAppLink");
 
-		preferences.setValue("lfr-facebook-api-key", facebookAPIKey);
+		preferences.setValue("lfrFacebookApiKey", facebookAPIKey);
 		preferences.setValue(
-			"lfr-facebook-canvas-page-url", facebookCanvasPageURL);
+			"lfrFacebookCanvasPageUrl", facebookCanvasPageURL);
 		preferences.setValue(
-			"lfr-facebook-show-add-app-link",
-			String.valueOf(facebookShowAddAppLink));
+			"lfrFacebookShowAddAppLink",
+				String.valueOf(facebookShowAddAppLink));
 	}
 
 	protected void updateFriends(
@@ -166,7 +166,7 @@ public class EditSharingAction extends EditConfigurationAction {
 			actionRequest, "appShowShareWithFriendsLink");
 
 		preferences.setValue(
-			"lfr-app-show-share-with-friends-link",
+			"lfrAppShowShareWithFriendsLink",
 			String.valueOf(appShowShareWithFriendsLink));
 	}
 
@@ -178,7 +178,7 @@ public class EditSharingAction extends EditConfigurationAction {
 			actionRequest, "iGoogleShowAddAppLink");
 
 		preferences.setValue(
-			"lfr-igoogle-show-add-app-link",
+			"lfrIgoogleShowAddAppLink",
 			String.valueOf(iGoogleShowAddAppLink));
 	}
 
@@ -190,7 +190,7 @@ public class EditSharingAction extends EditConfigurationAction {
 			actionRequest, "netvibesShowAddAppLink");
 
 		preferences.setValue(
-			"lfr-netvibes-show-add-app-link",
+			"lfrNetvibesShowAddAppLink",
 			String.valueOf(netvibesShowAddAppLink));
 	}
 

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSupportedClientsAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSupportedClientsAction.java
@@ -106,7 +106,7 @@ public class EditSupportedClientsAction extends EditConfigurationAction {
 
 		for (String portletMode : allPortletModes) {
 			String mobileDevicesParam =
-				"portletSetupSupportedClientsMobileDevices" + portletMode;
+				"portletSetupSupportedClientsMobileDevices_" + portletMode;
 
 			boolean mobileDevices = ParamUtil.getBoolean(
 				actionRequest, mobileDevicesParam);

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSupportedClientsAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSupportedClientsAction.java
@@ -106,7 +106,7 @@ public class EditSupportedClientsAction extends EditConfigurationAction {
 
 		for (String portletMode : allPortletModes) {
 			String mobileDevicesParam =
-				"portlet-setup-supported-clients-mobile-devices-" + portletMode;
+				"portletSetupSupportedClientsMobileDevices" + portletMode;
 
 			boolean mobileDevices = ParamUtil.getBoolean(
 				actionRequest, mobileDevicesParam);

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateLookAndFeelAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateLookAndFeelAction.java
@@ -113,10 +113,10 @@ public class UpdateLookAndFeelAction extends JSONAction {
 
 			if (Validator.isNotNull(title)) {
 				portletSetup.setValue(
-					"portletSetupTitle" + languageId, title);
+					"portletSetupTitle_" + languageId, title);
 			}
 			else {
-				portletSetup.reset("portletSetupTitle" + languageId);
+				portletSetup.reset("portletSetupTitle_" + languageId);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateLookAndFeelAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateLookAndFeelAction.java
@@ -113,36 +113,36 @@ public class UpdateLookAndFeelAction extends JSONAction {
 
 			if (Validator.isNotNull(title)) {
 				portletSetup.setValue(
-					"portlet-setup-title-" + languageId, title);
+					"portletSetupTitle" + languageId, title);
 			}
 			else {
-				portletSetup.reset("portlet-setup-title-" + languageId);
+				portletSetup.reset("portletSetupTitle" + languageId);
 			}
 		}
 
 		portletSetup.setValue(
-			"portlet-setup-use-custom-title", String.valueOf(useCustomTitle));
+			"portletSetupUseCustomTitle", String.valueOf(useCustomTitle));
 		portletSetup.setValue(
-			"portlet-setup-show-borders", String.valueOf(showBorders));
+			"portletSetupShowBorders", String.valueOf(showBorders));
 
 		if (Validator.isNotNull(linkToLayoutUuid)) {
 			portletSetup.setValue(
-				"portlet-setup-link-to-layout-uuid",linkToLayoutUuid);
+				"portletSetupLinkToLayoutUuid",linkToLayoutUuid);
 		}
 		else {
-			portletSetup.reset("portlet-setup-link-to-layout-uuid");
+			portletSetup.reset("portletSetupLinkToLayoutUuid");
 		}
 
-		portletSetup.setValue("portlet-setup-css", css);
+		portletSetup.setValue("portletSetupCss", css);
 
 		JSONObject wapData = jsonObj.getJSONObject("wapData");
 
 		String wapTitle = wapData.getString("title");
 		String wapInitialWindowState = wapData.getString("initialWindowState");
 
-		portletSetup.setValue("lfr-wap-title", wapTitle);
+		portletSetup.setValue("lfrWapTitle", wapTitle);
 		portletSetup.setValue(
-			"lfr-wap-initial-window-state", wapInitialWindowState);
+			"lfrWapInitialWindowState", wapInitialWindowState);
 
 		portletSetup.store();
 

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateTitleAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateTitleAction.java
@@ -72,8 +72,8 @@ public class UpdateTitleAction extends JSONAction {
 			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 				layout, portletId);
 
-		portletSetup.setValue("portlet-setup-title-" + languageId, title);
-		portletSetup.setValue("portlet-setup-use-custom-title", "true");
+		portletSetup.setValue("portletSetupTitle" + languageId, title);
+		portletSetup.setValue("portletSetupUseCustomTitle", "true");
 
 		portletSetup.store();
 

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateTitleAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/UpdateTitleAction.java
@@ -72,7 +72,7 @@ public class UpdateTitleAction extends JSONAction {
 			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 				layout, portletId);
 
-		portletSetup.setValue("portletSetupTitle" + languageId, title);
+		portletSetup.setValue("portletSetupTitle_" + languageId, title);
 		portletSetup.setValue("portletSetupUseCustomTitle", "true");
 
 		portletSetup.store();

--- a/portal-service/src/com/liferay/portlet/PortletSetupUtil.java
+++ b/portal-service/src/com/liferay/portlet/PortletSetupUtil.java
@@ -84,7 +84,7 @@ public class PortletSetupUtil {
 			String languageId = LocaleUtil.toLanguageId(locales[i]);
 
 			String title = portletSetup.getValue(
-				"portletSetupTitle" + languageId, null);
+				"portletSetupTitle_" + languageId, null);
 
 			if (Validator.isNotNull(languageId)) {
 				titles.put(languageId, title);

--- a/portal-service/src/com/liferay/portlet/PortletSetupUtil.java
+++ b/portal-service/src/com/liferay/portlet/PortletSetupUtil.java
@@ -42,7 +42,7 @@ public class PortletSetupUtil {
 
 	public static final String cssToString(PortletPreferences portletSetup) {
 		String css = portletSetup.getValue(
-			"portlet-setup-css", StringPool.BLANK);
+			"portletSetupCss", StringPool.BLANK);
 
 		try {
 			if (Validator.isNotNull(css)) {
@@ -84,7 +84,7 @@ public class PortletSetupUtil {
 			String languageId = LocaleUtil.toLanguageId(locales[i]);
 
 			String title = portletSetup.getValue(
-				"portlet-setup-title-" + languageId, null);
+				"portletSetupTitle" + languageId, null);
 
 			if (Validator.isNotNull(languageId)) {
 				titles.put(languageId, title);
@@ -92,11 +92,11 @@ public class PortletSetupUtil {
 		}
 
 		boolean useCustomTitle = GetterUtil.getBoolean(
-			portletSetup.getValue("portlet-setup-use-custom-title", null));
+			portletSetup.getValue("portletSetupUseCustomTitle", null));
 		boolean showBorders = GetterUtil.getBoolean(
-			portletSetup.getValue("portlet-setup-show-borders", null), true);
+			portletSetup.getValue("portletSetupShowBorders", null), true);
 		String linkToLayoutUuid = GetterUtil.getString(
-			portletSetup.getValue("portlet-setup-link-to-layout-uuid", null));
+			portletSetup.getValue("portletSetupLinkToLayoutUuid", null));
 
 		portletData.put("useCustomTitle", useCustomTitle);
 		portletData.put("showBorders", showBorders);

--- a/portal-service/src/com/liferay/portlet/portletconfiguration/util/PortletConfigurationUtil.java
+++ b/portal-service/src/com/liferay/portlet/portletconfiguration/util/PortletConfigurationUtil.java
@@ -68,10 +68,10 @@ public class PortletConfigurationUtil {
 			LocaleUtil.getDefault());
 
 		String defaultPortletTitle = portletSetup.getValue(
-			"portletSetupTitle" + defaultLanguageId, StringPool.BLANK);
+			"portletSetupTitle_" + defaultLanguageId, StringPool.BLANK);
 
 		String portletTitle = portletSetup.getValue(
-			"portletSetupTitle" + languageId, defaultPortletTitle);
+			"portletSetupTitle_" + languageId, defaultPortletTitle);
 
 		if (Validator.isNull(portletTitle)) {
 
@@ -87,7 +87,7 @@ public class PortletConfigurationUtil {
 
 				try {
 					portletSetup.setValue(
-						"portletSetupTitle" + defaultLanguageId,
+						"portletSetupTitle_" + defaultLanguageId,
 						portletTitle);
 					portletSetup.setValue(
 						"portletSetupUseCustomTitle", "true");

--- a/portal-service/src/com/liferay/portlet/portletconfiguration/util/PortletConfigurationUtil.java
+++ b/portal-service/src/com/liferay/portlet/portletconfiguration/util/PortletConfigurationUtil.java
@@ -37,7 +37,7 @@ public class PortletConfigurationUtil {
 		String customCSSClassName = StringPool.BLANK;
 
 		String css = portletSetup.getValue(
-			"portlet-setup-css", StringPool.BLANK);
+			"portletSetupCss", StringPool.BLANK);
 
 		if (Validator.isNotNull(css)) {
 			JSONObject cssJSON = PortletSetupUtil.cssToJSON(portletSetup, css);
@@ -58,7 +58,7 @@ public class PortletConfigurationUtil {
 
 		String useCustomTitle = GetterUtil.getString(
 			portletSetup.getValue(
-				"portlet-setup-use-custom-title", StringPool.BLANK));
+				"portletSetupUseCustomTitle", StringPool.BLANK));
 
 		if (!useCustomTitle.equals("true")) {
 			return null;
@@ -68,17 +68,17 @@ public class PortletConfigurationUtil {
 			LocaleUtil.getDefault());
 
 		String defaultPortletTitle = portletSetup.getValue(
-			"portlet-setup-title-" + defaultLanguageId, StringPool.BLANK);
+			"portletSetupTitle" + defaultLanguageId, StringPool.BLANK);
 
 		String portletTitle = portletSetup.getValue(
-			"portlet-setup-title-" + languageId, defaultPortletTitle);
+			"portletSetupTitle" + languageId, defaultPortletTitle);
 
 		if (Validator.isNull(portletTitle)) {
 
 			// For backwards compatibility
 
 			String oldPortletTitle = portletSetup.getValue(
-				"portlet-setup-title", null);
+				"portletSetupTitle", null);
 
 			if (Validator.isNull(useCustomTitle) &&
 				Validator.isNotNull(oldPortletTitle)) {
@@ -87,10 +87,10 @@ public class PortletConfigurationUtil {
 
 				try {
 					portletSetup.setValue(
-						"portlet-setup-title-" + defaultLanguageId,
+						"portletSetupTitle" + defaultLanguageId,
 						portletTitle);
 					portletSetup.setValue(
-						"portlet-setup-use-custom-title", "true");
+						"portletSetupUseCustomTitle", "true");
 
 					portletSetup.store();
 				}

--- a/portal-web/docroot/html/common/themes/portlet.jsp
+++ b/portal-web/docroot/html/common/themes/portlet.jsp
@@ -39,7 +39,7 @@ if (tilesPortletDecorateBoolean) {
 	portletDecorateDefault = GetterUtil.getBoolean(themeDisplay.getThemeSetting("portlet-setup-show-borders-default"), PropsValues.THEME_PORTLET_DECORATE_DEFAULT);
 }
 
-boolean portletDecorate = GetterUtil.getBoolean(portletSetup.getValue("portlet-setup-show-borders", String.valueOf(portletDecorateDefault)));
+boolean portletDecorate = GetterUtil.getBoolean(portletSetup.getValue("portletSetupShowBorders", String.valueOf(portletDecorateDefault)));
 
 Boolean portletDecorateObj = (Boolean)renderRequest.getAttribute(WebKeys.PORTLET_DECORATE);
 

--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -212,7 +212,7 @@ StringBundler pageTopSB = (StringBundler)request.getAttribute(WebKeys.PAGE_TOP);
 		for (Portlet portlet : portlets) {
 			PortletPreferences portletSetup = PortletPreferencesFactoryUtil.getStrictLayoutPortletSetup(layout, portlet.getPortletId());
 
-			String portletSetupCss = portletSetup.getValue("portlet-setup-css", StringPool.BLANK);
+			String portletSetupCss = portletSetup.getValue("portletSetupCss", StringPool.BLANK);
 		%>
 
 			<c:if test="<%= Validator.isNotNull(portletSetupCss) %>">

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -263,7 +263,7 @@ if (portlet.hasPortletMode(responseContentType, PortletMode.HELP)) {
 boolean supportsMimeType = portlet.hasPortletMode(responseContentType, portletMode);
 
 if (responseContentType.equals(ContentTypes.XHTML_MP) && portlet.hasMultipleMimeTypes()) {
-	supportsMimeType = GetterUtil.getBoolean(portletSetup.getValue("portlet-setup-supported-clients-mobile-devices-" + portletMode, String.valueOf(supportsMimeType)));
+	supportsMimeType = GetterUtil.getBoolean(portletSetup.getValue("portletSetupSupportedClientsMobileDevices" + portletMode, String.valueOf(supportsMimeType)));
 }
 
 // Only authenticated with the correct permissions can update a layout. If

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -263,7 +263,7 @@ if (portlet.hasPortletMode(responseContentType, PortletMode.HELP)) {
 boolean supportsMimeType = portlet.hasPortletMode(responseContentType, portletMode);
 
 if (responseContentType.equals(ContentTypes.XHTML_MP) && portlet.hasMultipleMimeTypes()) {
-	supportsMimeType = GetterUtil.getBoolean(portletSetup.getValue("portletSetupSupportedClientsMobileDevices" + portletMode, String.valueOf(supportsMimeType)));
+	supportsMimeType = GetterUtil.getBoolean(portletSetup.getValue("portletSetupSupportedClientsMobileDevices_" + portletMode, String.valueOf(supportsMimeType)));
 }
 
 // Only authenticated with the correct permissions can update a layout. If

--- a/portal-web/docroot/html/portlet/nested_portlets/configuration.jsp
+++ b/portal-web/docroot/html/portlet/nested_portlets/configuration.jsp
@@ -76,7 +76,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 	<%
 	boolean portletDecorateDefault = GetterUtil.getBoolean(themeDisplay.getThemeSetting("portlet-setup-show-borders-default"), true);
 
-	boolean portletSetupShowBorders = GetterUtil.getBoolean(preferences.getValue("portlet-setup-show-borders", String.valueOf(portletDecorateDefault)));
+	boolean portletSetupShowBorders = GetterUtil.getBoolean(preferences.getValue("portletSetupShowBorders", String.valueOf(portletDecorateDefault)));
 	%>
 
 	<aui:fieldset label="display-settings">

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_sharing.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_sharing.jsp
@@ -62,7 +62,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 			<c:when test='<%= tabs2.equals("any-website") %>'>
 
 				<%
-				boolean widgetShowAddAppLink = GetterUtil.getBoolean(preferences.getValue("lfr-widget-show-add-app-link", null), PropsValues.THEME_PORTLET_SHARING_DEFAULT);
+				boolean widgetShowAddAppLink = GetterUtil.getBoolean(preferences.getValue("lfrWidgetShowAddAppLink", null), PropsValues.THEME_PORTLET_SHARING_DEFAULT);
 				%>
 
 				<div class="portlet-msg-info">
@@ -82,9 +82,9 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 			<c:when test='<%= tabs2.equals("facebook") %>'>
 
 				<%
-				String facebookAPIKey = GetterUtil.getString(preferences.getValue("lfr-facebook-api-key", null));
-				String facebookCanvasPageURL = GetterUtil.getString(preferences.getValue("lfr-facebook-canvas-page-url", null));
-				boolean facebookShowAddAppLink = GetterUtil.getBoolean(preferences.getValue("lfr-facebook-show-add-app-link", null), true);
+				String facebookAPIKey = GetterUtil.getString(preferences.getValue("lfrFacebookApiKey", null));
+				String facebookCanvasPageURL = GetterUtil.getString(preferences.getValue("lfrFacebookCanvasPageUrl", null));
+				boolean facebookShowAddAppLink = GetterUtil.getBoolean(preferences.getValue("lfrFacebookShowAddAppLink", null), true);
 
 				String callbackURL = widgetURL;
 
@@ -127,7 +127,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 			<c:when test='<%= tabs2.equals("google-gadget") %>'>
 
 				<%
-				boolean iGoogleShowAddAppLink = PrefsParamUtil.getBoolean(preferences, request, "lfr-igoogle-show-add-app-link");
+				boolean iGoogleShowAddAppLink = PrefsParamUtil.getBoolean(preferences, request, "lfrIgoogleShowAddAppLink");
 				%>
 
 				<div class="portlet-msg-info">
@@ -143,7 +143,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 			<c:when test='<%= tabs2.equals("netvibes") %>'>
 
 				<%
-				boolean netvibesShowAddAppLink = PrefsParamUtil.getBoolean(preferences, request, "lfr-netvibes-show-add-app-link");
+				boolean netvibesShowAddAppLink = PrefsParamUtil.getBoolean(preferences, request, "lfrNetvibesShowAddAppLink");
 				%>
 
 				<div class="portlet-msg-info">
@@ -159,7 +159,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 			<c:when test='<%= tabs2.equals("friends") %>'>
 
 				<%
-				boolean appShowShareWithFriendsLink = GetterUtil.getBoolean(preferences.getValue("lfr-app-show-share-with-friends-link", null));
+				boolean appShowShareWithFriendsLink = GetterUtil.getBoolean(preferences.getValue("lfrAppShowShareWithFriendsLink", null));
 				%>
 
 				<aui:input inlineLabel="left" label='<%= LanguageUtil.format(pageContext, "allow-users-to-share-x-with-friends", portletDisplay.getTitle()) %>' name="appShowShareWithFriendsLink" type="checkbox" value="<%= appShowShareWithFriendsLink %>" />

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_supported_clients.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_supported_clients.jsp
@@ -44,7 +44,7 @@ Set allPortletModes = selPortlet.getAllPortletModes();
 	while (itr.hasNext()) {
 		String curPortletMode = (String)itr.next();
 
-		String mobileDevicesParam = "portlet-setup-supported-clients-mobile-devices-" + curPortletMode;
+		String mobileDevicesParam = "portletSetupSupportedClientsMobileDevices" + curPortletMode;
 		boolean mobileDevicesDefault = selPortlet.hasPortletMode(ContentTypes.XHTML_MP, PortletModeFactory.getPortletMode(curPortletMode));
 
 		boolean mobileDevices = GetterUtil.getBoolean(portletSetup.getValue(mobileDevicesParam, String.valueOf(mobileDevicesDefault)));

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_supported_clients.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_supported_clients.jsp
@@ -44,7 +44,7 @@ Set allPortletModes = selPortlet.getAllPortletModes();
 	while (itr.hasNext()) {
 		String curPortletMode = (String)itr.next();
 
-		String mobileDevicesParam = "portletSetupSupportedClientsMobileDevices" + curPortletMode;
+		String mobileDevicesParam = "portletSetupSupportedClientsMobileDevices_" + curPortletMode;
 		boolean mobileDevicesDefault = selPortlet.hasPortletMode(ContentTypes.XHTML_MP, PortletModeFactory.getPortletMode(curPortletMode));
 
 		boolean mobileDevices = GetterUtil.getBoolean(portletSetup.getValue(mobileDevicesParam, String.valueOf(mobileDevicesDefault)));

--- a/portal-web/docroot/html/taglib/portlet/icon_options/page.jsp
+++ b/portal-web/docroot/html/taglib/portlet/icon_options/page.jsp
@@ -53,19 +53,19 @@
 		<%
 		PortletPreferences portletSetup = PortletPreferencesFactoryUtil.getLayoutPortletSetup(layout, portletDisplay.getId());
 
-		boolean widgetShowAddAppLink = GetterUtil.getBoolean(portletSetup.getValue("lfr-widget-show-add-app-link", null), PropsValues.THEME_PORTLET_SHARING_DEFAULT);
+		boolean widgetShowAddAppLink = GetterUtil.getBoolean(portletSetup.getValue("lfrWidgetShowAddAppLink", null), PropsValues.THEME_PORTLET_SHARING_DEFAULT);
 
-		String facebookAPIKey = portletSetup.getValue("lfr-facebook-api-key", StringPool.BLANK);
-		String facebookCanvasPageURL = portletSetup.getValue("lfr-facebook-canvas-page-url", StringPool.BLANK);
-		boolean facebookShowAddAppLink = GetterUtil.getBoolean(portletSetup.getValue("lfr-facebook-show-add-app-link", null), true);
+		String facebookAPIKey = portletSetup.getValue("lfrFacebookApiKey", StringPool.BLANK);
+		String facebookCanvasPageURL = portletSetup.getValue("lfrFacebookCanvasPageUrl", StringPool.BLANK);
+		boolean facebookShowAddAppLink = GetterUtil.getBoolean(portletSetup.getValue("lfrFacebookShowAddAppLink", null), true);
 
 		if (Validator.isNull(facebookCanvasPageURL) || Validator.isNull(facebookAPIKey)) {
 			facebookShowAddAppLink = false;
 		}
 
-		boolean iGoogleShowAddAppLink = GetterUtil.getBoolean(portletSetup.getValue("lfr-igoogle-show-add-app-link", StringPool.BLANK));
-		boolean netvibesShowAddAppLinks = GetterUtil.getBoolean(portletSetup.getValue("lfr-netvibes-show-add-app-link", StringPool.BLANK));
-		boolean appShowShareWithFriendsLink = GetterUtil.getBoolean(portletSetup.getValue("lfr-app-show-share-with-friends-link", StringPool.BLANK));
+		boolean iGoogleShowAddAppLink = GetterUtil.getBoolean(portletSetup.getValue("lfrIgoogleShowAddAppLink", StringPool.BLANK));
+		boolean netvibesShowAddAppLinks = GetterUtil.getBoolean(portletSetup.getValue("lfrNetvibesShowAddAppLink", StringPool.BLANK));
+		boolean appShowShareWithFriendsLink = GetterUtil.getBoolean(portletSetup.getValue("lfrAppShowShareWithFriendsLink", StringPool.BLANK));
 		%>
 
 		<c:if test="<%= widgetShowAddAppLink || facebookShowAddAppLink || iGoogleShowAddAppLink || netvibesShowAddAppLinks || appShowShareWithFriendsLink %>">

--- a/portal-web/docroot/wap/themes/mobile/templates/portlet.vm
+++ b/portal-web/docroot/wap/themes/mobile/templates/portlet.vm
@@ -7,8 +7,8 @@
 
 #set ($portlet_setup = $portlet_display.getPortletSetup())
 
-#set ($portlet_wap_title = $portlet_setup.getValue("lfr-wap-title", ""))
-#set ($portlet_wap_initial_window_state = $portlet_setup.getValue("lfr-wap-initial-window-state", "NORMAL"))
+#set ($portlet_wap_title = $portlet_setup.getValue("lfrWapTitle", ""))
+#set ($portlet_wap_initial_window_state = $portlet_setup.getValue("lfrWapInitialWindowState", "NORMAL"))
 
 #if ($portlet_wap_title == "")
 	#set ($portlet_wap_title = $portlet_title)


### PR DESCRIPTION
As some of the portlets were already being migrated and they might contain lfr-scope-uuid and some others, we decided the best option was to migrate them all.

Special attention was needed for portlet-setup-title-es_ES, as it was converted automatically to portletSetupTitleEs_ES (which was wrong), so it was converted to portletSetupTitle_es_es
