### PR TITLE
LPS-19616 Improve updateAsset method

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -519,6 +519,23 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			long[] categoryIds, String[] tagNames)
 		throws PortalException, SystemException {
 
+		long classNameId = PortalUtil.getClassNameId(className);
+
+		AssetEntry entry = assetEntryPersistence.fetchByC_C(
+			classNameId, classPK);
+
+		if (entry != null) {
+			return updateEntry(
+				userId, groupId, className, classPK, entry.getClassUuid(),
+				categoryIds, tagNames, entry.getVisible(), entry.getStartDate(),
+				entry.getEndDate(), entry.getPublishDate(),
+				entry.getExpirationDate(), entry.getMimeType(),
+				entry.getTitle(), entry.getDescription(), entry.getSummary(),
+				entry.getUrl(), entry.getLayoutUuid(), entry.getHeight(),
+				entry.getWidth(), GetterUtil.getInteger(entry.getPriority()),
+				false);
+		}
+
 		return updateEntry(
 			userId, groupId, className, classPK, null, categoryIds, tagNames,
 			true, null, null, null, null, null, null, null, null, null, null, 0,


### PR DESCRIPTION
Right now, if the asset already exists, it is overwritten and the tags and categoriesIds lost. As the method is called update, it should only update if the asset already existes. (This is not affecting the portal, but the API may mislead developers)
