### PR TITLE
LPS-19424

### DIFF
--- a/portal-web/docroot/html/common/themes/portlet.jsp
+++ b/portal-web/docroot/html/common/themes/portlet.jsp
@@ -60,11 +60,7 @@ if (portletDisplay.isAccess() && portletDisplay.isActive() && (portletTitle == n
 ResourceBundle resourceBundle = portletConfig.getResourceBundle(locale);
 
 if (portletTitle == null) {
-	try {
-		portletTitle = resourceBundle.getString(JavaConstants.JAVAX_PORTLET_TITLE);
-	}
-	catch (Exception e) {
-	}
+	portletTitle = ResourceBundleUtil.getString(resourceBundle, JavaConstants.JAVAX_PORTLET_TITLE);
 }
 
 portletDisplay.setTitle(portletTitle);


### PR DESCRIPTION
LPS-19424 Use ResourceBundleUtil to safely get the resource String, rather than catching the exception
