### PR TITLE
LPS-19824

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/QueryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/QueryImpl.java
@@ -69,19 +69,26 @@ public class QueryImpl implements Query {
 	}
 
 	public List<?> list() throws ORMException {
-		return list(true);
+		return list(false, false);
 	}
 
 	public List<?> list(boolean unmodifiable) throws ORMException {
+		return list(true, unmodifiable);
+	}
+
+	public List<?> list(boolean copy, boolean unmodifiable)
+		throws ORMException {
 		try {
 			List<?> list = _query.list();
 
 			if (unmodifiable) {
-				return new UnmodifiableList<Object>(list);
+				list = new UnmodifiableList<Object>(list);
 			}
-			else {
-				return ListUtil.copy(list);
+			else if (copy) {
+				list = ListUtil.copy(list);
 			}
+
+			return list;
 		}
 		catch (Exception e) {
 			throw ExceptionTranslator.translate(e);

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SQLQueryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SQLQueryImpl.java
@@ -83,22 +83,27 @@ public class SQLQueryImpl implements SQLQuery {
 		}
 	}
 
-	@SuppressWarnings("rawtypes")
-	public List list() throws ORMException {
-		return list(true);
+	public List<?> list() throws ORMException {
+		return list(false, false);
 	}
 
-	@SuppressWarnings("rawtypes")
-	public List list(boolean unmodifiable) throws ORMException {
+	public List<?> list(boolean unmodifiable) throws ORMException {
+		return list(true, unmodifiable);
+	}
+
+	public List<?> list(boolean copy, boolean unmodifiable)
+		throws ORMException {
 		try {
 			List list = _sqlQuery.list();
 
 			if (unmodifiable) {
-				return new UnmodifiableList(list);
+				list = new UnmodifiableList<Object>(list);
 			}
-			else {
-				return ListUtil.copy(list);
+			else if (copy) {
+				list = ListUtil.copy(list);
 			}
+
+			return list;
 		}
 		catch (Exception e) {
 			throw ExceptionTranslator.translate(e);

--- a/portal-impl/src/com/liferay/portal/dao/orm/jpa/QueryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/jpa/QueryImpl.java
@@ -75,10 +75,15 @@ public class QueryImpl implements Query {
 	}
 
 	public List<?> list() throws ORMException {
-		return list(true);
+		return list(false, false);
 	}
 
 	public List<?> list(boolean unmodifiable) throws ORMException {
+		return list(true, unmodifiable);
+	}
+
+	public List<?> list(boolean copy, boolean unmodifiable)
+		throws ORMException {
 		try {
 			List<?> list = sessionImpl.list(
 				queryString, positionalParameterMap, namedParameterMap,
@@ -86,11 +91,13 @@ public class QueryImpl implements Query {
 				entityClass);
 
 			if (unmodifiable) {
-				return new UnmodifiableList<Object>(list);
+				list = new UnmodifiableList<Object>(list);
 			}
-			else {
-				return ListUtil.copy(list);
+			else if (copy) {
+				list = ListUtil.copy(list);
 			}
+
+			return list;
 		}
 		catch (Exception e) {
 			throw ExceptionTranslator.translate(e);

--- a/portal-impl/src/com/liferay/portal/dao/orm/jpa/SQLQueryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/jpa/SQLQueryImpl.java
@@ -119,7 +119,8 @@ public class SQLQueryImpl extends QueryImpl implements SQLQuery {
 	}
 
 	@Override
-	public List<?> list(boolean unmodifiable) throws ORMException {
+	public List<?> list(boolean copy, boolean unmodifiable)
+		throws ORMException {
 		try {
 			List<?> list = sessionImpl.list(
 				queryString, positionalParameterMap, namedParameterMap,
@@ -131,11 +132,13 @@ public class SQLQueryImpl extends QueryImpl implements SQLQuery {
 			}
 
 			if (unmodifiable) {
-				return new UnmodifiableList<Object>(list);
+				list = new UnmodifiableList<Object>(list);
 			}
-			else {
-				return ListUtil.copy(list);
+			else if (copy) {
+				list = ListUtil.copy(list);
 			}
+
+			return list;
 		}
 		catch (Exception e) {
 			throw ExceptionTranslator.translate(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/GroupFinderImpl.java
@@ -272,7 +272,7 @@ public class GroupFinderImpl
 
 			q.addEntity("Group_", GroupImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -302,7 +302,7 @@ public class GroupFinderImpl
 			qPos.add(classNameId);
 			qPos.add(privateLayout);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -324,7 +324,7 @@ public class GroupFinderImpl
 
 			q.addEntity("Group_", GroupImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -350,7 +350,7 @@ public class GroupFinderImpl
 
 			qPos.add(companyId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -646,7 +646,7 @@ public class GroupFinderImpl
 		qPos.add(description);
 		qPos.add(description);
 
-		return q.list();
+		return q.list(true);
 	}
 
 	protected String getJoin(LinkedHashMap<String, Object> params) {

--- a/portal-impl/src/com/liferay/portal/service/persistence/LayoutFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/LayoutFinderImpl.java
@@ -57,7 +57,7 @@ public class LayoutFinderImpl
 
 			q.addEntity("Layout", LayoutImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -86,7 +86,7 @@ public class LayoutFinderImpl
 			qPos.add(groupId);
 			qPos.add(privateLayout);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/PermissionFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/PermissionFinderImpl.java
@@ -683,7 +683,7 @@ public class PermissionFinderImpl
 			qPos.add(actionId);
 			qPos.add(codeId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -723,7 +723,7 @@ public class PermissionFinderImpl
 				qPos.add(actionId);
 				setResourceIds(qPos, resourceIds);
 
-				list = q.list();
+				list = q.list(true);
 			}
 			catch (Exception e) {
 				throw new SystemException(e);
@@ -762,7 +762,7 @@ public class PermissionFinderImpl
 			qPos.add(groupId);
 			qPos.add(resourceId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -790,7 +790,7 @@ public class PermissionFinderImpl
 			qPos.add(roleId);
 			qPos.add(resourceId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -819,7 +819,7 @@ public class PermissionFinderImpl
 			qPos.add(userId);
 			qPos.add(resourceId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -850,7 +850,7 @@ public class PermissionFinderImpl
 			qPos.add(groupId);
 			qPos.add(resourceId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -883,7 +883,7 @@ public class PermissionFinderImpl
 			qPos.add(userId);
 			qPos.add(resourceId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -917,7 +917,7 @@ public class PermissionFinderImpl
 			qPos.add(scope);
 			qPos.add(primKey);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -950,7 +950,7 @@ public class PermissionFinderImpl
 			qPos.add(scope);
 			qPos.add(primKey);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/PortletPreferencesFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/PortletPreferencesFinderImpl.java
@@ -53,7 +53,7 @@ public class PortletPreferencesFinderImpl
 
 			qPos.add(portletId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/ResourceFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/ResourceFinderImpl.java
@@ -57,7 +57,7 @@ public class ResourceFinderImpl
 
 			qPos.add(name);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -86,7 +86,7 @@ public class ResourceFinderImpl
 			qPos.add(companyId);
 			qPos.add(primKey);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -115,7 +115,7 @@ public class ResourceFinderImpl
 			qPos.add(name);
 			qPos.add(scope);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/ResourcePermissionFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/ResourcePermissionFinderImpl.java
@@ -173,7 +173,7 @@ public class ResourcePermissionFinderImpl
 			qPos.add(name);
 			qPos.add(scope);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/RoleFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/RoleFinderImpl.java
@@ -285,7 +285,7 @@ public class RoleFinderImpl
 
 			qPos.add(companyId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -314,7 +314,7 @@ public class RoleFinderImpl
 			qPos.add(userId);
 			qPos.add(groupId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -343,7 +343,7 @@ public class RoleFinderImpl
 			qPos.add(userId);
 			qPos.add(groupId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -426,7 +426,7 @@ public class RoleFinderImpl
 			qPos.add(userId);
 			qPos.add(groupIds);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -596,7 +596,7 @@ public class RoleFinderImpl
 			qPos.add(primKey);
 			qPos.add(actionId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
@@ -330,7 +330,7 @@ public class UserFinderImpl
 
 			qPos.add(type);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -352,7 +352,7 @@ public class UserFinderImpl
 
 			q.addEntity("User_", UserImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -374,7 +374,7 @@ public class UserFinderImpl
 
 			q.addEntity("User_", UserImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/UserGroupRoleFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/UserGroupRoleFinderImpl.java
@@ -54,7 +54,7 @@ public class UserGroupRoleFinderImpl
 			qPos.add(userId);
 			qPos.add(groupId);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/announcements/service/persistence/AnnouncementsEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/persistence/AnnouncementsEntryFinderImpl.java
@@ -209,7 +209,7 @@ public class AnnouncementsEntryFinderImpl
 			qPos.add(displayDateGT_TS);
 			qPos.add(displayDateLT_TS);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/blogs/service/persistence/BlogsEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/persistence/BlogsEntryFinderImpl.java
@@ -245,7 +245,7 @@ public class BlogsEntryFinderImpl
 
 			q.addEntity("BlogsEntry", BlogsEntryImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/bookmarks/service/persistence/BookmarksEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/service/persistence/BookmarksEntryFinderImpl.java
@@ -46,7 +46,7 @@ public class BookmarksEntryFinderImpl
 
 			q.addEntity("BookmarksEntry", BookmarksEntryImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/calendar/service/persistence/CalEventFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/calendar/service/persistence/CalEventFinderImpl.java
@@ -137,7 +137,7 @@ public class CalEventFinderImpl
 			qPos.add(calendar_TS);
 			qPos.add(calendar_TS);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -159,7 +159,7 @@ public class CalEventFinderImpl
 
 			q.addEntity("CalEvent", CalEventImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderImpl.java
@@ -190,7 +190,7 @@ public class DLFileEntryFinderImpl
 
 			q.addEntity("DLFileEntry", DLFileEntryImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -214,7 +214,7 @@ public class DLFileEntryFinderImpl
 
 			q.addEntity("DLFileEntry", DLFileEntryImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileRankFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileRankFinderImpl.java
@@ -51,7 +51,7 @@ public class DLFileRankFinderImpl
 
 			qPos.add(count);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/imagegallery/service/persistence/IGImageFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/imagegallery/service/persistence/IGImageFinderImpl.java
@@ -101,7 +101,7 @@ public class IGImageFinderImpl
 
 			q.addEntity("IGImage", IGImageImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/journal/service/persistence/JournalArticleFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/persistence/JournalArticleFinderImpl.java
@@ -350,7 +350,7 @@ public class JournalArticleFinderImpl
 
 			qPos.add(expirationDateLT_TS);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);
@@ -415,7 +415,7 @@ public class JournalArticleFinderImpl
 			qPos.add(reviewDateGT_TS);
 			qPos.add(reviewDateLT_TS);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/persistence/MBMessageFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/persistence/MBMessageFinderImpl.java
@@ -163,7 +163,7 @@ public class MBMessageFinderImpl
 
 			q.addEntity("MBMessage", MBMessageImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/ratings/service/persistence/RatingsEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/service/persistence/RatingsEntryFinderImpl.java
@@ -80,7 +80,7 @@ public class RatingsEntryFinderImpl
 				qPos.add(userId);
 				qPos.add(classNameId);
 
-				list = q.list();
+				list = q.list(true);
 			}
 			catch (Exception e) {
 				throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/ratings/service/persistence/RatingsStatsFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/service/persistence/RatingsStatsFinderImpl.java
@@ -76,7 +76,7 @@ public class RatingsStatsFinderImpl
 
 				qPos.add(classNameId);
 
-				list = q.list();
+				list = q.list(true);
 			}
 			catch (Exception e) {
 				throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/wiki/service/persistence/WikiPageFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/persistence/WikiPageFinderImpl.java
@@ -218,7 +218,7 @@ public class WikiPageFinderImpl
 
 			q.addEntity("WikiPage", WikiPageImpl.class);
 
-			return q.list();
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-service/src/com/liferay/portal/kernel/dao/orm/Query.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/orm/Query.java
@@ -41,6 +41,9 @@ public interface Query {
 	@SuppressWarnings("rawtypes")
 	public List list(boolean unmodifiable) throws ORMException;
 
+	@SuppressWarnings("rawtypes")
+	public List list(boolean copy, boolean unmodifiable) throws ORMException;
+
 	public ScrollableResults scroll() throws ORMException;
 
 	public Query setBoolean(int pos, boolean value);


### PR DESCRIPTION
LPS-19824 Avoid creating unecessary unmodifiable wrapper or copy for Query.list() when the result is only temporary used within the method scope
