### PR TITLE
LPS-14937 Update tinymce languages process

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -73,3 +73,18 @@
 ##
 
     #source.formatter.excludes=**/*Tests.java
+    
+##
+## TinyMCE
+##
+## These are properties needed to update languages from tinyMCE site.
+##
+##	tinyMCE.download.baseurl:	URL to download JS files
+##	tinyMCE.dest.dir: 		The folder to place downloaded files
+##	tinyMCE.languages: 		each language has three values: [standard locale, tinyMCE locale, tinyMCE id]
+##	tinyMCE.supportedlanguages:	these are languages supported by tinyMCE but not yet supported by Liferay
+##
+	tinyMCE.download.baseurl=http://www.tinymce.com/i18n/index.php?ctrl=export&act=js&pr_id=7&la_id=
+	tinyMCE.dest.dir=../portal-web/docroot/html/js/editor/tiny_mce/langs
+	tinyMCE.languages=[ar,ar,133];[nb,nb,207];[bg,bg,136];[es_CA,ca,140];[hr,hr,158];[cs ,cs,142];[nl,nl,176];[en_GB,en,132];[et,et,149];[fi,fi,152];[fr,fr,153];[es_GL,gl,154];[de,de,145];[el,el,147];[iw,he,156];[hi_IN,hi,157];[hu,hu,159];[in,id,162];[it,it,164];[ja,ja,165];[ko,ko,205];[fa,fa,151];[pt,pl,179];[pt_PT,pt,181];[ro,ro,182];[ru,ru,183];[sr,sr,190];[sk,sk,187];[sl,sl,188];[es_ES,es,148];[sv,sv,191];[tr,tr,196];[uk,uk,199];[vi,vi,201];[zh_TW ,zh-tw,221];[zh_CN,zh-cn,216]
+	tinyMCE.supported.languages=[Albanian,sq,189];[Armenian,hy,160];[Azerbaijani,az,134];[Basque,eu,150];[Belarusian,be,135];[Bengali,bn,137];[Bosnian,bs,139];[Breton,br,138];[Burmese,my,211];[Central Khmer,km,217];[Chamorro,ch,141];[Chinese,zh,202];[Danish,da,144];[Divehi; Dhivehi; Maldivian,dv,146];[Esperanto,eo,222];[Georgian,ka,166];[Gujarati,gu,155];[Icelandic,is,163];[Interlingua (International Auxiliary Language Association),ia,161];[Kalaallisut; Greenlandic,kl,167];[Latvian,lv,170];[Lithuanian,lt,169];[Luxembourgish; Letzeburgesch,lb,168];[Macedonian,mk,171];[Malay,ms,174];[Malayalam,ml,172];[Mongolian,mn,173];[Northern Sami,se,185];[Norwegian,no,178];[Norwegian Nynorsk; Nynorsk, Norwegian,nn,177];[Pushto,ps,180];[Sardinian,sc,184];[Simplified Chinese,cn,215];[Sinhala; Sinhalese,si,186];[Tamil,ta,192];[Tatar,tt,197];[Telugu,te,193];[Thai,th,194];[Tswana,tn,195];[Twi,tw,198];[Urdu,ur,200];[Welsh,cy,143];[Zulu,zu,203]    

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -2,9 +2,13 @@
 
 <project name="portal-impl" basedir="." default="compile" xmlns:antelope="antlib:ise.antelope.tasks">
 	<property name="test.properties" value="portal-test.properties" />
-
+	
 	<import file="../build-common-java.xml" />
 
+	<property name="tinyMCE.dest.dir" value="${tinyMCE.dest.dir}" />
+	<property name="tinyMCE.download.baseurl" value="${tinyMCE.download.baseurl}" />
+	<property name="tinyMCE.languages" value="${tinyMCE.languages}" />
+		
 	<property name="deploy.dir" value="${app.server.lib.portal.dir}" />
 	<property name="jar.file" value="${ant.project.name}" />
 	<property name="service.file" value="service.xml" />
@@ -180,8 +184,22 @@ public class Creole10Parser]]></replacevalue>
 		</java>
 
 		<copy file="${lang.dir}/${lang.file}.properties" tofile="${lang.dir}/${lang.file}_en.properties" />
+		
+		<antcall target="build-lang-tinymce" />
 	</target>
 
+	<target name="build-lang-tinymce">
+		<java 
+			classname="com.liferay.portal.tools.TinyMCELanguageBuilder"
+			classpathref="project.classpath"
+		>
+			<arg value="tinyMCE.dest.dir=${tinyMCE.dest.dir}" />
+			<arg value="tinyMCE.download.baseurl=${tinyMCE.download.baseurl}" />
+			<arg value="tinyMCE.languages=${tinyMCE.languages}" />
+		</java>
+		<antcall target="print-current-time" />
+	</target>
+	
 	<target name="build-lib-versions">
 		<java
 			classname="com.liferay.portal.tools.XSLTBuilder"

--- a/portal-impl/src/com/liferay/portal/tools/TinyMCELanguageBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/TinyMCELanguageBuilder.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2000-2011 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.tools;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+
+/**
+ * @author Manuel de la Peña
+ */
+public class TinyMCELanguageBuilder {
+	
+	public static void main(String[] args) {		
+		_tinyMCELanguageBuilder = new TinyMCELanguageBuilder(args);
+		
+		processLanguages(_languages);	
+	}
+	
+	private static void downloadLanguageFile(TinyMCELanguage tinyLang) 
+		throws IOException {
+		
+		URL u = null;
+	    InputStream is = null;
+	    OutputStream out = null;
+	 
+	    String downloadURL = _baseURL + tinyLang._tinyID; 
+	    String destFilePath = _destinationDirectory + "/" +
+	    	tinyLang._tinyCode + ".js";
+	    File dest = new File(destFilePath);
+	    
+	    try {
+	    	u = new URL(downloadURL);	    	
+	    	is = u.openStream();
+	    	out = new FileOutputStream(dest);
+	    	
+	    	byte[] buf = new byte[1024];
+	    	int len;
+	
+	    	while ((len = is.read(buf)) > 0) {
+	    		out.write(buf, 0, len);
+	    	}
+	    } catch(IOException ioe) {
+	    	System.out.println("An error has been produced downloading the " +
+    			"file from [" + downloadURL + "]");
+	    }
+	    finally {
+	    	is.close();
+	    	out.close();
+	    }
+	}
+	
+	private static void processLanguages(String languages) {		
+		StringTokenizer tokenizer = new StringTokenizer(languages,";");
+		
+		while (tokenizer.hasMoreElements()) {
+			String lang = tokenizer.nextToken();
+			
+			int firstComma = lang.indexOf(",");
+			int lastComma = lang.lastIndexOf(",");
+			
+			try {
+				String liferayCode = lang.substring(1,firstComma);
+				String tinyCode = lang.substring(firstComma + 1,lastComma);
+				int tinyID = GetterUtil.getInteger(
+					lang.substring(lastComma + 1));
+				
+				TinyMCELanguage tinyLang = 
+					_tinyMCELanguageBuilder.new TinyMCELanguage(
+							liferayCode, tinyCode, tinyID);
+				
+				downloadLanguageFile(tinyLang);
+			}
+			catch (IndexOutOfBoundsException ioobe) {
+				ioobe.printStackTrace();
+			}				
+			catch (IOException e) {
+				e.printStackTrace();
+			}			
+		}		
+	}
+	
+	private TinyMCELanguageBuilder(String[] args) {
+		Map<String, String> arguments = ArgumentsUtil.parseArguments(args);
+
+		_baseURL = GetterUtil.getString(
+			arguments.get("tinyMCE.download.baseurl"));
+		_destinationDirectory = GetterUtil.getString(
+				arguments.get("tinyMCE.dest.dir"));
+		_languages = GetterUtil.getString(arguments.get("tinyMCE.languages"));		
+	}
+	
+	private class TinyMCELanguage {
+		
+		public TinyMCELanguage(
+			String liferayCode, String tinyCode, int tinyID) {			
+			this._liferayCode = liferayCode;
+			this._tinyCode = tinyCode;
+			this._tinyID = tinyID;
+		}
+		
+		private String _liferayCode;
+		private String _tinyCode;
+		private int _tinyID;
+	}
+	
+	private static String _baseURL;
+	private static String _destinationDirectory;
+	private static String _languages;	
+	private static TinyMCELanguageBuilder _tinyMCELanguageBuilder;
+	
+}

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -765,6 +765,12 @@ var defaultTypes = []]>
 				/>
 			</not>
 			<then>
+				<zip destfile="third-party/${tinymce.file}"
+					update="true"
+				>
+					<zipfileset dir="docroot/html/js/editor/tiny_mce/langs" prefix="tinymce/jscripts/tiny_mce/langs" />
+	  			</zip>
+				
 				<delete dir="docroot/html/js/editor/tiny_mce" />
 				<delete dir="docroot/html/js/editor/tinymce" />
 


### PR DESCRIPTION
Ant-deploy calls build-tinymce target at portal-web/build.xml, which updates local tinyMCE with third-party zip file.
The new process is called by portal-impl/build.xml build-lang target, and it downloads files from tinyMCE site to "portal-web/docroot/html/js/editor/tinyMCE/langs". That directory has only one file (en.js), so when an user wants to update languages, he/she has to call build-lang (or build-lang-tinymce) first.

Next time he/she deploys trunk, language files will be available for tinyMCE, because build-tinymce target has been recoded to update tinyMCE.zip file with new languages.

(Reviewed by Juan Fernández)
