### PR TITLE
LPS-20191 Clicking the Undo button while in a staged and versionned page 

### DIFF
--- a/portal-web/docroot/html/js/liferay/staging_version.js
+++ b/portal-web/docroot/html/js/liferay/staging_version.js
@@ -10,6 +10,11 @@ AUI().add(
 			undo: 'undo_layout_revision'
 		};
 
+		var MAP_TEXT_REVISION = {
+			redo: Liferay.Language.get('are-you-sure-you-want-to-redo-your-last-changes'),
+			undo: Liferay.Language.get('are-you-sure-you-want-to-undo-your-last-changes')
+		};
+
 		A.mix(
 			StagingBar,
 			{


### PR DESCRIPTION
LPS-20191 Clicking the Undo button while in a staged and versionned page does nothing (throws a javascript error)
