### PR TITLE
LPS-20198 Changing site url from "DockBar -> Manage -> Site Settings" res

### DIFF
--- a/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
@@ -73,6 +73,11 @@ String[] advancedSections = PropsValues.SITES_FORM_ADD_ADVANCED;
 
 if (group != null) {
 	mainSections = PropsValues.SITES_FORM_UPDATE_MAIN;
+
+	if ((windowState == LiferayWindowState.POP_UP) && ArrayUtil.contains(mainSections, "site_url")) {
+		mainSections = ArrayUtil.remove(mainSections, "site_url");
+	}
+
 	seoSections = PropsValues.SITES_FORM_UPDATE_SEO;
 	advancedSections = PropsValues.SITES_FORM_UPDATE_ADVANCED;
 }


### PR DESCRIPTION
LPS-20198 Changing site url from "DockBar -> Manage -> Site Settings" results in an error after closing the configuration screen and refreshing the page
