### PR TITLE
Changing groupId to not be scoped

### DIFF
--- a/portal-web/docroot/html/portlet/journal/view_article.jsp
+++ b/portal-web/docroot/html/portlet/journal/view_article.jsp
@@ -28,7 +28,7 @@ String xmlRequest = PortletRequestUtil.toXML(renderRequest, renderResponse);
 JournalArticleDisplay articleDisplay = JournalContentUtil.getDisplay(groupId, articleId, null, null, languageId, themeDisplay, articlePage, xmlRequest);
 
 try {
-	article = JournalArticleLocalServiceUtil.getLatestArticle(scopeGroupId, articleId, WorkflowConstants.STATUS_ANY);
+	article = JournalArticleLocalServiceUtil.getLatestArticle(groupId, articleId, WorkflowConstants.STATUS_ANY);
 
 	boolean expired = article.isExpired();
 


### PR DESCRIPTION
Same as the issue with message boards, we are using scopeGroupId when we shouldn't be and it's breaking results from "other than active" communities.
