### PR TITLE
Force status_approved, not any!

### DIFF
--- a/portal-impl/src/com/liferay/portlet/usersadmin/util/UserIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/util/UserIndexer.java
@@ -71,9 +71,9 @@ public class UserIndexer extends BaseIndexer {
 
 		int status = GetterUtil.getInteger(
 			searchContext.getAttribute(Field.STATUS),
-			WorkflowConstants.STATUS_ANY);
+			WorkflowConstants.STATUS_APPROVED);
 
-		if (status != WorkflowConstants.STATUS_ANY) {
+		if (status != WorkflowConstants.STATUS_APPROVED) {
 			contextQuery.addRequiredTerm(Field.STATUS, status);
 		}
 


### PR DESCRIPTION
This makes it so all searches only return active users, unless specified otherwise on purpose by the user.
