### PR TITLE
LPS-20433 Set LiferayFileItem's default threshold to a value bigger than 

### DIFF
--- a/portal-impl/src/com/liferay/portal/upload/LiferayFileItemFactory.java
+++ b/portal-impl/src/com/liferay/portal/upload/LiferayFileItemFactory.java
@@ -24,7 +24,7 @@ import org.apache.commons.fileupload.disk.DiskFileItemFactory;
  */
 public class LiferayFileItemFactory extends DiskFileItemFactory {
 
-	public static final int DEFAULT_SIZE = 0;
+	public static final int DEFAULT_SIZE = 1024;
 
 	public LiferayFileItemFactory(File tempDir) {
 		_tempDir = tempDir;


### PR DESCRIPTION
LPS-20433 Set LiferayFileItem's default threshold to a value bigger than 0 to avoid creating tons tiny temporary files for parameters
