### PR TITLE
LPS-20454 WebServerServlet.writeImage() always retrieves the wrong mime t

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -818,7 +818,7 @@ public class WebServerServlet extends HttpServlet {
 		String type = image.getType();
 
 		if (!type.equals(ImageConstants.TYPE_NOT_AVAILABLE)) {
-			contentType = MimeTypesUtil.getContentType(type);
+			contentType = MimeTypesUtil.getContentType("A." + type);
 
 			response.setContentType(contentType);
 		}


### PR DESCRIPTION
LPS-20454 WebServerServlet.writeImage() always retrieves the wrong mime type
