### PR TITLE
LPS-20555

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LiferayResourceBundle.java
+++ b/portal-impl/src/com/liferay/portal/language/LiferayResourceBundle.java
@@ -96,7 +96,8 @@ public class LiferayResourceBundle extends ResourceBundle {
 	public Enumeration<String> getKeys() {
 		final Set<String> keys = _map.keySet();
 
-		final Enumeration<String> parentKeys = parent.getKeys();
+		final Enumeration<String> parentKeys =
+			parent == null ? null : parent.getKeys();
 
 		final Iterator<String> itr = keys.iterator();
 


### PR DESCRIPTION
LPS-20555 LiferayResourceBundle should skip checking parent's keys when parent is null
