### PR TITLE
LPS-20221 - Document Library - save button in Manage Metadata sets doesn't 

### DIFF
--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/form_builder.jspf
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/form_builder.jspf
@@ -150,12 +150,6 @@ String defaultLanguageId = LocalizationUtil.getDefaultLocale(script);
 						<form class="aui-form-builder-settings"></form>
 
 						<div class="aui-button-row aui-form-builder-settings-buttons">
-							<span class="aui-button aui-button-submit aui-priority-primary aui-state-positive">
-								<span class="aui-button-content">
-									<input type="button" value="<liferay-ui:message key="save" />" class="aui-button-input aui-form-builder-button-save">
-								</span>
-							</span>
-
 							<span class="aui-button aui-button-submit aui-priority-secondary aui-state-positive">
 								<span class="aui-button-content">
 									<input class="aui-button-input aui-form-builder-button-close" type="button" value="<liferay-ui:message key="close" />">


### PR DESCRIPTION
This button didn't make any sense: removed
