### PR TITLE
LPS-20608 Rollback

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
@@ -68,7 +68,7 @@ if (themeDisplay.getScopeGroup().isLayout()) {
 		<liferay-ui:icon
 			image="edit"
 			label="<%= showIconLabel %>"
-			message='<%= showIconLabel ? LanguageUtil.format(pageContext, "edit-x-x", new Object[] {"aui-helper-hidden-accessible", assetRenderer.getTitle(locale)}) : LanguageUtil.format(pageContext, "edit-x", assetRenderer.getTitle(locale)) %>'
+			message='<%= showIconLabel ? LanguageUtil.format(pageContext, "edit-x-x", new Object[] {"aui-helper-hidden-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}) : LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale))) %>'
 			url="<%= taglibEditURL %>"
 		/>
 	</div>

--- a/portal-web/docroot/html/portlet/asset_publisher/display/title_list.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/display/title_list.jsp
@@ -66,7 +66,7 @@ viewURL = _checkViewURL(viewURL, currentURL, themeDisplay);
 		<li class="title-list <%= assetRendererFactory.getType() %>">
 			<liferay-ui:icon
 				label="<%= true %>"
-				message="<%= title %>"
+				message="<%= HtmlUtil.escape(title) %>"
 				src="<%= assetRendererFactory.getIconPath(renderRequest) %>"
 				url="<%= viewURL %>"
 			/>

--- a/portal-web/docroot/html/portlet/bookmarks/view.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/view.jsp
@@ -185,7 +185,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 					<liferay-ui:icon
 						cssClass="lfr-asset-avatar"
 						image='<%= "../file_system/large/" + (((foldersCount + entriesCount) > 0) ? "folder_full_bookmark" : "folder_empty") %>'
-						message='<%= (folder != null) ? folder.getName() : LanguageUtil.get(pageContext, "bookmarks-home") %>'
+						message='<%= (folder != null) ? HtmlUtil.escapeAttribute(folder.getName()) : LanguageUtil.get(pageContext, "bookmarks-home") %>'
 					/>
 
 					<div class="lfr-asset-name">

--- a/portal-web/docroot/html/portlet/control_panel_menu/view.jsp
+++ b/portal-web/docroot/html/portlet/control_panel_menu/view.jsp
@@ -185,7 +185,7 @@
 
 									<liferay-ui:icon
 										image="<%= image %>"
-										message="<%= message %>"
+										message="<%= HtmlUtil.escape(message) %>"
 										url="<%= url %>"
 									/>
 
@@ -215,7 +215,7 @@
 								cssClass="lfr-panel-title-single"
 								image="<%= image %>"
 								label="<%= true %>"
-								message="<%= StringUtil.shorten(curGroupName, 25) %>"
+								message="<%= HtmlUtil.escape(StringUtil.shorten(curGroupName, 25)) %>"
 							/>
 						</c:otherwise>
 					</c:choose>
@@ -253,7 +253,7 @@
 
 								<liferay-ui:icon
 									image="folder"
-									message="<%= curScopeLayout.getName(locale) %>"
+									message="<%= HtmlUtil.escape(curScopeLayout.getName(locale)) %>"
 									url='<%= HttpUtil.setParameter(PortalUtil.getCurrentURL(request), "doAsGroupId", curScopeLayout.getScopeGroup().getGroupId()) %>'
 								/>
 

--- a/portal-web/docroot/html/portlet/document_library/asset/abstract.jsp
+++ b/portal-web/docroot/html/portlet/document_library/asset/abstract.jsp
@@ -58,7 +58,7 @@ if (showThumbnail) {
 				<liferay-ui:icon
 					image='<%= "../file_system/small/" + fileVersion.getIcon() %>'
 					label="<%= true %>"
-					message="<%= fileVersion.getTitle() %>"
+					message="<%= HtmlUtil.escape(fileVersion.getTitle()) %>"
 					url='<%= themeDisplay.getPortalURL() + themeDisplay.getPathContext() + "/documents/" + fileVersion.getRepositoryId() + StringPool.SLASH + fileEntry.getFolderId() + StringPool.SLASH + HttpUtil.encodeURL(HtmlUtil.unescape(fileEntry.getTitle())) + "?version=" + fileVersion.getVersion() %>'
 				/>
 			</c:otherwise>

--- a/portal-web/docroot/html/portlet/document_library/move_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/move_file_entry.jsp
@@ -101,6 +101,8 @@ portletURL.setParameter("fileEntryId", String.valueOf(fileEntryId));
 		if (folderId > 0) {
 			Folder folder = DLAppLocalServiceUtil.getFolder(folderId);
 
+			folder = folder.toEscapedModel();
+
 			folderId = folder.getFolderId();
 			folderName = folder.getName();
 		}
@@ -125,7 +127,7 @@ portletURL.setParameter("fileEntryId", String.valueOf(fileEntryId));
 		</aui:field-wrapper>
 
 		<aui:field-wrapper label="new-folder">
-			<aui:a href="<%= viewFolderURL %>" id="folderName"><%= HtmlUtil.escape(folderName) %></aui:a>
+			<aui:a href="<%= viewFolderURL %>" id="folderName"><%= folderName %></aui:a>
 
 			<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>" var="selectFolderURL">
 				<portlet:param name="struts_action" value="/document_library/select_folder" />

--- a/portal-web/docroot/html/portlet/sites_admin/toolbar.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/toolbar.jsp
@@ -61,7 +61,7 @@ String toolbarItem = ParamUtil.getString(request, "toolbarItem", "view-all");
 
 						<liferay-ui:icon
 							image="site_icon"
-							message="<%= layoutSetPrototype.getName(locale) %>"
+							message="<%= HtmlUtil.escape(layoutSetPrototype.getName(locale)) %>"
 							method="get"
 							url='<%= addSiteURL.toString() %>'
 						/>

--- a/portal-web/docroot/html/portlet/wiki/history_navigation.jsp
+++ b/portal-web/docroot/html/portlet/wiki/history_navigation.jsp
@@ -134,7 +134,7 @@ if (type.equals("html")) {
 					StringBundler sb = new StringBundler(intermediatePages.size() * 7);
 
 					for (WikiPage wikiPage: intermediatePages) {
-						sb.append(wikiPage.getUserName());
+						sb.append(HtmlUtil.escape(wikiPage.getUserName()));
 						sb.append(StringPool.SPACE);
 						sb.append(StringPool.OPEN_PARENTHESIS);
 						sb.append(wikiPage.getVersion());
@@ -165,7 +165,7 @@ if (type.equals("html")) {
 						cssClass="central-username"
 						image="user_icon"
 						label="<%= true %>"
-						message="<%= wikiPage.getUserName() %>"
+						message="<%= HtmlUtil.escape(wikiPage.getUserName()) %>"
 						toolTip="author"
 					/>
 

--- a/portal-web/docroot/html/taglib/ui/icon/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/init.jsp
@@ -111,7 +111,7 @@ else {
 	StringBundler sb = new StringBundler(6);
 
 	sb.append(" alt=\"");
-	sb.append(LanguageUtil.get(pageContext, HtmlUtil.escapeAttribute(message)));
+	sb.append(LanguageUtil.get(pageContext, message));
 	sb.append("\"");
 
 	if (toolTip) {
@@ -121,7 +121,7 @@ else {
 	}
 	else {
 		sb.append(" title=\"");
-		sb.append(LanguageUtil.get(pageContext, HtmlUtil.escapeAttribute(message)));
+		sb.append(LanguageUtil.get(pageContext, message));
 		sb.append("\"");
 	}
 

--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -129,14 +129,14 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 
 	<c:choose>
 		<c:when test="<%= (iconMenuIconCount != null) && ((iconMenuSingleIcon == null) || iconMenuShowWhenSingleIcon) %>">
-			<liferay-ui:message key="<%= HtmlUtil.escape(message) %>" />
+			<liferay-ui:message key="<%= message %>" />
 		</c:when>
 		<c:when test="<%= (iconListIconCount != null) && ((iconListSingleIcon == null) || iconListShowWhenSingleIcon) %>">
-			<span class="taglib-text"><liferay-ui:message key="<%= HtmlUtil.escape(message) %>" /></span>
+			<span class="taglib-text"><liferay-ui:message key="<%= message %>" /></span>
 		</c:when>
 		<c:otherwise>
 			<c:if test="<%= label %>">
-				<span class="taglib-text"><liferay-ui:message key="<%= HtmlUtil.escape(message) %>" /></span>
+				<span class="taglib-text"><liferay-ui:message key="<%= message %>" /></span>
 			</c:if>
 		</c:otherwise>
 	</c:choose>


### PR DESCRIPTION
Had to rollback this fix because the message parameter sometimes contains HTML so we can't escape it.

As it turns out if the message attribute is used in the image's alt/title attribute, then it won't be used in the label. And if it's used in label, it won't be used in the image's atl/title attribute. So it is possible to correctly escape the input from outside the taglib, however the user of the taglib will need to be responsible for calling the correct escape method to escape the message attribute. i.e., sometimes you'll need to do

```
<liferay-ui:icon message="<%= HtmlUtil.escape(message) %>" />
```

and sometimes you'll need

```
<liferay-ui:icon message="<%= HtmlUtil.escapeAttribute(message) %>" />
```

We'll also have a problem should we ever have a use case where we use both the image's attribute and the label at the same time.
