### PR TITLE
LPS-20492

### DIFF
--- a/app.server.properties
+++ b/app.server.properties
@@ -160,7 +160,7 @@
 ## Tomcat
 ##
 
-    app.server.tomcat.dir=${app.server.parent.dir}/tomcat-6.0.33
+    app.server.tomcat.dir=${app.server.parent.dir}/tomcat-7.0.20
     app.server.tomcat.bin.dir=${app.server.tomcat.dir}/bin
     app.server.tomcat.classes.global.dir=${app.server.tomcat.dir}/lib
     app.server.tomcat.classes.portal.dir=${app.server.tomcat.portal.dir}/WEB-INF/classes
@@ -174,8 +174,8 @@
     app.server.tomcat.log.dir=${app.server.tomcat.dir}/logs
     app.server.tomcat.temp.dir=${app.server.tomcat.dir}/temp
     app.server.tomcat.work.dir=${app.server.tomcat.dir}/work
-    app.server.tomcat.zip.name=apache-tomcat-6.0.33.zip
-    app.server.tomcat.zip.url=http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.33/bin/${app.server.tomcat.zip.name}
+    app.server.tomcat.zip.name=apache-tomcat-7.0.20.zip
+    app.server.tomcat.zip.url=http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.20/bin/${app.server.tomcat.zip.name}
 
 ##
 ## WebLogic

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -375,9 +375,9 @@
 		<delete file="app.server.${user.name}.properties" />
 
 		<antcall target="deploy-plugins">
-			<param name="deployer.dest.dir" value="${app.server.parent.dir}/tomcat-6.0.33/webapps" />
+			<param name="deployer.dest.dir" value="${app.server.parent.dir}/tomcat-7.0.20/webapps" />
 			<param name="deployer.app.server.type" value="tomcat" />
-			<param name="deployer.app.server.lib.portal.dir" value="${app.server.parent.dir}/tomcat-6.0.33/webapps/ROOT/WEB-INF/lib" />
+			<param name="deployer.app.server.lib.portal.dir" value="${app.server.parent.dir}/tomcat-7.0.20/webapps/ROOT/WEB-INF/lib" />
 		</antcall>
 	</target>
 
@@ -1049,11 +1049,11 @@ release was successful.</echo>
 			src="${app.server.parent.dir}/${app.server.tomcat.zip.name}"
 		>
 			<patternset
-				excludes="apache-tomcat-6.0.33/webapps/**"
+				excludes="apache-tomcat-7.0.20/webapps/**"
 			/>
 			<mapper
 				type="glob"
-				from="apache-tomcat-6.0.33/*"
+				from="apache-tomcat-7.0.20/*"
 				to="${app.server.tomcat.dir.name}/*"
 			/>
 		</unzip>


### PR DESCRIPTION
Upgrade to Tomcat 7.0.20, not sure if we need to restore the old logic that allowed 5.5 and 6.0 to co-exist so that we can still easily build both Tomcat 6.0.33 and Tomcat 7.0.20, though.
