### PR TITLE
LPS-20699 Creating users can result in permission checking error because 

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -544,9 +544,10 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 		if ((creatorUserId != 0) || !company.isStrangers()) {
 			if (!PortalPermissionUtil.contains(
 					getPermissionChecker(), ActionKeys.ADD_USER) &&
-				!UserPermissionUtil.contains(
-					getPermissionChecker(), 0, organizationIds,
-					ActionKeys.ADD_USER)) {
+				organizationIds != null && (organizationIds.length > 0) &&
+				!OrganizationPermissionUtil.contains(
+					getPermissionChecker(), organizationIds,
+					ActionKeys.ASSIGN_MEMBERS)) {
 
 				throw new PrincipalException();
 			}

--- a/portal-impl/src/com/liferay/portal/service/permission/OrganizationPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/OrganizationPermissionImpl.java
@@ -67,6 +67,18 @@ public class OrganizationPermissionImpl implements OrganizationPermission {
 	}
 
 	public boolean contains(
+			PermissionChecker permissionChecker, long[] organizationIds,
+			String actionId)
+		throws PortalException, SystemException {
+
+		for (long organizationId : organizationIds) {
+			check(permissionChecker, organizationId, actionId);
+		}
+
+		return true;
+	}
+
+	public boolean contains(
 			PermissionChecker permissionChecker, Organization organization,
 			String actionId)
 		throws PortalException, SystemException {

--- a/portal-service/src/com/liferay/portal/service/permission/OrganizationPermission.java
+++ b/portal-service/src/com/liferay/portal/service/permission/OrganizationPermission.java
@@ -40,6 +40,11 @@ public interface OrganizationPermission {
 		throws PortalException, SystemException;
 
 	public boolean contains(
+			PermissionChecker permissionChecker, long[] organizationIds,
+			String actionId)
+		throws PortalException, SystemException;
+
+	public boolean contains(
 			PermissionChecker permissionChecker, Organization organization,
 			String actionId)
 		throws PortalException, SystemException;

--- a/portal-service/src/com/liferay/portal/service/permission/OrganizationPermissionUtil.java
+++ b/portal-service/src/com/liferay/portal/service/permission/OrganizationPermissionUtil.java
@@ -52,6 +52,15 @@ public class OrganizationPermissionUtil {
 	}
 
 	public static boolean contains(
+			PermissionChecker permissionChecker, long[] organizationIds,
+			String actionId)
+		throws PortalException, SystemException {
+
+		return getOrganizationPermission().contains(
+			permissionChecker, organizationIds, actionId);
+	}
+
+	public static boolean contains(
 			PermissionChecker permissionChecker, Organization organization,
 			String actionId)
 		throws PortalException, SystemException {


### PR DESCRIPTION
LPS-20699 Creating users can result in permission checking error because checking ADD_USER on the User model (which is not defined)
