### PR TITLE
LPS-18992 Delta selector usability improvement

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -120,7 +120,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 	</div>
 </c:if>
 
-<c:if test="<%= total > delta %>">
+<c:if test="<%= (total > delta) || (total > PropsValues.SEARCH_CONTAINER_PAGE_DELTA_VALUES[0]) %>">
 	<div class="search-pages">
 		<c:if test='<%= type.equals("regular") %>'>
 			<c:if test="<%= PropsValues.SEARCH_CONTAINER_PAGE_DELTA_VALUES.length > 0 %>">


### PR DESCRIPTION
"I have added an option so that it'll appear when the results count is bigger that the first item in the paginator dropdown menu. 

So if you set the paginator to 20, you have 8 items and the first item in the menu is 5, then you'll see the paginator. But if you have less than 5 items, you won't see it. 

This way we have the best of the two worlds: it won't appear so fast, and it'll be available for your case scenario."
