### PR TITLE
LPS-20783

### DIFF
--- a/support-tomcat/src/com/liferay/support/tomcat/jasper/runtime/TagHandlerPool.java
+++ b/support-tomcat/src/com/liferay/support/tomcat/jasper/runtime/TagHandlerPool.java
@@ -68,8 +68,9 @@ public class TagHandlerPool extends org.apache.jasper.runtime.TagHandlerPool {
 
 			_tags.offer(tag);
 		}
-
-		tag.release();
+		else {
+			tag.release();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
LPS-20783 According to jsp tag lifecycle protocol, tag should only be released when failing en-pool
