### PR TITLE
LPS-19996 Editing friendly URL on Public Page change not saved

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -88,7 +88,6 @@ String[][] categorySections = {mainSections};
 	<aui:input name="selPlid" type="hidden" value="<%= selPlid %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutId" type="hidden" value="<%= layoutId %>" />
-	<aui:input name="friendlyURL" type="hidden" value="<%= (selLayout != null) ? selLayout.getFriendlyURL() : StringPool.BLANK %>" />
 	<aui:input name="<%= PortletDataHandlerKeys.SELECTED_LAYOUTS %>" type="hidden" />
 
 	<c:if test="<%= layoutRevision != null && !incomplete%>">

--- a/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
@@ -106,7 +106,7 @@ StringBuilder friendlyURLBase = new StringBuilder();
 					<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "for-example-x", "<em>/news</em>") %>' label="friendly-url" name="friendlyURL" prefix="<%= friendlyURLBase.toString() %>" />
 				</c:when>
 				<c:otherwise>
-					<aui:input name="friendlyURL" size="30" type="hidden" value="<%= HtmlUtil.escape(selLayout.getFriendlyURL()) %>" />
+					<aui:input name="friendlyURL" size="30" type="hidden" value="<%= HtmlUtil.escape((selLayout != null) ? selLayout.getFriendlyURL() : StringPool.BLANK) %>" />
 				</c:otherwise>
 			</c:choose>
 


### PR DESCRIPTION
This bug was introduced by LPS-18812, as it introduced a duplicate variable (friendlyURL)
I have removed the duplicated variable and applied the changes where it was needed, so this fixes both tickets
