### PR TITLE
LPS-16394

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryPropertyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryPropertyServiceImpl.java
@@ -16,8 +16,10 @@ package com.liferay.portlet.asset.service.impl;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portlet.asset.model.AssetCategoryProperty;
 import com.liferay.portlet.asset.service.base.AssetCategoryPropertyServiceBaseImpl;
+import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
 
 import java.util.List;
 
@@ -32,12 +34,23 @@ public class AssetCategoryPropertyServiceImpl
 			long entryId, String key, String value)
 		throws PortalException, SystemException {
 
+		AssetCategoryPermission.check(
+			getPermissionChecker(), entryId, ActionKeys.UPDATE);
+
 		return assetCategoryPropertyLocalService.addCategoryProperty(
 			getUserId(), entryId, key, value);
 	}
 
 	public void deleteCategoryProperty(long categoryPropertyId)
 		throws PortalException, SystemException {
+
+		AssetCategoryProperty assetCategoryProperty =
+			assetCategoryPropertyLocalService.getAssetCategoryProperty(
+				categoryPropertyId);
+
+		AssetCategoryPermission.check(
+			getPermissionChecker(), assetCategoryProperty.getCategoryId(),
+			ActionKeys.UPDATE);
 
 		assetCategoryPropertyLocalService.deleteCategoryProperty(
 			categoryPropertyId);
@@ -60,6 +73,14 @@ public class AssetCategoryPropertyServiceImpl
 	public AssetCategoryProperty updateCategoryProperty(
 			long categoryPropertyId, String key, String value)
 		throws PortalException, SystemException {
+
+		AssetCategoryProperty assetCategoryProperty =
+			assetCategoryPropertyLocalService.getAssetCategoryProperty(
+				categoryPropertyId);
+
+		AssetCategoryPermission.check(
+			getPermissionChecker(), assetCategoryProperty.getCategoryId(),
+			ActionKeys.UPDATE);
 
 		return assetCategoryPropertyLocalService.updateCategoryProperty(
 			categoryPropertyId, key, value);

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagPropertyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagPropertyServiceImpl.java
@@ -16,8 +16,10 @@ package com.liferay.portlet.asset.service.impl;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portlet.asset.model.AssetTagProperty;
 import com.liferay.portlet.asset.service.base.AssetTagPropertyServiceBaseImpl;
+import com.liferay.portlet.asset.service.permission.AssetTagPermission;
 
 import java.util.List;
 
@@ -30,12 +32,22 @@ public class AssetTagPropertyServiceImpl
 	public AssetTagProperty addTagProperty(long tagId, String key, String value)
 		throws PortalException, SystemException {
 
+		AssetTagPermission.check(
+			getPermissionChecker(), tagId, ActionKeys.UPDATE);
+
 		return assetTagPropertyLocalService.addTagProperty(
 			getUserId(), tagId, key, value);
 	}
 
 	public void deleteTagProperty(long tagPropertyId)
 		throws PortalException, SystemException {
+
+		AssetTagProperty assetTagProperty =
+			assetTagPropertyLocalService.getTagProperty(tagPropertyId);
+
+		AssetTagPermission.check(
+			getPermissionChecker(), assetTagProperty.getTagId(),
+			ActionKeys.UPDATE);
 
 		assetTagPropertyLocalService.deleteTagProperty(tagPropertyId);
 	}
@@ -57,6 +69,13 @@ public class AssetTagPropertyServiceImpl
 	public AssetTagProperty updateTagProperty(
 			long tagPropertyId, String key, String value)
 		throws PortalException, SystemException {
+
+		AssetTagProperty assetTagProperty =
+			assetTagPropertyLocalService.getTagProperty(tagPropertyId);
+
+		AssetTagPermission.check(
+			getPermissionChecker(), assetTagProperty.getTagId(),
+			ActionKeys.UPDATE);
 
 		return assetTagPropertyLocalService.updateTagProperty(
 			tagPropertyId, key, value);


### PR DESCRIPTION
Using the permission checker for AssetTag instead of creating a new permission checker for AssetTagProperty because the expected behavior is for a user to be able to edit a tag's property if he/she is able to edit the tag itself.
