### PR TITLE
LPS-20799 Custom Attributes should appear after document type metadata wh

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/css/main.jsp
+++ b/portal-web/docroot/html/portlet/document_library/css/main.jsp
@@ -632,6 +632,10 @@
 			margin: 0 0 10px;
 		}
 
+		.taglib-custom-attributes-list {
+			margin-bottom: 0;
+		}
+
 		.asset-details-content {
 			padding: 10px;
 

--- a/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
@@ -523,15 +523,6 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 
 
 					<aui:workflow-status model="<%= DLFileEntry.class %>" status="<%= fileVersion.getStatus() %>" />
-
-					<liferay-ui:custom-attributes-available className="<%= DLFileEntryConstants.getClassName() %>">
-						<liferay-ui:custom-attribute-list
-							className="<%= DLFileEntryConstants.getClassName() %>"
-							classPK="<%= fileVersionId %>"
-							editable="<%= false %>"
-							label="<%= true %>"
-						/>
-					</liferay-ui:custom-attributes-available>
 				</div>
 
 				<%
@@ -572,7 +563,20 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 							catch (Exception e) {
 							}
 						}
+						%>
 
+						<liferay-ui:custom-attributes-available className="<%= DLFileEntryConstants.getClassName() %>" classPK="<%= fileVersionId %>" editable="<%= false %>">
+							<liferay-ui:panel collapsible="<%= true %>" cssClass="custom-fields" id="documentLibraryCustomAttributesPanel" persistState="<%= true %>" title="custom-fields">
+								<liferay-ui:custom-attribute-list
+									className="<%= DLFileEntryConstants.getClassName() %>"
+									classPK="<%= fileVersionId %>"
+									editable="<%= false %>"
+									label="<%= true %>"
+								/>
+							</liferay-ui:panel>
+						</liferay-ui:custom-attributes-available>
+
+						<%
 						try {
 							List<DDMStructure> ddmStructures = DDMStructureLocalServiceUtil.getClassStructures(PortalUtil.getClassNameId(DLFileEntry.class));
 


### PR DESCRIPTION
LPS-20799 Custom Attributes should appear after document type metadata when viewing a file entry

Nate already reviewed this :)
