### PR TITLE
LPS-19301 CKeditor does not display when editing an article (CSS error) -

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -104,7 +104,8 @@ public class ComboServlet extends HttpServlet {
 					modulePath = StringUtil.replaceFirst(
 						p.concat(modulePath), contextPath, StringPool.BLANK);
 
-					bytes = getFileContent(response, modulePath, minifierType);
+					bytes = getFileContent(
+						request, response, modulePath, minifierType);
 				}
 
 				bytesArray[--length] = bytes;
@@ -171,7 +172,8 @@ public class ComboServlet extends HttpServlet {
 	}
 
 	protected byte[] getFileContent(
-			HttpServletResponse response, String path, String minifierType)
+			HttpServletRequest request, HttpServletResponse response,
+			String path, String minifierType)
 		throws IOException {
 
 		String fileContentKey = path.concat(StringPool.QUESTION).concat(
@@ -216,7 +218,7 @@ public class ComboServlet extends HttpServlet {
 
 					try {
 						stringFileContent = DynamicCSSUtil.parseSass(
-							cssRealPath, stringFileContent);
+							request, cssRealPath, stringFileContent);
 					}
 					catch (Exception e) {
 						_log.error(

--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
@@ -144,7 +144,8 @@ public class DynamicCSSFilter extends BasePortalFilter {
 
 				content = FileUtil.read(file);
 
-				dynamicContent = DynamicCSSUtil.parseSass(cssRealPath, content);
+				dynamicContent = DynamicCSSUtil.parseSass(
+					request, cssRealPath, content);
 
 				response.setContentType(ContentTypes.TEXT_CSS);
 
@@ -169,7 +170,8 @@ public class DynamicCSSFilter extends BasePortalFilter {
 
 				content = stringResponse.getString();
 
-				dynamicContent = DynamicCSSUtil.parseSass(cssRealPath, content);
+				dynamicContent = DynamicCSSUtil.parseSass(
+					request, cssRealPath, content);
 
 				FileUtil.write(
 					cacheContentTypeFile, stringResponse.getContentType());

--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
@@ -14,19 +14,28 @@
 
 package com.liferay.portal.servlet.filters.dynamiccss;
 
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.scripting.ScriptingException;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.UnsyncPrintWriterPool;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.Theme;
 import com.liferay.portal.scripting.ruby.RubyExecutor;
+import com.liferay.portal.service.ThemeLocalServiceUtil;
+import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortalUtil;
 import com.liferay.util.ContentUtil;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Raymond Augé
@@ -45,10 +54,13 @@ public class DynamicCSSUtil {
 		}
 	}
 
-	public static String parseSass(String cssRealPath, String content)
+	public static String parseSass(
+			HttpServletRequest request, String cssRealPath, String content)
 		throws ScriptingException {
 
-		if (!DynamicCSSFilter.ENABLED) {
+		String cssThemePath = getCssThemePath(request);
+
+		if (!DynamicCSSFilter.ENABLED || (cssThemePath == null)) {
 			return content;
 		}
 
@@ -56,6 +68,7 @@ public class DynamicCSSUtil {
 
 		inputObjects.put("content", content);
 		inputObjects.put("cssRealPath", cssRealPath);
+		inputObjects.put("cssThemePath", cssThemePath);
 
 		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
 			new UnsyncByteArrayOutputStream();
@@ -76,6 +89,39 @@ public class DynamicCSSUtil {
 		}
 
 		return content;
+	}
+
+	protected static String getCssThemePath(HttpServletRequest request) {
+		ThemeDisplay themeDisplay = null;
+
+		if (request != null) {
+			themeDisplay = (ThemeDisplay)request.getAttribute(
+				WebKeys.THEME_DISPLAY);
+		}
+
+		if (themeDisplay != null) {
+			return themeDisplay.getPathThemeCss();
+		}
+
+		long companyId = PortalUtil.getCompanyId(request);
+
+		String themeId = ParamUtil.getString(request, "themeId");
+
+		if (Validator.isNotNull(themeId)) {
+			try {
+				Theme theme = ThemeLocalServiceUtil.getTheme(
+					companyId, themeId, false);
+
+				String themeStaticResourcePath = theme.getStaticResourcePath();
+
+				return themeStaticResourcePath + theme.getCssPath();
+			}
+			catch (SystemException e) {
+				_log.error(e, e);
+			}
+		}
+
+		return null;
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(DynamicCSSUtil.class);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/minifier/MinifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/minifier/MinifierFilter.java
@@ -416,7 +416,8 @@ public class MinifierFilter extends BasePortalFilter {
 		String cssRealPath, String content) {
 
 		try {
-			content = DynamicCSSUtil.parseSass(cssRealPath, content);
+			content = DynamicCSSUtil.parseSass(
+				request, cssRealPath, content);
 		}
 		catch (Exception e) {
 			_log.error("Unable to parse SASS on CSS " + cssRealPath, e);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
@@ -205,7 +205,8 @@ public class StripFilter extends BasePortalFilter {
 	}
 
 	protected void processCSS(
-			HttpServletResponse response, CharBuffer charBuffer, Writer writer)
+			HttpServletRequest request, HttpServletResponse response,
+			CharBuffer charBuffer, Writer writer)
 		throws IOException {
 
 		outputOpenTag(charBuffer, writer, _MARKER_STYLE_OPEN);
@@ -238,7 +239,7 @@ public class StripFilter extends BasePortalFilter {
 
 			if (minifiedContent == null) {
 				try {
-					content = DynamicCSSUtil.parseSass(key, content);
+					content = DynamicCSSUtil.parseSass(request, key, content);
 				}
 				catch (ScriptingException se) {
 					_log.error("Unable to parse SASS on CSS " + key, se);
@@ -321,7 +322,7 @@ public class StripFilter extends BasePortalFilter {
 					new UnsyncByteArrayOutputStream();
 
 				strip(
-					response, oldCharBuffer,
+					request, response, oldCharBuffer,
 					new OutputStreamWriter(unsyncByteArrayOutputStream));
 
 				response.setContentLength(unsyncByteArrayOutputStream.size());
@@ -329,7 +330,7 @@ public class StripFilter extends BasePortalFilter {
 				unsyncByteArrayOutputStream.writeTo(response.getOutputStream());
 			}
 			else {
-				strip(response, oldCharBuffer, response.getWriter());
+				strip(request, response, oldCharBuffer, response.getWriter());
 			}
 		}
 		else {
@@ -508,7 +509,8 @@ public class StripFilter extends BasePortalFilter {
 	}
 
 	protected void strip(
-			HttpServletResponse response, CharBuffer charBuffer, Writer writer)
+			HttpServletRequest request, HttpServletResponse response,
+			CharBuffer charBuffer, Writer writer)
 		throws IOException {
 
 		skipWhiteSpace(charBuffer, writer, false);
@@ -545,7 +547,7 @@ public class StripFilter extends BasePortalFilter {
 					continue;
 				}
 				else if (hasMarker(charBuffer, _MARKER_STYLE_OPEN)) {
-					processCSS(response, charBuffer, writer);
+					processCSS(request, response, charBuffer, writer);
 
 					continue;
 				}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -985,6 +985,7 @@ public class PortalImpl implements Portal {
 	/**
 	 * @deprecated {@link #getCDNHost(boolean)}
 	 */
+	@Deprecated
 	public String getCDNHost() {
 		long companyId = CompanyThreadLocal.getCompanyId();
 
@@ -3426,20 +3427,20 @@ public class PortalImpl implements Portal {
 
 		// Theme and color scheme
 
-		if (uri.endsWith(".jsp")) {
-			if ((parameterMap == null) ||
-				(!parameterMap.containsKey("themeId"))) {
+		if ((uri.endsWith(".css") || uri.endsWith(".jsp")) &&
+			((parameterMap == null) ||
+			 (!parameterMap.containsKey("themeId")))) {
 
-				sb.append("&themeId=");
-				sb.append(theme.getThemeId());
-			}
+			sb.append("&themeId=");
+			sb.append(theme.getThemeId());
+		}
 
-			if ((parameterMap == null) ||
-				(!parameterMap.containsKey("colorSchemeId"))) {
+		if (uri.endsWith(".jsp") &&
+			((parameterMap == null) ||
+			 (!parameterMap.containsKey("colorSchemeId")))) {
 
-				sb.append("&colorSchemeId=");
-				sb.append(colorScheme.getColorSchemeId());
-			}
+			sb.append("&colorSchemeId=");
+			sb.append(colorScheme.getColorSchemeId());
 		}
 
 		// Minifier

--- a/portal-impl/test/com/liferay/portal/servlet/filters/strip/StripFilterTest.java
+++ b/portal-impl/test/com/liferay/portal/servlet/filters/strip/StripFilterTest.java
@@ -76,7 +76,7 @@ public class StripFilterTest extends TestCase {
 
 		StringWriter stringWriter = new StringWriter();
 
-		stripFilter.processCSS(null, charBuffer, stringWriter);
+		stripFilter.processCSS(null, null, charBuffer, stringWriter);
 
 		assertEquals("style type=\"text/css\">", stringWriter.toString());
 		assertEquals(22, charBuffer.position());
@@ -86,7 +86,7 @@ public class StripFilterTest extends TestCase {
 		charBuffer = CharBuffer.wrap("style type=\"text/css\"></style>");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(null, charBuffer, stringWriter);
+		stripFilter.processCSS(null, null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\"></style>", stringWriter.toString());
@@ -97,7 +97,7 @@ public class StripFilterTest extends TestCase {
 		charBuffer = CharBuffer.wrap("style type=\"text/css\"> \r\t\n</style>");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(null, charBuffer, stringWriter);
+		stripFilter.processCSS(null, null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\"></style>", stringWriter.toString());
@@ -114,7 +114,7 @@ public class StripFilterTest extends TestCase {
 			"style type=\"text/css\">" + code + "</style>");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(null, charBuffer, stringWriter);
+		stripFilter.processCSS(null, null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\">" + minifiedCode + "</style>",
@@ -127,7 +127,7 @@ public class StripFilterTest extends TestCase {
 			"style type=\"text/css\">" + code + "</style> \r\t\n");
 		stringWriter = new StringWriter();
 
-		stripFilter.processCSS(null, charBuffer, stringWriter);
+		stripFilter.processCSS(null, null, charBuffer, stringWriter);
 
 		assertEquals(
 			"style type=\"text/css\">" + minifiedCode + "</style> ",


### PR DESCRIPTION
LPS-19301 CKeditor does not display when editing an article (CSS error) - Only parse sass when the theme can be resolved (this will solve the issue of parsing the third party css files like ckeditor's and so on).
