### PR TITLE
LPS-21037 Upgrade from 6.06 to 6.1.x for tomcat + postgres fails

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
@@ -437,7 +437,7 @@ public class UpgradeImageGallery extends UpgradeProcess {
 		runSQL(
 			"delete from ResourcePermission where " +
 				"name = 'com.liferay.portlet.imagegallery.model.IGFolder' " +
-					"and primKey = 0");
+					"and primKey = '0'");
 
 		Connection con = null;
 		PreparedStatement ps = null;
@@ -574,7 +574,7 @@ public class UpgradeImageGallery extends UpgradeProcess {
 
 		runSQL(
 			"delete from ResourcePermission where name = '" +
-				_IG_IMAGE_CLASS_NAME + "' and primKey = 0");
+				_IG_IMAGE_CLASS_NAME + "' and primKey = '0'");
 
 		runSQL(
 			"update ResourcePermission set name = '" +


### PR DESCRIPTION
LPS-21037 Upgrade from 6.06 to 6.1.x for tomcat + postgres fails. Bad type on custom sql query will fail in PostgreSQL (no automatic cast from integer to char is available at Postgres)
