### PR TITLE
LPS-20917 Document Library Folder is able to choose itself as a Parent Fo

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/move_entries.jsp
+++ b/portal-web/docroot/html/portlet/document_library/move_entries.jsp
@@ -78,7 +78,7 @@ if (!fileEntries.isEmpty()) {
 else if (!folders.isEmpty()) {
 	Folder folder = folders.get(0);
 
-	folderId = folder.getFolderId();
+	folderId = folder.getParentFolderId();
 }
 %>
 


### PR DESCRIPTION
LPS-20917 Document Library Folder is able to choose itself as a Parent Folder
