### PR TITLE
LPS-20779

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
@@ -310,7 +310,9 @@ public class StripFilter extends BasePortalFilter {
 
 		response.setContentType(contentType);
 
-		if (contentType.startsWith(ContentTypes.TEXT_HTML)) {
+		if (contentType.startsWith(ContentTypes.TEXT_HTML) &&
+			(stringResponse.getStatus() == HttpServletResponse.SC_OK)) {
+
 			CharBuffer oldCharBuffer = CharBuffer.wrap(
 				stringResponse.getString());
 


### PR DESCRIPTION
Only apply strip filter to HTTP 200 responses to workaround Tomcat 7.0.20+ calling response.getWriter() on calls to response.sendRedirect().
