### PR TITLE
Javadoc - modify package HTML files

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/http/package.html
+++ b/portal-impl/src/com/liferay/portal/service/http/package.html
@@ -16,9 +16,9 @@ details.
 
 <html>
 	<body>
-		<p>This package defines the HTTP and SOAP portal service utilities.</p>
+		<p>This package defines the HTTP and SOAP portal service utility classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Classes</strong></p>
 

--- a/portal-impl/src/com/liferay/portal/service/impl/package.html
+++ b/portal-impl/src/com/liferay/portal/service/impl/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local and remote portal service implementations.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Classes</strong></p>
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/package.html
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local and remote asset portlet service implementations.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Classes</strong></p>
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/package.html
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/package.html
@@ -16,9 +16,9 @@ details.
 
 <html>
 	<body>
-		<p>This package defines the HTTP and SOAP document library portlet service utilities.</p>
+		<p>This package defines the HTTP and SOAP document library portlet service utility classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Classes</strong></p>
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/package.html
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local and remote document library portlet service implementations.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Classes</strong></p>
 

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/package.html
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local social related portlet service implementations.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portal/kernel/bean/package.html
+++ b/portal-service/src/com/liferay/portal/kernel/bean/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the kernel bean interfaces, classes, and annotation types.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portal/kernel/exception/package.html
+++ b/portal-service/src/com/liferay/portal/kernel/exception/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the kernel exception classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Exceptions</strong></p>
 

--- a/portal-service/src/com/liferay/portal/kernel/portlet/package.html
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the kernel portlet interfaces and classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portal/kernel/util/package.html
+++ b/portal-service/src/com/liferay/portal/kernel/util/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the kernel utility interfaces and classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portal/model/package.html
+++ b/portal-service/src/com/liferay/portal/model/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the portal model interfaces and classes, including SOAP and wrapper classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portal/security/permission/package.html
+++ b/portal-service/src/com/liferay/portal/security/permission/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the portal security permission interfaces and classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portal/service/package.html
+++ b/portal-service/src/com/liferay/portal/service/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local and remote portal service interfaces and classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portal/service/persistence/package.html
+++ b/portal-service/src/com/liferay/portal/service/persistence/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the portal service persistence interfaces and classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portlet/asset/service/package.html
+++ b/portal-service/src/com/liferay/portlet/asset/service/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local and remote asset portlet service interfaces and classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/package.html
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local and remote document library portlet service interfaces, utility and wrapper classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/store/package.html
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/store/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the document library portlet storage interfaces, utility and wrapper classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Classes</strong></p>
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/package.html
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/package.html
@@ -19,7 +19,7 @@ details.
 
 		<p>This package defines document library portlet utility interfaces and classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant classes that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 

--- a/portal-service/src/com/liferay/portlet/social/service/package.html
+++ b/portal-service/src/com/liferay/portlet/social/service/package.html
@@ -18,7 +18,7 @@ details.
 	<body>
 		<p>This package defines the local and remote social related portlet service interfaces, utility and wrapper classes.</p>
 
-		<p>Some of the classes ready with Javadoc are:</p>
+		<p>Some of the most significant services that you may need to use are:</p>
 
 		<p><strong>Interfaces</strong></p>
 


### PR DESCRIPTION
Modify descriptions of Javadoc'd class lists to use the pattern "Some of the most significant [services|classes] that you may need to use are:".  The term "classes" is used in the general sense when "services" does not apply.
