### PR TITLE
LPS-20674 Upgraded Images from 5.2.3 can not be viewed in the latest 6.1.x

### DIFF
--- a/portal-impl/src/com/liferay/portal/image/DatabaseHook.java
+++ b/portal-impl/src/com/liferay/portal/image/DatabaseHook.java
@@ -33,7 +33,7 @@ public class DatabaseHook extends BaseHook {
 	}
 
 	public InputStream getImageAsStream(Image image) {
-		return new UnsyncByteArrayInputStream(image.getTextObj());
+		return new UnsyncByteArrayInputStream(getImageAsBytes(image));
 	}
 
 	public void updateImage(Image image, String type, byte[] bytes) {


### PR DESCRIPTION
LPS-20674 Upgraded Images from 5.2.3 can not be viewed in the latest 6.1.x.
