### PR TITLE
LPS-14492 Define permission allowing Community Members to delete ONLY their own comments

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -397,6 +397,8 @@ public class PropsValues {
 
 	public static final String DISCUSSION_THREAD_VIEW = PropsUtil.get(PropsKeys.DISCUSSION_THREAD_VIEW);
 
+    public static final boolean DISCUSSION_ALLOW_OWNERS_EDIT = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.DISCUSSION_ALLOW_OWNERS_EDIT));
+
 	public static final String[] DL_COMPARABLE_FILE_EXTENSIONS = PropsUtil.getArray(PropsKeys.DL_COMPARABLE_FILE_EXTENSIONS);
 
 	public static final String[] DL_DISPLAY_VIEWS = PropsUtil.getArray(PropsKeys.DL_DISPLAY_VIEWS);

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/permission/MBDiscussionPermission.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/permission/MBDiscussionPermission.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.workflow.permission.WorkflowPermissionUtil;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.security.permission.ResourceActionsUtil;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.messageboards.model.MBMessage;
 import com.liferay.portlet.messageboards.service.MBBanLocalServiceUtil;
 import com.liferay.portlet.messageboards.service.MBMessageLocalServiceUtil;
@@ -66,6 +67,11 @@ public class MBDiscussionPermission {
 
 		MBMessage message = MBMessageLocalServiceUtil.getMessage(
 			messageId);
+
+        if (PropsValues.DISCUSSION_ALLOW_OWNERS_EDIT &&
+            permissionChecker.getUserId() == message.getUserId()) {
+            return true;
+        }
 
 		if (message.isPending()) {
 			Boolean hasPermission = WorkflowPermissionUtil.hasPermission(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6776,6 +6776,13 @@
     #discussion.thread.view=combination
     discussion.thread.view=flat
 
+    #
+    # Set this property to true for discussion comments to give their owners
+    # the possibility to edit their comments even if they don't have defined
+    # permissions through "Site Members" role.
+    #
+    discussion.allow.owners.edit=false
+
 ##
 ## Document Library Portlet
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -495,6 +495,8 @@ public interface PropsKeys {
 
 	public static final String DIRECT_SERVLET_CONTEXT_RELOAD = "direct.servlet.context.reload";
 
+    public static final String DISCUSSION_ALLOW_OWNERS_EDIT = "discussion.allow.owners.edit";
+
 	public static final String DISCUSSION_EMAIL_BODY = "discussion.email.body";
 
 	public static final String DISCUSSION_EMAIL_COMMENTS_ADDED_ENABLED = "discussion.email.comments.added.enabled";


### PR DESCRIPTION
Users can not edit their own comments and this can not be configured through permissions because the owner of the comments is actually the owner of the asset the comments belong to. This property allows users to edit their own comments. By default it is set to false.
