### PR TITLE
Test Fixes

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1890,6 +1890,8 @@
 				<delete file="app.server.${user.name}.properties" />
 			</then>
 		</if>
+
+		<ant dir="portal-impl" target="test-class" inheritAll="false" />
 	</target>
 
 	<target name="prepare-db2">


### PR DESCRIPTION
Need to compile the "portal-impl/test" directory for the Selenium Tests to run because "com.liferay.portal.util.TestPropsValues" is in that directory.

```
[javac] 1. ERROR in H:\hudson\jobs\portal-trunk\workspace\trunk\portal-web\test\com\liferay\portalweb\portal\util\TestPropsValues.java (at line 23)
[javac]     public class TestPropsValues extends com.liferay.portal.util.TestPropsValues {
[javac]                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[javac] com.liferay.portal.util.TestPropsValues cannot be resolved to a type
```
