### PR TITLE
LPS-17958 Categories should be displayed in the appropriate locale

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/action/GetCategoriesAction.java
+++ b/portal-impl/src/com/liferay/portlet/asset/action/GetCategoriesAction.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.struts.JSONAction;
 import com.liferay.portlet.asset.model.AssetCategory;
@@ -44,6 +45,8 @@ public class GetCategoriesAction extends JSONAction {
 			HttpServletResponse response)
 		throws Exception {
 
+		String languageId = LanguageUtil.getLanguageId(request);
+
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		List<AssetCategory> categories = getCategories(request);
@@ -59,7 +62,7 @@ public class GetCategoriesAction extends JSONAction {
 			jsonObject.put("hasChildren", !childCategories.isEmpty());
 			jsonObject.put("name", category.getName());
 			jsonObject.put("parentCategoryId", category.getParentCategoryId());
-			jsonObject.put("title", category.getTitle());
+			jsonObject.put("title", category.getTitle(languageId));
 
 			jsonArray.put(jsonObject);
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
@@ -314,13 +314,52 @@ public class AssetVocabularyServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupsVocabularies(
+		HttpPrincipal httpPrincipal, long[] groupIds,
+		java.lang.String className, java.lang.String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
+					"getGroupsVocabularies",
+					_getGroupsVocabulariesParameterTypes7);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					groupIds, className, languageId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portlet.asset.model.AssetVocabulary>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabularies(
 		HttpPrincipal httpPrincipal, long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
-					"getGroupVocabularies", _getGroupVocabulariesParameterTypes7);
+					"getGroupVocabularies", _getGroupVocabulariesParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -356,7 +395,7 @@ public class AssetVocabularyServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
-					"getGroupVocabularies", _getGroupVocabulariesParameterTypes8);
+					"getGroupVocabularies", _getGroupVocabulariesParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					start, end, obc);
@@ -389,7 +428,8 @@ public class AssetVocabularyServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
-					"getGroupVocabularies", _getGroupVocabulariesParameterTypes9);
+					"getGroupVocabularies",
+					_getGroupVocabulariesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, start, end, obc);
@@ -422,7 +462,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
 					"getGroupVocabulariesCount",
-					_getGroupVocabulariesCountParameterTypes10);
+					_getGroupVocabulariesCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -454,7 +494,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
 					"getGroupVocabulariesCount",
-					_getGroupVocabulariesCountParameterTypes11);
+					_getGroupVocabulariesCountParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name);
@@ -489,7 +529,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
 					"getJSONGroupVocabularies",
-					_getJSONGroupVocabulariesParameterTypes12);
+					_getJSONGroupVocabulariesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, start, end, obc);
@@ -526,10 +566,48 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
-					"getVocabularies", _getVocabulariesParameterTypes13);
+					"getVocabularies", _getVocabulariesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyIds);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portlet.asset.model.AssetVocabulary>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getVocabularies(
+		HttpPrincipal httpPrincipal, long[] vocabularyIds,
+		java.lang.String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
+					"getVocabularies", _getVocabulariesParameterTypes15);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					vocabularyIds, languageId);
 
 			Object returnObj = null;
 
@@ -563,7 +641,7 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
-					"getVocabulary", _getVocabularyParameterTypes14);
+					"getVocabulary", _getVocabularyParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId);
@@ -604,7 +682,7 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
-					"updateVocabulary", _updateVocabularyParameterTypes15);
+					"updateVocabulary", _updateVocabularyParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId, titleMap, descriptionMap, settings,
@@ -646,7 +724,7 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class.getName(),
-					"updateVocabulary", _updateVocabularyParameterTypes16);
+					"updateVocabulary", _updateVocabularyParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId, title, titleMap, descriptionMap, settings,
@@ -703,39 +781,45 @@ public class AssetVocabularyServiceHttp {
 	private static final Class<?>[] _getGroupsVocabulariesParameterTypes6 = new Class[] {
 			long[].class, java.lang.String.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesParameterTypes7 = new Class[] {
-			long.class
+	private static final Class<?>[] _getGroupsVocabulariesParameterTypes7 = new Class[] {
+			long[].class, java.lang.String.class, java.lang.String.class
 		};
 	private static final Class<?>[] _getGroupVocabulariesParameterTypes8 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _getGroupVocabulariesParameterTypes9 = new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getGroupVocabulariesParameterTypes10 = new Class[] {
 			long.class, java.lang.String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
-		};
-	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes10 = new Class[] {
-			long.class
 		};
 	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes11 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes12 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getJSONGroupVocabulariesParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getJSONGroupVocabulariesParameterTypes13 = new Class[] {
 			long.class, java.lang.String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabulariesParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getVocabulariesParameterTypes14 = new Class[] {
 			long[].class
 		};
-	private static final Class<?>[] _getVocabularyParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getVocabulariesParameterTypes15 = new Class[] {
+			long[].class, java.lang.String.class
+		};
+	private static final Class<?>[] _getVocabularyParameterTypes16 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateVocabularyParameterTypes15 = new Class[] {
+	private static final Class<?>[] _updateVocabularyParameterTypes17 = new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
 			java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateVocabularyParameterTypes16 = new Class[] {
+	private static final Class<?>[] _updateVocabularyParameterTypes18 = new Class[] {
 			long.class, java.lang.String.class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceSoap.java
@@ -135,6 +135,23 @@ public class AssetVocabularyServiceSoap {
 		}
 	}
 
+	public static com.liferay.portlet.asset.model.AssetVocabularySoap[] getGroupsVocabularies(
+		long[] groupIds, java.lang.String className, java.lang.String languageId)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> returnValue =
+				AssetVocabularyServiceUtil.getGroupsVocabularies(groupIds,
+					className, languageId);
+
+			return com.liferay.portlet.asset.model.AssetVocabularySoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.portlet.asset.model.AssetVocabularySoap[] getGroupVocabularies(
 		long groupId) throws RemoteException {
 		try {
@@ -237,6 +254,23 @@ public class AssetVocabularyServiceSoap {
 		try {
 			java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> returnValue =
 				AssetVocabularyServiceUtil.getVocabularies(vocabularyIds);
+
+			return com.liferay.portlet.asset.model.AssetVocabularySoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.portlet.asset.model.AssetVocabularySoap[] getVocabularies(
+		long[] vocabularyIds, java.lang.String languageId)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> returnValue =
+				AssetVocabularyServiceUtil.getVocabularies(vocabularyIds,
+					languageId);
 
 			return com.liferay.portlet.asset.model.AssetVocabularySoap.toSoapModels(returnValue);
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -223,6 +223,24 @@ public class AssetVocabularyLocalServiceImpl
 		return vocabularies;
 	}
 
+	public List<AssetVocabulary> getGroupsVocabularies(long[] groupIds,
+			String className, String languageId)
+		throws PortalException, SystemException {
+
+		List<AssetVocabulary> vocabularies =
+			getGroupsVocabularies(groupIds, null);
+
+		for (int pos = 0; pos < vocabularies.size(); pos++) {
+			AssetVocabulary curVocabulary = vocabularies.get(pos);
+
+			curVocabulary.setTitle(curVocabulary.getTitle(languageId));
+
+			vocabularies.set(pos, curVocabulary);
+		}
+
+		return vocabularies;
+	}
+
 	public List<AssetVocabulary> getGroupVocabularies(long groupId)
 		throws PortalException, SystemException {
 
@@ -288,6 +306,23 @@ public class AssetVocabularyLocalServiceImpl
 			AssetVocabulary vocabulary = getVocabulary(vocabularyId);
 
 			vocabularies.add(vocabulary);
+		}
+
+		return vocabularies;
+	}
+
+	public List<AssetVocabulary> getVocabularies(long[] vocabularyIds,
+			String languageId)
+		throws PortalException, SystemException {
+
+		List<AssetVocabulary> vocabularies = getVocabularies(vocabularyIds);
+
+		for (int pos = 0; pos < vocabularies.size(); pos++) {
+			AssetVocabulary curVocabulary = vocabularies.get(pos);
+
+			curVocabulary.setTitle(curVocabulary.getTitle(languageId));
+
+			vocabularies.set(pos, curVocabulary);
 		}
 
 		return vocabularies;

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -223,24 +223,6 @@ public class AssetVocabularyLocalServiceImpl
 		return vocabularies;
 	}
 
-	public List<AssetVocabulary> getGroupsVocabularies(long[] groupIds,
-			String className, String languageId)
-		throws PortalException, SystemException {
-
-		List<AssetVocabulary> vocabularies =
-			getGroupsVocabularies(groupIds, null);
-
-		for (int pos = 0; pos < vocabularies.size(); pos++) {
-			AssetVocabulary curVocabulary = vocabularies.get(pos);
-
-			curVocabulary.setTitle(curVocabulary.getTitle(languageId));
-
-			vocabularies.set(pos, curVocabulary);
-		}
-
-		return vocabularies;
-	}
-
 	public List<AssetVocabulary> getGroupVocabularies(long groupId)
 		throws PortalException, SystemException {
 
@@ -306,23 +288,6 @@ public class AssetVocabularyLocalServiceImpl
 			AssetVocabulary vocabulary = getVocabulary(vocabularyId);
 
 			vocabularies.add(vocabulary);
-		}
-
-		return vocabularies;
-	}
-
-	public List<AssetVocabulary> getVocabularies(long[] vocabularyIds,
-			String languageId)
-		throws PortalException, SystemException {
-
-		List<AssetVocabulary> vocabularies = getVocabularies(vocabularyIds);
-
-		for (int pos = 0; pos < vocabularies.size(); pos++) {
-			AssetVocabulary curVocabulary = vocabularies.get(pos);
-
-			curVocabulary.setTitle(curVocabulary.getTitle(languageId));
-
-			vocabularies.set(pos, curVocabulary);
 		}
 
 		return vocabularies;

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -118,6 +118,15 @@ public class AssetVocabularyServiceImpl
 				groupIds, className));
 	}
 
+	public List<AssetVocabulary> getGroupsVocabularies( long[] groupIds,
+			String className, String languageId)
+		throws PortalException, SystemException {
+
+		return filterVocabularies(
+			assetVocabularyLocalService.getGroupsVocabularies(
+				groupIds, className, languageId));
+	}
+
 	public List<AssetVocabulary> getGroupVocabularies(long groupId)
 		throws PortalException, SystemException {
 
@@ -196,6 +205,15 @@ public class AssetVocabularyServiceImpl
 
 		return filterVocabularies(
 			assetVocabularyLocalService.getVocabularies(vocabularyIds));
+	}
+
+	public List<AssetVocabulary> getVocabularies(long[] vocabularyIds,
+			String languageId)
+		throws PortalException, SystemException {
+
+		return filterVocabularies(
+			assetVocabularyLocalService.getVocabularies(
+				vocabularyIds,languageId));
 	}
 
 	public AssetVocabulary getVocabulary(long vocabularyId)

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -118,13 +118,13 @@ public class AssetVocabularyServiceImpl
 				groupIds, className));
 	}
 
-	public List<AssetVocabulary> getGroupsVocabularies( long[] groupIds,
+	public List<AssetVocabulary> getGroupsVocabularies(long[] groupIds,
 			String className, String languageId)
 		throws PortalException, SystemException {
 
-		return filterVocabularies(
-			assetVocabularyLocalService.getGroupsVocabularies(
-				groupIds, className, languageId));
+		return flattenTitleVocabularies(
+			filterVocabularies(
+				getGroupsVocabularies(groupIds, className)), languageId);
 	}
 
 	public List<AssetVocabulary> getGroupVocabularies(long groupId)
@@ -211,9 +211,8 @@ public class AssetVocabularyServiceImpl
 			String languageId)
 		throws PortalException, SystemException {
 
-		return filterVocabularies(
-			assetVocabularyLocalService.getVocabularies(
-				vocabularyIds,languageId));
+		return flattenTitleVocabularies(
+			filterVocabularies(getVocabularies(vocabularyIds)), languageId);
 	}
 
 	public AssetVocabulary getVocabulary(long vocabularyId)
@@ -271,6 +270,17 @@ public class AssetVocabularyServiceImpl
 
 				itr.remove();
 			}
+		}
+
+		return vocabularies;
+	}
+
+	protected List<AssetVocabulary> flattenTitleVocabularies(
+			List<AssetVocabulary> vocabularies, String languageId)
+		throws PortalException {
+
+		for (AssetVocabulary vocabulary : vocabularies) {
+			vocabulary.setTitle(vocabulary.getTitle(languageId));
 		}
 
 		return vocabularies;

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.util;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
@@ -80,6 +81,8 @@ public class AssetUtil {
 			PortletURL portletURL)
 		throws Exception {
 
+		String languageId = LanguageUtil.getLanguageId(request);
+
 		AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getCategory(
 			assetCategoryId);
 
@@ -92,13 +95,14 @@ public class AssetUtil {
 				ancestorCategory.getCategoryId()));
 
 			addPortletBreadcrumbEntry(
-				request, ancestorCategory.getName(), portletURL.toString());
+				request, ancestorCategory.getTitle(languageId),
+				portletURL.toString());
 		}
 
 		portletURL.setParameter("categoryId", String.valueOf(assetCategoryId));
 
 		addPortletBreadcrumbEntry(
-			request, assetCategory.getName(), portletURL.toString());
+			request, assetCategory.getTitle(languageId), portletURL.toString());
 	}
 
 	public static void addPortletBreadcrumbEntry(

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyService.java
@@ -91,6 +91,12 @@ public interface AssetVocabularyService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupsVocabularies(
+		long[] groupIds, java.lang.String className, java.lang.String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabularies(
 		long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -126,6 +132,12 @@ public interface AssetVocabularyService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getVocabularies(
 		long[] vocabularyIds)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getVocabularies(
+		long[] vocabularyIds, java.lang.String languageId)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceUtil.java
@@ -99,6 +99,14 @@ public class AssetVocabularyServiceUtil {
 		return getService().getGroupsVocabularies(groupIds, className);
 	}
 
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupsVocabularies(
+		long[] groupIds, java.lang.String className, java.lang.String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getGroupsVocabularies(groupIds, className, languageId);
+	}
+
 	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabularies(
 		long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -145,6 +153,13 @@ public class AssetVocabularyServiceUtil {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService().getVocabularies(vocabularyIds);
+	}
+
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getVocabularies(
+		long[] vocabularyIds, java.lang.String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService().getVocabularies(vocabularyIds, languageId);
 	}
 
 	public static com.liferay.portlet.asset.model.AssetVocabulary getVocabulary(

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceWrapper.java
@@ -88,6 +88,14 @@ public class AssetVocabularyServiceWrapper implements AssetVocabularyService {
 		return _assetVocabularyService.getGroupsVocabularies(groupIds, className);
 	}
 
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupsVocabularies(
+		long[] groupIds, java.lang.String className, java.lang.String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _assetVocabularyService.getGroupsVocabularies(groupIds,
+			className, languageId);
+	}
+
 	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabularies(
 		long groupId)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -135,6 +143,13 @@ public class AssetVocabularyServiceWrapper implements AssetVocabularyService {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _assetVocabularyService.getVocabularies(vocabularyIds);
+	}
+
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getVocabularies(
+		long[] vocabularyIds, java.lang.String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _assetVocabularyService.getVocabularies(vocabularyIds, languageId);
 	}
 
 	public com.liferay.portlet.asset.model.AssetVocabulary getVocabulary(

--- a/portal-web/docroot/html/js/liferay/asset_categories_selector.js
+++ b/portal-web/docroot/html/js/liferay/asset_categories_selector.js
@@ -178,7 +178,7 @@ AUI().add(
 									},
 									checked: checked,
 									id: treeId,
-									label: Liferay.Util.escapeHTML(item.name),
+									label: Liferay.Util.escapeHTML(item.title),
 									leaf: !item.hasChildren,
 									type: type
 								};
@@ -217,11 +217,24 @@ AUI().add(
 						var groupIds = [];
 
 						var vocabularyIds = instance.get('vocabularyIds');
+						
+						var svcParamTypesGetVocabularies = [
+ 						 	'[J',
+ 						 	'java.lang.String'
+ 						];
+
+						var svcParamTypesGetGroupsVocabularies = [
+ 						 	'[J',
+ 						 	'java.lang.String',
+ 						 	'java.lang.String',
+ 						];
 
 						if (vocabularyIds.length > 0) {
 							Liferay.Service.Asset.AssetVocabulary.getVocabularies(
 								{
-									vocabularyIds: vocabularyIds
+									vocabularyIds: vocabularyIds,
+									languageId: themeDisplay.getLanguageId(),
+									serviceParameterTypes: A.JSON.stringify(svcParamTypesGetVocabularies)
 								},
 								callback
 							);
@@ -236,7 +249,9 @@ AUI().add(
 							Liferay.Service.Asset.AssetVocabulary.getGroupsVocabularies(
 								{
 									groupIds: groupIds,
-									className: className
+									className: className,
+									languageId: themeDisplay.getLanguageId(),
+									serviceParameterTypes: A.JSON.stringify(svcParamTypesGetGroupsVocabularies)
 								},
 								callback
 							);
@@ -415,11 +430,11 @@ AUI().add(
 						var instance = this;
 
 						var popup = instance._popup;
-						var vocabularyName = item.name;
+						var vocabularyTitle = Liferay.Util.escapeHTML(item.title);
 						var vocabularyId = item.vocabularyId;
 
 						if (item.groupId == themeDisplay.getCompanyGroupId()) {
-							vocabularyName += ' (' + Liferay.Language.get('global') + ')';
+							vocabularyTitle += ' (' + Liferay.Language.get('global') + ')';
 						}
 
 						var treeId = 'vocabulary' + vocabularyId;
@@ -427,7 +442,7 @@ AUI().add(
 						var vocabularyRootNode = {
 							alwaysShowHitArea: true,
 							id: treeId,
-							label: Liferay.Util.escapeHTML(vocabularyName),
+							label: vocabularyTitle,
 							leaf: false,
 							type: 'io'
 						};

--- a/portal-web/docroot/html/js/liferay/asset_categories_selector.js
+++ b/portal-web/docroot/html/js/liferay/asset_categories_selector.js
@@ -217,13 +217,13 @@ AUI().add(
 						var groupIds = [];
 
 						var vocabularyIds = instance.get('vocabularyIds');
-						
-						var svcParamTypesGetVocabularies = [
+
+						var serviceParameterTypesGetVocabularies = [
  						 	'[J',
  						 	'java.lang.String'
  						];
 
-						var svcParamTypesGetGroupsVocabularies = [
+						var serviceParameterTypesGetGroupVocabularies = [
  						 	'[J',
  						 	'java.lang.String',
  						 	'java.lang.String',
@@ -234,7 +234,7 @@ AUI().add(
 								{
 									vocabularyIds: vocabularyIds,
 									languageId: themeDisplay.getLanguageId(),
-									serviceParameterTypes: A.JSON.stringify(svcParamTypesGetVocabularies)
+									serviceParameterTypes: A.JSON.stringify(serviceParameterTypesGetVocabularies)
 								},
 								callback
 							);
@@ -251,7 +251,7 @@ AUI().add(
 									groupIds: groupIds,
 									className: className,
 									languageId: themeDisplay.getLanguageId(),
-									serviceParameterTypes: A.JSON.stringify(svcParamTypesGetGroupsVocabularies)
+									serviceParameterTypes: A.JSON.stringify(serviceParameterTypesGetGroupVocabularies)
 								},
 								callback
 							);

--- a/portal-web/docroot/html/portlet/asset_categories_navigation/configuration.jsp
+++ b/portal-web/docroot/html/portlet/asset_categories_navigation/configuration.jsp
@@ -45,7 +45,9 @@ String redirect = ParamUtil.getString(request, "redirect");
 			try {
 				AssetVocabulary vocabulary = AssetVocabularyLocalServiceUtil.getVocabulary(vocabularyId);
 
-				typesLeftList.add(new KeyValuePair(String.valueOf(vocabularyId), _getName(vocabulary, themeDisplay)));
+				vocabulary.setEscapedModel(true);
+
+				typesLeftList.add(new KeyValuePair(String.valueOf(vocabularyId), _getTitle(vocabulary, themeDisplay)));
 			}
 			catch (NoSuchVocabularyException nsve) {
 			}
@@ -61,9 +63,9 @@ String redirect = ParamUtil.getString(request, "redirect");
 			if (Arrays.binarySearch(assetVocabularyIds, vocabularyId) < 0) {
 				AssetVocabulary vocabulary = AssetVocabularyLocalServiceUtil.getVocabulary(vocabularyId);
 
-				vocabulary = vocabulary.toEscapedModel();
+				vocabulary.setEscapedModel(true);
 
-				typesRightList.add(new KeyValuePair(String.valueOf(vocabularyId), _getName(vocabulary, themeDisplay)));
+				typesRightList.add(new KeyValuePair(String.valueOf(vocabularyId), _getTitle(vocabulary, themeDisplay)));
 			}
 		}
 
@@ -106,13 +108,13 @@ String redirect = ParamUtil.getString(request, "redirect");
 </aui:script>
 
 <%!
-private String _getName(AssetVocabulary vocabulary, ThemeDisplay themeDisplay) {
-	String name = vocabulary.getName();
+private String _getTitle(AssetVocabulary vocabulary, ThemeDisplay themeDisplay) {
+	String title = vocabulary.getTitle(themeDisplay.getLanguageId());
 
 	if (vocabulary.getGroupId() == themeDisplay.getCompanyGroupId()) {
-		name += " (" + LanguageUtil.get(themeDisplay.getLocale(), "global") + ")";
+		title += " (" + LanguageUtil.get(themeDisplay.getLocale(), "global") + ")";
 	}
 
-	return name;
+	return title;
 }
 %>

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration.jsp
@@ -608,10 +608,10 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 
 												<%
 												for (AssetVocabulary assetVocabulary : assetVocabularies) {
-													assetVocabulary = assetVocabulary.toEscapedModel();
+													assetVocabulary.setEscapedModel(true);
 												%>
 
-													<aui:option label="<%= assetVocabulary.getName() %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
+													<aui:option label="<%= assetVocabulary.getTitle(locale) %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
 
 												<%
 												}
@@ -634,10 +634,10 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 
 											<%
 											for (AssetVocabulary assetVocabulary : assetVocabularies) {
-												assetVocabulary = assetVocabulary.toEscapedModel();
+												assetVocabulary.setEscapedModel(true);
 											%>
 
-												<aui:option label="<%= assetVocabulary.getName() %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
+												<aui:option label="<%= assetVocabulary.getTitle(locale) %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
 
 											<%
 											}

--- a/portal-web/docroot/html/portlet/asset_publisher/init.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/init.jsp
@@ -113,25 +113,25 @@ long assetVocabularyId = GetterUtil.getLong(preferences.getValue("assetVocabular
 
 long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 
-String assetCategoryName = null;
-String assetVocabularyName = null;
+String assetCategoryTitle = null;
+String assetVocabularyTitle = null;
 
 if (assetCategoryId > 0) {
 	assetEntryQuery.setAllCategoryIds(new long[] {assetCategoryId});
 
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getCategory(assetCategoryId);
 
-	assetCategory = assetCategory.toEscapedModel();
+	assetCategory.setEscapedModel(true);
 
-	assetCategoryName = assetCategory.getName();
+	assetCategoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
-	assetVocabulary = assetVocabulary.toEscapedModel();
+	assetVocabulary.setEscapedModel(true);
 
-	assetVocabularyName = assetVocabulary.getName();
+	assetVocabularyTitle = assetVocabulary.getTitle(locale);
 
-	PortalUtil.setPageKeywords(assetCategory.getName(), request);
+	PortalUtil.setPageKeywords(assetCategoryTitle, request);
 }
 
 String assetTagName = ParamUtil.getString(request, "tag");

--- a/portal-web/docroot/html/portlet/asset_publisher/view.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/view.jsp
@@ -112,7 +112,7 @@ if (!paginationType.equals("none")) {
 
 <c:if test='<%= (assetCategoryId > 0) && selectionStyle.equals("dynamic") %>'>
 	<h1 class="asset-categorization-title">
-		<%= LanguageUtil.format(pageContext, "content-with-x-x", new String[] {assetVocabularyName, assetCategoryName}) %>
+		<%= LanguageUtil.format(pageContext, "content-with-x-x", new String[] {assetVocabularyTitle, assetCategoryTitle}) %>
 	</h1>
 
 	<%

--- a/portal-web/docroot/html/portlet/asset_publisher/view_dynamic_list.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/view_dynamic_list.jspf
@@ -41,7 +41,7 @@ if (!portletName.equals(PortletKeys.RELATED_ASSETS) || (assetEntryQuery.getLinke
 		}
 
 		for (AssetCategory assetCategory : assetCategories) {
-			assetCategory = assetCategory.toEscapedModel();
+			assetCategory.setEscapedModel(true);
 
 			long[] oldAllCategoryIds = assetEntryQuery.getAllCategoryIds();
 
@@ -61,7 +61,7 @@ if (!portletName.equals(PortletKeys.RELATED_ASSETS) || (assetEntryQuery.getLinke
 				request.setAttribute("view.jsp-results", results);
 	%>
 
-				<h3 class="asset-entries-group-label"><%= assetCategory.getName() %></h3>
+				<h3 class="asset-entries-group-label"><%= assetCategory.getTitle(locale) %></h3>
 
 				<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
 

--- a/portal-web/docroot/html/portlet/blogs/view.jsp
+++ b/portal-web/docroot/html/portlet/blogs/view.jsp
@@ -19,21 +19,21 @@
 <%
 long categoryId = ParamUtil.getLong(request, "categoryId");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
-	assetCategory = assetCategory.toEscapedModel();
+	assetCategory.setEscapedModel(true);
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
-	assetVocabulary = assetVocabulary.toEscapedModel();
+	assetVocabulary.setEscapedModel(true);
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 String tagName = ParamUtil.getString(request, "tag");

--- a/portal-web/docroot/html/portlet/blogs/view_entries.jspf
+++ b/portal-web/docroot/html/portlet/blogs/view_entries.jspf
@@ -54,9 +54,9 @@ showSearch = showSearch && !results.isEmpty();
 	</div>
 </c:if>
 
-<c:if test="<%= Validator.isNotNull(categoryName) %>">
+<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 	<h1 class="entry-title">
-		<%= LanguageUtil.format(pageContext, "entries-with-x-x", new String[] {vocabularyName, categoryName}) %>
+		<%= LanguageUtil.format(pageContext, "entries-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 	</h1>
 
 	<%

--- a/portal-web/docroot/html/portlet/bookmarks/view.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/view.jsp
@@ -40,21 +40,21 @@ int entriesCount = BookmarksEntryServiceUtil.getEntriesCount(scopeGroupId, folde
 long categoryId = ParamUtil.getLong(request, "categoryId");
 String tagName = ParamUtil.getString(request, "tag");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
-	assetCategory = assetCategory.toEscapedModel();
+	assetCategory.setEscapedModel(true);
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
-	assetVocabulary = assetVocabulary.toEscapedModel();
+	assetVocabulary.setEscapedModel(true);
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 boolean useAssetEntryQuery = (categoryId > 0) || Validator.isNotNull(tagName);
@@ -78,9 +78,9 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 
 <c:choose>
 	<c:when test="<%= useAssetEntryQuery %>">
-		<c:if test="<%= Validator.isNotNull(categoryName) %>">
+		<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 			<h1 class="entry-title">
-				<%= LanguageUtil.format(pageContext, "bookmarks-with-x-x", new String[] {vocabularyName, categoryName}) %>
+				<%= LanguageUtil.format(pageContext, "bookmarks-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 			</h1>
 		</c:if>
 
@@ -95,7 +95,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 		<%
 		if (portletName.equals(PortletKeys.BOOKMARKS)) {
 			PortalUtil.addPageKeywords(tagName, request);
-			PortalUtil.addPageKeywords(categoryName, request);
+			PortalUtil.addPageKeywords(categoryTitle, request);
 		}
 		%>
 

--- a/portal-web/docroot/html/portlet/document_library_display/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/view.jsp
@@ -54,21 +54,21 @@ int fileEntriesCount = DLAppServiceUtil.getFileEntriesAndFileShortcutsCount(repo
 long categoryId = ParamUtil.getLong(request, "categoryId");
 String tagName = ParamUtil.getString(request, "tag");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
-	assetCategory = assetCategory.toEscapedModel();
+	assetCategory.setEscapedModel(true);
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
-	assetVocabulary = assetVocabulary.toEscapedModel();
+	assetVocabulary.setEscapedModel(true);
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 boolean useAssetEntryQuery = (categoryId > 0) || Validator.isNotNull(tagName);
@@ -96,9 +96,9 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 
 <c:choose>
 	<c:when test="<%= useAssetEntryQuery %>">
-		<c:if test="<%= Validator.isNotNull(categoryName) %>">
+		<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 			<h1 class="entry-title">
-				<%= LanguageUtil.format(pageContext, "documents-with-x-x", new String[] {vocabularyName, categoryName}) %>
+				<%= LanguageUtil.format(pageContext, "documents-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 			</h1>
 		</c:if>
 
@@ -112,7 +112,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 
 		<%
 		PortalUtil.addPageKeywords(tagName, request);
-		PortalUtil.addPageKeywords(categoryName, request);
+		PortalUtil.addPageKeywords(categoryTitle, request);
 		%>
 
 	</c:when>

--- a/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
@@ -52,21 +52,21 @@ int imagesCount = DLAppServiceUtil.getFileEntriesAndFileShortcutsCount(repositor
 long categoryId = ParamUtil.getLong(request, "categoryId");
 String tagName = ParamUtil.getString(request, "tag");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
-	assetCategory = assetCategory.toEscapedModel();
+	assetCategory.setEscapedModel(true);
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
-	assetVocabulary = assetVocabulary.toEscapedModel();
+	assetVocabulary.setEscapedModel(true);
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 boolean useAssetEntryQuery = (categoryId > 0) || Validator.isNotNull(tagName);
@@ -96,9 +96,9 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 
 <c:choose>
 	<c:when test="<%= useAssetEntryQuery %>">
-		<c:if test="<%= Validator.isNotNull(categoryName) %>">
+		<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 			<h1 class="entry-title">
-				<%= LanguageUtil.format(pageContext, "images-with-x-x", new String[] {vocabularyName, categoryName}) %>
+				<%= LanguageUtil.format(pageContext, "images-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 			</h1>
 		</c:if>
 
@@ -133,7 +133,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 		<%
 		if (portletName.equals(PortletKeys.IMAGE_GALLERY_DISPLAY)) {
 			PortalUtil.addPageKeywords(tagName, request);
-			PortalUtil.addPageKeywords(categoryName, request);
+			PortalUtil.addPageKeywords(categoryTitle, request);
 		}
 		%>
 

--- a/portal-web/docroot/html/portlet/wiki/view_categorized_pages.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view_categorized_pages.jsp
@@ -19,21 +19,21 @@
 <%
 long categoryId = GetterUtil.getLong(ParamUtil.getString(request, "categoryId"));
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
-	assetCategory = assetCategory.toEscapedModel();
+	assetCategory.setEscapedModel(true);
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
-	assetVocabulary = assetVocabulary.toEscapedModel();
+	assetVocabulary.setEscapedModel(true);
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 %>
 
@@ -42,7 +42,7 @@ if (categoryId != 0) {
 <liferay-ui:header
 	escapeXml="<%= false %>"
 	localizeTitle="<%= false %>"
-	title='<%= LanguageUtil.format(pageContext, "pages-with-x-x", new String[] {vocabularyName, categoryName}) %>'
+	title='<%= LanguageUtil.format(pageContext, "pages-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>'
 />
 
 <liferay-util:include page="/html/portlet/wiki/page_iterator.jsp">

--- a/portal-web/docroot/html/taglib/ui/asset_categories_navigation/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_navigation/page.jsp
@@ -48,15 +48,15 @@ PortletURL portletURL = renderResponse.createRenderURL();
 	for (int i = 0; i < vocabularies.size(); i++) {
 		AssetVocabulary vocabulary = vocabularies.get(i);
 
-		vocabulary = vocabulary.toEscapedModel();
+		vocabulary.setEscapedModel(true);
 
-		String vocabularyNavigation = _buildVocabularyNavigation(vocabulary, categoryId, portletURL);
+		String vocabularyNavigation = _buildVocabularyNavigation(vocabulary, categoryId, portletURL, locale);
 
 		if (Validator.isNotNull(vocabularyNavigation)) {
 			hidePortletWhenEmpty = false;
 	%>
 
-			<liferay-ui:panel collapsible="<%= false %>" extended="<%= true %>" persistState="<%= true %>" title="<%= vocabulary.getName() %>">
+			<liferay-ui:panel collapsible="<%= false %>" extended="<%= true %>" persistState="<%= true %>" title="<%= vocabulary.getTitle(locale) %>">
 				<%= vocabularyNavigation %>
 			</liferay-ui:panel>
 
@@ -113,12 +113,12 @@ if (hidePortletWhenEmpty) {
 </aui:script>
 
 <%!
-private void _buildCategoriesNavigation(List<AssetCategory> categories, long curCategoryId, PortletURL portletURL, StringBundler sb) throws Exception {
+private void _buildCategoriesNavigation(List<AssetCategory> categories, long curCategoryId, PortletURL portletURL, StringBundler sb, Locale locale) throws Exception {
 	for (AssetCategory category : categories) {
-		category = category.toEscapedModel();
+		category.setEscapedModel(true);
 
 		long categoryId = category.getCategoryId();
-		String name = category.getName();
+		String title = category.getTitle(locale);
 
 		List<AssetCategory> categoriesChildren = AssetCategoryServiceUtil.getChildCategories(category.getCategoryId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
@@ -126,7 +126,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 
 		if (categoryId == curCategoryId) {
 			sb.append("<strong>");
-			sb.append(name);
+			sb.append(title);
 			sb.append("</strong>");
 		}
 		else {
@@ -135,7 +135,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 			sb.append("<a href=\"");
 			sb.append(portletURL.toString());
 			sb.append("\">");
-			sb.append(name);
+			sb.append(title);
 			sb.append("</a>");
 		}
 
@@ -144,7 +144,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 		if (!categoriesChildren.isEmpty()) {
 			sb.append("<ul>");
 
-			_buildCategoriesNavigation(categoriesChildren, curCategoryId, portletURL, sb);
+			_buildCategoriesNavigation(categoriesChildren, curCategoryId, portletURL, sb, locale);
 
 			sb.append("</ul>");
 		}
@@ -153,7 +153,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 	}
 }
 
-private String _buildVocabularyNavigation(AssetVocabulary vocabulary, long categoryId, PortletURL portletURL) throws Exception {
+private String _buildVocabularyNavigation(AssetVocabulary vocabulary, long categoryId, PortletURL portletURL, Locale locale) throws Exception {
 	List<AssetCategory> categories = AssetCategoryServiceUtil.getVocabularyRootCategories(vocabulary.getVocabularyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 	if (categories.isEmpty()) {
@@ -164,7 +164,7 @@ private String _buildVocabularyNavigation(AssetVocabulary vocabulary, long categ
 
 	sb.append("<div class=\"lfr-asset-category-list-container\"><ul class=\"lfr-asset-category-list\">");
 
-	_buildCategoriesNavigation(categories, categoryId, portletURL, sb);
+	_buildCategoriesNavigation(categories, categoryId, portletURL, sb, locale);
 
 	sb.append("</ul></div>");
 

--- a/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
@@ -74,7 +74,9 @@ if (Validator.isNotNull(className)) {
 			curCategoryNames = StringPool.BLANK;
 		}
 
-		String[] categoryIdsNames = _getCategoryIdsNames(curCategoryIds, curCategoryNames, vocabulary.getVocabularyId());
+		String[] categoryIdsTitles = _getCategoryIdsTitles(curCategoryIds, curCategoryNames, vocabulary.getVocabularyId(), locale);
+
+		vocabulary.setEscapedModel(true);
 	%>
 
 		<span class="aui-field-content">
@@ -100,8 +102,8 @@ if (Validator.isNotNull(className)) {
 				{
 					className: '<%= className %>',
 					contentBox: '#<%= namespace + randomNamespace %>assetCategoriesSelector_<%= vocabulary.getVocabularyId() %>',
-					curEntries: '<%= HtmlUtil.escapeJS(categoryIdsNames[1]) %>',
-					curEntryIds: '<%= categoryIdsNames[0] %>',
+					curEntries: '<%= HtmlUtil.escapeJS(categoryIdsTitles[1]) %>',
+					curEntryIds: '<%= categoryIdsTitles[0] %>',
 					hiddenInput: '#<%= namespace + hiddenInput + StringPool.UNDERLINE + vocabulary.getVocabularyId() %>',
 					instanceVar: '<%= namespace + randomNamespace %>',
 					labelNode: '#<%= namespace %>assetCategoriesLabel_<%= vocabulary.getVocabularyId() %>',
@@ -122,7 +124,7 @@ else {
 		curCategoryIds = curCategoryIdsParam;
 	}
 
-	String[] categoryIdsNames = _getCategoryIdsNames(curCategoryIds, curCategoryNames, 0);
+	String[] categoryIdsTitles = _getCategoryIdsTitles(curCategoryIds, curCategoryNames, 0, locale);
 %>
 
 	<div class="lfr-tags-selector-content" id="<%= namespace + randomNamespace %>assetCategoriesSelector">
@@ -134,8 +136,8 @@ else {
 			{
 				className: '<%= className %>',
 				contentBox: '#<%= namespace + randomNamespace %>assetCategoriesSelector',
-				curEntries: '<%= HtmlUtil.escapeJS(categoryIdsNames[1]) %>',
-				curEntryIds: '<%= categoryIdsNames[0] %>',
+				curEntries: '<%= HtmlUtil.escapeJS(categoryIdsTitles[1]) %>',
+				curEntryIds: '<%= categoryIdsTitles[0] %>',
 				hiddenInput: '#<%= namespace + hiddenInput %>',
 				instanceVar: '<%= namespace + randomNamespace %>',
 				portalModelResource: <%= Validator.isNotNull(className) && (ResourceActionsUtil.isPortalModelResource(className) || className.equals(Group.class.getName())) %>
@@ -162,7 +164,7 @@ private long[] _filterCategoryIds(long vocabularyId, long[] categoryIds) throws 
 	return ArrayUtil.toArray(filteredCategoryIds.toArray(new Long[filteredCategoryIds.size()]));
 }
 
-private String[] _getCategoryIdsNames(String categoryIds, String categoryNames, long vocabularyId) throws PortalException, SystemException {
+private String[] _getCategoryIdsTitles(String categoryIds, String categoryNames, long vocabularyId, Locale locale) throws PortalException, SystemException {
 	if (Validator.isNotNull(categoryIds)) {
 		long[] categoryIdsArray = GetterUtil.getLongValues(StringUtil.split(categoryIds));
 
@@ -180,9 +182,9 @@ private String[] _getCategoryIdsNames(String categoryIds, String categoryNames, 
 			for (long categoryId : categoryIdsArray) {
 				AssetCategory category = AssetCategoryLocalServiceUtil.getCategory(categoryId);
 
-				category = category.toEscapedModel();
+				category.setEscapedModel(true);
 
-				sb.append(category.getName());
+				sb.append(category.getTitle(locale));
 				sb.append(_CATEGORY_SEPARATOR);
 			}
 

--- a/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
@@ -46,6 +46,8 @@ if (Validator.isNotNull(className)) {
 	}
 
 	for (AssetVocabulary vocabulary : vocabularies) {
+		vocabulary.setEscapedModel(true);
+
 		int vocabularyCategoriesCount = AssetCategoryLocalServiceUtil.getVocabularyCategoriesCount(vocabulary.getVocabularyId());
 
 		if (vocabularyCategoriesCount == 0) {
@@ -75,8 +77,6 @@ if (Validator.isNotNull(className)) {
 		}
 
 		String[] categoryIdsTitles = _getCategoryIdsTitles(curCategoryIds, curCategoryNames, vocabulary.getVocabularyId(), locale);
-
-		vocabulary.setEscapedModel(true);
 	%>
 
 		<span class="aui-field-content">

--- a/portal-web/docroot/html/taglib/ui/asset_categories_summary/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_summary/page.jsp
@@ -30,23 +30,23 @@ List<AssetVocabulary> vocabularies = AssetVocabularyServiceUtil.getGroupsVocabul
 List<AssetCategory> categories = AssetCategoryServiceUtil.getCategories(className, classPK);
 
 for (AssetVocabulary vocabulary : vocabularies) {
-	vocabulary = vocabulary.toEscapedModel();
+	vocabulary.setEscapedModel(true);
 
-	String vocabularyName = vocabulary.getTitle(themeDisplay.getLocale());
+	String vocabularyTitle = vocabulary.getTitle(themeDisplay.getLocale());
 
 	List<AssetCategory> curCategories = _filterCategories(categories, vocabulary);
 %>
 
 	<c:if test="<%= !curCategories.isEmpty() %>">
 		<span class="taglib-asset-categories-summary">
-			<%= vocabularyName %>:
+			<%= vocabularyTitle %>:
 
 			<c:choose>
 				<c:when test="<%= portletURL != null %>">
 
 					<%
 					for (AssetCategory category : curCategories) {
-						category = category.toEscapedModel();
+						category.setEscapedModel(true);
 
 						portletURL.setParameter("categoryId", String.valueOf(category.getCategoryId()));
 					%>
@@ -62,7 +62,7 @@ for (AssetVocabulary vocabulary : vocabularies) {
 
 					<%
 					for (AssetCategory category : curCategories) {
-						category = category.toEscapedModel();
+						category.setEscapedModel(true);
 					%>
 
 						<span class="asset-category">
@@ -94,7 +94,7 @@ private String _buildCategoryPath(AssetCategory category, ThemeDisplay themeDisp
 	StringBundler sb = new StringBundler(ancestorCategories.size() * 2 + 1);
 
 	for (AssetCategory ancestorCategory : ancestorCategories) {
-		ancestorCategory = ancestorCategory.toEscapedModel();
+		category.setEscapedModel(true);
 
 		sb.append(ancestorCategory.getTitle(themeDisplay.getLocale()));
 		sb.append(" &raquo; ");


### PR DESCRIPTION
Displaying categories in the appropiate locale taking in account:

1- To escape title you need to do setEscapedModel(true) instead of toEscapedModel(valid for getName())
2- Prevent XSS Attack

Plugins here: https://github.com/brianchandotcom/liferay-plugins/pull/177
