### PR TITLE
LPS-17958 Categories should be displayed in the appropriate locale

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.util;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
@@ -80,6 +81,8 @@ public class AssetUtil {
 			PortletURL portletURL)
 		throws Exception {
 
+		String languageId = LanguageUtil.getLanguageId(request);
+
 		AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getCategory(
 			assetCategoryId);
 
@@ -92,13 +95,14 @@ public class AssetUtil {
 				ancestorCategory.getCategoryId()));
 
 			addPortletBreadcrumbEntry(
-				request, ancestorCategory.getName(), portletURL.toString());
+				request, ancestorCategory.getTitle(languageId),
+				portletURL.toString());
 		}
 
 		portletURL.setParameter("categoryId", String.valueOf(assetCategoryId));
 
 		addPortletBreadcrumbEntry(
-			request, assetCategory.getName(), portletURL.toString());
+			request, assetCategory.getTitle(languageId), portletURL.toString());
 	}
 
 	public static void addPortletBreadcrumbEntry(

--- a/portal-web/docroot/html/portlet/asset_categories_navigation/configuration.jsp
+++ b/portal-web/docroot/html/portlet/asset_categories_navigation/configuration.jsp
@@ -45,7 +45,9 @@ String redirect = ParamUtil.getString(request, "redirect");
 			try {
 				AssetVocabulary vocabulary = AssetVocabularyLocalServiceUtil.getVocabulary(vocabularyId);
 
-				typesLeftList.add(new KeyValuePair(String.valueOf(vocabularyId), _getName(vocabulary, themeDisplay)));
+				vocabulary = vocabulary.toEscapedModel();
+
+				typesLeftList.add(new KeyValuePair(String.valueOf(vocabularyId), _getTitle(vocabulary, themeDisplay)));
 			}
 			catch (NoSuchVocabularyException nsve) {
 			}
@@ -63,7 +65,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 
 				vocabulary = vocabulary.toEscapedModel();
 
-				typesRightList.add(new KeyValuePair(String.valueOf(vocabularyId), _getName(vocabulary, themeDisplay)));
+				typesRightList.add(new KeyValuePair(String.valueOf(vocabularyId), _getTitle(vocabulary, themeDisplay)));
 			}
 		}
 
@@ -106,13 +108,13 @@ String redirect = ParamUtil.getString(request, "redirect");
 </aui:script>
 
 <%!
-private String _getName(AssetVocabulary vocabulary, ThemeDisplay themeDisplay) {
-	String name = vocabulary.getName();
+private String _getTitle(AssetVocabulary vocabulary, ThemeDisplay themeDisplay) {
+	String title = vocabulary.getTitle(themeDisplay.getLanguageId());
 
 	if (vocabulary.getGroupId() == themeDisplay.getCompanyGroupId()) {
-		name += " (" + LanguageUtil.get(themeDisplay.getLocale(), "global") + ")";
+		title += " (" + LanguageUtil.get(themeDisplay.getLocale(), "global") + ")";
 	}
 
-	return name;
+	return title;
 }
 %>

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration.jsp
@@ -611,7 +611,7 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 													assetVocabulary = assetVocabulary.toEscapedModel();
 												%>
 
-													<aui:option label="<%= assetVocabulary.getName() %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
+													<aui:option label="<%= assetVocabulary.getTitle(locale) %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
 
 												<%
 												}
@@ -637,7 +637,7 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 												assetVocabulary = assetVocabulary.toEscapedModel();
 											%>
 
-												<aui:option label="<%= assetVocabulary.getName() %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
+												<aui:option label="<%= assetVocabulary.getTitle(locale) %>" selected="<%= assetVocabularyId == assetVocabulary.getVocabularyId() %>" value="<%= assetVocabulary.getVocabularyId() %>" />
 
 											<%
 											}

--- a/portal-web/docroot/html/portlet/asset_publisher/init.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/init.jsp
@@ -76,8 +76,8 @@ long assetVocabularyId = GetterUtil.getLong(preferences.getValue("assetVocabular
 
 long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 
-String assetCategoryName = null;
-String assetVocabularyName = null;
+String assetCategoryTitle = null;
+String assetVocabularyTitle = null;
 
 if (assetCategoryId > 0) {
 	assetEntryQuery.setAllCategoryIds(new long[] {assetCategoryId});
@@ -86,15 +86,15 @@ if (assetCategoryId > 0) {
 
 	assetCategory = assetCategory.toEscapedModel();
 
-	assetCategoryName = assetCategory.getName();
+	assetCategoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
 	assetVocabulary = assetVocabulary.toEscapedModel();
 
-	assetVocabularyName = assetVocabulary.getName();
+	assetVocabularyTitle = assetVocabulary.getTitle(locale);
 
-	PortalUtil.setPageKeywords(assetCategory.getName(), request);
+	PortalUtil.setPageKeywords(assetCategoryTitle, request);
 }
 
 String assetTagName = ParamUtil.getString(request, "tag");

--- a/portal-web/docroot/html/portlet/asset_publisher/view.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/view.jsp
@@ -112,7 +112,7 @@ if (!paginationType.equals("none")) {
 
 <c:if test='<%= (assetCategoryId > 0) && selectionStyle.equals("dynamic") %>'>
 	<h1 class="asset-categorization-title">
-		<%= LanguageUtil.format(pageContext, "content-with-x-x", new String[] {assetVocabularyName, assetCategoryName}) %>
+		<%= LanguageUtil.format(pageContext, "content-with-x-x", new String[] {assetVocabularyTitle, assetCategoryTitle}) %>
 	</h1>
 
 	<%

--- a/portal-web/docroot/html/portlet/asset_publisher/view_dynamic_list.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/view_dynamic_list.jspf
@@ -61,7 +61,7 @@ if (!portletName.equals(PortletKeys.RELATED_ASSETS) || (assetEntryQuery.getLinke
 				request.setAttribute("view.jsp-results", results);
 	%>
 
-				<h3 class="asset-entries-group-label"><%= assetCategory.getName() %></h3>
+				<h3 class="asset-entries-group-label"><%= assetCategory.getTitle(locale) %></h3>
 
 				<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
 

--- a/portal-web/docroot/html/portlet/blogs/view.jsp
+++ b/portal-web/docroot/html/portlet/blogs/view.jsp
@@ -19,21 +19,21 @@
 <%
 long categoryId = ParamUtil.getLong(request, "categoryId");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
 	assetCategory = assetCategory.toEscapedModel();
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
 	assetVocabulary = assetVocabulary.toEscapedModel();
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 String tagName = ParamUtil.getString(request, "tag");

--- a/portal-web/docroot/html/portlet/blogs/view_entries.jspf
+++ b/portal-web/docroot/html/portlet/blogs/view_entries.jspf
@@ -54,9 +54,9 @@ showSearch = showSearch && !results.isEmpty();
 	</div>
 </c:if>
 
-<c:if test="<%= Validator.isNotNull(categoryName) %>">
+<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 	<h1 class="entry-title">
-		<%= LanguageUtil.format(pageContext, "entries-with-x-x", new String[] {vocabularyName, categoryName}) %>
+		<%= LanguageUtil.format(pageContext, "entries-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 	</h1>
 
 	<%

--- a/portal-web/docroot/html/portlet/bookmarks/view.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/view.jsp
@@ -40,21 +40,21 @@ int entriesCount = BookmarksEntryServiceUtil.getEntriesCount(scopeGroupId, folde
 long categoryId = ParamUtil.getLong(request, "categoryId");
 String tagName = ParamUtil.getString(request, "tag");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
 	assetCategory = assetCategory.toEscapedModel();
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
 	assetVocabulary = assetVocabulary.toEscapedModel();
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 boolean useAssetEntryQuery = (categoryId > 0) || Validator.isNotNull(tagName);
@@ -78,9 +78,9 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 
 <c:choose>
 	<c:when test="<%= useAssetEntryQuery %>">
-		<c:if test="<%= Validator.isNotNull(categoryName) %>">
+		<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 			<h1 class="entry-title">
-				<%= LanguageUtil.format(pageContext, "bookmarks-with-x-x", new String[] {vocabularyName, categoryName}) %>
+				<%= LanguageUtil.format(pageContext, "bookmarks-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 			</h1>
 		</c:if>
 
@@ -95,7 +95,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 		<%
 		if (portletName.equals(PortletKeys.BOOKMARKS)) {
 			PortalUtil.addPageKeywords(tagName, request);
-			PortalUtil.addPageKeywords(categoryName, request);
+			PortalUtil.addPageKeywords(categoryTitle, request);
 		}
 		%>
 

--- a/portal-web/docroot/html/portlet/document_library_display/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/view.jsp
@@ -54,21 +54,21 @@ int fileEntriesCount = DLAppServiceUtil.getFileEntriesAndFileShortcutsCount(repo
 long categoryId = ParamUtil.getLong(request, "categoryId");
 String tagName = ParamUtil.getString(request, "tag");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
 	assetCategory = assetCategory.toEscapedModel();
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
 	assetVocabulary = assetVocabulary.toEscapedModel();
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 boolean useAssetEntryQuery = (categoryId > 0) || Validator.isNotNull(tagName);
@@ -96,9 +96,9 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 
 <c:choose>
 	<c:when test="<%= useAssetEntryQuery %>">
-		<c:if test="<%= Validator.isNotNull(categoryName) %>">
+		<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 			<h1 class="entry-title">
-				<%= LanguageUtil.format(pageContext, "documents-with-x-x", new String[] {vocabularyName, categoryName}) %>
+				<%= LanguageUtil.format(pageContext, "documents-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 			</h1>
 		</c:if>
 
@@ -112,7 +112,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 
 		<%
 		PortalUtil.addPageKeywords(tagName, request);
-		PortalUtil.addPageKeywords(categoryName, request);
+		PortalUtil.addPageKeywords(categoryTitle, request);
 		%>
 
 	</c:when>

--- a/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
@@ -52,21 +52,21 @@ int imagesCount = DLAppServiceUtil.getFileEntriesAndFileShortcutsCount(repositor
 long categoryId = ParamUtil.getLong(request, "categoryId");
 String tagName = ParamUtil.getString(request, "tag");
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
 	assetCategory = assetCategory.toEscapedModel();
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
 	assetVocabulary = assetVocabulary.toEscapedModel();
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 
 boolean useAssetEntryQuery = (categoryId > 0) || Validator.isNotNull(tagName);
@@ -96,9 +96,9 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 
 <c:choose>
 	<c:when test="<%= useAssetEntryQuery %>">
-		<c:if test="<%= Validator.isNotNull(categoryName) %>">
+		<c:if test="<%= Validator.isNotNull(categoryTitle) %>">
 			<h1 class="entry-title">
-				<%= LanguageUtil.format(pageContext, "images-with-x-x", new String[] {vocabularyName, categoryName}) %>
+				<%= LanguageUtil.format(pageContext, "images-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>
 			</h1>
 		</c:if>
 
@@ -133,7 +133,7 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 		<%
 		if (portletName.equals(PortletKeys.IMAGE_GALLERY_DISPLAY)) {
 			PortalUtil.addPageKeywords(tagName, request);
-			PortalUtil.addPageKeywords(categoryName, request);
+			PortalUtil.addPageKeywords(categoryTitle, request);
 		}
 		%>
 

--- a/portal-web/docroot/html/portlet/wiki/view_categorized_pages.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view_categorized_pages.jsp
@@ -19,21 +19,21 @@
 <%
 long categoryId = GetterUtil.getLong(ParamUtil.getString(request, "categoryId"));
 
-String categoryName = null;
-String vocabularyName = null;
+String categoryTitle = null;
+String vocabularyTitle = null;
 
 if (categoryId != 0) {
 	AssetCategory assetCategory = AssetCategoryLocalServiceUtil.getAssetCategory(categoryId);
 
 	assetCategory = assetCategory.toEscapedModel();
 
-	categoryName = assetCategory.getName();
+	categoryTitle = assetCategory.getTitle(locale);
 
 	AssetVocabulary assetVocabulary = AssetVocabularyLocalServiceUtil.getAssetVocabulary(assetCategory.getVocabularyId());
 
 	assetVocabulary = assetVocabulary.toEscapedModel();
 
-	vocabularyName = assetVocabulary.getName();
+	vocabularyTitle = assetVocabulary.getTitle(locale);
 }
 %>
 
@@ -42,7 +42,7 @@ if (categoryId != 0) {
 <liferay-ui:header
 	escapeXml="<%= false %>"
 	localizeTitle="<%= false %>"
-	title='<%= LanguageUtil.format(pageContext, "pages-with-x-x", new String[] {vocabularyName, categoryName}) %>'
+	title='<%= LanguageUtil.format(pageContext, "pages-with-x-x", new String[] {vocabularyTitle, categoryTitle}) %>'
 />
 
 <liferay-util:include page="/html/portlet/wiki/page_iterator.jsp">

--- a/portal-web/docroot/html/taglib/ui/asset_categories_navigation/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_navigation/page.jsp
@@ -50,13 +50,13 @@ PortletURL portletURL = renderResponse.createRenderURL();
 
 		vocabulary = vocabulary.toEscapedModel();
 
-		String vocabularyNavigation = _buildVocabularyNavigation(vocabulary, categoryId, portletURL);
+		String vocabularyNavigation = _buildVocabularyNavigation(vocabulary, categoryId, portletURL, locale);
 
 		if (Validator.isNotNull(vocabularyNavigation)) {
 			hidePortletWhenEmpty = false;
 	%>
 
-			<liferay-ui:panel collapsible="<%= false %>" extended="<%= true %>" persistState="<%= true %>" title="<%= vocabulary.getName() %>">
+			<liferay-ui:panel collapsible="<%= false %>" extended="<%= true %>" persistState="<%= true %>" title="<%= vocabulary.getTitle(locale) %>">
 				<%= vocabularyNavigation %>
 			</liferay-ui:panel>
 
@@ -113,12 +113,12 @@ if (hidePortletWhenEmpty) {
 </aui:script>
 
 <%!
-private void _buildCategoriesNavigation(List<AssetCategory> categories, long curCategoryId, PortletURL portletURL, StringBundler sb) throws Exception {
+private void _buildCategoriesNavigation(List<AssetCategory> categories, long curCategoryId, PortletURL portletURL, StringBundler sb, Locale locale) throws Exception {
 	for (AssetCategory category : categories) {
 		category = category.toEscapedModel();
 
 		long categoryId = category.getCategoryId();
-		String name = category.getName();
+		String title = category.getTitle(locale);
 
 		List<AssetCategory> categoriesChildren = AssetCategoryServiceUtil.getChildCategories(category.getCategoryId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
@@ -126,7 +126,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 
 		if (categoryId == curCategoryId) {
 			sb.append("<strong>");
-			sb.append(name);
+			sb.append(title);
 			sb.append("</strong>");
 		}
 		else {
@@ -135,7 +135,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 			sb.append("<a href=\"");
 			sb.append(portletURL.toString());
 			sb.append("\">");
-			sb.append(name);
+			sb.append(title);
 			sb.append("</a>");
 		}
 
@@ -144,7 +144,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 		if (!categoriesChildren.isEmpty()) {
 			sb.append("<ul>");
 
-			_buildCategoriesNavigation(categoriesChildren, curCategoryId, portletURL, sb);
+			_buildCategoriesNavigation(categoriesChildren, curCategoryId, portletURL, sb, locale);
 
 			sb.append("</ul>");
 		}
@@ -153,7 +153,7 @@ private void _buildCategoriesNavigation(List<AssetCategory> categories, long cur
 	}
 }
 
-private String _buildVocabularyNavigation(AssetVocabulary vocabulary, long categoryId, PortletURL portletURL) throws Exception {
+private String _buildVocabularyNavigation(AssetVocabulary vocabulary, long categoryId, PortletURL portletURL, Locale locale) throws Exception {
 	List<AssetCategory> categories = AssetCategoryServiceUtil.getVocabularyRootCategories(vocabulary.getVocabularyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 	if (categories.isEmpty()) {
@@ -164,7 +164,7 @@ private String _buildVocabularyNavigation(AssetVocabulary vocabulary, long categ
 
 	sb.append("<div class=\"lfr-asset-category-list-container\"><ul class=\"lfr-asset-category-list\">");
 
-	_buildCategoriesNavigation(categories, categoryId, portletURL, sb);
+	_buildCategoriesNavigation(categories, categoryId, portletURL, sb, locale);
 
 	sb.append("</ul></div>");
 

--- a/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
@@ -46,6 +46,8 @@ if (Validator.isNotNull(className)) {
 	}
 
 	for (AssetVocabulary vocabulary : vocabularies) {
+		vocabulary = vocabulary.toEscapedModel();
+
 		int vocabularyCategoriesCount = AssetCategoryLocalServiceUtil.getVocabularyCategoriesCount(vocabulary.getVocabularyId());
 
 		if (vocabularyCategoriesCount == 0) {
@@ -74,7 +76,7 @@ if (Validator.isNotNull(className)) {
 			curCategoryNames = StringPool.BLANK;
 		}
 
-		String[] categoryIdsNames = _getCategoryIdsNames(curCategoryIds, curCategoryNames, vocabulary.getVocabularyId());
+		String[] categoryIdsTitles = _getCategoryIdsTitles(curCategoryIds, curCategoryNames, vocabulary.getVocabularyId(), locale);
 	%>
 
 		<span class="aui-field-content">
@@ -100,8 +102,8 @@ if (Validator.isNotNull(className)) {
 				{
 					className: '<%= className %>',
 					contentBox: '#<%= namespace + randomNamespace %>assetCategoriesSelector_<%= vocabulary.getVocabularyId() %>',
-					curEntries: '<%= HtmlUtil.escapeJS(categoryIdsNames[1]) %>',
-					curEntryIds: '<%= categoryIdsNames[0] %>',
+					curEntries: '<%= HtmlUtil.escapeJS(categoryIdsTitles[1]) %>',
+					curEntryIds: '<%= categoryIdsTitles[0] %>',
 					hiddenInput: '#<%= namespace + hiddenInput + StringPool.UNDERLINE + vocabulary.getVocabularyId() %>',
 					instanceVar: '<%= namespace + randomNamespace %>',
 					labelNode: '#<%= namespace %>assetCategoriesLabel_<%= vocabulary.getVocabularyId() %>',
@@ -122,7 +124,7 @@ else {
 		curCategoryIds = curCategoryIdsParam;
 	}
 
-	String[] categoryIdsNames = _getCategoryIdsNames(curCategoryIds, curCategoryNames, 0);
+	String[] categoryIdsTitles = _getCategoryIdsTitles(curCategoryIds, curCategoryNames, 0, locale);
 %>
 
 	<div class="lfr-tags-selector-content" id="<%= namespace + randomNamespace %>assetCategoriesSelector">
@@ -134,8 +136,8 @@ else {
 			{
 				className: '<%= className %>',
 				contentBox: '#<%= namespace + randomNamespace %>assetCategoriesSelector',
-				curEntries: '<%= HtmlUtil.escapeJS(categoryIdsNames[1]) %>',
-				curEntryIds: '<%= categoryIdsNames[0] %>',
+				curEntries: '<%= HtmlUtil.escapeJS(categoryIdsTitles[1]) %>',
+				curEntryIds: '<%= categoryIdsTitles[0] %>',
 				hiddenInput: '#<%= namespace + hiddenInput %>',
 				instanceVar: '<%= namespace + randomNamespace %>',
 				portalModelResource: <%= Validator.isNotNull(className) && (ResourceActionsUtil.isPortalModelResource(className) || className.equals(Group.class.getName())) %>
@@ -162,7 +164,7 @@ private long[] _filterCategoryIds(long vocabularyId, long[] categoryIds) throws 
 	return ArrayUtil.toArray(filteredCategoryIds.toArray(new Long[filteredCategoryIds.size()]));
 }
 
-private String[] _getCategoryIdsNames(String categoryIds, String categoryNames, long vocabularyId) throws PortalException, SystemException {
+private String[] _getCategoryIdsTitles(String categoryIds, String categoryNames, long vocabularyId, Locale locale) throws PortalException, SystemException {
 	if (Validator.isNotNull(categoryIds)) {
 		long[] categoryIdsArray = GetterUtil.getLongValues(StringUtil.split(categoryIds));
 
@@ -182,7 +184,7 @@ private String[] _getCategoryIdsNames(String categoryIds, String categoryNames, 
 
 				category = category.toEscapedModel();
 
-				sb.append(category.getName());
+				sb.append(category.getTitle(locale));
 				sb.append(_CATEGORY_SEPARATOR);
 			}
 

--- a/portal-web/docroot/html/taglib/ui/asset_categories_summary/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_summary/page.jsp
@@ -32,14 +32,14 @@ List<AssetCategory> categories = AssetCategoryServiceUtil.getCategories(classNam
 for (AssetVocabulary vocabulary : vocabularies) {
 	vocabulary = vocabulary.toEscapedModel();
 
-	String vocabularyName = vocabulary.getTitle(themeDisplay.getLocale());
+	String vocabularyTitle = vocabulary.getTitle(themeDisplay.getLocale());
 
 	List<AssetCategory> curCategories = _filterCategories(categories, vocabulary);
 %>
 
 	<c:if test="<%= !curCategories.isEmpty() %>">
 		<span class="taglib-asset-categories-summary">
-			<%= vocabularyName %>:
+			<%= vocabularyTitle %>:
 
 			<c:choose>
 				<c:when test="<%= portletURL != null %>">


### PR DESCRIPTION
This part only includes the code where we have changed getName() por getTitle(locale) using toEscapedModel() to escape the titles.
