### PR TITLE
LPS-21530  Localized fields are never escaped using toEscapedModel

### DIFF
--- a/portal-impl/src/com/liferay/counter/model/impl/CounterModelImpl.java
+++ b/portal-impl/src/com/liferay/counter/model/impl/CounterModelImpl.java
@@ -119,18 +119,13 @@ public class CounterModelImpl extends BaseModelImpl<Counter>
 
 	@Override
 	public Counter toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Counter)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Counter)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Counter)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/AccountModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/AccountModelImpl.java
@@ -371,18 +371,13 @@ public class AccountModelImpl extends BaseModelImpl<Account>
 
 	@Override
 	public Account toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Account)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Account)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Account)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/AddressModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/AddressModelImpl.java
@@ -476,18 +476,13 @@ public class AddressModelImpl extends BaseModelImpl<Address>
 
 	@Override
 	public Address toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Address)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Address)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Address)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/BrowserTrackerModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/BrowserTrackerModelImpl.java
@@ -153,18 +153,13 @@ public class BrowserTrackerModelImpl extends BaseModelImpl<BrowserTracker>
 
 	@Override
 	public BrowserTracker toEscapedModel() {
-		if (isEscapedModel()) {
-			return (BrowserTracker)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (BrowserTracker)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (BrowserTracker)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ClassNameModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ClassNameModelImpl.java
@@ -187,18 +187,13 @@ public class ClassNameModelImpl extends BaseModelImpl<ClassName>
 
 	@Override
 	public ClassName toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ClassName)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ClassName)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ClassName)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ClusterGroupModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ClusterGroupModelImpl.java
@@ -148,18 +148,13 @@ public class ClusterGroupModelImpl extends BaseModelImpl<ClusterGroup>
 
 	@Override
 	public ClusterGroup toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ClusterGroup)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ClusterGroup)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ClusterGroup)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/CompanyModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CompanyModelImpl.java
@@ -333,18 +333,13 @@ public class CompanyModelImpl extends BaseModelImpl<Company>
 
 	@Override
 	public Company toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Company)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Company)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Company)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ContactModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ContactModelImpl.java
@@ -593,18 +593,13 @@ public class ContactModelImpl extends BaseModelImpl<Contact>
 
 	@Override
 	public Contact toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Contact)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Contact)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Contact)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/CountryModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CountryModelImpl.java
@@ -309,18 +309,13 @@ public class CountryModelImpl extends BaseModelImpl<Country>
 
 	@Override
 	public Country toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Country)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Country)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Country)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/EmailAddressModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/EmailAddressModelImpl.java
@@ -362,18 +362,13 @@ public class EmailAddressModelImpl extends BaseModelImpl<EmailAddress>
 
 	@Override
 	public EmailAddress toEscapedModel() {
-		if (isEscapedModel()) {
-			return (EmailAddress)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (EmailAddress)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (EmailAddress)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/GroupModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupModelImpl.java
@@ -482,18 +482,13 @@ public class GroupModelImpl extends BaseModelImpl<Group> implements GroupModel {
 
 	@Override
 	public Group toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Group)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Group)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Group)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ImageModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ImageModelImpl.java
@@ -242,18 +242,13 @@ public class ImageModelImpl extends BaseModelImpl<Image> implements ImageModel {
 
 	@Override
 	public Image toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Image)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Image)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Image)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutBranchModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutBranchModelImpl.java
@@ -318,18 +318,13 @@ public class LayoutBranchModelImpl extends BaseModelImpl<LayoutBranch>
 
 	@Override
 	public LayoutBranch toEscapedModel() {
-		if (isEscapedModel()) {
-			return (LayoutBranch)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (LayoutBranch)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (LayoutBranch)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutModelImpl.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -393,26 +392,12 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -482,26 +467,12 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -571,27 +542,12 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -664,27 +620,12 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 	}
 
 	public String getKeywords(String languageId) {
-		String value = LocalizationUtil.getLocalization(getKeywords(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getKeywords(), languageId);
 	}
 
 	public String getKeywords(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getKeywords(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getKeywords(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getKeywordsMap() {
@@ -755,26 +696,12 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 	}
 
 	public String getRobots(String languageId) {
-		String value = LocalizationUtil.getLocalization(getRobots(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getRobots(), languageId);
 	}
 
 	public String getRobots(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getRobots(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getRobots(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getRobotsMap() {
@@ -1067,18 +994,13 @@ public class LayoutModelImpl extends BaseModelImpl<Layout>
 
 	@Override
 	public Layout toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Layout)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Layout)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Layout)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutPrototypeModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutPrototypeModelImpl.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -234,26 +233,12 @@ public class LayoutPrototypeModelImpl extends BaseModelImpl<LayoutPrototype>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -359,18 +344,13 @@ public class LayoutPrototypeModelImpl extends BaseModelImpl<LayoutPrototype>
 
 	@Override
 	public LayoutPrototype toEscapedModel() {
-		if (isEscapedModel()) {
-			return (LayoutPrototype)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (LayoutPrototype)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (LayoutPrototype)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -449,26 +448,12 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -538,26 +523,12 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -627,27 +598,12 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -720,27 +676,12 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 	}
 
 	public String getKeywords(String languageId) {
-		String value = LocalizationUtil.getLocalization(getKeywords(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getKeywords(), languageId);
 	}
 
 	public String getKeywords(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getKeywords(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getKeywords(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getKeywordsMap() {
@@ -811,26 +752,12 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 	}
 
 	public String getRobots(String languageId) {
-		String value = LocalizationUtil.getLocalization(getRobots(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getRobots(), languageId);
 	}
 
 	public String getRobots(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getRobots(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getRobots(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getRobotsMap() {
@@ -1094,18 +1021,13 @@ public class LayoutRevisionModelImpl extends BaseModelImpl<LayoutRevision>
 
 	@Override
 	public LayoutRevision toEscapedModel() {
-		if (isEscapedModel()) {
-			return (LayoutRevision)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (LayoutRevision)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (LayoutRevision)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetBranchModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetBranchModelImpl.java
@@ -335,18 +335,13 @@ public class LayoutSetBranchModelImpl extends BaseModelImpl<LayoutSetBranch>
 
 	@Override
 	public LayoutSetBranch toEscapedModel() {
-		if (isEscapedModel()) {
-			return (LayoutSetBranch)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (LayoutSetBranch)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (LayoutSetBranch)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetModelImpl.java
@@ -390,18 +390,13 @@ public class LayoutSetModelImpl extends BaseModelImpl<LayoutSet>
 
 	@Override
 	public LayoutSet toEscapedModel() {
-		if (isEscapedModel()) {
-			return (LayoutSet)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (LayoutSet)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (LayoutSet)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutSetPrototypeModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutSetPrototypeModelImpl.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -234,26 +233,12 @@ public class LayoutSetPrototypeModelImpl extends BaseModelImpl<LayoutSetPrototyp
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -359,18 +344,13 @@ public class LayoutSetPrototypeModelImpl extends BaseModelImpl<LayoutSetPrototyp
 
 	@Override
 	public LayoutSetPrototype toEscapedModel() {
-		if (isEscapedModel()) {
-			return (LayoutSetPrototype)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (LayoutSetPrototype)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (LayoutSetPrototype)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ListTypeModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ListTypeModelImpl.java
@@ -192,18 +192,13 @@ public class ListTypeModelImpl extends BaseModelImpl<ListType>
 
 	@Override
 	public ListType toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ListType)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ListType)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ListType)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LockModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LockModelImpl.java
@@ -285,18 +285,13 @@ public class LockModelImpl extends BaseModelImpl<Lock> implements LockModel {
 
 	@Override
 	public Lock toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Lock)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Lock)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Lock)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/MembershipRequestModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/MembershipRequestModelImpl.java
@@ -323,18 +323,13 @@ public class MembershipRequestModelImpl extends BaseModelImpl<MembershipRequest>
 
 	@Override
 	public MembershipRequest toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MembershipRequest)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MembershipRequest)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MembershipRequest)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/OrgGroupPermissionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/OrgGroupPermissionModelImpl.java
@@ -155,18 +155,13 @@ public class OrgGroupPermissionModelImpl extends BaseModelImpl<OrgGroupPermissio
 
 	@Override
 	public OrgGroupPermission toEscapedModel() {
-		if (isEscapedModel()) {
-			return (OrgGroupPermission)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (OrgGroupPermission)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (OrgGroupPermission)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/OrgGroupRoleModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/OrgGroupRoleModelImpl.java
@@ -155,18 +155,13 @@ public class OrgGroupRoleModelImpl extends BaseModelImpl<OrgGroupRole>
 
 	@Override
 	public OrgGroupRole toEscapedModel() {
-		if (isEscapedModel()) {
-			return (OrgGroupRole)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (OrgGroupRole)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (OrgGroupRole)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/OrgLaborModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/OrgLaborModelImpl.java
@@ -341,18 +341,13 @@ public class OrgLaborModelImpl extends BaseModelImpl<OrgLabor>
 
 	@Override
 	public OrgLabor toEscapedModel() {
-		if (isEscapedModel()) {
-			return (OrgLabor)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (OrgLabor)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (OrgLabor)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/OrganizationModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/OrganizationModelImpl.java
@@ -346,18 +346,13 @@ public class OrganizationModelImpl extends BaseModelImpl<Organization>
 
 	@Override
 	public Organization toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Organization)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Organization)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Organization)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PasswordPolicyModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PasswordPolicyModelImpl.java
@@ -591,18 +591,13 @@ public class PasswordPolicyModelImpl extends BaseModelImpl<PasswordPolicy>
 
 	@Override
 	public PasswordPolicy toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PasswordPolicy)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PasswordPolicy)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PasswordPolicy)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PasswordPolicyRelModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PasswordPolicyRelModelImpl.java
@@ -188,18 +188,13 @@ public class PasswordPolicyRelModelImpl extends BaseModelImpl<PasswordPolicyRel>
 
 	@Override
 	public PasswordPolicyRel toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PasswordPolicyRel)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PasswordPolicyRel)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PasswordPolicyRel)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PasswordTrackerModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PasswordTrackerModelImpl.java
@@ -173,18 +173,13 @@ public class PasswordTrackerModelImpl extends BaseModelImpl<PasswordTracker>
 
 	@Override
 	public PasswordTracker toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PasswordTracker)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PasswordTracker)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PasswordTracker)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PermissionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PermissionModelImpl.java
@@ -237,18 +237,13 @@ public class PermissionModelImpl extends BaseModelImpl<Permission>
 
 	@Override
 	public Permission toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Permission)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Permission)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Permission)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PhoneModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PhoneModelImpl.java
@@ -377,18 +377,13 @@ public class PhoneModelImpl extends BaseModelImpl<Phone> implements PhoneModel {
 
 	@Override
 	public Phone toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Phone)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Phone)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Phone)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PluginSettingModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PluginSettingModelImpl.java
@@ -260,18 +260,13 @@ public class PluginSettingModelImpl extends BaseModelImpl<PluginSetting>
 
 	@Override
 	public PluginSetting toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PluginSetting)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PluginSetting)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PluginSetting)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PortalPreferencesModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortalPreferencesModelImpl.java
@@ -171,18 +171,13 @@ public class PortalPreferencesModelImpl extends BaseModelImpl<PortalPreferences>
 
 	@Override
 	public PortalPreferences toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PortalPreferences)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PortalPreferences)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PortalPreferences)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PortletItemModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletItemModelImpl.java
@@ -277,18 +277,13 @@ public class PortletItemModelImpl extends BaseModelImpl<PortletItem>
 
 	@Override
 	public PortletItem toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PortletItem)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PortletItem)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PortletItem)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PortletModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletModelImpl.java
@@ -233,18 +233,13 @@ public class PortletModelImpl extends BaseModelImpl<Portlet>
 
 	@Override
 	public Portlet toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Portlet)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Portlet)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Portlet)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/PortletPreferencesModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletPreferencesModelImpl.java
@@ -267,18 +267,13 @@ public class PortletPreferencesModelImpl extends BaseModelImpl<PortletPreference
 
 	@Override
 	public PortletPreferences toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PortletPreferences)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PortletPreferences)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PortletPreferences)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/RegionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RegionModelImpl.java
@@ -237,18 +237,13 @@ public class RegionModelImpl extends BaseModelImpl<Region>
 
 	@Override
 	public Region toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Region)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Region)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Region)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ReleaseModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ReleaseModelImpl.java
@@ -203,18 +203,13 @@ public class ReleaseModelImpl extends BaseModelImpl<Release>
 
 	@Override
 	public Release toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Release)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Release)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Release)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/RepositoryEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RepositoryEntryModelImpl.java
@@ -205,18 +205,13 @@ public class RepositoryEntryModelImpl extends BaseModelImpl<RepositoryEntry>
 
 	@Override
 	public RepositoryEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (RepositoryEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (RepositoryEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (RepositoryEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/RepositoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RepositoryModelImpl.java
@@ -304,18 +304,13 @@ public class RepositoryModelImpl extends BaseModelImpl<Repository>
 
 	@Override
 	public Repository toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Repository)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Repository)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Repository)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ResourceActionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ResourceActionModelImpl.java
@@ -174,18 +174,13 @@ public class ResourceActionModelImpl extends BaseModelImpl<ResourceAction>
 
 	@Override
 	public ResourceAction toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ResourceAction)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ResourceAction)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ResourceAction)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ResourceBlockModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ResourceBlockModelImpl.java
@@ -264,18 +264,13 @@ public class ResourceBlockModelImpl extends BaseModelImpl<ResourceBlock>
 
 	@Override
 	public ResourceBlock toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ResourceBlock)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ResourceBlock)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ResourceBlock)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ResourceBlockPermissionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ResourceBlockPermissionModelImpl.java
@@ -165,18 +165,13 @@ public class ResourceBlockPermissionModelImpl extends BaseModelImpl<ResourceBloc
 
 	@Override
 	public ResourceBlockPermission toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ResourceBlockPermission)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ResourceBlockPermission)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ResourceBlockPermission)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ResourceCodeModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ResourceCodeModelImpl.java
@@ -182,18 +182,13 @@ public class ResourceCodeModelImpl extends BaseModelImpl<ResourceCode>
 
 	@Override
 	public ResourceCode toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ResourceCode)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ResourceCode)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ResourceCode)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ResourceModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ResourceModelImpl.java
@@ -202,18 +202,13 @@ public class ResourceModelImpl extends BaseModelImpl<Resource>
 
 	@Override
 	public Resource toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Resource)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Resource)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Resource)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ResourcePermissionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ResourcePermissionModelImpl.java
@@ -326,18 +326,13 @@ public class ResourcePermissionModelImpl extends BaseModelImpl<ResourcePermissio
 
 	@Override
 	public ResourcePermission toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ResourcePermission)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ResourcePermission)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ResourcePermission)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ResourceTypePermissionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ResourceTypePermissionModelImpl.java
@@ -213,18 +213,13 @@ public class ResourceTypePermissionModelImpl extends BaseModelImpl<ResourceTypeP
 
 	@Override
 	public ResourceTypePermission toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ResourceTypePermission)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ResourceTypePermission)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ResourceTypePermission)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/RoleModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RoleModelImpl.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -318,26 +317,12 @@ public class RoleModelImpl extends BaseModelImpl<Role> implements RoleModel {
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -407,27 +392,12 @@ public class RoleModelImpl extends BaseModelImpl<Role> implements RoleModel {
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -528,18 +498,13 @@ public class RoleModelImpl extends BaseModelImpl<Role> implements RoleModel {
 
 	@Override
 	public Role toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Role)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Role)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Role)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ServiceComponentModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ServiceComponentModelImpl.java
@@ -185,18 +185,13 @@ public class ServiceComponentModelImpl extends BaseModelImpl<ServiceComponent>
 
 	@Override
 	public ServiceComponent toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ServiceComponent)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ServiceComponent)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ServiceComponent)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/ShardModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ShardModelImpl.java
@@ -190,18 +190,13 @@ public class ShardModelImpl extends BaseModelImpl<Shard> implements ShardModel {
 
 	@Override
 	public Shard toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Shard)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Shard)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Shard)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/SubscriptionModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/SubscriptionModelImpl.java
@@ -267,18 +267,13 @@ public class SubscriptionModelImpl extends BaseModelImpl<Subscription>
 
 	@Override
 	public Subscription toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Subscription)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Subscription)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Subscription)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/TeamModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/TeamModelImpl.java
@@ -306,18 +306,13 @@ public class TeamModelImpl extends BaseModelImpl<Team> implements TeamModel {
 
 	@Override
 	public Team toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Team)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Team)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Team)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/TicketModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/TicketModelImpl.java
@@ -219,18 +219,13 @@ public class TicketModelImpl extends BaseModelImpl<Ticket>
 
 	@Override
 	public Ticket toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Ticket)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Ticket)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Ticket)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserGroupGroupRoleModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserGroupGroupRoleModelImpl.java
@@ -211,18 +211,13 @@ public class UserGroupGroupRoleModelImpl extends BaseModelImpl<UserGroupGroupRol
 
 	@Override
 	public UserGroupGroupRole toEscapedModel() {
-		if (isEscapedModel()) {
-			return (UserGroupGroupRole)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (UserGroupGroupRole)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (UserGroupGroupRole)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserGroupModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserGroupModelImpl.java
@@ -305,18 +305,13 @@ public class UserGroupModelImpl extends BaseModelImpl<UserGroup>
 
 	@Override
 	public UserGroup toEscapedModel() {
-		if (isEscapedModel()) {
-			return (UserGroup)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (UserGroup)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (UserGroup)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserGroupRoleModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserGroupRoleModelImpl.java
@@ -220,18 +220,13 @@ public class UserGroupRoleModelImpl extends BaseModelImpl<UserGroupRole>
 
 	@Override
 	public UserGroupRole toEscapedModel() {
-		if (isEscapedModel()) {
-			return (UserGroupRole)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (UserGroupRole)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (UserGroupRole)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserIdMapperModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserIdMapperModelImpl.java
@@ -209,18 +209,13 @@ public class UserIdMapperModelImpl extends BaseModelImpl<UserIdMapper>
 
 	@Override
 	public UserIdMapper toEscapedModel() {
-		if (isEscapedModel()) {
-			return (UserIdMapper)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (UserIdMapper)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (UserIdMapper)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserModelImpl.java
@@ -874,18 +874,13 @@ public class UserModelImpl extends BaseModelImpl<User> implements UserModel {
 
 	@Override
 	public User toEscapedModel() {
-		if (isEscapedModel()) {
-			return (User)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (User)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (User)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
@@ -251,18 +251,13 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 
 	@Override
 	public UserNotificationEvent toEscapedModel() {
-		if (isEscapedModel()) {
-			return (UserNotificationEvent)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (UserNotificationEvent)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (UserNotificationEvent)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserTrackerModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserTrackerModelImpl.java
@@ -245,18 +245,13 @@ public class UserTrackerModelImpl extends BaseModelImpl<UserTracker>
 
 	@Override
 	public UserTracker toEscapedModel() {
-		if (isEscapedModel()) {
-			return (UserTracker)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (UserTracker)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (UserTracker)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/UserTrackerPathModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserTrackerPathModelImpl.java
@@ -160,18 +160,13 @@ public class UserTrackerPathModelImpl extends BaseModelImpl<UserTrackerPath>
 
 	@Override
 	public UserTrackerPath toEscapedModel() {
-		if (isEscapedModel()) {
-			return (UserTrackerPath)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (UserTrackerPath)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (UserTrackerPath)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/VirtualHostModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/VirtualHostModelImpl.java
@@ -182,18 +182,13 @@ public class VirtualHostModelImpl extends BaseModelImpl<VirtualHost>
 
 	@Override
 	public VirtualHost toEscapedModel() {
-		if (isEscapedModel()) {
-			return (VirtualHost)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (VirtualHost)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (VirtualHost)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/WebDAVPropsModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/WebDAVPropsModelImpl.java
@@ -209,18 +209,13 @@ public class WebDAVPropsModelImpl extends BaseModelImpl<WebDAVProps>
 
 	@Override
 	public WebDAVProps toEscapedModel() {
-		if (isEscapedModel()) {
-			return (WebDAVProps)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (WebDAVProps)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (WebDAVProps)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/WebsiteModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/WebsiteModelImpl.java
@@ -362,18 +362,13 @@ public class WebsiteModelImpl extends BaseModelImpl<Website>
 
 	@Override
 	public Website toEscapedModel() {
-		if (isEscapedModel()) {
-			return (Website)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (Website)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (Website)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/WorkflowDefinitionLinkModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/WorkflowDefinitionLinkModelImpl.java
@@ -333,18 +333,13 @@ public class WorkflowDefinitionLinkModelImpl extends BaseModelImpl<WorkflowDefin
 
 	@Override
 	public WorkflowDefinitionLink toEscapedModel() {
-		if (isEscapedModel()) {
-			return (WorkflowDefinitionLink)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (WorkflowDefinitionLink)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (WorkflowDefinitionLink)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/WorkflowInstanceLinkModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/WorkflowInstanceLinkModelImpl.java
@@ -274,18 +274,13 @@ public class WorkflowInstanceLinkModelImpl extends BaseModelImpl<WorkflowInstanc
 
 	@Override
 	public WorkflowInstanceLink toEscapedModel() {
-		if (isEscapedModel()) {
-			return (WorkflowInstanceLink)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (WorkflowInstanceLink)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (WorkflowInstanceLink)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model.ftl
@@ -127,6 +127,9 @@ public interface ${entity.name}Model extends
 			 * @param locale the locale of the language
 			 * @return the localized ${column.humanName} of this ${entity.humanName}
 			 */
+			<#if (column.type == "String") >
+				@AutoEscape
+			</#if>
 			public ${column.type} get${column.methodName}(Locale locale);
 
 			/**
@@ -136,6 +139,9 @@ public interface ${entity.name}Model extends
 			 * @param useDefault whether to use the default language if no localization exists for the requested language
 			 * @return the localized ${column.humanName} of this ${entity.humanName}. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 			 */
+			<#if (column.type == "String") >
+				@AutoEscape
+			</#if>
 			public ${column.type} get${column.methodName}(Locale locale, boolean useDefault);
 
 			/**
@@ -144,6 +150,9 @@ public interface ${entity.name}Model extends
 			 * @param languageId the ID of the language
 			 * @return the localized ${column.humanName} of this ${entity.humanName}
 			 */
+			<#if (column.type == "String") >
+				@AutoEscape
+			</#if>
 			public ${column.type} get${column.methodName}(String languageId);
 
 			/**
@@ -153,6 +162,9 @@ public interface ${entity.name}Model extends
 			 * @param useDefault whether to use the default language if no localization exists for the requested language
 			 * @return the localized ${column.humanName} of this ${entity.humanName}
 			 */
+			<#if (column.type == "String") >
+				@AutoEscape
+			</#if>
 			public String get${column.methodName}(String languageId, boolean useDefault);
 
 			/**
@@ -288,8 +300,6 @@ public interface ${entity.name}Model extends
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
@@ -417,25 +417,11 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 			}
 
 			public String get${column.methodName}(String languageId) {
-				String value = LocalizationUtil.getLocalization(get${column.methodName}(), languageId);
-
-				if (isEscapedModel()) {
-					return HtmlUtil.escape(value);
-				}
-				else {
-					return value;
-				}
+				return LocalizationUtil.getLocalization(get${column.methodName}(), languageId);
 			}
 
 			public String get${column.methodName}(String languageId, boolean useDefault) {
-				String value = LocalizationUtil.getLocalization(get${column.methodName}(), languageId, useDefault);
-
-				if (isEscapedModel()) {
-					return HtmlUtil.escape(value);
-				}
-				else {
-					return value;
-				}
+				return LocalizationUtil.getLocalization(get${column.methodName}(), languageId, useDefault);
 			}
 
 			public Map<Locale, String> get${column.methodName}Map() {
@@ -625,16 +611,11 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 
 	@Override
 	public ${entity.name} toEscapedModel() {
-		if (isEscapedModel()) {
-			return (${entity.name})this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (${entity.name})ProxyUtil.newProxyInstance(_classLoader, _escapedModelProxyInterfaces, new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (${entity.name})ProxyUtil.newProxyInstance(_classLoader, _escapedModelProxyInterfaces, new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	<#if (entity.PKClassName == "long") && !stringUtil.startsWith(entity.name, "Expando")>

--- a/portal-impl/src/com/liferay/portlet/announcements/model/impl/AnnouncementsDeliveryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/model/impl/AnnouncementsDeliveryModelImpl.java
@@ -271,18 +271,13 @@ public class AnnouncementsDeliveryModelImpl extends BaseModelImpl<AnnouncementsD
 
 	@Override
 	public AnnouncementsDelivery toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AnnouncementsDelivery)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AnnouncementsDelivery)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AnnouncementsDelivery)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/announcements/model/impl/AnnouncementsEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/model/impl/AnnouncementsEntryModelImpl.java
@@ -446,18 +446,13 @@ public class AnnouncementsEntryModelImpl extends BaseModelImpl<AnnouncementsEntr
 
 	@Override
 	public AnnouncementsEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AnnouncementsEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AnnouncementsEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AnnouncementsEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/announcements/model/impl/AnnouncementsFlagModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/model/impl/AnnouncementsFlagModelImpl.java
@@ -249,18 +249,13 @@ public class AnnouncementsFlagModelImpl extends BaseModelImpl<AnnouncementsFlag>
 
 	@Override
 	public AnnouncementsFlag toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AnnouncementsFlag)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AnnouncementsFlag)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AnnouncementsFlag)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -390,26 +389,12 @@ public class AssetCategoryModelImpl extends BaseModelImpl<AssetCategory>
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -479,27 +464,12 @@ public class AssetCategoryModelImpl extends BaseModelImpl<AssetCategory>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -576,18 +546,13 @@ public class AssetCategoryModelImpl extends BaseModelImpl<AssetCategory>
 
 	@Override
 	public AssetCategory toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetCategory)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetCategory)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetCategory)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryPropertyModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetCategoryPropertyModelImpl.java
@@ -307,18 +307,13 @@ public class AssetCategoryPropertyModelImpl extends BaseModelImpl<AssetCategoryP
 
 	@Override
 	public AssetCategoryProperty toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetCategoryProperty)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetCategoryProperty)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetCategoryProperty)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetEntryModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -527,26 +526,12 @@ public class AssetEntryModelImpl extends BaseModelImpl<AssetEntry>
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -691,18 +676,13 @@ public class AssetEntryModelImpl extends BaseModelImpl<AssetEntry>
 
 	@Override
 	public AssetEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetLinkModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetLinkModelImpl.java
@@ -244,18 +244,13 @@ public class AssetLinkModelImpl extends BaseModelImpl<AssetLink>
 
 	@Override
 	public AssetLink toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetLink)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetLink)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetLink)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagModelImpl.java
@@ -285,18 +285,13 @@ public class AssetTagModelImpl extends BaseModelImpl<AssetTag>
 
 	@Override
 	public AssetTag toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetTag)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetTag)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetTag)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagPropertyModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagPropertyModelImpl.java
@@ -306,18 +306,13 @@ public class AssetTagPropertyModelImpl extends BaseModelImpl<AssetTagProperty>
 
 	@Override
 	public AssetTagProperty toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetTagProperty)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetTagProperty)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetTagProperty)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagStatsModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetTagStatsModelImpl.java
@@ -178,18 +178,13 @@ public class AssetTagStatsModelImpl extends BaseModelImpl<AssetTagStats>
 
 	@Override
 	public AssetTagStats toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetTagStats)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetTagStats)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetTagStats)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/model/impl/AssetVocabularyModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -345,26 +344,12 @@ public class AssetVocabularyModelImpl extends BaseModelImpl<AssetVocabulary>
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -434,27 +419,12 @@ public class AssetVocabularyModelImpl extends BaseModelImpl<AssetVocabulary>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -524,18 +494,13 @@ public class AssetVocabularyModelImpl extends BaseModelImpl<AssetVocabulary>
 
 	@Override
 	public AssetVocabulary toEscapedModel() {
-		if (isEscapedModel()) {
-			return (AssetVocabulary)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (AssetVocabulary)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (AssetVocabulary)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsEntryModelImpl.java
@@ -601,18 +601,13 @@ public class BlogsEntryModelImpl extends BaseModelImpl<BlogsEntry>
 
 	@Override
 	public BlogsEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (BlogsEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (BlogsEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (BlogsEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsStatsUserModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsStatsUserModelImpl.java
@@ -270,18 +270,13 @@ public class BlogsStatsUserModelImpl extends BaseModelImpl<BlogsStatsUser>
 
 	@Override
 	public BlogsStatsUser toEscapedModel() {
-		if (isEscapedModel()) {
-			return (BlogsStatsUser)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (BlogsStatsUser)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (BlogsStatsUser)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/bookmarks/model/impl/BookmarksEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/model/impl/BookmarksEntryModelImpl.java
@@ -405,18 +405,13 @@ public class BookmarksEntryModelImpl extends BaseModelImpl<BookmarksEntry>
 
 	@Override
 	public BookmarksEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (BookmarksEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (BookmarksEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (BookmarksEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/bookmarks/model/impl/BookmarksFolderModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/model/impl/BookmarksFolderModelImpl.java
@@ -368,18 +368,13 @@ public class BookmarksFolderModelImpl extends BaseModelImpl<BookmarksFolder>
 
 	@Override
 	public BookmarksFolder toEscapedModel() {
-		if (isEscapedModel()) {
-			return (BookmarksFolder)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (BookmarksFolder)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (BookmarksFolder)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/calendar/model/impl/CalEventModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/calendar/model/impl/CalEventModelImpl.java
@@ -527,18 +527,13 @@ public class CalEventModelImpl extends BaseModelImpl<CalEvent>
 
 	@Override
 	public CalEvent toEscapedModel() {
-		if (isEscapedModel()) {
-			return (CalEvent)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (CalEvent)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (CalEvent)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLContentModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLContentModelImpl.java
@@ -284,18 +284,13 @@ public class DLContentModelImpl extends BaseModelImpl<DLContent>
 
 	@Override
 	public DLContent toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLContent)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLContent)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLContent)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -393,9 +388,9 @@ public class DLContentModelImpl extends BaseModelImpl<DLContent>
 
 		dlContentModelImpl._originalVersion = dlContentModelImpl._version;
 
-		_dataBlobModel = null;
+		dlContentModelImpl._dataBlobModel = null;
 
-		_columnBitmask = 0;
+		dlContentModelImpl._columnBitmask = 0;
 	}
 
 	@Override
@@ -457,8 +452,6 @@ public class DLContentModelImpl extends BaseModelImpl<DLContent>
 		sb.append(getPath());
 		sb.append(", version=");
 		sb.append(getVersion());
-		sb.append(", data=");
-		sb.append(getData());
 		sb.append(", size=");
 		sb.append(getSize());
 		sb.append("}");
@@ -500,10 +493,6 @@ public class DLContentModelImpl extends BaseModelImpl<DLContent>
 		sb.append(
 			"<column><column-name>version</column-name><column-value><![CDATA[");
 		sb.append(getVersion());
-		sb.append("]]></column-value></column>");
-		sb.append(
-			"<column><column-name>data</column-name><column-value><![CDATA[");
-		sb.append(getData());
 		sb.append("]]></column-value></column>");
 		sb.append(
 			"<column><column-name>size</column-name><column-value><![CDATA[");

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryMetadataModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryMetadataModelImpl.java
@@ -234,18 +234,13 @@ public class DLFileEntryMetadataModelImpl extends BaseModelImpl<DLFileEntryMetad
 
 	@Override
 	public DLFileEntryMetadata toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLFileEntryMetadata)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLFileEntryMetadata)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLFileEntryMetadata)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -346,7 +341,7 @@ public class DLFileEntryMetadataModelImpl extends BaseModelImpl<DLFileEntryMetad
 
 		dlFileEntryMetadataModelImpl._setOriginalFileVersionId = false;
 
-		_columnBitmask = 0;
+		dlFileEntryMetadataModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryModelImpl.java
@@ -595,18 +595,13 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 
 	@Override
 	public DLFileEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLFileEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLFileEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLFileEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -746,7 +741,7 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 
 		dlFileEntryModelImpl._setOriginalFileEntryTypeId = false;
 
-		_columnBitmask = 0;
+		dlFileEntryModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryTypeModelImpl.java
@@ -326,18 +326,13 @@ public class DLFileEntryTypeModelImpl extends BaseModelImpl<DLFileEntryType>
 
 	@Override
 	public DLFileEntryType toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLFileEntryType)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLFileEntryType)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLFileEntryType)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -430,7 +425,7 @@ public class DLFileEntryTypeModelImpl extends BaseModelImpl<DLFileEntryType>
 
 		dlFileEntryTypeModelImpl._originalDescription = dlFileEntryTypeModelImpl._description;
 
-		_columnBitmask = 0;
+		dlFileEntryTypeModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileRankModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileRankModelImpl.java
@@ -225,18 +225,13 @@ public class DLFileRankModelImpl extends BaseModelImpl<DLFileRank>
 
 	@Override
 	public DLFileRank toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLFileRank)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLFileRank)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLFileRank)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -334,7 +329,7 @@ public class DLFileRankModelImpl extends BaseModelImpl<DLFileRank>
 
 		dlFileRankModelImpl._setOriginalFileEntryId = false;
 
-		_columnBitmask = 0;
+		dlFileRankModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutModelImpl.java
@@ -446,18 +446,13 @@ public class DLFileShortcutModelImpl extends BaseModelImpl<DLFileShortcut>
 
 	@Override
 	public DLFileShortcut toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLFileShortcut)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLFileShortcut)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLFileShortcut)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -566,7 +561,7 @@ public class DLFileShortcutModelImpl extends BaseModelImpl<DLFileShortcut>
 
 		dlFileShortcutModelImpl._setOriginalStatus = false;
 
-		_columnBitmask = 0;
+		dlFileShortcutModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
@@ -565,18 +565,13 @@ public class DLFileVersionModelImpl extends BaseModelImpl<DLFileVersion>
 
 	@Override
 	public DLFileVersion toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLFileVersion)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLFileVersion)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLFileVersion)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -704,7 +699,7 @@ public class DLFileVersionModelImpl extends BaseModelImpl<DLFileVersion>
 
 		dlFileVersionModelImpl._setOriginalStatus = false;
 
-		_columnBitmask = 0;
+		dlFileVersionModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
@@ -454,18 +454,13 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 
 	@Override
 	public DLFolder toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLFolder)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLFolder)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLFolder)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -594,7 +589,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 
 		dlFolderModelImpl._originalName = dlFolderModelImpl._name;
 
-		_columnBitmask = 0;
+		dlFolderModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLSyncModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLSyncModelImpl.java
@@ -304,18 +304,13 @@ public class DLSyncModelImpl extends BaseModelImpl<DLSync>
 
 	@Override
 	public DLSync toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DLSync)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DLSync)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DLSync)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override
@@ -440,7 +435,7 @@ public class DLSyncModelImpl extends BaseModelImpl<DLSync>
 
 		dlSyncModelImpl._setOriginalRepositoryId = false;
 
-		_columnBitmask = 0;
+		dlSyncModelImpl._columnBitmask = 0;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordModelImpl.java
@@ -383,18 +383,13 @@ public class DDLRecordModelImpl extends BaseModelImpl<DDLRecord>
 
 	@Override
 	public DDLRecord toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDLRecord)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDLRecord)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDLRecord)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordSetModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordSetModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -342,26 +341,12 @@ public class DDLRecordSetModelImpl extends BaseModelImpl<DDLRecordSet>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -431,27 +416,12 @@ public class DDLRecordSetModelImpl extends BaseModelImpl<DDLRecordSet>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -525,18 +495,13 @@ public class DDLRecordSetModelImpl extends BaseModelImpl<DDLRecordSet>
 
 	@Override
 	public DDLRecordSet toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDLRecordSet)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDLRecordSet)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDLRecordSet)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordVersionModelImpl.java
@@ -357,18 +357,13 @@ public class DDLRecordVersionModelImpl extends BaseModelImpl<DDLRecordVersion>
 
 	@Override
 	public DDLRecordVersion toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDLRecordVersion)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDLRecordVersion)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDLRecordVersion)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMContentModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMContentModelImpl.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -260,26 +259,12 @@ public class DDMContentModelImpl extends BaseModelImpl<DDMContent>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -358,18 +343,13 @@ public class DDMContentModelImpl extends BaseModelImpl<DDMContent>
 
 	@Override
 	public DDMContent toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDMContent)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDMContent)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDMContent)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStorageLinkModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStorageLinkModelImpl.java
@@ -199,18 +199,13 @@ public class DDMStorageLinkModelImpl extends BaseModelImpl<DDMStorageLink>
 
 	@Override
 	public DDMStorageLink toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDMStorageLink)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDMStorageLink)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDMStorageLink)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureLinkModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureLinkModelImpl.java
@@ -234,18 +234,13 @@ public class DDMStructureLinkModelImpl extends BaseModelImpl<DDMStructureLink>
 
 	@Override
 	public DDMStructureLink toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDMStructureLink)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDMStructureLink)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDMStructureLink)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -365,26 +364,12 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -464,27 +449,12 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -578,18 +548,13 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 
 	@Override
 	public DDMStructure toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDMStructure)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDMStructure)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDMStructure)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMTemplateModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMTemplateModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -332,26 +331,12 @@ public class DDMTemplateModelImpl extends BaseModelImpl<DDMTemplate>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -421,27 +406,12 @@ public class DDMTemplateModelImpl extends BaseModelImpl<DDMTemplate>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -559,18 +529,13 @@ public class DDMTemplateModelImpl extends BaseModelImpl<DDMTemplate>
 
 	@Override
 	public DDMTemplate toEscapedModel() {
-		if (isEscapedModel()) {
-			return (DDMTemplate)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (DDMTemplate)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (DDMTemplate)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoColumnModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoColumnModelImpl.java
@@ -256,18 +256,13 @@ public class ExpandoColumnModelImpl extends BaseModelImpl<ExpandoColumn>
 
 	@Override
 	public ExpandoColumn toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ExpandoColumn)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ExpandoColumn)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ExpandoColumn)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoRowModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoRowModelImpl.java
@@ -163,18 +163,13 @@ public class ExpandoRowModelImpl extends BaseModelImpl<ExpandoRow>
 
 	@Override
 	public ExpandoRow toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ExpandoRow)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ExpandoRow)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ExpandoRow)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoTableModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoTableModelImpl.java
@@ -189,18 +189,13 @@ public class ExpandoTableModelImpl extends BaseModelImpl<ExpandoTable>
 
 	@Override
 	public ExpandoTable toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ExpandoTable)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ExpandoTable)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ExpandoTable)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoValueModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoValueModelImpl.java
@@ -318,18 +318,13 @@ public class ExpandoValueModelImpl extends BaseModelImpl<ExpandoValue>
 
 	@Override
 	public ExpandoValue toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ExpandoValue)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ExpandoValue)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ExpandoValue)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleImageModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleImageModelImpl.java
@@ -284,18 +284,13 @@ public class JournalArticleImageModelImpl extends BaseModelImpl<JournalArticleIm
 
 	@Override
 	public JournalArticleImage toEscapedModel() {
-		if (isEscapedModel()) {
-			return (JournalArticleImage)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (JournalArticleImage)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (JournalArticleImage)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -491,26 +490,12 @@ public class JournalArticleModelImpl extends BaseModelImpl<JournalArticle>
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -604,27 +589,12 @@ public class JournalArticleModelImpl extends BaseModelImpl<JournalArticle>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -973,18 +943,13 @@ public class JournalArticleModelImpl extends BaseModelImpl<JournalArticle>
 
 	@Override
 	public JournalArticle toEscapedModel() {
-		if (isEscapedModel()) {
-			return (JournalArticle)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (JournalArticle)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (JournalArticle)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleResourceModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleResourceModelImpl.java
@@ -184,18 +184,13 @@ public class JournalArticleResourceModelImpl extends BaseModelImpl<JournalArticl
 
 	@Override
 	public JournalArticleResource toEscapedModel() {
-		if (isEscapedModel()) {
-			return (JournalArticleResource)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (JournalArticleResource)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (JournalArticleResource)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalContentSearchModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalContentSearchModelImpl.java
@@ -243,18 +243,13 @@ public class JournalContentSearchModelImpl extends BaseModelImpl<JournalContentS
 
 	@Override
 	public JournalContentSearch toEscapedModel() {
-		if (isEscapedModel()) {
-			return (JournalContentSearch)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (JournalContentSearch)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (JournalContentSearch)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalFeedModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalFeedModelImpl.java
@@ -515,18 +515,13 @@ public class JournalFeedModelImpl extends BaseModelImpl<JournalFeed>
 
 	@Override
 	public JournalFeed toEscapedModel() {
-		if (isEscapedModel()) {
-			return (JournalFeed)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (JournalFeed)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (JournalFeed)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalStructureModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalStructureModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -359,26 +358,12 @@ public class JournalStructureModelImpl extends BaseModelImpl<JournalStructure>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -448,27 +433,12 @@ public class JournalStructureModelImpl extends BaseModelImpl<JournalStructure>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -538,18 +508,13 @@ public class JournalStructureModelImpl extends BaseModelImpl<JournalStructure>
 
 	@Override
 	public JournalStructure toEscapedModel() {
-		if (isEscapedModel()) {
-			return (JournalStructure)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (JournalStructure)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (JournalStructure)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalTemplateModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalTemplateModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -370,26 +369,12 @@ public class JournalTemplateModelImpl extends BaseModelImpl<JournalTemplate>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -459,27 +444,12 @@ public class JournalTemplateModelImpl extends BaseModelImpl<JournalTemplate>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -624,18 +594,13 @@ public class JournalTemplateModelImpl extends BaseModelImpl<JournalTemplate>
 
 	@Override
 	public JournalTemplate toEscapedModel() {
-		if (isEscapedModel()) {
-			return (JournalTemplate)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (JournalTemplate)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (JournalTemplate)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBBanModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBBanModelImpl.java
@@ -291,18 +291,13 @@ public class MBBanModelImpl extends BaseModelImpl<MBBan> implements MBBanModel {
 
 	@Override
 	public MBBan toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBBan)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBBan)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBBan)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBCategoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBCategoryModelImpl.java
@@ -392,18 +392,13 @@ public class MBCategoryModelImpl extends BaseModelImpl<MBCategory>
 
 	@Override
 	public MBCategory toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBCategory)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBCategory)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBCategory)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBDiscussionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBDiscussionModelImpl.java
@@ -189,18 +189,13 @@ public class MBDiscussionModelImpl extends BaseModelImpl<MBDiscussion>
 
 	@Override
 	public MBDiscussion toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBDiscussion)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBDiscussion)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBDiscussion)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMailingListModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMailingListModelImpl.java
@@ -474,18 +474,13 @@ public class MBMailingListModelImpl extends BaseModelImpl<MBMailingList>
 
 	@Override
 	public MBMailingList toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBMailingList)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBMailingList)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBMailingList)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMessageModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMessageModelImpl.java
@@ -687,18 +687,13 @@ public class MBMessageModelImpl extends BaseModelImpl<MBMessage>
 
 	@Override
 	public MBMessage toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBMessage)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBMessage)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBMessage)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBStatsUserModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBStatsUserModelImpl.java
@@ -210,18 +210,13 @@ public class MBStatsUserModelImpl extends BaseModelImpl<MBStatsUser>
 
 	@Override
 	public MBStatsUser toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBStatsUser)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBStatsUser)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBStatsUser)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadFlagModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadFlagModelImpl.java
@@ -178,18 +178,13 @@ public class MBThreadFlagModelImpl extends BaseModelImpl<MBThreadFlag>
 
 	@Override
 	public MBThreadFlag toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBThreadFlag)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBThreadFlag)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBThreadFlag)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadModelImpl.java
@@ -479,18 +479,13 @@ public class MBThreadModelImpl extends BaseModelImpl<MBThread>
 
 	@Override
 	public MBThread toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MBThread)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MBThread)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MBThread)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRActionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRActionModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -358,26 +357,12 @@ public class MDRActionModelImpl extends BaseModelImpl<MDRAction>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -447,27 +432,12 @@ public class MDRActionModelImpl extends BaseModelImpl<MDRAction>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -551,18 +521,13 @@ public class MDRActionModelImpl extends BaseModelImpl<MDRAction>
 
 	@Override
 	public MDRAction toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MDRAction)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MDRAction)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MDRAction)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleGroupInstanceModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleGroupInstanceModelImpl.java
@@ -365,18 +365,13 @@ public class MDRRuleGroupInstanceModelImpl extends BaseModelImpl<MDRRuleGroupIns
 
 	@Override
 	public MDRRuleGroupInstance toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MDRRuleGroupInstance)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MDRRuleGroupInstance)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MDRRuleGroupInstance)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleGroupModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleGroupModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -300,26 +299,12 @@ public class MDRRuleGroupModelImpl extends BaseModelImpl<MDRRuleGroup>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -389,27 +374,12 @@ public class MDRRuleGroupModelImpl extends BaseModelImpl<MDRRuleGroup>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -465,18 +435,13 @@ public class MDRRuleGroupModelImpl extends BaseModelImpl<MDRRuleGroup>
 
 	@Override
 	public MDRRuleGroup toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MDRRuleGroup)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MDRRuleGroup)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MDRRuleGroup)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/model/impl/MDRRuleModelImpl.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -328,26 +327,12 @@ public class MDRRuleModelImpl extends BaseModelImpl<MDRRule>
 	}
 
 	public String getName(String languageId) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId);
 	}
 
 	public String getName(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getName(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getName(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getNameMap() {
@@ -417,27 +402,12 @@ public class MDRRuleModelImpl extends BaseModelImpl<MDRRule>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -521,18 +491,13 @@ public class MDRRuleModelImpl extends BaseModelImpl<MDRRule>
 
 	@Override
 	public MDRRule toEscapedModel() {
-		if (isEscapedModel()) {
-			return (MDRRule)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (MDRRule)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (MDRRule)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsChoiceModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsChoiceModelImpl.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.polls.model.impl;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -211,27 +210,12 @@ public class PollsChoiceModelImpl extends BaseModelImpl<PollsChoice>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -287,18 +271,13 @@ public class PollsChoiceModelImpl extends BaseModelImpl<PollsChoice>
 
 	@Override
 	public PollsChoice toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PollsChoice)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PollsChoice)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PollsChoice)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsQuestionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsQuestionModelImpl.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.json.JSON;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -307,26 +306,12 @@ public class PollsQuestionModelImpl extends BaseModelImpl<PollsQuestion>
 	}
 
 	public String getTitle(String languageId) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId);
 	}
 
 	public String getTitle(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getTitle(), languageId,
-				useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getTitle(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getTitleMap() {
@@ -396,27 +381,12 @@ public class PollsQuestionModelImpl extends BaseModelImpl<PollsQuestion>
 	}
 
 	public String getDescription(String languageId) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId);
 	}
 
 	public String getDescription(String languageId, boolean useDefault) {
-		String value = LocalizationUtil.getLocalization(getDescription(),
-				languageId, useDefault);
-
-		if (isEscapedModel()) {
-			return HtmlUtil.escape(value);
-		}
-		else {
-			return value;
-		}
+		return LocalizationUtil.getLocalization(getDescription(), languageId,
+			useDefault);
 	}
 
 	public Map<Locale, String> getDescriptionMap() {
@@ -490,18 +460,13 @@ public class PollsQuestionModelImpl extends BaseModelImpl<PollsQuestion>
 
 	@Override
 	public PollsQuestion toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PollsQuestion)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PollsQuestion)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PollsQuestion)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsVoteModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/model/impl/PollsVoteModelImpl.java
@@ -295,18 +295,13 @@ public class PollsVoteModelImpl extends BaseModelImpl<PollsVote>
 
 	@Override
 	public PollsVote toEscapedModel() {
-		if (isEscapedModel()) {
-			return (PollsVote)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (PollsVote)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (PollsVote)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/ratings/model/impl/RatingsEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/model/impl/RatingsEntryModelImpl.java
@@ -316,18 +316,13 @@ public class RatingsEntryModelImpl extends BaseModelImpl<RatingsEntry>
 
 	@Override
 	public RatingsEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (RatingsEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (RatingsEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (RatingsEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/ratings/model/impl/RatingsStatsModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/model/impl/RatingsStatsModelImpl.java
@@ -194,18 +194,13 @@ public class RatingsStatsModelImpl extends BaseModelImpl<RatingsStats>
 
 	@Override
 	public RatingsStats toEscapedModel() {
-		if (isEscapedModel()) {
-			return (RatingsStats)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (RatingsStats)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (RatingsStats)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingCartModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingCartModelImpl.java
@@ -261,18 +261,13 @@ public class ShoppingCartModelImpl extends BaseModelImpl<ShoppingCart>
 
 	@Override
 	public ShoppingCart toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingCart)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingCart)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingCart)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingCategoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingCategoryModelImpl.java
@@ -306,18 +306,13 @@ public class ShoppingCategoryModelImpl extends BaseModelImpl<ShoppingCategory>
 
 	@Override
 	public ShoppingCategory toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingCategory)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingCategory)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingCategory)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingCouponModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingCouponModelImpl.java
@@ -416,18 +416,13 @@ public class ShoppingCouponModelImpl extends BaseModelImpl<ShoppingCoupon>
 
 	@Override
 	public ShoppingCoupon toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingCoupon)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingCoupon)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingCoupon)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingItemFieldModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingItemFieldModelImpl.java
@@ -180,18 +180,13 @@ public class ShoppingItemFieldModelImpl extends BaseModelImpl<ShoppingItemField>
 
 	@Override
 	public ShoppingItemField toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingItemField)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingItemField)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingItemField)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingItemModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingItemModelImpl.java
@@ -698,18 +698,13 @@ public class ShoppingItemModelImpl extends BaseModelImpl<ShoppingItem>
 
 	@Override
 	public ShoppingItem toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingItem)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingItem)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingItem)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingItemPriceModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingItemPriceModelImpl.java
@@ -217,18 +217,13 @@ public class ShoppingItemPriceModelImpl extends BaseModelImpl<ShoppingItemPrice>
 
 	@Override
 	public ShoppingItemPrice toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingItemPrice)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingItemPrice)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingItemPrice)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingOrderItemModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingOrderItemModelImpl.java
@@ -237,18 +237,13 @@ public class ShoppingOrderItemModelImpl extends BaseModelImpl<ShoppingOrderItem>
 
 	@Override
 	public ShoppingOrderItem toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingOrderItem)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingOrderItem)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingOrderItem)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingOrderModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/model/impl/ShoppingOrderModelImpl.java
@@ -960,18 +960,13 @@ public class ShoppingOrderModelImpl extends BaseModelImpl<ShoppingOrder>
 
 	@Override
 	public ShoppingOrder toEscapedModel() {
-		if (isEscapedModel()) {
-			return (ShoppingOrder)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (ShoppingOrder)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (ShoppingOrder)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialActivityModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialActivityModelImpl.java
@@ -355,18 +355,13 @@ public class SocialActivityModelImpl extends BaseModelImpl<SocialActivity>
 
 	@Override
 	public SocialActivity toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialActivity)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialActivity)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialActivity)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityAssetEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityAssetEntryModelImpl.java
@@ -190,18 +190,13 @@ public class SocialEquityAssetEntryModelImpl extends BaseModelImpl<SocialEquityA
 
 	@Override
 	public SocialEquityAssetEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialEquityAssetEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialEquityAssetEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialEquityAssetEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityGroupSettingModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityGroupSettingModelImpl.java
@@ -211,18 +211,13 @@ public class SocialEquityGroupSettingModelImpl extends BaseModelImpl<SocialEquit
 
 	@Override
 	public SocialEquityGroupSetting toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialEquityGroupSetting)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialEquityGroupSetting)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialEquityGroupSetting)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityHistoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityHistoryModelImpl.java
@@ -164,18 +164,13 @@ public class SocialEquityHistoryModelImpl extends BaseModelImpl<SocialEquityHist
 
 	@Override
 	public SocialEquityHistory toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialEquityHistory)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialEquityHistory)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialEquityHistory)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityLogModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityLogModelImpl.java
@@ -324,18 +324,13 @@ public class SocialEquityLogModelImpl extends BaseModelImpl<SocialEquityLog>
 
 	@Override
 	public SocialEquityLog toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialEquityLog)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialEquityLog)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialEquityLog)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquitySettingModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquitySettingModelImpl.java
@@ -263,18 +263,13 @@ public class SocialEquitySettingModelImpl extends BaseModelImpl<SocialEquitySett
 
 	@Override
 	public SocialEquitySetting toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialEquitySetting)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialEquitySetting)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialEquitySetting)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityUserModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialEquityUserModelImpl.java
@@ -243,18 +243,13 @@ public class SocialEquityUserModelImpl extends BaseModelImpl<SocialEquityUser>
 
 	@Override
 	public SocialEquityUser toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialEquityUser)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialEquityUser)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialEquityUser)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialRelationModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialRelationModelImpl.java
@@ -234,18 +234,13 @@ public class SocialRelationModelImpl extends BaseModelImpl<SocialRelation>
 
 	@Override
 	public SocialRelation toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialRelation)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialRelation)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialRelation)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialRequestModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialRequestModelImpl.java
@@ -374,18 +374,13 @@ public class SocialRequestModelImpl extends BaseModelImpl<SocialRequest>
 
 	@Override
 	public SocialRequest toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SocialRequest)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SocialRequest)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SocialRequest)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCFrameworkVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCFrameworkVersionModelImpl.java
@@ -347,18 +347,13 @@ public class SCFrameworkVersionModelImpl extends BaseModelImpl<SCFrameworkVersio
 
 	@Override
 	public SCFrameworkVersion toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SCFrameworkVersion)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SCFrameworkVersion)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SCFrameworkVersion)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCLicenseModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCLicenseModelImpl.java
@@ -269,18 +269,13 @@ public class SCLicenseModelImpl extends BaseModelImpl<SCLicense>
 
 	@Override
 	public SCLicense toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SCLicense)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SCLicense)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SCLicense)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCProductEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCProductEntryModelImpl.java
@@ -454,18 +454,13 @@ public class SCProductEntryModelImpl extends BaseModelImpl<SCProductEntry>
 
 	@Override
 	public SCProductEntry toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SCProductEntry)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SCProductEntry)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SCProductEntry)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCProductScreenshotModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCProductScreenshotModelImpl.java
@@ -221,18 +221,13 @@ public class SCProductScreenshotModelImpl extends BaseModelImpl<SCProductScreens
 
 	@Override
 	public SCProductScreenshot toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SCProductScreenshot)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SCProductScreenshot)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SCProductScreenshot)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCProductVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/model/impl/SCProductVersionModelImpl.java
@@ -354,18 +354,13 @@ public class SCProductVersionModelImpl extends BaseModelImpl<SCProductVersion>
 
 	@Override
 	public SCProductVersion toEscapedModel() {
-		if (isEscapedModel()) {
-			return (SCProductVersion)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (SCProductVersion)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (SCProductVersion)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiNodeModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiNodeModelImpl.java
@@ -341,18 +341,13 @@ public class WikiNodeModelImpl extends BaseModelImpl<WikiNode>
 
 	@Override
 	public WikiNode toEscapedModel() {
-		if (isEscapedModel()) {
-			return (WikiNode)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (WikiNode)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (WikiNode)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageModelImpl.java
@@ -661,18 +661,13 @@ public class WikiPageModelImpl extends BaseModelImpl<WikiPage>
 
 	@Override
 	public WikiPage toEscapedModel() {
-		if (isEscapedModel()) {
-			return (WikiPage)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (WikiPage)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (WikiPage)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageResourceModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageResourceModelImpl.java
@@ -184,18 +184,13 @@ public class WikiPageResourceModelImpl extends BaseModelImpl<WikiPageResource>
 
 	@Override
 	public WikiPageResource toEscapedModel() {
-		if (isEscapedModel()) {
-			return (WikiPageResource)this;
+		if (_escapedModelProxy == null) {
+			_escapedModelProxy = (WikiPageResource)ProxyUtil.newProxyInstance(_classLoader,
+					_escapedModelProxyInterfaces,
+					new AutoEscapeBeanHandler(this));
 		}
-		else {
-			if (_escapedModelProxy == null) {
-				_escapedModelProxy = (WikiPageResource)ProxyUtil.newProxyInstance(_classLoader,
-						_escapedModelProxyInterfaces,
-						new AutoEscapeBeanHandler(this));
-			}
 
-			return _escapedModelProxy;
-		}
+		return _escapedModelProxy;
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/counter/model/CounterModel.java
+++ b/portal-service/src/com/liferay/counter/model/CounterModel.java
@@ -96,8 +96,6 @@ public interface CounterModel extends BaseModel<Counter> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/counter/model/CounterWrapper.java
+++ b/portal-service/src/com/liferay/counter/model/CounterWrapper.java
@@ -110,10 +110,6 @@ public class CounterWrapper implements Counter {
 		return _counter.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_counter.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _counter.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/AccountModel.java
+++ b/portal-service/src/com/liferay/portal/model/AccountModel.java
@@ -317,8 +317,6 @@ public interface AccountModel extends AuditedModel, BaseModel<Account> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/AccountWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/AccountWrapper.java
@@ -382,10 +382,6 @@ public class AccountWrapper implements Account {
 		return _account.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_account.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _account.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/AddressModel.java
+++ b/portal-service/src/com/liferay/portal/model/AddressModel.java
@@ -363,8 +363,6 @@ public interface AddressModel extends AttachedModel, AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/AddressWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/AddressWrapper.java
@@ -445,10 +445,6 @@ public class AddressWrapper implements Address {
 		return _address.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_address.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _address.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/BaseModel.java
+++ b/portal-service/src/com/liferay/portal/model/BaseModel.java
@@ -69,24 +69,8 @@ public interface BaseModel<T>
 	 *
 	 * @return <code>true</code> if this model instance is escaped;
 	 *         <code>false</code> otherwise
-	 * @see    #setEscapedModel(boolean)
 	 */
 	public boolean isEscapedModel();
-
-	/**
-	 * Sets whether this model instance is escaped, meaning that all strings
-	 * returned from getter methods are HTML safe.
-	 *
-	 * <p>
-	 * A model instance can be made escaped by wrapping it with an HTML auto
-	 * escape handler using its <code>toEscapedModel</code> method. For example,
-	 * {@link com.liferay.portal.model.UserModel#toEscapedModel()}.
-	 * </p>
-	 *
-	 * @param escapedModel whether this model instance is escaped
-	 * @see   com.liferay.portal.kernel.bean.AutoEscapeBeanHandler
-	 */
-	public void setEscapedModel(boolean escapedModel);
 
 	/**
 	 * Returns the primary key of this model instance.

--- a/portal-service/src/com/liferay/portal/model/BrowserTrackerModel.java
+++ b/portal-service/src/com/liferay/portal/model/BrowserTrackerModel.java
@@ -122,8 +122,6 @@ public interface BrowserTrackerModel extends BaseModel<BrowserTracker> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/BrowserTrackerWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/BrowserTrackerWrapper.java
@@ -148,10 +148,6 @@ public class BrowserTrackerWrapper implements BrowserTracker {
 		return _browserTracker.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_browserTracker.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _browserTracker.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ClassNameModel.java
+++ b/portal-service/src/com/liferay/portal/model/ClassNameModel.java
@@ -101,8 +101,6 @@ public interface ClassNameModel extends BaseModel<ClassName> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ClassNameWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ClassNameWrapper.java
@@ -119,10 +119,6 @@ public class ClassNameWrapper implements ClassName {
 		return _className.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_className.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _className.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ClusterGroupModel.java
+++ b/portal-service/src/com/liferay/portal/model/ClusterGroupModel.java
@@ -130,8 +130,6 @@ public interface ClusterGroupModel extends BaseModel<ClusterGroup> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ClusterGroupWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ClusterGroupWrapper.java
@@ -155,10 +155,6 @@ public class ClusterGroupWrapper implements ClusterGroup {
 		return _clusterGroup.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_clusterGroup.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _clusterGroup.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/CompanyModel.java
+++ b/portal-service/src/com/liferay/portal/model/CompanyModel.java
@@ -223,8 +223,6 @@ public interface CompanyModel extends BaseModel<Company> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/CompanyWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/CompanyWrapper.java
@@ -272,10 +272,6 @@ public class CompanyWrapper implements Company {
 		return _company.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_company.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _company.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ContactModel.java
+++ b/portal-service/src/com/liferay/portal/model/ContactModel.java
@@ -529,8 +529,6 @@ public interface ContactModel extends AuditedModel, BaseModel<Contact> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ContactWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ContactWrapper.java
@@ -643,10 +643,6 @@ public class ContactWrapper implements Contact {
 		return _contact.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_contact.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _contact.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/CountryModel.java
+++ b/portal-service/src/com/liferay/portal/model/CountryModel.java
@@ -196,8 +196,6 @@ public interface CountryModel extends BaseModel<Country> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/CountryWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/CountryWrapper.java
@@ -236,10 +236,6 @@ public class CountryWrapper implements Country {
 		return _country.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_country.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _country.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/EmailAddressModel.java
+++ b/portal-service/src/com/liferay/portal/model/EmailAddressModel.java
@@ -254,8 +254,6 @@ public interface EmailAddressModel extends AttachedModel, AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/EmailAddressWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/EmailAddressWrapper.java
@@ -310,10 +310,6 @@ public class EmailAddressWrapper implements EmailAddress {
 		return _emailAddress.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_emailAddress.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _emailAddress.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/GroupModel.java
+++ b/portal-service/src/com/liferay/portal/model/GroupModel.java
@@ -302,8 +302,6 @@ public interface GroupModel extends AttachedModel, BaseModel<Group> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/GroupWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/GroupWrapper.java
@@ -373,10 +373,6 @@ public class GroupWrapper implements Group {
 		return _group.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_group.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _group.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ImageModel.java
+++ b/portal-service/src/com/liferay/portal/model/ImageModel.java
@@ -167,8 +167,6 @@ public interface ImageModel extends BaseModel<Image> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ImageWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ImageWrapper.java
@@ -200,10 +200,6 @@ public class ImageWrapper implements Image {
 		return _image.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_image.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _image.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LayoutBranchModel.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutBranchModel.java
@@ -231,8 +231,6 @@ public interface LayoutBranchModel extends BaseModel<LayoutBranch> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/LayoutBranchWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutBranchWrapper.java
@@ -283,10 +283,6 @@ public class LayoutBranchWrapper implements LayoutBranch {
 		return _layoutBranch.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_layoutBranch.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _layoutBranch.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LayoutModel.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutModel.java
@@ -206,6 +206,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param locale the locale of the language
 	 * @return the localized name of this layout
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -215,6 +216,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -223,6 +225,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param languageId the ID of the language
 	 * @return the localized name of this layout
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -232,6 +235,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -293,6 +297,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param locale the locale of the language
 	 * @return the localized title of this layout
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -302,6 +307,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this layout. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -310,6 +316,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param languageId the ID of the language
 	 * @return the localized title of this layout
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -319,6 +326,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this layout
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -380,6 +388,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param locale the locale of the language
 	 * @return the localized description of this layout
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -389,6 +398,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this layout. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -397,6 +407,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param languageId the ID of the language
 	 * @return the localized description of this layout
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -406,6 +417,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this layout
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -469,6 +481,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param locale the locale of the language
 	 * @return the localized keywords of this layout
 	 */
+	@AutoEscape
 	public String getKeywords(Locale locale);
 
 	/**
@@ -478,6 +491,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized keywords of this layout. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getKeywords(Locale locale, boolean useDefault);
 
 	/**
@@ -486,6 +500,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param languageId the ID of the language
 	 * @return the localized keywords of this layout
 	 */
+	@AutoEscape
 	public String getKeywords(String languageId);
 
 	/**
@@ -495,6 +510,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized keywords of this layout
 	 */
+	@AutoEscape
 	public String getKeywords(String languageId, boolean useDefault);
 
 	/**
@@ -557,6 +573,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param locale the locale of the language
 	 * @return the localized robots of this layout
 	 */
+	@AutoEscape
 	public String getRobots(Locale locale);
 
 	/**
@@ -566,6 +583,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized robots of this layout. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getRobots(Locale locale, boolean useDefault);
 
 	/**
@@ -574,6 +592,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param languageId the ID of the language
 	 * @return the localized robots of this layout
 	 */
+	@AutoEscape
 	public String getRobots(String languageId);
 
 	/**
@@ -583,6 +602,7 @@ public interface LayoutModel extends BaseModel<Layout> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized robots of this layout
 	 */
+	@AutoEscape
 	public String getRobots(String languageId, boolean useDefault);
 
 	/**
@@ -882,8 +902,6 @@ public interface LayoutModel extends BaseModel<Layout> {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portal/model/LayoutPrototypeModel.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutPrototypeModel.java
@@ -114,6 +114,7 @@ public interface LayoutPrototypeModel extends BaseModel<LayoutPrototype> {
 	 * @param locale the locale of the language
 	 * @return the localized name of this layout prototype
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -123,6 +124,7 @@ public interface LayoutPrototypeModel extends BaseModel<LayoutPrototype> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout prototype. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -131,6 +133,7 @@ public interface LayoutPrototypeModel extends BaseModel<LayoutPrototype> {
 	 * @param languageId the ID of the language
 	 * @return the localized name of this layout prototype
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -140,6 +143,7 @@ public interface LayoutPrototypeModel extends BaseModel<LayoutPrototype> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout prototype
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -248,8 +252,6 @@ public interface LayoutPrototypeModel extends BaseModel<LayoutPrototype> {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portal/model/LayoutPrototypeWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutPrototypeWrapper.java
@@ -305,10 +305,6 @@ public class LayoutPrototypeWrapper implements LayoutPrototype {
 		return _layoutPrototype.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_layoutPrototype.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _layoutPrototype.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LayoutRevisionModel.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutRevisionModel.java
@@ -307,6 +307,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param locale the locale of the language
 	 * @return the localized name of this layout revision
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -316,6 +317,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout revision. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -324,6 +326,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param languageId the ID of the language
 	 * @return the localized name of this layout revision
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -333,6 +336,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout revision
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -394,6 +398,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param locale the locale of the language
 	 * @return the localized title of this layout revision
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -403,6 +408,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this layout revision. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -411,6 +417,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param languageId the ID of the language
 	 * @return the localized title of this layout revision
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -420,6 +427,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this layout revision
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -481,6 +489,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param locale the locale of the language
 	 * @return the localized description of this layout revision
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -490,6 +499,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this layout revision. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -498,6 +508,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this layout revision
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -507,6 +518,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this layout revision
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -570,6 +582,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param locale the locale of the language
 	 * @return the localized keywords of this layout revision
 	 */
+	@AutoEscape
 	public String getKeywords(Locale locale);
 
 	/**
@@ -579,6 +592,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized keywords of this layout revision. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getKeywords(Locale locale, boolean useDefault);
 
 	/**
@@ -587,6 +601,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param languageId the ID of the language
 	 * @return the localized keywords of this layout revision
 	 */
+	@AutoEscape
 	public String getKeywords(String languageId);
 
 	/**
@@ -596,6 +611,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized keywords of this layout revision
 	 */
+	@AutoEscape
 	public String getKeywords(String languageId, boolean useDefault);
 
 	/**
@@ -658,6 +674,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param locale the locale of the language
 	 * @return the localized robots of this layout revision
 	 */
+	@AutoEscape
 	public String getRobots(Locale locale);
 
 	/**
@@ -667,6 +684,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized robots of this layout revision. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getRobots(Locale locale, boolean useDefault);
 
 	/**
@@ -675,6 +693,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param languageId the ID of the language
 	 * @return the localized robots of this layout revision
 	 */
+	@AutoEscape
 	public String getRobots(String languageId);
 
 	/**
@@ -684,6 +703,7 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized robots of this layout revision
 	 */
+	@AutoEscape
 	public String getRobots(String languageId, boolean useDefault);
 
 	/**
@@ -971,8 +991,6 @@ public interface LayoutRevisionModel extends BaseModel<LayoutRevision>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portal/model/LayoutRevisionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutRevisionWrapper.java
@@ -1235,10 +1235,6 @@ public class LayoutRevisionWrapper implements LayoutRevision {
 		return _layoutRevision.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_layoutRevision.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _layoutRevision.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LayoutSetBranchModel.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetBranchModel.java
@@ -255,8 +255,6 @@ public interface LayoutSetBranchModel extends BaseModel<LayoutSetBranch>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/LayoutSetBranchWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetBranchWrapper.java
@@ -310,10 +310,6 @@ public class LayoutSetBranchWrapper implements LayoutSetBranch {
 		return _layoutSetBranch.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_layoutSetBranch.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _layoutSetBranch.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LayoutSetModel.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetModel.java
@@ -304,8 +304,6 @@ public interface LayoutSetModel extends BaseModel<LayoutSet> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/LayoutSetPrototypeModel.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetPrototypeModel.java
@@ -114,6 +114,7 @@ public interface LayoutSetPrototypeModel extends BaseModel<LayoutSetPrototype> {
 	 * @param locale the locale of the language
 	 * @return the localized name of this layout set prototype
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -123,6 +124,7 @@ public interface LayoutSetPrototypeModel extends BaseModel<LayoutSetPrototype> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout set prototype. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -131,6 +133,7 @@ public interface LayoutSetPrototypeModel extends BaseModel<LayoutSetPrototype> {
 	 * @param languageId the ID of the language
 	 * @return the localized name of this layout set prototype
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -140,6 +143,7 @@ public interface LayoutSetPrototypeModel extends BaseModel<LayoutSetPrototype> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this layout set prototype
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -248,8 +252,6 @@ public interface LayoutSetPrototypeModel extends BaseModel<LayoutSetPrototype> {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portal/model/LayoutSetPrototypeWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetPrototypeWrapper.java
@@ -305,10 +305,6 @@ public class LayoutSetPrototypeWrapper implements LayoutSetPrototype {
 		return _layoutSetPrototype.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_layoutSetPrototype.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _layoutSetPrototype.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LayoutSetWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetWrapper.java
@@ -373,10 +373,6 @@ public class LayoutSetWrapper implements LayoutSet {
 		return _layoutSet.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_layoutSet.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _layoutSet.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LayoutWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutWrapper.java
@@ -1117,10 +1117,6 @@ public class LayoutWrapper implements Layout {
 		return _layout.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_layout.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _layout.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ListTypeModel.java
+++ b/portal-service/src/com/liferay/portal/model/ListTypeModel.java
@@ -109,8 +109,6 @@ public interface ListTypeModel extends BaseModel<ListType> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ListTypeWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ListTypeWrapper.java
@@ -128,10 +128,6 @@ public class ListTypeWrapper implements ListType {
 		return _listType.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_listType.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _listType.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/LockModel.java
+++ b/portal-service/src/com/liferay/portal/model/LockModel.java
@@ -249,8 +249,6 @@ public interface LockModel extends BaseModel<Lock> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/LockWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LockWrapper.java
@@ -301,10 +301,6 @@ public class LockWrapper implements Lock {
 		return _lock.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_lock.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _lock.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/MembershipRequestModel.java
+++ b/portal-service/src/com/liferay/portal/model/MembershipRequestModel.java
@@ -240,8 +240,6 @@ public interface MembershipRequestModel extends BaseModel<MembershipRequest> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/MembershipRequestWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/MembershipRequestWrapper.java
@@ -294,10 +294,6 @@ public class MembershipRequestWrapper implements MembershipRequest {
 		return _membershipRequest.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_membershipRequest.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _membershipRequest.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/OrgGroupPermissionModel.java
+++ b/portal-service/src/com/liferay/portal/model/OrgGroupPermissionModel.java
@@ -107,8 +107,6 @@ public interface OrgGroupPermissionModel extends BaseModel<OrgGroupPermission> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/OrgGroupPermissionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/OrgGroupPermissionWrapper.java
@@ -129,10 +129,6 @@ public class OrgGroupPermissionWrapper implements OrgGroupPermission {
 		return _orgGroupPermission.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_orgGroupPermission.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _orgGroupPermission.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/OrgGroupRoleModel.java
+++ b/portal-service/src/com/liferay/portal/model/OrgGroupRoleModel.java
@@ -107,8 +107,6 @@ public interface OrgGroupRoleModel extends BaseModel<OrgGroupRole> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/OrgGroupRoleWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/OrgGroupRoleWrapper.java
@@ -129,10 +129,6 @@ public class OrgGroupRoleWrapper implements OrgGroupRole {
 		return _orgGroupRole.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_orgGroupRole.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _orgGroupRole.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/OrgLaborModel.java
+++ b/portal-service/src/com/liferay/portal/model/OrgLaborModel.java
@@ -302,8 +302,6 @@ public interface OrgLaborModel extends BaseModel<OrgLabor> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/OrgLaborWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/OrgLaborWrapper.java
@@ -380,10 +380,6 @@ public class OrgLaborWrapper implements OrgLabor {
 		return _orgLabor.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_orgLabor.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _orgLabor.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/OrganizationModel.java
+++ b/portal-service/src/com/liferay/portal/model/OrganizationModel.java
@@ -242,8 +242,6 @@ public interface OrganizationModel extends BaseModel<Organization> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/OrganizationWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/OrganizationWrapper.java
@@ -299,10 +299,6 @@ public class OrganizationWrapper implements Organization {
 		return _organization.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_organization.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _organization.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PasswordPolicyModel.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordPolicyModel.java
@@ -598,8 +598,6 @@ public interface PasswordPolicyModel extends AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PasswordPolicyRelModel.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordPolicyRelModel.java
@@ -128,8 +128,6 @@ public interface PasswordPolicyRelModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PasswordPolicyRelWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordPolicyRelWrapper.java
@@ -155,10 +155,6 @@ public class PasswordPolicyRelWrapper implements PasswordPolicyRel {
 		return _passwordPolicyRel.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_passwordPolicyRel.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _passwordPolicyRel.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PasswordPolicyWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordPolicyWrapper.java
@@ -751,10 +751,6 @@ public class PasswordPolicyWrapper implements PasswordPolicy {
 		return _passwordPolicy.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_passwordPolicy.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _passwordPolicy.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PasswordTrackerModel.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordTrackerModel.java
@@ -140,8 +140,6 @@ public interface PasswordTrackerModel extends BaseModel<PasswordTracker> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PasswordTrackerWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordTrackerWrapper.java
@@ -166,10 +166,6 @@ public class PasswordTrackerWrapper implements PasswordTracker {
 		return _passwordTracker.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_passwordTracker.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _passwordTracker.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PermissionModel.java
+++ b/portal-service/src/com/liferay/portal/model/PermissionModel.java
@@ -122,8 +122,6 @@ public interface PermissionModel extends BaseModel<Permission> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PermissionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PermissionWrapper.java
@@ -146,10 +146,6 @@ public class PermissionWrapper implements Permission {
 		return _permission.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_permission.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _permission.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PhoneModel.java
+++ b/portal-service/src/com/liferay/portal/model/PhoneModel.java
@@ -268,8 +268,6 @@ public interface PhoneModel extends AttachedModel, AuditedModel, BaseModel<Phone
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PhoneWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PhoneWrapper.java
@@ -328,10 +328,6 @@ public class PhoneWrapper implements Phone {
 		return _phone.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_phone.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _phone.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PluginSettingModel.java
+++ b/portal-service/src/com/liferay/portal/model/PluginSettingModel.java
@@ -159,8 +159,6 @@ public interface PluginSettingModel extends BaseModel<PluginSetting> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PluginSettingWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PluginSettingWrapper.java
@@ -191,10 +191,6 @@ public class PluginSettingWrapper implements PluginSetting {
 		return _pluginSetting.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_pluginSetting.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _pluginSetting.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PortalPreferencesModel.java
+++ b/portal-service/src/com/liferay/portal/model/PortalPreferencesModel.java
@@ -122,8 +122,6 @@ public interface PortalPreferencesModel extends BaseModel<PortalPreferences> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PortalPreferencesWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PortalPreferencesWrapper.java
@@ -146,10 +146,6 @@ public class PortalPreferencesWrapper implements PortalPreferences {
 		return _portalPreferences.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_portalPreferences.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _portalPreferences.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PortletItemModel.java
+++ b/portal-service/src/com/liferay/portal/model/PortletItemModel.java
@@ -233,8 +233,6 @@ public interface PortletItemModel extends BaseModel<PortletItem>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PortletItemWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PortletItemWrapper.java
@@ -283,10 +283,6 @@ public class PortletItemWrapper implements PortletItem {
 		return _portletItem.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_portletItem.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _portletItem.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PortletModel.java
+++ b/portal-service/src/com/liferay/portal/model/PortletModel.java
@@ -144,8 +144,6 @@ public interface PortletModel extends BaseModel<Portlet> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PortletPreferencesModel.java
+++ b/portal-service/src/com/liferay/portal/model/PortletPreferencesModel.java
@@ -151,8 +151,6 @@ public interface PortletPreferencesModel extends BaseModel<PortletPreferences> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/PortletPreferencesWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PortletPreferencesWrapper.java
@@ -182,10 +182,6 @@ public class PortletPreferencesWrapper implements PortletPreferences {
 		return _portletPreferences.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_portletPreferences.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _portletPreferences.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/PortletWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PortletWrapper.java
@@ -173,10 +173,6 @@ public class PortletWrapper implements Portlet {
 		return _portlet.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_portlet.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _portlet.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/RegionModel.java
+++ b/portal-service/src/com/liferay/portal/model/RegionModel.java
@@ -144,8 +144,6 @@ public interface RegionModel extends BaseModel<Region> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/RegionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/RegionWrapper.java
@@ -173,10 +173,6 @@ public class RegionWrapper implements Region {
 		return _region.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_region.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _region.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ReleaseModel.java
+++ b/portal-service/src/com/liferay/portal/model/ReleaseModel.java
@@ -188,8 +188,6 @@ public interface ReleaseModel extends BaseModel<Release> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ReleaseWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ReleaseWrapper.java
@@ -227,10 +227,6 @@ public class ReleaseWrapper implements Release {
 		return _release.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_release.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _release.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/RepositoryEntryModel.java
+++ b/portal-service/src/com/liferay/portal/model/RepositoryEntryModel.java
@@ -137,8 +137,6 @@ public interface RepositoryEntryModel extends BaseModel<RepositoryEntry> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/RepositoryEntryWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/RepositoryEntryWrapper.java
@@ -164,10 +164,6 @@ public class RepositoryEntryWrapper implements RepositoryEntry {
 		return _repositoryEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_repositoryEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _repositoryEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/RepositoryModel.java
+++ b/portal-service/src/com/liferay/portal/model/RepositoryModel.java
@@ -232,8 +232,6 @@ public interface RepositoryModel extends BaseModel<Repository> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/RepositoryWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/RepositoryWrapper.java
@@ -281,10 +281,6 @@ public class RepositoryWrapper implements Repository {
 		return _repository.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_repository.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _repository.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ResourceActionModel.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceActionModel.java
@@ -123,8 +123,6 @@ public interface ResourceActionModel extends BaseModel<ResourceAction> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ResourceActionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceActionWrapper.java
@@ -146,10 +146,6 @@ public class ResourceActionWrapper implements ResourceAction {
 		return _resourceAction.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_resourceAction.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _resourceAction.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ResourceBlockModel.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceBlockModel.java
@@ -151,8 +151,6 @@ public interface ResourceBlockModel extends BaseModel<ResourceBlock> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ResourceBlockPermissionModel.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceBlockPermissionModel.java
@@ -120,8 +120,6 @@ public interface ResourceBlockPermissionModel extends BaseModel<ResourceBlockPer
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ResourceBlockPermissionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceBlockPermissionWrapper.java
@@ -147,10 +147,6 @@ public class ResourceBlockPermissionWrapper implements ResourceBlockPermission {
 		return _resourceBlockPermission.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_resourceBlockPermission.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _resourceBlockPermission.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ResourceBlockWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceBlockWrapper.java
@@ -182,10 +182,6 @@ public class ResourceBlockWrapper implements ResourceBlock {
 		return _resourceBlock.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_resourceBlock.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _resourceBlock.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ResourceCodeModel.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceCodeModel.java
@@ -122,8 +122,6 @@ public interface ResourceCodeModel extends BaseModel<ResourceCode> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ResourceCodeWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceCodeWrapper.java
@@ -146,10 +146,6 @@ public class ResourceCodeWrapper implements ResourceCode {
 		return _resourceCode.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_resourceCode.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _resourceCode.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ResourceModel.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceModel.java
@@ -108,8 +108,6 @@ public interface ResourceModel extends BaseModel<Resource> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ResourcePermissionModel.java
+++ b/portal-service/src/com/liferay/portal/model/ResourcePermissionModel.java
@@ -179,8 +179,6 @@ public interface ResourcePermissionModel extends BaseModel<ResourcePermission> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ResourcePermissionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ResourcePermissionWrapper.java
@@ -218,10 +218,6 @@ public class ResourcePermissionWrapper implements ResourcePermission {
 		return _resourcePermission.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_resourcePermission.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _resourcePermission.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ResourceTypePermissionModel.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceTypePermissionModel.java
@@ -150,8 +150,6 @@ public interface ResourceTypePermissionModel extends BaseModel<ResourceTypePermi
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ResourceTypePermissionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceTypePermissionWrapper.java
@@ -183,10 +183,6 @@ public class ResourceTypePermissionWrapper implements ResourceTypePermission {
 		return _resourceTypePermission.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_resourceTypePermission.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _resourceTypePermission.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ResourceWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceWrapper.java
@@ -128,10 +128,6 @@ public class ResourceWrapper implements Resource {
 		return _resource.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_resource.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _resource.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/RoleModel.java
+++ b/portal-service/src/com/liferay/portal/model/RoleModel.java
@@ -149,6 +149,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param locale the locale of the language
 	 * @return the localized title of this role
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -158,6 +159,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this role. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -166,6 +168,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param languageId the ID of the language
 	 * @return the localized title of this role
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -175,6 +178,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this role
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -236,6 +240,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param locale the locale of the language
 	 * @return the localized description of this role
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -245,6 +250,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this role. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -253,6 +259,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param languageId the ID of the language
 	 * @return the localized description of this role
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -262,6 +269,7 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this role
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -350,8 +358,6 @@ public interface RoleModel extends AttachedModel, BaseModel<Role> {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portal/model/RoleWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/RoleWrapper.java
@@ -439,10 +439,6 @@ public class RoleWrapper implements Role {
 		return _role.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_role.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _role.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ServiceComponentModel.java
+++ b/portal-service/src/com/liferay/portal/model/ServiceComponentModel.java
@@ -137,8 +137,6 @@ public interface ServiceComponentModel extends BaseModel<ServiceComponent> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ServiceComponentWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ServiceComponentWrapper.java
@@ -164,10 +164,6 @@ public class ServiceComponentWrapper implements ServiceComponent {
 		return _serviceComponent.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_serviceComponent.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _serviceComponent.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/ShardModel.java
+++ b/portal-service/src/com/liferay/portal/model/ShardModel.java
@@ -129,8 +129,6 @@ public interface ShardModel extends AttachedModel, BaseModel<Shard> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/ShardWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/ShardWrapper.java
@@ -155,10 +155,6 @@ public class ShardWrapper implements Shard {
 		return _shard.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shard.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shard.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/SubscriptionModel.java
+++ b/portal-service/src/com/liferay/portal/model/SubscriptionModel.java
@@ -219,8 +219,6 @@ public interface SubscriptionModel extends AttachedModel, AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/SubscriptionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/SubscriptionWrapper.java
@@ -265,10 +265,6 @@ public class SubscriptionWrapper implements Subscription {
 		return _subscription.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_subscription.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _subscription.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/TeamModel.java
+++ b/portal-service/src/com/liferay/portal/model/TeamModel.java
@@ -212,8 +212,6 @@ public interface TeamModel extends BaseModel<Team>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/TeamWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/TeamWrapper.java
@@ -256,10 +256,6 @@ public class TeamWrapper implements Team {
 		return _team.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_team.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _team.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/TicketModel.java
+++ b/portal-service/src/com/liferay/portal/model/TicketModel.java
@@ -202,8 +202,6 @@ public interface TicketModel extends AttachedModel, BaseModel<Ticket> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/TicketWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/TicketWrapper.java
@@ -245,10 +245,6 @@ public class TicketWrapper implements Ticket {
 		return _ticket.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ticket.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ticket.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserGroupGroupRoleModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupGroupRoleModel.java
@@ -107,8 +107,6 @@ public interface UserGroupGroupRoleModel extends BaseModel<UserGroupGroupRole> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserGroupGroupRoleWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupGroupRoleWrapper.java
@@ -129,10 +129,6 @@ public class UserGroupGroupRoleWrapper implements UserGroupGroupRole {
 		return _userGroupGroupRole.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_userGroupGroupRole.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _userGroupGroupRole.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserGroupModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupModel.java
@@ -186,8 +186,6 @@ public interface UserGroupModel extends BaseModel<UserGroup> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserGroupRoleModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupRoleModel.java
@@ -123,8 +123,6 @@ public interface UserGroupRoleModel extends BaseModel<UserGroupRole> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserGroupRoleWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupRoleWrapper.java
@@ -149,10 +149,6 @@ public class UserGroupRoleWrapper implements UserGroupRole {
 		return _userGroupRole.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_userGroupRole.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _userGroupRole.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserGroupWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupWrapper.java
@@ -227,10 +227,6 @@ public class UserGroupWrapper implements UserGroup {
 		return _userGroup.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_userGroup.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _userGroup.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserIdMapperModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserIdMapperModel.java
@@ -154,8 +154,6 @@ public interface UserIdMapperModel extends BaseModel<UserIdMapper> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserIdMapperWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserIdMapperWrapper.java
@@ -184,10 +184,6 @@ public class UserIdMapperWrapper implements UserIdMapper {
 		return _userIdMapper.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_userIdMapper.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _userIdMapper.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserModel.java
@@ -689,8 +689,6 @@ public interface UserModel extends BaseModel<User> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserNotificationEventModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationEventModel.java
@@ -217,8 +217,6 @@ public interface UserNotificationEventModel extends BaseModel<UserNotificationEv
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserNotificationEventWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationEventWrapper.java
@@ -266,10 +266,6 @@ public class UserNotificationEventWrapper implements UserNotificationEvent {
 		return _userNotificationEvent.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_userNotificationEvent.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _userNotificationEvent.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserTrackerModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserTrackerModel.java
@@ -199,8 +199,6 @@ public interface UserTrackerModel extends BaseModel<UserTracker> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserTrackerPathModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserTrackerPathModel.java
@@ -124,8 +124,6 @@ public interface UserTrackerPathModel extends BaseModel<UserTrackerPath> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/UserTrackerPathWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserTrackerPathWrapper.java
@@ -146,10 +146,6 @@ public class UserTrackerPathWrapper implements UserTrackerPath {
 		return _userTrackerPath.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_userTrackerPath.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _userTrackerPath.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserTrackerWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserTrackerWrapper.java
@@ -238,10 +238,6 @@ public class UserTrackerWrapper implements UserTracker {
 		return _userTracker.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_userTracker.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _userTracker.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/UserWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserWrapper.java
@@ -850,10 +850,6 @@ public class UserWrapper implements User {
 		return _user.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_user.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _user.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/VirtualHostModel.java
+++ b/portal-service/src/com/liferay/portal/model/VirtualHostModel.java
@@ -122,8 +122,6 @@ public interface VirtualHostModel extends BaseModel<VirtualHost> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/VirtualHostWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/VirtualHostWrapper.java
@@ -146,10 +146,6 @@ public class VirtualHostWrapper implements VirtualHost {
 		return _virtualHost.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_virtualHost.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _virtualHost.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/WebDAVPropsModel.java
+++ b/portal-service/src/com/liferay/portal/model/WebDAVPropsModel.java
@@ -173,8 +173,6 @@ public interface WebDAVPropsModel extends AttachedModel, BaseModel<WebDAVProps> 
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/WebDAVPropsWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/WebDAVPropsWrapper.java
@@ -209,10 +209,6 @@ public class WebDAVPropsWrapper implements WebDAVProps {
 		return _webDAVProps.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_webDAVProps.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _webDAVProps.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/WebsiteModel.java
+++ b/portal-service/src/com/liferay/portal/model/WebsiteModel.java
@@ -254,8 +254,6 @@ public interface WebsiteModel extends AttachedModel, AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/WebsiteWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/WebsiteWrapper.java
@@ -310,10 +310,6 @@ public class WebsiteWrapper implements Website {
 		return _website.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_website.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _website.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/WorkflowDefinitionLinkModel.java
+++ b/portal-service/src/com/liferay/portal/model/WorkflowDefinitionLinkModel.java
@@ -261,8 +261,6 @@ public interface WorkflowDefinitionLinkModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/WorkflowDefinitionLinkWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/WorkflowDefinitionLinkWrapper.java
@@ -321,10 +321,6 @@ public class WorkflowDefinitionLinkWrapper implements WorkflowDefinitionLink {
 		return _workflowDefinitionLink.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_workflowDefinitionLink.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _workflowDefinitionLink.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/WorkflowInstanceLinkModel.java
+++ b/portal-service/src/com/liferay/portal/model/WorkflowInstanceLinkModel.java
@@ -232,8 +232,6 @@ public interface WorkflowInstanceLinkModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portal/model/WorkflowInstanceLinkWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/WorkflowInstanceLinkWrapper.java
@@ -284,10 +284,6 @@ public class WorkflowInstanceLinkWrapper implements WorkflowInstanceLink {
 		return _workflowInstanceLink.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_workflowInstanceLink.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _workflowInstanceLink.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portal/model/impl/BaseModelImpl.java
+++ b/portal-service/src/com/liferay/portal/model/impl/BaseModelImpl.java
@@ -47,11 +47,7 @@ public abstract class BaseModelImpl<T> implements BaseModel<T> {
 	}
 
 	public boolean isEscapedModel() {
-		return _escapedModel;
-	}
-
-	public void setEscapedModel(boolean escapedModel) {
-		_escapedModel = escapedModel;
+		return false;
 	}
 
 	public ExpandoBridge getExpandoBridge() {
@@ -78,6 +74,5 @@ public abstract class BaseModelImpl<T> implements BaseModel<T> {
 
 	private boolean _new;
 	private boolean _cachedModel;
-	private boolean _escapedModel;
 
 }

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsDeliveryModel.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsDeliveryModel.java
@@ -203,8 +203,6 @@ public interface AnnouncementsDeliveryModel extends BaseModel<AnnouncementsDeliv
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsDeliveryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsDeliveryWrapper.java
@@ -248,10 +248,6 @@ public class AnnouncementsDeliveryWrapper implements AnnouncementsDelivery {
 		return _announcementsDelivery.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_announcementsDelivery.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _announcementsDelivery.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsEntryModel.java
@@ -346,8 +346,6 @@ public interface AnnouncementsEntryModel extends AttachedModel, AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsEntryWrapper.java
@@ -418,10 +418,6 @@ public class AnnouncementsEntryWrapper implements AnnouncementsEntry {
 		return _announcementsEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_announcementsEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _announcementsEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsFlagModel.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsFlagModel.java
@@ -154,8 +154,6 @@ public interface AnnouncementsFlagModel extends BaseModel<AnnouncementsFlag> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsFlagWrapper.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsFlagWrapper.java
@@ -184,10 +184,6 @@ public class AnnouncementsFlagWrapper implements AnnouncementsFlag {
 		return _announcementsFlag.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_announcementsFlag.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _announcementsFlag.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryModel.java
@@ -263,6 +263,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param locale the locale of the language
 	 * @return the localized title of this asset category
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -272,6 +273,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this asset category. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -280,6 +282,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param languageId the ID of the language
 	 * @return the localized title of this asset category
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -289,6 +292,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this asset category
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -350,6 +354,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param locale the locale of the language
 	 * @return the localized description of this asset category
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -359,6 +364,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this asset category. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -367,6 +373,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this asset category
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -376,6 +383,7 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this asset category
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -449,8 +457,6 @@ public interface AssetCategoryModel extends BaseModel<AssetCategory>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryPropertyModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryPropertyModel.java
@@ -216,8 +216,6 @@ public interface AssetCategoryPropertyModel extends AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryPropertyWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryPropertyWrapper.java
@@ -257,10 +257,6 @@ public class AssetCategoryPropertyWrapper implements AssetCategoryProperty {
 		return _assetCategoryProperty.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetCategoryProperty.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetCategoryProperty.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryWrapper.java
@@ -558,10 +558,6 @@ public class AssetCategoryWrapper implements AssetCategory {
 		return _assetCategory.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetCategory.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetCategory.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetEntryModel.java
@@ -348,6 +348,7 @@ public interface AssetEntryModel extends AttachedModel, BaseModel<AssetEntry>,
 	 * @param locale the locale of the language
 	 * @return the localized title of this asset entry
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -357,6 +358,7 @@ public interface AssetEntryModel extends AttachedModel, BaseModel<AssetEntry>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this asset entry. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -365,6 +367,7 @@ public interface AssetEntryModel extends AttachedModel, BaseModel<AssetEntry>,
 	 * @param languageId the ID of the language
 	 * @return the localized title of this asset entry
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -374,6 +377,7 @@ public interface AssetEntryModel extends AttachedModel, BaseModel<AssetEntry>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this asset entry
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -547,8 +551,6 @@ public interface AssetEntryModel extends AttachedModel, BaseModel<AssetEntry>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetEntryWrapper.java
@@ -676,10 +676,6 @@ public class AssetEntryWrapper implements AssetEntry {
 		return _assetEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetLinkModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetLinkModel.java
@@ -212,8 +212,6 @@ public interface AssetLinkModel extends BaseModel<AssetLink> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetLinkWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetLinkWrapper.java
@@ -256,10 +256,6 @@ public class AssetLinkWrapper implements AssetLink {
 		return _assetLink.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetLink.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetLink.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTagModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTagModel.java
@@ -214,8 +214,6 @@ public interface AssetTagModel extends BaseModel<AssetTag>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTagPropertyModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTagPropertyModel.java
@@ -216,8 +216,6 @@ public interface AssetTagPropertyModel extends AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTagPropertyWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTagPropertyWrapper.java
@@ -256,10 +256,6 @@ public class AssetTagPropertyWrapper implements AssetTagProperty {
 		return _assetTagProperty.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetTagProperty.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetTagProperty.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTagStatsModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTagStatsModel.java
@@ -129,8 +129,6 @@ public interface AssetTagStatsModel extends BaseModel<AssetTagStats> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTagStatsWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTagStatsWrapper.java
@@ -155,10 +155,6 @@ public class AssetTagStatsWrapper implements AssetTagStats {
 		return _assetTagStats.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetTagStats.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetTagStats.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTagWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTagWrapper.java
@@ -256,10 +256,6 @@ public class AssetTagWrapper implements AssetTag {
 		return _assetTag.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetTag.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetTag.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetVocabularyModel.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetVocabularyModel.java
@@ -221,6 +221,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param locale the locale of the language
 	 * @return the localized title of this asset vocabulary
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -230,6 +231,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this asset vocabulary. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -238,6 +240,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param languageId the ID of the language
 	 * @return the localized title of this asset vocabulary
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -247,6 +250,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this asset vocabulary
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -308,6 +312,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param locale the locale of the language
 	 * @return the localized description of this asset vocabulary
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -317,6 +322,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this asset vocabulary. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -325,6 +331,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this asset vocabulary
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -334,6 +341,7 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this asset vocabulary
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -408,8 +416,6 @@ public interface AssetVocabularyModel extends BaseModel<AssetVocabulary>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetVocabularyWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetVocabularyWrapper.java
@@ -504,10 +504,6 @@ public class AssetVocabularyWrapper implements AssetVocabulary {
 		return _assetVocabulary.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_assetVocabulary.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _assetVocabulary.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/blogs/model/BlogsEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/blogs/model/BlogsEntryModel.java
@@ -488,8 +488,6 @@ public interface BlogsEntryModel extends BaseModel<BlogsEntry>, GroupedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/blogs/model/BlogsEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/blogs/model/BlogsEntryWrapper.java
@@ -598,10 +598,6 @@ public class BlogsEntryWrapper implements BlogsEntry {
 		return _blogsEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_blogsEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _blogsEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/blogs/model/BlogsStatsUserModel.java
+++ b/portal-service/src/com/liferay/portlet/blogs/model/BlogsStatsUserModel.java
@@ -225,8 +225,6 @@ public interface BlogsStatsUserModel extends BaseModel<BlogsStatsUser> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/blogs/model/BlogsStatsUserWrapper.java
+++ b/portal-service/src/com/liferay/portlet/blogs/model/BlogsStatsUserWrapper.java
@@ -276,10 +276,6 @@ public class BlogsStatsUserWrapper implements BlogsStatsUser {
 		return _blogsStatsUser.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_blogsStatsUser.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _blogsStatsUser.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksEntryModel.java
@@ -302,8 +302,6 @@ public interface BookmarksEntryModel extends BaseModel<BookmarksEntry>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksEntryWrapper.java
@@ -364,10 +364,6 @@ public class BookmarksEntryWrapper implements BookmarksEntry {
 		return _bookmarksEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_bookmarksEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _bookmarksEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksFolderModel.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksFolderModel.java
@@ -259,8 +259,6 @@ public interface BookmarksFolderModel extends BaseModel<BookmarksFolder>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksFolderWrapper.java
+++ b/portal-service/src/com/liferay/portlet/bookmarks/model/BookmarksFolderWrapper.java
@@ -310,10 +310,6 @@ public class BookmarksFolderWrapper implements BookmarksFolder {
 		return _bookmarksFolder.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_bookmarksFolder.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _bookmarksFolder.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/calendar/model/CalEventModel.java
+++ b/portal-service/src/com/liferay/portlet/calendar/model/CalEventModel.java
@@ -435,8 +435,6 @@ public interface CalEventModel extends BaseModel<CalEvent>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/calendar/model/CalEventWrapper.java
+++ b/portal-service/src/com/liferay/portlet/calendar/model/CalEventWrapper.java
@@ -535,10 +535,6 @@ public class CalEventWrapper implements CalEvent {
 		return _calEvent.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_calEvent.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _calEvent.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLContentModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLContentModel.java
@@ -198,8 +198,6 @@ public interface DLContentModel extends BaseModel<DLContent> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLContentWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLContentWrapper.java
@@ -236,10 +236,6 @@ public class DLContentWrapper implements DLContent {
 		return _dlContent.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlContent.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlContent.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryMetadataModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryMetadataModel.java
@@ -166,8 +166,6 @@ public interface DLFileEntryMetadataModel extends BaseModel<DLFileEntryMetadata>
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryMetadataWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryMetadataWrapper.java
@@ -200,10 +200,6 @@ public class DLFileEntryMetadataWrapper implements DLFileEntryMetadata {
 		return _dlFileEntryMetadata.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlFileEntryMetadata.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlFileEntryMetadata.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryModel.java
@@ -475,8 +475,6 @@ public interface DLFileEntryModel extends BaseModel<DLFileEntry>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryTypeModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryTypeModel.java
@@ -216,8 +216,6 @@ public interface DLFileEntryTypeModel extends BaseModel<DLFileEntryType>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryTypeWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryTypeWrapper.java
@@ -256,10 +256,6 @@ public class DLFileEntryTypeWrapper implements DLFileEntryType {
 		return _dlFileEntryType.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlFileEntryType.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlFileEntryType.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryWrapper.java
@@ -582,10 +582,6 @@ public class DLFileEntryWrapper implements DLFileEntry {
 		return _dlFileEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlFileEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlFileEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileRankModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileRankModel.java
@@ -168,8 +168,6 @@ public interface DLFileRankModel extends BaseModel<DLFileRank> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileRankWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileRankWrapper.java
@@ -202,10 +202,6 @@ public class DLFileRankWrapper implements DLFileRank {
 		return _dlFileRank.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlFileRank.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlFileRank.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcutModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcutModel.java
@@ -349,8 +349,6 @@ public interface DLFileShortcutModel extends BaseModel<DLFileShortcut>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcutWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcutWrapper.java
@@ -427,10 +427,6 @@ public class DLFileShortcutWrapper implements DLFileShortcut {
 		return _dlFileShortcut.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlFileShortcut.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlFileShortcut.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersionModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersionModel.java
@@ -494,8 +494,6 @@ public interface DLFileVersionModel extends BaseModel<DLFileVersion>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersionWrapper.java
@@ -607,10 +607,6 @@ public class DLFileVersionWrapper implements DLFileVersion {
 		return _dlFileVersion.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlFileVersion.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlFileVersion.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderModel.java
@@ -328,8 +328,6 @@ public interface DLFolderModel extends BaseModel<DLFolder>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
@@ -400,10 +400,6 @@ public class DLFolderWrapper implements DLFolder {
 		return _dlFolder.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlFolder.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlFolder.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLSyncModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLSyncModel.java
@@ -197,8 +197,6 @@ public interface DLSyncModel extends BaseModel<DLSync> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLSyncWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLSyncWrapper.java
@@ -236,10 +236,6 @@ public class DLSyncWrapper implements DLSync {
 		return _dlSync.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_dlSync.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _dlSync.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordModel.java
@@ -301,8 +301,6 @@ public interface DDLRecordModel extends BaseModel<DDLRecord>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordSetModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordSetModel.java
@@ -233,6 +233,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param locale the locale of the language
 	 * @return the localized name of this d d l record set
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -242,6 +243,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d l record set. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -250,6 +252,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param languageId the ID of the language
 	 * @return the localized name of this d d l record set
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -259,6 +262,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d l record set
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -320,6 +324,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param locale the locale of the language
 	 * @return the localized description of this d d l record set
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -329,6 +334,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this d d l record set. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -337,6 +343,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param languageId the ID of the language
 	 * @return the localized description of this d d l record set
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -346,6 +353,7 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this d d l record set
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -433,8 +441,6 @@ public interface DDLRecordSetModel extends BaseModel<DDLRecordSet>, GroupedModel
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordSetWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordSetWrapper.java
@@ -540,10 +540,6 @@ public class DDLRecordSetWrapper implements DDLRecordSet {
 		return _ddlRecordSet.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddlRecordSet.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddlRecordSet.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordVersionModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordVersionModel.java
@@ -348,8 +348,6 @@ public interface DDLRecordVersionModel extends BaseModel<DDLRecordVersion>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordVersionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordVersionWrapper.java
@@ -427,10 +427,6 @@ public class DDLRecordVersionWrapper implements DDLRecordVersion {
 		return _ddlRecordVersion.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddlRecordVersion.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddlRecordVersion.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatalists/model/DDLRecordWrapper.java
@@ -366,10 +366,6 @@ public class DDLRecordWrapper implements DDLRecord {
 		return _ddlRecord.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddlRecord.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddlRecord.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMContentModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMContentModel.java
@@ -205,6 +205,7 @@ public interface DDMContentModel extends BaseModel<DDMContent>, GroupedModel {
 	 * @param locale the locale of the language
 	 * @return the localized name of this d d m content
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -214,6 +215,7 @@ public interface DDMContentModel extends BaseModel<DDMContent>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d m content. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -222,6 +224,7 @@ public interface DDMContentModel extends BaseModel<DDMContent>, GroupedModel {
 	 * @param languageId the ID of the language
 	 * @return the localized name of this d d m content
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -231,6 +234,7 @@ public interface DDMContentModel extends BaseModel<DDMContent>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d m content
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -318,8 +322,6 @@ public interface DDMContentModel extends BaseModel<DDMContent>, GroupedModel {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMContentWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMContentWrapper.java
@@ -388,10 +388,6 @@ public class DDMContentWrapper implements DDMContent {
 		return _ddmContent.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddmContent.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddmContent.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStorageLinkModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStorageLinkModel.java
@@ -147,8 +147,6 @@ public interface DDMStorageLinkModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStorageLinkWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStorageLinkWrapper.java
@@ -173,10 +173,6 @@ public class DDMStorageLinkWrapper implements DDMStorageLink {
 		return _ddmStorageLink.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddmStorageLink.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddmStorageLink.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureLinkModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureLinkModel.java
@@ -131,8 +131,6 @@ public interface DDMStructureLinkModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureLinkWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureLinkWrapper.java
@@ -155,10 +155,6 @@ public class DDMStructureLinkWrapper implements DDMStructureLink {
 		return _ddmStructureLink.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddmStructureLink.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddmStructureLink.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureModel.java
@@ -240,6 +240,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param locale the locale of the language
 	 * @return the localized name of this d d m structure
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -249,6 +250,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d m structure. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -257,6 +259,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param languageId the ID of the language
 	 * @return the localized name of this d d m structure
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -266,6 +269,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d m structure
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -327,6 +331,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param locale the locale of the language
 	 * @return the localized description of this d d m structure
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -336,6 +341,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this d d m structure. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -344,6 +350,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param languageId the ID of the language
 	 * @return the localized description of this d d m structure
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -353,6 +360,7 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this d d m structure
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -442,8 +450,6 @@ public interface DDMStructureModel extends BaseModel<DDMStructure>, GroupedModel
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMStructureWrapper.java
@@ -549,10 +549,6 @@ public class DDMStructureWrapper implements DDMStructure {
 		return _ddmStructure.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddmStructure.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddmStructure.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMTemplateModel.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMTemplateModel.java
@@ -219,6 +219,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param locale the locale of the language
 	 * @return the localized name of this d d m template
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -228,6 +229,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d m template. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -236,6 +238,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param languageId the ID of the language
 	 * @return the localized name of this d d m template
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -245,6 +248,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this d d m template
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -306,6 +310,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param locale the locale of the language
 	 * @return the localized description of this d d m template
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -315,6 +320,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this d d m template. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -323,6 +329,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param languageId the ID of the language
 	 * @return the localized description of this d d m template
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -332,6 +339,7 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this d d m template
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -436,8 +444,6 @@ public interface DDMTemplateModel extends BaseModel<DDMTemplate>, GroupedModel {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMTemplateWrapper.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/model/DDMTemplateWrapper.java
@@ -540,10 +540,6 @@ public class DDMTemplateWrapper implements DDMTemplate {
 		return _ddmTemplate.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ddmTemplate.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ddmTemplate.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoColumnModel.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoColumnModel.java
@@ -166,8 +166,6 @@ public interface ExpandoColumnModel extends BaseModel<ExpandoColumn> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoColumnWrapper.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoColumnWrapper.java
@@ -200,10 +200,6 @@ public class ExpandoColumnWrapper implements ExpandoColumn {
 		return _expandoColumn.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_expandoColumn.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _expandoColumn.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoRowModel.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoRowModel.java
@@ -120,8 +120,6 @@ public interface ExpandoRowModel extends BaseModel<ExpandoRow> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoRowWrapper.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoRowWrapper.java
@@ -146,10 +146,6 @@ public class ExpandoRowWrapper implements ExpandoRow {
 		return _expandoRow.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_expandoRow.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _expandoRow.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoTableModel.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoTableModel.java
@@ -129,8 +129,6 @@ public interface ExpandoTableModel extends BaseModel<ExpandoTable> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoTableWrapper.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoTableWrapper.java
@@ -155,10 +155,6 @@ public class ExpandoTableWrapper implements ExpandoTable {
 		return _expandoTable.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_expandoTable.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _expandoTable.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoValueModel.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoValueModel.java
@@ -186,8 +186,6 @@ public interface ExpandoValueModel extends AttachedModel, BaseModel<ExpandoValue
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoValueWrapper.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoValueWrapper.java
@@ -227,10 +227,6 @@ public class ExpandoValueWrapper implements ExpandoValue {
 		return _expandoValue.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_expandoValue.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _expandoValue.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalArticleImageModel.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalArticleImageModel.java
@@ -190,8 +190,6 @@ public interface JournalArticleImageModel extends BaseModel<JournalArticleImage>
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalArticleImageWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalArticleImageWrapper.java
@@ -227,10 +227,6 @@ public class JournalArticleImageWrapper implements JournalArticleImage {
 		return _journalArticleImage.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_journalArticleImage.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _journalArticleImage.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalArticleModel.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalArticleModel.java
@@ -288,6 +288,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param locale the locale of the language
 	 * @return the localized title of this journal article
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -297,6 +298,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this journal article. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -305,6 +307,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param languageId the ID of the language
 	 * @return the localized title of this journal article
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -314,6 +317,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this journal article
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -390,6 +394,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param locale the locale of the language
 	 * @return the localized description of this journal article
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -399,6 +404,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this journal article. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -407,6 +413,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this journal article
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -416,6 +423,7 @@ public interface JournalArticleModel extends AttachedModel,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this journal article
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -766,8 +774,6 @@ public interface JournalArticleModel extends AttachedModel,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalArticleResourceModel.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalArticleResourceModel.java
@@ -125,8 +125,6 @@ public interface JournalArticleResourceModel extends BaseModel<JournalArticleRes
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalArticleResourceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalArticleResourceWrapper.java
@@ -147,10 +147,6 @@ public class JournalArticleResourceWrapper implements JournalArticleResource {
 		return _journalArticleResource.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_journalArticleResource.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _journalArticleResource.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalArticleWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalArticleWrapper.java
@@ -958,10 +958,6 @@ public class JournalArticleWrapper implements JournalArticle {
 		return _journalArticle.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_journalArticle.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _journalArticle.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalContentSearchModel.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalContentSearchModel.java
@@ -174,8 +174,6 @@ public interface JournalContentSearchModel extends BaseModel<JournalContentSearc
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalContentSearchWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalContentSearchWrapper.java
@@ -210,10 +210,6 @@ public class JournalContentSearchWrapper implements JournalContentSearch {
 		return _journalContentSearch.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_journalContentSearch.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _journalContentSearch.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalFeedModel.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalFeedModel.java
@@ -420,8 +420,6 @@ public interface JournalFeedModel extends BaseModel<JournalFeed>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalFeedWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalFeedWrapper.java
@@ -509,10 +509,6 @@ public class JournalFeedWrapper implements JournalFeed {
 		return _journalFeed.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_journalFeed.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _journalFeed.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalStructureModel.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalStructureModel.java
@@ -235,6 +235,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param locale the locale of the language
 	 * @return the localized name of this journal structure
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -244,6 +245,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this journal structure. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -252,6 +254,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param languageId the ID of the language
 	 * @return the localized name of this journal structure
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -261,6 +264,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this journal structure
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -322,6 +326,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param locale the locale of the language
 	 * @return the localized description of this journal structure
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -331,6 +336,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this journal structure. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -339,6 +345,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this journal structure
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -348,6 +355,7 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this journal structure
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -422,8 +430,6 @@ public interface JournalStructureModel extends BaseModel<JournalStructure>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalStructureWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalStructureWrapper.java
@@ -522,10 +522,6 @@ public class JournalStructureWrapper implements JournalStructure {
 		return _journalStructure.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_journalStructure.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _journalStructure.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalTemplateModel.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalTemplateModel.java
@@ -234,6 +234,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param locale the locale of the language
 	 * @return the localized name of this journal template
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -243,6 +244,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this journal template. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -251,6 +253,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param languageId the ID of the language
 	 * @return the localized name of this journal template
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -260,6 +263,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this journal template
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -321,6 +325,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param locale the locale of the language
 	 * @return the localized description of this journal template
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -330,6 +335,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this journal template. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -338,6 +344,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this journal template
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -347,6 +354,7 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this journal template
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -507,8 +515,6 @@ public interface JournalTemplateModel extends BaseModel<JournalTemplate>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/journal/model/JournalTemplateWrapper.java
+++ b/portal-service/src/com/liferay/portlet/journal/model/JournalTemplateWrapper.java
@@ -630,10 +630,6 @@ public class JournalTemplateWrapper implements JournalTemplate {
 		return _journalTemplate.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_journalTemplate.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _journalTemplate.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBBanModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBBanModel.java
@@ -214,8 +214,6 @@ public interface MBBanModel extends BaseModel<MBBan>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBBanWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBBanWrapper.java
@@ -258,10 +258,6 @@ public class MBBanWrapper implements MBBan {
 		return _mbBan.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbBan.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbBan.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBCategoryModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBCategoryModel.java
@@ -301,8 +301,6 @@ public interface MBCategoryModel extends BaseModel<MBCategory>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBCategoryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBCategoryWrapper.java
@@ -364,10 +364,6 @@ public class MBCategoryWrapper implements MBCategory {
 		return _mbCategory.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbCategory.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbCategory.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBDiscussionModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBDiscussionModel.java
@@ -130,8 +130,6 @@ public interface MBDiscussionModel extends AttachedModel, BaseModel<MBDiscussion
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBDiscussionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBDiscussionWrapper.java
@@ -155,10 +155,6 @@ public class MBDiscussionWrapper implements MBDiscussion {
 		return _mbDiscussion.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbDiscussion.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbDiscussion.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBMailingListModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBMailingListModel.java
@@ -497,8 +497,6 @@ public interface MBMailingListModel extends BaseModel<MBMailingList>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBMailingListWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBMailingListWrapper.java
@@ -607,10 +607,6 @@ public class MBMailingListWrapper implements MBMailingList {
 		return _mbMailingList.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbMailingList.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbMailingList.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBMessageModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBMessageModel.java
@@ -542,8 +542,6 @@ public interface MBMessageModel extends AttachedModel, BaseModel<MBMessage>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBMessageWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBMessageWrapper.java
@@ -670,10 +670,6 @@ public class MBMessageWrapper implements MBMessage {
 		return _mbMessage.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbMessage.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbMessage.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBStatsUserModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBStatsUserModel.java
@@ -169,8 +169,6 @@ public interface MBStatsUserModel extends BaseModel<MBStatsUser> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBStatsUserWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBStatsUserWrapper.java
@@ -204,10 +204,6 @@ public class MBStatsUserWrapper implements MBStatsUser {
 		return _mbStatsUser.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbStatsUser.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbStatsUser.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadFlagModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadFlagModel.java
@@ -140,8 +140,6 @@ public interface MBThreadFlagModel extends BaseModel<MBThreadFlag> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadFlagWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadFlagWrapper.java
@@ -166,10 +166,6 @@ public class MBThreadFlagWrapper implements MBThreadFlag {
 		return _mbThreadFlag.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbThreadFlag.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbThreadFlag.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadModel.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadModel.java
@@ -381,8 +381,6 @@ public interface MBThreadModel extends BaseModel<MBThread>, WorkflowedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadWrapper.java
@@ -474,10 +474,6 @@ public class MBThreadWrapper implements MBThread {
 		return _mbThread.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mbThread.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mbThread.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRActionModel.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRActionModel.java
@@ -256,6 +256,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param locale the locale of the language
 	 * @return the localized name of this m d r action
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -265,6 +266,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this m d r action. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -273,6 +275,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param languageId the ID of the language
 	 * @return the localized name of this m d r action
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -282,6 +285,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this m d r action
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -343,6 +347,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param locale the locale of the language
 	 * @return the localized description of this m d r action
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -352,6 +357,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this m d r action. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -360,6 +366,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this m d r action
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -369,6 +376,7 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this m d r action
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -458,8 +466,6 @@ public interface MDRActionModel extends AttachedModel, BaseModel<MDRAction>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRActionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRActionWrapper.java
@@ -567,10 +567,6 @@ public class MDRActionWrapper implements MDRAction {
 		return _mdrAction.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mdrAction.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mdrAction.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupInstanceModel.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupInstanceModel.java
@@ -265,8 +265,6 @@ public interface MDRRuleGroupInstanceModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupInstanceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupInstanceWrapper.java
@@ -320,10 +320,6 @@ public class MDRRuleGroupInstanceWrapper implements MDRRuleGroupInstance {
 		return _mdrRuleGroupInstance.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mdrRuleGroupInstance.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mdrRuleGroupInstance.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupModel.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupModel.java
@@ -205,6 +205,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param locale the locale of the language
 	 * @return the localized name of this m d r rule group
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -214,6 +215,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this m d r rule group. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -222,6 +224,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param languageId the ID of the language
 	 * @return the localized name of this m d r rule group
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -231,6 +234,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this m d r rule group
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -292,6 +296,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param locale the locale of the language
 	 * @return the localized description of this m d r rule group
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -301,6 +306,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this m d r rule group. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -309,6 +315,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param languageId the ID of the language
 	 * @return the localized description of this m d r rule group
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -318,6 +325,7 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this m d r rule group
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -377,8 +385,6 @@ public interface MDRRuleGroupModel extends BaseModel<MDRRuleGroup>, GroupedModel
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleGroupWrapper.java
@@ -468,10 +468,6 @@ public class MDRRuleGroupWrapper implements MDRRuleGroup {
 		return _mdrRuleGroup.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mdrRuleGroup.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mdrRuleGroup.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleModel.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleModel.java
@@ -219,6 +219,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param locale the locale of the language
 	 * @return the localized name of this m d r rule
 	 */
+	@AutoEscape
 	public String getName(Locale locale);
 
 	/**
@@ -228,6 +229,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this m d r rule. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getName(Locale locale, boolean useDefault);
 
 	/**
@@ -236,6 +238,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param languageId the ID of the language
 	 * @return the localized name of this m d r rule
 	 */
+	@AutoEscape
 	public String getName(String languageId);
 
 	/**
@@ -245,6 +248,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized name of this m d r rule
 	 */
+	@AutoEscape
 	public String getName(String languageId, boolean useDefault);
 
 	/**
@@ -306,6 +310,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param locale the locale of the language
 	 * @return the localized description of this m d r rule
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -315,6 +320,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this m d r rule. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -323,6 +329,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param languageId the ID of the language
 	 * @return the localized description of this m d r rule
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -332,6 +339,7 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this m d r rule
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -421,8 +429,6 @@ public interface MDRRuleModel extends BaseModel<MDRRule>, GroupedModel {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/model/MDRRuleWrapper.java
@@ -522,10 +522,6 @@ public class MDRRuleWrapper implements MDRRule {
 		return _mdrRule.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_mdrRule.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _mdrRule.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/polls/model/PollsChoiceModel.java
+++ b/portal-service/src/com/liferay/portlet/polls/model/PollsChoiceModel.java
@@ -131,6 +131,7 @@ public interface PollsChoiceModel extends BaseModel<PollsChoice> {
 	 * @param locale the locale of the language
 	 * @return the localized description of this polls choice
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -140,6 +141,7 @@ public interface PollsChoiceModel extends BaseModel<PollsChoice> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this polls choice. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -148,6 +150,7 @@ public interface PollsChoiceModel extends BaseModel<PollsChoice> {
 	 * @param languageId the ID of the language
 	 * @return the localized description of this polls choice
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -157,6 +160,7 @@ public interface PollsChoiceModel extends BaseModel<PollsChoice> {
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this polls choice
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -216,8 +220,6 @@ public interface PollsChoiceModel extends BaseModel<PollsChoice> {
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/polls/model/PollsChoiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/polls/model/PollsChoiceWrapper.java
@@ -262,10 +262,6 @@ public class PollsChoiceWrapper implements PollsChoice {
 		return _pollsChoice.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_pollsChoice.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _pollsChoice.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/polls/model/PollsQuestionModel.java
+++ b/portal-service/src/com/liferay/portlet/polls/model/PollsQuestionModel.java
@@ -206,6 +206,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param locale the locale of the language
 	 * @return the localized title of this polls question
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale);
 
 	/**
@@ -215,6 +216,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this polls question. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getTitle(Locale locale, boolean useDefault);
 
 	/**
@@ -223,6 +225,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param languageId the ID of the language
 	 * @return the localized title of this polls question
 	 */
+	@AutoEscape
 	public String getTitle(String languageId);
 
 	/**
@@ -232,6 +235,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized title of this polls question
 	 */
+	@AutoEscape
 	public String getTitle(String languageId, boolean useDefault);
 
 	/**
@@ -293,6 +297,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param locale the locale of the language
 	 * @return the localized description of this polls question
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale);
 
 	/**
@@ -302,6 +307,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this polls question. If <code>useDefault</code> is <code>false</code> and no localization exists for the requested language, an empty string will be returned.
 	 */
+	@AutoEscape
 	public String getDescription(Locale locale, boolean useDefault);
 
 	/**
@@ -310,6 +316,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param languageId the ID of the language
 	 * @return the localized description of this polls question
 	 */
+	@AutoEscape
 	public String getDescription(String languageId);
 
 	/**
@@ -319,6 +326,7 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	 * @param useDefault whether to use the default language if no localization exists for the requested language
 	 * @return the localized description of this polls question
 	 */
+	@AutoEscape
 	public String getDescription(String languageId, boolean useDefault);
 
 	/**
@@ -406,8 +414,6 @@ public interface PollsQuestionModel extends BaseModel<PollsQuestion>,
 	public void setCachedModel(boolean cachedModel);
 
 	public boolean isEscapedModel();
-
-	public void setEscapedModel(boolean escapedModel);
 
 	public Serializable getPrimaryKeyObj();
 

--- a/portal-service/src/com/liferay/portlet/polls/model/PollsQuestionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/polls/model/PollsQuestionWrapper.java
@@ -504,10 +504,6 @@ public class PollsQuestionWrapper implements PollsQuestion {
 		return _pollsQuestion.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_pollsQuestion.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _pollsQuestion.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/polls/model/PollsVoteModel.java
+++ b/portal-service/src/com/liferay/portlet/polls/model/PollsVoteModel.java
@@ -213,8 +213,6 @@ public interface PollsVoteModel extends AuditedModel, BaseModel<PollsVote> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/polls/model/PollsVoteWrapper.java
+++ b/portal-service/src/com/liferay/portlet/polls/model/PollsVoteWrapper.java
@@ -256,10 +256,6 @@ public class PollsVoteWrapper implements PollsVote {
 		return _pollsVote.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_pollsVote.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _pollsVote.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/ratings/model/RatingsEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/ratings/model/RatingsEntryModel.java
@@ -222,8 +222,6 @@ public interface RatingsEntryModel extends AttachedModel, AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/ratings/model/RatingsEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/ratings/model/RatingsEntryWrapper.java
@@ -265,10 +265,6 @@ public class RatingsEntryWrapper implements RatingsEntry {
 		return _ratingsEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ratingsEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ratingsEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/ratings/model/RatingsStatsModel.java
+++ b/portal-service/src/com/liferay/portlet/ratings/model/RatingsStatsModel.java
@@ -158,8 +158,6 @@ public interface RatingsStatsModel extends AttachedModel, BaseModel<RatingsStats
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/ratings/model/RatingsStatsWrapper.java
+++ b/portal-service/src/com/liferay/portlet/ratings/model/RatingsStatsWrapper.java
@@ -191,10 +191,6 @@ public class RatingsStatsWrapper implements RatingsStats {
 		return _ratingsStats.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_ratingsStats.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _ratingsStats.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCartModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCartModel.java
@@ -250,8 +250,6 @@ public interface ShoppingCartModel extends BaseModel<ShoppingCart>, GroupedModel
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCartWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCartWrapper.java
@@ -301,10 +301,6 @@ public class ShoppingCartWrapper implements ShoppingCart {
 		return _shoppingCart.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingCart.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingCart.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCategoryModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCategoryModel.java
@@ -230,8 +230,6 @@ public interface ShoppingCategoryModel extends BaseModel<ShoppingCategory>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCategoryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCategoryWrapper.java
@@ -274,10 +274,6 @@ public class ShoppingCategoryWrapper implements ShoppingCategory {
 		return _shoppingCategory.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingCategory.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingCategory.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCouponModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCouponModel.java
@@ -353,8 +353,6 @@ public interface ShoppingCouponModel extends BaseModel<ShoppingCoupon>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCouponWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingCouponWrapper.java
@@ -427,10 +427,6 @@ public class ShoppingCouponWrapper implements ShoppingCoupon {
 		return _shoppingCoupon.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingCoupon.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingCoupon.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemFieldModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemFieldModel.java
@@ -140,8 +140,6 @@ public interface ShoppingItemFieldModel extends BaseModel<ShoppingItemField> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemFieldWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemFieldWrapper.java
@@ -164,10 +164,6 @@ public class ShoppingItemFieldWrapper implements ShoppingItemField {
 		return _shoppingItemField.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingItemField.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingItemField.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemModel.java
@@ -634,8 +634,6 @@ public interface ShoppingItemModel extends BaseModel<ShoppingItem>, GroupedModel
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemPriceModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemPriceModel.java
@@ -220,8 +220,6 @@ public interface ShoppingItemPriceModel extends BaseModel<ShoppingItemPrice> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemPriceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemPriceWrapper.java
@@ -272,10 +272,6 @@ public class ShoppingItemPriceWrapper implements ShoppingItemPrice {
 		return _shoppingItemPrice.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingItemPrice.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingItemPrice.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingItemWrapper.java
@@ -787,10 +787,6 @@ public class ShoppingItemWrapper implements ShoppingItem {
 		return _shoppingItem.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingItem.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingItem.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderItemModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderItemModel.java
@@ -214,8 +214,6 @@ public interface ShoppingOrderItemModel extends BaseModel<ShoppingOrderItem> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderItemWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderItemWrapper.java
@@ -254,10 +254,6 @@ public class ShoppingOrderItemWrapper implements ShoppingOrderItem {
 		return _shoppingOrderItem.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingOrderItem.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingOrderItem.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderModel.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderModel.java
@@ -869,8 +869,6 @@ public interface ShoppingOrderModel extends BaseModel<ShoppingOrder>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderWrapper.java
+++ b/portal-service/src/com/liferay/portlet/shopping/model/ShoppingOrderWrapper.java
@@ -1057,10 +1057,6 @@ public class ShoppingOrderWrapper implements ShoppingOrder {
 		return _shoppingOrder.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_shoppingOrder.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _shoppingOrder.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivityModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivityModel.java
@@ -262,8 +262,6 @@ public interface SocialActivityModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivityWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivityWrapper.java
@@ -321,10 +321,6 @@ public class SocialActivityWrapper implements SocialActivity {
 		return _socialActivity.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialActivity.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialActivity.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityAssetEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityAssetEntryModel.java
@@ -180,8 +180,6 @@ public interface SocialEquityAssetEntryModel extends BaseModel<SocialEquityAsset
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityAssetEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityAssetEntryWrapper.java
@@ -221,10 +221,6 @@ public class SocialEquityAssetEntryWrapper implements SocialEquityAssetEntry {
 		return _socialEquityAssetEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialEquityAssetEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialEquityAssetEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityGroupSettingModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityGroupSettingModel.java
@@ -164,8 +164,6 @@ public interface SocialEquityGroupSettingModel extends BaseModel<SocialEquityGro
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityGroupSettingWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityGroupSettingWrapper.java
@@ -201,10 +201,6 @@ public class SocialEquityGroupSettingWrapper implements SocialEquityGroupSetting
 		return _socialEquityGroupSetting.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialEquityGroupSetting.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialEquityGroupSetting.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityHistoryModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityHistoryModel.java
@@ -168,8 +168,6 @@ public interface SocialEquityHistoryModel extends BaseModel<SocialEquityHistory>
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityHistoryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityHistoryWrapper.java
@@ -202,10 +202,6 @@ public class SocialEquityHistoryWrapper implements SocialEquityHistory {
 		return _socialEquityHistory.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialEquityHistory.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialEquityHistory.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityLogModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityLogModel.java
@@ -260,8 +260,6 @@ public interface SocialEquityLogModel extends BaseModel<SocialEquityLog> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityLogWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityLogWrapper.java
@@ -319,10 +319,6 @@ public class SocialEquityLogWrapper implements SocialEquityLog {
 		return _socialEquityLog.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialEquityLog.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialEquityLog.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquitySettingModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquitySettingModel.java
@@ -222,8 +222,6 @@ public interface SocialEquitySettingModel extends BaseModel<SocialEquitySetting>
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquitySettingWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquitySettingWrapper.java
@@ -272,10 +272,6 @@ public class SocialEquitySettingWrapper implements SocialEquitySetting {
 		return _socialEquitySetting.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialEquitySetting.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialEquitySetting.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityUserModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityUserModel.java
@@ -223,8 +223,6 @@ public interface SocialEquityUserModel extends BaseModel<SocialEquityUser> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialEquityUserWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialEquityUserWrapper.java
@@ -276,10 +276,6 @@ public class SocialEquityUserWrapper implements SocialEquityUser {
 		return _socialEquityUser.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialEquityUser.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialEquityUser.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialRelationModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialRelationModel.java
@@ -166,8 +166,6 @@ public interface SocialRelationModel extends BaseModel<SocialRelation> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialRelationWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialRelationWrapper.java
@@ -200,10 +200,6 @@ public class SocialRelationWrapper implements SocialRelation {
 		return _socialRelation.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialRelation.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialRelation.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/social/model/SocialRequestModel.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialRequestModel.java
@@ -291,8 +291,6 @@ public interface SocialRequestModel extends AttachedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/social/model/SocialRequestWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialRequestWrapper.java
@@ -357,10 +357,6 @@ public class SocialRequestWrapper implements SocialRequest {
 		return _socialRequest.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_socialRequest.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _socialRequest.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCFrameworkVersionModel.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCFrameworkVersionModel.java
@@ -251,8 +251,6 @@ public interface SCFrameworkVersionModel extends BaseModel<SCFrameworkVersion>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCFrameworkVersionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCFrameworkVersionWrapper.java
@@ -301,10 +301,6 @@ public class SCFrameworkVersionWrapper implements SCFrameworkVersion {
 		return _scFrameworkVersion.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_scFrameworkVersion.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _scFrameworkVersion.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCLicenseModel.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCLicenseModel.java
@@ -174,8 +174,6 @@ public interface SCLicenseModel extends BaseModel<SCLicense> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCLicenseWrapper.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCLicenseWrapper.java
@@ -209,10 +209,6 @@ public class SCLicenseWrapper implements SCLicense {
 		return _scLicense.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_scLicense.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _scLicense.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductEntryModel.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductEntryModel.java
@@ -321,8 +321,6 @@ public interface SCProductEntryModel extends BaseModel<SCProductEntry>,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductEntryWrapper.java
@@ -382,10 +382,6 @@ public class SCProductEntryWrapper implements SCProductEntry {
 		return _scProductEntry.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_scProductEntry.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _scProductEntry.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductScreenshotModel.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductScreenshotModel.java
@@ -164,8 +164,6 @@ public interface SCProductScreenshotModel extends BaseModel<SCProductScreenshot>
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductScreenshotWrapper.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductScreenshotWrapper.java
@@ -200,10 +200,6 @@ public class SCProductScreenshotWrapper implements SCProductScreenshot {
 		return _scProductScreenshot.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_scProductScreenshot.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _scProductScreenshot.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductVersionModel.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductVersionModel.java
@@ -267,8 +267,6 @@ public interface SCProductVersionModel extends AuditedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductVersionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/softwarecatalog/model/SCProductVersionWrapper.java
@@ -319,10 +319,6 @@ public class SCProductVersionWrapper implements SCProductVersion {
 		return _scProductVersion.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_scProductVersion.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _scProductVersion.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/wiki/model/WikiNodeModel.java
+++ b/portal-service/src/com/liferay/portlet/wiki/model/WikiNodeModel.java
@@ -244,8 +244,6 @@ public interface WikiNodeModel extends BaseModel<WikiNode>, GroupedModel {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/wiki/model/WikiNodeWrapper.java
+++ b/portal-service/src/com/liferay/portlet/wiki/model/WikiNodeWrapper.java
@@ -292,10 +292,6 @@ public class WikiNodeWrapper implements WikiNode {
 		return _wikiNode.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_wikiNode.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _wikiNode.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/wiki/model/WikiPageModel.java
+++ b/portal-service/src/com/liferay/portlet/wiki/model/WikiPageModel.java
@@ -484,8 +484,6 @@ public interface WikiPageModel extends BaseModel<WikiPage>, GroupedModel,
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/wiki/model/WikiPageResourceModel.java
+++ b/portal-service/src/com/liferay/portlet/wiki/model/WikiPageResourceModel.java
@@ -125,8 +125,6 @@ public interface WikiPageResourceModel extends BaseModel<WikiPageResource> {
 
 	public boolean isEscapedModel();
 
-	public void setEscapedModel(boolean escapedModel);
-
 	public Serializable getPrimaryKeyObj();
 
 	public void setPrimaryKeyObj(Serializable primaryKeyObj);

--- a/portal-service/src/com/liferay/portlet/wiki/model/WikiPageResourceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/wiki/model/WikiPageResourceWrapper.java
@@ -146,10 +146,6 @@ public class WikiPageResourceWrapper implements WikiPageResource {
 		return _wikiPageResource.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_wikiPageResource.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _wikiPageResource.getPrimaryKeyObj();
 	}

--- a/portal-service/src/com/liferay/portlet/wiki/model/WikiPageWrapper.java
+++ b/portal-service/src/com/liferay/portlet/wiki/model/WikiPageWrapper.java
@@ -593,10 +593,6 @@ public class WikiPageWrapper implements WikiPage {
 		return _wikiPage.isEscapedModel();
 	}
 
-	public void setEscapedModel(boolean escapedModel) {
-		_wikiPage.setEscapedModel(escapedModel);
-	}
-
 	public java.io.Serializable getPrimaryKeyObj() {
 		return _wikiPage.getPrimaryKeyObj();
 	}

--- a/portal-web/docroot/html/portlet/announcements/view_manage_entries.jspf
+++ b/portal-web/docroot/html/portlet/announcements/view_manage_entries.jspf
@@ -77,7 +77,8 @@ if ((classNameId == 0) && (classPK == 0) && !permissionChecker.isOmniadmin()) {
 		for (int i = 0; i < results.size(); i++) {
 			AnnouncementsEntry entry = results.get(i);
 
-			entry = entry.toEscapedModel();
+			entry = entry.
+				toEscapedModel();
 
 			ResultRow row = new ResultRow(entry, entry.getEntryId(), i);
 


### PR DESCRIPTION
The problem was the following:
- The method isEscaped() created by Service Builder always returned true as it was being called from the entity and the call was not being intercepted by the proxy.
- Please, see AutoEscapeBeanHandler.java to understand this change.
