### PR TITLE
ant -f build-dist.xml unzip-glassfish

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -862,7 +862,7 @@ release was successful.</echo>
 			</fileset>
 		</chmod>
 
-		<replace file="${app.server.parent.dir}/${app.server.glassfish.dir}/osgi/felix/conf/config.properties">
+		<replace file="${app.server.glassfish.dir}/osgi/felix/conf/config.properties">
 			<replacetoken><![CDATA[org.xml.sax.helpers ${endorsed-standard-packages}]]></replacetoken>
 			<replacevalue><![CDATA[org.xml.sax.helpers, org.apache.felix.framework ${endorsed-standard-packages}]]></replacevalue>
 		</replace>


### PR DESCRIPTION
unzip-glassfish:
[unzip] Expanding: H:\hudson\bundles\trunk\glassfish-3.1.1-web.zip into H:\hudson\bundles\trunk

BUILD FAILED
H:\hudson\jobs\portal-trunk\workspace\trunk\portal-web\test-ant-scripts\build-test-smoke-test.xml:11: The following error occurred while executing this line:
H:\hudson\jobs\portal-trunk\workspace\trunk\build-test-glassfish.xml:26: The following error occurred while executing this line:
H:\hudson\jobs\portal-trunk\workspace\trunk\build-dist.xml:23: The following error occurred while executing this line:
H:\hudson\jobs\portal-trunk\workspace\trunk\build-dist.xml:865: Replace: source file H:\hudson\bundles\trunk\H:\hudson\bundles\trunk\glassfish-3.1.1\osgi\felix\conf\config.properties doesn't exist
