### PR TITLE
LPS-21574 Documents and Media - User has to refresh page in order to display a newly created document type in the Add drop down

### DIFF
--- a/portal-impl/src/com/liferay/portlet/assetpublisher/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/action/ConfigurationActionImpl.java
@@ -101,6 +101,11 @@ public class ConfigurationActionImpl extends DefaultConfigurationAction {
 					SessionMessages.add(
 						actionRequest,
 						portletConfig.getPortletName() + ".doConfigure");
+
+					SessionMessages.add(
+						actionRequest,
+						portletConfig.getPortletName() + ".doRefresh",
+						portletResource);
 				}
 
 				String redirect = PortalUtil.escapeRedirect(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/EditFileEntryTypeAction.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/EditFileEntryTypeAction.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.documentlibrary.action;
 
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -26,6 +27,7 @@ import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextFactory;
 import com.liferay.portal.struts.PortletAction;
 import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.WebKeys;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryTypeException;
 import com.liferay.portlet.documentlibrary.NoSuchMetadataSetException;
@@ -67,6 +69,13 @@ public class EditFileEntryTypeAction extends PortletAction {
 			}
 			else if (cmd.equals(Constants.DELETE)) {
 				deleteFileEntryType(actionRequest, actionResponse);
+			}
+
+			if (SessionErrors.isEmpty(actionRequest)) {
+				SessionMessages.add(
+					actionRequest,
+					portletConfig.getPortletName() + ".doRefresh",
+					PortletKeys.DOCUMENT_LIBRARY);
 			}
 
 			sendRedirect(actionRequest, actionResponse);

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditArchivedSetupsAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditArchivedSetupsAction.java
@@ -101,6 +101,13 @@ public class EditArchivedSetupsAction extends EditConfigurationAction {
 				actionRequest,
 				portletConfig.getPortletName() + ".doConfigure");
 
+			String portletResource = ParamUtil.getString(
+				actionRequest, "portletResource");
+
+			SessionMessages.add(
+				actionRequest, portletConfig.getPortletName() + ".doRefresh",
+				portletResource);
+
 			String redirect = PortalUtil.escapeRedirect(
 				ParamUtil.getString(actionRequest, "redirect"));
 

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditPublicRenderParametersAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditPublicRenderParametersAction.java
@@ -71,6 +71,13 @@ public class EditPublicRenderParametersAction extends EditConfigurationAction {
 				actionRequest,
 				portletConfig.getPortletName() + ".doConfigure");
 
+			String portletResource = ParamUtil.getString(
+				actionRequest, "portletResource");
+
+			SessionMessages.add(
+				actionRequest, portletConfig.getPortletName() + ".doRefresh",
+				portletResource);
+
 			String redirect = PortalUtil.escapeRedirect(
 				ParamUtil.getString(actionRequest, "redirect"));
 

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditScopeAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditScopeAction.java
@@ -88,6 +88,13 @@ public class EditScopeAction extends EditConfigurationAction {
 				actionRequest,
 				portletConfig.getPortletName() + ".doConfigure");
 
+			String portletResource = ParamUtil.getString(
+				actionRequest, "portletResource");
+
+			SessionMessages.add(
+				actionRequest, portletConfig.getPortletName() + ".doRefresh",
+				portletResource);
+
 			String redirect = PortalUtil.escapeRedirect(
 				ParamUtil.getString(actionRequest, "redirect"));
 

--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSharingAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditSharingAction.java
@@ -94,6 +94,13 @@ public class EditSharingAction extends EditConfigurationAction {
 				actionRequest,
 				portletConfig.getPortletName() + ".doConfigure");
 
+			String portletResource = ParamUtil.getString(
+				actionRequest, "portletResource");
+
+			SessionMessages.add(
+				actionRequest, portletConfig.getPortletName() + ".doRefresh",
+				portletResource);
+
 			String redirect = PortalUtil.escapeRedirect(
 				ParamUtil.getString(actionRequest, "redirect"));
 

--- a/portal-impl/src/com/liferay/portlet/rss/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/rss/action/ConfigurationActionImpl.java
@@ -85,6 +85,11 @@ public class ConfigurationActionImpl extends DefaultConfigurationAction {
 				SessionMessages.add(
 					actionRequest,
 					portletConfig.getPortletName() + ".doConfigure");
+
+				SessionMessages.add(
+					actionRequest,
+					portletConfig.getPortletName() + ".doRefresh",
+					portletResource);
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portlet/shopping/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/action/ConfigurationActionImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.WebKeys;
 import com.liferay.portlet.shopping.util.ShoppingPreferences;
 
@@ -81,6 +82,10 @@ public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 			SessionMessages.add(
 				actionRequest, portletConfig.getPortletName() + ".doConfigure");
+
+			SessionMessages.add(
+				actionRequest, portletConfig.getPortletName() + ".doRefresh",
+				PortletKeys.SHOPPING);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/stagingbar/action/EditLayoutBranchAction.java
+++ b/portal-impl/src/com/liferay/portlet/stagingbar/action/EditLayoutBranchAction.java
@@ -25,6 +25,7 @@ import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.service.LayoutBranchServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextFactory;
+import com.liferay.portal.util.PortletKeys;
 import com.liferay.portlet.layoutsadmin.action.EditLayoutsAction;
 
 import javax.portlet.ActionRequest;
@@ -69,7 +70,8 @@ public class EditLayoutBranchAction extends EditLayoutsAction {
 			if (SessionErrors.isEmpty(actionRequest)) {
 				SessionMessages.add(
 					actionRequest,
-					portletConfig.getPortletName() + ".doConfigure");
+					portletConfig.getPortletName() + ".doRefresh",
+					PortletKeys.STAGING_BAR);
 			}
 
 			sendRedirect(actionRequest, actionResponse);

--- a/portal-impl/src/com/liferay/portlet/stagingbar/action/EditLayoutSetBranchAction.java
+++ b/portal-impl/src/com/liferay/portlet/stagingbar/action/EditLayoutSetBranchAction.java
@@ -26,6 +26,7 @@ import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.service.LayoutSetBranchServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextFactory;
+import com.liferay.portal.util.PortletKeys;
 import com.liferay.portlet.layoutsadmin.action.EditLayoutsAction;
 
 import javax.portlet.ActionRequest;
@@ -73,7 +74,8 @@ public class EditLayoutSetBranchAction extends EditLayoutsAction {
 			if (SessionErrors.isEmpty(actionRequest)) {
 				SessionMessages.add(
 					actionRequest,
-					portletConfig.getPortletName() + ".doConfigure");
+					portletConfig.getPortletName() + ".doRefresh",
+					PortletKeys.STAGING_BAR);
 			}
 
 			sendRedirect(actionRequest, actionResponse);

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultConfigurationAction.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultConfigurationAction.java
@@ -118,6 +118,10 @@ public class DefaultConfigurationAction
 
 			SessionMessages.add(
 				actionRequest, portletConfig.getPortletName() + ".doConfigure");
+
+			SessionMessages.add(
+				actionRequest, portletConfig.getPortletName() + ".doRefresh",
+				portletResource);
 		}
 	}
 

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -1013,6 +1013,41 @@ else {
 </c:if>
 
 <%
+PortletRequest portletRequest = (PortletRequest) request.getAttribute(JavaConstants.JAVAX_PORTLET_REQUEST);
+%>
+
+<c:if test='<%= themeDisplay.isStatePopUp() && SessionMessages.contains(portletRequest, portletConfig.getPortletName() + ".doRefresh") %>'>
+
+	<%
+	String portletResource = ParamUtil.getString(request, "portletResource");
+
+	Portlet selPortlet = PortletLocalServiceUtil.getPortletById(company.getCompanyId(), portletResource);
+
+	String p_p_id = (String)SessionMessages.get(portletRequest, portletConfig.getPortletName() + ".doRefresh");
+
+	if (Validator.isNull(p_p_id)) {
+		p_p_id = portletResource;
+	}
+	%>
+
+	<aui:script position="inline" use="aui-base">
+		if (window.parent) {
+			var data = null;
+
+			var curPortletBoundaryId = '#p_p_id_<%= p_p_id %>_';
+
+			<c:if test='<%= !selPortlet.isAjaxable() || SessionMessages.contains(portletRequest, portletConfig.getPortletName() + ".notAjaxable") %>'>
+				data = {
+					portletAjaxable: false
+				};
+			</c:if>
+
+			Liferay.Util.getOpener().Liferay.Portlet.refresh(curPortletBoundaryId, data);
+		}
+	</aui:script>
+</c:if>
+
+<%
 themeDisplay.setScopeGroupId(previousScopeGroupId);
 themeDisplay.setParentGroupId(previousParentGroupId);
 

--- a/portal-web/docroot/html/portlet/portlet_configuration/init.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/init.jsp
@@ -51,21 +51,3 @@ Portlet selPortlet = PortletLocalServiceUtil.getPortletById(company.getCompanyId
 
 Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 %>
-
-<c:if test='<%= themeDisplay.isStatePopUp() && SessionMessages.contains(renderRequest, portletName + ".doConfigure") %>'>
-	<aui:script use="aui-base">
-		if (window.parent) {
-			var curPortletBoundaryId = '#p_p_id_<%= portletResource %>_';
-
-			var data;
-
-			<c:if test="<%= !selPortlet.isAjaxable() %>">
-				data = {
-					portletAjaxable: false
-				};
-			</c:if>
-
-			Liferay.Util.getOpener().Liferay.Portlet.refresh(curPortletBoundaryId, data);
-		}
-	</aui:script>
-</c:if>

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_branches.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_branches.jsp
@@ -146,16 +146,4 @@ request.setAttribute("view_layout_branches.jsp-currenttLayoutBranchId", String.v
 			namespace: '<portlet:namespace />'
 		}
 	);
-
-	<c:if test='<%= themeDisplay.isStatePopUp() && SessionMessages.contains(renderRequest, portletName + ".doConfigure") %>'>
-		var data = null;
-
-		<c:if test='<%= SessionMessages.contains(renderRequest, portletName + ".notAjaxable") %>'>
-			data = {
-				portletAjaxable: false
-			};
-		</c:if>
-
-		Liferay.Util.getOpener().Liferay.Portlet.refresh('#p_p_id_<%= PortletKeys.STAGING_BAR %>_', data);
-	</c:if>
 </aui:script>

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_set_branches.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_set_branches.jsp
@@ -125,19 +125,3 @@ request.setAttribute("view_layout_set_branches.jsp-currentLayoutSetBranchId", St
 		}
 	);
 </aui:script>
-
-<c:if test='<%= themeDisplay.isStatePopUp() && SessionMessages.contains(renderRequest, portletName + ".doConfigure") %>'>
-	<aui:script use="aui-base">
-		if (window.parent) {
-			var data;
-
-			<c:if test='<%= SessionMessages.contains(renderRequest, portletName + ".notAjaxable") %>'>
-				data = {
-					portletAjaxable: false
-				};
-			</c:if>
-
-			Liferay.Util.getOpener().Liferay.Portlet.refresh('#p_p_id_<%= PortletKeys.STAGING_BAR %>_', data);
-		}
-	</aui:script>
-</c:if>


### PR DESCRIPTION
As we have seen the code to refresh a portlet duplicated in several places, we decided to encapsulate the logic. Now, if you add the .doRefresh SessionMessage, the selected portlet will refresh.

We initially added this code to portlet.jsp but we realized it was not being loaded in embebed portlets so we then moved it to render_portlet.jsp which was always loaded.
