### PR TITLE
LPS-20230 Clicking on a Page Version link in a staged site's "History" po

### DIFF
--- a/portal-web/docroot/html/js/liferay/staging_version.js
+++ b/portal-web/docroot/html/js/liferay/staging_version.js
@@ -129,7 +129,7 @@ AUI().add(
 						graphDialog.bodyNode.delegate(
 							'click',
 							function(event) {
-								instance._selectRevision(event.currentTarget);
+								instance._selectRevision(event.target);
 							},
 							'a.layout-revision.selection-handle'
 						);
@@ -186,7 +186,7 @@ AUI().add(
 					var instance = this;
 
 					instance._updateRevision(
-						node,
+						'select_layout_revision',
 						node.attr('data-layoutRevisionId'),
 						node.attr('data-layoutSetBranchId')
 					);


### PR DESCRIPTION
LPS-20230 Clicking on a Page Version link in a staged site's "History" popup results in javascript error: Uncaught Error: QueryString.stringify. Cyclical reference
