### PR TITLE
LPS-19013 Sybase exception in console when using Document Library.

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/common/SQLTransformer.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/common/SQLTransformer.java
@@ -195,6 +195,10 @@ public class SQLTransformer {
 		return matcher.replaceAll("$1 ($2)");
 	}
 
+	private String _replaceTextReplacementFunction(String newSQL) {
+		return StringUtil.replace(newSQL, "replace(", "str_replace(");
+	}
+
 	private String _replaceUnion(String sql) {
 		Matcher matcher = _unionAllPattern.matcher(sql);
 
@@ -225,8 +229,15 @@ public class SQLTransformer {
 		else if (_vendorPostgreSQL) {
 			newSQL = _replaceNegativeComparison(newSQL);
 		}
-		else if (_vendorSQLServer || _vendorSybase) {
+		else if (_vendorSQLServer) {
 			newSQL = _replaceMod(newSQL);
+		}
+		else if (_vendorSybase) {
+			newSQL = _replaceMod(newSQL);
+
+			// replace function is not available in Sybase ASE
+
+			newSQL = _replaceTextReplacementFunction(newSQL);
 		}
 
 		if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderFinderImpl.java
@@ -379,7 +379,7 @@ public class DLFolderFinderImpl
 
 			StringBundler sb = new StringBundler(7);
 
-			sb.append("SELECT * FROM ((");
+			sb.append("SELECT * FROM (");
 
 			String sql = CustomSQLUtil.get(FIND_F_BY_G_M_F);
 
@@ -390,7 +390,7 @@ public class DLFolderFinderImpl
 			}
 
 			sb.append(sql);
-			sb.append(") UNION ALL (");
+			sb.append(" UNION ALL ");
 
 			sql = CustomSQLUtil.get(FIND_FE_BY_G_F_S);
 
@@ -419,7 +419,7 @@ public class DLFolderFinderImpl
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 
-			sb.append(") UNION ALL (");
+			sb.append(" UNION ALL ");
 
 			sql = CustomSQLUtil.get(FIND_FS_BY_G_F_S);
 
@@ -448,7 +448,7 @@ public class DLFolderFinderImpl
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 
-			sb.append(")) TEMP_TABLE ORDER BY modelFolder DESC, title ASC");
+			sb.append(") TEMP_TABLE ORDER BY modelFolder DESC, title ASC");
 
 			sql = sb.toString();
 


### PR DESCRIPTION
LPS-19013 Sybase exception in console when using Document Library. In SYSBASE the removed parenthesis are not mandatory (keeps working at all the remaining databases)
