### PR TITLE
LPS-21770 Moving document between repositories cause document library to become temporarily unavailable

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -2530,9 +2530,9 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		try {
 			FileEntry fileEntry = fromRepository.getFileEntry(oldFileEntryId);
 
-			fromRepository.deleteFileEntry(oldFileEntryId);
-
 			dlAppHelperLocalService.deleteFileEntry(fileEntry);
+
+			fromRepository.deleteFileEntry(oldFileEntryId);
 		}
 		catch (PortalException pe) {
 			FileEntry fileEntry = toRepository.getFileEntry(newFileEntryId);


### PR DESCRIPTION
LPS-21770 Moving document between repositories cause document library to become temporarily unavailable
