### PR TITLE
LPS-19760 Deprecate web content layout type

### DIFF
--- a/portal-impl/src/portal-legacy-6.0.properties
+++ b/portal-impl/src/portal-legacy-6.0.properties
@@ -5,3 +5,5 @@ editor.wysiwyg.portal-web.docroot.html.portlet.message_boards.edit_message.bb_co
 discussion.subscribe.by.default=false
 
 message.boards.subscribe.by.default=false
+
+layout.types=portlet,panel,embedded,article,url,link_to_layout

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3828,7 +3828,7 @@
     # configuration actions that will be called for your layout when it is
     # updated or deleted.
     #
-    layout.types=portlet,panel,embedded,article,url,link_to_layout
+    layout.types=portlet,panel,embedded,url,link_to_layout
 
     #
     # Input a list of sections that will be included as part of the layout form


### PR DESCRIPTION
There are several mechanisms to achieve the same in 6.1, so this mechanism is deprecated and will be removed in the future.
