### PR TITLE
LPS-21928 - Parent category needs to be cleared from Hibernate Session Cache(first level cache) during categories hierarchy building

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -3647,6 +3647,8 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 				if (list.isEmpty()) {
 					if (parent${pkColumn.methodName} > 0) {
+						session.clear();
+					
 						${entity.name} parent${entity.name} = findByPrimaryKey(parent${pkColumn.methodName});
 
 						return parent${entity.name}.getLeft${pkColumn.methodName}();

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceImpl.java
@@ -6455,6 +6455,8 @@ public class AssetCategoryPersistenceImpl extends BasePersistenceImpl<AssetCateg
 
 			if (list.isEmpty()) {
 				if (parentCategoryId > 0) {
+					session.clear();
+
 					AssetCategory parentAssetCategory = findByPrimaryKey(parentCategoryId);
 
 					return parentAssetCategory.getLeftCategoryId();


### PR DESCRIPTION
We have two options for this problem:

1- This solution, using session.clear()

2- Use evict to remove only parentCategory but for this we need to call findByPrimaryKey, after we have to call evict() for this object, deleting liferay cache and call findByPrimaryKey again in getLastRightCategoryId method.
