### PR TITLE
LPS-22268 java.io.File.deleteOnExit() causes memory leak on massive usage

### DIFF
--- a/portal-impl/src/com/liferay/portal/upload/LiferayFileItem.java
+++ b/portal-impl/src/com/liferay/portal/upload/LiferayFileItem.java
@@ -14,9 +14,10 @@
 
 package com.liferay.portal.upload;
 
+import com.liferay.portal.kernel.memory.DeleteFileAction;
+import com.liferay.portal.kernel.memory.FinalizeManager;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.JavaProps;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.util.PropsUtil;
 
@@ -119,9 +120,8 @@ public class LiferayFileItem extends DiskFileItem {
 
 		File tempFile = new File(_repository, tempFileName);
 
-		if (!JavaProps.hasSunBug6291034()) {
-			tempFile.deleteOnExit();
-		}
+		FinalizeManager.register(tempFile,
+			new DeleteFileAction(tempFile.getAbsolutePath()));
 
 		return tempFile;
 	}

--- a/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
+++ b/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
@@ -18,8 +18,9 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.memory.DeleteFileAction;
+import com.liferay.portal.kernel.memory.FinalizeManager;
 import com.liferay.portal.kernel.util.FileUtil;
-import com.liferay.portal.kernel.util.JavaProps;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -56,9 +57,8 @@ public class ZipWriterImpl implements ZipWriter {
 
 		_file.mkdir();
 
-		if (!JavaProps.hasSunBug6291034()) {
-			_file.deleteOnExit();
-		}
+		FinalizeManager.register(_file,
+			new DeleteFileAction(_file.getAbsolutePath()));
 	}
 
 	public ZipWriterImpl(java.io.File file) {

--- a/portal-service/src/com/liferay/portal/kernel/memory/DeleteFileAction.java
+++ b/portal-service/src/com/liferay/portal/kernel/memory/DeleteFileAction.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-2011 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.memory;
+
+import java.io.File;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class DeleteFileAction implements FinalizeAction {
+
+	public DeleteFileAction(String fileName) {
+		_fileName = fileName;
+	}
+
+	public void doFinalize() {
+		new File(_fileName).delete();
+	}
+
+	private final String _fileName;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/util/JavaProps.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/JavaProps.java
@@ -59,10 +59,6 @@ public class JavaProps {
 		return _instance._javaVmVersion;
 	}
 
-	public static boolean hasSunBug6291034() {
-		return _instance._sunBug6291034;
-	}
-
 	public static boolean is64bit() {
 		return _instance._64bit;
 	}
@@ -134,10 +130,6 @@ public class JavaProps {
 		}
 
 		LogUtil.debug(_log, System.getProperties());
-
-		if (_javaVersion.compareTo("1.5.0_06-") < 0) {
-			_sunBug6291034 = true;
-		}
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(JavaProps.class);
@@ -153,6 +145,5 @@ public class JavaProps {
 	private String _javaVendor;
 	private String _javaVersion;
 	private String _javaVmVersion;
-	private boolean _sunBug6291034;
 
 }


### PR DESCRIPTION
LPS-22268 java.io.File.deleteOnExit() causes memory leak on massive usage
