### PR TITLE
LPS-22327 When there's no structure description, the search container is 

### DIFF
--- a/portal-web/docroot/html/portlet/journal/view.jsp
+++ b/portal-web/docroot/html/portlet/journal/view.jsp
@@ -197,9 +197,7 @@ portletURL.setParameter("tabs1", tabs1);
 
 				// Description
 
-				if (Validator.isNotNull(structure.getDescription(locale))) {
-					row.addText(HtmlUtil.escape(structure.getDescription(locale)), rowURL);
-				}
+				row.addText(HtmlUtil.escape(structure.getDescription(locale)), rowURL);
 
 				// Action
 


### PR DESCRIPTION
LPS-22327 When there's no structure description, the search container is incorrectly printed
