### PR TITLE
LPS-22328 Preload a structure on template creation when there's a structu

### DIFF
--- a/portal-web/docroot/html/portlet/journal/article/content.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/content.jsp
@@ -672,7 +672,7 @@ if (Validator.isNotNull(content)) {
 							width:680
 						},
 						title: '<liferay-ui:message key="template" />',
-						uri: '<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="struts_action" value="/journal/select_template" /><portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" /></portlet:renderURL>'
+						uri: '<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="struts_action" value="/journal/select_template" /><portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" /><portlet:param name="structureId" value="<%= String.valueOf(structureId) %>" /></portlet:renderURL>'
 					}
 				);
 			}

--- a/portal-web/docroot/html/portlet/journal/template_search.jsp
+++ b/portal-web/docroot/html/portlet/journal/template_search.jsp
@@ -19,6 +19,8 @@
 <%
 String strutsAction = ParamUtil.getString(request, "struts_action");
 
+long structureId = ParamUtil.getLong(request, "structureId");
+
 long groupId = ParamUtil.getLong(request, "groupId", scopeGroupId);
 
 TemplateSearch searchContainer = (TemplateSearch)request.getAttribute("liferay-ui:search:searchContainer");
@@ -98,7 +100,7 @@ boolean showPermissionsButton = GroupPermissionUtil.contains(permissionChecker, 
 
 <aui:script>
 	function <portlet:namespace />addTemplate() {
-		var url = '<portlet:renderURL><portlet:param name="struts_action" value="/journal/edit_template" /><portlet:param name="redirect" value="<%= currentURL %>" /><portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" /><portlet:param name="structureId" value="<%= displayTerms.getStructureId() %>" /></portlet:renderURL>';
+		var url = '<portlet:renderURL><portlet:param name="struts_action" value="/journal/edit_template" /><portlet:param name="redirect" value="<%= currentURL %>" /><portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" /><portlet:param name="structureId" value="<%= (structureId > 0)? String.valueOf(structureId): displayTerms.getStructureId() %>" /></portlet:renderURL>';
 
 		if (toggle_id_journal_template_searchcurClickValue == 'basic') {
 			url += '&<portlet:namespace /><%= displayTerms.NAME %>=' + document.<portlet:namespace />fm.<portlet:namespace /><%= displayTerms.KEYWORDS %>.value;


### PR DESCRIPTION
LPS-22328 Preload a structure on template creation when there's a structure already choosen

This is an important usability issue several customers pointed us to. 
The problem is that when a structure doesn't have a template, when you create a content with that structure and you click on "choose template" and then on "create template", users usually forget to set the structure field to the correct value, so when they save and go back to the previous screen (which is a search container filtering by the structure id) your recently created template isn't there...
With the current fix, the structure will be preloaded in the form, so that it is never forgotten. 
