### PR TITLE
LPS-22278 Remove unneeded DLFileEntry table join for DLFolderFinder.count

### DIFF
--- a/portal-impl/src/custom-sql/documentlibrary.xml
+++ b/portal-impl/src/custom-sql/documentlibrary.xml
@@ -181,6 +181,9 @@
 				COUNT(DISTINCT fileShortcutId) AS COUNT_VALUE
 			FROM
 				DLFileShortcut
+			INNER JOIN
+				DLFileEntry ON
+					(DLFileEntry.fileEntryId = DLFileShortcut.toFileEntryId)
 			WHERE
 				(DLFileShortcut.groupId = ?) AND
 				(DLFileShortcut.status = 0) AND


### PR DESCRIPTION
LPS-22278 Remove unneeded DLFileEntry table join for DLFolderFinder.countFS_ByG_F_S (reverse-merged from commit 26e0c2db230e6d3a8873db28cc0d1a82f6c1d7c5)
