### PR TITLE
LPS-22254

### DIFF
--- a/portal-web/docroot/html/portal/terms_of_use.jsp
+++ b/portal-web/docroot/html/portal/terms_of_use.jsp
@@ -16,9 +16,17 @@
 
 <%@ include file="/html/portal/init.jsp" %>
 
+<%
+String referer = ParamUtil.get(request, WebKeys.REFERER, PortalUtil.getCurrentURL(request));
+
+if (referer.equals(themeDisplay.getPathMain() + "/portal/update_terms_of_use")) {
+	referer = themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId();
+}
+%>
+
 <aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_terms_of_use" %>' name="fm">
 	<aui:input name="doAsUserId" type="hidden" value="<%= themeDisplay.getDoAsUserId() %>" />
-	<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId() %>' />
+	<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= referer %>' />
 
 	<c:choose>
 		<c:when test="<%= (PropsValues.TERMS_OF_USE_JOURNAL_ARTICLE_GROUP_ID > 0) && Validator.isNotNull(PropsValues.TERMS_OF_USE_JOURNAL_ARTICLE_ID) %>">

--- a/portal-web/docroot/html/portal/update_email_address.jsp
+++ b/portal-web/docroot/html/portal/update_email_address.jsp
@@ -19,12 +19,18 @@
 <%
 String emailAddress1 = ParamUtil.getString(request, "emailAddress1");
 String emailAddress2 = ParamUtil.getString(request, "emailAddress2");
+
+String referer = ParamUtil.get(request, WebKeys.REFERER, PortalUtil.getCurrentURL(request));
+
+if (referer.equals(themeDisplay.getPathMain() + "/portal/update_email_address")) {
+	referer = themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId();
+}
 %>
 
 <aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_email_address" %>' method="post" name="fm">
 	<aui:input name="doAsUserId" type="hidden" value="<%= themeDisplay.getDoAsUserId() %>" />
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
-	<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId() %>' />
+	<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= referer %>' />
 
 	<c:choose>
 		<c:when test="<%= SessionErrors.contains(request, DuplicateUserEmailAddressException.class.getName()) %>">

--- a/portal-web/docroot/html/portal/update_password.jsp
+++ b/portal-web/docroot/html/portal/update_password.jsp
@@ -20,6 +20,12 @@
 PasswordPolicy passwordPolicy = user.getPasswordPolicy();
 
 String ticketKey = ParamUtil.getString(request, "ticketKey");
+
+String referer = ParamUtil.get(request, WebKeys.REFERER, PortalUtil.getCurrentURL(request));
+
+if (referer.equals(themeDisplay.getPathMain() + "/portal/update_password")) {
+	referer = themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId();
+}
 %>
 
 <c:choose>
@@ -34,7 +40,7 @@ String ticketKey = ParamUtil.getString(request, "ticketKey");
 			<aui:input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
 			<aui:input name="doAsUserId" type="hidden" value="<%= themeDisplay.getDoAsUserId() %>" />
 			<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
-			<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId() %>' />
+			<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= referer %>' />
 			<aui:input name="ticketKey" type="hidden" value="<%= ticketKey %>" />
 
 			<div class="portlet-msg-info">

--- a/portal-web/docroot/html/portal/update_reminder_query.jsp
+++ b/portal-web/docroot/html/portal/update_reminder_query.jsp
@@ -16,11 +16,19 @@
 
 <%@ include file="/html/portal/init.jsp" %>
 
+<%
+String referer = ParamUtil.get(request, WebKeys.REFERER, PortalUtil.getCurrentURL(request));
+
+if (referer.equals(themeDisplay.getPathMain() + "/portal/update_reminder_query")) {
+	referer = themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId();
+}
+%>
+
 <aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_reminder_query" %>' method="post" name="fm">
 	<aui:input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
 	<aui:input name="doAsUserId" type="hidden" value="<%= themeDisplay.getDoAsUserId() %>" />
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
-	<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= themeDisplay.getPathMain() + "?doAsUserId=" + themeDisplay.getDoAsUserId() %>' />
+	<aui:input name="<%= WebKeys.REFERER %>" type="hidden" value='<%= referer %>' />
 
 	<div class="portlet-msg-info">
 		<liferay-ui:message key="please-choose-a-reminder-query" />


### PR DESCRIPTION
Portal loses context when ever we force user to accept terms, update password or email. This fixes it not just for FB but also SAML and everything else that expects to be redirected to certain url.
