### PR TITLE
LPS-22481

### DIFF
--- a/portal-web/docroot/html/portlet/search/open_search.jspf
+++ b/portal-web/docroot/html/portlet/search/open_search.jspf
@@ -48,16 +48,6 @@ while (itr.hasNext()) {
 		continue;
 	}
 
-	if (groupId != 0) {
-		long curPlid = PortalUtil.getPlidFromPortletId(groupId, portlet.getPortletId());
-
-		if (!PortletPermissionUtil.contains(permissionChecker, curPlid, portlet, ActionKeys.VIEW)) {
-			itr.remove();
-
-			continue;
-		}
-	}
-
 	portletTitles.add(PortalUtil.getPortletTitle(portlet, application, locale));
 }
 


### PR DESCRIPTION
this is rollback of LPS-10036

Confirmation from Peter that this is correct solution:

Hello Angelo,

Thank you for the detailed explanation.  Yes, let's remove it to fix the issue.
The original intent was to display content from a portlet only if these two conditions were met:
1.the portlet exists on one of the pages in the community, is a dynamic portlet or system portlet
2.the current user had VIEW permission for the portlet

It skips search "Everything" (if groupId > 0) because it would have been too expensive to check all groups.

In any case, the logic is incorrect and it'd be best to remove it.

Peter Shin
