### PR TITLE
LPS-22684 DLFileVersion's folderId needs to be update when DLFileEntry mo

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1400,6 +1400,17 @@ public class DLFileEntryLocalServiceImpl
 
 		dlFileEntryPersistence.update(dlFileEntry, false);
 
+		// FileVersion
+
+		List<DLFileVersion> dlFileVersions =
+			dlFileVersionPersistence.findByFileEntryId(fileEntryId);
+
+		for (DLFileVersion dlFileVersion : dlFileVersions) {
+			dlFileVersion.setFolderId(newFolderId);
+
+			dlFileVersionPersistence.update(dlFileVersion, false);
+		}
+
 		// File
 
 		DLStoreUtil.updateFile(


### PR DESCRIPTION
LPS-22684 DLFileVersion's folderId needs to be update when DLFileEntry moves to new folder
