### PR TITLE
LPS-21885 re-commit after rollback and research

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -67,7 +67,7 @@ Map<String, PortletURL> addPortletURLs = getAddPortletURLs(liferayPortletRequest
 				addPortletURLString = HttpUtil.addParameter(addPortletURLString, "layoutUuid", layout.getUuid());
 			}
 
-			String taglibEditURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + liferayPortletResponse.getNamespace() + "', title: '" + ResourceActionsUtil.getModelResource(locale, className) + "', uri:'" + addPortletURLString + "'});";
+			String taglibEditURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + liferayPortletResponse.getNamespace() + "', title: '" + ResourceActionsUtil.getModelResource(locale, className) + "', uri:'" + HtmlUtil.escapeURL(addPortletURLString) + "'});";
 		%>
 
 			<liferay-ui:icon
@@ -111,7 +111,7 @@ public PortletURL getAddPortletURL(LiferayPortletRequest liferayPortletRequest, 
 
 	redirectURL.setParameter("struts_action", "/asset_publisher/add_asset_redirect");
 
-	addPortletURL.setParameter("redirect", HtmlUtil.escapeURL(redirectURL.toString()));
+	addPortletURL.setParameter("redirect", redirectURL.toString());
 
 	String referringPortletResource = ParamUtil.getString(liferayPortletRequest, "portletResource");
 

--- a/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
@@ -44,7 +44,7 @@ if (showEditURL && (editPortletURL != null)) {
 
 	redirectURL.setParameter("struts_action", "/asset_publisher/add_asset_redirect");
 
-	editPortletURL.setParameter("redirect", HtmlUtil.escapeURL(redirectURL.toString()));
+	editPortletURL.setParameter("redirect", redirectURL.toString());
 
 	editPortletURLString = editPortletURL.toString();
 
@@ -63,7 +63,7 @@ if (themeDisplay.getScopeGroup().isLayout()) {
 	<div class="lfr-meta-actions asset-actions">
 
 		<%
-		String taglibEditURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + renderResponse.getNamespace() + "', title: '" + LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale))) + "', uri:'" + editPortletURLString + "'});";
+		String taglibEditURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + renderResponse.getNamespace() + "', title: '" + LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale))) + "', uri:'" + HtmlUtil.escapeURL(editPortletURLString) + "'});";
 		%>
 
 		<liferay-ui:icon

--- a/portal-web/docroot/html/portlet/polls_display/view.jsp
+++ b/portal-web/docroot/html/portlet/polls_display/view.jsp
@@ -155,7 +155,7 @@ boolean showIconsActions = themeDisplay.isSignedIn() && (showEditPollIcon || sho
 				</liferay-portlet:renderURL>
 
 				<%
-				String editQuestionURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + liferayPortletResponse.getNamespace() + "', title: '" + ResourceActionsUtil.getModelResource(locale, PollsQuestion.class.getName()) + "', uri:'" + editPollURL.toString() + "'});";
+				String editQuestionURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + liferayPortletResponse.getNamespace() + "', title: '" + ResourceActionsUtil.getModelResource(locale, PollsQuestion.class.getName()) + "', uri:'" + HtmlUtil.escapeURL(editPollURL.toString()) + "'});";
 				%>
 
 				<liferay-ui:icon
@@ -184,7 +184,7 @@ boolean showIconsActions = themeDisplay.isSignedIn() && (showEditPollIcon || sho
 				</liferay-portlet:renderURL>
 
 				<%
-				String addQuestionURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + liferayPortletResponse.getNamespace() + "', title: '" + ResourceActionsUtil.getModelResource(locale, PollsQuestion.class.getName()) + "', uri:'" + addPollURL.toString() + "'});";
+				String addQuestionURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id: '" + liferayPortletResponse.getNamespace() + "', title: '" + ResourceActionsUtil.getModelResource(locale, PollsQuestion.class.getName()) + "', uri:'" + HtmlUtil.escapeURL(addPollURL.toString()) + "'});";
 				%>
 
 				<liferay-ui:icon


### PR DESCRIPTION
Eudaldo found out that we needed to escape because we are using the url in javascript. The same approach was followed in asset publisher.

We have changed the pattern everywhere to make clearer that it is only needed to be escaped when used in javascript code.

Brian, can you also close this one now? http://issues.liferay.com/browse/LPS-22034
