### PR TITLE
LPS-22453 Exception deploying mail portlet on Resin.

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -762,6 +762,13 @@
     hibernate.cache.use_structured_entries=false
 
     #
+    # Disable the validation api for Hibernate. Some application servers have the validation
+    # jars in the classpath causing validation errors. Removing this jars from the classpath
+    # will have the same effect than using this property.
+    #
+    javax.persistence.validation.mode=none
+
+    #
     # Uncomment these properties to disable Hibernate caching.
     #
     #hibernate.cache.use_query_cache=false


### PR DESCRIPTION
LPS-22453 Exception deploying mail portlet on Resin. By default, some servers has validation libraries present on classpath (as Resin does). Using this property this validation is ignored (removing the validation jar from the classpath could be another solution)
