### PR TITLE
LPS-22742 Queries created by AssetEntryFinderImpl not working with PostgreSQL

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetEntryFinderImpl.java
@@ -155,6 +155,12 @@ public class AssetEntryFinderImpl
 		}
 		else {
 			sb.append("SELECT DISTINCT {AssetEntry.*} ");
+
+			if (entryQuery.getOrderByCol1().equals("ratings") ||
+				entryQuery.getOrderByCol2().equals("ratings")) {
+				
+				sb.append(", RatingsEntry.score ");
+			}
 		}
 
 		sb.append("FROM AssetEntry ");

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetEntryFinderImpl.java
@@ -158,7 +158,7 @@ public class AssetEntryFinderImpl
 
 			if (entryQuery.getOrderByCol1().equals("ratings") ||
 				entryQuery.getOrderByCol2().equals("ratings")) {
-				
+
 				sb.append(", RatingsEntry.score ");
 			}
 		}


### PR DESCRIPTION
SQL Standard defines that fields used in ORDER BY or GROUP BY should be present in the SELECT clause. Some databases, like PostgreSQL, meet this part of the standard in a strict way
