### PR TITLE
LPS-21192 Replace all usages of the word "Community" in Plugins. 

### DIFF
--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1260,9 +1260,9 @@
 					(Role_.companyId = ?) AND
 					(
 						(Role_.name = 'Administrator') OR
-						(Role_.name = 'Community Administrator') OR
-						(Role_.name = 'Community Member') OR
-						(Role_.name = 'Community Owner') OR
+						(Role_.name = 'Site Administrator') OR
+						(Role_.name = 'Site Member') OR
+						(Role_.name = 'Site Owner') OR
 						(Role_.name = 'Guest') OR
 						(Role_.name = 'Organization Administrator') OR
 						(Role_.name = 'Organization Member') OR


### PR DESCRIPTION
LPS-21192 Replace all usages of the word "Community" in Plugins. This query was not updated when doing the whole refactor of the portal
