### PR TITLE
LPS-22794 Refresh dialog success message should not appear if you are not in a pop up

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -704,7 +704,9 @@ public class EditLayoutsAction extends PortletAction {
 		String closeRedirect, Group group, Layout layout,
 		String oldLayoutFriendlyURL) {
 
-		if (Validator.isNull(oldLayoutFriendlyURL)) {
+		if (Validator.isNull(oldLayoutFriendlyURL) ||
+			Validator.isNull(closeRedirect)) {
+
 			return closeRedirect;
 		}
 

--- a/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
+++ b/portal-impl/src/com/liferay/portlet/sites/action/EditGroupAction.java
@@ -249,7 +249,7 @@ public class EditGroupAction extends PortletAction {
 			String oldFriendlyURL, String oldStagingFriendlyURL)
 		throws SystemException, PortalException {
 
-		if (group == null) {
+		if (group == null || Validator.isNull(closeRedirect)) {
 			return closeRedirect;
 		}
 

--- a/portal-web/docroot/html/common/themes/portlet_messages.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_messages.jspf
@@ -74,7 +74,7 @@ else if (group.isStagingGroup()) {
 			</c:otherwise>
 		</c:choose>
 
-		<c:if test='<%= SessionMessages.contains(renderRequest, portletConfig.getPortletName() + ".doCloseRedirect") %>'>
+		<c:if test='<%= themeDisplay.isStatePopUp() && SessionMessages.contains(renderRequest, portletConfig.getPortletName() + ".doCloseRedirect") %>'>
 
 			<%
 			String taglibMessage = "class=\"lfr-hide-dialog\" href=\"javascript:;\"";


### PR DESCRIPTION
In order to make it robust:
- closeRedirect should be empty when initially is empty in the Actions (which means we don't show the message)
- in addition, only show the message when the window state is pop up 
