### PR TITLE
LPS-22899 Non localizable images get erased on content translation

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
+++ b/portal-impl/src/com/liferay/portlet/journal/action/EditArticleAction.java
@@ -686,10 +686,12 @@ public class EditArticleAction extends PortletAction {
 								themeDisplay.getCompanyGroupId(), structureId);
 					}
 
-					content = JournalUtil.mergeArticleContent(
-						curArticle.getContent(), content, true);
-					content = JournalUtil.removeOldContent(
-						content, structure.getMergedXsd());
+					if (!cmd.equals(Constants.TRANSLATE)) {
+						content = JournalUtil.mergeArticleContent(
+							curArticle.getContent(), content, true);
+						content = JournalUtil.removeOldContent(
+							content, structure.getMergedXsd());
+					}
 				}
 			}
 


### PR DESCRIPTION
This processing was being done twice: once here and once in "updateArticleTranslation" method, so this has to be bypassed when we're translating a content
