### PR TITLE
LPS-16597

### DIFF
--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityLocalServiceImpl.java
@@ -340,6 +340,22 @@ public class SocialActivityLocalServiceImpl
 	}
 
 	/**
+	 * Removes stored activities for the asset identified by the class name and
+	 * class primary key.
+	 *
+	 * @param  className the target asset's class name
+	 * @param  classPK the primary key of the target asset
+	 * @throws SystemException if a system exception occurred
+	 */
+	public void deleteActivities(String className, long classPK)
+		throws SystemException {
+
+		long classNameId = PortalUtil.getClassNameId(className);
+
+		socialActivityPersistence.removeByC_C(classNameId, classPK);
+	}
+
+	/**
 	 * Removes the stored activity from the database.
 	 *
 	 * @param  activityId the primary key of the stored activity

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityLocalService.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityLocalService.java
@@ -370,6 +370,17 @@ public interface SocialActivityLocalService extends PersistedModelLocalService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
+	* Removes stored activities for the asset identified by the class name and
+	* class primary key.
+	*
+	* @param className the target asset's class name
+	* @param classPK the primary key of the target asset
+	* @throws SystemException if a system exception occurred
+	*/
+	public void deleteActivities(java.lang.String className, long classPK)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
 	* Removes the stored activity from the database.
 	*
 	* @param activityId the primary key of the stored activity

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityLocalServiceUtil.java
@@ -415,6 +415,19 @@ public class SocialActivityLocalServiceUtil {
 	}
 
 	/**
+	* Removes stored activities for the asset identified by the class name and
+	* class primary key.
+	*
+	* @param className the target asset's class name
+	* @param classPK the primary key of the target asset
+	* @throws SystemException if a system exception occurred
+	*/
+	public static void deleteActivities(java.lang.String className, long classPK)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		getService().deleteActivities(className, classPK);
+	}
+
+	/**
 	* Removes the stored activity from the database.
 	*
 	* @param activityId the primary key of the stored activity

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityLocalServiceWrapper.java
@@ -407,6 +407,19 @@ public class SocialActivityLocalServiceWrapper
 	}
 
 	/**
+	* Removes stored activities for the asset identified by the class name and
+	* class primary key.
+	*
+	* @param className the target asset's class name
+	* @param classPK the primary key of the target asset
+	* @throws SystemException if a system exception occurred
+	*/
+	public void deleteActivities(java.lang.String className, long classPK)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		_socialActivityLocalService.deleteActivities(className, classPK);
+	}
+
+	/**
 	* Removes the stored activity from the database.
 	*
 	* @param activityId the primary key of the stored activity


### PR DESCRIPTION
Rollback method that was removed. 

Currently, you can only remove a activities by AssetEntry. However, it's possible to add an activity for a class that is not a AssetEntry. So this method needs to be restored.
