### PR TITLE
LPS-21435 Contents categorized with children categories aren't show filtering by their parent category

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -3589,8 +3589,8 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 			this.rebuildTreeEnabled = rebuildTreeEnabled;
 		}
 
-		protected String buildSqlInClause(List<Long> ${entity.varNames}Ids){
-			if  (${entity.varNames}Ids.size() == 0){
+		protected String buildSqlInClause(List<Long> ${entity.varNames}Ids) {
+			if (${entity.varNames}Ids.size() == 0) {
 				return StringPool.BLANK;
 			}
 			

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_test.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_test.ftl
@@ -500,7 +500,252 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 
 		return ${entity.varName};
 	}
+	
+	<#if entity.isHierarchicalTree()>
+	public void testMove() throws Exception {
+		long groupId = nextLong();
 
+		${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+		
+		long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
+		long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
+		
+		${entity.name} child${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		
+		assertEquals(previousRootLeft${pkColumn.methodName}, root${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(previousRootRight${pkColumn.methodName} + 2, root${entity.name}.getRight${pkColumn.methodName}());		
+		assertEquals(root${entity.name}.getLeft${pkColumn.methodName}() + 1, child${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getRight${pkColumn.methodName}() - 1, child${entity.name}.getRight${pkColumn.methodName}());
+	}
+	
+	public void testMoveTreeFromRight() throws Exception {
+		long groupId = nextLong();
+
+		${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+		
+		long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
+		long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
+		
+		${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+		
+		${entity.name} child${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+		
+		parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
+		
+		parent${entity.name}.setParent${pkColumn.methodName}(root${entity.name}.get${pkColumn.methodName}());
+		
+		_persistence.update(parent${entity.name}, false);
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		child${entity.name} = _persistence.fetchByPrimaryKey(child${entity.name}.getPrimaryKey());
+		
+		assertEquals(previousRootLeft${pkColumn.methodName}, root${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(previousRootRight${pkColumn.methodName} + 4, root${entity.name}.getRight${pkColumn.methodName}());		
+		assertEquals(root${entity.name}.getLeft${pkColumn.methodName}() + 1, parent${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getRight${pkColumn.methodName}() + -1, parent${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getLeft${pkColumn.methodName}() + 1, child${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getRight${pkColumn.methodName}() + -1, child${entity.name}.getRight${pkColumn.methodName}());
+	}
+	
+	public void testMoveTreeFromLeft() throws Exception {
+		long groupId = nextLong();
+		
+		${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+		
+		${entity.name} child${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+		
+		parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
+		
+		${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+		
+		long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
+		long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
+		
+		parent${entity.name}.setParent${pkColumn.methodName}(root${entity.name}.get${pkColumn.methodName}());
+		
+		_persistence.update(parent${entity.name}, false);
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		child${entity.name} = _persistence.fetchByPrimaryKey(child${entity.name}.getPrimaryKey());
+		
+		assertEquals(previousRootLeft${pkColumn.methodName} - 4, root${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(previousRootRight${pkColumn.methodName}, root${entity.name}.getRight${pkColumn.methodName}());		
+		assertEquals(root${entity.name}.getLeft${pkColumn.methodName}() + 1, parent${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getRight${pkColumn.methodName}() -1 , parent${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getLeft${pkColumn.methodName}() + 1, child${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getRight${pkColumn.methodName}() - 1, child${entity.name}.getRight${pkColumn.methodName}());
+	}
+	
+	public void testMoveTreeIntoTreeFromRight() throws Exception {
+		long groupId = nextLong();
+
+		${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+		
+		${entity.name} leftRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		
+		${entity.name} rightRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		
+		long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
+		long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
+		
+		${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+		
+		${entity.name} parentChild${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+		
+		parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
+		
+		parent${entity.name}.setParent${pkColumn.methodName}(leftRootChild${entity.name}.get${pkColumn.methodName}());
+		
+		_persistence.update(parent${entity.name}, false);
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		leftRootChild${entity.name} = _persistence.fetchByPrimaryKey(leftRootChild${entity.name}.getPrimaryKey());
+		rightRootChild${entity.name} = _persistence.fetchByPrimaryKey(rightRootChild${entity.name}.getPrimaryKey());
+		parentChild${entity.name} = _persistence.fetchByPrimaryKey(parentChild${entity.name}.getPrimaryKey());
+		
+		assertEquals(previousRootLeft${pkColumn.methodName}, root${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(previousRootRight${pkColumn.methodName} + 4, root${entity.name}.getRight${pkColumn.methodName}());		
+		assertEquals(root${entity.name}.getLeft${pkColumn.methodName}() + 1, leftRootChild${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getRight${pkColumn.methodName}() - 3, leftRootChild${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getLeft${pkColumn.methodName}() + 7, rightRootChild${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getRight${pkColumn.methodName}() - 1, rightRootChild${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(leftRootChild${entity.name}.getLeft${pkColumn.methodName}() + 1, parent${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(leftRootChild${entity.name}.getRight${pkColumn.methodName}() - 1, parent${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getLeft${pkColumn.methodName}() + 1, parentChild${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getRight${pkColumn.methodName}() - 1, parentChild${entity.name}.getRight${pkColumn.methodName}());
+	}
+	
+	public void testMoveTreeIntoTreeFromLeft() throws Exception {
+		long groupId = nextLong();
+	
+		${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+		
+		${entity.name} parentChild${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+		
+		parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
+		
+		${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+		
+		${entity.name} leftRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		
+		${entity.name} rightRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		
+		long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
+		long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
+		
+		parent${entity.name}.setParent${pkColumn.methodName}(rightRootChild${entity.name}.get${pkColumn.methodName}());
+		
+		_persistence.update(parent${entity.name}, false);
+		
+		root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
+		leftRootChild${entity.name} = _persistence.fetchByPrimaryKey(leftRootChild${entity.name}.getPrimaryKey());
+		rightRootChild${entity.name} = _persistence.fetchByPrimaryKey(rightRootChild${entity.name}.getPrimaryKey());
+		parentChild${entity.name} = _persistence.fetchByPrimaryKey(parentChild${entity.name}.getPrimaryKey());
+		
+		assertEquals(previousRootLeft${pkColumn.methodName} - 4, root${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(previousRootRight${pkColumn.methodName}, root${entity.name}.getRight${pkColumn.methodName}());		
+		assertEquals(root${entity.name}.getLeft${pkColumn.methodName}() + 1, leftRootChild${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getRight${pkColumn.methodName}() - 7, leftRootChild${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getLeft${pkColumn.methodName}() + 3, rightRootChild${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(root${entity.name}.getRight${pkColumn.methodName}() - 1, rightRootChild${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(rightRootChild${entity.name}.getLeft${pkColumn.methodName}() + 1, parent${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(rightRootChild${entity.name}.getRight${pkColumn.methodName}() - 1, parent${entity.name}.getRight${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getLeft${pkColumn.methodName}() + 1, parentChild${entity.name}.getLeft${pkColumn.methodName}());
+		assertEquals(parent${entity.name}.getRight${pkColumn.methodName}() - 1, parentChild${entity.name}.getRight${pkColumn.methodName}());
+	}
+	
+	protected ${entity.name} add${entity.name}(long groupId, Long parent${pkColumn.methodName}) throws Exception {
+		<#if entity.hasCompoundPK()>
+			${entity.PKClassName} pk = new ${entity.PKClassName}(
+
+			<#list entity.PKList as column>
+				<#if column.type == "int">
+					nextInt()
+				<#elseif column.type == "long">
+					nextLong()
+				<#elseif column.type == "String">
+					randomString()
+				</#if>
+
+				<#if column_has_next>
+					,
+				</#if>
+			</#list>
+
+			);
+		<#else>
+			<#assign column = entity.PKList[0]>
+
+			${column.type} pk =
+
+			<#if column.type == "int">
+				nextInt()
+			<#elseif column.type == "long">
+				nextLong()
+			<#elseif column.type == "String">
+				randomString()
+			</#if>
+
+			;
+		</#if>
+
+		${entity.name} ${entity.varName} = _persistence.create(pk);
+
+		<#list entity.regularColList as column>
+			<#if !column.primary && ((parentPKColumn == "") || (parentPKColumn.name != column.name))>
+				<#if column.name ="groupId">
+					
+					${entity.varName}.set${column.methodName}(groupId);
+				<#else>
+					<#if column.type == "Blob">
+						byte[] ${column.name}Bytes = randomString().getBytes(StringPool.UTF8);
+	
+						Blob ${column.name}Blob = new OutputBlob(new UnsyncByteArrayInputStream(${column.name}Bytes), ${column.name}Bytes.length);
+					</#if>
+	
+					${entity.varName}.set${column.methodName}(
+	
+					<#if column.type == "boolean">
+						randomBoolean()
+					<#elseif column.type == "double">
+						nextDouble()
+					<#elseif column.type == "int">
+						nextInt()
+					<#elseif column.type == "long">
+						nextLong()
+					<#elseif column.type == "Blob">
+						${column.name}Blob
+					<#elseif column.type == "Date">
+						nextDate()
+					<#elseif column.type == "String">
+						randomString()
+					</#if>
+	
+					);
+				</#if>
+			</#if>
+		</#list>
+		
+		if (parent${pkColumn.methodName} != null){
+			${entity.varName}.setParent${pkColumn.methodName}(parent${pkColumn.methodName});
+		}
+		
+		_persistence.update(${entity.varName}, false);
+
+		return ${entity.varName};
+	}
+	</#if>
+	
 	private ${entity.name}Persistence _persistence;
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceImpl.java
@@ -544,12 +544,14 @@ public class AssetCategoryPersistenceImpl extends BasePersistenceImpl<AssetCateg
 		}
 
 		if (isNew) {
-			expandTree(assetCategory);
+			expandTree(assetCategory, null);
 		}
 		else {
 			if (assetCategory.getParentCategoryId() != assetCategoryModelImpl.getOriginalParentCategoryId()) {
+				List<Long> childrenCategoryIds = getChildrenTreeCategoryIds(assetCategory);
+
 				shrinkTree(assetCategory);
-				expandTree(assetCategory);
+				expandTree(assetCategory, childrenCategoryIds);
 			}
 		}
 
@@ -6414,8 +6416,8 @@ public class AssetCategoryPersistenceImpl extends BasePersistenceImpl<AssetCateg
 		}
 	}
 
-	protected void expandTree(AssetCategory assetCategory)
-		throws SystemException {
+	protected void expandTree(AssetCategory assetCategory,
+		List<Long> childrenCategoryIds) throws SystemException {
 		if (!rebuildTreeEnabled) {
 			return;
 		}
@@ -6430,10 +6432,29 @@ public class AssetCategoryPersistenceImpl extends BasePersistenceImpl<AssetCateg
 
 		if (lastRightCategoryId > 0) {
 			leftCategoryId = lastRightCategoryId + 1;
-			rightCategoryId = lastRightCategoryId + 2;
 
-			expandTreeLeftCategoryId.expand(groupId, lastRightCategoryId);
-			expandTreeRightCategoryId.expand(groupId, lastRightCategoryId);
+			long childrenDistance = assetCategory.getRightCategoryId() -
+				assetCategory.getLeftCategoryId();
+
+			if (childrenDistance > 1) {
+				rightCategoryId = leftCategoryId + childrenDistance;
+
+				long diff = leftCategoryId - assetCategory.getLeftCategoryId();
+
+				updateChildrenTree(diff, groupId, childrenCategoryIds);
+
+				expandNoChildrenLeftCategoryId(childrenDistance + 1, groupId,
+					lastRightCategoryId, childrenCategoryIds);
+
+				expandNoChildrenRightCategoryId(childrenDistance + 1, groupId,
+					lastRightCategoryId, childrenCategoryIds);
+			}
+			else {
+				rightCategoryId = lastRightCategoryId + 2;
+
+				expandTreeLeftCategoryId.expand(groupId, lastRightCategoryId);
+				expandTreeRightCategoryId.expand(groupId, lastRightCategoryId);
+			}
 
 			CacheRegistryUtil.clear(AssetCategoryImpl.class.getName());
 			EntityCacheUtil.clearCache(AssetCategoryImpl.class.getName());
@@ -6553,6 +6574,97 @@ public class AssetCategoryPersistenceImpl extends BasePersistenceImpl<AssetCateg
 		EntityCacheUtil.clearCache(AssetCategoryImpl.class.getName());
 		FinderCacheUtil.clearCache(FINDER_CLASS_NAME_ENTITY);
 		FinderCacheUtil.clearCache(FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION);
+	}
+
+	protected List<Long> getChildrenTreeCategoryIds(
+		AssetCategory parentAssetCategory) throws SystemException {
+		List<Long> childrenCategoryIds = null;
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery q = session.createSQLQuery(
+					"SELECT categoryId FROM AssetCategory WHERE (groupId = ?) AND (leftcategoryId BETWEEN ? AND ?)");
+
+			q.addScalar("CategoryId",
+				com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(parentAssetCategory.getGroupId());
+			qPos.add(parentAssetCategory.getLeftCategoryId() + 1);
+			qPos.add(parentAssetCategory.getRightCategoryId());
+
+			childrenCategoryIds = q.list();
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+
+		return childrenCategoryIds;
+	}
+
+	protected void updateChildrenTree(long delta, long groupId,
+		List<Long> childrenCategoryIds) {
+		String sql = "UPDATE AssetCategory SET leftcategoryId = (leftcategoryId + ?), rightcategoryId = (rightcategoryId + ?) WHERE (groupId = ?) AND (categoryId IN (" +
+			buildSqlInClause(childrenCategoryIds) + "))";
+
+		SqlUpdate _sqlUpdate = SqlUpdateFactoryUtil.getSqlUpdate(getDataSource(),
+				sql,
+				new int[] {
+					java.sql.Types.BIGINT, java.sql.Types.BIGINT,
+					java.sql.Types.BIGINT
+				});
+
+		_sqlUpdate.update(new Object[] { delta, delta, groupId });
+	}
+
+	protected void expandNoChildrenLeftCategoryId(long delta, long groupId,
+		long leftCategoryId, List<Long> childrenCategoryIds) {
+		String sql = "UPDATE AssetCategory SET leftcategoryId = (leftcategoryId + ?) WHERE (groupId = ?) AND (leftcategoryId > ?) AND (categoryId NOT IN (" +
+			buildSqlInClause(childrenCategoryIds) + "))";
+
+		SqlUpdate _sqlUpdate = SqlUpdateFactoryUtil.getSqlUpdate(getDataSource(),
+				sql,
+				new int[] {
+					java.sql.Types.BIGINT, java.sql.Types.BIGINT,
+					java.sql.Types.BIGINT
+				});
+
+		_sqlUpdate.update(new Object[] { delta, groupId, leftCategoryId });
+	}
+
+	protected void expandNoChildrenRightCategoryId(long delta, long groupId,
+		long rightCategoryId, List<Long> childrenCategoryIds) {
+		String sql = "UPDATE AssetCategory SET rightcategoryId = (rightcategoryId + ?) WHERE (groupId = ?) AND (rightcategoryId > ?) AND (categoryId NOT IN (" +
+			buildSqlInClause(childrenCategoryIds) + "))";
+
+		SqlUpdate _sqlUpdate = SqlUpdateFactoryUtil.getSqlUpdate(getDataSource(),
+				sql,
+				new int[] {
+					java.sql.Types.BIGINT, java.sql.Types.BIGINT,
+					java.sql.Types.BIGINT
+				});
+
+		_sqlUpdate.update(new Object[] { delta, groupId, rightCategoryId });
+	}
+
+	protected String buildSqlInClause(List<Long> CategoryIds) {
+		String sqlInClause = StringPool.BLANK;
+
+		for (long CategoryId : CategoryIds) {
+			sqlInClause = sqlInClause + CategoryId +
+				StringPool.COMMA_AND_SPACE;
+		}
+
+		return sqlInClause.equals(StringPool.BLANK) ? sqlInClause
+													: sqlInClause.substring(0,
+			sqlInClause.length() - 2);
 	}
 
 	/**

--- a/portal-impl/test/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceTest.java
+++ b/portal-impl/test/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceTest.java
@@ -295,5 +295,253 @@ public class AssetCategoryPersistenceTest extends BasePersistenceTestCase {
 		return assetCategory;
 	}
 
+	public void testMove() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		AssetCategory childAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId + 2,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			childAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			childAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeFromRight() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory childAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		parentAssetCategory.setParentCategoryId(rootAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		childAssetCategory = _persistence.fetchByPrimaryKey(childAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId + 4,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() + -1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			childAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() + -1,
+			childAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeFromLeft() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory childAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		parentAssetCategory.setParentCategoryId(rootAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		childAssetCategory = _persistence.fetchByPrimaryKey(childAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId - 4,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			childAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() - 1,
+			childAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeIntoTreeFromRight() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory leftRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		AssetCategory rightRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory parentChildAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		parentAssetCategory.setParentCategoryId(leftRootChildAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		leftRootChildAssetCategory = _persistence.fetchByPrimaryKey(leftRootChildAssetCategory.getPrimaryKey());
+		rightRootChildAssetCategory = _persistence.fetchByPrimaryKey(rightRootChildAssetCategory.getPrimaryKey());
+		parentChildAssetCategory = _persistence.fetchByPrimaryKey(parentChildAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId + 4,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			leftRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 3,
+			leftRootChildAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 7,
+			rightRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			rightRootChildAssetCategory.getRightCategoryId());
+		assertEquals(leftRootChildAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(leftRootChildAssetCategory.getRightCategoryId() - 1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			parentChildAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() - 1,
+			parentChildAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeIntoTreeFromLeft() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory parentChildAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory leftRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		AssetCategory rightRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		parentAssetCategory.setParentCategoryId(rightRootChildAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		leftRootChildAssetCategory = _persistence.fetchByPrimaryKey(leftRootChildAssetCategory.getPrimaryKey());
+		rightRootChildAssetCategory = _persistence.fetchByPrimaryKey(rightRootChildAssetCategory.getPrimaryKey());
+		parentChildAssetCategory = _persistence.fetchByPrimaryKey(parentChildAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId - 4,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			leftRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 7,
+			leftRootChildAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 3,
+			rightRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			rightRootChildAssetCategory.getRightCategoryId());
+		assertEquals(rightRootChildAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(rightRootChildAssetCategory.getRightCategoryId() - 1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			parentChildAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() - 1,
+			parentChildAssetCategory.getRightCategoryId());
+	}
+
+	protected AssetCategory addAssetCategory(long groupId, Long parentCategoryId)
+		throws Exception {
+		long pk = nextLong();
+
+		AssetCategory assetCategory = _persistence.create(pk);
+
+		assetCategory.setUuid(randomString());
+
+		assetCategory.setGroupId(groupId);
+
+		assetCategory.setCompanyId(nextLong());
+
+		assetCategory.setUserId(nextLong());
+
+		assetCategory.setUserName(randomString());
+
+		assetCategory.setCreateDate(nextDate());
+
+		assetCategory.setModifiedDate(nextDate());
+
+		assetCategory.setLeftCategoryId(nextLong());
+
+		assetCategory.setRightCategoryId(nextLong());
+
+		assetCategory.setName(randomString());
+
+		assetCategory.setTitle(randomString());
+
+		assetCategory.setDescription(randomString());
+
+		assetCategory.setVocabularyId(nextLong());
+
+		if (parentCategoryId != null) {
+			assetCategory.setParentCategoryId(parentCategoryId);
+		}
+
+		_persistence.update(assetCategory, false);
+
+		return assetCategory;
+	}
+
 	private AssetCategoryPersistence _persistence;
 }


### PR DESCRIPTION
This pull request includes:
- Junit Tests
- Persistence implementation source code

The changes have two main reason:
- The expandTree method didn't take into account the possibility to move a tree inside another node.
- It's necessary to precalculate the children nodes at the beginning because after the updates of shrinkTree method there could be several nodes with the same value for Right or Left category id and we need to distinct the children nodes.

We haven't created three new classes for the updates because it seems that IN clause doesn't allow this, instead of this we have created three methods.
