### PR TITLE
Test Fixes

### DIFF
--- a/build-test-jetty.xml
+++ b/build-test-jetty.xml
@@ -36,8 +36,8 @@
 		</if>
 
 		<replace file="${app.server.jetty.bin.dir}/run.bat">
-			<replacetoken>set "JAVA_OPTS=-Djetty.version=7.5.1 -Djetty.version.date=20110908 -Dfile.encoding=UTF8 -Djava.io.tmpdir=../temp -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=256m"</replacetoken>
-			<replacevalue expandProperties="true">set "JAVA_OPTS=-Djetty.version=7.5.1 -Djetty.version.date=20110908 -Dfile.encoding=UTF8 -Djava.io.tmpdir=../temp -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=256m -DSTOP.PORT=8079 -DSTOP.KEY=secret"</replacevalue>
+			<replacetoken>set "JAVA_OPTS=-D</replacetoken>
+			<replacevalue>set "JAVA_OPTS=-DSTOP.PORT=8079 -DSTOP.KEY=secret -D</replacevalue>
 		</replace>
 
 		<copy
@@ -47,7 +47,7 @@
 
 		<replace file="${app.server.jetty.bin.dir}/shutdown.bat">
 			<replacetoken>"%JAVA_HOME%/bin/java" %JAVA_OPTS% -jar ../start.jar</replacetoken>
-			<replacevalue expandProperties="true">"%JAVA_HOME%/bin/java" %JAVA_OPTS% -jar ../start.jar --stop</replacevalue>
+			<replacevalue>"%JAVA_HOME%/bin/java" %JAVA_OPTS% -jar ../start.jar --stop</replacevalue>
 		</replace>
 
 		<antcall target="revert-test-properties" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -211,6 +211,16 @@
 	</target>
 
 	<target name="build-test-ant-script-db-upgrade-smoke">
+		<if>
+			<isset property="test.ant.script.evaluate.logs" />
+			<then>
+				<property name="test.ant.script.file.evaluate.logs" value="&lt;property name=&quot;test.evaluate.logs&quot; value=&quot;true&quot; /&gt;" />
+			</then>
+			<else>
+				<property name="test.ant.script.file.evaluate.logs" value=" " />
+			</else>
+		</if>
+
 		<for list="${test.ant.script.versions}" param="test.ant.script.version">
 			<sequential>
 				<if>
@@ -255,7 +265,7 @@
 	</target>
 
 	<target name="build-test-ant-scripts">
-		<property name="build-test-ant-scripts.version" value="5" />
+		<property name="build-test-ant-scripts.version" value="6" />
 
 		<if>
 			<available file="portal-web/test-ant-scripts/version" />

--- a/build.xml
+++ b/build.xml
@@ -413,8 +413,16 @@ JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Dus
 
 						<replace file="${app.server.jetty.bin.dir}/run.bat">
 							<replacetoken>set "JAVA_OPTS=-D</replacetoken>
-							<replacevalue expandProperties="true">set "JAVA_OPTS=-Djetty.version=${app.server.jetty.version} -Djetty.version.date=${app.server.jetty.version.date} -D</replacevalue>
+							<replacevalue>set "JAVA_OPTS=-Djetty.version=${app.server.jetty.version} -Djetty.version.date=${app.server.jetty.version.date} -D</replacevalue>
 						</replace>
+
+						<loadfile property="run.bat.content" srcfile="${app.server.jetty.bin.dir}/run.bat">
+							<filterchain>
+								<expandproperties />
+							</filterchain>
+						</loadfile>
+
+						<echo file="${app.server.jetty.bin.dir}/run.bat">${run.bat.content}</echo>
 					</then>
 				</if>
 
@@ -435,8 +443,16 @@ JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Dus
 
 						<replace file="${app.server.jetty.bin.dir}/run.sh">
 							<replacetoken>export JAVA_OPTS="-D</replacetoken>
-							<replacevalue expandProperties="true">export JAVA_OPTS="-Djetty.version=${app.server.jetty.version} -Djetty.version.date=${app.server.jetty.version.date} -D</replacevalue>
+							<replacevalue>export JAVA_OPTS="-Djetty.version=${app.server.jetty.version} -Djetty.version.date=${app.server.jetty.version.date} -D</replacevalue>
 						</replace>
+
+						<loadfile property="run.sh.content" srcfile="${app.server.jetty.bin.dir}/run.sh">
+							<filterchain>
+								<expandproperties />
+							</filterchain>
+						</loadfile>
+
+						<echo file="${app.server.jetty.bin.dir}/run.sh">${run.sh.content}</echo>
 					</then>
 				</if>
 


### PR DESCRIPTION
All of the hudson slaves use "ant-1.7", so expandProperties doesn't work for the replace filter.
So we needed a work around.
