### PR TITLE
LPS-21435 Contents categorized with children categories aren't show filtering by their parent category 

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -3614,7 +3614,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		}
 
 		protected void expandNoChildrenLeft${pkColumn.methodName}(long ${scopeColumn.name}, long left${pkColumn.methodName}, List<Long> children${pkColumn.methodNames}, long delta) {
-			String sql = "UPDATE ${entity.name} SET left${entity.PKDBName} = (left${entity.PKDBName} + ?) WHERE (${scopeColumn.DBName} = ?) AND (left${entity.PKDBName} > ?) AND (${entity.PKDBName} NOT IN (" + StringUtil.merge(children${pkColumn.methodNames}) + "))";
+			String sql = "UPDATE ${entity.table} SET left${entity.PKDBName} = (left${entity.PKDBName} + ?) WHERE (${scopeColumn.DBName} = ?) AND (left${entity.PKDBName} > ?) AND (${entity.PKDBName} NOT IN (" + StringUtil.merge(children${pkColumn.methodNames}) + "))";
 
 			SqlUpdate _sqlUpdate = SqlUpdateFactoryUtil.getSqlUpdate(getDataSource(), sql, new int[] {java.sql.Types.BIGINT, java.sql.Types.BIGINT, java.sql.Types.BIGINT});
 
@@ -3622,7 +3622,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		}
 
 		protected void expandNoChildrenRight${pkColumn.methodName}(long ${scopeColumn.name}, long right${pkColumn.methodName}, List<Long> children${pkColumn.methodNames}, long delta) {
-			String sql = "UPDATE ${entity.name} SET right${entity.PKDBName} = (right${entity.PKDBName} + ?) WHERE (${scopeColumn.DBName} = ?) AND (right${entity.PKDBName} > ?) AND (${entity.PKDBName} NOT IN (" + StringUtil.merge(children${pkColumn.methodNames}) + "))";
+			String sql = "UPDATE ${entity.table} SET right${entity.PKDBName} = (right${entity.PKDBName} + ?) WHERE (${scopeColumn.DBName} = ?) AND (right${entity.PKDBName} > ?) AND (${entity.PKDBName} NOT IN (" + StringUtil.merge(children${pkColumn.methodNames}) + "))";
 
 			SqlUpdate _sqlUpdate = SqlUpdateFactoryUtil.getSqlUpdate(getDataSource(), sql, new int[] {java.sql.Types.BIGINT, java.sql.Types.BIGINT, java.sql.Types.BIGINT});
 
@@ -3802,7 +3802,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		}
 
 		protected void updateChildrenTree(long ${scopeColumn.name}, List<Long> children${pkColumn.methodNames}, long delta) {
-			String sql = "UPDATE ${entity.name} SET left${entity.PKDBName} = (left${entity.PKDBName} + ?), right${entity.PKDBName} = (right${entity.PKDBName} + ?) WHERE (${scopeColumn.DBName} = ?) AND (${entity.PKDBName} IN (" + StringUtil.merge(children${pkColumn.methodNames}) + "))";
+			String sql = "UPDATE ${entity.table} SET left${entity.PKDBName} = (left${entity.PKDBName} + ?), right${entity.PKDBName} = (right${entity.PKDBName} + ?) WHERE (${scopeColumn.DBName} = ?) AND (${entity.PKDBName} IN (" + StringUtil.merge(children${pkColumn.methodNames}) + "))";
 
 			SqlUpdate _sqlUpdate = SqlUpdateFactoryUtil.getSqlUpdate(getDataSource(), sql, new int[] {java.sql.Types.BIGINT, java.sql.Types.BIGINT, java.sql.Types.BIGINT});
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_test.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_test.ftl
@@ -1,6 +1,12 @@
 <#assign parentPKColumn = "">
 
 <#if entity.isHierarchicalTree()>
+	<#if entity.hasColumn("groupId")>
+		<#assign scopeColumn = entity.getColumn("groupId")>
+	<#else>
+		<#assign scopeColumn = entity.getColumn("companyId")>
+	</#if>
+
 	<#assign pkColumn = entity.getPKList()?first>
 
 	<#assign parentPKColumn = entity.getColumn("parent" + pkColumn.methodName)>
@@ -507,14 +513,14 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 
 	<#if entity.isHierarchicalTree()>
 		public void testMoveTree() throws Exception {
-			long groupId = nextLong();
+			long ${scopeColumn.name} = nextLong();
 
-			${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} root${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
 			long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
 			long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
 
-			${entity.name} child${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+			${entity.name} child${entity.name} = add${entity.name}(${scopeColumn.name}, root${entity.name}.get${pkColumn.methodName}());
 
 			root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
 
@@ -525,15 +531,15 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 		}
 
 		public void testMoveTreeFromLeft() throws Exception {
-			long groupId = nextLong();
+			long ${scopeColumn.name} = nextLong();
 
-			${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} parent${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
-			${entity.name} child${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+			${entity.name} child${entity.name} = add${entity.name}(${scopeColumn.name}, parent${entity.name}.get${pkColumn.methodName}());
 
 			parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
 
-			${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} root${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
 			long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
 			long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
@@ -554,16 +560,16 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 		}
 
 		public void testMoveTreeFromRight() throws Exception {
-			long groupId = nextLong();
+			long ${scopeColumn.name} = nextLong();
 
-			${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} root${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
 			long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
 			long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
 
-			${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} parent${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
-			${entity.name} child${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+			${entity.name} child${entity.name} = add${entity.name}(${scopeColumn.name}, parent${entity.name}.get${pkColumn.methodName}());
 
 			parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
 
@@ -583,21 +589,21 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 		}
 
 		public void testMoveTreeIntoTreeFromLeft() throws Exception {
-			long groupId = nextLong();
+			long ${scopeColumn.name} = nextLong();
 
-			${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} parent${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
-			${entity.name} parentChild${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+			${entity.name} parentChild${entity.name} = add${entity.name}(${scopeColumn.name}, parent${entity.name}.get${pkColumn.methodName}());
 
 			parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
 
-			${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} root${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
-			${entity.name} leftRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+			${entity.name} leftRootChild${entity.name} = add${entity.name}(${scopeColumn.name}, root${entity.name}.get${pkColumn.methodName}());
 
 			root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
 
-			${entity.name} rightRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+			${entity.name} rightRootChild${entity.name} = add${entity.name}(${scopeColumn.name}, root${entity.name}.get${pkColumn.methodName}());
 
 			root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
 
@@ -626,24 +632,24 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 		}
 
 		public void testMoveTreeIntoTreeFromRight() throws Exception {
-			long groupId = nextLong();
+			long ${scopeColumn.name} = nextLong();
 
-			${entity.name} root${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} root${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
-			${entity.name} leftRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+			${entity.name} leftRootChild${entity.name} = add${entity.name}(${scopeColumn.name}, root${entity.name}.get${pkColumn.methodName}());
 
 			root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
 
-			${entity.name} rightRootChild${entity.name} = add${entity.name}(groupId, root${entity.name}.get${pkColumn.methodName}());
+			${entity.name} rightRootChild${entity.name} = add${entity.name}(${scopeColumn.name}, root${entity.name}.get${pkColumn.methodName}());
 
 			root${entity.name} = _persistence.fetchByPrimaryKey(root${entity.name}.getPrimaryKey());
 
 			long previousRootLeft${pkColumn.methodName} = root${entity.name}.getLeft${pkColumn.methodName}();
 			long previousRootRight${pkColumn.methodName} = root${entity.name}.getRight${pkColumn.methodName}();
 
-			${entity.name} parent${entity.name} = add${entity.name}(groupId, null);
+			${entity.name} parent${entity.name} = add${entity.name}(${scopeColumn.name}, null);
 
-			${entity.name} parentChild${entity.name} = add${entity.name}(groupId, parent${entity.name}.get${pkColumn.methodName}());
+			${entity.name} parentChild${entity.name} = add${entity.name}(${scopeColumn.name}, parent${entity.name}.get${pkColumn.methodName}());
 
 			parent${entity.name} = _persistence.fetchByPrimaryKey(parent${entity.name}.getPrimaryKey());
 
@@ -668,7 +674,7 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 			assertEquals(parent${entity.name}.getRight${pkColumn.methodName}() - 1, parentChild${entity.name}.getRight${pkColumn.methodName}());
 		}
 
-		protected ${entity.name} add${entity.name}(long groupId, Long parent${pkColumn.methodName}) throws Exception {
+		protected ${entity.name} add${entity.name}(long ${scopeColumn.name}, Long parent${pkColumn.methodName}) throws Exception {
 			<#if entity.hasCompoundPK()>
 				${entity.PKClassName} pk = new ${entity.PKClassName}(
 
@@ -707,8 +713,8 @@ public class ${entity.name}PersistenceTest extends BasePersistenceTestCase {
 
 			<#list entity.regularColList as column>
 				<#if !column.primary && ((parentPKColumn == "") || (parentPKColumn.name != column.name))>
-					<#if column.name ="groupId">
-						${entity.varName}.set${column.methodName}(groupId);
+					<#if column.name ="${scopeColumn.name}">
+						${entity.varName}.set${column.methodName}(${scopeColumn.name});
 					<#else>
 						<#if column.type == "Blob">
 							String ${column.name}String = randomString();

--- a/portal-impl/test/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceTest.java
+++ b/portal-impl/test/com/liferay/portlet/asset/service/persistence/AssetCategoryPersistenceTest.java
@@ -295,5 +295,252 @@ public class AssetCategoryPersistenceTest extends BasePersistenceTestCase {
 		return assetCategory;
 	}
 
+	public void testMoveTree() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		AssetCategory childAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId + 2,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			childAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			childAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeFromLeft() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory childAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		parentAssetCategory.setParentCategoryId(rootAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		childAssetCategory = _persistence.fetchByPrimaryKey(childAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId - 4,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			childAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() - 1,
+			childAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeFromRight() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory childAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		parentAssetCategory.setParentCategoryId(rootAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		childAssetCategory = _persistence.fetchByPrimaryKey(childAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId + 4,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			childAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() - 1,
+			childAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeIntoTreeFromLeft() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory parentChildAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory leftRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		AssetCategory rightRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		parentAssetCategory.setParentCategoryId(rightRootChildAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		leftRootChildAssetCategory = _persistence.fetchByPrimaryKey(leftRootChildAssetCategory.getPrimaryKey());
+		rightRootChildAssetCategory = _persistence.fetchByPrimaryKey(rightRootChildAssetCategory.getPrimaryKey());
+		parentChildAssetCategory = _persistence.fetchByPrimaryKey(parentChildAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId - 4,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			leftRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 7,
+			leftRootChildAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 3,
+			rightRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			rightRootChildAssetCategory.getRightCategoryId());
+		assertEquals(rightRootChildAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(rightRootChildAssetCategory.getRightCategoryId() - 1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			parentChildAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() - 1,
+			parentChildAssetCategory.getRightCategoryId());
+	}
+
+	public void testMoveTreeIntoTreeFromRight() throws Exception {
+		long groupId = nextLong();
+
+		AssetCategory rootAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory leftRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		AssetCategory rightRootChildAssetCategory = addAssetCategory(groupId,
+				rootAssetCategory.getCategoryId());
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+
+		long previousRootLeftCategoryId = rootAssetCategory.getLeftCategoryId();
+		long previousRootRightCategoryId = rootAssetCategory.getRightCategoryId();
+
+		AssetCategory parentAssetCategory = addAssetCategory(groupId, null);
+
+		AssetCategory parentChildAssetCategory = addAssetCategory(groupId,
+				parentAssetCategory.getCategoryId());
+
+		parentAssetCategory = _persistence.fetchByPrimaryKey(parentAssetCategory.getPrimaryKey());
+
+		parentAssetCategory.setParentCategoryId(leftRootChildAssetCategory.getCategoryId());
+
+		_persistence.update(parentAssetCategory, false);
+
+		rootAssetCategory = _persistence.fetchByPrimaryKey(rootAssetCategory.getPrimaryKey());
+		leftRootChildAssetCategory = _persistence.fetchByPrimaryKey(leftRootChildAssetCategory.getPrimaryKey());
+		rightRootChildAssetCategory = _persistence.fetchByPrimaryKey(rightRootChildAssetCategory.getPrimaryKey());
+		parentChildAssetCategory = _persistence.fetchByPrimaryKey(parentChildAssetCategory.getPrimaryKey());
+
+		assertEquals(previousRootLeftCategoryId,
+			rootAssetCategory.getLeftCategoryId());
+		assertEquals(previousRootRightCategoryId + 4,
+			rootAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 1,
+			leftRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 3,
+			leftRootChildAssetCategory.getRightCategoryId());
+		assertEquals(rootAssetCategory.getLeftCategoryId() + 7,
+			rightRootChildAssetCategory.getLeftCategoryId());
+		assertEquals(rootAssetCategory.getRightCategoryId() - 1,
+			rightRootChildAssetCategory.getRightCategoryId());
+		assertEquals(leftRootChildAssetCategory.getLeftCategoryId() + 1,
+			parentAssetCategory.getLeftCategoryId());
+		assertEquals(leftRootChildAssetCategory.getRightCategoryId() - 1,
+			parentAssetCategory.getRightCategoryId());
+		assertEquals(parentAssetCategory.getLeftCategoryId() + 1,
+			parentChildAssetCategory.getLeftCategoryId());
+		assertEquals(parentAssetCategory.getRightCategoryId() - 1,
+			parentChildAssetCategory.getRightCategoryId());
+	}
+
+	protected AssetCategory addAssetCategory(long groupId, Long parentCategoryId)
+		throws Exception {
+		long pk = nextLong();
+
+		AssetCategory assetCategory = _persistence.create(pk);
+
+		assetCategory.setUuid(randomString());
+		assetCategory.setGroupId(groupId);
+
+		assetCategory.setCompanyId(nextLong());
+
+		assetCategory.setUserId(nextLong());
+
+		assetCategory.setUserName(randomString());
+
+		assetCategory.setCreateDate(nextDate());
+
+		assetCategory.setModifiedDate(nextDate());
+
+		assetCategory.setLeftCategoryId(nextLong());
+
+		assetCategory.setRightCategoryId(nextLong());
+
+		assetCategory.setName(randomString());
+
+		assetCategory.setTitle(randomString());
+
+		assetCategory.setDescription(randomString());
+
+		assetCategory.setVocabularyId(nextLong());
+
+		if (parentCategoryId != null) {
+			assetCategory.setParentCategoryId(parentCategoryId);
+		}
+
+		_persistence.update(assetCategory, false);
+
+		return assetCategory;
+	}
+
 	private AssetCategoryPersistence _persistence;
 }


### PR DESCRIPTION
Reasons for this modifications:

1- Scope is different between organizations and categories, we have switched groupId to ${scopeColumn.name}
2- We should use ${entity.table} instead of ${entity.name} in UPDATE clauses
