### PR TITLE
LPS-23268

### DIFF
--- a/app.server.properties
+++ b/app.server.properties
@@ -71,7 +71,7 @@
 ## JBoss
 ##
 
-    app.server.jboss.version=7.0.1
+    app.server.jboss.version=7.0.2
     app.server.jboss.dir=${app.server.parent.dir}/jboss-${app.server.jboss.version}
     app.server.jboss.bin.dir=${app.server.jboss.dir}/bin
     app.server.jboss.classes.global.dir=${app.server.jboss.dir}/modules/com/liferay/portal/main


### PR DESCRIPTION
Error goes away after upgrading from JBoss 7.0.2, assuming it's a JBoss bug that's fixed with this incremental release.
