### PR TITLE
LPS-23471 Cannot join an organization's related site as a 'normal' user

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -103,9 +103,7 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 				if (user.getUserId() == userIds[0]) {
 					Group group = groupPersistence.findByPrimaryKey(groupId);
 
-					if (!group.isOrganization() &&
-						(user.getCompanyId() == group.getCompanyId())) {
-
+					if (user.getCompanyId() == group.getCompanyId()) {
 						int type = group.getType();
 
 						if (type == GroupConstants.TYPE_SITE_OPEN) {


### PR DESCRIPTION
The check " if (!group.isOrganization() &&..." is no longer needed, as organizations can have sites that can be open. 
