### PR TITLE
LPS-23752

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/action/SplitThreadAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/SplitThreadAction.java
@@ -163,6 +163,15 @@ public class SplitThreadAction extends PortletAction {
 			body = StringUtil.replace(
 				body,
 				new String[] {
+					"[url=]"
+				},
+				new String[] {
+					"[url=" + newThreadURL + "]"
+				});
+
+			body = StringUtil.replace(
+				body,
+				new String[] {
 					"${newThreadURL}",
 				},
 				new String[] {


### PR DESCRIPTION
Small bug fix in order to display the splitted message board thread's new location as a link
