### PR TITLE
LPS-23592 Cannot view or delete a wiki page in Sybase that contains more than 30 characters in the title

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/common/SQLTransformer.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/common/SQLTransformer.java
@@ -176,7 +176,7 @@ public class SQLTransformer {
 			return matcher.replaceAll("CAST($1 AS NVARCHAR(MAX))");
 		}
 		else if (_vendorSybase) {
-			return matcher.replaceAll("CAST($1 AS NVARCHAR)");
+			return matcher.replaceAll("CAST($1 AS NVARCHAR(16384))");
 		}
 		else {
 			return matcher.replaceAll("$1");


### PR DESCRIPTION
When casting (or using CONVERT function) Sybase cast on the 30th character. Set the max length 16K in the transformer (16 \* 1024)
