### PR TITLE
LPS-24145 Download button when adding specific web content shouldn't be displayed

### DIFF
--- a/portal-web/docroot/html/portlet/journal/article_toolbar.jsp
+++ b/portal-web/docroot/html/portlet/journal/article_toolbar.jsp
@@ -50,7 +50,7 @@ if ((article != null) && article.isDraft()) {
 					},
 				</c:if>
 
-				<c:if test="<%= Validator.isNotNull(structureId) %>">
+				<c:if test="<%= (article != null) && Validator.isNotNull(structureId) %>">
 					{
 						icon: 'arrowreturnthick-1-b',
 						id: '<portlet:namespace />downloadArticleContentButton',


### PR DESCRIPTION
This will be shown only when there's content  to download
