### PR TITLE
LPS-23738

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseConstants.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseConstants.java
@@ -19,12 +19,12 @@ package com.liferay.portal.kernel.servlet;
  */
 public interface ServletResponseConstants {
 
-	public static final int SC_DUPLICATE_FILE_EXCEPTION = 1000;
+	public static final int SC_DUPLICATE_FILE_EXCEPTION = 490;
 
-	public static final int SC_FILE_EXTENSION_EXCEPTION = 1001;
+	public static final int SC_FILE_EXTENSION_EXCEPTION = 491;
 
-	public static final int SC_FILE_NAME_EXCEPTION = 1002;
+	public static final int SC_FILE_NAME_EXCEPTION = 492;
 
-	public static final int SC_FILE_SIZE_EXCEPTION = 1003;
+	public static final int SC_FILE_SIZE_EXCEPTION = 493;
 
 }

--- a/portal-web/docroot/html/js/liferay/upload.js
+++ b/portal-web/docroot/html/js/liferay/upload.js
@@ -116,10 +116,10 @@ AUI().add(
 			instance._zeroByteFileText = Liferay.Language.get('the-file-contains-no-data-and-cannot-be-uploaded.-please-use-the-classic-uploader');
 
 			instance._errorMessages = {
-				'1000': instance._duplicateFileText,
-				'1001': instance._invalidFileExtensionText,
-				'1002': instance._invalidFileNameText,
-				'1003': instance._invalidFileSizeText
+				'490': instance._duplicateFileText,
+				'491': instance._invalidFileExtensionText,
+				'492': instance._invalidFileNameText,
+				'493': instance._invalidFileSizeText
 			};
 
 			if (instance._fallbackContainer) {


### PR DESCRIPTION
Document Library file uploader returns illegal http status codes when errors.

Brian,

There was a commit to the 60x branch regarding these status codes as well, affecting only the 60x branch. This means that there are currently more status codes in the 60x branch than on trunk.

It turned out that the error codes we were using (1000, 1001, etc) are not standard compliant so we had to change it on trunk. When backporting to 60x these status codes and the other status codes should follow the new numbering (493, 494, etc).

Just wanted to give you a heads up.

Thanks,

Máté
