### PR TITLE
LPS-24307 When creating WC translations the title and description fallback to the default language of the portal, instead of the default language of the content

### DIFF
--- a/portal-web/docroot/html/portlet/journal/article/abstract.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/abstract.jsp
@@ -28,7 +28,7 @@ String toLanguageId = (String)request.getAttribute("edit_article.jsp-toLanguageI
 
 <liferay-ui:error-marker key="errorSection" value="abstract" />
 
-<aui:model-context bean="<%= article %>" model="<%= JournalArticle.class %>" />
+<aui:model-context bean="<%= article %>" defaultLanguageId="<%= defaultLanguageId %>" model="<%= JournalArticle.class %>" />
 
 <h3><liferay-ui:message key="abstract" /></h3>
 

--- a/portal-web/docroot/html/portlet/journal/article/content.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/content.jsp
@@ -159,7 +159,7 @@ if (Validator.isNotNull(content)) {
 
 <liferay-ui:error-marker key="errorSection" value="content" />
 
-<aui:model-context bean="<%= article %>" model="<%= JournalArticle.class %>" />
+<aui:model-context bean="<%= article %>" defaultLanguageId="<%= defaultLanguageId %>" model="<%= JournalArticle.class %>" />
 
 <portlet:renderURL var="editArticleRenderPopUpURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 	<portlet:param name="struts_action" value="/journal/edit_article" />

--- a/portal-web/docroot/html/portlet/journal/edit_article.jsp
+++ b/portal-web/docroot/html/portlet/journal/edit_article.jsp
@@ -168,7 +168,7 @@ request.setAttribute("edit_article.jsp-toLanguageId", toLanguageId);
 
 	<liferay-ui:error exception="<%= ArticleContentSizeException.class %>" message="you-have-exceeded-the-maximum-article-content-size-allowed" />
 
-	<aui:model-context bean="<%= article %>" model="<%= JournalArticle.class %>" />
+	<aui:model-context bean="<%= article %>" defaultLanguageId="<%= defaultLanguageId %>" model="<%= JournalArticle.class %>" />
 
 	<table class="lfr-table" id="<portlet:namespace />journalArticleWrapper" width="100%">
 	<tr>

--- a/portal-web/docroot/html/taglib/aui/button_item/init.jsp
+++ b/portal-web/docroot/html/taglib/aui/button_item/init.jsp
@@ -35,7 +35,7 @@ if ((dynamicAttributes != null) && !dynamicAttributes.isEmpty()) {
 
 %>
 
-<%@ include file="/html/taglib/aui/init-alloy.jspf" %>
+<%@ include file="/html/taglib/aui/init-alloy.jsp" %>
 
 <%
 boolean activeState = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:button-item:activeState")), false);

--- a/portal-web/docroot/html/taglib/aui/input/init.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/init.jsp
@@ -39,6 +39,7 @@ boolean checked = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui
 long classPK = GetterUtil.getLong(String.valueOf(request.getAttribute("aui:input:classPK")));
 java.lang.String cssClass = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:cssClass"));
 java.util.Map data = (java.util.Map)request.getAttribute("aui:input:data");
+java.lang.String defaultLanguageId = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:defaultLanguageId"));
 boolean disabled = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:disabled")));
 java.lang.String field = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:field"));
 java.lang.String fieldParam = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:fieldParam"));
@@ -73,6 +74,7 @@ _updateOptions(_options, "checked", checked);
 _updateOptions(_options, "classPK", classPK);
 _updateOptions(_options, "cssClass", cssClass);
 _updateOptions(_options, "data", data);
+_updateOptions(_options, "defaultLanguageId", defaultLanguageId);
 _updateOptions(_options, "disabled", disabled);
 _updateOptions(_options, "field", field);
 _updateOptions(_options, "fieldParam", fieldParam);

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -64,6 +64,7 @@
 		<liferay-ui:input-field
 			bean="<%= bean %>"
 			cssClass="<%= inputCss %>"
+			defaultLanguageId="<%= defaultLanguageId %>"
 			defaultValue="<%= value %>"
 			disabled="<%= disabled %>"
 			field="<%= field %>"

--- a/portal-web/docroot/html/taglib/ui/input_field/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_field/page.jsp
@@ -19,6 +19,7 @@
 <%
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-field:cssClass"));
 String formName = (String)request.getAttribute("liferay-ui:input-field:formName");
+String defaultLanguageId = (String)request.getAttribute("liferay-ui:input-field:defaultLanguageId");
 String languageId = (String)request.getAttribute("liferay-ui:input-field:languageId");
 String model = (String)request.getAttribute("liferay-ui:input-field:model");
 Object bean = request.getAttribute("liferay-ui:input-field:bean");
@@ -377,7 +378,7 @@ Map<String, String> hints = ModelHintsUtil.getHints(model, field);
 
 					<c:choose>
 						<c:when test="<%= localized %>">
-							<liferay-ui:input-localized cssClass='<%= cssClass + " lfr-input-text" %>' disabled="<%= disabled %>" formName="<%= formName %>" languageId="<%= languageId %>" name="<%= fieldParam %>" style='<%= "max-width: " + displayWidth + (Validator.isDigit(displayWidth) ? "px" : "") + "; " + (upperCase ? "text-transform: uppercase;" : "" ) %>' xml="<%= BeanPropertiesUtil.getString(bean, field) %>" />
+							<liferay-ui:input-localized cssClass='<%= cssClass + " lfr-input-text" %>' defaultLanguageId="<%= defaultLanguageId %>" disabled="<%= disabled %>" formName="<%= formName %>" languageId="<%= languageId %>" name="<%= fieldParam %>" style='<%= "max-width: " + displayWidth + (Validator.isDigit(displayWidth) ? "px" : "") + "; " + (upperCase ? "text-transform: uppercase;" : "" ) %>' xml="<%= BeanPropertiesUtil.getString(bean, field) %>" />
 						</c:when>
 						<c:otherwise>
 							<input <%= Validator.isNotNull(cssClass) ? "class=\"" + cssClass + " lfr-input-text\"" : StringPool.BLANK %> <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace %><%= fieldParam %>" name="<%= namespace %><%= fieldParam %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(pageContext, placeholder) + "\"" : StringPool.BLANK %> style="max-width: <%= displayWidth %><%= Validator.isDigit(displayWidth) ? "px" : "" %>; <%= upperCase ? "text-transform: uppercase;" : "" %>" type="<%= secret ? "password" : "text" %>" value="<%= autoEscape ? HtmlUtil.escape(value) : value %>" />
@@ -387,7 +388,7 @@ Map<String, String> hints = ModelHintsUtil.getHints(model, field);
 				<c:otherwise>
 					<c:choose>
 						<c:when test="<%= localized %>">
-							<liferay-ui:input-localized cssClass='<%= cssClass + " lfr-input-text" %>' disabled="<%= disabled %>" formName="<%= formName %>" languageId="<%= languageId %>" name="<%= fieldParam %>" onKeyDown='<%= (checkTab ? "Liferay.Util.checkTab(this); " : "") + "Liferay.Util.disableEsc();" %>' style='<%= "height: " + displayHeight + (Validator.isDigit(displayHeight) ? "px" : "" ) + "; " + "max-width: " + displayWidth + (Validator.isDigit(displayWidth) ? "px" : "") +";" %>' type="textarea" wrap="soft" xml="<%= BeanPropertiesUtil.getString(bean, field) %>" />
+							<liferay-ui:input-localized cssClass='<%= cssClass + " lfr-input-text" %>' defaultLanguageId="<%= defaultLanguageId %>" disabled="<%= disabled %>" formName="<%= formName %>" languageId="<%= languageId %>" name="<%= fieldParam %>" onKeyDown='<%= (checkTab ? "Liferay.Util.checkTab(this); " : "") + "Liferay.Util.disableEsc();" %>' style='<%= "height: " + displayHeight + (Validator.isDigit(displayHeight) ? "px" : "" ) + "; " + "max-width: " + displayWidth + (Validator.isDigit(displayWidth) ? "px" : "") +";" %>' type="textarea" wrap="soft" xml="<%= BeanPropertiesUtil.getString(bean, field) %>" />
 						</c:when>
 						<c:otherwise>
 							<textarea <%= Validator.isNotNull(cssClass) ? "class=\"" + cssClass + " lfr-textarea\"" : StringPool.BLANK %> <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace %><%= fieldParam %>" name="<%= namespace %><%= fieldParam %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(pageContext, placeholder) + "\"" : StringPool.BLANK %> style="height: <%= displayHeight %><%= Validator.isDigit(displayHeight) ? "px" : "" %>; max-width: <%= displayWidth %><%= Validator.isDigit(displayWidth) ? "px" : "" %>;" wrap="soft" onKeyDown="<%= checkTab ? "Liferay.Util.checkTab(this); " : "" %> Liferay.Util.disableEsc();"><%= autoEscape ? HtmlUtil.escape(value) : value %></textarea>

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -20,6 +20,7 @@
 String randomNamespace = PortalUtil.generateRandomKey(request, "taglib_ui_input_localized_page");
 
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-localized:cssClass"));
+String defaultLanguageId = (String)request.getAttribute("liferay-ui:input-localized:defaultLanguageId");
 boolean disabled = GetterUtil.getBoolean((String) request.getAttribute("liferay-ui:input-localized:disabled"));
 Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribute("liferay-ui:input-localized:dynamicAttributes");
 String formName = (String)request.getAttribute("liferay-ui:input-localized:formName");
@@ -28,8 +29,16 @@ String name = (String)request.getAttribute("liferay-ui:input-localized:name");
 String xml = (String)request.getAttribute("liferay-ui:input-localized:xml");
 String type = (String)request.getAttribute("liferay-ui:input-localized:type");
 
-Locale defaultLocale = LocaleUtil.getDefault();
-String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
+Locale defaultLocale = null;
+
+if (Validator.isNotNull(defaultLanguageId)) {
+	defaultLocale = LocaleUtil.fromLanguageId(defaultLanguageId);
+}
+else {
+	defaultLocale = LocaleUtil.getDefault();
+	defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
+}
+
 Locale[] locales = LanguageUtil.getAvailableLocales();
 
 String mainLanguageId = defaultLanguageId;
@@ -38,7 +47,15 @@ if (Validator.isNotNull(languageId)) {
 	mainLanguageId = languageId;
 }
 
-String mainLanguageValue = ParamUtil.getString(request, name + StringPool.UNDERLINE + mainLanguageId, LocalizationUtil.getLocalization(xml, mainLanguageId));
+String mainLanguageValue = ParamUtil.getString(request, name + StringPool.UNDERLINE + mainLanguageId);
+
+if (Validator.isNull(mainLanguageValue)) {
+	mainLanguageValue = LocalizationUtil.getLocalization(xml, mainLanguageId, false);
+}
+
+if (Validator.isNull(mainLanguageValue)) {
+	mainLanguageValue = LocalizationUtil.getLocalization(xml, defaultLanguageId, true);
+}
 %>
 
 <span class="taglib-input-localized">

--- a/util-taglib/src/META-INF/aui.tld
+++ b/util-taglib/src/META-INF/aui.tld
@@ -1301,6 +1301,12 @@
 			<type>java.lang.Object</type>
 		</attribute>
 		<attribute>
+			<name>defaultLanguageId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>java.lang.String</type>
+		</attribute>
+		<attribute>
 			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1485,6 +1491,12 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>java.lang.Object</type>
+		</attribute>
+		<attribute>
+			<name>defaultLanguageId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>java.lang.String</type>
 		</attribute>
 		<attribute>
 			<name>model</name>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1225,6 +1225,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>defaultLanguageId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>defaultValue</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1276,6 +1281,11 @@
 		<body-content>JSP</body-content>
 		<attribute>
 			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>defaultLanguageId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/util-taglib/src/com/liferay/taglib/aui/InputTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/InputTag.java
@@ -180,6 +180,18 @@ public class InputTag extends BaseInputTag {
 				"aui:model-context:model");
 		}
 
+		String defaultLanguageId = getDefaultLanguageId();
+
+		if (Validator.isNull(defaultLanguageId)) {
+			defaultLanguageId = (String)pageContext.getAttribute(
+				"aui:model-context:defaultLanguageId");
+		}
+
+		if (Validator.isNull(defaultLanguageId)) {
+			Locale defaultLocale = LocaleUtil.getDefault();
+			defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
+		}
+
 		_forLabel = id;
 		_inputName = getName();
 
@@ -196,10 +208,6 @@ public class InputTag extends BaseInputTag {
 			}
 
 			if (ModelHintsUtil.isLocalized(model.getName(), field)) {
-				Locale defaultLocale = LocaleUtil.getDefault();
-				String defaultLanguageId = LocaleUtil.toLanguageId(
-					defaultLocale);
-
 				_forLabel += StringPool.UNDERLINE + defaultLanguageId;
 				_inputName += StringPool.UNDERLINE + defaultLanguageId;
 			}
@@ -218,6 +226,7 @@ public class InputTag extends BaseInputTag {
 
 		setNamespacedAttribute(request, "baseType", baseType);
 		setNamespacedAttribute(request, "bean", bean);
+		setNamespacedAttribute(request, "defaultLanguageId", defaultLanguageId);
 		setNamespacedAttribute(request, "field", field);
 		setNamespacedAttribute(request, "forLabel", _forLabel);
 		setNamespacedAttribute(request, "formName", formName);

--- a/util-taglib/src/com/liferay/taglib/aui/ModelContextTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ModelContextTag.java
@@ -30,10 +30,13 @@ public class ModelContextTag extends BaseModelContextTag {
 
 		if (model != null) {
 			pageContext.setAttribute("aui:model-context:bean", getBean());
+			pageContext.setAttribute(
+				"aui:model-context:defaultLanguageId", getDefaultLanguageId());
 			pageContext.setAttribute("aui:model-context:model", model);
 		}
 		else {
 			pageContext.removeAttribute("aui:model-context:bean");
+			pageContext.removeAttribute("aui:model-context:defaultLanguageId");
 			pageContext.removeAttribute("aui:model-context::model");
 		}
 	}

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseInputTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseInputTag.java
@@ -57,6 +57,10 @@ public class BaseInputTag extends com.liferay.taglib.util.IncludeTag {
 		return _data;
 	}
 
+	public java.lang.String getDefaultLanguageId() {
+		return _defaultLanguageId;
+	}
+
 	public boolean getDisabled() {
 		return _disabled;
 	}
@@ -199,6 +203,12 @@ public class BaseInputTag extends com.liferay.taglib.util.IncludeTag {
 		_data = data;
 
 		setScopedAttribute("data", data);
+	}
+
+	public void setDefaultLanguageId(java.lang.String defaultLanguageId) {
+		_defaultLanguageId = defaultLanguageId;
+
+		setScopedAttribute("defaultLanguageId", defaultLanguageId);
 	}
 
 	public void setDisabled(boolean disabled) {
@@ -371,6 +381,7 @@ public class BaseInputTag extends com.liferay.taglib.util.IncludeTag {
 		_classPK = 0;
 		_cssClass = null;
 		_data = null;
+		_defaultLanguageId = null;
 		_disabled = false;
 		_field = null;
 		_fieldParam = null;
@@ -413,6 +424,7 @@ public class BaseInputTag extends com.liferay.taglib.util.IncludeTag {
 		setNamespacedAttribute(request, "classPK", _classPK);
 		setNamespacedAttribute(request, "cssClass", _cssClass);
 		setNamespacedAttribute(request, "data", _data);
+		setNamespacedAttribute(request, "defaultLanguageId", _defaultLanguageId);
 		setNamespacedAttribute(request, "disabled", _disabled);
 		setNamespacedAttribute(request, "field", _field);
 		setNamespacedAttribute(request, "fieldParam", _fieldParam);
@@ -453,6 +465,7 @@ public class BaseInputTag extends com.liferay.taglib.util.IncludeTag {
 	private long _classPK = 0;
 	private java.lang.String _cssClass = null;
 	private java.lang.Object _data = null;
+	private java.lang.String _defaultLanguageId = null;
 	private boolean _disabled = false;
 	private java.lang.String _field = null;
 	private java.lang.String _fieldParam = null;

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseModelContextTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseModelContextTag.java
@@ -36,6 +36,10 @@ public class BaseModelContextTag extends com.liferay.taglib.util.IncludeTag {
 		return _bean;
 	}
 
+	public java.lang.String getDefaultLanguageId() {
+		return _defaultLanguageId;
+	}
+
 	public java.lang.Class<?> getModel() {
 		return _model;
 	}
@@ -44,6 +48,12 @@ public class BaseModelContextTag extends com.liferay.taglib.util.IncludeTag {
 		_bean = bean;
 
 		setScopedAttribute("bean", bean);
+	}
+
+	public void setDefaultLanguageId(java.lang.String defaultLanguageId) {
+		_defaultLanguageId = defaultLanguageId;
+
+		setScopedAttribute("defaultLanguageId", defaultLanguageId);
 	}
 
 	public void setModel(java.lang.Class<?> model) {
@@ -55,6 +65,7 @@ public class BaseModelContextTag extends com.liferay.taglib.util.IncludeTag {
 	@Override
 	protected void cleanUp() {
 		_bean = null;
+		_defaultLanguageId = null;
 		_model = null;
 	}
 
@@ -69,6 +80,7 @@ public class BaseModelContextTag extends com.liferay.taglib.util.IncludeTag {
 		"/html/taglib/aui/model_context/page.jsp";
 
 	private java.lang.Object _bean = null;
+	private java.lang.String _defaultLanguageId = null;
 	private java.lang.Class<?> _model = null;
 
 }

--- a/util-taglib/src/com/liferay/taglib/liferay-aui.xml
+++ b/util-taglib/src/com/liferay/taglib/liferay-aui.xml
@@ -356,6 +356,11 @@
 				<outputType>java.util.Map</outputType>
 			</attribute>
 			<attribute>
+				<name>defaultLanguageId</name>
+				<inputType>java.lang.String</inputType>
+				<outputType>java.lang.String</outputType>
+			</attribute>
+			<attribute>
 				<name>disabled</name>
 				<inputType>boolean</inputType>
 				<outputType>boolean</outputType>
@@ -510,6 +515,11 @@
 				<name>bean</name>
 				<inputType>java.lang.Object</inputType>
 				<outputType>java.lang.Object</outputType>
+			</attribute>
+			<attribute>
+				<name>defaultLanguageId</name>
+				<inputType>java.lang.String</inputType>
+				<outputType>java.lang.String</outputType>
 			</attribute>
 			<attribute>
 				<name>model</name>

--- a/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputFieldTag.java
@@ -33,6 +33,10 @@ public class InputFieldTag extends IncludeTag {
 		_cssClass = cssClass;
 	}
 
+	public void setDefaultLanguageId(String defaultLanguageId) {
+		_defaultLanguageId = defaultLanguageId;
+	}
+
 	public void setDefaultValue(Object defaultValue) {
 		_defaultValue = defaultValue;
 	}
@@ -73,6 +77,7 @@ public class InputFieldTag extends IncludeTag {
 	protected void cleanUp() {
 		_bean = null;
 		_cssClass = null;
+		_defaultLanguageId = null;
 		_defaultValue = null;
 		_disabled = false;
 		_field = null;
@@ -94,6 +99,8 @@ public class InputFieldTag extends IncludeTag {
 		request.setAttribute("liferay-ui:input-field:bean", _bean);
 		request.setAttribute("liferay-ui:input-field:cssClass", _cssClass);
 		request.setAttribute(
+			"liferay-ui:input-field:defaultLanguageId", _defaultLanguageId);
+		request.setAttribute(
 			"liferay-ui:input-field:defaultValue", _defaultValue);
 		request.setAttribute(
 			"liferay-ui:input-field:disabled", String.valueOf(_disabled));
@@ -111,6 +118,7 @@ public class InputFieldTag extends IncludeTag {
 
 	private Object _bean;
 	private String _cssClass;
+	private String _defaultLanguageId;
 	private Object _defaultValue;
 	private boolean _disabled;
 	private String _field;

--- a/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
@@ -28,6 +28,10 @@ public class InputLocalizedTag extends IncludeTag {
 		_cssClass = cssClass;
 	}
 
+	public void setDefaultLanguageId(String defaultLanguageId) {
+		_defaultLanguageId = defaultLanguageId;
+	}
+
 	public void setDisabled(boolean disabled) {
 		_disabled = disabled;
 	}
@@ -78,6 +82,8 @@ public class InputLocalizedTag extends IncludeTag {
 
 		request.setAttribute("liferay-ui:input-localized:cssClass", _cssClass);
 		request.setAttribute(
+			"liferay-ui:input-localized:defaultLanguageId", _defaultLanguageId);
+		request.setAttribute(
 			"liferay-ui:input-localized:disabled", String.valueOf(_disabled));
 		request.setAttribute(
 			"liferay-ui:input-localized:dynamicAttributes",
@@ -94,6 +100,7 @@ public class InputLocalizedTag extends IncludeTag {
 		"/html/taglib/ui/input_localized/page.jsp";
 
 	private String _cssClass;
+	private String _defaultLanguageId;
 	private boolean _disabled;
 	private String _formName;
 	private String _languageId;


### PR DESCRIPTION
This has been reviewed by Jorge

This implied modifying two taglibs aui:input and aui:model-context so that we can tell the input which is the default language we want to fall back. This is affecting journal articles. 
