### PR TITLE
LPS-24336

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -214,9 +214,6 @@ public class LayoutExporter {
 			parameterMap, PortletDataHandlerKeys.THEME);
 		boolean exportThemeSettings = MapUtil.getBoolean(
 			parameterMap, PortletDataHandlerKeys.THEME_REFERENCE);
-		boolean layoutSetPrototypeInherited = MapUtil.getBoolean(
-			parameterMap,
-			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_LINK_ENABLED);
 		boolean publishToRemote = MapUtil.getBoolean(
 			parameterMap, PortletDataHandlerKeys.PUBLISH_TO_REMOTE);
 		boolean updateLastPublishDate = MapUtil.getBoolean(
@@ -316,7 +313,7 @@ public class LayoutExporter {
 
 		Group group = layoutSet.getGroup();
 
-		if (layoutSetPrototypeInherited && group.isLayoutSetPrototype()) {
+		if (group.isLayoutSetPrototype()) {
 			LayoutSetPrototype layoutSetPrototype =
 				LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(
 					group.getClassPK());

--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesUtil.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesUtil.java
@@ -249,7 +249,7 @@ public class SitesUtil {
 		Map<String, String[]> parameterMap = getLayoutSetPrototypeParameters(
 			serviceContext);
 
-		setLayoutSetPrototypeLinkEnabled(
+		setLayoutSetPrototypeLinkEnabledParameter(
 			parameterMap, targetLayoutSet, serviceContext);
 
 		if (!targetLayoutSet.isPrivateLayout()) {
@@ -582,7 +582,7 @@ public class SitesUtil {
 		Map<String, String[]> parameterMap = getLayoutSetPrototypeParameters(
 			serviceContext);
 
-		setLayoutSetPrototypeLinkEnabled(
+		setLayoutSetPrototypeLinkEnabledParameter(
 			parameterMap, layoutSet, serviceContext);
 
 		LayoutServiceUtil.importLayouts(
@@ -769,7 +769,7 @@ public class SitesUtil {
 		}
 	}
 
-	protected static void setLayoutSetPrototypeLinkEnabled(
+	protected static void setLayoutSetPrototypeLinkEnabledParameter(
 		Map<String, String[]> parameterMap, LayoutSet targetLayoutSet,
 		ServiceContext serviceContext) {
 


### PR DESCRIPTION
LPS-24336 When creating a site and unchecking 'Keep a link to the site template' it does not keep a reference to the template which would allow enabling the link later
