### PR TITLE
LPS-21456

### DIFF
--- a/portal-web/docroot/html/taglib/ui/flash/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/flash/page.jsp
@@ -53,7 +53,6 @@ String wmode = (String)request.getAttribute("liferay-ui:flash:wmode");
 				base: '<%= base %>',
 				bgcolor: '<%= bgcolor %>',
 				devicefont: '<%= devicefont %>',
-				flashvars: '<%= flashvars %>',
 				loop: '<%= loop %>',
 				menu: '<%= menu %>',
 				play: '<%= play %>',
@@ -63,6 +62,7 @@ String wmode = (String)request.getAttribute("liferay-ui:flash:wmode");
 				swliveconnect: '<%= swliveconnect %>',
 				wmode: '<%= wmode %>'
 			},
+			flashVars: '<%= flashvars %>',
 			height: '<%= height %>',
 			id: '<%= id %>',
 			url: '<%= movie %>',


### PR DESCRIPTION
liferay-ui:flash mishandles flashVars parameter and does not use it

Hi Brian,

This is a combined fix for liferay-portal, liferay-plugins and for alloy-ui as well. I'm going to send an email about this to you and Nate as well describing the problem.

Máté
