### PR TITLE
LPS-24449

### DIFF
--- a/portal-impl/src/com/liferay/portlet/directory/asset/UserAssetRendererFactory.java
+++ b/portal-impl/src/com/liferay/portlet/directory/asset/UserAssetRendererFactory.java
@@ -22,7 +22,7 @@ import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.GroupLocalServiceUtil;
-import com.liferay.portal.service.UserServiceUtil;
+import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.service.permission.UserPermissionUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portlet.asset.model.AssetRenderer;
@@ -42,7 +42,7 @@ public class UserAssetRendererFactory extends BaseAssetRendererFactory {
 	public AssetRenderer getAssetRenderer(long classPK, int type)
 		throws PortalException, SystemException {
 
-		User user = UserServiceUtil.getUserById(classPK);
+		User user = UserLocalServiceUtil.getUserById(classPK);
 
 		return new UserAssetRenderer(user);
 	}
@@ -53,7 +53,7 @@ public class UserAssetRendererFactory extends BaseAssetRendererFactory {
 
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 
-		User user = UserServiceUtil.getUserByScreenName(
+		User user = UserLocalServiceUtil.getUserByScreenName(
 			group.getCompanyId(), urlTitle);
 
 		return new UserAssetRenderer(user);


### PR DESCRIPTION
This exception is being thrown because the search term ('test') is also the screen name of a user that Guest does not have permission to see. So when it runs into the 'test' user result, an exception is thrown. Everything else that is shown in search (such as web content, blogs, wikis) do not require a permission check before returning an AssetRenderer. As such, the most natural fix is to leave the permission check to anything that wants to call AssetRenderer.hasViewPermission and to not do a premature permission check when returning the AssetRenderer itself.
