### PR TITLE
LPS-24403

### DIFF
--- a/portal-web/docroot/html/portlet/asset_category_admin/edit_category.jsp
+++ b/portal-web/docroot/html/portlet/asset_category_admin/edit_category.jsp
@@ -172,12 +172,12 @@ else {
 <aui:script use="liferay-auto-fields">
 	var autoFields = new Liferay.AutoFields(
 		{
-			contentBox: 'fieldset#categoryProperties',
+			contentBox: 'fieldset#<portlet:namespace />categoryProperties',
 			fieldIndexes: '<portlet:namespace />categoryPropertiesIndexes'
 		}
 	).render();
 
-	var categoryPropertiesTrigger = A.one('fieldset#categoryProperties');
+	var categoryPropertiesTrigger = A.one('fieldset#<portlet:namespace />categoryProperties');
 
 	if (categoryPropertiesTrigger) {
 		categoryPropertiesTrigger.setData('autoFieldsInstance', autoFields);

--- a/portal-web/docroot/html/portlet/asset_category_admin/js/main.js
+++ b/portal-web/docroot/html/portlet/asset_category_admin/js/main.js
@@ -1895,10 +1895,11 @@ AUI.add(
 
 					_resetCategoriesProperties: function(event) {
 						var instance = this;
+						var namespace = instance._prefixedPortletId;
 
 						var contextPanel = event.currentTarget;
 						var boundingBox = contextPanel.get('boundingBox');
-						var propertiesTrigger = boundingBox.one('fieldset#categoryProperties');
+						var propertiesTrigger = boundingBox.one('fieldset#' + namespace + 'categoryProperties');
 
 						var autoFieldsInstance = propertiesTrigger.getData('autoFieldsInstance');
 

--- a/portal-web/docroot/html/portlet/asset_tag_admin/edit_tag.jsp
+++ b/portal-web/docroot/html/portlet/asset_tag_admin/edit_tag.jsp
@@ -148,12 +148,12 @@ else {
 <aui:script use="liferay-auto-fields">
 	var autoFields = new Liferay.AutoFields(
 		{
-			contentBox: 'fieldset#tagProperties',
+			contentBox: 'fieldset#<portlet:namespace />tagProperties',
 			fieldIndexes: '<portlet:namespace />tagPropertiesIndexes'
 		}
 	).render();
 
-	var tagPropertiesTrigger = A.one('fieldset#tagProperties');
+	var tagPropertiesTrigger = A.one('fieldset#<portlet:namespace />tagProperties');
 
 	if (tagPropertiesTrigger) {
 		tagPropertiesTrigger.setData('autoFieldsInstance', autoFields);

--- a/portal-web/docroot/html/portlet/asset_tag_admin/js/main.js
+++ b/portal-web/docroot/html/portlet/asset_tag_admin/js/main.js
@@ -1438,10 +1438,11 @@ AUI.add(
 
 					_resetTagsProperties: function(event) {
 						var instance = this;
+						var namespace = instance._prefixedPortletId;
 
 						var contextPanel = event.currentTarget;
 						var boundingBox = contextPanel.get('boundingBox');
-						var propertiesTrigger = boundingBox.one('fieldset#tagProperties');
+						var propertiesTrigger = boundingBox.one('fieldset#' + namespace + 'tagProperties');
 
 						var autoFieldsInstance = propertiesTrigger.getData('autoFieldsInstance');
 


### PR DESCRIPTION
Fieldset id attribute now includes the portlet namespace, so any Javascript that is looking for a fieldset node without that namespace breaks.  This occurs in both asset categories and asset tags.
