### PR TITLE
LPS-24481 Cache logic added for new objects in persist()

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model_base_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model_base_impl.ftl
@@ -30,7 +30,12 @@ public abstract class ${entity.name}BaseImpl extends ${entity.name}ModelImpl imp
 
 	<#if entity.hasLocalService() && entity.hasColumns()>
 		public void persist() throws SystemException {
-			${entity.name}LocalServiceUtil.update${entity.name}(this);
+			if (this.isNew()) {
+				${entity.name}LocalServiceUtil.add${entity.name}(this);
+			}
+			else {
+				${entity.name}LocalServiceUtil.update${entity.name}(this);
+			}
 		}
 	</#if>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_clp.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_clp.ftl
@@ -342,7 +342,12 @@ public class ${entity.name}Clp extends BaseModelImpl<${entity.name}> implements 
 
 	<#if entity.hasLocalService() && entity.hasColumns()>
 		public void persist() throws SystemException {
-			${entity.name}LocalServiceUtil.update${entity.name}(this);
+			if (this.isNew()) {
+				${entity.name}LocalServiceUtil.add${entity.name}(this);
+			}
+			else {
+				${entity.name}LocalServiceUtil.update${entity.name}(this);
+			}
 		}
 	</#if>
 


### PR DESCRIPTION
Need to rebuild services.  I didn't want to change the persistence layer code or the updateXXX() code in checking the isNew() for an object.  So I tacked on more logic to the persist method instead to hopefully have a minimal impact, since not a lot of Liferay code uses persist().
