### PR TITLE
LPS-24508

### DIFF
--- a/portal-impl/src/com/liferay/portal/xml/ElementImpl.java
+++ b/portal-impl/src/com/liferay/portal/xml/ElementImpl.java
@@ -294,6 +294,18 @@ public class ElementImpl extends BranchImpl implements Element {
 
 	@Override
 	public boolean equals(Object obj) {
+		if (obj instanceof NodeImpl) {
+			NodeImpl nodeImpl = (NodeImpl)obj;
+
+			if (nodeImpl.getWrappedNode() instanceof org.dom4j.Element) {
+				obj = new ElementImpl(
+					(org.dom4j.Element)nodeImpl.getWrappedNode());
+			}
+			else {
+				return false;
+			}
+		}
+
 		org.dom4j.Element element = ((ElementImpl)obj).getWrappedElement();
 
 		return _element.equals(element);


### PR DESCRIPTION
LPS-24508 An ClassCastException results when doing indexOf(Element) on List<Node> Element.content()
