### PR TITLE
LPS-24512

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
+++ b/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.javadoc.JavadocManagerUtil;
 import com.liferay.portal.kernel.log.Jdk14LogFactoryImpl;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.scheduler.SchedulerEngineUtil;
 import com.liferay.portal.kernel.util.CentralizedThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -177,7 +178,14 @@ public class GlobalShutdownAction extends SimpleAction {
 		catch (Exception e) {
 		}
 
-		// Wait 1 second so Quartz threads can cleanly shutdown
+		// Shutdown scheduler engine and wait 1 second so Quartz threads can
+		// cleanly shutdown
+
+		try {
+			SchedulerEngineUtil.shutdown();
+		}
+		catch (Exception e) {
+		}
 
 		try {
 			Thread.sleep(1000);

--- a/portal-service/src/com/liferay/portal/kernel/scheduler/SchedulerEngineUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/scheduler/SchedulerEngineUtil.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.PortalLifecycle;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringPool;
 
@@ -187,7 +188,7 @@ public class SchedulerEngineUtil {
 
 		SchedulerLifecycle schedulerLifecycle = new SchedulerLifecycle();
 
-		schedulerLifecycle.registerPortalLifecycle();
+		schedulerLifecycle.registerPortalLifecycle(PortalLifecycle.METHOD_INIT);
 	}
 
 	public static String namespaceGroupName(

--- a/portal-service/src/com/liferay/portal/kernel/scheduler/SchedulerLifecycle.java
+++ b/portal-service/src/com/liferay/portal/kernel/scheduler/SchedulerLifecycle.java
@@ -23,7 +23,7 @@ public class SchedulerLifecycle extends BasePortalLifecycle {
 
 	@Override
 	protected void doPortalDestroy() throws Exception {
-		SchedulerEngineUtil.shutdown();
+
 	}
 
 	@Override


### PR DESCRIPTION
Scheduler engine needs to shutdown after plugins are unregistered, because some plugins will be unregistering things from the scheduler as they shutdown.  Regression bug introduced in LPS-23983, since SchedulerLifecycle might run its doPortalDestroy() before plugins get a chance to run their doPortalDestroy().  Fix is to only make scheduler start part of doPortalInit(), but leave the shutdown inside of GlobalShutdownAction after plugins onPortalDestroy() have all been flushed.
