### PR TITLE
LPS-24379 Make urls in serviceContext canonicals

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
@@ -347,16 +347,6 @@ public class EditMessageAction extends PortletAction {
 			boolean preview = ParamUtil.getBoolean(actionRequest, "preview");
 
 			serviceContext.setAttribute("preview", preview);
-			
-			String canonicalLayoutFullURL = PortalUtil.getCanonicalURL(
-				serviceContext.getLayoutFullURL(), themeDisplay);
-			
-			serviceContext.setLayoutFullURL(canonicalLayoutFullURL);
-			
-			String canonicalPortalURL = PortalUtil.getCanonicalURL(
-				serviceContext.getPortalURL(), themeDisplay);
-			
-			serviceContext.setPortalURL(canonicalPortalURL);
 
 			MBMessage message = null;
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
@@ -347,6 +347,16 @@ public class EditMessageAction extends PortletAction {
 			boolean preview = ParamUtil.getBoolean(actionRequest, "preview");
 
 			serviceContext.setAttribute("preview", preview);
+			
+			String canonicalLayoutFullURL = PortalUtil.getCanonicalURL(
+				serviceContext.getLayoutFullURL(), themeDisplay);
+			
+			serviceContext.setLayoutFullURL(canonicalLayoutFullURL);
+			
+			String canonicalPortalURL = PortalUtil.getCanonicalURL(
+				serviceContext.getPortalURL(), themeDisplay);
+			
+			serviceContext.setPortalURL(canonicalPortalURL);
 
 			MBMessage message = null;
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -1761,7 +1761,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			return;
 		}
 
-		String contentURL = (String)serviceContext.getAttribute("redirect");
+		String contentURL = (String)serviceContext.getAttribute("contentURL");
 
 		String userAddress = StringPool.BLANK;
 		String userName = (String)serviceContext.getAttribute(

--- a/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
+++ b/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
@@ -63,14 +63,17 @@ public class ServiceContextFactory {
 			serviceContext.setCompanyId(themeDisplay.getCompanyId());
 			serviceContext.setLanguageId(themeDisplay.getLanguageId());
 			serviceContext.setLayoutFullURL(
-				PortalUtil.getLayoutFullURL(themeDisplay));
-			serviceContext.setLayoutURL(PortalUtil.getLayoutURL(themeDisplay));
+				PortalUtil.getCanonicalURL(
+					PortalUtil.getLayoutFullURL(themeDisplay), themeDisplay));
+			serviceContext.setLayoutURL(PortalUtil.getCanonicalURL(
+				PortalUtil.getLayoutURL(themeDisplay), themeDisplay));
 			serviceContext.setPathMain(PortalUtil.getPathMain());
 			serviceContext.setPlid(themeDisplay.getPlid());
-			serviceContext.setPortalURL(PortalUtil.getPortalURL(request));
+			serviceContext.setPortalURL(PortalUtil.getCanonicalURL(
+				PortalUtil.getPortalURL(request), themeDisplay));
 			serviceContext.setScopeGroupId(themeDisplay.getScopeGroupId());
 			serviceContext.setSignedIn(themeDisplay.isSignedIn());
-
+			
 			User user = themeDisplay.getUser();
 
 			serviceContext.setUserDisplayURL(user.getDisplayURL(themeDisplay));

--- a/portal-web/docroot/html/taglib/ui/discussion/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/discussion/page.jsp
@@ -86,6 +86,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 			<aui:input name="randomNamespace" type="hidden" value="<%= randomNamespace %>" />
 			<aui:input name="<%= Constants.CMD %>" type="hidden" />
 			<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+			<aui:input name="contentURL" type="hidden" value="<%= PortalUtil.getCanonicalURL(redirect, themeDisplay) %>" />
 			<aui:input name="assetEntryVisible" type="hidden" value="<%= assetEntryVisible %>" />
 			<aui:input name="className" type="hidden" value="<%= className %>" />
 			<aui:input name="classPK" type="hidden" value="<%= classPK %>" />


### PR DESCRIPTION
these urls are used for pingbacks, trackbacks, emails.... and SEO will improve if they are canonical.

Also, emails to users will contain the canonical url instead of the url pointint to the language of the user who edited the conent.
