### PR TITLE
LPS-23457 Move google analytics code

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom.jsp
+++ b/portal-web/docroot/html/common/themes/bottom.jsp
@@ -111,36 +111,6 @@ StringBundler pageBottomSB = (StringBundler)request.getAttribute(WebKeys.PAGE_BO
 		// ]]>
 	</script>
 
-	<%-- Google Analytics --%>
-
-	<%
-	UnicodeProperties groupTypeSettings = group.getTypeSettingsProperties();
-
-	String googleAnalyticsId = groupTypeSettings.getProperty("googleAnalyticsId");
-
-	if (Validator.isNotNull(googleAnalyticsId)) {
-	%>
-
-		<script type="text/javascript">
-			var _gaq = _gaq || [];
-
-			_gaq.push(['_setAccount', '<%= googleAnalyticsId %>']);
-			_gaq.push(['_trackPageview']);
-
-			(function() {
-				var ga = document.createElement('script');
-
-				ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-				ga.setAttribute('async', 'true');
-
-				document.documentElement.firstChild.appendChild(ga);
-			})();
-		</script>
-
-	<%
-	}
-	%>
-
 </c:if>
 
 <c:if test="<%= PropsValues.MONITORING_PORTAL_REQUEST %>">

--- a/portal-web/docroot/html/common/themes/bottom.jsp
+++ b/portal-web/docroot/html/common/themes/bottom.jsp
@@ -96,6 +96,8 @@ StringBundler pageBottomSB = (StringBundler)request.getAttribute(WebKeys.PAGE_BO
 	<%-- User Inputted Layout and LayoutSet JavaScript --%>
 
 	<%
+		group.getTypeSettingsProperties();
+
 	LayoutSet layoutSet = themeDisplay.getLayoutSet();
 
 	UnicodeProperties layoutSetSettings = layoutSet.getSettingsProperties();

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -354,7 +354,7 @@
 				Liferay.Portlet.list = ['<%= ListUtil.toString(allPortlets, Portlet.PORTLET_ID_ACCESSOR, "','") %>'];
 			</c:if>
 		</c:if>
-		
+
 		<%
 		Group group = null;
 
@@ -364,7 +364,6 @@
 		%>
 
 		<c:if test="<%= themeDisplay.isSignedIn() %>">
-
 			<c:choose>
 				<c:when test="<%= (group != null) && group.isControlPanel() && !LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) && !(layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE)) %>">
 					Liferay._editControlsState = 'visible';
@@ -383,10 +382,9 @@
 UnicodeProperties groupTypeSettings = group.getTypeSettingsProperties();
 
 String googleAnalyticsId = groupTypeSettings.getProperty("googleAnalyticsId");
-
-if (Validator.isNotNull(googleAnalyticsId)) {
 %>
 
+<c:if test="<%= Validator.isNotNull(googleAnalyticsId) %>">
 	<script type="text/javascript">
 		var _gaq = _gaq || [];
 
@@ -402,7 +400,4 @@ if (Validator.isNotNull(googleAnalyticsId)) {
 			document.documentElement.firstChild.appendChild(ga);
 		})();
 	</script>
-
-<%
-}
-%>
+</c:if>

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -354,16 +354,16 @@
 				Liferay.Portlet.list = ['<%= ListUtil.toString(allPortlets, Portlet.PORTLET_ID_ACCESSOR, "','") %>'];
 			</c:if>
 		</c:if>
+		
+		<%
+		Group group = null;
+
+		if (layout != null) {
+			group = layout.getGroup();
+		}
+		%>
 
 		<c:if test="<%= themeDisplay.isSignedIn() %>">
-
-			<%
-			Group group = null;
-
-			if (layout != null) {
-				group = layout.getGroup();
-			}
-			%>
 
 			<c:choose>
 				<c:when test="<%= (group != null) && group.isControlPanel() && !LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.UPDATE) && !(layoutTypePortlet.isCustomizable() && layoutTypePortlet.isCustomizedView() && LayoutPermissionUtil.contains(permissionChecker, layout, ActionKeys.CUSTOMIZE)) %>">
@@ -376,3 +376,33 @@
 		</c:if>
 	// ]]>
 </script>
+
+<%-- Google Analytics --%>
+
+<%
+UnicodeProperties groupTypeSettings = group.getTypeSettingsProperties();
+
+String googleAnalyticsId = groupTypeSettings.getProperty("googleAnalyticsId");
+
+if (Validator.isNotNull(googleAnalyticsId)) {
+%>
+
+	<script type="text/javascript">
+		var _gaq = _gaq || [];
+
+		_gaq.push(['_setAccount', '<%= googleAnalyticsId %>']);
+		_gaq.push(['_trackPageview']);
+
+		(function() {
+			var ga = document.createElement('script');
+
+			ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+			ga.setAttribute('async', 'true');
+
+			document.documentElement.firstChild.appendChild(ga);
+		})();
+	</script>
+
+<%
+}
+%>


### PR DESCRIPTION
When you enable google analytics tracking in liferay via manage > settings > monitoring the google analytics tracking javascript is included at the bottom of the page. This is not the correct place. According to google's documentation (http://www.google.com/support/analytics/bin/answer.py?answer=174090) the code should be placed in the head section.

Because the javascript is in the wrong location you cannot verify site ownership in Webmaster Tools.

For more information see this thread :

https://www.google.com/support/forum/p/Google+Analytics/thread?tid=7f356684e4344a9d&hl=en
