### PR TITLE
LPS-24384

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -31,7 +31,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
-import com.liferay.portal.kernel.servlet.ServletRequestUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -766,7 +765,7 @@ public class ServicePreAction extends Action {
 		themeDisplay.setThemeImagesFastLoad(themeImagesFastLoad);
 		themeDisplay.setThemeJsBarebone(themeJsBarebone);
 		themeDisplay.setThemeJsFastLoad(themeJsFastLoad);
-		themeDisplay.setServerName(ServletRequestUtil.getServerName(request));
+		themeDisplay.setServerName(request.getServerName());
 		themeDisplay.setServerPort(request.getServerPort());
 		themeDisplay.setSecure(PortalUtil.isSecure(request));
 		themeDisplay.setLifecycle(lifecycle);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/audit/AuditFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/audit/AuditFilter.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.servlet.filters.audit;
 
 import com.liferay.portal.kernel.audit.AuditRequestThreadLocal;
-import com.liferay.portal.kernel.servlet.ServletRequestUtil;
 import com.liferay.portal.kernel.servlet.TryFilter;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
@@ -51,8 +50,7 @@ public class AuditFilter extends BasePortalFilter implements TryFilter {
 
 		auditRequestThreadLocal.setRequestURL(
 			request.getRequestURL().toString());
-		auditRequestThreadLocal.setServerName(
-			ServletRequestUtil.getServerName(request));
+		auditRequestThreadLocal.setServerName(request.getServerName());
 		auditRequestThreadLocal.setServerPort(request.getServerPort());
 		auditRequestThreadLocal.setSessionID(session.getId());
 

--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/SecureFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/SecureFilter.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ProtectedServletRequest;
-import com.liferay.portal.kernel.servlet.ServletRequestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
@@ -152,7 +151,7 @@ public class SecureFilter extends BasePortalFilter {
 			StringBundler redirectURL = new StringBundler(5);
 
 			redirectURL.append(Http.HTTPS_WITH_SLASH);
-			redirectURL.append(ServletRequestUtil.getServerName(request));
+			redirectURL.append(request.getServerName());
 			redirectURL.append(request.getServletPath());
 
 			String queryString = request.getQueryString();

--- a/portal-impl/src/com/liferay/portal/servlet/filters/validhostname/ValidHostNameFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/validhostname/ValidHostNameFilter.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.servlet.filters.validservername;
+package com.liferay.portal.servlet.filters.validhostname;
 
 import com.liferay.portal.kernel.servlet.TryFilter;
 import com.liferay.portal.kernel.util.Validator;
@@ -24,8 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * @author Shuyang Zhou
  */
-public class ValidServerNameFilter
-	extends BasePortalFilter implements TryFilter {
+public class ValidHostNameFilter extends BasePortalFilter implements TryFilter {
 
 	public Object doFilterTry(
 			HttpServletRequest request, HttpServletResponse response)

--- a/portal-impl/src/com/liferay/portal/servlet/filters/validhostname/ValidHostNameFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/validhostname/ValidHostNameFilter.java
@@ -32,8 +32,8 @@ public class ValidHostNameFilter extends BasePortalFilter implements TryFilter {
 
 		String serverName = request.getServerName();
 
-		if (!Validator.isDomain(serverName)) {
-			throw new RuntimeException("Invalid server name " + serverName);
+		if (!Validator.isHostName(serverName)) {
+			throw new RuntimeException("Invalid host name " + serverName);
 		}
 
 		return null;

--- a/portal-impl/src/com/liferay/portal/servlet/filters/validservername/ValidServerNameFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/validservername/ValidServerNameFilter.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.servlet.filters.validservername;
+
+import com.liferay.portal.kernel.servlet.TryFilter;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.servlet.filters.BasePortalFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ValidServerNameFilter
+	extends BasePortalFilter implements TryFilter {
+
+	public Object doFilterTry(
+			HttpServletRequest request, HttpServletResponse response)
+		throws Exception {
+
+		String serverName = request.getServerName();
+
+		if (!Validator.isDomain(serverName)) {
+			throw new RuntimeException("Invalid server name " + serverName);
+		}
+
+		return null;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/util/CookieKeys.java
+++ b/portal-impl/src/com/liferay/portal/util/CookieKeys.java
@@ -17,7 +17,6 @@ package com.liferay.portal.util;
 import com.liferay.portal.CookieNotSupportedException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.servlet.ServletRequestUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
@@ -133,7 +132,7 @@ public class CookieKeys implements com.liferay.portal.kernel.util.CookieKeys {
 			return PropsValues.SESSION_COOKIE_DOMAIN;
 		}
 
-		String host = ServletRequestUtil.getServerName(request);
+		String host = request.getServerName();
 
 		return getDomain(host);
 	}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -44,7 +44,6 @@ import com.liferay.portal.kernel.servlet.FileTimestampUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
-import com.liferay.portal.kernel.servlet.ServletRequestUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.StringServletResponse;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
@@ -188,7 +187,6 @@ import com.liferay.util.Encryptor;
 import com.liferay.util.JS;
 import com.liferay.util.PwdGenerator;
 import com.liferay.util.UniqueList;
-import com.liferay.util.portlet.PortletRequestUtil;
 import com.liferay.util.servlet.DynamicServletRequest;
 
 import java.io.IOException;
@@ -2727,9 +2725,8 @@ public class PortalImpl implements Portal {
 	}
 
 	public String getPortalURL(HttpServletRequest request, boolean secure) {
-		String serverName = ServletRequestUtil.getServerName(request);
-
-		return getPortalURL(serverName, request.getServerPort(), secure);
+		return getPortalURL(
+			request.getServerName(), request.getServerPort(), secure);
 	}
 
 	public String getPortalURL(Layout layout, ThemeDisplay themeDisplay)
@@ -2760,9 +2757,9 @@ public class PortalImpl implements Portal {
 	}
 
 	public String getPortalURL(PortletRequest portletRequest, boolean secure) {
-		String serverName = PortletRequestUtil.getServerName(portletRequest);
-
-		return getPortalURL(serverName, portletRequest.getServerPort(), secure);
+		return getPortalURL(
+			portletRequest.getServerName(), portletRequest.getServerPort(),
+			secure);
 	}
 
 	public String getPortalURL(

--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.ProtectedPrincipal;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
-import com.liferay.portal.kernel.servlet.ServletRequestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ContextPathUtil;
@@ -440,7 +439,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 	}
 
 	public String getServerName() {
-		return ServletRequestUtil.getServerName(_request);
+		return _request.getServerName();
 	}
 
 	public int getServerPort() {

--- a/portal-impl/src/com/liferay/portlet/PortletServletRequest.java
+++ b/portal-impl/src/com/liferay/portlet/PortletServletRequest.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.util.portlet.PortletRequestUtil;
 import com.liferay.util.servlet.GenericServletInputStream;
 
 import java.io.BufferedReader;
@@ -385,7 +384,7 @@ public class PortletServletRequest extends HttpServletRequestWrapper {
 
 	@Override
 	public String getServerName() {
-		return PortletRequestUtil.getServerName(_portletRequest);
+		return _portletRequest.getServerName();
 	}
 
 	@Override

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6674,10 +6674,18 @@
     # body tag causes the page to render faster. However, the side effect is
     # that it will also make the site unaccessible to screen readers because the
     # HTML is technically invalid. Setting this property to true optimizes for
-    # accessibility while setting this property to false optimzes for browser
+    # accessibility while setting this property to false optimizes for browser
     # performance.
     #
     com.liferay.portal.servlet.filters.validhtml.ValidHtmlFilter=false
+
+	#
+	# The valid server name filter will check the server name from request's 
+	# host header. It rejects request with invalid server name to prevent XSS.
+	# Setting this property to true increases security level while setting this
+	# property to false optimizes server side performance.
+	#
+	com.liferay.portal.servlet.filters.validservername.ValidServerNameFilter=false
 
     #
     # The virtual host filter maps hosts to public and private pages. For

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6668,6 +6668,14 @@
     com.liferay.portal.servlet.filters.unsyncprintwriterpool.UnsyncPrintWriterPoolFilter=true
 
     #
+    # The valid host name filter will check the host name from request's 
+    # host header. It rejects request with invalid server name to prevent XSS.
+    # Setting this property to true increases security level while setting this
+    # property to false optimizes server side performance.
+    #
+    com.liferay.portal.servlet.filters.validhostname.ValidHostNameFilter=true
+
+    #
     # The valid HTML filter will move JavaScript that is outside of the closing
     # body tag to its proper place inside the body tag. Most sites will prefer
     # to leave this filter disabled because having JavaScript outside of the
@@ -6678,14 +6686,6 @@
     # performance.
     #
     com.liferay.portal.servlet.filters.validhtml.ValidHtmlFilter=false
-
-	#
-	# The valid server name filter will check the server name from request's 
-	# host header. It rejects request with invalid server name to prevent XSS.
-	# Setting this property to true increases security level while setting this
-	# property to false optimizes server side performance.
-	#
-	com.liferay.portal.servlet.filters.validservername.ValidServerNameFilter=false
 
     #
     # The virtual host filter maps hosts to public and private pages. For

--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletRequestUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletRequestUtil.java
@@ -16,7 +16,6 @@ package com.liferay.portal.kernel.servlet;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -25,19 +24,6 @@ import javax.servlet.http.HttpServletRequestWrapper;
  * @author Brian Wing Shun Chan
  */
 public class ServletRequestUtil {
-
-	/**
-	 * @see {@link PortletRequestUtil#getServerName(PortletRequest)}
-	 */
-	public static String getServerName(HttpServletRequest request) {
-		String serverName = request.getServerName();
-
-		if (!Validator.isDomain(serverName)) {
-			throw new RuntimeException("Invalid server name " + serverName);
-		}
-
-		return serverName;
-	}
 
 	public static void logRequestWrappers(HttpServletRequest request) {
 		HttpServletRequest tempRequest = request;

--- a/portal-service/src/com/liferay/portal/kernel/util/Validator.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Validator.java
@@ -501,6 +501,38 @@ public class Validator {
 	}
 
 	/**
+	 * Returns <code>true</code> if the string is a valid host name.
+	 *
+	 * @param  name the string to check
+	 * @return <code>true</code> if the string is a valid host name;
+	 *         <code>false</code> otherwise
+	 */
+	public static boolean isHostName(String name) {
+		if (isNull(name)) {
+			return false;
+		}
+
+		char[] nameCharArray = name.toCharArray();
+
+		if ((nameCharArray[0] == CharPool.DASH) ||
+			(nameCharArray[0] == CharPool.PERIOD) ||
+			(nameCharArray[nameCharArray.length - 1] == CharPool.DASH)) {
+
+			return false;
+		}
+
+		for (char c : nameCharArray) {
+			if (!isChar(c) && !isDigit(c) && (c != CharPool.DASH) &&
+				(c != CharPool.PERIOD)) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Returns <code>true</code> if the string is an HTML document. The only
 	 * requirement is that it contain the opening and closing html tags.
 	 *

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -466,12 +466,12 @@
 		</init-param>
 	</filter>
 	<filter>
-		<filter-name>Valid Html Filter</filter-name>
-		<filter-class>com.liferay.portal.servlet.filters.validhtml.ValidHtmlFilter</filter-class>
+		<filter-name>Valid Host Name Filter</filter-name>
+		<filter-class>com.liferay.portal.servlet.filters.validhostname.ValidHostNameFilter</filter-class>
 	</filter>
 	<filter>
-		<filter-name>Valid Server Name Filter</filter-name>
-		<filter-class>com.liferay.portal.servlet.filters.validservername.ValidServerNameFilter</filter-class>
+		<filter-name>Valid Html Filter</filter-name>
+		<filter-class>com.liferay.portal.servlet.filters.validhtml.ValidHtmlFilter</filter-class>
 	</filter>
 	<filter>
 		<filter-name>Virtual Host Filter</filter-name>
@@ -502,7 +502,7 @@
 		<url-pattern>*.vm</url-pattern>
 	</filter-mapping>
 	<filter-mapping>
-		<filter-name>Valid Server Name Filter</filter-name>
+		<filter-name>Valid Host Name Filter</filter-name>
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 	<filter-mapping>

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -470,6 +470,10 @@
 		<filter-class>com.liferay.portal.servlet.filters.validhtml.ValidHtmlFilter</filter-class>
 	</filter>
 	<filter>
+		<filter-name>Valid Server Name Filter</filter-name>
+		<filter-class>com.liferay.portal.servlet.filters.validservername.ValidServerNameFilter</filter-class>
+	</filter>
+	<filter>
 		<filter-name>Virtual Host Filter</filter-name>
 		<filter-class>com.liferay.portal.servlet.filters.virtualhost.VirtualHostFilter</filter-class>
 		<init-param>
@@ -496,6 +500,10 @@
 	<filter-mapping>
 		<filter-name>Ignore Filter - VM</filter-name>
 		<url-pattern>*.vm</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>Valid Server Name Filter</filter-name>
+		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>Thread Dump Filter</filter-name>

--- a/util-java/src/com/liferay/util/portlet/PortletRequestUtil.java
+++ b/util-java/src/com/liferay/util/portlet/PortletRequestUtil.java
@@ -56,19 +56,6 @@ import org.apache.commons.fileupload.portlet.PortletFileUpload;
  */
 public class PortletRequestUtil {
 
-	/**
-	 * @see {@link ServletRequestUtil#getServerName(HttpServletRequest)}
-	 */
-	public static String getServerName(PortletRequest request) {
-		String serverName = request.getServerName();
-
-		if (!Validator.isDomain(serverName)) {
-			throw new RuntimeException("Invalid server name " + serverName);
-		}
-
-		return serverName;
-	}
-
 	public static List<DiskFileItem> testMultipartWithCommonsFileUpload(
 			ActionRequest actionRequest)
 		throws Exception {
@@ -146,7 +133,8 @@ public class PortletRequestUtil {
 			"container-namespace", portletRequest.getContextPath());
 		requestElement.addElement(
 			"content-type", portletRequest.getResponseContentType());
-		requestElement.addElement("server-name", getServerName(portletRequest));
+		requestElement.addElement(
+			"server-name", portletRequest.getServerName());
 		requestElement.addElement(
 			"server-port", portletRequest.getServerPort());
 		requestElement.addElement("secure", portletRequest.isSecure());


### PR DESCRIPTION
This needs to go into 6.1 or the previous fix needs to be rollback. The current fix breaks on any intranet site that is running on a host that doesn't contain a "."

Also redesigning the fix because of performance issues.
