### PR TITLE
LPS-24661

### DIFF
--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -321,8 +321,17 @@ if (Validator.isNotNull(layout.getLayoutPrototypeUuid()) && layout.getLayoutProt
 
 // Deny access to edit mode if you do not have permission
 
-if (access && !PropsValues.TCK_URL && portletMode.equals(PortletMode.EDIT) && !PortletPermissionUtil.contains(permissionChecker, layout, portletId, ActionKeys.PREFERENCES)) {
-	access = false;
+if (access && !PropsValues.TCK_URL && portletMode.equals(PortletMode.EDIT)) {
+	if (group.isControlPanel()) {
+		if (!PortletPermissionUtil.contains(permissionChecker, themeDisplay.getScopeGroupId(), null, portletId, ActionKeys.PREFERENCES)) {
+			access = false;
+		}
+	}
+	else {
+		if (!PortletPermissionUtil.contains(permissionChecker, layout, portletId, ActionKeys.PREFERENCES)) {
+			access = false;
+		}
+	}
 }
 
 // Deny access


### PR DESCRIPTION
Problem is that we use the control panel layout rather than the current scope group to see if a user has the ability to access edit mode, so fix it by passing in the scope group and a null layout when inside the control panel and leave the logic alone when on a non control panel layout.
