### PR TITLE
LPS-24640

### DIFF
--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -1480,7 +1480,7 @@
 		<!-- Finder methods -->
 
 		<finder name="ServletContextName" return-type="Release">
-			<finder-column name="servletContextName" />
+			<finder-column name="servletContextName" case-sensitive="false"/>
 		</finder>
 	</entity>
 	<entity name="Repository" uuid="true" local-service="true" remote-service="true">

--- a/portal-impl/src/com/liferay/portal/service/impl/ReleaseLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ReleaseLocalServiceImpl.java
@@ -173,8 +173,6 @@ public class ReleaseLocalServiceImpl extends ReleaseLocalServiceBaseImpl {
 				"Servlet context name cannot be null");
 		}
 
-		servletContextName = servletContextName.toLowerCase();
-
 		Release release = null;
 
 		if (servletContextName.equals(

--- a/portal-impl/src/com/liferay/portal/service/persistence/ReleasePersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/ReleasePersistenceImpl.java
@@ -1000,9 +1000,9 @@ public class ReleasePersistenceImpl extends BasePersistenceImpl<Release>
 	private static final String _FINDER_COLUMN_SERVLETCONTEXTNAME_SERVLETCONTEXTNAME_1 =
 		"release.servletContextName IS NULL";
 	private static final String _FINDER_COLUMN_SERVLETCONTEXTNAME_SERVLETCONTEXTNAME_2 =
-		"release.servletContextName = ?";
+		"lower(release.servletContextName) = lower(CAST_TEXT(?))";
 	private static final String _FINDER_COLUMN_SERVLETCONTEXTNAME_SERVLETCONTEXTNAME_3 =
-		"(release.servletContextName IS NULL OR release.servletContextName = ?)";
+		"(release.servletContextName IS NULL OR lower(release.servletContextName) = lower(CAST_TEXT(?)))";
 	private static final String _ORDER_BY_ENTITY_ALIAS = "release.";
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY = "No Release exists with the primary key ";
 	private static final String _NO_SUCH_ENTITY_WITH_KEY = "No Release exists with the key {";


### PR DESCRIPTION
servlet context name select doesn't work properly with case sensitive database

Hi Brian,

This bug is a classic lower case/upper case matching problem: when the hook's servlet context is being inserted into the release_ table is contains both lower and upper case letters, but before the portal queries that table based on the servlet context it makes it lower case first.

With Kálmán we were thinking of that the best would be if the portal could query that record in a case insensitive way no matter how the servlet context has been inserted. This is not just application server independent solution but also when someone upgrades it will remain consistent with the already existing data in the user's database.

Máté
