### PR TITLE
LPS-23809 ClassCastException in error handling

### DIFF
--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/ExportImportAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/ExportImportAction.java
@@ -258,7 +258,7 @@ public class ExportImportAction extends EditConfigurationAction {
 				_log.debug(e, e);
 			}
 
-			SessionErrors.add(actionRequest, e.getClass().getName());
+			SessionErrors.add(actionRequest, e.getClass().getName(), e);
 		}
 	}
 


### PR DESCRIPTION
Hi Brian,

There was a slight problem with a previous fix, the Exception object wasn't passed to the SessionErrors class so  on the UI side the portal couldn't use that specific exception object.

Máté
