### PR TITLE
LPS-23297

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -163,7 +163,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 					new String[] {
 						<#list finderColsList as finderCol>
 							${serviceBuilder.getPrimitiveObj("${finderCol.type}")}.class.getName()
-	
+
 							<#if finderCol_has_next>
 								,
 							</#if>
@@ -172,16 +172,16 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 					<#if columnBitmaskEnabled>
 						,
-	
+
 						<#list finderColsList as finderCol>
 							${entity.name}ModelImpl.${finderCol.name?upper_case}_COLUMN_BITMASK
-	
+
 							<#if finderCol_has_next>
 								|
 							</#if>
 						</#list>
 					</#if>
-	
+
 					);
 			</#if>
 
@@ -657,6 +657,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 							<#if finder.hasArrayableOperator()>
 								args = (Object[])FinderCacheUtil.getResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS, args, this);
+
 								if (args != null) {
 									FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_${finder.name?upper_case}, args);
 									FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}, args);
@@ -686,6 +687,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 							<#if finder.hasArrayableOperator()>
 								args = (Object[])FinderCacheUtil.getResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS, args, this);
+
 								if (args != null) {
 									FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_${finder.name?upper_case}, args);
 									FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}, args);
@@ -1551,7 +1553,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 									<#list finderColsList as finderCol>
 										<#if finderCol.hasArrayableOperator()>
 											Object[] arrayableFinderArgs;
-											for(${finderCol.type} finderColName : ${finderCol.names}){
+											for (${finderCol.type} finderColName : ${finderCol.names}) {
 
 												arrayableFinderArgs = new Object[] {
 													<#list finderColsList as subFinderCol>
@@ -2811,8 +2813,8 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 						<#list finderColsList as finderCol>
 							<#if finderCol.hasArrayableOperator()>
 								Object[] arrayableFinderArgs;
-								for(${finderCol.type} finderColName : ${finderCol.names}){
-	
+								for (${finderCol.type} finderColName : ${finderCol.names}) {
+
 									arrayableFinderArgs = new Object[] {
 										<#list finderColsList as subFinderCol>
 											<#if subFinderCol.hasArrayableOperator()>
@@ -2820,13 +2822,13 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 											<#else>
 												${subFinderCol.name}
 											</#if>
-	
+
 											<#if subFinderCol_has_next>
 												,
 											</#if>
 										</#list>
 									};
-	
+
 									FinderCacheUtil.putResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS, arrayableFinderArgs, finderArgs);
 								}
 							</#if>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -152,6 +152,39 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 				</#if>
 
 				);
+
+			<#if finder.hasArrayableOperator()>
+				public static final FinderPath FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS = new FinderPath(
+					${entity.name}ModelImpl.ENTITY_CACHE_ENABLED,
+					${entity.name}ModelImpl.FINDER_CACHE_ENABLED,
+					Object[].class,
+					FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION,
+					"findBy${finder.name}_ARGS",
+					new String[] {
+						<#list finderColsList as finderCol>
+							${serviceBuilder.getPrimitiveObj("${finderCol.type}")}.class.getName()
+	
+							<#if finderCol_has_next>
+								,
+							</#if>
+						</#list>
+					}
+
+					<#if columnBitmaskEnabled>
+						,
+	
+						<#list finderColsList as finderCol>
+							${entity.name}ModelImpl.${finderCol.name?upper_case}_COLUMN_BITMASK
+	
+							<#if finderCol_has_next>
+								|
+							</#if>
+						</#list>
+					</#if>
+	
+					);
+			</#if>
+
 		<#else>
 			public static final FinderPath FINDER_PATH_FETCH_BY_${finder.name?upper_case} = new FinderPath(
 				${entity.name}ModelImpl.ENTITY_CACHE_ENABLED,
@@ -622,6 +655,14 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 							FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_${finder.name?upper_case}, args);
 							FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}, args);
 
+							<#if finder.hasArrayableOperator()>
+								args = (Object[])FinderCacheUtil.getResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS, args, this);
+								if (args != null) {
+									FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_${finder.name?upper_case}, args);
+									FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}, args);
+								}
+							</#if>
+
 							args = new Object[] {
 								<#list finder.getColumns() as finderCol>
 									<#if finderCol.isPrimitiveType()>
@@ -642,6 +683,15 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 							FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_${finder.name?upper_case}, args);
 							FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}, args);
+
+							<#if finder.hasArrayableOperator()>
+								args = (Object[])FinderCacheUtil.getResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS, args, this);
+								if (args != null) {
+									FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_${finder.name?upper_case}, args);
+									FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}, args);
+								}
+							</#if>
+
 						}
 					</#list>
 				}
@@ -1496,6 +1546,32 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 								cacheResult(list);
 
 								FinderCacheUtil.putResult(finderPath, finderArgs, list);
+
+								if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) && (orderByComparator == null)) {
+									<#list finderColsList as finderCol>
+										<#if finderCol.hasArrayableOperator()>
+											Object[] arrayableFinderArgs;
+											for(${finderCol.type} finderColName : ${finderCol.names}){
+
+												arrayableFinderArgs = new Object[] {
+													<#list finderColsList as subFinderCol>
+														<#if subFinderCol.hasArrayableOperator()>
+															finderColName
+														<#else>
+															${subFinderCol.name}
+														</#if>
+
+														<#if subFinderCol_has_next>
+															,
+														</#if>
+													</#list>
+												};
+
+												FinderCacheUtil.putResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS, arrayableFinderArgs, finderArgs);
+											}
+										</#if>
+									</#list>
+								}
 							}
 
 							closeSession(session);
@@ -2731,6 +2807,30 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 						}
 
 						FinderCacheUtil.putResult(FINDER_PATH_COUNT_BY_${finder.name?upper_case}, finderArgs, count);
+
+						<#list finderColsList as finderCol>
+							<#if finderCol.hasArrayableOperator()>
+								Object[] arrayableFinderArgs;
+								for(${finderCol.type} finderColName : ${finderCol.names}){
+	
+									arrayableFinderArgs = new Object[] {
+										<#list finderColsList as subFinderCol>
+											<#if subFinderCol.hasArrayableOperator()>
+												finderColName
+											<#else>
+												${subFinderCol.name}
+											</#if>
+	
+											<#if subFinderCol_has_next>
+												,
+											</#if>
+										</#list>
+									};
+	
+									FinderCacheUtil.putResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_${finder.name?upper_case}_ARGS, arrayableFinderArgs, finderArgs);
+								}
+							</#if>
+						</#list>
 
 						closeSession(session);
 					}


### PR DESCRIPTION
1 bug reason:
cache arrayable operator using  key {"id1","id2"...}
never get chance to clean the cache.

2 solution:
cache the arguments each entity using key id1 and id2 ...
key    result
id1   {"id1","id2"...}
id2   {"id1","id2"...}
when id1 be updated, get the arguments  {"id1","id2"...} and remove cache . 
FinderCacheUtil.remove( {"id1","id2"...} )
# only submit the template, need run build service.
