### PR TITLE
LPS-24609

### DIFF
--- a/portal-impl/src/com/liferay/portal/repository/search/RepositorySearchQueryBuilderImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/search/RepositorySearchQueryBuilderImpl.java
@@ -172,9 +172,14 @@ public class RepositorySearchQueryBuilderImpl
 			queryParser.setAllowLeadingWildcard(true);
 			queryParser.setLowercaseExpandedTerms(false);
 
-			value = KeywordsUtil.escape(value);
+			org.apache.lucene.search.Query query = null;
 
-			org.apache.lucene.search.Query query = queryParser.parse(value);
+			try {
+				query = queryParser.parse(value);
+			}
+			catch (Exception e) {
+				query = queryParser.parse(KeywordsUtil.escape(value));
+			}
 
 			translateQuery(
 				booleanQuery, searchContext, query,

--- a/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperImpl.java
@@ -196,9 +196,14 @@ public class LuceneHelperImpl implements LuceneHelper {
 			QueryParser queryParser = new QueryParser(
 				getVersion(), field, getAnalyzer());
 
-			value = KeywordsUtil.escape(value);
+			Query query = null;
 
-			Query query = queryParser.parse(value);
+			try {
+				query = queryParser.parse(value);
+			}
+			catch (Exception e) {
+				query = queryParser.parse(KeywordsUtil.escape(value));
+			}
 
 			BooleanClause.Occur occur = null;
 


### PR DESCRIPTION
Current solution disallows us from using complex Lucene queries directly from the UI and also breaks unit tests.  Would be better to only fall back to escaping when the original query fails.
