### PR TITLE
LPS-25009

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/ThemeImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ThemeImpl.java
@@ -419,6 +419,10 @@ public class ThemeImpl extends PluginBaseImpl implements Theme {
 				servletContext, this, portletId, path);
 		}
 
+		if (Validator.isNull(path)) {
+			return false;
+		}
+
 		String key = path;
 
 		if (Validator.isNotNull(portletId)) {


### PR DESCRIPTION
LPS-25009 NullPointerException thrown when a null path is passed to Theme.resourceExists()
