### PR TITLE
LPS-25139

### DIFF
--- a/portal-web/test/com/liferay/portalweb/portal/evaluatelog/EvaluateLogTest.java
+++ b/portal-web/test/com/liferay/portalweb/portal/evaluatelog/EvaluateLogTest.java
@@ -75,6 +75,12 @@ public class EvaluateLogTest extends BaseTestCase {
 
 					continue;
 				}
+
+				if (line.contains(
+					"[org.python.google.common.base.internal.Finalizer]")) {
+
+					continue;
+				}
 			}
 
 			// LPS-17639


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-25139

Ignore line:

SEVERE: The web application [] appears to have started a thread named [org.python.google.common.base.internal.Finalizer] but has failed to stop it. This is very likely to create a memory leak.
