### PR TITLE
LPS-21818 Editing a Page Variation without saving changes will make variations un-editable/un-deleteable until refreshed

### DIFF
--- a/portal-web/docroot/html/portlet/staging_bar/layout_branch_action.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/layout_branch_action.jsp
@@ -28,7 +28,7 @@ long currentLayoutBranchId = GetterUtil.getLong((String)request.getAttribute("vi
 
 <liferay-ui:icon-menu>
 	<c:if test="<%= LayoutBranchPermissionUtil.contains(permissionChecker, layoutBranch, ActionKeys.UPDATE) %>">
-		<portlet:renderURL var="editURL">
+		<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>" var="editURL">
 			<portlet:param name="struts_action" value="/staging_bar/edit_layout_branch" />
 			<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.UPDATE %>" />
 			<portlet:param name="redirect" value="<%= currentURL %>" />

--- a/portal-web/docroot/html/portlet/staging_bar/layout_set_branch_action.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/layout_set_branch_action.jsp
@@ -26,7 +26,7 @@ long currentLayoutSetBranchId = GetterUtil.getLong((String)request.getAttribute(
 
 <liferay-ui:icon-menu>
 	<c:if test="<%= LayoutSetBranchPermissionUtil.contains(permissionChecker, layoutSetBranch, ActionKeys.UPDATE) %>">
-		<portlet:renderURL var="editURL">
+		<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>" var="editURL">
 			<portlet:param name="struts_action" value="/staging_bar/edit_layout_set_branch" />
 			<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.UPDATE %>" />
 			<portlet:param name="redirect" value="<%= currentURL %>" />


### PR DESCRIPTION
The problem is that the windowState was by default pop_up and this would overwrite the Liferay javascript object in top_js.jspf
