### PR TITLE
LPS-25261

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -867,8 +867,25 @@ public class ServiceBuilder {
 		}
 		else {
 			String refPackage = name.substring(0, pos);
-			String refPackageDir = StringUtil.replace(refPackage, ".", "/");
 			String refEntity = name.substring(pos + 1, name.length());
+
+			if (refPackage.equals(_packagePath)) {
+				pos = _ejbList.indexOf(new Entity(refEntity));
+
+				if (pos == -1) {
+					throw new RuntimeException(
+						"Cannot find " + refEntity + " in " +
+							ListUtil.toString(_ejbList, Entity.NAME_ACCESSOR));
+				}
+
+				entity = _ejbList.get(pos);
+
+				_entityPool.put(name, entity);
+
+				return entity;
+			}
+
+			String refPackageDir = StringUtil.replace(refPackage, ".", "/");
 			String refFileName =
 				_implDir + "/" + refPackageDir + "/service.xml";
 


### PR DESCRIPTION
When using plugins SDK, if a List<ModelEntity> is returned from a ServiceImpl method, the ServiceSoap class that is generated by ServiceBuilder has a return type of ModelEntity[](incorrect) instead of ModelEntitySoap[](correct).  This is because when it is trying to find the entity from the generic type, it is unable to find it since it's using the fully qualified name instead of the shortened name that excludes the package path.
