### PR TITLE
LPS-25248 sendRedirect in a web content display added dynamically causes NullpointerException

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/PortletAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortletAction.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.struts;
 
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
@@ -255,7 +256,7 @@ public class PortletAction extends Action {
 
 	protected void sendRedirect(
 			ActionRequest actionRequest, ActionResponse actionResponse)
-		throws IOException {
+		throws IOException, SystemException {
 
 		sendRedirect(actionRequest, actionResponse, null);
 	}
@@ -263,7 +264,7 @@ public class PortletAction extends Action {
 	protected void sendRedirect(
 			ActionRequest actionRequest, ActionResponse actionResponse,
 			String redirect)
-		throws IOException {
+		throws IOException, SystemException {
 
 		if (SessionErrors.isEmpty(actionRequest)) {
 			ThemeDisplay themeDisplay =
@@ -276,14 +277,17 @@ public class PortletAction extends Action {
 
 			String portletId = (String)actionRequest.getAttribute(
 				WebKeys.PORTLET_ID);
-
+			
 			try {
 				hasPortletId = layoutTypePortlet.hasPortletId(portletId);
 			}
 			catch (Exception e) {
 			}
 
-			Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);
+			long companyId = themeDisplay.getCompanyId();
+				
+			Portlet portlet = PortletLocalServiceUtil.getPortletById(
+				companyId,portletId);
 
 			if (hasPortletId || portlet.isAddDefaultResource()) {
 				addSuccessMessage(actionRequest, actionResponse);

--- a/portal-impl/src/com/liferay/portal/struts/PortletAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortletAction.java
@@ -277,17 +277,15 @@ public class PortletAction extends Action {
 
 			String portletId = (String)actionRequest.getAttribute(
 				WebKeys.PORTLET_ID);
-			
+
 			try {
 				hasPortletId = layoutTypePortlet.hasPortletId(portletId);
 			}
 			catch (Exception e) {
 			}
 
-			long companyId = themeDisplay.getCompanyId();
-				
 			Portlet portlet = PortletLocalServiceUtil.getPortletById(
-				companyId,portletId);
+				themeDisplay.getCompanyId(), portletId);
 
 			if (hasPortletId || portlet.isAddDefaultResource()) {
 				addSuccessMessage(actionRequest, actionResponse);


### PR DESCRIPTION
Brian, we found that the method which has the companyId has a lot more of checks and seems to filter by company. For example, the rootPortletId check was the one we needed to fix the issue. So we thought it would be better to call this method instead of the one without the companyId. Do you see any inconvenient of doing this?
