### PR TITLE
LPS-19114

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/ContentTypes.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/ContentTypes.java
@@ -21,6 +21,8 @@ public interface ContentTypes {
 
 	public static final String APPLICATION_ATOM_XML = "application/atom+xml";
 
+	public static final String APPLICATION_GZIP = "application/gzip";
+
 	public static final String APPLICATION_JSON = "application/json";
 
 	public static final String APPLICATION_MSWORD = "application/msword";
@@ -37,6 +39,9 @@ public interface ContentTypes {
 
 	public static final String APPLICATION_VND_MS_POWERPOINT =
 		"application/vnd.ms-powerpoint";
+
+	public static final String APPLICATION_X_GZIP =
+		"application/x-gzip";
 
 	public static final String APPLICATION_X_JAVA_SERIALIZED_OBJECT =
 		"application/x-java-serialized-object";

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -124,10 +124,6 @@
 	<filter>
 		<filter-name>GZip Filter</filter-name>
 		<filter-class>com.liferay.portal.servlet.filters.gzip.GZipFilter</filter-class>
-		<init-param>
-			<param-name>url-regex-ignore-pattern</param-name>
-			<param-value>^(/c/document_library/get_file|/c/message_boards/get_message_attachment|/c/wiki/get_page_attachment)(\?.*)?$</param-value>
-		</init-param>
 	</filter>
 	<filter>
 		<filter-name>GZip Filter - Theme PNG</filter-name>


### PR DESCRIPTION
Can't fix the problem with GZipFilter via changing the URL ignore patterns, because eventually the dispatcher FORWARDs to another URL that will never match any of our ignore patterns, so fixing it directly in GZipResponse.  This means that we don't need the existing ignore patterns anymore.
