### PR TITLE
LPS-25341

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/gzip/GZipResponse.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/gzip/GZipResponse.java
@@ -53,6 +53,8 @@ public class GZipResponse extends HttpServletResponseWrapper {
 
 		_response.setContentLength(-1);
 
+		_response.addHeader(HttpHeaders.CONTENT_ENCODING, _GZIP);
+
 		_firefox = BrowserSnifferUtil.isFirefox(request);
 	}
 
@@ -93,8 +95,6 @@ public class GZipResponse extends HttpServletResponseWrapper {
 				_servletOutputStream = _response.getOutputStream();
 			}
 			else {
-				_response.addHeader(HttpHeaders.CONTENT_ENCODING, _GZIP);
-
 				if (_firefox && RSSThreadLocal.isExportRSS()) {
 					_unsyncByteArrayOutputStream =
 						new UnsyncByteArrayOutputStream();


### PR DESCRIPTION
There's no harm in saying that the content encoding is gzip if the content type is gzip and we don't add another layer of gzip on top of it.  Therefore, to avoid the problem that comes up if we call addHeader() too late, always set the content encoding to gzip if we wrap things in a GZipResponse.
