### PR TITLE
LPS-25277

### DIFF
--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
@@ -420,8 +421,14 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			String value = null;
 
 			if (displayStyle.equals(RSSUtil.DISPLAY_STYLE_ABSTRACT)) {
+				String summary = entry.getDescription();
+
+				if (Validator.isNull(summary)) {
+					summary = entry.getContent();
+				}
+
 				value = StringUtil.shorten(
-					HtmlUtil.extractText(entry.getDescription()),
+					HtmlUtil.extractText(summary),
 					PropsValues.BLOGS_RSS_ABSTRACT_LENGTH, StringPool.BLANK);
 			}
 			else if (displayStyle.equals(RSSUtil.DISPLAY_STYLE_TITLE)) {

--- a/portal-web/docroot/html/portlet/blogs/asset/abstract.jsp
+++ b/portal-web/docroot/html/portlet/blogs/asset/abstract.jsp
@@ -44,8 +44,8 @@ BlogsEntry entry = (BlogsEntry)request.getAttribute(WebKeys.BLOGS_ENTRY);
 String summary = entry.getDescription();
 
 if (Validator.isNull(summary)) {
-	summary = StringUtil.shorten(HtmlUtil.stripHtml(entry.getContent()), abstractLength);
+	summary = entry.getContent();
 }
 %>
 
-<%= summary %>
+<%= StringUtil.shorten(HtmlUtil.stripHtml(entry.getContent()), abstractLength) %>

--- a/portal-web/docroot/html/portlet/blogs/asset/abstract.jsp
+++ b/portal-web/docroot/html/portlet/blogs/asset/abstract.jsp
@@ -48,4 +48,4 @@ if (Validator.isNull(summary)) {
 }
 %>
 
-<%= StringUtil.shorten(HtmlUtil.stripHtml(entry.getContent()), abstractLength) %>
+<%= StringUtil.shorten(HtmlUtil.stripHtml(summary), abstractLength) %>

--- a/portal-web/docroot/html/portlet/blogs/asset/abstract.jsp
+++ b/portal-web/docroot/html/portlet/blogs/asset/abstract.jsp
@@ -44,8 +44,8 @@ BlogsEntry entry = (BlogsEntry)request.getAttribute(WebKeys.BLOGS_ENTRY);
 String summary = entry.getDescription();
 
 if (Validator.isNull(summary)) {
-	summary = entry.getContent();
+	summary = HtmlUtil.stripHtml(entry.getContent());
 }
 %>
 
-<%= StringUtil.shorten(HtmlUtil.stripHtml(summary), abstractLength) %>
+<%= StringUtil.shorten(summary, abstractLength) %>

--- a/portal-web/docroot/html/portlet/blogs/view_entry_content.jsp
+++ b/portal-web/docroot/html/portlet/blogs/view_entry_content.jsp
@@ -135,8 +135,6 @@ AssetEntry assetEntry = (AssetEntry)request.getAttribute("view_entry_content.jsp
 			<div class="entry-body">
 				<c:choose>
 					<c:when test='<%= pageDisplayStyle.equals(RSSUtil.DISPLAY_STYLE_ABSTRACT) && !strutsAction.equals("/blogs/view_entry") %>'>
-						<%= StringUtil.shorten(HtmlUtil.stripHtml(entry.getDescription()), pageAbstractLength) %>
-
 						<c:if test="<%= entry.isSmallImage() %>">
 
 							<%
@@ -151,6 +149,16 @@ AssetEntry assetEntry = (AssetEntry)request.getAttribute("view_entry_content.jsp
 								<img alt="" class="asset-small-image" src="<%= HtmlUtil.escape(src) %>" width="150" />
 							</div>
 						</c:if>
+
+						<%
+							String summary = entry.getDescription();
+
+							if (Validator.isNull(summary)) {
+								summary = entry.getContent();
+							}
+						%>
+
+						<%= StringUtil.shorten(HtmlUtil.stripHtml(summary), pageAbstractLength) %>
 
 						<br />
 

--- a/portal-web/docroot/html/portlet/blogs/view_entry_content.jsp
+++ b/portal-web/docroot/html/portlet/blogs/view_entry_content.jsp
@@ -151,11 +151,11 @@ AssetEntry assetEntry = (AssetEntry)request.getAttribute("view_entry_content.jsp
 						</c:if>
 
 						<%
-							String summary = entry.getDescription();
+						String summary = entry.getDescription();
 
-							if (Validator.isNull(summary)) {
-								summary = entry.getContent();
-							}
+						if (Validator.isNull(summary)) {
+							summary = entry.getContent();
+						}
 						%>
 
 						<%= StringUtil.shorten(HtmlUtil.stripHtml(summary), pageAbstractLength) %>

--- a/portal-web/docroot/html/portlet/journal/asset/abstract.jsp
+++ b/portal-web/docroot/html/portlet/journal/asset/abstract.jsp
@@ -59,8 +59,8 @@ else {
 String summary = articleDisplay.getDescription();
 
 if (Validator.isNull(summary)) {
-	summary = StringUtil.shorten(HtmlUtil.stripHtml(articleDisplay.getContent()), abstractLength);
+	summary = HtmlUtil.stripHtml(articleDisplay.getContent());
 }
 %>
 
-<%= summary %>
+<%= StringUtil.shorten(summary, abstractLength) %>


### PR DESCRIPTION
Hi Brian,

This fix is about to make the blogs entries abstract's description field similar to how the description is being used by the asset publisher. If there is no abstract text entered it will fall back to the blog entry's content.

Sergio reviewed this change, he performed some source formatting what I've reviewed so I'm forwarding this to you now.

Thanks,

Máté

(cc-ing ZBerentey: @zberentey)
