### PR TITLE
LPS-23929 use escape instead of escapeAttribute in input name of layout ...

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
@@ -127,7 +127,7 @@ StringBuilder friendlyURLBase = new StringBuilder();
 			</c:if>
 		</c:when>
 		<c:otherwise>
-			<aui:input name='<%= "name_" + defaultLanguageId %>' type="hidden" value="<%= HtmlUtil.escapeAttribute(selLayout.getName(defaultLocale)) %>" />
+			<aui:input name='<%= "name_" + defaultLanguageId %>' type="hidden" value="<%= HtmlUtil.escape(selLayout.getName(defaultLocale)) %>" />
 		</c:otherwise>
 	</c:choose>
 


### PR DESCRIPTION
...template

Can not use HtmlUtil.escapeAttribute(value) for value containing spaces. It will append "&#x20;"
