### PR TITLE
LPS-25696

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v5_2_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v5_2_0/UpgradeDocumentLibrary.java
@@ -40,6 +40,8 @@ public class UpgradeDocumentLibrary extends BaseUpgradePortletPreferences {
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -52,9 +54,16 @@ public class UpgradeDocumentLibrary extends BaseUpgradePortletPreferences {
 				fileEntryColumns, "document", "name");
 
 			portletPreferences.setValue("fileEntryColumns", fileEntryColumns);
+
+			changed = true;
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v5_2_3/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v5_2_3/UpgradeDocumentLibrary.java
@@ -130,6 +130,8 @@ public class UpgradeDocumentLibrary extends BaseUpgradePortletPreferences {
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -139,9 +141,16 @@ public class UpgradeDocumentLibrary extends BaseUpgradePortletPreferences {
 
 		if (Validator.isNull(fileEntryColumns)) {
 			portletPreferences.reset("fileEntryColumns");
+
+			changed = true;
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_0_3/UpgradeAssetPublisher.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_0_3/UpgradeAssetPublisher.java
@@ -62,6 +62,8 @@ public class UpgradeAssetPublisher extends BaseUpgradePortletPreferences {
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -78,9 +80,16 @@ public class UpgradeAssetPublisher extends BaseUpgradePortletPreferences {
 			String[] newAssetEntryXmls = getAssetEntryXmls(assetEntryXmls);
 
 			portletPreferences.setValues("asset-entry-xml", newAssetEntryXmls);
+
+			changed = true;
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_0_3/UpgradeLookAndFeel.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_0_3/UpgradeLookAndFeel.java
@@ -36,6 +36,8 @@ public class UpgradeLookAndFeel extends BaseUpgradePortletPreferences {
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -60,9 +62,16 @@ public class UpgradeLookAndFeel extends BaseUpgradePortletPreferences {
 
 			portletPreferences.reset("portlet-setup-link-to-layout-id");
 			portletPreferences.reset("portlet-setup-link-to-plid");
+
+			changed = true;
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_0_3/UpgradeSitemap.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_0_3/UpgradeSitemap.java
@@ -37,6 +37,8 @@ public class UpgradeSitemap extends BaseUpgradePortletPreferences {
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -52,9 +54,16 @@ public class UpgradeSitemap extends BaseUpgradePortletPreferences {
 			}
 
 			portletPreferences.reset("root-layout-id");
+
+			changed = true;
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeCamelCasePortletPreferences.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeCamelCasePortletPreferences.java
@@ -74,6 +74,8 @@ public class UpgradeCamelCasePortletPreferences
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -103,10 +105,17 @@ public class UpgradeCamelCasePortletPreferences
 
 				portletPreferences.reset(oldName);
 				portletPreferences.setValues(newName, values);
+
+				changed = true;
 			}
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 	private Map<String, String> _camelCasePreferenceNames =

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeNavigation.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeNavigation.java
@@ -37,6 +37,8 @@ public class UpgradeNavigation extends BaseUpgradePortletPreferences {
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -53,9 +55,16 @@ public class UpgradeNavigation extends BaseUpgradePortletPreferences {
 
 			portletPreferences.setValue(
 				"display-style", _DISPLAY_STYLES[index]);
+
+			changed = true;
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 	private static final String[] _DISPLAY_STYLES = {

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeScopes.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeScopes.java
@@ -41,6 +41,8 @@ public class UpgradeScopes extends BaseUpgradePortletPreferences {
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -50,9 +52,16 @@ public class UpgradeScopes extends BaseUpgradePortletPreferences {
 
 		if (!hasScopeType) {
 			portletPreferences.setValue("lfrScopeType", "layout");
+
+			changed = true;
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletPreferences.java
+++ b/portal-service/src/com/liferay/portal/kernel/upgrade/BaseUpgradePortletPreferences.java
@@ -271,8 +271,10 @@ public abstract class BaseUpgradePortletPreferences extends UpgradeProcess {
 						companyId, ownerId, ownerType, plid, portletId,
 						preferences);
 
-					updatePortletPreferences(
-						portletPreferencesId, newPreferences);
+					if (preferences != newPreferences) {
+						updatePortletPreferences(
+							portletPreferencesId, newPreferences);
+					}
 				}
 				else {
 					deletePortletPreferences(portletPreferencesId);

--- a/portal-service/src/com/liferay/portal/kernel/upgrade/CamelCaseUpgradePortletPreferences.java
+++ b/portal-service/src/com/liferay/portal/kernel/upgrade/CamelCaseUpgradePortletPreferences.java
@@ -33,6 +33,8 @@ public class CamelCaseUpgradePortletPreferences
 			String portletId, String xml)
 		throws Exception {
 
+		boolean changed = false;
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -44,12 +46,21 @@ public class CamelCaseUpgradePortletPreferences
 
 			String newName = TextFormatter.format(oldName, TextFormatter.M);
 
-			portletPreferences.reset(oldName);
+			if (!newName.equals(oldName)) {
+				portletPreferences.reset(oldName);
 
-			portletPreferences.setValues(newName, values);
+				portletPreferences.setValues(newName, values);
+
+				changed = true;
+			}
 		}
 
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		if (changed) {
+			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+		}
+		else {
+			return xml;
+		}
 	}
 
 }


### PR DESCRIPTION
Using != rather than !equals() check because the code returns the original xml that was passed in, which is faster than doing the full String.equals() check.
