### PR TITLE
LPS-25081

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_0_0/UpgradeDocumentLibrary.java
@@ -54,6 +54,28 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 		Connection con = null;
 		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getConnection();
+
+			ps = con.prepareStatement(
+				"select fileVersionId from DLFileVersion where folderId = ? " +
+					"and name = ? and version = ?");
+
+			ps.setLong(1, folderId);
+			ps.setString(2, name);
+			ps.setDouble(3, version);
+
+			rs = ps.executeQuery();
+
+			if (rs.next()) {
+				return;
+			}
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
 
 		try {
 			con = DataAccess.getConnection();


### PR DESCRIPTION
While there's nothing native to Liferay 5.2.3 which creates the problem where DLFileVersions exist for some DLFileEntries but not others, since the resulting situation is identical to what we need to deal with in LPS-25844, the same fix of checking for whether a DLFileVersion already exists will also fix this issue.
