### PR TITLE
LPS-25835

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyDocumentLibrary.java
@@ -14,27 +14,86 @@
 
 package com.liferay.portal.verify;
 
+import com.liferay.counter.service.CounterLocalServiceUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryType;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryTypeConstants;
+import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.service.DLAppHelperLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryTypeLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileVersionLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.store.DLStoreUtil;
+import com.liferay.portlet.documentlibrary.util.comparator.FileVersionVersionComparator;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 /**
  * @author Raymond Augé
  * @author Douglas Wong
+ * @author Alexander Chow
  */
 public class VerifyDocumentLibrary extends VerifyProcess {
+
+	protected void addFileVersion(DLFileEntry dlFileEntry)
+		throws SystemException {
+
+		long fileVersionId = CounterLocalServiceUtil.increment();
+
+		DLFileVersion dlFileVersion =
+			DLFileVersionLocalServiceUtil.createDLFileVersion(fileVersionId);
+
+		dlFileVersion.setGroupId(dlFileEntry.getGroupId());
+		dlFileVersion.setCompanyId(dlFileEntry.getCompanyId());
+
+		long versionUserId = dlFileEntry.getVersionUserId();
+
+		if (versionUserId <= 0) {
+			versionUserId = dlFileEntry.getUserId();
+		}
+
+		dlFileVersion.setUserId(versionUserId);
+
+		String versionUserName = GetterUtil.getString(
+			dlFileEntry.getVersionUserName(), dlFileEntry.getUserName());
+
+		dlFileVersion.setUserName(versionUserName);
+
+		Date now = new Date();
+
+		dlFileVersion.setCreateDate(dlFileEntry.getModifiedDate());
+		dlFileVersion.setModifiedDate(dlFileEntry.getModifiedDate());
+		dlFileVersion.setRepositoryId(dlFileEntry.getRepositoryId());
+		dlFileVersion.setFolderId(dlFileEntry.getFolderId());
+		dlFileVersion.setFileEntryId(dlFileEntry.getFileEntryId());
+		dlFileVersion.setExtension(dlFileEntry.getExtension());
+		dlFileVersion.setMimeType(dlFileEntry.getMimeType());
+		dlFileVersion.setTitle(dlFileEntry.getTitle());
+		dlFileVersion.setDescription(dlFileEntry.getDescription());
+		dlFileVersion.setExtraSettings(dlFileEntry.getExtraSettings());
+		dlFileVersion.setFileEntryTypeId(dlFileEntry.getFileEntryTypeId());
+		dlFileVersion.setVersion(dlFileEntry.getVersion());
+		dlFileVersion.setSize(dlFileEntry.getSize());
+		dlFileVersion.setStatus(WorkflowConstants.STATUS_APPROVED);
+		dlFileVersion.setStatusByUserId(versionUserId);
+		dlFileVersion.setStatusByUserName(versionUserName);
+		dlFileVersion.setStatusDate(now);
+
+		DLFileVersionLocalServiceUtil.updateDLFileVersion(dlFileVersion);
+	}
 
 	protected void checkFileEntryType() throws Exception {
 		DLFileEntryType dlFileEntryType =
@@ -54,13 +113,74 @@ public class VerifyDocumentLibrary extends VerifyProcess {
 		dlFileEntryType.setModifiedDate(now);
 		dlFileEntryType.setName(DLFileEntryTypeConstants.NAME_BASIC_DOCUMENT);
 
-		DLFileEntryTypeLocalServiceUtil.updateDLFileEntryType(
-			dlFileEntryType, false);
+		DLFileEntryTypeLocalServiceUtil.updateDLFileEntryType(dlFileEntryType);
+	}
+
+	protected void checkMisversionedFileEntries() throws Exception {
+		List<DLFileEntry> dlFileEntries =
+			DLFileEntryLocalServiceUtil.getMisversionedFileEntries();
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				"Processing " + dlFileEntries.size() +
+					" file entries with invalid version");
+		}
+
+		for (DLFileEntry dlFileEntry : dlFileEntries) {
+			copyFile(dlFileEntry);
+
+			addFileVersion(dlFileEntry);
+		}
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Fixed misversioned file entries");
+		}
+	}
+
+	protected void copyFile(DLFileEntry dlFileEntry)
+		throws PortalException, SystemException {
+
+		long companyId = dlFileEntry.getCompanyId();
+		long dataRepositoryId = dlFileEntry.getDataRepositoryId();
+		String name = dlFileEntry.getName();
+		String version = dlFileEntry.getVersion();
+
+		if (DLStoreUtil.hasFile(companyId, dataRepositoryId, name, version)) {
+			return;
+		}
+
+		FileVersionVersionComparator comparator =
+			new FileVersionVersionComparator();
+
+		List<DLFileVersion> dlFileVersions = dlFileEntry.getFileVersions(
+			WorkflowConstants.STATUS_APPROVED);
+
+		if (dlFileVersions.isEmpty()) {
+			dlFileVersions = dlFileEntry.getFileVersions(
+				WorkflowConstants.STATUS_ANY);
+		}
+
+		if (dlFileVersions.isEmpty()) {
+			DLStoreUtil.addFile(companyId, dataRepositoryId, name, new byte[0]);
+
+			return;
+		}
+
+		dlFileVersions = ListUtil.copy(dlFileVersions);
+
+		Collections.sort(dlFileVersions, comparator);
+
+		DLFileVersion dlFileVersion = dlFileVersions.get(0);
+
+		DLStoreUtil.copyFileVersion(
+			companyId, dataRepositoryId, name, dlFileVersion.getVersion(),
+			version);
 	}
 
 	@Override
 	protected void doVerify() throws Exception {
 		checkFileEntryType();
+		checkMisversionedFileEntries();
 		removeOrphanedFileEntries();
 		updateAssets();
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -677,10 +677,7 @@ public class DLFileEntryLocalServiceImpl
 		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByPrimaryKey(
 			fileEntryId);
 
-		DLFileVersion dlFileVersion = dlFileVersionLocalService.getFileVersion(
-			fileEntryId, dlFileEntry.getVersion());
-
-		dlFileEntry.setFileVersion(dlFileVersion);
+		setFileVersion(dlFileEntry);
 
 		return dlFileEntry;
 	}
@@ -691,10 +688,7 @@ public class DLFileEntryLocalServiceImpl
 		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByG_F_T(
 			groupId, folderId, title);
 
-		DLFileVersion dlFileVersion = dlFileVersionLocalService.getFileVersion(
-			dlFileEntry.getFileEntryId(), dlFileEntry.getVersion());
-
-		dlFileEntry.setFileVersion(dlFileVersion);
+		setFileVersion(dlFileEntry);
 
 		return dlFileEntry;
 	}
@@ -706,10 +700,7 @@ public class DLFileEntryLocalServiceImpl
 		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByG_F_N(
 			groupId, folderId, name);
 
-		DLFileVersion dlFileVersion = dlFileVersionLocalService.getFileVersion(
-			dlFileEntry.getFileEntryId(), dlFileEntry.getVersion());
-
-		dlFileEntry.setFileVersion(dlFileVersion);
+		setFileVersion(dlFileEntry);
 
 		return dlFileEntry;
 	}
@@ -720,10 +711,7 @@ public class DLFileEntryLocalServiceImpl
 		DLFileEntry dlFileEntry = dlFileEntryPersistence.findByUUID_G(
 			uuid, groupId);
 
-		DLFileVersion dlFileVersion = dlFileVersionLocalService.getFileVersion(
-			dlFileEntry.getFileEntryId(), dlFileEntry.getVersion());
-
-		dlFileEntry.setFileVersion(dlFileVersion);
+		setFileVersion(dlFileEntry);
 
 		return dlFileEntry;
 	}
@@ -780,6 +768,12 @@ public class DLFileEntryLocalServiceImpl
 		else {
 			return dlFileEntryPersistence.countByG_U(groupId, userId);
 		}
+	}
+
+	public List<DLFileEntry> getMisversionedFileEntries()
+		throws SystemException {
+
+		return dlFileEntryFinder.findByMisversionedFileEntries();
 	}
 
 	public List<DLFileEntry> getNoAssetFileEntries() throws SystemException {
@@ -1499,6 +1493,20 @@ public class DLFileEntryLocalServiceImpl
 			DLFileEntry.class);
 
 		indexer.reindex(dlFileEntry);
+	}
+
+	protected void setFileVersion(DLFileEntry dlFileEntry)
+		throws PortalException, SystemException {
+
+		try {
+			DLFileVersion dlFileVersion =
+				dlFileVersionLocalService.getFileVersion(
+					dlFileEntry.getFileEntryId(), dlFileEntry.getVersion());
+
+			dlFileEntry.setFileVersion(dlFileVersion);
+		}
+		catch (NoSuchFileVersionException nsfve) {
+		}
 	}
 
 	protected void startWorkflowInstance(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderImpl.java
@@ -64,6 +64,9 @@ public class DLFileEntryFinderImpl
 	public static final String FIND_BY_EXTRA_SETTINGS =
 		DLFileEntryFinder.class.getName() + ".findByExtraSettings";
 
+	public static final String FIND_BY_MISVERSIONED_FILE_ENTRIES =
+		DLFileEntryFinder.class.getName() + ".findByMisversionedFileEntries";
+
 	public static final String FIND_BY_NO_ASSETS =
 		DLFileEntryFinder.class.getName() + ".findByNoAssets";
 
@@ -282,6 +285,30 @@ public class DLFileEntryFinderImpl
 
 			return (List<DLFileEntry>)QueryUtil.list(
 				q, getDialect(), start, end);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	public List<DLFileEntry> findByMisversionedFileEntries()
+		throws SystemException {
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = CustomSQLUtil.get(FIND_BY_MISVERSIONED_FILE_ENTRIES);
+
+			SQLQuery q = session.createSQLQuery(sql);
+
+			q.addEntity("DLFileEntry", DLFileEntryImpl.class);
+
+			return q.list(true);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/custom-sql/documentlibrary.xml
+++ b/portal-impl/src/custom-sql/documentlibrary.xml
@@ -78,6 +78,24 @@
 				(DLFileEntry.custom2ImageId = ?)
 		]]>
 	</sql>
+	<sql id="com.liferay.portlet.documentlibrary.service.persistence.DLFileEntryFinder.findByMisversionedFileEntries">
+		<![CDATA[
+			SELECT
+				{DLFileEntry.*}
+			FROM
+				DLFileEntry
+			WHERE
+				(fileEntryId NOT IN(
+					SELECT
+						DLFileVersion.fileEntryId
+					FROM
+						DLFileVersion
+					WHERE
+						(DLFileVersion.fileEntryId = DLFileEntry.fileEntryId) AND
+						(DLFileVersion.version = DLFileEntry.version)
+				))
+		]]>
+	</sql>
 	<sql id="com.liferay.portlet.documentlibrary.service.persistence.DLFileEntryFinder.findByNoAssets">
 		<![CDATA[
 			SELECT

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalService.java
@@ -442,6 +442,10 @@ public interface DLFileEntryLocalService extends PersistedModelLocalService {
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getMisversionedFileEntries()
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getNoAssetFileEntries()
 		throws com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceUtil.java
@@ -537,6 +537,11 @@ public class DLFileEntryLocalServiceUtil {
 		return getService().getGroupFileEntriesCount(groupId, userId);
 	}
 
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getMisversionedFileEntries()
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getService().getMisversionedFileEntries();
+	}
+
 	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getNoAssetFileEntries()
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return getService().getNoAssetFileEntries();

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFileEntryLocalServiceWrapper.java
@@ -533,6 +533,11 @@ public class DLFileEntryLocalServiceWrapper implements DLFileEntryLocalService,
 		return _dlFileEntryLocalService.getGroupFileEntriesCount(groupId, userId);
 	}
 
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getMisversionedFileEntries()
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return _dlFileEntryLocalService.getMisversionedFileEntries();
+	}
+
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> getNoAssetFileEntries()
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return _dlFileEntryLocalService.getNoAssetFileEntries();

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinder.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinder.java
@@ -46,6 +46,9 @@ public interface DLFileEntryFinder {
 		int start, int end)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> findByMisversionedFileEntries()
+		throws com.liferay.portal.kernel.exception.SystemException;
+
 	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> findByNoAssets()
 		throws com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFileEntryFinderUtil.java
@@ -65,6 +65,11 @@ public class DLFileEntryFinderUtil {
 		return getFinder().findByExtraSettings(start, end);
 	}
 
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> findByMisversionedFileEntries()
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getFinder().findByMisversionedFileEntries();
+	}
+
 	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFileEntry> findByNoAssets()
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return getFinder().findByNoAssets();


### PR DESCRIPTION
Add a verify process to fix DLFileVersion entries that are missing when starting from a version after 6.0.0 (possibly due to custom code), as those versions are not affected by the fixes we put in for LPS-25081 and LPS-25844.
