### PR TITLE
LPS-25921

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/DirectServletRegistry.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/DirectServletRegistry.java
@@ -183,6 +183,8 @@ public class DirectServletRegistry {
 			if (reloadServlet) {
 				_servletInfos.remove(path);
 
+				_updateFileLastModified(path, servlet);
+
 				servlet = null;
 			}
 		}
@@ -200,6 +202,18 @@ public class DirectServletRegistry {
 		}
 
 		return servlet;
+	}
+
+	private void _updateFileLastModified(String path, Servlet servlet) {
+		ServletConfig servletConfig = servlet.getServletConfig();
+
+		ServletContext servletContext = servletConfig.getServletContext();
+
+		String rootPath = servletContext.getRealPath(StringPool.BLANK);
+
+		File file = new File(rootPath, path);
+
+		file.setLastModified(System.currentTimeMillis());
 	}
 
 	private static final boolean _DIRECT_SERVLET_CONTEXT_RELOAD =

--- a/portal-service/src/com/liferay/portal/kernel/servlet/DirectServletRegistry.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/DirectServletRegistry.java
@@ -162,6 +162,8 @@ public class DirectServletRegistry {
 				Long previousLastModified = _dependantTimestamps.get(dependant);
 
 				if (previousLastModified == null) {
+					_dependantTimestamps.put(dependant, lastModified);
+
 					previousLastModified = lastModified;
 				}
 


### PR DESCRIPTION
Dependents map was not getting populated. Some versions of Tomcat also need to have the timestamp updated in order to force the JSP to recompile.
