### PR TITLE
LPS-25861. Oracle discourage the use of VARCHAR. 

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/OracleDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/OracleDB.java
@@ -231,7 +231,7 @@ public class OracleDB extends BaseDB {
 				size = 4000;
 			}
 
-			matcher.appendReplacement(sb, "VARCHAR(" + size + " CHAR)");
+			matcher.appendReplacement(sb, "VARCHAR2(" + size + " CHAR)");
 		}
 
 		matcher.appendTail(sb);


### PR DESCRIPTION
We should use VARCHAR2 instead. The first one is reserved for future use
