### PR TITLE
LPS-26003 Default phone validator should allow any phone number by default

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6023,9 +6023,9 @@
     # com.liferay.portal.kernel.format.PhoneNumberFormat. It will be used for
     # formatting and validating phone numbers.
     #
-    #phone.number.format.impl=com.liferay.portal.format.IdenticalPhoneNumberFormatImpl
+    phone.number.format.impl=com.liferay.portal.format.IdenticalPhoneNumberFormatImpl
     #phone.number.format.impl=com.liferay.portal.format.InternationalPhoneNumberFormatImpl
-    phone.number.format.impl=com.liferay.portal.format.USAPhoneNumberFormatImpl
+    #phone.number.format.impl=com.liferay.portal.format.USAPhoneNumberFormatImpl
 
     #
     # This regular expression follows the international phone number notation


### PR DESCRIPTION
Plase backport to 6.1.x. The default configuration only allowed to store US numbers... but even US citizens may have other countries contacts whose phone numbers could not be saved.
