### PR TITLE
[SUPPORT ESCALATION] LPS-25799 Reminder Queries and Terms of Use without javascript

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdateEmailAddressAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateEmailAddressAction.java
@@ -60,7 +60,7 @@ public class UpdateEmailAddressAction extends Action {
 		try {
 			updateEmailAddress(request);
 
-			return mapping.findForward(ActionConstants.COMMON_REFERER);
+			return mapping.findForward(ActionConstants.COMMON_REFERER_JSP);
 		}
 		catch (Exception e) {
 			if (e instanceof DuplicateUserEmailAddressException ||

--- a/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
@@ -69,7 +69,7 @@ public class UpdatePasswordAction extends Action {
 		Ticket ticket = getTicket(request);
 
 		if (!themeDisplay.isSignedIn() && (ticket == null)) {
-			return mapping.findForward(ActionConstants.COMMON_REFERER);
+			return mapping.findForward(ActionConstants.COMMON_REFERER_JSP);
 		}
 
 		String cmd = ParamUtil.getString(request, Constants.CMD);

--- a/portal-impl/src/com/liferay/portal/action/UpdateReminderQueryAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateReminderQueryAction.java
@@ -55,7 +55,7 @@ public class UpdateReminderQueryAction extends Action {
 		try {
 			updateReminderQuery(request, response);
 
-			return mapping.findForward(ActionConstants.COMMON_REFERER);
+			return mapping.findForward(ActionConstants.COMMON_REFERER_JSP);
 		}
 		catch (Exception e) {
 			if (e instanceof UserReminderQueryException) {

--- a/portal-impl/src/com/liferay/portal/action/UpdateTermsOfUseAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateTermsOfUseAction.java
@@ -41,7 +41,7 @@ public class UpdateTermsOfUseAction extends Action {
 
 		UserServiceUtil.updateAgreedToTermsOfUse(userId, true);
 
-		return mapping.findForward(ActionConstants.COMMON_REFERER);
+		return mapping.findForward(ActionConstants.COMMON_REFERER_JSP);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/action/VerifyEmailAddressAction.java
+++ b/portal-impl/src/com/liferay/portal/action/VerifyEmailAddressAction.java
@@ -82,7 +82,7 @@ public class VerifyEmailAddressAction extends Action {
 				return null;
 			}
 			else {
-				return mapping.findForward(ActionConstants.COMMON_REFERER);
+				return mapping.findForward(ActionConstants.COMMON_REFERER_JSP);
 			}
 		}
 		catch (Exception e) {

--- a/portal-impl/src/com/liferay/portlet/login/action/FacebookConnectAction.java
+++ b/portal-impl/src/com/liferay/portlet/login/action/FacebookConnectAction.java
@@ -100,7 +100,7 @@ public class FacebookConnectAction extends PortletAction {
 			setFacebookCredentials(session, themeDisplay.getCompanyId(), token);
 		}
 		else {
-			return mapping.findForward(ActionConstants.COMMON_REFERER);
+			return mapping.findForward(ActionConstants.COMMON_REFERER_JSP);
 		}
 
 		response.sendRedirect(redirect);


### PR DESCRIPTION
Brian, we have kept 2 places with the referer_js:
- Logout --> Because there is some js action done when logging out in IE
- JSONAction --> Because we asumed that if you are doing a JSON call, then you have javascript enabled

Let us know if we should change these too.

thank you!
