### PR TITLE
LPS-26745 Use full language keys instead of concatenetions

### DIFF
--- a/portal-impl/src/com/liferay/portlet/blogs/social/BlogsActivityInterpreter.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/social/BlogsActivityInterpreter.java
@@ -81,14 +81,21 @@ public class BlogsActivityInterpreter extends BaseSocialActivityInterpreter {
 		if ((activityType == BlogsActivityKeys.ADD_COMMENT) ||
 			(activityType == SocialActivityConstants.TYPE_ADD_COMMENT)) {
 
-			titlePattern = "activity-blogs-add-comment";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-blogs-add-comment";
+			}
+			else {
+				titlePattern = "activity-blogs-add-comment-in";
+			}
 		}
 		else if (activityType == BlogsActivityKeys.ADD_ENTRY) {
-			titlePattern = "activity-blogs-add-entry";
-		}
 
-		if (Validator.isNotNull(groupName)) {
-			titlePattern += "-in";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-blogs-add-entry";
+			}
+			else {
+				titlePattern = "activity-blogs-add-entry-in";
+			}
 		}
 
 		String entryTitle = wrapLink(

--- a/portal-impl/src/com/liferay/portlet/bookmarks/social/BookmarksActivityInterpreter.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/social/BookmarksActivityInterpreter.java
@@ -78,14 +78,20 @@ public class BookmarksActivityInterpreter
 		String titlePattern = null;
 
 		if (activityType == BookmarksActivityKeys.ADD_ENTRY) {
-			titlePattern = "activity-bookmarks-add-entry";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-bookmarks-add-entry";
+			}
+			else {
+				titlePattern = "activity-bookmarks-add-entry-in";
+			}
 		}
 		else if (activityType == BookmarksActivityKeys.UPDATE_ENTRY) {
-			titlePattern = "activity-bookmarks-update-entry";
-		}
-
-		if (Validator.isNotNull(groupName)) {
-			titlePattern += "-in";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-bookmarks-update-entry";
+			}
+			else {
+				titlePattern = "activity-bookmarks-update-entry-in";
+			}
 		}
 
 		String entryTitle = wrapLink(

--- a/portal-impl/src/com/liferay/portlet/calendar/social/CalendarActivityInterpreter.java
+++ b/portal-impl/src/com/liferay/portlet/calendar/social/CalendarActivityInterpreter.java
@@ -78,14 +78,20 @@ public class CalendarActivityInterpreter extends BaseSocialActivityInterpreter {
 		String titlePattern = null;
 
 		if (activityType == CalendarActivityKeys.ADD_EVENT) {
-			titlePattern = "activity-calendar-add-event";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-calendar-add-event";
+			}
+			else {
+				titlePattern = "activity-calendar-add-event-in";
+			}
 		}
 		else if (activityType == CalendarActivityKeys.UPDATE_EVENT) {
-			titlePattern = "activity-calendar-update-event";
-		}
-
-		if (Validator.isNotNull(groupName)) {
-			titlePattern += "-in";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-calendar-update-event";
+			}
+			else {
+				titlePattern = "activity-calendar-update-event-in";
+			}
 		}
 
 		String eventTitle = wrapLink(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/social/DLActivityInterpreter.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/social/DLActivityInterpreter.java
@@ -82,14 +82,20 @@ public class DLActivityInterpreter extends BaseSocialActivityInterpreter {
 		String titlePattern = null;
 
 		if (activityType == DLActivityKeys.ADD_FILE_ENTRY) {
-			titlePattern = "activity-document-library-add-file";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-document-library-add-file";
+			}
+			else {
+				titlePattern = "activity-document-library-add-file-in";
+			}
 		}
 		else if (activityType == DLActivityKeys.UPDATE_FILE_ENTRY) {
-			titlePattern = "activity-document-library-update-file";
-		}
-
-		if (Validator.isNotNull(groupName)) {
-			titlePattern += "-in";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-document-library-update-file";
+			}
+			else {
+				titlePattern = "activity-document-library-update-file-in";
+			}
 		}
 
 		String fileTitle = wrapLink(

--- a/portal-impl/src/com/liferay/portlet/messageboards/social/MBActivityInterpreter.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/social/MBActivityInterpreter.java
@@ -85,20 +85,31 @@ public class MBActivityInterpreter extends BaseSocialActivityInterpreter {
 
 		if (activityType == MBActivityKeys.ADD_MESSAGE) {
 			if (activity.getReceiverUserId() == 0) {
-				titlePattern = "activity-message-boards-add-message";
+				if (Validator.isNull(groupName)) {
+					titlePattern = "activity-message-boards-add-message";
+				}
+				else {
+					titlePattern = "activity-message-boards-add-message-in";
+				}
 			}
 			else {
-				titlePattern = "activity-message-boards-reply-message";
+				if (Validator.isNull(groupName)) {
+					titlePattern = "activity-message-boards-reply-message";
+				}
+				else {
+					titlePattern = "activity-message-boards-reply-message-in";
+				}
 			}
 		}
 		else if ((activityType == MBActivityKeys.REPLY_MESSAGE) &&
 				 (activity.getReceiverUserId() > 0)) {
 
-			titlePattern = "activity-message-boards-reply-message";
-		}
-
-		if (Validator.isNotNull(groupName)) {
-			titlePattern += "-in";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-message-boards-reply-message";
+			}
+			else {
+				titlePattern = "activity-message-boards-reply-message-in";
+			}
 		}
 
 		String messageSubject = wrapLink(

--- a/portal-impl/src/com/liferay/portlet/wiki/social/WikiActivityInterpreter.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/social/WikiActivityInterpreter.java
@@ -81,17 +81,28 @@ public class WikiActivityInterpreter extends BaseSocialActivityInterpreter {
 		if ((activityType == WikiActivityKeys.ADD_COMMENT) ||
 			(activityType == SocialActivityConstants.TYPE_ADD_COMMENT)) {
 
-			titlePattern = "activity-wiki-add-comment";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-wiki-add-comment";
+			} 
+			else {
+				titlePattern = "activity-wiki-add-comment-in";
+			}
 		}
 		else if (activityType == WikiActivityKeys.ADD_PAGE) {
-			titlePattern = "activity-wiki-add-page";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-wiki-add-page";
+			} 
+			else {
+				titlePattern = "activity-wiki-add-page-in";
+			}
 		}
 		else if (activityType == WikiActivityKeys.UPDATE_PAGE) {
-			titlePattern = "activity-wiki-update-page";
-		}
-
-		if (Validator.isNotNull(groupName)) {
-			titlePattern += "-in";
+			if (Validator.isNull(groupName)) {
+				titlePattern = "activity-wiki-update-page";
+			}
+			else {
+				titlePattern = "activity-wiki-update-page-in";
+			}
 		}
 
 		String pageTitle = wrapLink(


### PR DESCRIPTION
Hi Brian, 

the reason for this change is that it is really hard to find where a key is used or even if it is used at all if we generate the keys in this way.

We wanted to consider "concatenation to create language keys" a bad practice from now on.
