### PR TITLE
[TECH SUPPORT] LPS-26805 Nested Porlets missing from merge portlets

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -1394,6 +1394,23 @@ public class LayoutImporter {
 				LayoutTypePortletConstants.LAYOUT_TEMPLATE_ID,
 				layoutTemplateId);
 
+			String nestedColumnIds = newTypeSettingsProperties.getProperty(
+				LayoutTypePortletConstants.NESTED_COLUMN_IDS, StringPool.BLANK);
+
+			if (!nestedColumnIds.equals(StringPool.BLANK)) {
+				previousTypeSettingsProperties.setProperty(
+					LayoutTypePortletConstants.NESTED_COLUMN_IDS,
+					nestedColumnIds);
+
+				for (String nestedColumnId :
+					StringUtil.split(nestedColumnIds)) {
+
+					previousTypeSettingsProperties.setProperty(
+						nestedColumnId,
+						newTypeSettingsProperties.getProperty(nestedColumnId));
+				}
+			}
+
 			LayoutTemplate newLayoutTemplate =
 				LayoutTemplateLocalServiceUtil.getLayoutTemplate(
 					layoutTemplateId, false, null);

--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -1395,19 +1395,22 @@ public class LayoutImporter {
 				layoutTemplateId);
 
 			String nestedColumnIds = newTypeSettingsProperties.getProperty(
-				LayoutTypePortletConstants.NESTED_COLUMN_IDS, StringPool.BLANK);
+				LayoutTypePortletConstants.NESTED_COLUMN_IDS);
 
-			if (!nestedColumnIds.equals(StringPool.BLANK)) {
+			if (Validator.isNotNull(nestedColumnIds)) {
 				previousTypeSettingsProperties.setProperty(
 					LayoutTypePortletConstants.NESTED_COLUMN_IDS,
 					nestedColumnIds);
 
-				for (String nestedColumnId :
-					StringUtil.split(nestedColumnIds)) {
+				String[] nestedColumnIdsArray = StringUtil.split(
+					nestedColumnIds);
+
+				for (String nestedColumnId : nestedColumnIdsArray) {
+					String nestedColumnValue =
+						newTypeSettingsProperties.getProperty(nestedColumnId);
 
 					previousTypeSettingsProperties.setProperty(
-						nestedColumnId,
-						newTypeSettingsProperties.getProperty(nestedColumnId));
+						nestedColumnId, nestedColumnValue);
 				}
 			}
 


### PR DESCRIPTION
Hi Brian,

to reproduce the issue we need to have a user group with a site template for public pages and a Nested Portlets portlet on a template page with some other portlets inside. In this case when you assign a new user to this User Org and use the:

user.groups.copy.layouts.to.user.personal.site=true

property, the portlets inside of the Nested Portlets portlet will be missing from the result page. Without this property the problem doesn't occur, but in 6.0.x this is the default mode and the support needs this fix to be backported to 6.0.x. 

The changes I am sending you now was reviewed by Sergio before, but he asked me to reviewed and re-tested his changes once-again and send it to You if I am OK with that.

Thank you very much,
Daniel
