### PR TITLE
LPS-27094 Calendar Event Meta Content

### DIFF
--- a/portal-web/docroot/html/portlet/calendar/view_event.jsp
+++ b/portal-web/docroot/html/portlet/calendar/view_event.jsp
@@ -282,7 +282,7 @@ request.setAttribute("view_event.jsp-event", event);
 
 <%
 PortalUtil.setPageSubtitle(event.getTitle(), request);
-PortalUtil.setPageDescription(event.getDescription(), request);
+PortalUtil.setPageDescription(HtmlUtil.extractText(event.getDescription()), request);
 
 List<AssetTag> assetTags = AssetTagLocalServiceUtil.getTags(CalEvent.class.getName(), event.getEventId());
 


### PR DESCRIPTION
This is a quick-fix derived from ticket LPS-26276. Now page meta content tag for Calendar Event detail-view is properly displayed.
