### PR TITLE
LPS-27116 Site Admin can not create Announcements in its site

### DIFF
--- a/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryServiceImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.permission.GroupPermissionUtil;
 import com.liferay.portal.service.permission.OrganizationPermissionUtil;
-import com.liferay.portal.service.permission.PortletPermissionUtil;
 import com.liferay.portal.service.permission.RolePermissionUtil;
 import com.liferay.portal.service.permission.UserGroupPermissionUtil;
 import com.liferay.portal.util.PortalUtil;
@@ -53,12 +52,12 @@ public class AnnouncementsEntryServiceImpl
 		PermissionChecker permissionChecker = getPermissionChecker();
 
 		if (alert) {
-			PortletPermissionUtil.check(
+			AnnouncementsEntryPermission.check(
 				permissionChecker, plid, PortletKeys.ALERTS,
 				ActionKeys.ADD_ENTRY);
 		}
 		else {
-			PortletPermissionUtil.check(
+			AnnouncementsEntryPermission.check(
 				permissionChecker, plid, PortletKeys.ANNOUNCEMENTS,
 				ActionKeys.ADD_ENTRY);
 		}

--- a/portal-impl/src/com/liferay/portlet/announcements/service/permission/AnnouncementsEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/permission/AnnouncementsEntryPermission.java
@@ -16,8 +16,11 @@ package com.liferay.portlet.announcements.service.permission;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.model.Layout;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.service.LayoutLocalServiceUtil;
+import com.liferay.portal.service.permission.PortletPermissionUtil;
 import com.liferay.portlet.announcements.model.AnnouncementsEntry;
 import com.liferay.portlet.announcements.service.AnnouncementsEntryLocalServiceUtil;
 
@@ -41,6 +44,26 @@ public class AnnouncementsEntryPermission {
 		throws PortalException, SystemException {
 
 		if (!contains(permissionChecker, entryId, actionId)) {
+			throw new PrincipalException();
+		}
+	}
+
+	public static void check(
+			PermissionChecker permissionChecker, Layout layout, String name,
+			String actionId)
+		throws PortalException, SystemException {
+
+		if (!contains(permissionChecker, layout, name, actionId)) {
+			throw new PrincipalException();
+		}
+	}
+
+	public static void check(
+			PermissionChecker permissionChecker, long plid, String name,
+			String actionId)
+		throws PortalException, SystemException {
+
+		if (!contains(permissionChecker, plid, name, actionId)) {
 			throw new PrincipalException();
 		}
 	}
@@ -70,6 +93,31 @@ public class AnnouncementsEntryPermission {
 			entryId);
 
 		return contains(permissionChecker, entry, actionId);
+	}
+
+	public static boolean contains(
+			PermissionChecker permissionChecker, Layout layout, String name,
+			String actionId)
+		throws PortalException, SystemException {
+
+		if (permissionChecker.isGroupAdmin(layout.getGroupId()) ||
+				permissionChecker.isGroupOwner(layout.getGroupId())) {
+
+			return true;
+		}
+
+		return PortletPermissionUtil.contains(
+				permissionChecker, layout, name, actionId);
+	}
+
+	public static boolean contains(
+			PermissionChecker permissionChecker, long plid, String name,
+			String actionId)
+		throws PortalException, SystemException {
+
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(plid);
+
+		return contains(permissionChecker, layout, name, actionId);
 	}
 
 }

--- a/portal-web/docroot/html/portlet/announcements/tabs1.jsp
+++ b/portal-web/docroot/html/portlet/announcements/tabs1.jsp
@@ -26,7 +26,7 @@ tabs1URL.setParameter("tabs1", tabs1);
 
 String tabs1Names = "entries";
 
-if (PortletPermissionUtil.contains(permissionChecker, layout, portletName, ActionKeys.ADD_ENTRY)) {
+if (AnnouncementsEntryPermission.contains(permissionChecker, layout, portletName, ActionKeys.ADD_ENTRY)) {
 	tabs1Names += ",manage-entries";
 }
 %>

--- a/portal-web/docroot/html/portlet/announcements/view.jsp
+++ b/portal-web/docroot/html/portlet/announcements/view.jsp
@@ -27,7 +27,7 @@ portletURL.setParameter("struts_action", "/announcements/view");
 portletURL.setParameter("tabs1", tabs1);
 %>
 
-<c:if test="<%= !portletName.equals(PortletKeys.ALERTS) || (portletName.equals(PortletKeys.ALERTS) && PortletPermissionUtil.contains(permissionChecker, layout, PortletKeys.ALERTS, ActionKeys.ADD_ENTRY)) %>">
+<c:if test="<%= !portletName.equals(PortletKeys.ALERTS) || (portletName.equals(PortletKeys.ALERTS) && AnnouncementsEntryPermission.contains(permissionChecker, layout, PortletKeys.ALERTS, ActionKeys.ADD_ENTRY)) %>">
 	<liferay-util:include page="/html/portlet/announcements/tabs1.jsp" />
 </c:if>
 

--- a/portal-web/docroot/html/portlet/announcements/view_entries.jspf
+++ b/portal-web/docroot/html/portlet/announcements/view_entries.jspf
@@ -129,7 +129,7 @@ hasResults = hasResults || (total > 0);
 	);
 </aui:script>
 
-<c:if test="<%= !hasResults && portletName.equals(PortletKeys.ALERTS) && !PortletPermissionUtil.contains(permissionChecker, layout, PortletKeys.ANNOUNCEMENTS, ActionKeys.ADD_ENTRY) %>">
+<c:if test="<%= !hasResults && portletName.equals(PortletKeys.ALERTS) && !AnnouncementsEntryPermission.contains(permissionChecker, layout, PortletKeys.ANNOUNCEMENTS, ActionKeys.ADD_ENTRY) %>">
 	<aui:script use="aui-base">
 		var portlet = A.one('#p_p_id<portlet:namespace />');
 


### PR DESCRIPTION
This is a fix needed by the SO team. We are thinking of re-writing all the permissions for announcements for 6.2 so that they follow the patter of the other portlets based on the model and not on the portlet.

We haven't been able to make the source formatter pass without the "sort" problem :(
