### PR TITLE
LPS-25816

### DIFF
--- a/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperImpl.java
@@ -70,6 +70,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryParser.QueryParser;
 import org.apache.lucene.search.BooleanClause;
@@ -390,8 +391,10 @@ public class LuceneHelperImpl implements LuceneHelper {
 
 		IndexAccessor indexAccessor = _getIndexAccessor(companyId);
 
-		IndexSearcher indexSearcher = new IndexSearcher(
+		IndexReader indexReader = IndexReader.open(
 			indexAccessor.getLuceneDir(), readOnly);
+
+		IndexSearcher indexSearcher = new IndexSearcher(indexReader);
 
 		indexSearcher.setDefaultFieldSortScoring(true, true);
 		indexSearcher.setSimilarity(new FieldWeightSimilarity());

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -644,6 +644,8 @@ public class PropsValues {
 
 	public static final boolean INDEX_DUMP_COMPRESSION_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.INDEX_DUMP_COMPRESSION_ENABLED));
 
+	public static final boolean INDEX_FORCE_GC_BEFORE_DELETE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.INDEX_FORCE_GC_BEFORE_DELETE));
+
 	public static boolean INDEX_ON_STARTUP = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.INDEX_ON_STARTUP));
 
 	public static final int INDEX_ON_STARTUP_DELAY = GetterUtil.getInteger(PropsUtil.get(PropsKeys.INDEX_ON_STARTUP_DELAY));
@@ -903,8 +905,6 @@ public class PropsValues {
 	public static final String LUCENE_FILE_EXTRACTOR_REGEXP_STRIP = PropsUtil.get(PropsKeys.LUCENE_FILE_EXTRACTOR_REGEXP_STRIP);
 
 	public static final int LUCENE_MERGE_FACTOR = GetterUtil.getInteger(PropsUtil.get(PropsKeys.LUCENE_MERGE_FACTOR));
-
-	public static final int LUCENE_OPTIMIZE_INTERVAL = GetterUtil.getInteger(PropsUtil.get(PropsKeys.LUCENE_OPTIMIZE_INTERVAL));
 
 	public static final boolean LUCENE_REPLICATE_WRITE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.LUCENE_REPLICATE_WRITE));
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -4941,6 +4941,18 @@
     index.sortable.text.fields.truncated.length=255
 
     #
+    # Force to perform GC before deleting the index files or folders. According
+    # to the Lucene documentation due to a JRE bug, the OS (usually Windows)
+    # can not close the file handle until the garbage collector hasn't
+    # collected the underlying objects. If the file handle is still open that
+    # result some error messages. Turning this property to true will force the
+    # portal to perform a GC before file operations on the index.
+    #
+    # http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038
+    #
+    index.force.gc.before.delete=false
+
+    #
     # Designate whether Lucene stores indexes in a file system or in RAM.
     #
     lucene.store.type=file
@@ -5006,12 +5018,17 @@
     lucene.merge.factor=10
 
     #
-    # Set how often to run Lucene's optimize method. Optimization speeds up
-    # searching but slows down writing. Set this property to 0 to always
-    # optimize. Set this property to an integer greater than 0 to optimize every
-    # X writes.
+    # Set the Lucene's merge policy. A MergePolicy determines the sequence of
+    # primitive merge operations. The implementation class for this property
+    # should extends the org.apache.lucene.index.MergePolicy
+    # Possible values are: org.apache.lucene.index.NoMergePolicy,
+    # org.apache.lucene.index.LogDocMergePolicy,
+    # org.apache.lucene.index.LogByteSizeMergePolicy
+    # org.apache.lucene.index.TieredMergePolicy and
+    # org.apache.lucene.index.UpgradeIndexMergePolicy. Please note that the
+    # merge factor might be ignored based on the chosen MergePolicy.
     #
-    lucene.optimize.interval=100
+    lucene.merge.policy=org.apache.lucene.index.LogDocMergePolicy
 
     #
     # Set this to true if you want the portal to replicate an index write across

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -817,6 +817,8 @@ public interface PropsKeys {
 
 	public static final String INDEX_FILTER_SEARCH_LIMIT = "index.filter.search.limit";
 
+	public static final String INDEX_FORCE_GC_BEFORE_DELETE = "index.force.gc.before.delete";
+
 	public static final String INDEX_ON_STARTUP = "index.on.startup";
 
 	public static final String INDEX_ON_STARTUP_DELAY = "index.on.startup.delay";
@@ -1275,7 +1277,7 @@ public interface PropsKeys {
 
 	public static final String LUCENE_MERGE_FACTOR = "lucene.merge.factor";
 
-	public static final String LUCENE_OPTIMIZE_INTERVAL = "lucene.optimize.interval";
+	public static final String LUCENE_MERGE_POLICY = "lucene.merge.policy";
 
 	public static final String LUCENE_REPLICATE_WRITE = "lucene.replicate.write";
 


### PR DESCRIPTION
Hi Brian,

I'm not sure if you remember but I've implemented the new Lucene version to the portal, and you have asked me to resolve the deprecated items around it. I've coded the way the Lucene wants us to use their library, and I've submitted the changes to Ray for review, but he is on a longer vacation. I didn't want the pull request to be forgotten, and also you have asked me to send the pull request to you directly, so I'm sending it right now.

Here are some comments on the changelist:

I've removed the optimize feature, according to the lucene teams it's extremely inefficient.

The changes are quite straightforward although there is one change I wan't to highlight. There is a bug in the JRE, this is a known bug: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038

Because of this bug the OS (typically Windows) cannot release the native file handler while the GC hasn't collected all the underlying objects. This means if you want to delete or overwrite a file and the OS still holds the native file handle, then it might result in an IOException. To prevent this case I've introduced some System.gc() statements - it can be switched off since most of the systems/JREs won't have problems with that. Please read the details here: http://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/api/core/org/apache/lucene/store/FSDirectory.html
This has been revealed during running the IndexAccessorImplTest tests, and for me the test is running perfectly with the GC calls.

The Lucene documentation mentions at multiple places that the windows JRE implementation has multiple bugs.

Please let me know if you have any questions or concerns.

Thanks,

Máté
