### PR TITLE
LPS-27431 [TECHNICAL SUPPORT]

### DIFF
--- a/portal-impl/src/com/liferay/portal/velocity/LiferayResourceLoader.java
+++ b/portal-impl/src/com/liferay/portal/velocity/LiferayResourceLoader.java
@@ -101,14 +101,18 @@ public class LiferayResourceLoader extends ResourceLoader {
 
 	@Override
 	public boolean resourceExists(String resourceName) {
-		InputStream is = doGetResourceStream(resourceName);
+		InputStream is = null;
 
 		try {
+			is = doGetResourceStream(resourceName);
+
 			if (is != null) {
 				is.close();
 			}
 		}
 		catch (IOException ioe) {
+		}
+		catch (ResourceNotFoundException rnfe) {
 		}
 
 		if (is != null) {


### PR DESCRIPTION
Fixed by handling the exception in resourceExists instead of forcing the resource loader to return null. See comment in ticket.
