### PR TITLE
LPS-26260 Fixing improper group query

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/export_import.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_import.jsp
@@ -23,9 +23,16 @@ String redirectWindowState = ParamUtil.getString(request, "redirectWindowState")
 
 String cmd = ParamUtil.getString(request, Constants.CMD, Constants.EXPORT);
 
-Group group = (Group)request.getAttribute(WebKeys.GROUP);
-
 long groupId = ParamUtil.getLong(request, "groupId");
+
+Group group = null;
+
+if (groupId > 0) {
+	group = GroupLocalServiceUtil.getGroup(groupId);
+}
+else {
+	group = (Group)request.getAttribute(WebKeys.GROUP);
+}
 
 Group liveGroup = group;
 


### PR DESCRIPTION
Hi Brian,

Yesterday you have merged the changes for the LPS-26260, and I've re-tested it today and it seems that a small bug has shown up after the review changes. The problem is that on the export_import.jsp the group variable will be something completely different what we need, while the groupId variable is correct. I've re-organized a little bit the querying of the group in this JSP.

Speaking of that, do we have a centralized, common way to query the group id on a JSP page? As far as I i know I've seen several different ways to query it, for this JSP this simple solution seemed to be the best though.

Thanks,

Máté
