### PR TITLE
Lps 27846

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -436,11 +436,11 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 		int x = fullFileName.lastIndexOf(CharPool.SLASH);
 		int y = fullFileName.lastIndexOf(CharPool.BACK_SLASH);
 
-		String shortFileName = fullFileName.substring(0, Math.max(x, y));
-
-		if (Validator.isNull(shortFileName)) {
+		if ((x == -1) && (y == -1)) {
 			return StringPool.SLASH;
 		}
+
+		String shortFileName = fullFileName.substring(0, Math.max(x, y));
 
 		return shortFileName;
 	}

--- a/portal-impl/test/unit/com/liferay/portal/util/FileImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/FileImplTest.java
@@ -15,7 +15,9 @@
 package com.liferay.portal.util;
 
 import com.liferay.portal.kernel.test.TestCase;
+import com.liferay.portal.kernel.util.StringPool;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -24,11 +26,39 @@ import org.junit.Test;
 public class FileImplTest extends TestCase {
 
 	@Test
-	public void testGetPath() {
+	public void testGetPathBackSlashForwardSlash() {
+		Assert.assertEquals(
+			"aaa\\bbb/ccc\\ddd",
+			_fileImpl.getPath("aaa\\bbb/ccc\\ddd/eee.fff"));
 	}
 
 	@Test
-	public void testGetShortFileName() {
+	public void testGetPathForwardSlashBackSlash() {
+		Assert.assertEquals(
+			"aaa/bbb\\ccc/ddd",
+			_fileImpl.getPath("aaa/bbb\\ccc/ddd\\eee.fff"));
+	}
+
+	@Test
+	public void testGetPathNoPath() {
+		Assert.assertEquals(StringPool.SLASH, _fileImpl.getPath("aaa.bbb"));
+	}
+
+	@Test
+	public void testGetShortFileNameBackSlashForwardSlash() {
+		Assert.assertEquals(
+			"eee.fff", _fileImpl.getShortFileName("aaa\\bbb/ccc\\ddd/eee.fff"));
+	}
+
+	@Test
+	public void testGetShortFileNameForwardSlashBackSlash() {
+		Assert.assertEquals(
+			"eee.fff", _fileImpl.getShortFileName("aaa/bbb\\ccc/ddd\\eee.fff"));
+	}
+
+	@Test
+	public void testGetShortFileNameNoPath() {
+		Assert.assertEquals("aaa.bbb", _fileImpl.getShortFileName("aaa.bbb"));
 	}
 
 	private FileImpl _fileImpl = new FileImpl();


### PR DESCRIPTION
Previous implementation (prior to LPS-27846) would break on testGetPathForwardSlashBackSlash and testGetShortFileNameForwardSlashBackSlash.

LPS-27859 fixes problem found from testGetPathNoPath
