### PR TITLE
LPS-21046 Removing stacktrace when doAsUserId param has wrong format

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5654,8 +5654,7 @@ public class PortalImpl implements Portal {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Unable to impersonate " + doAsUserIdString +
-						" because the string cannot be decrypted",
-					e);
+						" because the string cannot be decrypted");
 			}
 
 			return 0;


### PR DESCRIPTION
See converstation with @igorspasic in http://issues.liferay.com/browse/LPS-21046 to understand the reasons.
