### PR TITLE
[TECHNICAL SUPPORT] LPS-28030 Partial Kaleo forms delete values from fields that are not shown

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
@@ -136,7 +136,9 @@ public class DDMImpl implements DDM {
 				fieldValue = String.valueOf(fieldValueDate.getTime());
 			}
 
-			if (fieldDataType.equals(FieldConstants.FILE_UPLOAD)) {
+			if (fieldValue == null ||
+				fieldDataType.equals(FieldConstants.FILE_UPLOAD)) {
+
 				continue;
 			}
 
@@ -156,10 +158,6 @@ public class DDMImpl implements DDM {
 				}
 
 				fieldValue = JSONFactoryUtil.serialize(fieldValues);
-			}
-
-			if (fieldValue == null) {
-				continue;
 			}
 
 			Serializable fieldValueSerializable =

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
@@ -136,7 +136,7 @@ public class DDMImpl implements DDM {
 				fieldValue = String.valueOf(fieldValueDate.getTime());
 			}
 
-			if (fieldValue == null ||
+			if ((fieldValue == null) ||
 				fieldDataType.equals(FieldConstants.FILE_UPLOAD)) {
 
 				continue;


### PR DESCRIPTION
We need to execute the code about the date first to obtain the date from the request (it will be still null if the date was not displayed in the form). Then, we need to continue before the code for the Select or Radio because otherwise, that code introduces {} and then the value is never null.
