### PR TITLE
LPS-28251 Finalize Thread should use global Classloader as context Class...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/memory/FinalizeManager.java
+++ b/portal-service/src/com/liferay/portal/kernel/memory/FinalizeManager.java
@@ -91,6 +91,9 @@ public class FinalizeManager {
 		if (THREAD_ENABLED) {
 			Thread thread = new FinalizeThread("Finalize Thread");
 
+			thread.setContextClassLoader(
+				FinalizeManager.class.getClassLoader());
+
 			thread.setDaemon(true);
 
 			thread.start();


### PR DESCRIPTION
...Loader rather than pick it up from parent Thread
