### PR TITLE
LPS-28253 MessageBus default response destination should use Synchronous...

### DIFF
--- a/portal-impl/src/META-INF/messaging-core-spring.xml
+++ b/portal-impl/src/META-INF/messaging-core-spring.xml
@@ -36,7 +36,7 @@
 	<bean id="destination.global" class="com.liferay.portal.kernel.messaging.ParallelDestination">
 		<property name="name" value="liferay/global" />
 	</bean>
-	<bean id="destination.message_bus_default_response" class="com.liferay.portal.kernel.messaging.ParallelDestination">
+	<bean id="destination.message_bus_default_response" class="com.liferay.portal.kernel.messaging.SynchronousDestination">
 		<property name="name" value="liferay/message_bus/default_response" />
 	</bean>
 	<bean id="destination.message_bus_message_status" class="com.liferay.portal.kernel.messaging.ParallelDestination">


### PR DESCRIPTION
...Destination to prevent creating new MessageBus Thread under MessageBus Thread which could cause AccessContext leak when SecurityManager present
