### PR TITLE
LPS-25816 Restructuring Lucene index deletion

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -656,8 +656,6 @@ public class PropsValues {
 
 	public static final boolean INDEX_DUMP_COMPRESSION_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.INDEX_DUMP_COMPRESSION_ENABLED));
 
-	public static final boolean INDEX_FORCE_GC_BEFORE_DELETE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.INDEX_FORCE_GC_BEFORE_DELETE));
-
 	public static boolean INDEX_ON_STARTUP = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.INDEX_ON_STARTUP));
 
 	public static final int INDEX_ON_STARTUP_DELAY = GetterUtil.getInteger(PropsUtil.get(PropsKeys.INDEX_ON_STARTUP_DELAY));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5153,17 +5153,6 @@
     index.sortable.text.fields.truncated.length=255
 
     #
-    # According to the Lucene documentation, Windows may sometimes not be able
-    # to close file handles due to a bug in the JRE. Setting this property to
-    # true will force the portal to garbage collect before file operations on
-    # the index.
-    #
-    # See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4724038 for more
-    # information.
-    #
-    index.force.gc.before.delete=false
-
-    #
     # Designate whether Lucene stores indexes in a file system or in RAM.
     #
     lucene.store.type=file

--- a/portal-impl/test/integration/com/liferay/portal/search/lucene/dump/IndexAccessorImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/search/lucene/dump/IndexAccessorImplTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.search.lucene.dump;
 
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.search.lucene.IndexAccessorImpl;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.ExecutionTestListeners;
@@ -32,6 +34,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,6 +50,16 @@ import org.powermock.api.mockito.PowerMockito;
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
 public class IndexAccessorImplTest extends PowerMockito {
 
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		System.gc();
+
+		String indexPath = PropsValues.LUCENE_DIR.concat(
+			String.valueOf(_TEST_COMPANY_ID)).concat(StringPool.SLASH);
+
+		FileUtil.deltree(indexPath);
+	}
+
 	@Before
 	public void setUp() throws Exception {
 		_documentsCount = PropsValues.LUCENE_COMMIT_BATCH_SIZE;
@@ -60,8 +73,6 @@ public class IndexAccessorImplTest extends PowerMockito {
 
 	@After
 	public void tearDown() throws Exception {
-		System.gc();
-
 		_indexAccessorImpl.delete();
 		_indexAccessorImpl.close();
 	}

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -829,8 +829,6 @@ public interface PropsKeys {
 
 	public static final String INDEX_FILTER_SEARCH_LIMIT = "index.filter.search.limit";
 
-	public static final String INDEX_FORCE_GC_BEFORE_DELETE = "index.force.gc.before.delete";
-
 	public static final String INDEX_ON_STARTUP = "index.on.startup";
 
 	public static final String INDEX_ON_STARTUP_DELAY = "index.on.startup.delay";


### PR DESCRIPTION
Hi Brian,

I still owe you this set of change. I'm not sure if you remember that when I've upgraded the Lucene to 3.5 I've identified some problems with the windows JVM and Lucene collaboration. (https://github.com/brianchandotcom/liferay-portal/pull/5223)

The solution back then was to run a System.gc() before we deleting the index, but as we had a discussion it's not really a good solution since the behavior of the GC is not deterministic.

This change supposed to fix that, now it does not rely on the System.gc() anymore.

I was hesitating that I should separate the index deletion behavior for windows like system and linux like system, but I have decided to do the same for every kind of platform, it feels more consistent this way. Basically the index deletion is now handled with the Lucene API itself, the Lucene will delete the documents in the index. The same happens when we read back the index from a dump, the Lucene will read it and insert it. According to the Lucene doc, the deleteAll method is the most efficient for deleting, and also for querying this way seems to be the best.

Please let me know if you have any concerns with this solution, in that case I'll re-do the change.

Thanks,

Máté
