### PR TITLE
LPS-26674

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyOracle.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyOracle.java
@@ -45,9 +45,17 @@ public class VerifyOracle extends VerifyProcess {
 		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
+		int buildNumber;
 
 		try {
 			con = DataAccess.getUpgradeOptimizedConnection();
+
+			ps = con.prepareStatement("select buildNumber from release_");
+
+			rs = ps.executeQuery();
+
+			rs.next();
+			buildNumber = rs.getInt(1);
 
 			ps = con.prepareStatement(
 				"select table_name, column_name, data_length from " +
@@ -62,7 +70,12 @@ public class VerifyOracle extends VerifyProcess {
 				int dataLength = rs.getInt(3);
 
 				if (dataLength != 4000) {
-					dataLength = dataLength / 4;
+
+					// LPS-26674
+
+					if ((buildNumber >= 6000) && (buildNumber < 6120)) {
+						dataLength = dataLength / 4;
+					}
 				}
 
 				try {


### PR DESCRIPTION
Hi Brian,
sorry for duplicate code :(. I will briefly try to explain what is going on here:

we had a problem with wrong craetion  VARCHAR columns in Oracle so the select needs to be always executed and we need to alter tables to set right length of VARCHAR columns. 

But also at the same time we have a problem with length definition of VARCHAR columns where because of UTF8 problem in Oracle we have started multiply by 4 in versions of portal starting from 6 till 6.1.20. So if the version we are upgrading from is in that range we need also to divide by 4 column to get back to the original length.

To get version we are upgrading from we need it from the database, not the actual version we will upgrade to. It is not the same version. Before we upgrade we have the old version and after upgrade and verify process we have the new one that is equal to ReleaseInfo.buildNumber
