### PR TITLE
Lps 28359

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/view_display.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/view_display.jspf
@@ -18,7 +18,7 @@
 if (!ArrayUtil.contains(PropsValues.ASSET_PUBLISHER_DISPLAY_STYLES, displayStyle)) {
 %>
 
-	<%= UnicodeLanguageUtil.format(pageContext, "x-is-not-a-display-type", displayStyle) %>
+	<%= HtmlUtil.escape(LanguageUtil.format(pageContext, "x-is-not-a-display-type", displayStyle)) %>
 
 <%
 }

--- a/portal-web/docroot/html/portlet/directory/view_users.jsp
+++ b/portal-web/docroot/html/portlet/directory/view_users.jsp
@@ -65,7 +65,7 @@ if (Validator.isNotNull(viewUsersRedirect)) {
 	<c:if test="<%= organization != null %>">
 		<aui:input name="<%= UserDisplayTerms.ORGANIZATION_ID %>" type="hidden" value="<%= organization.getOrganizationId() %>" />
 
-		<h3><%= UnicodeLanguageUtil.format(pageContext, "users-of-x", organization.getName()) %></h3>
+		<h3><%= HtmlUtil.escape(LanguageUtil.format(pageContext, "users-of-x", organization.getName())) %></h3>
 	</c:if>
 
 	<c:if test="<%= userGroup != null %>">

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
@@ -101,7 +101,6 @@ if (!portletName.equals(PortletKeys.PORTLET_DISPLAY_TEMPLATES)) {
 
 		<liferay-ui:search-container-row
 			className="com.liferay.portlet.dynamicdatamapping.model.DDMTemplate"
-			escapedModel="<%= true %>"
 			keyProperty="templateId"
 			modelVar="template"
 		>
@@ -117,7 +116,7 @@ if (!portletName.equals(PortletKeys.PORTLET_DISPLAY_TEMPLATES)) {
 				sb.append("']('");
 				sb.append(template.getTemplateId());
 				sb.append("', '");
-				sb.append(template.getName(locale));
+				sb.append(HtmlUtil.escapeJS(template.getName(locale)));
 				sb.append("', Liferay.Util.getWindow());");
 
 				rowHREF = sb.toString();
@@ -149,7 +148,7 @@ if (!portletName.equals(PortletKeys.PORTLET_DISPLAY_TEMPLATES)) {
 			<liferay-ui:search-container-column-text
 				href="<%= rowHREF %>"
 				name="name"
-				value="<%= LanguageUtil.get(pageContext, template.getName(locale)) %>"
+				value="<%= HtmlUtil.escape(LanguageUtil.get(pageContext, template.getName(locale))) %>"
 			/>
 
 			<c:if test="<%= Validator.isNull(templateTypeValue) && (classNameId == 0) %>">

--- a/portal-web/docroot/html/portlet/staging_bar/merge_layout_set_branch.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/merge_layout_set_branch.jsp
@@ -70,9 +70,9 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 					buffer.append("<a class='layout-set-branch' data-layoutSetBranchId='");
 					buffer.append(curLayoutSetBranch.getLayoutSetBranchId());
 					buffer.append("' data-layoutSetBranchName='");
-					buffer.append(HtmlUtil.escape(curLayoutSetBranch.getName()));
+					buffer.append(HtmlUtil.escapeAttribute(curLayoutSetBranch.getName()));
 					buffer.append("' data-layoutSetBranchMessage='");
-					buffer.append(HtmlUtil.escape(LanguageUtil.format(pageContext, "are-you-sure-you-want-to-merge-changes-from-x", curLayoutSetBranch.getName())));
+					buffer.append(HtmlUtil.escapeAttribute(LanguageUtil.format(pageContext, "are-you-sure-you-want-to-merge-changes-from-x", curLayoutSetBranch.getName())));
 					buffer.append("' href='#'>");
 					buffer.append(LanguageUtil.get(pageContext, "select"));
 					buffer.append("</a>");

--- a/portal-web/docroot/html/portlet/staging_bar/merge_layout_set_branch.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/merge_layout_set_branch.jsp
@@ -72,7 +72,7 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 					buffer.append("' data-layoutSetBranchName='");
 					buffer.append(HtmlUtil.escape(curLayoutSetBranch.getName()));
 					buffer.append("' data-layoutSetBranchMessage='");
-					buffer.append(UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-merge-changes-from-x", curLayoutSetBranch.getName()));
+					buffer.append(HtmlUtil.escape(LanguageUtil.format(pageContext, "are-you-sure-you-want-to-merge-changes-from-x", curLayoutSetBranch.getName())));
 					buffer.append("' href='#'>");
 					buffer.append(LanguageUtil.get(pageContext, "select"));
 					buffer.append("</a>");


### PR DESCRIPTION
We can't use UnicodeLanguageUtil in HTML. You can only use it in JS strings. (Side note, I generally prefer HtmlUtil.escapeJS over UnicodeLanguageUtil because the later generates much longer strings.)

I also reverted both my change and your change to view_template.jsp. We need to use escapeJS in the JavaScript because the escaping done by escapedModel is not sufficient for JavaScript.
