### PR TITLE
LPS-28614 [TECHNICAL SUPPORT]

### DIFF
--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
@@ -31,6 +31,8 @@ if (wikiPageResourcePrimKey > 0) {
 }
 %>
 
+CKEDITOR.config.disableObjectResizing=true;
+
 CKEDITOR.config.height = 265;
 
 CKEDITOR.config.removePlugins = [


### PR DESCRIPTION
This one disables the resize handles in FF and IE that are still available after removing the dialog options to set image size (the reason for that was that creole 1.0 doesn't support the image size parameters).
