### PR TITLE
LPS-28118 Don't propagate preferences referencing data when data is not being propagated

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -700,6 +700,11 @@ public class LayoutImporter {
 
 			long portletPreferencesGroupId = groupId;
 
+			Element portletDataElement = portletElement.element("portlet-data");
+
+			boolean importData =
+				importPortletData && (portletDataElement != null);
+
 			try {
 				if ((layout != null) && !group.isCompany()) {
 					portletPreferencesGroupId = layout.getGroupId();
@@ -711,14 +716,11 @@ public class LayoutImporter {
 					portletDataContext, layoutSet.getCompanyId(),
 					portletPreferencesGroupId, layout, null, portletElement,
 					importPortletSetup, importPortletArchivedSetups,
-					importPortletUserPreferences, false);
+					importPortletUserPreferences, false, importData);
 
 				// Portlet data
 
-				Element portletDataElement = portletElement.element(
-					"portlet-data");
-
-				if (importPortletData && (portletDataElement != null)) {
+				if (importData) {
 					_portletImporter.importPortletData(
 						portletDataContext, portletId, plid,
 						portletDataElement);
@@ -743,7 +745,7 @@ public class LayoutImporter {
 				portletDataContext, layoutSet.getCompanyId(), groupId, null,
 				null, portletElement, importPortletSetup,
 				importPortletArchivedSetups, importPortletUserPreferences,
-				false);
+				false, importData);
 		}
 
 		if (importPermissions) {

--- a/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
@@ -416,6 +416,10 @@ public class PortletImporter {
 
 		setPortletScope(portletDataContext, portletElement);
 
+		Element portletDataElement = portletElement.element("portlet-data");
+
+		boolean importData = importPortletData && (portletDataElement != null);
+
 		try {
 
 			// Portlet preferences
@@ -423,14 +427,12 @@ public class PortletImporter {
 			importPortletPreferences(
 				portletDataContext, layout.getCompanyId(), groupId, layout,
 				portletId, portletElement, importPortletSetup,
-				importPortletArchivedSetups, importPortletUserPreferences,
-				true);
+				importPortletArchivedSetups, importPortletUserPreferences, true,
+				importData);
 
 			// Portlet data
 
-			Element portletDataElement = portletElement.element("portlet-data");
-
-			if (importPortletData && (portletDataElement != null)) {
+			if (importData) {
 				if (_log.isDebugEnabled()) {
 					_log.debug("Importing portlet data");
 				}
@@ -1067,7 +1069,8 @@ public class PortletImporter {
 			PortletDataContext portletDataContext, long companyId, long groupId,
 			Layout layout, String portletId, Element parentElement,
 			boolean importPortletSetup, boolean importPortletArchivedSetups,
-			boolean importPortletUserPreferences, boolean preserveScopeLayoutId)
+			boolean importPortletUserPreferences, boolean preserveScopeLayoutId,
+			boolean importPortletData)
 		throws Exception {
 
 		long defaultUserId = UserLocalServiceUtil.getDefaultUserId(companyId);
@@ -1192,8 +1195,9 @@ public class PortletImporter {
 						portletId, xml);
 				}
 
-				PortletPreferencesLocalServiceUtil.updatePreferences(
-					ownerId, ownerType, plid, portletId, xml);
+				updatePortletPreferences(
+					portletDataContext, ownerId, ownerType, plid, portletId,
+					xml, importPortletData);
 			}
 		}
 
@@ -1866,6 +1870,59 @@ public class PortletImporter {
 		}
 
 		return PortletPreferencesFactoryUtil.toXML(jxPreferences);
+	}
+
+	protected void updatePortletPreferences(
+			PortletDataContext portletDataContext, long ownerId, int ownerType,
+			long plid, String portletId, String xml, boolean importData)
+		throws Exception {
+
+		if (importData) {
+			PortletPreferencesLocalServiceUtil.updatePreferences(
+				ownerId, ownerType, plid, portletId, xml);
+		}
+		else {
+			Portlet portlet = PortletLocalServiceUtil.getPortletById(
+				portletDataContext.getCompanyId(), portletId);
+
+			PortletDataHandler portletDataHandler =
+				portlet.getPortletDataHandlerInstance();
+
+			// Portlet preferences to be updated only when importing data
+
+			String[] dataPortletPreferences =
+				portletDataHandler.getDataPortletPreferences();
+
+			// Current portlet preferences
+
+			javax.portlet.PortletPreferences portletPreferences =
+				PortletPreferencesLocalServiceUtil.getPreferences(
+					portletDataContext.getCompanyId(), ownerId, ownerType, plid,
+					portletId);
+
+			// New portlet preferences
+
+			javax.portlet.PortletPreferences jxPreferences =
+				PortletPreferencesFactoryUtil.fromXML(
+					portletDataContext.getCompanyId(), ownerId, ownerType, plid,
+					portletId, xml);
+
+			Enumeration<String> enu = jxPreferences.getNames();
+
+			while (enu.hasMoreElements()) {
+				String name = enu.nextElement();
+
+				if (!ArrayUtil.contains(dataPortletPreferences, name)) {
+					String value = GetterUtil.getString(
+						jxPreferences.getValue(name, null));
+
+					portletPreferences.setValue(name, value);
+				}
+			}
+
+			PortletPreferencesLocalServiceUtil.updatePreferences(
+				ownerId, ownerType, plid, portletId, portletPreferences);
+		}
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(PortletImporter.class);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLDisplayPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLDisplayPortletDataHandlerImpl.java
@@ -42,6 +42,11 @@ import javax.portlet.PortletPreferences;
 public class DLDisplayPortletDataHandlerImpl extends BasePortletDataHandler {
 
 	@Override
+	public String[] getDataPortletPreferences() {
+		return new String[] {"rootFolderId"};
+	}
+
+	@Override
 	public PortletDataHandlerControl[] getExportControls() {
 		return new PortletDataHandlerControl[] {
 			_foldersAndDocuments, _shortcuts, _previewsAndThumbnails, _ranks

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandlerImpl.java
@@ -684,6 +684,11 @@ public class DLPortletDataHandlerImpl extends BasePortletDataHandler {
 	}
 
 	@Override
+	public String[] getDataPortletPreferences() {
+		return new String[] {"rootFolderId"};
+	}
+
+	@Override
 	public PortletDataHandlerControl[] getExportControls() {
 		return new PortletDataHandlerControl[] {
 			_foldersAndDocuments, _shortcuts, _previewsAndThumbnails, _ranks

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/lar/DDLDisplayPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/lar/DDLDisplayPortletDataHandlerImpl.java
@@ -39,6 +39,12 @@ import javax.portlet.PortletPreferences;
 public class DDLDisplayPortletDataHandlerImpl extends BasePortletDataHandler {
 
 	@Override
+	public String[] getDataPortletPreferences() {
+		return new String[] {
+			"recordSetId", "detailDDMTemplateId", "listDDMTemplateId"};
+	}
+
+	@Override
 	public boolean isAlwaysExportable() {
 		return _ALWAYS_EXPORTABLE;
 	}

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalContentPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalContentPortletDataHandlerImpl.java
@@ -71,6 +71,11 @@ public class JournalContentPortletDataHandlerImpl
 	extends BasePortletDataHandler {
 
 	@Override
+	public String[] getDataPortletPreferences() {
+		return new String[] {"groupId", "articleId", "templateId"};
+	}
+
+	@Override
 	public PortletDataHandlerControl[] getExportControls() {
 		return new PortletDataHandlerControl[] {
 			_selectedArticles, _embeddedAssets

--- a/portal-impl/src/com/liferay/portlet/polls/lar/PollsDisplayPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/lar/PollsDisplayPortletDataHandlerImpl.java
@@ -43,6 +43,11 @@ import javax.portlet.PortletPreferences;
 public class PollsDisplayPortletDataHandlerImpl extends BasePortletDataHandler {
 
 	@Override
+	public String[] getDataPortletPreferences() {
+		return new String[] {"questionId"};
+	}
+
+	@Override
 	public PortletDataHandlerControl[] getExportControls() {
 		return new PortletDataHandlerControl[] {_questions, _votes};
 	}

--- a/portal-impl/src/com/liferay/portlet/rss/lar/RSSPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/rss/lar/RSSPortletDataHandlerImpl.java
@@ -48,6 +48,11 @@ import javax.portlet.PortletPreferences;
 public class RSSPortletDataHandlerImpl extends JournalPortletDataHandlerImpl {
 
 	@Override
+	public String[] getDataPortletPreferences() {
+		return new String[] {"footerArticleValues", "headerArticleValues"};
+	}
+
+	@Override
 	public PortletDataHandlerControl[] getExportControls() {
 		return new PortletDataHandlerControl[] {
 			_selectedArticles, _embeddedAssets

--- a/portal-impl/src/com/liferay/portlet/wiki/lar/WikiDisplayPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/lar/WikiDisplayPortletDataHandlerImpl.java
@@ -46,6 +46,11 @@ import javax.portlet.PortletPreferences;
 public class WikiDisplayPortletDataHandlerImpl extends BasePortletDataHandler {
 
 	@Override
+	public String[] getDataPortletPreferences() {
+		return new String[] {"title", "nodeId"};
+	}
+
+	@Override
 	public PortletDataHandlerControl[] getExportControls() {
 		return new PortletDataHandlerControl[] {
 			_nodesAndPages

--- a/portal-impl/test/integration/com/liferay/portal/lar/BaseExportImportTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/BaseExportImportTestCase.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar;
+
+import com.liferay.portal.NoSuchLayoutException;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.*;
+import com.liferay.portal.service.LayoutLocalServiceUtil;
+import com.liferay.portal.service.LayoutServiceUtil;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.util.TestPropsValues;
+
+import org.powermock.api.mockito.PowerMockito;
+
+/**
+ * @author Eduardo Garcia
+ */
+public class BaseExportImportTestCase extends PowerMockito {
+
+	protected Layout addLayout(
+			long groupId, String name, LayoutPrototype layoutPrototype,
+			boolean linkEnabled)
+		throws Exception {
+
+		String friendlyURL =
+			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name);
+
+		Layout layout = null;
+
+		try {
+			layout = LayoutLocalServiceUtil.getFriendlyURLLayout(
+				groupId, false, friendlyURL);
+
+			return layout;
+		}
+		catch (NoSuchLayoutException nsle) {
+		}
+
+		String description = "This is a test page.";
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
+
+		serviceContext.setAttribute("layoutPrototypeLinkEnabled", linkEnabled);
+		serviceContext.setAttribute(
+			"layoutPrototypeUuid", layoutPrototype.getUuid());
+
+		return LayoutLocalServiceUtil.addLayout(
+			TestPropsValues.getUserId(), groupId, false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, name, null, description,
+			LayoutConstants.TYPE_PORTLET, false, friendlyURL, serviceContext);
+	}
+
+	protected void propagateChanges(Group group) throws Exception {
+		LayoutLocalServiceUtil.getLayouts(
+			group.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+	}
+
+	protected void propagateChanges(Layout layout) throws Exception {
+		LayoutLocalServiceUtil.getLayout(layout.getPlid());
+	}
+
+	protected Layout updateLayoutTemplateId(
+		Layout layout, String layoutTemplateId) throws Exception {
+
+		LayoutTypePortlet layoutTypePortlet =
+			(LayoutTypePortlet)layout.getLayoutType();
+
+		layoutTypePortlet.setLayoutTemplateId(
+			TestPropsValues.getUserId(), layoutTemplateId);
+
+		return LayoutServiceUtil.updateLayout(
+			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
+			layout.getTypeSettings());
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/lar/LayoutExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/LayoutExportImportTest.java
@@ -14,28 +14,20 @@
 
 package com.liferay.portal.lar;
 
-import com.liferay.portal.NoSuchLayoutException;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
-import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
-import com.liferay.portal.model.LayoutConstants;
 import com.liferay.portal.model.LayoutPrototype;
 import com.liferay.portal.model.LayoutSetPrototype;
-import com.liferay.portal.model.LayoutTypePortlet;
 import com.liferay.portal.model.LayoutTypePortletConstants;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
-import com.liferay.portal.service.LayoutServiceUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
-import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.ExecutionTestListeners;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
 import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
-import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portlet.sites.util.SitesUtil;
 
 import org.junit.Assert;
@@ -43,7 +35,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
 /**
@@ -57,7 +48,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 		TransactionalCallbackAwareExecutionTestListener.class
 	})
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
-public class LayoutExportImportTest extends PowerMockito {
+public class LayoutExportImportTest extends BaseExportImportTestCase {
 
 	@Before
 	public void setUp() {
@@ -120,49 +111,6 @@ public class LayoutExportImportTest extends PowerMockito {
 	@Transactional
 	public void testLSPLinkEnabledwithPageDeletionFromLP() throws Exception {
 		testLayoutSetPrototype(true, false, true, true, true);
-	}
-
-	protected Layout addLayout(
-			long groupId, String name, LayoutPrototype layoutPrototype,
-			boolean linkEnabled)
-		throws Exception {
-
-		String friendlyURL =
-			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name);
-
-		Layout layout = null;
-
-		try {
-			layout = LayoutLocalServiceUtil.getFriendlyURLLayout(
-				groupId, false, friendlyURL);
-
-			return layout;
-		}
-		catch (NoSuchLayoutException nsle) {
-		}
-
-		String description = "This is a test page.";
-
-		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
-
-		serviceContext.setAttribute("layoutPrototypeLinkEnabled", linkEnabled);
-		serviceContext.setAttribute(
-			"layoutPrototypeUuid", layoutPrototype.getUuid());
-
-		return LayoutLocalServiceUtil.addLayout(
-			TestPropsValues.getUserId(), groupId, false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, name, null, description,
-			LayoutConstants.TYPE_PORTLET, false, friendlyURL, serviceContext);
-	}
-
-	protected void propagateChanges(Group group) throws Exception {
-		LayoutLocalServiceUtil.getLayouts(
-			group.getGroupId(), false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-	}
-
-	protected void propagateChanges(Layout layout) throws Exception {
-		LayoutLocalServiceUtil.getLayout(layout.getPlid());
 	}
 
 	protected void testLayoutSetPrototype(
@@ -295,20 +243,6 @@ public class LayoutExportImportTest extends PowerMockito {
 					groupLayoutsCount, layoutSetPrototypeLayoutsCount + 2);
 			}
 		}
-	}
-
-	protected Layout updateLayoutTemplateId(
-		Layout layout, String layoutTemplateId) throws Exception {
-
-		LayoutTypePortlet layoutTypePortlet =
-			(LayoutTypePortlet)layout.getLayoutType();
-
-		layoutTypePortlet.setLayoutTemplateId(
-			TestPropsValues.getUserId(), layoutTemplateId);
-
-		return LayoutServiceUtil.updateLayout(
-			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
-			layout.getTypeSettings());
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/lar/PortletExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/PortletExportImportTest.java
@@ -1,0 +1,304 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar;
+
+import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.LayoutSetPrototype;
+import com.liferay.portal.model.LayoutTypePortlet;
+import com.liferay.portal.model.PortletPreferences;
+import com.liferay.portal.service.LayoutLocalServiceUtil;
+import com.liferay.portal.service.PortletLocalServiceUtil;
+import com.liferay.portal.service.PortletPreferencesLocalServiceUtil;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.test.ExecutionTestListeners;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.MainServletExecutionTestListener;
+import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
+import com.liferay.portal.util.PortletKeys;
+import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.journal.model.JournalArticle;
+import com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.portlet.journal.service.persistence.JournalArticleUtil;
+import com.liferay.portlet.sites.util.SitesUtil;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+/**
+ * @author Eduardo Garcia
+ */
+@PrepareForTest({PortletLocalServiceUtil.class})
+
+@ExecutionTestListeners(
+	listeners = {
+		MainServletExecutionTestListener.class,
+		TransactionalCallbackAwareExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class PortletExportImportTest extends BaseExportImportTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		FinderCacheUtil.clearCache();
+
+		long userId = TestPropsValues.getUserId();
+
+		//Create site template
+
+		LayoutSetPrototype layoutSetPrototype =
+			ServiceTestUtil.addLayoutSetPrototype(
+				ServiceTestUtil.randomString());
+
+		_lspGroup = layoutSetPrototype.getGroup();
+
+		_lspLayout = ServiceTestUtil.addLayout(
+			_lspGroup.getGroupId(), ServiceTestUtil.randomString(), true);
+
+		updateLayoutTemplateId(_lspLayout, "1_column");
+
+		_lspArticle = addArticle(
+			_lspGroup.getGroupId(), 0, "Test Article", "Test Content");
+
+		_lspJournalContentPortletId = addJournalContentPortletToLayout(
+			userId, _lspLayout, _lspArticle, "column-1");
+
+		//Create site from site template
+
+		_group = ServiceTestUtil.addGroup(ServiceTestUtil.randomString());
+
+		SitesUtil.updateLayoutSetPrototypesLinks(
+			_group, layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
+			true);
+
+		propagateChanges(_group);
+	}
+
+	@Test
+	public void testExportImportPortletData() throws Exception {
+
+		// Check data after site creation
+
+		String initContent = _lspArticle.getContent();
+
+		JournalArticle article =
+			JournalArticleLocalServiceUtil.getArticleByUrlTitle(
+				_group.getGroupId(), _lspArticle.getUrlTitle());
+
+		Assert.assertEquals(initContent, article.getContent());
+
+		// Update site template data
+
+		updateArticle(_lspArticle, "New Test Content");
+
+		// Check data after layout reset
+
+		Layout layout = LayoutLocalServiceUtil.getFriendlyURLLayout(
+			_group.getGroupId(), false, _lspLayout.getFriendlyURL());
+
+		SitesUtil.resetPrototype(layout);
+
+		Assert.assertEquals(initContent, article.getContent());
+	}
+
+	@Test
+	public void testExportImportPortletPreferences() throws Exception {
+
+		// Check preferences after site creation
+
+		JournalArticle article =
+			JournalArticleLocalServiceUtil.getArticleByUrlTitle(
+				_group.getGroupId(), _lspArticle.getUrlTitle());
+
+		Layout layout = LayoutLocalServiceUtil.getFriendlyURLLayout(
+			_group.getGroupId(), false, _lspLayout.getFriendlyURL());
+
+		javax.portlet.PortletPreferences portletPreferences =
+			getPortletPreferences(
+				layout.getCompanyId(), layout.getPlid(),
+				_lspJournalContentPortletId);
+
+		Assert.assertEquals(
+			article.getArticleId(),
+			portletPreferences.getValue("articleId", StringPool.BLANK));
+
+		Assert.assertEquals(
+			String.valueOf(article.getGroupId()),
+			portletPreferences.getValue("groupId", StringPool.BLANK));
+
+		Assert.assertEquals(
+			String.valueOf(true), portletPreferences.getValue(
+				"showAvailableLocales", StringPool.BLANK));
+
+		// Update site template preferences
+
+		javax.portlet.PortletPreferences prefs = getPortletPreferences(
+			_lspLayout.getCompanyId(), _lspLayout.getPlid(),
+			_lspJournalContentPortletId);
+
+		prefs.setValue("showAvailableLocales", String.valueOf(false));
+
+		updatePortletPreferences(
+			_lspLayout.getPlid(), _lspJournalContentPortletId, prefs);
+
+		// Check preferences after layout reset
+
+		SitesUtil.resetPrototype(layout);
+
+		portletPreferences = getPortletPreferences(
+			_group.getCompanyId(), layout.getPlid(),
+			_lspJournalContentPortletId);
+
+		Assert.assertEquals(
+			article.getArticleId(),
+			portletPreferences.getValue("articleId", StringPool.BLANK));
+
+		Assert.assertEquals(
+			String.valueOf(article.getGroupId()),
+			portletPreferences.getValue("groupId", StringPool.BLANK));
+
+		Assert.assertEquals(
+			String.valueOf(false), portletPreferences.getValue(
+			"showAvailableLocales", StringPool.BLANK));
+
+	}
+
+	protected JournalArticle addArticle(
+			long groupId, long folderId, String name, String content)
+		throws Exception {
+
+		Map<Locale, String> titleMap = new HashMap<Locale, String>();
+
+		Locale locale = LocaleUtil.getDefault();
+
+		String localeId = locale.toString();
+
+		titleMap.put(locale, name);
+
+		Map<Locale, String> descriptionMap = new HashMap<Locale, String>();
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
+
+		String xmlContent = getArticleContent(content, localeId);
+
+		return JournalArticleLocalServiceUtil.addArticle(
+			TestPropsValues.getUserId(), groupId, folderId, 0, 0,
+			StringPool.BLANK, true, 1, titleMap, descriptionMap, xmlContent,
+			"general", null, null, null, 1, 1, 1965, 0, 0, 0, 0, 0, 0, 0, true,
+			0, 0, 0, 0, 0, true, false, false, null, null, null, null,
+			serviceContext);
+	}
+
+	protected String addJournalContentPortletToLayout(
+			long userId, Layout layout, JournalArticle article, String columnId)
+		throws Exception {
+
+		LayoutTypePortlet layoutTypePortlet =
+			(LayoutTypePortlet) layout.getLayoutType();
+
+		String journalPortletId = layoutTypePortlet.addPortletId(
+			userId, PortletKeys.JOURNAL_CONTENT, columnId, -1);
+
+		LayoutLocalServiceUtil.updateLayout(
+			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
+			layout.getTypeSettings());
+
+		javax.portlet.PortletPreferences prefs = getPortletPreferences(
+			layout.getCompanyId(), layout.getPlid(), journalPortletId);
+
+		prefs.setValue("articleId", article.getArticleId());
+		prefs.setValue("groupId", String.valueOf(article.getGroupId()));
+		prefs.setValue("showAvailableLocales", String.valueOf(true));
+
+		updatePortletPreferences(layout.getPlid(), journalPortletId, prefs);
+
+		return journalPortletId;
+	}
+
+	protected String getArticleContent(String content, String localeId) {
+		StringBundler sb = new StringBundler();
+
+		sb.append("<?xml version=\"1.0\"?><root available-locales=");
+		sb.append("\"" + localeId + "\" ");
+		sb.append("default-locale=\"" + localeId + "\">");
+		sb.append("<static-content language-id=\"" + localeId + "\">");
+		sb.append("<![CDATA[<p>");
+		sb.append(content);
+		sb.append("</p>]]>");
+		sb.append("</static-content></root>");
+
+		return sb.toString();
+	}
+
+	protected javax.portlet.PortletPreferences getPortletPreferences(
+			long companyId, long plid, String portletId)
+		throws Exception {
+
+		javax.portlet.PortletPreferences portletPreferences =
+			PortletPreferencesLocalServiceUtil.getPreferences(
+				companyId, PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid, portletId);
+
+		return portletPreferences;
+	}
+
+	protected JournalArticle updateArticle(
+		JournalArticle article, String content) throws Exception {
+
+		Locale locale = LocaleUtil.getDefault();
+
+		String localeId = locale.toString();
+
+		String xmlContent = getArticleContent(content, localeId);
+
+		_lspArticle.setContent(xmlContent);
+
+		return JournalArticleUtil.update(article, true);
+	}
+
+	protected PortletPreferences updatePortletPreferences(
+			long plid, String portletId, javax.portlet.PortletPreferences prefs)
+		throws Exception {
+
+		PortletPreferences portletPrefs =
+			PortletPreferencesLocalServiceUtil.updatePreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid, portletId, prefs);
+
+		return portletPrefs;
+	}
+
+	private Group _group;
+	private JournalArticle _lspArticle;
+	private Group _lspGroup;
+	private String _lspJournalContentPortletId;
+	private Layout _lspLayout;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/BasePortletDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/BasePortletDataHandler.java
@@ -49,6 +49,10 @@ public abstract class BasePortletDataHandler implements PortletDataHandler {
 		}
 	}
 
+	public String[] getDataPortletPreferences() {
+		return new String[0];
+	}
+
 	public PortletDataHandlerControl[] getExportControls() {
 		return new PortletDataHandlerControl[0];
 	}

--- a/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandler.java
@@ -66,6 +66,15 @@ public interface PortletDataHandler {
 		throws PortletDataException;
 
 	/**
+	 * Returns an array of the portlet preferences that reference to data.
+	 * These references should only be updated if the referenced data is
+	 * imported
+	 *
+	 * @return A String array
+	 */
+	public String[] getDataPortletPreferences();
+
+	/**
 	 * Returns an array of the controls defined for this data handler. These
 	 * controls enable the developer to create fine grained controls over export
 	 * behavior. The controls are rendered in the export UI.


### PR DESCRIPTION
Some information by @epgarcia:

Current status:

Create a site from a site template:

copy portlet preferences from the imported portlet (overwritting existing ones, if any)
copy data from the imported portlet and map the ids at portlet preferences to the imported data
Merging site template and site (e.g when resetting)

copy portlet preferences from the imported portlet (overwritting existing ones, if any)
Result: when mergin a site template, ids at portlet preferences point to the data in the site template, instead to the data in the site.

Solution:

Create a site from a site template

Remains as in current status
Merging site template and site (e.g when resetting)

copy portlet preferences from the imported portlet (overwritting existing ones, if any)
overwritte only portlet preferences which do not refer to data
To notify the PortletImporter which portlet preferences refer to data, they must be declared in the getDataPortletPreferences() method of the corresponding *PortletDataHandlerImpl class.

The PortletExportImportTest class has been created to test this behaviour.
