### PR TITLE
LPS-28833 RSS Import fails when checking "delete existing data"

### DIFF
--- a/portal-impl/src/com/liferay/portlet/rss/lar/RSSPortletDataHandlerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/rss/lar/RSSPortletDataHandlerImpl.java
@@ -110,8 +110,10 @@ public class RSSPortletDataHandlerImpl extends JournalPortletDataHandlerImpl {
 			PortletPreferences portletPreferences)
 		throws Exception {
 
-		portletPreferences.setValue("footerArticleValues", StringPool.BLANK);
-		portletPreferences.setValue("headerArticleValues", StringPool.BLANK);
+		portletPreferences.setValues(
+			"footerArticleValues", new String[] {"0", ""});
+		portletPreferences.setValues(
+			"headerArticleValues", new String[] {"0", ""});
 		portletPreferences.setValue("urls", StringPool.BLANK);
 		portletPreferences.setValue("titles", StringPool.BLANK);
 		portletPreferences.setValue("itemsPerChannel", StringPool.BLANK);


### PR DESCRIPTION
The reason is that the portlet assumes the preference is an array with 2 positions. If we set the preferences to StringPool.BLANK, then it is not null, and the preferences.getValues("headerArticleValues", new String[] {"0", ""}) in init.jsp returns StringPool.BLANK instead.
