### PR TITLE
LPS-28944 Add shallow clone support to PersistentHttpServletRequestWrapp...

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_javaterm_alphabetize_exclusions.properties
+++ b/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_javaterm_alphabetize_exclusions.properties
@@ -1,7 +1,7 @@
 #
 # Files that are allowed to have unalphabetized javaterms.
 #
-portal-impl/src/com/liferay/portal/util/PortalImpl.java@6151=true
+portal-impl/src/com/liferay/portal/util/PortalImpl.java@6156=true
 portal-impl/src/com/liferay/portal/webdav/methods/Method.java@54=true
 portal-impl/test/integration/com/liferay/portal/test/TestContext.java@54=true
 portal-impl/test/integration/com/liferay/portal/util/DiffImplTest.java

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -2715,8 +2715,9 @@ public class PortalImpl implements Portal {
 	public HttpServletRequest getOriginalServletRequest(
 		HttpServletRequest request) {
 
-		List<HttpServletRequestWrapper> persistentHttpServletRequestWrappers =
-			new ArrayList<HttpServletRequestWrapper>();
+		List<PersistentHttpServletRequestWrapper>
+			persistentHttpServletRequestWrappers =
+				new ArrayList<PersistentHttpServletRequestWrapper>();
 
 		HttpServletRequest originalRequest = request;
 
@@ -2726,8 +2727,12 @@ public class PortalImpl implements Portal {
 			if (originalRequest instanceof
 					PersistentHttpServletRequestWrapper) {
 
+				PersistentHttpServletRequestWrapper
+					persistentHttpServletRequestWrapper =
+						(PersistentHttpServletRequestWrapper)originalRequest;
+
 				persistentHttpServletRequestWrappers.add(
-					(HttpServletRequestWrapper)originalRequest);
+					persistentHttpServletRequestWrapper.clone());
 			}
 
 			// Get original request so that portlets inside portlets render

--- a/portal-service/src/com/liferay/portal/kernel/servlet/PersistentHttpServletRequestWrapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/PersistentHttpServletRequestWrapper.java
@@ -21,10 +21,19 @@ import javax.servlet.http.HttpServletRequestWrapper;
  * @author Shuyang Zhou
  */
 public class PersistentHttpServletRequestWrapper
-	extends HttpServletRequestWrapper {
+	extends HttpServletRequestWrapper implements Cloneable {
 
 	public PersistentHttpServletRequestWrapper(HttpServletRequest request) {
 		super(request);
+	}
+
+	public PersistentHttpServletRequestWrapper clone() {
+		try {
+			return (PersistentHttpServletRequestWrapper)super.clone();
+		}
+		catch (CloneNotSupportedException cnse) {
+			throw new RuntimeException(cnse);
+		}
 	}
 
 }


### PR DESCRIPTION
...er, so Portalmpl.getOriginalServletRequest() can leave the orginal wrapper stack untouched.
