### PR TITLE
LPS-27510 Integration tests for trashed subentries

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/EditFileShortcutAction.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/EditFileShortcutAction.java
@@ -170,8 +170,7 @@ public class EditFileShortcutAction extends PortletAction {
 
 		if (moveFromTrash) {
 			DLAppServiceUtil.moveFileShortcutFromTrash(
-				fileShortcutId, newFolderId, fileShortcut.getToFileEntryId(),
-				serviceContext);
+				fileShortcutId, newFolderId, serviceContext);
 		}
 		else {
 			DLAppServiceUtil.updateFileShortcut(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceHttp.java
@@ -2924,7 +2924,6 @@ public class DLAppServiceHttp {
 
 	public static com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutFromTrash(
 		HttpPrincipal httpPrincipal, long fileShortcutId, long newFolderId,
-		long toFileEntryId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
@@ -2934,7 +2933,7 @@ public class DLAppServiceHttp {
 					_moveFileShortcutFromTrashParameterTypes76);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
-					fileShortcutId, newFolderId, toFileEntryId, serviceContext);
+					fileShortcutId, newFolderId, serviceContext);
 
 			Object returnObj = null;
 
@@ -4199,7 +4198,7 @@ public class DLAppServiceHttp {
 			long.class
 		};
 	private static final Class<?>[] _moveFileShortcutFromTrashParameterTypes76 = new Class[] {
-			long.class, long.class, long.class,
+			long.class, long.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
 	private static final Class<?>[] _moveFileShortcutToTrashParameterTypes77 = new Class[] {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/http/DLAppServiceSoap.java
@@ -2005,13 +2005,13 @@ public class DLAppServiceSoap {
 	* @throws SystemException if a system exception occurred
 	*/
 	public static com.liferay.portlet.documentlibrary.model.DLFileShortcutSoap moveFileShortcutFromTrash(
-		long fileShortcutId, long newFolderId, long toFileEntryId,
+		long fileShortcutId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws RemoteException {
 		try {
 			com.liferay.portlet.documentlibrary.model.DLFileShortcut returnValue =
 				DLAppServiceUtil.moveFileShortcutFromTrash(fileShortcutId,
-					newFolderId, toFileEntryId, serviceContext);
+					newFolderId, serviceContext);
 
 			return com.liferay.portlet.documentlibrary.model.DLFileShortcutSoap.toSoapModel(returnValue);
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -481,7 +481,7 @@ public class DLAppHelperLocalServiceImpl
 
 	public DLFileShortcut moveFileShortcutFromTrash(
 			long userId, DLFileShortcut dlFileShortcut, long newFolderId,
-			long toFileEntryId, ServiceContext serviceContext)
+			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
 		if (dlFileShortcut.isInTrash()) {
@@ -489,8 +489,8 @@ public class DLAppHelperLocalServiceImpl
 		}
 
 		return dlAppService.updateFileShortcut(
-			dlFileShortcut.getFileShortcutId(), newFolderId, toFileEntryId,
-			serviceContext);
+			dlFileShortcut.getFileShortcutId(), newFolderId,
+			dlFileShortcut.getToFileEntryId(), serviceContext);
 	}
 
 	public DLFileShortcut moveFileShortcutToTrash(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -2141,7 +2141,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	 * @throws SystemException if a system exception occurred
 	 */
 	public DLFileShortcut moveFileShortcutFromTrash(
-			long fileShortcutId, long newFolderId, long toFileEntryId,
+			long fileShortcutId, long newFolderId,
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
@@ -2151,8 +2151,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 			getPermissionChecker(), fileShortcut, ActionKeys.UPDATE);
 
 		return dlAppHelperLocalService.moveFileShortcutFromTrash(
-			getUserId(), fileShortcut, newFolderId, toFileEntryId,
-			serviceContext);
+			getUserId(), fileShortcut, newFolderId, serviceContext);
 	}
 
 	/**

--- a/portal-impl/test/integration/com/liferay/portal/image/ImageToolImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/image/ImageToolImplTest.java
@@ -46,30 +46,30 @@ public class ImageToolImplTest {
 
 	@Test
 	public void testReadBMP() throws Exception {
-		testRead("liferay.bmp");
+		read("liferay.bmp");
 	}
 
 	@Test
 	public void testReadGIF() throws Exception {
-		testRead("liferay.gif");
+		read("liferay.gif");
 	}
 
 	@Test
 	public void testReadJPEG() throws Exception {
-		testRead("liferay.jpeg");
+		read("liferay.jpeg");
 	}
 
 	@Test
 	public void testReadJPG() throws Exception {
-		testRead("liferay.jpg");
+		read("liferay.jpg");
 	}
 
 	@Test
 	public void testReadPNG() throws Exception {
-		testRead("liferay.png");
+		read("liferay.png");
 	}
 
-	protected void testRead(String fileName) throws Exception {
+	protected void read(String fileName) throws Exception {
 		fileName =
 			"portal-impl/test/integration/com/liferay/portal/image/" +
 				"dependencies/" + fileName;

--- a/portal-impl/test/integration/com/liferay/portal/lar/LayoutExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/LayoutExportImportTest.java
@@ -58,31 +58,31 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 	@Test
 	@Transactional
 	public void testLSPLinkDisabled() throws Exception {
-		testLayoutSetPrototype(false, false, false, false, false);
+		runLayoutSetPrototype(false, false, false, false, false);
 	}
 
 	@Test
 	@Transactional
 	public void testLSPLinkDisabledWithPageAddition() throws Exception {
-		testLayoutSetPrototype(false, false, true, false, false);
+		runLayoutSetPrototype(false, false, true, false, false);
 	}
 
 	@Test
 	@Transactional
 	public void testLSPLinkDisabledWithPageDeletion() throws Exception {
-		testLayoutSetPrototype(false, false, true, true, false);
+		runLayoutSetPrototype(false, false, true, true, false);
 	}
 
 	@Test
 	@Transactional
 	public void testLSPLinkEnabled() throws Exception {
-		testLayoutSetPrototype(true, false, false, false, false);
+		runLayoutSetPrototype(true, false, false, false, false);
 	}
 
 	@Test
 	@Transactional
 	public void testLSPLinkEnabledwithPageAddition() throws Exception {
-		testLayoutSetPrototype(true, false, true, false, false);
+		runLayoutSetPrototype(true, false, true, false, false);
 	}
 
 	@Test
@@ -90,7 +90,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 	public void testLSPLinkEnabledwithPageAdditionFromLPLinkDisabled()
 		throws Exception {
 
-		testLayoutSetPrototype(true, false, true, false, true);
+		runLayoutSetPrototype(true, false, true, false, true);
 	}
 
 	@Test
@@ -98,24 +98,24 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 	public void testLSPLinkEnabledwithPageAdditionFromLPLinkEnabled()
 		throws Exception {
 
-		testLayoutSetPrototype(true, true, true, false, true);
+		runLayoutSetPrototype(true, true, true, false, true);
 	}
 
 	@Test
 	@Transactional
 	public void testLSPLinkEnabledwithPageDeletion() throws Exception {
-		testLayoutSetPrototype(true, false, true, true, false);
+		runLayoutSetPrototype(true, false, true, true, false);
 	}
 
 	@Test
 	@Transactional
 	public void testLSPLinkEnabledwithPageDeletionFromLP() throws Exception {
-		testLayoutSetPrototype(true, false, true, true, true);
+		runLayoutSetPrototype(true, false, true, true, true);
 	}
 
-	protected void testLayoutSetPrototype(
-			boolean layoutSetLinkEnabled, boolean layoutLinkEnabled,
-			boolean addPage, boolean deletePage, boolean useLayoutPrototype)
+	protected void runLayoutSetPrototype(
+		boolean layoutSetLinkEnabled, boolean layoutLinkEnabled,
+		boolean addPage, boolean deletePage, boolean useLayoutPrototype)
 		throws Exception {
 
 		LayoutSetPrototype layoutSetPrototype =

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/BaseDLAppTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/BaseDLAppTestCase.java
@@ -127,14 +127,20 @@ public abstract class BaseDLAppTestCase {
 	protected DLFileShortcut addFileShortcut(FileEntry fileEntry)
 		throws Exception {
 
+		return addFileShortcut(fileEntry, fileEntry.getFolderId());
+	}
+
+	protected DLFileShortcut addFileShortcut(FileEntry fileEntry, long folderId)
+		throws Exception {
+
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
 
 		return DLAppServiceUtil.addFileShortcut(
-			TestPropsValues.getGroupId(), fileEntry.getFolderId(),
-			fileEntry.getFileEntryId(), serviceContext);
+			TestPropsValues.getGroupId(), folderId, fileEntry.getFileEntryId(),
+			serviceContext);
 	}
 
 	protected Folder addFolder(boolean rootFolder, String name)

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
@@ -372,12 +372,12 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testSearchFileInRootFolder() throws Exception {
-		testSearchFile(true);
+		searchFile(true);
 	}
 
 	@Test
 	public void testSearchFileInSubFolder() throws Exception {
-		testSearchFile(false);
+		searchFile(false);
 	}
 
 	@Test
@@ -467,7 +467,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 		}
 	}
 
-	protected void testSearchFile(boolean rootFolder) throws Exception {
+	protected void searchFile(boolean rootFolder) throws Exception {
 		addFileEntry(rootFolder);
 
 		Thread.sleep(1000 * TestPropsValues.JUNIT_DELAY_FACTOR);

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryExtensionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryExtensionTest.java
@@ -186,50 +186,50 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testAddFileEntryBasic01() throws Exception {
-		testAddFileEntryBasic(_FILE_NAME, "Test.pdf", "txt", "Test.pdf.txt");
+		addFileEntryBasic(_FILE_NAME, "Test.pdf", "txt", "Test.pdf.txt");
 	}
 
 	@Test
 	public void testAddFileEntryBasic02() throws Exception {
-		testAddFileEntryBasic(_FILE_NAME, _FILE_NAME, "txt", _FILE_NAME);
+		addFileEntryBasic(_FILE_NAME, _FILE_NAME, "txt", _FILE_NAME);
 	}
 
 	@Test
 	public void testAddFileEntryBasic03() throws Exception {
-		testAddFileEntryBasic(
+		addFileEntryBasic(
 			_FILE_NAME, _STRIPPED_FILE_NAME, "txt", _FILE_NAME);
 	}
 
 	@Test
 	public void testAddFileEntryBasic04() throws Exception {
-		testAddFileEntryBasic(_FILE_NAME, "", "txt", _FILE_NAME);
+		addFileEntryBasic(_FILE_NAME, "", "txt", _FILE_NAME);
 	}
 
 	@Test
 	public void testAddFileEntryBasic05() throws Exception {
-		testAddFileEntryBasic(
+		addFileEntryBasic(
 			_STRIPPED_FILE_NAME, _FILE_NAME, "txt", _FILE_NAME);
 	}
 
 	@Test
 	public void testAddFileEntryBasic06() throws Exception {
-		testAddFileEntryBasic(
+		addFileEntryBasic(
 			_STRIPPED_FILE_NAME, _STRIPPED_FILE_NAME, "", _STRIPPED_FILE_NAME);
 	}
 
 	@Test
 	public void testAddFileEntryBasic07() throws Exception {
-		testAddFileEntryBasic(_STRIPPED_FILE_NAME, "", "", _STRIPPED_FILE_NAME);
+		addFileEntryBasic(_STRIPPED_FILE_NAME, "", "", _STRIPPED_FILE_NAME);
 	}
 
 	@Test
 	public void testAddFileEntryBasic08() throws Exception {
-		testAddFileEntryBasic("", _FILE_NAME, "txt", _FILE_NAME);
+		addFileEntryBasic("", _FILE_NAME, "txt", _FILE_NAME);
 	}
 
 	@Test
 	public void testAddFileEntryBasic09() throws Exception {
-		testAddFileEntryBasic("", _STRIPPED_FILE_NAME, "", _STRIPPED_FILE_NAME);
+		addFileEntryBasic("", _STRIPPED_FILE_NAME, "", _STRIPPED_FILE_NAME);
 	}
 
 	@Test
@@ -448,7 +448,7 @@ public class DLFileEntryExtensionTest extends BaseDLAppTestCase {
 		DLAppLocalServiceUtil.deleteFileEntry(fileEntry.getFileEntryId());
 	}
 
-	protected void testAddFileEntryBasic(
+	protected void addFileEntryBasic(
 			String sourceFileName, String title, String extension,
 			String titleWithExtension)
 		throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileVersionHistoryTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileVersionHistoryTest.java
@@ -41,42 +41,42 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 
 	@Test
 	public void testDeleteOneVersion() throws Exception {
-		testDeleteVersion(false, false);
+		deleteVersion(false, false);
 	}
 
 	@Test
 	public void testDeleteOneVersionOnePWC() throws Exception {
-		testDeleteVersion(false, true);
+		deleteVersion(false, true);
 	}
 
 	@Test
 	public void testDeleteTwoVersions() throws Exception {
-		testDeleteVersion(true, false);
+		deleteVersion(true, false);
 	}
 
 	@Test
 	public void testDeleteTwoVersionsOnePWC() throws Exception {
-		testDeleteVersion(true, true);
+		deleteVersion(true, true);
 	}
 
 	@Test
 	public void testRevertOneVersion() throws Exception {
-		testRevertVersion(false, false);
+		revertVersion(false, false);
 	}
 
 	@Test
 	public void testRevertOneVersionOnePWC() throws Exception {
-		testRevertVersion(false, true);
+		revertVersion(false, true);
 	}
 
 	@Test
 	public void testRevertTwoVersions() throws Exception {
-		testRevertVersion(true, false);
+		revertVersion(true, false);
 	}
 
 	@Test
 	public void testRevertTwoVersionsOnePWC() throws Exception {
-		testRevertVersion(true, true);
+		revertVersion(true, true);
 	}
 
 	protected void assertFileEntryTitle(String fileName)
@@ -157,7 +157,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		}
 	}
 
-	protected void testDeleteVersion(boolean versioned, boolean leaveCheckedOut)
+	protected void deleteVersion(boolean versioned, boolean leaveCheckedOut)
 		throws Exception {
 
 		_fileEntry = addFileEntry(false, _VERSION_1_0);
@@ -209,7 +209,7 @@ public class DLFileVersionHistoryTest extends BaseDLAppTestCase {
 		}
 	}
 
-	protected void testRevertVersion(boolean versioned, boolean leaveCheckedOut)
+	protected void revertVersion(boolean versioned, boolean leaveCheckedOut)
 		throws Exception {
 
 		_fileEntry = addFileEntry(false, _VERSION_1_0);

--- a/portal-impl/test/integration/com/liferay/portlet/trash/BaseDLTrashHandlerTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/BaseDLTrashHandlerTestCase.java
@@ -51,12 +51,12 @@ public abstract class BaseDLTrashHandlerTestCase extends BaseDLAppTestCase {
 
 	@Test
 	public void testTrashSubEntryAndDeleteFolder() throws Exception {
-		testTrashSubEntry(true);
+		trashSubEntry(true);
 	}
 
 	@Test
 	public void testTrashSubEntryAndRestoreSubEntry() throws Exception {
-		testTrashSubEntry(false);
+		trashSubEntry(false);
 	}
 
 	protected abstract long doAddSubEntry(long folderId1, long folderId2)
@@ -136,7 +136,7 @@ public abstract class BaseDLTrashHandlerTestCase extends BaseDLAppTestCase {
 		return hits.getLength();
 	}
 
-	protected void testTrashSubEntry(boolean deleteFolder) throws Exception {
+	protected void trashSubEntry(boolean deleteFolder) throws Exception {
 		int initialNotInTrashCount = getNotInTrashCount();
 		int initialTrashEntriesCount = getTrashEntriesCount();
 

--- a/portal-impl/test/integration/com/liferay/portlet/trash/BlogsEntryTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/BlogsEntryTrashHandlerTest.java
@@ -72,19 +72,19 @@ public class BlogsEntryTrashHandlerTest {
 	@Test
 	@Transactional
 	public void testTrashAndDelete() throws Exception {
-		testTrash(false, true);
+		trashBlogEntry(false, true);
 	}
 
 	@Test
 	@Transactional
 	public void testTrashAndRestoreApproved() throws Exception {
-		testTrash(true, false);
+		trashBlogEntry(true, false);
 	}
 
 	@Test
 	@Transactional
 	public void testTrashAndRestoreDraft() throws Exception {
-		testTrash(false, false);
+		trashBlogEntry(false, false);
 	}
 
 	protected BlogsEntry addBlogsEntry(
@@ -182,7 +182,7 @@ public class BlogsEntryTrashHandlerTest {
 		return results.getLength();
 	}
 
-	protected void testTrash(boolean approved, boolean delete)
+	protected void trashBlogEntry(boolean approved, boolean delete)
 		throws Exception {
 
 		Group group = ServiceTestUtil.addGroup(

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLFileEntryTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLFileEntryTrashHandlerTest.java
@@ -81,6 +81,23 @@ public class DLFileEntryTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 		testTrash(true, false, false, false, false);
 	}
 
+	protected long doAddSubEntry(long folderId1, long folderId2)
+		throws Exception {
+
+		FileEntry fileEntry = addFileEntry(folderId1, "Subentry.txt");
+
+		return fileEntry.getFileEntryId();
+	}
+
+	protected void doMoveSubEntryFromTrash(long subEntryId) throws Exception {
+		DLAppServiceUtil.moveFileEntryFromTrash(
+			subEntryId, parentFolder.getFolderId(), new ServiceContext());
+	}
+
+	protected void doMoveSubEntryToTrash(long subEntryId) throws Exception {
+		DLAppServiceUtil.moveFileEntryToTrash(subEntryId);
+	}
+
 	protected void testTrash(
 			boolean draft, boolean delete, boolean versioned,
 			boolean leaveCheckedOut, boolean fileRank)

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLFileEntryTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLFileEntryTrashHandlerTest.java
@@ -38,47 +38,47 @@ public class DLFileEntryTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 
 	@Test
 	public void testTrashAndDelete() throws Exception {
-		testTrash(false, true, false, false, false);
+		trashDLFileEntry(false, true, false, false, false);
 	}
 
 	@Test
 	public void testTrashAndDeleteVersioned() throws Exception {
-		testTrash(false, true, true, false, false);
+		trashDLFileEntry(false, true, true, false, false);
 	}
 
 	@Test
 	public void testTrashAndDeleteVersionedAndCheckedOut() throws Exception {
-		testTrash(false, true, true, true, false);
+		trashDLFileEntry(false, true, true, true, false);
 	}
 
 	@Test
 	public void testTrashAndRestore() throws Exception {
-		testTrash(false, false, false, false, false);
+		trashDLFileEntry(false, false, false, false, false);
 	}
 
 	@Test
 	public void testTrashAndRestoreVersioned() throws Exception {
-		testTrash(false, false, true, false, false);
+		trashDLFileEntry(false, false, true, false, false);
 	}
 
 	@Test
 	public void testTrashAndRestoreVersionedAndCheckedOut() throws Exception {
-		testTrash(false, false, true, true, false);
+		trashDLFileEntry(false, false, true, true, false);
 	}
 
 	@Test
 	public void testTrashAndRestoreWithFileRank() throws Exception {
-		testTrash(false, false, false, false, true);
+		trashDLFileEntry(false, false, false, false, true);
 	}
 
 	@Test
 	public void testTrashDraftAndCheckedOutAndRestore() throws Exception {
-		testTrash(true, false, false, true, false);
+		trashDLFileEntry(true, false, false, true, false);
 	}
 
 	@Test
 	public void testTrashDraftAndRestore() throws Exception {
-		testTrash(true, false, false, false, false);
+		trashDLFileEntry(true, false, false, false, false);
 	}
 
 	protected long doAddSubEntry(long folderId1, long folderId2)
@@ -98,7 +98,7 @@ public class DLFileEntryTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 		DLAppServiceUtil.moveFileEntryToTrash(subEntryId);
 	}
 
-	protected void testTrash(
+	protected void trashDLFileEntry(
 			boolean draft, boolean delete, boolean versioned,
 			boolean leaveCheckedOut, boolean fileRank)
 		throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLFileShortcutTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLFileShortcutTrashHandlerTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.trash;
 
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.ExecutionTestListeners;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
@@ -41,6 +42,25 @@ public class DLFileShortcutTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 	@Test
 	public void testTrashAndRestore() throws Exception {
 		testTrash(false);
+	}
+
+	protected long doAddSubEntry(long folderId1, long folderId2)
+		throws Exception {
+
+		FileEntry fileEntry = addFileEntry(folderId2, "Subentry.txt");
+
+		DLFileShortcut dlFileShortcut = addFileShortcut(fileEntry, folderId1);
+
+		return dlFileShortcut.getFileShortcutId();
+	}
+
+	protected void doMoveSubEntryFromTrash(long subEntryId) throws Exception {
+		DLAppServiceUtil.moveFileShortcutFromTrash(
+			subEntryId, parentFolder.getFolderId(), new ServiceContext());
+	}
+
+	protected void doMoveSubEntryToTrash(long subEntryId) throws Exception {
+		DLAppServiceUtil.moveFileShortcutToTrash(subEntryId);
 	}
 
 	protected void testTrash(boolean delete) throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLFileShortcutTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLFileShortcutTrashHandlerTest.java
@@ -36,12 +36,12 @@ public class DLFileShortcutTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 
 	@Test
 	public void testTrashAndDelete() throws Exception {
-		testTrash(true);
+		trashDLFileShortcut(true);
 	}
 
 	@Test
 	public void testTrashAndRestore() throws Exception {
-		testTrash(false);
+		trashDLFileShortcut(false);
 	}
 
 	protected long doAddSubEntry(long folderId1, long folderId2)
@@ -63,7 +63,7 @@ public class DLFileShortcutTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 		DLAppServiceUtil.moveFileShortcutToTrash(subEntryId);
 	}
 
-	protected void testTrash(boolean delete) throws Exception {
+	protected void trashDLFileShortcut(boolean delete) throws Exception {
 		int initialNotInTrashCount = getNotInTrashCount();
 		int initialTrashEntriesCount = getTrashEntriesCount();
 

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLFolderTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLFolderTrashHandlerTest.java
@@ -17,6 +17,7 @@ package com.liferay.portlet.trash;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
+import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.ExecutionTestListeners;
@@ -89,6 +90,23 @@ public class DLFolderTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 	@Test
 	public void testTrashAndRestoreAndTrashFile() throws Exception {
 		testTrash(false, true, true, false);
+	}
+
+	protected long doAddSubEntry(long folderId1, long folderId2)
+		throws Exception {
+
+		Folder folder = addFolder(folderId1, "Sub Folder");
+
+		return folder.getFolderId();
+	}
+
+	protected void doMoveSubEntryFromTrash(long subEntryId) throws Exception {
+		DLAppServiceUtil.moveFolderFromTrash(
+			subEntryId, parentFolder.getFolderId(), new ServiceContext());
+	}
+
+	protected void doMoveSubEntryToTrash(long subEntryId) throws Exception {
+		DLAppServiceUtil.moveFolderToTrash(subEntryId);
 	}
 
 	protected void testTrash(

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLFolderTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLFolderTrashHandlerTest.java
@@ -59,37 +59,37 @@ public class DLFolderTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 
 	@Test
 	public void testTrashAndDelete() throws Exception {
-		testTrash(true, false, false, false);
+		trashDLFolder(true, false, false, false);
 	}
 
 	@Test
 	public void testTrashAndDeleteAndAddFile() throws Exception {
-		testTrash(true, true, false, false);
+		trashDLFolder(true, true, false, false);
 	}
 
 	@Test
 	public void testTrashAndDeleteAndTrashFile() throws Exception {
-		testTrash(true, true, true, false);
+		trashDLFolder(true, true, true, false);
 	}
 
 	@Test
 	public void testTrashAndMoveFile() throws Exception {
-		testTrash(false, true, false, true);
+		trashDLFolder(false, true, false, true);
 	}
 
 	@Test
 	public void testTrashAndRestore() throws Exception {
-		testTrash(false, false, false, false);
+		trashDLFolder(false, false, false, false);
 	}
 
 	@Test
 	public void testTrashAndRestoreAndAddFile() throws Exception {
-		testTrash(false, true, false, false);
+		trashDLFolder(false, true, false, false);
 	}
 
 	@Test
 	public void testTrashAndRestoreAndTrashFile() throws Exception {
-		testTrash(false, true, true, false);
+		trashDLFolder(false, true, true, false);
 	}
 
 	protected long doAddSubEntry(long folderId1, long folderId2)
@@ -109,7 +109,7 @@ public class DLFolderTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 		DLAppServiceUtil.moveFolderToTrash(subEntryId);
 	}
 
-	protected void testTrash(
+	protected void trashDLFolder(
 			boolean delete, boolean file, boolean trashFile,
 			boolean moveFileFromTrash)
 		throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLTrashHandlerTest.java
@@ -65,6 +65,18 @@ public class DLTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 		Assert.assertFalse(folder.getName().contains(StringPool.SLASH));
 	}
 
+	protected long doAddSubEntry(long folderId1, long folderId2)
+		throws Exception {
+
+		return 0;
+	}
+
+	protected void doMoveSubEntryFromTrash(long subEntryId) throws Exception {
+	}
+
+	protected void doMoveSubEntryToTrash(long subEntryId) throws Exception {
+	}
+
 	protected void testDuplicate(
 			boolean duplicateFileEntry, boolean duplicateFolder)
 		throws Exception {
@@ -105,6 +117,10 @@ public class DLTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 		Assert.assertEquals(initialNotInTrashCount, getNotInTrashCount());
 		Assert.assertEquals(
 			initialTrashEntriesCount + trashCount, getTrashEntriesCount());
+	}
+
+	@Override
+	protected void testTrashSubEntry(boolean deleteFolder) throws Exception {
 	}
 
 	private static final String _NAME = "Test Name";

--- a/portal-impl/test/integration/com/liferay/portlet/trash/DLTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/DLTrashHandlerTest.java
@@ -35,17 +35,17 @@ public class DLTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 
 	@Test
 	public void testDuplicateFileEntry() throws Exception {
-		testDuplicate(true, false);
+		checkDuplicate(true, false);
 	}
 
 	@Test
 	public void testDuplicateFolder() throws Exception {
-		testDuplicate(false, true);
+		checkDuplicate(false, true);
 	}
 
 	@Test
 	public void testDuplicateFolderAndFileEntry() throws Exception {
-		testDuplicate(true, true);
+		checkDuplicate(true, true);
 	}
 
 	protected void addAndTrashFileEntry() throws Exception {
@@ -77,7 +77,7 @@ public class DLTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 	protected void doMoveSubEntryToTrash(long subEntryId) throws Exception {
 	}
 
-	protected void testDuplicate(
+	protected void checkDuplicate(
 			boolean duplicateFileEntry, boolean duplicateFolder)
 		throws Exception {
 
@@ -120,7 +120,7 @@ public class DLTrashHandlerTest extends BaseDLTrashHandlerTestCase {
 	}
 
 	@Override
-	protected void testTrashSubEntry(boolean deleteFolder) throws Exception {
+	protected void trashSubEntry(boolean deleteFolder) throws Exception {
 	}
 
 	private static final String _NAME = "Test Name";

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntry.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntry.java
@@ -82,11 +82,11 @@ public interface DLFileEntry extends DLFileEntryModel, PersistedModel {
 
 	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashFolder();
 
-	public boolean isInTrashFolder();
-
 	public boolean hasLock();
 
 	public boolean isCheckedOut();
+
+	public boolean isInTrashFolder();
 
 	public void setExtraSettings(java.lang.String extraSettings);
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryWrapper.java
@@ -911,16 +911,16 @@ public class DLFileEntryWrapper implements DLFileEntry,
 		return _dlFileEntry.getTrashFolder();
 	}
 
-	public boolean isInTrashFolder() {
-		return _dlFileEntry.isInTrashFolder();
-	}
-
 	public boolean hasLock() {
 		return _dlFileEntry.hasLock();
 	}
 
 	public boolean isCheckedOut() {
 		return _dlFileEntry.isCheckedOut();
+	}
+
+	public boolean isInTrashFolder() {
+		return _dlFileEntry.isInTrashFolder();
 	}
 
 	public void setExtraSettingsProperties(

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolder.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolder.java
@@ -49,11 +49,11 @@ public interface DLFolder extends DLFolderModel, PersistedModel {
 
 	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashFolder();
 
-	public boolean isInTrashFolder();
-
 	public boolean hasInheritableLock();
 
 	public boolean hasLock();
+
+	public boolean isInTrashFolder();
 
 	public boolean isLocked();
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
@@ -819,16 +819,16 @@ public class DLFolderWrapper implements DLFolder, ModelWrapper<DLFolder> {
 		return _dlFolder.getTrashFolder();
 	}
 
-	public boolean isInTrashFolder() {
-		return _dlFolder.isInTrashFolder();
-	}
-
 	public boolean hasInheritableLock() {
 		return _dlFolder.hasInheritableLock();
 	}
 
 	public boolean hasLock() {
 		return _dlFolder.hasLock();
+	}
+
+	public boolean isInTrashFolder() {
+		return _dlFolder.isInTrashFolder();
 	}
 
 	public boolean isLocked() {

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalService.java
@@ -151,7 +151,7 @@ public interface DLAppHelperLocalService extends BaseLocalService {
 	public com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutFromTrash(
 		long userId,
 		com.liferay.portlet.documentlibrary.model.DLFileShortcut dlFileShortcut,
-		long newFolderId, long toFileEntryId,
+		long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceUtil.java
@@ -178,13 +178,13 @@ public class DLAppHelperLocalServiceUtil {
 	public static com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutFromTrash(
 		long userId,
 		com.liferay.portlet.documentlibrary.model.DLFileShortcut dlFileShortcut,
-		long newFolderId, long toFileEntryId,
+		long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService()
 				   .moveFileShortcutFromTrash(userId, dlFileShortcut,
-			newFolderId, toFileEntryId, serviceContext);
+			newFolderId, serviceContext);
 	}
 
 	public static com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutToTrash(

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceWrapper.java
@@ -177,12 +177,12 @@ public class DLAppHelperLocalServiceWrapper implements DLAppHelperLocalService,
 	public com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutFromTrash(
 		long userId,
 		com.liferay.portlet.documentlibrary.model.DLFileShortcut dlFileShortcut,
-		long newFolderId, long toFileEntryId,
+		long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _dlAppHelperLocalService.moveFileShortcutFromTrash(userId,
-			dlFileShortcut, newFolderId, toFileEntryId, serviceContext);
+			dlFileShortcut, newFolderId, serviceContext);
 	}
 
 	public com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutToTrash(

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppService.java
@@ -1667,7 +1667,7 @@ public interface DLAppService extends BaseService {
 	* @throws SystemException if a system exception occurred
 	*/
 	public com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutFromTrash(
-		long fileShortcutId, long newFolderId, long toFileEntryId,
+		long fileShortcutId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceUtil.java
@@ -1844,13 +1844,13 @@ public class DLAppServiceUtil {
 	* @throws SystemException if a system exception occurred
 	*/
 	public static com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutFromTrash(
-		long fileShortcutId, long newFolderId, long toFileEntryId,
+		long fileShortcutId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService()
 				   .moveFileShortcutFromTrash(fileShortcutId, newFolderId,
-			toFileEntryId, serviceContext);
+			serviceContext);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceWrapper.java
@@ -1807,12 +1807,12 @@ public class DLAppServiceWrapper implements DLAppService,
 	* @throws SystemException if a system exception occurred
 	*/
 	public com.liferay.portlet.documentlibrary.model.DLFileShortcut moveFileShortcutFromTrash(
-		long fileShortcutId, long newFolderId, long toFileEntryId,
+		long fileShortcutId, long newFolderId,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _dlAppService.moveFileShortcutFromTrash(fileShortcutId,
-			newFolderId, toFileEntryId, serviceContext);
+			newFolderId, serviceContext);
 	}
 
 	/**

--- a/portal-service/test/unit/com/liferay/portal/kernel/cal/TZSRecurrenceTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/cal/TZSRecurrenceTest.java
@@ -26,11 +26,11 @@ import java.util.TimeZone;
 public class TZSRecurrenceTest extends RecurrenceTestCase {
 
 	public void testCompleteTimeZoneWithinTSZRecurrence() {
-		testWithinTSZRecurrence(_timeZone);
+		checkWithinTSZRecurrence(_timeZone);
 	}
 
 	public void testIncompleteTimeZoneWithinTSZRecurrence() {
-		testWithinTSZRecurrence(getIncompleteTimeZone());
+		checkWithinTSZRecurrence(getIncompleteTimeZone());
 	}
 
 	public void testInsideDSTTZSRecurrence() {
@@ -40,9 +40,9 @@ public class TZSRecurrenceTest extends RecurrenceTestCase {
 		TZSRecurrence firstSunOfMonth = getMonthByDayTSZRecurrence(
 			_insideDSTCalendar, _durationHour, SUNDAY, 1, 1, _timeZone);
 
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getInsideDSTCalendar(AUGUST, 7), _durationHour, firstSunOfMonth);
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getInsideDSTCalendar(DECEMBER, 4), _durationHour, firstSunOfMonth);
 
 		// Events starting inside DST matched second day of the month
@@ -51,10 +51,10 @@ public class TZSRecurrenceTest extends RecurrenceTestCase {
 			getMonthByMonthDayTSZRecurrence(
 				_insideDSTCalendar, _durationHour, 2, 1, _timeZone);
 
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getInsideDSTCalendar(AUGUST, 2), _durationHour,
 			secondDayOfMonthTSZRecurrence);
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getInsideDSTCalendar(DECEMBER, 2), _durationHour,
 			secondDayOfMonthTSZRecurrence);
 	}
@@ -68,10 +68,10 @@ public class TZSRecurrenceTest extends RecurrenceTestCase {
 			getMonthByDayTSZRecurrence(
 				_outsideDSTCalendar, _durationHour, MONDAY, 1, 1, _timeZone);
 
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getOutsideDSTCalendar(AUGUST, 1), _durationHour,
 			firstMondayOfMonthTSZRecurrence);
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getOutsideDSTCalendar(DECEMBER, 5), _durationHour,
 			firstMondayOfMonthTSZRecurrence);
 
@@ -81,10 +81,10 @@ public class TZSRecurrenceTest extends RecurrenceTestCase {
 			getMonthByMonthDayTSZRecurrence(
 				_outsideDSTCalendar, _durationHour, 6, 1, _timeZone);
 
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getOutsideDSTCalendar(AUGUST, 6), _durationHour,
 			sixthDayOfMonthTSZRecurrence);
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			getOutsideDSTCalendar(DECEMBER, 6), _durationHour,
 			sixthDayOfMonthTSZRecurrence);
 	}
@@ -165,7 +165,7 @@ public class TZSRecurrenceTest extends RecurrenceTestCase {
 		return getCalendar(2011, month, date, 5, 0);
 	}
 
-	protected void testWithinTSZRecurrence(
+	protected void checkWithinTSZRecurrence(
 		Calendar calendar, Duration duration, TZSRecurrence tszRecurrence) {
 
 		Calendar afterTSZRecurrenceCalendar = Calendar.getInstance();
@@ -201,13 +201,13 @@ public class TZSRecurrenceTest extends RecurrenceTestCase {
 			true, tszRecurrence, startOfTSZRecurrenceCalendar);
 	}
 
-	protected void testWithinTSZRecurrence(TimeZone timeZone) {
+	protected void checkWithinTSZRecurrence(TimeZone timeZone) {
 		TZSRecurrence insideDSTTSZRecurrence = getMonthByDayTSZRecurrence(
 			_insideDSTCalendar, _durationHour, SUNDAY, 1, 1, timeZone);
 
 		Calendar insideDSTCalendar = getCalendar(2013, JULY, 7, 4, 0);
 
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			insideDSTCalendar, _durationHour, insideDSTTSZRecurrence);
 
 		TZSRecurrence outsideDSTTSZRecurrence = getMonthByDayTSZRecurrence(
@@ -215,7 +215,7 @@ public class TZSRecurrenceTest extends RecurrenceTestCase {
 
 		Calendar outsideDSTCalendar = getCalendar(2013, JANUARY, 6, 5, 0);
 
-		testWithinTSZRecurrence(
+		checkWithinTSZRecurrence(
 			outsideDSTCalendar, _durationHour, outsideDSTTSZRecurrence);
 	}
 


### PR DESCRIPTION
I renamed all the test methods which are not tests for JUnit and start with the word test. @migue suggested me that we should follow this pattern.
