### PR TITLE
LPS-29198 NullPointer when opening web content control panel

### DIFF
--- a/portal-web/docroot/html/portlet/journal/init.jsp
+++ b/portal-web/docroot/html/portlet/journal/init.jsp
@@ -122,9 +122,9 @@ page import="com.liferay.util.RSSUtil" %>
 <%
 PortalPreferences portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(liferayPortletRequest);
 
-PortletPreferences preferences = renderRequest.getPreferences();
+PortletPreferences preferences = liferayPortletRequest.getPreferences();
 
-String[] displayViews = StringUtil.split(PrefsParamUtil.getString(preferences, renderRequest, "displayViews", StringUtil.merge(PropsValues.JOURNAL_DISPLAY_VIEWS)));
+String[] displayViews = StringUtil.split(PrefsParamUtil.getString(preferences, liferayPortletRequest, "displayViews", StringUtil.merge(PropsValues.JOURNAL_DISPLAY_VIEWS)));
 
 Format dateFormatDate = FastDateFormatFactoryUtil.getDate(locale, timeZone);
 Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);


### PR DESCRIPTION
This was broken on source formatting. Note that this portlet follows the same pattern as document library (see init.jsp in that portlet)
