### PR TITLE
LPS-29308 Asset Categories URL escaping

### DIFF
--- a/portal-web/docroot/html/taglib/ui/asset_categories_summary/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_summary/page.jsp
@@ -51,7 +51,7 @@ for (AssetVocabulary vocabulary : vocabularies) {
 						portletURL.setParameter("categoryId", String.valueOf(category.getCategoryId()));
 					%>
 
-						<a class="asset-category" href="<%= portletURL.toString() %>"><%= _buildCategoryPath(category, themeDisplay) %></a>
+						<a class="asset-category" href="<%= HtmlUtil.escape(portletURL.toString()) %>"><%= _buildCategoryPath(category, themeDisplay) %></a>
 
 					<%
 					}


### PR DESCRIPTION
Hey Brian, This is a small fix for the asset categories URLs. The URLs were not escaped but this change will fix this. Thanks, Mate
