### PR TITLE
LPS-29266 Fix performance regression

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/pacl/PACLAdvice.java
+++ b/portal-impl/src/com/liferay/portal/security/pacl/PACLAdvice.java
@@ -31,11 +31,24 @@ public class PACLAdvice extends ChainableMethodAdvice {
 
 	@Override
 	public Object invoke(MethodInvocation methodInvocation) throws Throwable {
-		if (!PACLPolicyManager.isActive() ||
-			!PortalSecurityManagerThreadLocal.isEnabled()) {
+		if (!PortalSecurityManagerThreadLocal.isEnabled()) {
+
+			// Proceed so that we do not remove the advice
 
 			try {
-				return proceed(methodInvocation);
+				return methodInvocation.proceed();
+			}
+			catch (Throwable throwable) {
+				throw throwable;
+			}
+		}
+
+		if (!PACLPolicyManager.isActive()) {
+			serviceBeanAopCacheManager.removeMethodInterceptor(
+				methodInvocation, this);
+
+			try {
+				return methodInvocation.proceed();
 			}
 			catch (Throwable throwable) {
 				throw throwable;
@@ -76,8 +89,12 @@ public class PACLAdvice extends ChainableMethodAdvice {
 				}
 			}
 			else if (methodName.equals("toString")) {
-				return proceed(methodInvocation);
+				return method.invoke(thisObject, arguments);
 			}
+		}
+
+		if (!PACLPolicyManager.isActive()) {
+			return method.invoke(thisObject, arguments);
 		}
 
 		PACLPolicy paclPolicy = PACLClassUtil.getPACLPolicy(false, debug);
@@ -91,7 +108,7 @@ public class PACLAdvice extends ChainableMethodAdvice {
 		}
 
 		if (paclPolicy == null) {
-			return proceed(methodInvocation);
+			return methodInvocation.proceed();
 		}
 
 		if (!paclPolicy.hasPortalService(thisObject, method, arguments)) {
@@ -101,10 +118,10 @@ public class PACLAdvice extends ChainableMethodAdvice {
 		boolean checkSQL = PortalSecurityManagerThreadLocal.isCheckSQL();
 
 		try {
-			Class<?> clazz = thisObject.getClass();
+			Class<?> thisObjectClass = thisObject.getClass();
 
 			if (paclPolicy.getClassLoader() !=
-					PACLClassLoaderUtil.getClassLoader(clazz)) {
+					PACLClassLoaderUtil.getClassLoader(thisObjectClass)) {
 
 				// Disable the portal security manager so that PACLDataSource
 				// does not try to check access to tables that can be accessed
@@ -113,36 +130,10 @@ public class PACLAdvice extends ChainableMethodAdvice {
 				PortalSecurityManagerThreadLocal.setCheckSQL(false);
 			}
 
-			return proceed(methodInvocation);
-		}
-		finally {
-			PortalSecurityManagerThreadLocal.setCheckSQL(checkSQL);
-		}
-	}
-
-	protected Object proceed(MethodInvocation methodInvocation)
-		throws Throwable {
-
-		ClassLoader contextClassLoader =
-			PACLClassLoaderUtil.getContextClassLoader();
-
-		Object thisObject = methodInvocation.getThis();
-
-		Class<?> clazz = thisObject.getClass();
-
-		ClassLoader classLoader = PACLClassLoaderUtil.getClassLoader(clazz);
-
-		try {
-			if (contextClassLoader != classLoader) {
-				PACLClassLoaderUtil.setContextClassLoader(classLoader);
-			}
-
 			return methodInvocation.proceed();
 		}
 		finally {
-			if (contextClassLoader != classLoader) {
-				PACLClassLoaderUtil.setContextClassLoader(contextClassLoader);
-			}
+			PortalSecurityManagerThreadLocal.setCheckSQL(checkSQL);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_base_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_base_impl.ftl
@@ -514,7 +514,25 @@ import javax.sql.DataSource;
 				String name, String[] parameterTypes, Object[] arguments)
 			throws Throwable {
 
-			return _clpInvoker.invokeMethod(name, parameterTypes, arguments);
+			Thread currentThread = Thread.currentThread();
+
+			ClassLoader contextClassLoader =
+				currentThread.getContextClassLoader();
+
+			ClassLoader classLoader = getClass().getClassLoader();
+
+			if (contextClassLoader != classLoader) {
+				currentThread.setContextClassLoader(classLoader);
+			}
+
+			try {
+				return _clpInvoker.invokeMethod(name, parameterTypes, arguments);
+			}
+			finally {
+				if (contextClassLoader != classLoader) {
+					currentThread.setContextClassLoader(contextClassLoader);
+				}
+			}
 		}
 	</#if>
 


### PR DESCRIPTION
Only two files change, the PACLAdvice one is undoing previous change, so ignore it.

The service_base_impl.ftl one is switching context classloader on receiver side, by getting service's own define classloader(You should always have permission to do so). 

I am not using the PACLClassLoaderUtil, which means no SecurityManager logic will be shortcut. This may cause it a little bit slower for PACL + CLP, but both PACL and CLP are very slow already, it won't make a difference. But it can improve the general performance when not using CLP, even when PACL is on, and when PACL is off, there is no additional overhead at all.

So basically this is making a rarely used slow path more slower, but making most often used paths much more faster.
