### PR TITLE
[TECH SUPPORT] LPS-29370 Exporting a page template doesn't export configuration of some portlets

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -504,7 +504,8 @@ public class LayoutExporter {
 			portletDataContext.setScopeLayoutUuid(scopeLayoutUuid);
 
 			boolean[] exportPortletControls = getExportPortletControls(
-				companyId, portletId, portletDataContext, parameterMap);
+				companyId, portletId, portletDataContext, parameterMap,
+				group.isLayoutPrototype());
 
 			_portletExporter.exportPortlet(
 				portletDataContext, layoutCache, portletId, layout,
@@ -1047,7 +1048,7 @@ public class LayoutExporter {
 	protected boolean[] getExportPortletControls(
 			long companyId, String portletId,
 			PortletDataContext portletDataContext,
-			Map<String, String[]> parameterMap)
+			Map<String, String[]> parameterMap, boolean layoutPrototypeExport)
 		throws Exception {
 
 		boolean exportPortletData = MapUtil.getBoolean(
@@ -1116,14 +1117,9 @@ public class LayoutExporter {
 			}
 		}
 
-		Group group = GroupLocalServiceUtil.fetchGroup(
-			portletDataContext.getGroupId());
+		if ((layoutPrototypeExport && exportPortletSetup) ||
+			exportPortletSetupAll) {
 
-		if (Validator.isNotNull(group) && group.isLayoutPrototype() && exportPortletSetup) {
-			exportCurPortletSetup = true;
-		}
-
-		if (exportPortletSetupAll) {
 			exportCurPortletSetup = true;
 		}
 

--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -1116,6 +1116,13 @@ public class LayoutExporter {
 			}
 		}
 
+		Group group = GroupLocalServiceUtil.fetchGroup(
+			portletDataContext.getGroupId());
+
+		if (Validator.isNotNull(group) && group.isLayoutPrototype() && exportPortletSetup) {
+			exportCurPortletSetup = true;
+		}
+
 		if (exportPortletSetupAll) {
 			exportCurPortletSetup = true;
 		}

--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -504,8 +504,7 @@ public class LayoutExporter {
 			portletDataContext.setScopeLayoutUuid(scopeLayoutUuid);
 
 			boolean[] exportPortletControls = getExportPortletControls(
-				companyId, portletId, portletDataContext, parameterMap,
-				group.isLayoutPrototype());
+				companyId, portletId, portletDataContext, parameterMap, type);
 
 			_portletExporter.exportPortlet(
 				portletDataContext, layoutCache, portletId, layout,
@@ -1048,7 +1047,7 @@ public class LayoutExporter {
 	protected boolean[] getExportPortletControls(
 			long companyId, String portletId,
 			PortletDataContext portletDataContext,
-			Map<String, String[]> parameterMap, boolean layoutPrototypeExport)
+			Map<String, String[]> parameterMap, String type)
 		throws Exception {
 
 		boolean exportPortletData = MapUtil.getBoolean(
@@ -1117,8 +1116,8 @@ public class LayoutExporter {
 			}
 		}
 
-		if ((layoutPrototypeExport && exportPortletSetup) ||
-			exportPortletSetupAll) {
+		if (exportPortletSetupAll ||
+			(exportPortletSetup && type.equals("layout-prototype"))) {
 
 			exportCurPortletSetup = true;
 		}


### PR DESCRIPTION
When exporting a page template, there are no individual checkboxes for each portlet, so we need to make sure that if the user has checked "Export Portlet Configuration" we export all the portlets configuration.
