### PR TITLE
LPS-28904 Support title and description translation for multi-portlet plugins

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -68,6 +68,7 @@ import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringComparator;
@@ -3160,8 +3161,21 @@ public class PortalImpl implements Portal {
 
 		ResourceBundle resourceBundle = portletConfig.getResourceBundle(locale);
 
-		return resourceBundle.getString(
-			JavaConstants.JAVAX_PORTLET_DESCRIPTION);
+		String portletId = portlet.getRootPortletId();
+
+		String portletDescription =
+			ResourceBundleUtil.getString(
+				resourceBundle,
+				JavaConstants.JAVAX_PORTLET_DESCRIPTION.concat(
+					StringPool.PERIOD).concat(portletId));
+
+		if (Validator.isNull(portletDescription)) {
+			portletDescription =
+				ResourceBundleUtil.getString(
+					resourceBundle, JavaConstants.JAVAX_PORTLET_DESCRIPTION);
+		}
+
+		return portletDescription;
 	}
 
 	public String getPortletDescription(Portlet portlet, User user) {
@@ -3433,7 +3447,21 @@ public class PortalImpl implements Portal {
 
 		ResourceBundle resourceBundle = portletConfig.getResourceBundle(locale);
 
-		return resourceBundle.getString(JavaConstants.JAVAX_PORTLET_TITLE);
+		String portletId = portlet.getRootPortletId();
+
+		String portletTitle =
+			ResourceBundleUtil.getString(
+				resourceBundle,
+				JavaConstants.JAVAX_PORTLET_TITLE.concat(StringPool.PERIOD)
+					.concat(portletId));
+
+		if (Validator.isNull(portletTitle)) {
+			portletTitle =
+				ResourceBundleUtil.getString(
+					resourceBundle, JavaConstants.JAVAX_PORTLET_TITLE);
+		}
+
+		return portletTitle;
 	}
 
 	public String getPortletTitle(Portlet portlet, String languageId) {
@@ -3442,6 +3470,23 @@ public class PortalImpl implements Portal {
 
 	public String getPortletTitle(Portlet portlet, User user) {
 		return getPortletTitle(portlet.getPortletId(), user);
+	}
+
+	public String getPortletTitle(RenderRequest renderRequest) {
+		String portletId = (String)renderRequest.getAttribute(
+			WebKeys.PORTLET_ID);
+
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);
+
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			renderRequest);
+
+		ServletContext servletContext = (ServletContext)request.getAttribute(
+			WebKeys.CTX);
+
+		Locale locale = request.getLocale();
+
+		return getPortletTitle(portlet, servletContext, locale);
 	}
 
 	public String getPortletTitle(RenderResponse renderResponse) {

--- a/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -290,6 +290,16 @@ public class LiferayPortlet extends GenericPortlet {
 		return redirect;
 	}
 
+	@Override
+	protected String getTitle(RenderRequest renderRequest) {
+		try {
+			return PortalUtil.getPortletTitle(renderRequest);
+		}
+		catch (Exception e) {
+			return super.getTitle(renderRequest);
+		}
+	}
+
 	protected boolean isProcessActionRequest(ActionRequest actionRequest) {
 		return isProcessPortletRequest(actionRequest);
 	}

--- a/portal-service/src/com/liferay/portal/util/Portal.java
+++ b/portal-service/src/com/liferay/portal/util/Portal.java
@@ -847,6 +847,8 @@ public interface Portal {
 
 	public String getPortletTitle(Portlet portlet, User user);
 
+	public String getPortletTitle(RenderRequest renderRequest);
+
 	public String getPortletTitle(RenderResponse renderResponse);
 
 	public String getPortletTitle(String portletId, Locale locale);

--- a/portal-service/src/com/liferay/portal/util/PortalUtil.java
+++ b/portal-service/src/com/liferay/portal/util/PortalUtil.java
@@ -1010,6 +1010,10 @@ public class PortalUtil {
 		return getPortal().getPortletTitle(portlet, user);
 	}
 
+	public static String getPortletTitle(RenderRequest renderRequest) {
+		return getPortal().getPortletTitle(renderRequest);
+	}
+
 	public static String getPortletTitle(RenderResponse renderResponse) {
 		return getPortal().getPortletTitle(renderResponse);
 	}

--- a/portal-web/docroot/html/common/themes/portlet.jsp
+++ b/portal-web/docroot/html/common/themes/portlet.jsp
@@ -57,21 +57,15 @@ if (portletDisplay.isAccess() && portletDisplay.isActive() && (portletTitle == n
 	portletTitle = HtmlUtil.extractText(renderResponseImpl.getTitle());
 }
 
-ResourceBundle resourceBundle = portletConfig.getResourceBundle(locale);
-
 if (portletTitle == null) {
-	portletTitle = ResourceBundleUtil.getString(resourceBundle, JavaConstants.JAVAX_PORTLET_TITLE);
+	portletTitle = PortalUtil.getPortletTitle(portlet, pageContext.getServletContext(), locale);
 }
 
 portletDisplay.setTitle(portletTitle);
 
 // Portlet description
 
-String portletDescription = ResourceBundleUtil.getString(resourceBundle, JavaConstants.JAVAX_PORTLET_DESCRIPTION);
-
-if (Validator.isNull(portletDescription)) {
-	portletDescription = PortalUtil.getPortletDescription(portlet.getPortletId(), locale);
-}
+String portletDescription = PortalUtil.getPortletDescription(portlet, pageContext.getServletContext(), locale);
 
 portletDisplay.setDescription(portletDescription);
 


### PR DESCRIPTION
The method _javax.portlet.GenericPortlet.render(renderRequest, renderResponse)_ set the title of the renderResponse to the value obtained by the method _GenericPortlet.getTitle(renderRequest)_. By default this method obtains the portletTitle as:

```
config.getResourceBundle(request.getLocale()).getString("javax.portlet.title");
```

Afterwards some portlets may set a custom title in the renderResponse. For example, the login portlet changes the title of the renderResponse to "Create Account", "Log In", "Sign In" when needed. Thus, the portletTitle to be displayed at portlet.jsp MUST be recovered from the renderResponse and not directly from language resource bundle, in order to keep this feature working.

Since our LiferayPortlet class (extending GenericPortlet) does not override getTitle(renderRequest), it will never return a title defined with our non-standard format javax.portlet.title.portletId. To support this feature, I have overriden the GenericPortlet.getTitle at LiferayPortlet, so that it first tries to recover the title in our non-standard way, and if it fails it does it as in GenericPortlet. This is actually the recommended way to provide dynamic titles (see http://portals.apache.org/pluto/portlet-2.0-apidocs/javax/portlet/GenericPortlet.html#getTitle(javax.portlet.RenderRequest)).

I've tested it and portlet titles are properly translated. Portlets changing/recovering their portletTitle through renderResponse (as login portlet) work fine, too. This case was not considered in the previous pull-request.

@juliocamarero
