### PR TITLE
LPS-29371 The message URLs generated in Message Board mails returns a HTTP status 404

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1066,6 +1066,14 @@ public class PortalImpl implements Portal {
 			String completeURL, ThemeDisplay themeDisplay, Layout layout)
 		throws PortalException, SystemException {
 
+		return getCanonicalURL(completeURL, themeDisplay, layout, false);
+	}
+
+	public String getCanonicalURL(
+			String completeURL, ThemeDisplay themeDisplay, Layout layout,
+			boolean forceLayoutInURL)
+		throws PortalException, SystemException {
+
 		completeURL = removeRedirectParameter(completeURL);
 
 		String parametersURL = StringPool.BLANK;
@@ -1090,10 +1098,11 @@ public class PortalImpl implements Portal {
 
 		String layoutFriendlyURL = StringPool.BLANK;
 
-		if ((groupFriendlyURL.contains(layout.getFriendlyURL()) ||
+		if (forceLayoutInURL ||
+				((groupFriendlyURL.contains(layout.getFriendlyURL()) ||
 			 groupFriendlyURL.contains(
 				StringPool.SLASH + layout.getLayoutId())) &&
-			(!layout.isFirstParent() || Validator.isNotNull(parametersURL))) {
+			(!layout.isFirstParent() || Validator.isNotNull(parametersURL)))) {
 
 			layoutFriendlyURL = layout.getFriendlyURL();
 		}

--- a/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
+++ b/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
@@ -67,11 +67,11 @@ public class ServiceContextFactory {
 			serviceContext.setLayoutFullURL(
 				PortalUtil.getCanonicalURL(
 					PortalUtil.getLayoutFullURL(themeDisplay), themeDisplay,
-					themeDisplay.getLayout()));
+					themeDisplay.getLayout(), true));
 			serviceContext.setLayoutURL(
 				PortalUtil.getCanonicalURL(
 					PortalUtil.getLayoutURL(themeDisplay), themeDisplay,
-					themeDisplay.getLayout()));
+					themeDisplay.getLayout(), true));
 			serviceContext.setPathMain(PortalUtil.getPathMain());
 			serviceContext.setPlid(themeDisplay.getPlid());
 			serviceContext.setPortalURL(PortalUtil.getPortalURL(request));

--- a/portal-service/src/com/liferay/portal/util/Portal.java
+++ b/portal-service/src/com/liferay/portal/util/Portal.java
@@ -358,6 +358,26 @@ public interface Portal {
 		throws PortalException, SystemException;
 
 	/**
+	 * Returns the canonical URL of the page, to distinguish it among its
+	 * translations.
+	 *
+	 * @param  completeURL the complete URL of the page
+	 * @param  themeDisplay the current theme display
+	 * @param  layout the layout. If it is <code>null</code>, then it is
+	 *         generated for the current layout
+	 * @param  forceLayoutInURL adds the page friendlyURL  to the canonical URL
+	 *         even if it is not needed
+	 * @return the canonical URL
+	 * @throws PortalException if a friendly URL or the group could not be
+	 *         retrieved
+	 * @throws SystemException if a system exception occurred
+	 */
+	public String getCanonicalURL(
+			String completeURL, ThemeDisplay themeDisplay, Layout layout,
+			boolean forceLayoutInURL)
+		throws PortalException, SystemException;
+
+	/**
 	 * @deprecated Replaced by the more general {@link #getCDNHost(boolean)}
 	 */
 	public String getCDNHost();

--- a/portal-service/src/com/liferay/portal/util/Portal.java
+++ b/portal-service/src/com/liferay/portal/util/Portal.java
@@ -365,7 +365,7 @@ public interface Portal {
 	 * @param  themeDisplay the current theme display
 	 * @param  layout the layout. If it is <code>null</code>, then it is
 	 *         generated for the current layout
-	 * @param  forceLayoutInURL adds the page friendlyURL  to the canonical URL
+	 * @param  forceLayoutInURL adds the page friendlyURL to the canonical URL
 	 *         even if it is not needed
 	 * @return the canonical URL
 	 * @throws PortalException if a friendly URL or the group could not be

--- a/portal-service/src/com/liferay/portal/util/PortalUtil.java
+++ b/portal-service/src/com/liferay/portal/util/PortalUtil.java
@@ -252,6 +252,15 @@ public class PortalUtil {
 		return getPortal().getCanonicalURL(completeURL, themeDisplay, layout);
 	}
 
+	public static String getCanonicalURL(
+			String completeURL, ThemeDisplay themeDisplay, Layout layout,
+			boolean forceLayoutInURL)
+		throws PortalException, SystemException {
+
+		return getPortal().getCanonicalURL(
+			completeURL, themeDisplay, layout, forceLayoutInURL);
+	}
+
 	/**
 	 * @deprecated {@link #getCDNHost(boolean)}
 	 */


### PR DESCRIPTION
Hi Brian, the reason is that the URL was generated from the one in serviceContext for the layout only (without parameters) and then the message part is concatenated.

In that case the canonical of "liferay.com/home" is "liferay.com", however the canonical of "liferay.com/home/-/message/123" should be "liferay.com/home/-/message/123"... so to avoid this situation we are going to force to include the page part in some situations in which we concatenate the portlet part later.

thank you!
