### PR TITLE
LPS-29476

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -152,10 +152,15 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				List<Role> roles = RoleLocalServiceUtil.getUserRelatedRoles(
 					defaultUserId, groups);
 
+				// Only use the guest group for deriving the roles for
+				// unauthenticated users. Do not add the group to the permission
+				// bag as this implies group membership which is incorrect in
+				// the case of unauthenticated users.
+
 				bag = new PermissionCheckerBagImpl(
 					defaultUserId, new ArrayList<Group>(),
 					new ArrayList<Organization>(), new ArrayList<Group>(),
-					new ArrayList<Group>(), groups, roles);
+					new ArrayList<Group>(), new ArrayList<Group>(), roles);
 			}
 			finally {
 				if (bag == null) {

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -158,17 +158,21 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				// the case of unauthenticated users.
 
 				bag = new PermissionCheckerBagImpl(
-					defaultUserId, new ArrayList<Group>(),
-					new ArrayList<Organization>(), new ArrayList<Group>(),
-					new ArrayList<Group>(), new ArrayList<Group>(), roles);
+					defaultUserId, Collections.<Group>emptyList(),
+					Collections.<Organization>emptyList(),
+					Collections.<Group>emptyList(),
+					Collections.<Group>emptyList(),
+					Collections.<Group>emptyList(), roles);
 			}
 			finally {
 				if (bag == null) {
 					bag = new PermissionCheckerBagImpl(
-						defaultUserId, new ArrayList<Group>(),
-						new ArrayList<Organization>(), new ArrayList<Group>(),
-						new ArrayList<Group>(), new ArrayList<Group>(),
-						new ArrayList<Role>());
+						defaultUserId, Collections.<Group>emptyList(),
+						Collections.<Organization>emptyList(),
+						Collections.<Group>emptyList(),
+						Collections.<Group>emptyList(),
+						Collections.<Group>emptyList(),
+						Collections.<Role>emptyList());
 				}
 
 				PermissionCacheUtil.putBag(
@@ -439,10 +443,12 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		finally {
 			if (bag == null) {
 				bag = new PermissionCheckerBagImpl(
-					userId, new ArrayList<Group>(),
-					new ArrayList<Organization>(), new ArrayList<Group>(),
-					new ArrayList<Group>(), new ArrayList<Group>(),
-					new ArrayList<Role>());
+					userId, Collections.<Group>emptyList(),
+					Collections.<Organization>emptyList(),
+					Collections.<Group>emptyList(),
+					Collections.<Group>emptyList(),
+					Collections.<Group>emptyList(),
+					Collections.<Role>emptyList());
 			}
 
 			PermissionCacheUtil.putBag(userId, groupId, bag);

--- a/portal-impl/src/com/liferay/portlet/journal/util/JournalIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/JournalIndexer.java
@@ -45,8 +45,6 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.security.pacl.PACLClassLoaderUtil;
-import com.liferay.portal.security.permission.ActionKeys;
-import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portlet.journal.NoSuchStructureException;
 import com.liferay.portlet.journal.model.JournalArticle;
@@ -54,7 +52,6 @@ import com.liferay.portlet.journal.model.JournalArticleConstants;
 import com.liferay.portlet.journal.model.JournalStructure;
 import com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.portlet.journal.service.JournalStructureLocalServiceUtil;
-import com.liferay.portlet.journal.service.permission.JournalArticlePermission;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -79,7 +76,6 @@ public class JournalIndexer extends BaseIndexer {
 	public static final String PORTLET_ID = PortletKeys.JOURNAL;
 
 	public JournalIndexer() {
-		setFilterSearch(true);
 		setPermissionAware(true);
 	}
 
@@ -89,16 +85,6 @@ public class JournalIndexer extends BaseIndexer {
 
 	public String getPortletId() {
 		return PORTLET_ID;
-	}
-
-	@Override
-	public boolean hasPermission(
-			PermissionChecker permissionChecker, String entryClassName,
-			long entryClassPK, String actionId)
-		throws Exception {
-
-		return JournalArticlePermission.contains(
-			permissionChecker, entryClassPK, ActionKeys.VIEW);
 	}
 
 	@Override


### PR DESCRIPTION
@ahwongLR @brianchandotcom this fix is wrong. I tested the scenario before the commit and everything worked as expected. Furthermore setting filterSearch true is only for entities which have hierarchical permissions. JournalArticlePermission does not check the web content folder hierarchy and so all this check is doing is making the search slower.
