### PR TITLE
LPS-29482

### DIFF
--- a/build-common-java.xml
+++ b/build-common-java.xml
@@ -75,7 +75,29 @@
 		<if>
 			<available file="bnd.bnd" />
 			<then>
-				<antcall target="manifest-helper" />
+				<trycatch>
+					<try>
+						<taskdef
+							classname="com.liferay.util.ant.ManifestHelperTask"
+							classpathref="project.classpath"
+							name="liferay-manifest-helper"
+						/>
+					</try>
+					<catch>
+						<ant antfile="${project.dir}/portal-service/build.xml" target="compile" inheritAll="false" />
+						<ant antfile="${project.dir}/util-java/build.xml" target="compile" inheritAll="false" />
+
+						<taskdef
+							classname="com.liferay.util.ant.ManifestHelperTask"
+							classpathref="project.classpath"
+							name="liferay-manifest-helper"
+						/>
+					</catch>
+				</trycatch>
+
+				<liferay-manifest-helper
+					classpathref="project.classpath"
+				/>
 
 				<bndexpand propertyfile="${project.dir}/common.bnd" />
 
@@ -142,7 +164,30 @@
 				<available file="classes/META-INF/MANIFEST.MF" />
 			</not>
 			<then>
-				<antcall target="manifest-helper" />
+				<trycatch>
+					<try>
+						<taskdef
+							classname="com.liferay.util.ant.ManifestHelperTask"
+							classpathref="project.classpath"
+							name="liferay-manifest-helper"
+						/>
+					</try>
+					<catch>
+						<ant antfile="${project.dir}/portal-service/build.xml" target="compile" inheritAll="false" />
+						<ant antfile="${project.dir}/util-java/build.xml" target="compile" inheritAll="false" />
+
+						<taskdef
+							classname="com.liferay.util.ant.ManifestHelperTask"
+							classpathref="project.classpath"
+							name="liferay-manifest-helper"
+						/>
+					</catch>
+				</trycatch>
+
+				<liferay-manifest-helper
+					analyze="true"
+					classpathref="project.classpath"
+				/>
 
 				<mkdir dir="classes/META-INF" />
 
@@ -187,32 +232,5 @@
 				</if>
 			</then>
 		</if>
-	</target>
-
-	<target name="manifest-helper">
-		<trycatch>
-			<try>
-				<taskdef
-					classname="com.liferay.util.ant.ManifestHelperTask"
-					classpathref="project.classpath"
-					name="liferay-manifest-helper"
-				/>
-			</try>
-			<catch>
-				<ant antfile="${project.dir}/portal-service/build.xml" target="compile" inheritAll="false" />
-				<ant antfile="${project.dir}/util-java/build.xml" target="compile" inheritAll="false" />
-
-				<taskdef
-					classname="com.liferay.util.ant.ManifestHelperTask"
-					classpathref="project.classpath"
-					name="liferay-manifest-helper"
-				/>
-			</catch>
-		</trycatch>
-
-		<liferay-manifest-helper
-			analyze="true"
-			classpathref="project.classpath"
-		/>
 	</target>
 </project>


### PR DESCRIPTION
This causes the build to be slower by performing a redundant and expensive manifest calculation. Note one case used analyze=true, now they both do.
