### PR TITLE
LPS-29527 Use RenderRequest locale to get the portlet title

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3489,7 +3489,7 @@ public class PortalImpl implements Portal {
 		ServletContext servletContext = (ServletContext)request.getAttribute(
 			WebKeys.CTX);
 
-		Locale locale = request.getLocale();
+		Locale locale = renderRequest.getLocale();
 
 		return getPortletTitle(portlet, servletContext, locale);
 	}


### PR DESCRIPTION
This was a regression related to my changes to support multiple localized titles for plugin portlets. 
I'm still working on solving the TCK test problems. 
