### PR TITLE
LPS-29341

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/EditMessageAction.java
@@ -376,9 +376,8 @@ public class EditMessageAction extends PortletAction {
 					// Post reply
 
 					message = MBMessageServiceUtil.addMessage(
-						groupId, categoryId, threadId, parentMessageId, subject,
-						body, format, inputStreamOVPs, anonymous, priority,
-						allowPingbacks, serviceContext);
+						parentMessageId, subject, body, format, inputStreamOVPs,
+						anonymous, priority, allowPingbacks, serviceContext);
 				}
 			}
 			else {

--- a/portal-impl/src/com/liferay/portlet/messageboards/action/MoveThreadAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/MoveThreadAction.java
@@ -146,8 +146,7 @@ public class MoveThreadAction extends PortletAction {
 				MBMessage.class.getName(), actionRequest);
 
 			MBMessageServiceUtil.addMessage(
-				groupId, categoryId, threadId, thread.getRootMessageId(),
-				subject, body, format,
+				thread.getRootMessageId(), subject, body, format,
 				Collections.<ObjectValuePair<String, InputStream>>emptyList(),
 				false, MBThreadConstants.PRIORITY_NOT_GIVEN, false,
 				serviceContext);

--- a/portal-impl/src/com/liferay/portlet/messageboards/action/SplitThreadAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/SplitThreadAction.java
@@ -166,7 +166,6 @@ public class SplitThreadAction extends PortletAction {
 			serviceContext.setAddGuestPermissions(true);
 
 			MBMessageServiceUtil.addMessage(
-				message.getGroupId(), message.getCategoryId(), oldThreadId,
 				oldParentMessageId, subject, body, format,
 				Collections.<ObjectValuePair<String, InputStream>>emptyList(),
 				false, MBThreadConstants.PRIORITY_NOT_GIVEN,

--- a/portal-impl/src/com/liferay/portlet/messageboards/messaging/MailingListMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/messaging/MailingListMessageListener.java
@@ -248,7 +248,6 @@ public class MailingListMessageListener extends BaseMessageListener {
 			}
 			else {
 				MBMessageServiceUtil.addMessage(
-					groupId, categoryId, parentMessage.getThreadId(),
 					parentMessage.getMessageId(), subject,
 					mbMailMessage.getBody(), MBMessageConstants.DEFAULT_FORMAT,
 					inputStreamOVPs, anonymous, 0.0, true, serviceContext);

--- a/portal-impl/src/com/liferay/portlet/messageboards/pop/MessageListenerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/pop/MessageListenerImpl.java
@@ -203,7 +203,6 @@ public class MessageListenerImpl implements MessageListener {
 			}
 			else {
 				MBMessageServiceUtil.addMessage(
-					groupId, categoryId, parentMessage.getThreadId(),
 					parentMessage.getMessageId(), subject,
 					mbMailMessage.getBody(), MBMessageConstants.DEFAULT_FORMAT,
 					inputStreamOVPs, false, 0.0, true, serviceContext);

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
@@ -142,7 +142,7 @@ public class MBMessageServiceHttp {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
-		HttpPrincipal httpPrincipal, long groupId, long categoryId,
+		HttpPrincipal httpPrincipal, long parentMessageId,
 		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
@@ -153,6 +153,49 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"addMessage", _addMessageParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					parentMessageId, subject, body, format, inputStreamOVPs,
+					anonymous, priority, allowPingbacks, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portlet.messageboards.model.MBMessage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		HttpPrincipal httpPrincipal, long groupId, long categoryId,
+		java.lang.String subject, java.lang.String body,
+		java.lang.String format,
+		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
+					"addMessage", _addMessageParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, subject, body, format, inputStreamOVPs,
@@ -193,7 +236,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"deleteDiscussionMessage",
-					_deleteDiscussionMessageParameterTypes3);
+					_deleteDiscussionMessageParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					className, classPK, permissionClassName, permissionClassPK,
@@ -226,7 +269,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"deleteMessage", _deleteMessageParameterTypes4);
+					"deleteMessage", _deleteMessageParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -259,7 +302,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"deleteMessageAttachments",
-					_deleteMessageAttachmentsParameterTypes5);
+					_deleteMessageAttachmentsParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -292,7 +335,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"getCategoryMessages", _getCategoryMessagesParameterTypes6);
+					"getCategoryMessages", _getCategoryMessagesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status, start, end);
@@ -329,7 +372,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"getCategoryMessagesCount",
-					_getCategoryMessagesCountParameterTypes7);
+					_getCategoryMessagesCountParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status);
@@ -367,7 +410,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"getCategoryMessagesRSS",
-					_getCategoryMessagesRSSParameterTypes8);
+					_getCategoryMessagesRSSParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status, max, type, version, displayStyle,
@@ -409,7 +452,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"getCompanyMessagesRSS",
-					_getCompanyMessagesRSSParameterTypes9);
+					_getCompanyMessagesRSSParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, status, max, type, version, displayStyle,
@@ -447,7 +490,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"getGroupMessagesCount",
-					_getGroupMessagesCountParameterTypes10);
+					_getGroupMessagesCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status);
@@ -483,7 +526,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes11);
+					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, max, type, version, displayStyle, feedURL,
@@ -525,7 +568,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes12);
+					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status, max, type, version, displayStyle, feedURL,
@@ -563,7 +606,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"getMessage", _getMessageParameterTypes13);
+					"getMessage", _getMessageParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -600,7 +643,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"getMessageDisplay", _getMessageDisplayParameterTypes14);
+					"getMessageDisplay", _getMessageDisplayParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, status, threadView, includePrevAndNext);
@@ -637,7 +680,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"getThreadAnswersCount",
-					_getThreadAnswersCountParameterTypes15);
+					_getThreadAnswersCountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId);
@@ -670,7 +713,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"getThreadMessages", _getThreadMessagesParameterTypes16);
+					"getThreadMessages", _getThreadMessagesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId, status, start, end);
@@ -703,7 +746,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"getThreadMessagesCount",
-					_getThreadMessagesCountParameterTypes17);
+					_getThreadMessagesCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId, status);
@@ -740,7 +783,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"getThreadMessagesRSS",
-					_getThreadMessagesRSSParameterTypes18);
+					_getThreadMessagesRSSParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					threadId, status, max, type, version, displayStyle,
@@ -778,7 +821,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"subscribeMessage", _subscribeMessageParameterTypes19);
+					"subscribeMessage", _subscribeMessageParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -810,7 +853,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"unsubscribeMessage", _unsubscribeMessageParameterTypes20);
+					"unsubscribeMessage", _unsubscribeMessageParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -842,7 +885,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"updateAnswer", _updateAnswerParameterTypes21);
+					"updateAnswer", _updateAnswerParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, answer, cascade);
@@ -880,7 +923,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"updateDiscussionMessage",
-					_updateDiscussionMessageParameterTypes22);
+					_updateDiscussionMessageParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					className, classPK, permissionClassName, permissionClassPK,
@@ -923,7 +966,7 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
-					"updateMessage", _updateMessageParameterTypes23);
+					"updateMessage", _updateMessageParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, subject, body, inputStreamOVPs, existingFiles,
@@ -970,86 +1013,92 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addMessageParameterTypes2 = new Class[] {
+			long.class, java.lang.String.class, java.lang.String.class,
+			java.lang.String.class, java.util.List.class, boolean.class,
+			double.class, boolean.class,
+			com.liferay.portal.service.ServiceContext.class
+		};
+	private static final Class<?>[] _addMessageParameterTypes3 = new Class[] {
 			long.class, long.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class, java.util.List.class,
 			boolean.class, double.class, boolean.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteDiscussionMessageParameterTypes3 = new Class[] {
+	private static final Class<?>[] _deleteDiscussionMessageParameterTypes4 = new Class[] {
 			long.class, java.lang.String.class, long.class,
 			java.lang.String.class, long.class, long.class, long.class
 		};
-	private static final Class<?>[] _deleteMessageParameterTypes4 = new Class[] {
+	private static final Class<?>[] _deleteMessageParameterTypes5 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _deleteMessageAttachmentsParameterTypes5 = new Class[] {
+	private static final Class<?>[] _deleteMessageAttachmentsParameterTypes6 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getCategoryMessagesParameterTypes6 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesParameterTypes7 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getCategoryMessagesCountParameterTypes7 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesCountParameterTypes8 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getCategoryMessagesRSSParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesRSSParameterTypes9 = new Class[] {
 			long.class, long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getCompanyMessagesRSSParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getCompanyMessagesRSSParameterTypes10 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupMessagesCountParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesCountParameterTypes11 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupMessagesRSSParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesRSSParameterTypes12 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupMessagesRSSParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesRSSParameterTypes13 = new Class[] {
 			long.class, long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getMessageParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getMessageParameterTypes14 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getMessageDisplayParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getMessageDisplayParameterTypes15 = new Class[] {
 			long.class, int.class, java.lang.String.class, boolean.class
 		};
-	private static final Class<?>[] _getThreadAnswersCountParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getThreadAnswersCountParameterTypes16 = new Class[] {
 			long.class, long.class, long.class
 		};
-	private static final Class<?>[] _getThreadMessagesParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesParameterTypes17 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getThreadMessagesCountParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesCountParameterTypes18 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getThreadMessagesRSSParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesRSSParameterTypes19 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _subscribeMessageParameterTypes19 = new Class[] {
+	private static final Class<?>[] _subscribeMessageParameterTypes20 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _unsubscribeMessageParameterTypes20 = new Class[] {
+	private static final Class<?>[] _unsubscribeMessageParameterTypes21 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateAnswerParameterTypes21 = new Class[] {
+	private static final Class<?>[] _updateAnswerParameterTypes22 = new Class[] {
 			long.class, boolean.class, boolean.class
 		};
-	private static final Class<?>[] _updateDiscussionMessageParameterTypes22 = new Class[] {
+	private static final Class<?>[] _updateDiscussionMessageParameterTypes23 = new Class[] {
 			java.lang.String.class, long.class, java.lang.String.class,
 			long.class, long.class, long.class, java.lang.String.class,
 			java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateMessageParameterTypes23 = new Class[] {
+	private static final Class<?>[] _updateMessageParameterTypes24 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.util.List.class, java.util.List.class, double.class,
 			boolean.class, com.liferay.portal.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
@@ -142,7 +142,7 @@ public class MBMessageServiceHttp {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
-		HttpPrincipal httpPrincipal, long parentMessageId,
+		HttpPrincipal httpPrincipal, long groupId, long categoryId,
 		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
@@ -154,8 +154,8 @@ public class MBMessageServiceHttp {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"addMessage", _addMessageParameterTypes2);
 
-			MethodHandler methodHandler = new MethodHandler(methodKey,
-					parentMessageId, subject, body, format, inputStreamOVPs,
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					categoryId, subject, body, format, inputStreamOVPs,
 					anonymous, priority, allowPingbacks, serviceContext);
 
 			Object returnObj = null;
@@ -185,7 +185,7 @@ public class MBMessageServiceHttp {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
-		HttpPrincipal httpPrincipal, long groupId, long categoryId,
+		HttpPrincipal httpPrincipal, long parentMessageId,
 		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
@@ -197,8 +197,8 @@ public class MBMessageServiceHttp {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class.getName(),
 					"addMessage", _addMessageParameterTypes3);
 
-			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
-					categoryId, subject, body, format, inputStreamOVPs,
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					parentMessageId, subject, body, format, inputStreamOVPs,
 					anonymous, priority, allowPingbacks, serviceContext);
 
 			Object returnObj = null;
@@ -1013,15 +1013,15 @@ public class MBMessageServiceHttp {
 			com.liferay.portal.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addMessageParameterTypes2 = new Class[] {
-			long.class, java.lang.String.class, java.lang.String.class,
-			java.lang.String.class, java.util.List.class, boolean.class,
-			double.class, boolean.class,
-			com.liferay.portal.service.ServiceContext.class
-		};
-	private static final Class<?>[] _addMessageParameterTypes3 = new Class[] {
 			long.class, long.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class, java.util.List.class,
 			boolean.class, double.class, boolean.class,
+			com.liferay.portal.service.ServiceContext.class
+		};
+	private static final Class<?>[] _addMessageParameterTypes3 = new Class[] {
+			long.class, java.lang.String.class, java.lang.String.class,
+			java.lang.String.class, java.util.List.class, boolean.class,
+			double.class, boolean.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteDiscussionMessageParameterTypes4 = new Class[] {

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceSoap.java
@@ -86,6 +86,11 @@ public class MBMessageServiceSoap {
 		}
 	}
 
+	/**
+	* @deprecated {@link #addMessage(long, long, long, long, String, String,
+	String, java.util.List, boolean, double, boolean,
+	com.liferay.portal.service.ServiceContext)}
+	*/
 	public static com.liferay.portlet.messageboards.model.MBMessageSoap addMessage(
 		long groupId, long categoryId, long threadId, long parentMessageId,
 		java.lang.String subject, java.lang.String body,
@@ -99,6 +104,27 @@ public class MBMessageServiceSoap {
 					categoryId, threadId, parentMessageId, subject, body,
 					format, inputStreamOVPs, anonymous, priority,
 					allowPingbacks, serviceContext);
+
+			return com.liferay.portlet.messageboards.model.MBMessageSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessageSoap addMessage(
+		long parentMessageId, java.lang.String subject, java.lang.String body,
+		java.lang.String format,
+		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.portlet.messageboards.model.MBMessage returnValue = MBMessageServiceUtil.addMessage(parentMessageId,
+					subject, body, format, inputStreamOVPs, anonymous,
+					priority, allowPingbacks, serviceContext);
 
 			return com.liferay.portlet.messageboards.model.MBMessageSoap.toSoapModel(returnValue);
 		}

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceSoap.java
@@ -87,8 +87,8 @@ public class MBMessageServiceSoap {
 	}
 
 	/**
-	* @deprecated {@link #addMessage(long, long, long, long, String, String,
-	String, java.util.List, boolean, double, boolean,
+	* @deprecated {@link #addMessage(long, String, String, String,
+	java.util.List, boolean, double, boolean,
 	com.liferay.portal.service.ServiceContext)}
 	*/
 	public static com.liferay.portlet.messageboards.model.MBMessageSoap addMessage(
@@ -115,16 +115,16 @@ public class MBMessageServiceSoap {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessageSoap addMessage(
-		long parentMessageId, java.lang.String subject, java.lang.String body,
-		java.lang.String format,
+		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws RemoteException {
 		try {
-			com.liferay.portlet.messageboards.model.MBMessage returnValue = MBMessageServiceUtil.addMessage(parentMessageId,
-					subject, body, format, inputStreamOVPs, anonymous,
-					priority, allowPingbacks, serviceContext);
+			com.liferay.portlet.messageboards.model.MBMessage returnValue = MBMessageServiceUtil.addMessage(groupId,
+					categoryId, subject, body, format, inputStreamOVPs,
+					anonymous, priority, allowPingbacks, serviceContext);
 
 			return com.liferay.portlet.messageboards.model.MBMessageSoap.toSoapModel(returnValue);
 		}
@@ -136,16 +136,16 @@ public class MBMessageServiceSoap {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessageSoap addMessage(
-		long groupId, long categoryId, java.lang.String subject,
-		java.lang.String body, java.lang.String format,
+		long parentMessageId, java.lang.String subject, java.lang.String body,
+		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws RemoteException {
 		try {
-			com.liferay.portlet.messageboards.model.MBMessage returnValue = MBMessageServiceUtil.addMessage(groupId,
-					categoryId, subject, body, format, inputStreamOVPs,
-					anonymous, priority, allowPingbacks, serviceContext);
+			com.liferay.portlet.messageboards.model.MBMessage returnValue = MBMessageServiceUtil.addMessage(parentMessageId,
+					subject, body, format, inputStreamOVPs, anonymous,
+					priority, allowPingbacks, serviceContext);
 
 			return com.liferay.portlet.messageboards.model.MBMessageSoap.toSoapModel(returnValue);
 		}

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageServiceImpl.java
@@ -88,9 +88,9 @@ public class MBMessageServiceImpl extends MBMessageServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated {@link #addMessage(long, long, long, long, String, String,
-	 * String, java.util.List, boolean, double, boolean,
-	 * com.liferay.portal.service.ServiceContext)}
+	 * @deprecated {@link #addMessage(long, String, String, String,
+	 *             java.util.List, boolean, double, boolean,
+	 *             com.liferay.portal.service.ServiceContext)}
 	 */
 	public MBMessage addMessage(
 			long groupId, long categoryId, long threadId, long parentMessageId,

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
@@ -70,9 +70,23 @@ public interface MBMessageService extends BaseService {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
+	/**
+	* @deprecated {@link #addMessage(long, long, long, long, String, String,
+	String, java.util.List, boolean, double, boolean,
+	com.liferay.portal.service.ServiceContext)}
+	*/
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, long threadId, long parentMessageId,
 		java.lang.String subject, java.lang.String body,
+		java.lang.String format,
+		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long parentMessageId, java.lang.String subject, java.lang.String body,
 		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
@@ -71,8 +71,8 @@ public interface MBMessageService extends BaseService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addMessage(long, long, long, long, String, String,
-	String, java.util.List, boolean, double, boolean,
+	* @deprecated {@link #addMessage(long, String, String, String,
+	java.util.List, boolean, double, boolean,
 	com.liferay.portal.service.ServiceContext)}
 	*/
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
@@ -86,8 +86,8 @@ public interface MBMessageService extends BaseService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
-		long parentMessageId, java.lang.String subject, java.lang.String body,
-		java.lang.String format,
+		long groupId, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -95,8 +95,8 @@ public interface MBMessageService extends BaseService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
-		long groupId, long categoryId, java.lang.String subject,
-		java.lang.String body, java.lang.String format,
+		long parentMessageId, java.lang.String subject, java.lang.String body,
+		java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
 		com.liferay.portal.service.ServiceContext serviceContext)

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
@@ -69,6 +69,11 @@ public class MBMessageServiceUtil {
 			threadId, parentMessageId, subject, body, serviceContext);
 	}
 
+	/**
+	* @deprecated {@link #addMessage(long, long, long, long, String, String,
+	String, java.util.List, boolean, double, boolean,
+	com.liferay.portal.service.ServiceContext)}
+	*/
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, long threadId, long parentMessageId,
 		java.lang.String subject, java.lang.String body,
@@ -82,6 +87,19 @@ public class MBMessageServiceUtil {
 				   .addMessage(groupId, categoryId, threadId, parentMessageId,
 			subject, body, format, inputStreamOVPs, anonymous, priority,
 			allowPingbacks, serviceContext);
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long parentMessageId, java.lang.String subject, java.lang.String body,
+		java.lang.String format,
+		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .addMessage(parentMessageId, subject, body, format,
+			inputStreamOVPs, anonymous, priority, allowPingbacks, serviceContext);
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
@@ -70,8 +70,8 @@ public class MBMessageServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addMessage(long, long, long, long, String, String,
-	String, java.util.List, boolean, double, boolean,
+	* @deprecated {@link #addMessage(long, String, String, String,
+	java.util.List, boolean, double, boolean,
 	com.liferay.portal.service.ServiceContext)}
 	*/
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
@@ -90,19 +90,6 @@ public class MBMessageServiceUtil {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
-		long parentMessageId, java.lang.String subject, java.lang.String body,
-		java.lang.String format,
-		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
-		boolean anonymous, double priority, boolean allowPingbacks,
-		com.liferay.portal.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return getService()
-				   .addMessage(parentMessageId, subject, body, format,
-			inputStreamOVPs, anonymous, priority, allowPingbacks, serviceContext);
-	}
-
-	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, java.lang.String subject,
 		java.lang.String body, java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
@@ -112,6 +99,19 @@ public class MBMessageServiceUtil {
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService()
 				   .addMessage(groupId, categoryId, subject, body, format,
+			inputStreamOVPs, anonymous, priority, allowPingbacks, serviceContext);
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long parentMessageId, java.lang.String subject, java.lang.String body,
+		java.lang.String format,
+		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .addMessage(parentMessageId, subject, body, format,
 			inputStreamOVPs, anonymous, priority, allowPingbacks, serviceContext);
 	}
 

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
@@ -62,6 +62,11 @@ public class MBMessageServiceWrapper implements MBMessageService,
 			threadId, parentMessageId, subject, body, serviceContext);
 	}
 
+	/**
+	* @deprecated {@link #addMessage(long, long, long, long, String, String,
+	String, java.util.List, boolean, double, boolean,
+	com.liferay.portal.service.ServiceContext)}
+	*/
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, long threadId, long parentMessageId,
 		java.lang.String subject, java.lang.String body,
@@ -74,6 +79,19 @@ public class MBMessageServiceWrapper implements MBMessageService,
 		return _mbMessageService.addMessage(groupId, categoryId, threadId,
 			parentMessageId, subject, body, format, inputStreamOVPs, anonymous,
 			priority, allowPingbacks, serviceContext);
+	}
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long parentMessageId, java.lang.String subject, java.lang.String body,
+		java.lang.String format,
+		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _mbMessageService.addMessage(parentMessageId, subject, body,
+			format, inputStreamOVPs, anonymous, priority, allowPingbacks,
+			serviceContext);
 	}
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
@@ -63,8 +63,8 @@ public class MBMessageServiceWrapper implements MBMessageService,
 	}
 
 	/**
-	* @deprecated {@link #addMessage(long, long, long, long, String, String,
-	String, java.util.List, boolean, double, boolean,
+	* @deprecated {@link #addMessage(long, String, String, String,
+	java.util.List, boolean, double, boolean,
 	com.liferay.portal.service.ServiceContext)}
 	*/
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
@@ -82,19 +82,6 @@ public class MBMessageServiceWrapper implements MBMessageService,
 	}
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
-		long parentMessageId, java.lang.String subject, java.lang.String body,
-		java.lang.String format,
-		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
-		boolean anonymous, double priority, boolean allowPingbacks,
-		com.liferay.portal.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return _mbMessageService.addMessage(parentMessageId, subject, body,
-			format, inputStreamOVPs, anonymous, priority, allowPingbacks,
-			serviceContext);
-	}
-
-	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long groupId, long categoryId, java.lang.String subject,
 		java.lang.String body, java.lang.String format,
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
@@ -103,6 +90,19 @@ public class MBMessageServiceWrapper implements MBMessageService,
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _mbMessageService.addMessage(groupId, categoryId, subject, body,
+			format, inputStreamOVPs, anonymous, priority, allowPingbacks,
+			serviceContext);
+	}
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long parentMessageId, java.lang.String subject, java.lang.String body,
+		java.lang.String format,
+		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
+		boolean anonymous, double priority, boolean allowPingbacks,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _mbMessageService.addMessage(parentMessageId, subject, body,
 			format, inputStreamOVPs, anonymous, priority, allowPingbacks,
 			serviceContext);
 	}


### PR DESCRIPTION
Hey Brian,

We needed to deprecate the method and create a new method because there were some params that could potentially be inconsistent (i.e: the parentMessageId didn't match the groupId) and it lead to some security issues (adding messages to some groups where you don't have permission to do it)

Then, we came up with this cleaner solution. We use only the necessary parameters in the method and we get the rest of the necessary information from them. That way we are more robust with the information we are checking and storing.

Thanks!
