### PR TITLE
LPS-28147 Portlet permissions removed when resetting site to site template

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutPrototypesAction.java
+++ b/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutPrototypesAction.java
@@ -147,8 +147,6 @@ public class AddDefaultLayoutPrototypesAction extends SimpleAction {
 		updateLayout(layout);
 
 		addResourcePermissions(layout, portletId);
-		addResourcePermissions(layout, portletId);
-		addResourcePermissions(layout, portletId);
 
 		return portletId;
 	}

--- a/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
+++ b/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
@@ -26,8 +26,10 @@ import com.liferay.portal.model.LayoutConstants;
 import com.liferay.portal.model.LayoutSet;
 import com.liferay.portal.model.LayoutSetPrototype;
 import com.liferay.portal.model.LayoutTypePortlet;
+import com.liferay.portal.model.Portlet;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutSetPrototypeLocalServiceUtil;
+import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
@@ -127,6 +129,8 @@ public class AddDefaultLayoutSetPrototypesAction extends SimpleAction {
 			0, portletId, columnId, -1, false);
 
 		updateLayout(layout);
+
+		addResourcePermissions(layout, portletId);
 
 		return portletId;
 	}
@@ -307,6 +311,16 @@ public class AddDefaultLayoutSetPrototypesAction extends SimpleAction {
 		addPortletId(
 			layout, PortletKeys.TAGS_CATEGORIES_NAVIGATION, "column-2");
 		addPortletId(layout, PortletKeys.TAGS_CLOUD, "column-2");
+	}
+
+	protected void addResourcePermissions(Layout layout, String portletId)
+			throws Exception {
+
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(
+			layout.getCompanyId(), portletId);
+
+		PortalUtil.addPortletDefaultResource(
+			layout.getCompanyId(), layout, portlet);
 	}
 
 	protected void doRun(long companyId) throws Exception {


### PR DESCRIPTION
Portlet permissions are set when the page is first rendered. Since default site templates are created programmatically and usually never rendered, we have to make sure the portlet permissions are properly set to the default values to prevent the site portlet permissions to be removed when resetting the site to its site template.

@JorgeFerrer
@igorbeslic
