### PR TITLE
LPS-29667 Use portal session context to redirect to error pages

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_javaterm_alphabetize_exclusions.properties
+++ b/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_javaterm_alphabetize_exclusions.properties
@@ -2,7 +2,7 @@
 # Files that are allowed to have unalphabetized Java terms. In addition these
 # files are allowed to have non-final variables that are capitalized.
 #
-portal-impl/src/com/liferay/portal/util/PortalImpl.java@6288=true
+portal-impl/src/com/liferay/portal/util/PortalImpl.java@6295=true
 portal-impl/src/com/liferay/portal/webdav/methods/Method.java@54=true
 portal-impl/test/integration/com/liferay/portal/test/TestContext.java@54=true
 portal-impl/test/integration/com/liferay/portal/util/DiffImplTest.java

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.PersistentHttpServletRequestWrapper;
+import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
 import com.liferay.portal.kernel.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
@@ -5263,9 +5264,15 @@ public class PortalImpl implements Portal {
 			}
 		}
 
-		HttpSession session = request.getSession();
+		// LPS-29667
 
-		ServletContext servletContext = session.getServletContext();
+		HttpSession portalSession = PortalSessionThreadLocal.getHttpSession();
+
+		if (portalSession == null) {
+			portalSession = request.getSession();
+		}
+
+		ServletContext portalServletContext = portalSession.getServletContext();
 
 		String redirect = PATH_MAIN + "/portal/status";
 
@@ -5278,7 +5285,7 @@ public class PortalImpl implements Portal {
 			redirect = PropsValues.LAYOUT_FRIENDLY_URL_PAGE_NOT_FOUND;
 
 			RequestDispatcher requestDispatcher =
-				servletContext.getRequestDispatcher(redirect);
+				portalServletContext.getRequestDispatcher(redirect);
 
 			if (requestDispatcher != null) {
 				requestDispatcher.forward(request, response);
@@ -5287,10 +5294,10 @@ public class PortalImpl implements Portal {
 		else if (PropsValues.LAYOUT_SHOW_HTTP_STATUS) {
 			response.setStatus(status);
 
-			SessionErrors.add(request, e.getClass(), e);
+			SessionErrors.add(portalSession, e.getClass(), e);
 
 			RequestDispatcher requestDispatcher =
-				servletContext.getRequestDispatcher(redirect);
+				portalServletContext.getRequestDispatcher(redirect);
 
 			if (requestDispatcher != null) {
 				requestDispatcher.forward(request, response);


### PR DESCRIPTION
We make sure we use the portalSession context for the redirection to the error pages. The portalSession is obtained from the PortalSessionThreadLocal, which has been set by the MainServlet or by the WebServerServlet. We need to check whether this value is null for those cases when it is not initialised, as in FriendlyURLServlet when the page is not found. In those cases, the request session context is always relative to the portal. 
