### PR TITLE
LPS-29720 Undo wrong/unnecessary changes. Whenever FileChannel is retrie...

### DIFF
--- a/portal-impl/src/com/liferay/portal/template/CacheTemplateResource.java
+++ b/portal-impl/src/com/liferay/portal/template/CacheTemplateResource.java
@@ -68,7 +68,6 @@ public class CacheTemplateResource implements TemplateResource {
 		}
 
 		Reader reader = null;
-		UnsyncCharArrayWriter unsyncCharArrayWriter = null;
 
 		try {
 			reader = _templateResource.getReader();
@@ -77,7 +76,8 @@ public class CacheTemplateResource implements TemplateResource {
 
 			int result = -1;
 
-			unsyncCharArrayWriter = new UnsyncCharArrayWriter();
+			UnsyncCharArrayWriter unsyncCharArrayWriter =
+				new UnsyncCharArrayWriter();
 
 			while ((result = reader.read(buffer)) != -1) {
 				unsyncCharArrayWriter.write(buffer, 0, result);
@@ -90,10 +90,6 @@ public class CacheTemplateResource implements TemplateResource {
 		finally {
 			if (reader != null) {
 				reader.close();
-			}
-
-			if (unsyncCharArrayWriter != null) {
-				unsyncCharArrayWriter.close();
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/SampleSQLBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/samplesqlbuilder/SampleSQLBuilder.java
@@ -641,8 +641,6 @@ public class SampleSQLBuilder {
 				FileChannel insertSQLFileChannel =
 					insertSQLFileInputStream.getChannel();
 
-				insertSQLFileInputStream.close();
-
 				insertSQLFileChannel.transferTo(
 					0, insertSQLFileChannel.size(), fileChannel);
 

--- a/portal-impl/src/com/liferay/portal/util/FileImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FileImpl.java
@@ -494,10 +494,9 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 
 	public boolean isSameContent(File file, byte[] bytes, int length) {
 		FileChannel fileChannel = null;
-		FileInputStream fileInputStream = null;
 
 		try {
-			fileInputStream = new FileInputStream(file);
+			FileInputStream fileInputStream = new FileInputStream(file);
 
 			fileChannel = fileInputStream.getChannel();
 
@@ -538,14 +537,6 @@ public class FileImpl implements com.liferay.portal.kernel.util.File {
 			if (fileChannel != null) {
 				try {
 					fileChannel.close();
-				}
-				catch (IOException ioe) {
-				}
-			}
-
-			if (fileInputStream != null) {
-				try {
-					fileInputStream.close();
 				}
 				catch (IOException ioe) {
 				}

--- a/portal-service/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
@@ -234,7 +234,6 @@ public class PortletResponseUtil {
 		}
 		finally {
 			fileChannel.close();
-			fileInputStream.close();
 		}
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/process/ProcessExecutor.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/ProcessExecutor.java
@@ -513,11 +513,11 @@ public class ProcessExecutor {
 			UnsyncBufferedInputStream unsyncBufferedInputStream =
 				new UnsyncBufferedInputStream(_process.getInputStream());
 
-			ObjectInputStream objectInputStream = null;
-			UnsyncByteArrayOutputStream unsyncByteArrayOutputStream = null;
-
 			try {
-				unsyncByteArrayOutputStream = new UnsyncByteArrayOutputStream();
+				ObjectInputStream objectInputStream = null;
+
+				UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+					new UnsyncByteArrayOutputStream();
 
 				while (true) {
 					try {
@@ -540,8 +540,6 @@ public class ProcessExecutor {
 										unsyncByteArrayOutputStream.toString());
 							}
 						}
-
-						unsyncByteArrayOutputStream.close();
 
 						unsyncByteArrayOutputStream = null;
 
@@ -625,14 +623,6 @@ public class ProcessExecutor {
 					// Override previous process exception if there was one
 
 					return resultProcessCallable;
-				}
-
-				if (objectInputStream != null) {
-					objectInputStream.close();
-				}
-
-				if (unsyncByteArrayOutputStream != null) {
-					unsyncByteArrayOutputStream.close();
 				}
 			}
 		}

--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -500,7 +500,6 @@ public class ServletResponseUtil {
 			}
 			finally {
 				fileChannel.close();
-				fileInputStream.close();
 			}
 		}
 	}


### PR DESCRIPTION
...veLPS-29720 Undo wrong/unnecessary changes. Whenever FileChannel is retrieved from FileInput/OutputStream/RandomAccessFile, closing FileChannel is enough, as the parent resource is closed automatically. Whenever dealing with pure in memory IO, unless this is a helpful for GC(to null out internal buffer explicitly, rather than waiting GC to walk through object graph to detach them), closing is not necessary, some in memory IO's close is just a NOP. More importantly, to do complete this meaningless close, it may force to refactor the code to do some try/finally with null checking which may create dead code(never called for sure, see ProcessExecutor change) breaks code coveraged from FileInput/OutputStream/RandomAccessFile, closing FileChannel is enough, as the parent resource is closed automatically. Whenever dealing with pure in memory IO, unless this is a helpful for GC, closing is not necessary, some in memory IO's close is just a NP. More importantly, to do complete this meaningless close, it may force to refactor the code to do some try/finally with null checking which may create dead code(never called for sure) breaks code coverage
