### PR TITLE
LPS-29728 Make strip configurable by content type

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
@@ -27,12 +27,12 @@ import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.KMPSearch;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 import com.liferay.portal.servlet.filters.dynamiccss.DynamicCSSUtil;
@@ -213,6 +213,28 @@ public class StripFilter extends BasePortalFilter {
 		}
 	}
 
+	protected boolean isStripContentType(String contentType) {
+		boolean isStripContentType = false;
+
+		for (String stripContentType : PropsValues.STRIP_MIME_TYPES) {
+			if (stripContentType.endsWith(StringPool.STAR)) {
+				stripContentType = stripContentType.substring(
+					0, stripContentType.length() - 1);
+
+				isStripContentType = contentType.startsWith(stripContentType);
+			}
+			else {
+				isStripContentType = contentType.equals(stripContentType);
+			}
+
+			if (isStripContentType) {
+				break;
+			}
+		}
+
+		return isStripContentType;
+	}
+
 	protected void outputCloseTag(
 			CharBuffer charBuffer, Writer writer, String closeTag)
 		throws Exception {
@@ -348,7 +370,7 @@ public class StripFilter extends BasePortalFilter {
 
 		response.setContentType(contentType);
 
-		if (contentType.startsWith(ContentTypes.TEXT_HTML) &&
+		if (isStripContentType(contentType) &&
 			(bufferCacheServletResponse.getStatus() ==
 				HttpServletResponse.SC_OK)) {
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1556,6 +1556,8 @@ public class PropsValues {
 
 	public static boolean STRIP_JS_LANGUAGE_ATTRIBUTE_SUPPORT_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STRIP_JS_LANGUAGE_ATTRIBUTE_SUPPORT_ENABLED));
 
+	public static String[] STRIP_MIME_TYPES = PropsUtil.getArray(PropsKeys.STRIP_MIME_TYPES);
+
 	public static final String STRUTS_PORTLET_REQUEST_PROCESSOR = PropsUtil.get(PropsKeys.STRUTS_PORTLET_REQUEST_PROCESSOR);
 
 	public static final boolean TAGS_COMPILER_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.TAGS_COMPILER_ENABLED));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6802,6 +6802,12 @@
     #
     strip.js.language.attribute.support.enabled=false
 
+	#
+	# Input a list of comma delimited MIME types that will have its content
+	# stripped by the strip filter.
+	#
+	strip.mime.types=text/html*,text/xml*
+
 ##
 ## Social Activity
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2123,6 +2123,8 @@ public interface PropsKeys {
 
 	public static final String STRIP_JS_LANGUAGE_ATTRIBUTE_SUPPORT_ENABLED = "strip.js.language.attribute.support.enabled";
 
+	public static final String STRIP_MIME_TYPES = "strip.mime.types";
+
 	public static final String STRUTS_PORTLET_REQUEST_PROCESSOR = "struts.portlet.request.processor";
 
 	public static final String SYSTEM_GROUPS = "system.groups";


### PR DESCRIPTION
StripFilter only strips responses with a content type starting with text/html. It might be necessary to strip other response types (see LPS-29607). After reviewing this issue with Jorge, we decided to make configurable which content types will have their response stripped and add text/html\* and text/xml\* by default.
