### PR TITLE
LPS-29715

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/DateFormatFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/DateFormatFactoryImpl.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.util.DateFormatFactory;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 import java.util.Locale;
 import java.util.TimeZone;

--- a/portal-impl/src/com/liferay/portal/util/SimpleDateFormat.java
+++ b/portal-impl/src/com/liferay/portal/util/SimpleDateFormat.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.StringPool;
+
+import java.text.FieldPosition;
+
+import java.util.Date;
+import java.util.Locale;
+
+/**
+ * @author Mate Thurzo
+ */
+public class SimpleDateFormat extends java.text.SimpleDateFormat {
+
+	public SimpleDateFormat(String pattern, Locale locale) {
+		super(pattern, locale);
+
+		if (pattern.equals(DateUtil.ISO_8601_PATTERN)) {
+			_iso8601Format = true;
+		}
+	}
+
+	@Override
+	public StringBuffer format(
+		Date date, StringBuffer toAppendTo, FieldPosition pos) {
+
+		StringBuffer originalFormat = super.format(date, toAppendTo, pos);
+
+		StringBuffer sb = new StringBuffer();
+
+		sb.append(originalFormat.substring(0, 22));
+		sb.append(StringPool.COLON);
+		sb.append(originalFormat.substring(22));
+
+		return sb;
+	}
+
+	private boolean _iso8601Format = false;
+
+}

--- a/portal-impl/src/com/liferay/portlet/expando/util/ExpandoConverterUtil.java
+++ b/portal-impl/src/com/liferay/portlet/expando/util/ExpandoConverterUtil.java
@@ -24,7 +24,6 @@ import com.liferay.portlet.expando.model.ExpandoColumnConstants;
 import java.io.Serializable;
 
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 import java.util.Date;
 
@@ -192,7 +191,7 @@ public class ExpandoConverterUtil {
 	}
 
 	private static DateFormat _getDateFormat() {
-		return new SimpleDateFormat(DateUtil.ISO_8601_PATTERN);
+		return DateUtil.getISO8601Format();
 	}
 
 }


### PR DESCRIPTION
This seems to be the only option for formatting ISO8601 date. Only JDK 7+ will have proper support for it when you use X instead of Z for timezone.
