### PR TITLE
LPS-29922 Fix compile error. FinderCache interface has been left to use ...

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/common/EntityCacheImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/common/EntityCacheImpl.java
@@ -79,7 +79,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 		return CACHE_NAME;
 	}
 
-	public Object getResult(
+	public Serializable getResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey) {
 
 		if (!PropsValues.VALUE_OBJECT_ENTITY_CACHE_ENABLED ||
@@ -88,9 +88,9 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 			return null;
 		}
 
-		Object result = null;
+		Serializable result = null;
 
-		Map<Serializable, Object> localCache = null;
+		Map<Serializable, Serializable> localCache = null;
 
 		Serializable localCacheKey = null;
 
@@ -103,8 +103,8 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 		}
 
 		if (result == null) {
-			PortalCache<Serializable, ?> portalCache = _getPortalCache(
-				clazz.getName(), true);
+			PortalCache<Serializable, Serializable> portalCache =
+				_getPortalCache(clazz.getName(), true);
 
 			Serializable cacheKey = _encodeCacheKey(primaryKey);
 
@@ -126,7 +126,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 		clearCache();
 	}
 
-	public Object loadResult(
+	public Serializable loadResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey,
 		SessionFactory sessionFactory) {
 
@@ -138,16 +138,16 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 			try {
 				session = sessionFactory.openSession();
 
-				return session.load(clazz, primaryKey);
+				return (Serializable)session.load(clazz, primaryKey);
 			}
 			finally {
 				sessionFactory.closeSession(session);
 			}
 		}
 
-		Object result = null;
+		Serializable result = null;
 
-		Map<Serializable, Object> localCache = null;
+		Map<Serializable, Serializable> localCache = null;
 
 		Serializable localCacheKey = null;
 
@@ -159,11 +159,11 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 			result = localCache.get(localCacheKey);
 		}
 
-		Object loadResult = null;
+		Serializable loadResult = null;
 
 		if (result == null) {
-			PortalCache<Serializable, Object> portalCache = _getPortalCache(
-				clazz.getName(), true);
+			PortalCache<Serializable, Serializable> portalCache =
+				_getPortalCache(clazz.getName(), true);
 
 			Serializable cacheKey = _encodeCacheKey(primaryKey);
 
@@ -180,7 +180,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 				try {
 					session = sessionFactory.openSession();
 
-					loadResult = session.load(clazz, primaryKey);
+					loadResult = (Serializable)session.load(clazz, primaryKey);
 				}
 				finally {
 					if (loadResult == null) {
@@ -211,7 +211,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 
 	public void putResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey,
-		Object result) {
+		Serializable result) {
 
 		if (!PropsValues.VALUE_OBJECT_ENTITY_CACHE_ENABLED ||
 			!entityCacheEnabled || !CacheRegistryUtil.isActive() ||
@@ -223,7 +223,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 		result = ((BaseModel<?>)result).toCacheModel();
 
 		if (_localCacheAvailable) {
-			Map<Serializable, Object> localCache = _localCache.get();
+			Map<Serializable, Serializable> localCache = _localCache.get();
 
 			Serializable localCacheKey = _encodeLocalCacheKey(
 				clazz, primaryKey);
@@ -231,7 +231,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 			localCache.put(localCacheKey, result);
 		}
 
-		PortalCache<Serializable, Object> portalCache = _getPortalCache(
+		PortalCache<Serializable, Serializable> portalCache = _getPortalCache(
 			clazz.getName(), true);
 
 		Serializable cacheKey = _encodeCacheKey(primaryKey);
@@ -257,7 +257,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 		}
 
 		if (_localCacheAvailable) {
-			Map<Serializable, Object> localCache = _localCache.get();
+			Map<Serializable, Serializable> localCache = _localCache.get();
 
 			Serializable localCacheKey = _encodeLocalCacheKey(
 				clazz, primaryKey);
@@ -265,7 +265,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 			localCache.remove(localCacheKey);
 		}
 
-		PortalCache<Serializable, Object> portalCache = _getPortalCache(
+		PortalCache<Serializable, Serializable> portalCache = _getPortalCache(
 			clazz.getName(), true);
 
 		Serializable cacheKey = _encodeCacheKey(primaryKey);
@@ -288,20 +288,20 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 			ShardUtil.getCurrentShardName(), clazz.getName(), primaryKey);
 	}
 
-	private PortalCache<Serializable, Object> _getPortalCache(
+	private PortalCache<Serializable, Serializable> _getPortalCache(
 		String className, boolean createIfAbsent) {
 
-		PortalCache<Serializable, Object> portalCache = _portalCaches.get(
+		PortalCache<Serializable, Serializable> portalCache = _portalCaches.get(
 			className);
 
 		if ((portalCache == null) && createIfAbsent) {
 			String groupKey = _GROUP_KEY_PREFIX.concat(className);
 
 			portalCache =
-				(PortalCache<Serializable, Object>)_multiVMPool.getCache(
+				(PortalCache<Serializable, Serializable>)_multiVMPool.getCache(
 					groupKey, PropsValues.VALUE_OBJECT_ENTITY_BLOCKING_CACHE);
 
-			PortalCache<Serializable, Object> previousPortalCache =
+			PortalCache<Serializable, Serializable> previousPortalCache =
 				_portalCaches.putIfAbsent(className, portalCache);
 
 			if (previousPortalCache != null) {
@@ -312,7 +312,7 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 		return portalCache;
 	}
 
-	private Object _toEntityModel(Object result) {
+	private Serializable _toEntityModel(Serializable result) {
 		if (result == StringPool.BLANK) {
 			return null;
 		}
@@ -347,9 +347,10 @@ public class EntityCacheImpl implements CacheRegistryItem, EntityCache {
 	}
 
 	private MultiVMPool _multiVMPool;
-	private ConcurrentMap<String, PortalCache<Serializable, Object>>
+	private ConcurrentMap<String, PortalCache<Serializable, Serializable>>
 		_portalCaches =
-			new ConcurrentHashMap<String, PortalCache<Serializable, Object>>();
+			new ConcurrentHashMap
+				<String, PortalCache<Serializable, Serializable>>();
 
 	private static class CacheKey implements Serializable {
 

--- a/portal-service/src/com/liferay/portal/kernel/dao/orm/EntityCache.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/orm/EntityCache.java
@@ -27,18 +27,18 @@ public interface EntityCache {
 
 	public void clearLocalCache();
 
-	public Object getResult(
+	public Serializable getResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey);
 
 	public void invalidate();
 
-	public Object loadResult(
+	public Serializable loadResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey,
 		SessionFactory sessionFactory);
 
 	public void putResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey,
-		Object result);
+		Serializable result);
 
 	public void removeCache(String className);
 

--- a/portal-service/src/com/liferay/portal/kernel/dao/orm/EntityCacheUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/orm/EntityCacheUtil.java
@@ -41,7 +41,7 @@ public class EntityCacheUtil {
 		return _entityCache;
 	}
 
-	public static Object getResult(
+	public static Serializable getResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey) {
 
 		return getEntityCache().getResult(
@@ -52,7 +52,7 @@ public class EntityCacheUtil {
 		getEntityCache().invalidate();
 	}
 
-	public static Object loadResult(
+	public static Serializable loadResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey,
 		SessionFactory sessionFactory) {
 
@@ -62,7 +62,7 @@ public class EntityCacheUtil {
 
 	public static void putResult(
 		boolean entityCacheEnabled, Class<?> clazz, Serializable primaryKey,
-		Object result) {
+		Serializable result) {
 
 		getEntityCache().putResult(
 			entityCacheEnabled, clazz, primaryKey, result);


### PR DESCRIPTION
...Object raw type due the direct collection interface usage. But all Entity/Finder cacheable objects are actually Serializable, so the inside casting is safe. Will cleanup entity/finder cache api to be more generic in next round refactor
