### PR TITLE
LPS-28165

### DIFF
--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -1528,6 +1528,7 @@
 		<property name="createDate" type="org.hibernate.type.TimestampType" />
 		<property name="modifiedDate" type="org.hibernate.type.TimestampType" />
 		<property name="repositoryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property name="repositoryType" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property name="mountPoint" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property name="parentFolderId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1439,6 +1439,7 @@
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
 		<field name="repositoryId" type="long" />
+		<field name="repositoryType" type="int" />
 		<field name="mountPoint" type="boolean" />
 		<field name="parentFolderId" type="long" />
 		<field name="name" type="String">

--- a/portal-impl/src/META-INF/portal-orm.xml
+++ b/portal-impl/src/META-INF/portal-orm.xml
@@ -2021,6 +2021,7 @@
 				<temporal>TIMESTAMP</temporal>
 			</basic>
 			<basic name="repositoryId" />
+			<basic name="repositoryType" />
 			<basic name="mountPoint" />
 			<basic name="parentFolderId" />
 			<basic name="name" />

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -878,9 +878,9 @@
 	<bean id="com.liferay.portlet.rolesadmin.util.RolesAdminUtil" class="com.liferay.portlet.rolesadmin.util.RolesAdminUtil">
 		<property name="rolesAdmin" ref="com.liferay.portlet.rolesadmin.util.RolesAdmin" />
 	</bean>
-	<bean id="com.liferay.portal.portletFileRepository.PortletFileRepository" class="com.liferay.portal.portletfilerepository.PortletFileRepositoryImpl" />
-	<bean id="com.liferay.portal.portletFileRepository.PortletFileRepositoryUtil" class="com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil">
-		<property name="portletFileRepository" ref="com.liferay.portal.portletFileRepository.PortletFileRepository" />
+	<bean id="com.liferay.portal.portletfilerepository.PortletFileRepository" class="com.liferay.portal.portletfilerepository.PortletFileRepositoryImpl" />
+	<bean id="com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil" class="com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil">
+		<property name="portletFileRepository" ref="com.liferay.portal.portletfilerepository.PortletFileRepository" />
 	</bean>
 	<bean id="com.liferay.portlet.trash.util.Trash" class="com.liferay.portlet.trash.util.TrashImpl" />
 	<bean id="com.liferay.portlet.trash.util.TrashUtil" class="com.liferay.portlet.trash.util.TrashUtil">

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -878,6 +878,10 @@
 	<bean id="com.liferay.portlet.rolesadmin.util.RolesAdminUtil" class="com.liferay.portlet.rolesadmin.util.RolesAdminUtil">
 		<property name="rolesAdmin" ref="com.liferay.portlet.rolesadmin.util.RolesAdmin" />
 	</bean>
+	<bean id="com.liferay.portal.portletFileRepository.PortletFileRepository" class="com.liferay.portal.portletfilerepository.PortletFileRepositoryImpl" />
+	<bean id="com.liferay.portal.portletFileRepository.PortletFileRepositoryUtil" class="com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil">
+		<property name="portletFileRepository" ref="com.liferay.portal.portletFileRepository.PortletFileRepository" />
+	</bean>
 	<bean id="com.liferay.portlet.trash.util.Trash" class="com.liferay.portlet.trash.util.TrashImpl" />
 	<bean id="com.liferay.portlet.trash.util.TrashUtil" class="com.liferay.portlet.trash.util.TrashUtil">
 		<property name="trash" ref="com.liferay.portlet.trash.util.Trash" />

--- a/portal-impl/src/com/liferay/portal/model/impl/RepositoryModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/RepositoryModelImpl.java
@@ -96,7 +96,8 @@ public class RepositoryModelImpl extends BaseModelImpl<Repository>
 			true);
 	public static long COMPANYID_COLUMN_BITMASK = 1L;
 	public static long GROUPID_COLUMN_BITMASK = 2L;
-	public static long UUID_COLUMN_BITMASK = 4L;
+	public static long PORTLETID_COLUMN_BITMASK = 4L;
+	public static long UUID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * Converts the soap model instance into a normal model instance.
@@ -476,7 +477,17 @@ public class RepositoryModelImpl extends BaseModelImpl<Repository>
 	}
 
 	public void setPortletId(String portletId) {
+		_columnBitmask |= PORTLETID_COLUMN_BITMASK;
+
+		if (_originalPortletId == null) {
+			_originalPortletId = _portletId;
+		}
+
 		_portletId = portletId;
+	}
+
+	public String getOriginalPortletId() {
+		return GetterUtil.getString(_originalPortletId);
 	}
 
 	@JSON
@@ -611,6 +622,8 @@ public class RepositoryModelImpl extends BaseModelImpl<Repository>
 		repositoryModelImpl._originalCompanyId = repositoryModelImpl._companyId;
 
 		repositoryModelImpl._setOriginalCompanyId = false;
+
+		repositoryModelImpl._originalPortletId = repositoryModelImpl._portletId;
 
 		repositoryModelImpl._columnBitmask = 0;
 	}
@@ -828,6 +841,7 @@ public class RepositoryModelImpl extends BaseModelImpl<Repository>
 	private String _name;
 	private String _description;
 	private String _portletId;
+	private String _originalPortletId;
 	private String _typeSettings;
 	private long _dlFolderId;
 	private long _columnBitmask;

--- a/portal-impl/src/com/liferay/portal/portletFileRepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletFileRepository/PortletFileRepositoryImpl.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.portletfilerepository;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Repository;
+import com.liferay.portal.model.User;
+import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.RepositoryLocalServiceUtil;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.UserLocalServiceUtil;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PortletKeys;
+import com.liferay.portlet.documentlibrary.NoSuchFolderException;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
+import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.util.DLAppHelperThreadLocal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class PortletFileRepositoryImpl implements PortletFileRepository {
+
+	public void addPortletFileEntries(
+			long groupId, long userId, long folderId,
+			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
+			String portletId)
+		throws PortalException, SystemException {
+
+		for (int i = 0; i < inputStreamOVPs.size(); i++) {
+			ObjectValuePair<String, InputStream> inputStreamOVP =
+				inputStreamOVPs.get(i);
+
+			addPortletFileEntry(
+				groupId, userId, folderId, portletId, inputStreamOVP.getValue(),
+				inputStreamOVP.getKey());
+		}
+	}
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			File file, String fileName)
+		throws PortalException, SystemException {
+
+		if (Validator.isNull(fileName)) {
+			return;
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
+		long repositoryId = getPortletRepository(
+			groupId, portletId, serviceContext);
+
+		String contentType = MimeTypesUtil.getContentType(file);
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.addFileEntry(
+			userId, repositoryId, folderId, fileName, contentType, fileName,
+			StringPool.BLANK, StringPool.BLANK, file, serviceContext);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			InputStream inputStream, String fileName)
+		throws PortalException, SystemException {
+
+		if (inputStream == null) {
+			return;
+		}
+
+		long size = 0;
+
+		try {
+			byte[] bytes = FileUtil.getBytes(inputStream, -1, false);
+
+			size = bytes.length;
+		}
+		catch (IOException ioe) {
+			return;
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
+		long repositoryId = getPortletRepository(
+			groupId, portletId, serviceContext);
+
+		String contentType = MimeTypesUtil.getContentType(
+			inputStream, fileName);
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.addFileEntry(
+			userId, repositoryId, folderId, fileName, contentType, fileName,
+			StringPool.BLANK, StringPool.BLANK, inputStream, size,
+			serviceContext);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void deletePortletFileEntries(long groupId, long folderId)
+		throws PortalException, SystemException {
+
+		List<DLFileEntry> dlFileEntries =
+			DLFileEntryLocalServiceUtil.getFileEntries(
+				groupId, folderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		for (DLFileEntry dlFileEntry : dlFileEntries) {
+			deletePortletFileEntry(dlFileEntry.getFileEntryId());
+		}
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void deletePortletFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.deleteFileEntry(fileEntryId);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void deletePortletFileEntry(
+			long groupId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			groupId, folderId, fileName);
+
+		deletePortletFileEntry(fileEntry.getFileEntryId());
+	}
+
+	public long getFolder(
+			long userId, long repositoryId, long parentFolderId,
+			String folderName, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		Folder folder = null;
+
+		try {
+			folder = DLAppLocalServiceUtil.getFolder(
+				repositoryId, parentFolderId, folderName);
+		}
+		catch (NoSuchFolderException nsfe) {
+			folder = DLAppLocalServiceUtil.addFolder(
+				userId, repositoryId, parentFolderId, folderName,
+				StringPool.BLANK, serviceContext);
+		}
+
+		return folder.getFolderId();
+	}
+
+	public long getPortletRepository(
+			long groupId, String portletId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		Repository repository = RepositoryLocalServiceUtil.getRepository(
+			groupId, portletId);
+
+		if (repository != null) {
+			return repository.getRepositoryId();
+		}
+
+		Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+		User defaultUser = UserLocalServiceUtil.getDefaultUser(
+			group.getCompanyId());
+
+		long classNameId = PortalUtil.getClassNameId(
+			LiferayRepository.class.getName());
+
+		UnicodeProperties typeSettingsProperties = new UnicodeProperties(true);
+
+		return RepositoryLocalServiceUtil.addRepository(
+			defaultUser.getUserId(), groupId, classNameId,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, PortletKeys.WIKI,
+			StringPool.BLANK, PortletKeys.WIKI, typeSettingsProperties,
+			DLFolderConstants.PORTLET_REPOSITORY, serviceContext);
+	}
+
+	public void movePortletFileEntryFromTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.restoreFileEntryFromTrash(userId, fileEntryId);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void movePortletFileEntryFromTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			groupId, folderId, fileName);
+
+		movePortletFileEntryFromTrash(userId, fileEntry.getFileEntryId());
+	}
+
+	public void movePortletFileEntryToTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.moveFileEntryToTrash(userId, fileEntryId);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void movePortletFileEntryToTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			groupId, folderId, fileName);
+
+		movePortletFileEntryToTrash(userId, fileEntry.getFileEntryId());
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
@@ -88,13 +88,17 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 		String contentType = MimeTypesUtil.getContentType(file);
 
-		DLAppHelperThreadLocal.setEnabled(false);
+		try {
+			DLAppHelperThreadLocal.setEnabled(false);
 
-		DLAppLocalServiceUtil.addFileEntry(
-			userId, repositoryId, folderId, fileName, contentType, fileName,
-			StringPool.BLANK, StringPool.BLANK, file, serviceContext);
+			DLAppLocalServiceUtil.addFileEntry(
+				userId, repositoryId, folderId, fileName, contentType, fileName,
+				StringPool.BLANK, StringPool.BLANK, file, serviceContext);
+		}
+		finally {
+			DLAppHelperThreadLocal.setEnabled(true);
+		}
 
-		DLAppHelperThreadLocal.setEnabled(true);
 	}
 
 	public void addPortletFileEntry(
@@ -128,14 +132,17 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 		String contentType = MimeTypesUtil.getContentType(
 			inputStream, fileName);
 
-		DLAppHelperThreadLocal.setEnabled(false);
+		try {
+			DLAppHelperThreadLocal.setEnabled(false);
 
-		DLAppLocalServiceUtil.addFileEntry(
-			userId, repositoryId, folderId, fileName, contentType, fileName,
-			StringPool.BLANK, StringPool.BLANK, inputStream, size,
-			serviceContext);
-
-		DLAppHelperThreadLocal.setEnabled(true);
+			DLAppLocalServiceUtil.addFileEntry(
+				userId, repositoryId, folderId, fileName, contentType, fileName,
+				StringPool.BLANK, StringPool.BLANK, inputStream, size,
+				serviceContext);
+		}
+		finally {
+			DLAppHelperThreadLocal.setEnabled(true);
+		}
 	}
 
 	public void deletePortletFileEntries(long groupId, long folderId)
@@ -153,11 +160,14 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	public void deletePortletFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
-		DLAppHelperThreadLocal.setEnabled(false);
+		try {
+			DLAppHelperThreadLocal.setEnabled(false);
 
-		DLAppLocalServiceUtil.deleteFileEntry(fileEntryId);
-
-		DLAppHelperThreadLocal.setEnabled(true);
+			DLAppLocalServiceUtil.deleteFileEntry(fileEntryId);
+		}
+		finally {
+			DLAppHelperThreadLocal.setEnabled(true);
+		}
 	}
 
 	public void deletePortletFileEntry(
@@ -221,11 +231,15 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	public void movePortletFileEntryFromTrash(long userId, long fileEntryId)
 		throws PortalException, SystemException {
 
-		DLAppHelperThreadLocal.setEnabled(false);
+		try {
+			DLAppHelperThreadLocal.setEnabled(false);
 
-		DLAppLocalServiceUtil.restoreFileEntryFromTrash(userId, fileEntryId);
-
-		DLAppHelperThreadLocal.setEnabled(true);
+			DLAppLocalServiceUtil.restoreFileEntryFromTrash(
+				userId, fileEntryId);
+		}
+		finally {
+			DLAppHelperThreadLocal.setEnabled(true);
+		}
 	}
 
 	public void movePortletFileEntryFromTrash(
@@ -241,11 +255,14 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	public void movePortletFileEntryToTrash(long userId, long fileEntryId)
 		throws PortalException, SystemException {
 
-		DLAppHelperThreadLocal.setEnabled(false);
+		try {
+			DLAppHelperThreadLocal.setEnabled(false);
 
-		DLAppLocalServiceUtil.moveFileEntryToTrash(userId, fileEntryId);
-
-		DLAppHelperThreadLocal.setEnabled(true);
+			DLAppLocalServiceUtil.moveFileEntryToTrash(userId, fileEntryId);
+		}
+		finally {
+			DLAppHelperThreadLocal.setEnabled(true);
+		}
 	}
 
 	public void movePortletFileEntryToTrash(

--- a/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
@@ -148,8 +148,6 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 		for (DLFileEntry dlFileEntry : dlFileEntries) {
 			deletePortletFileEntry(dlFileEntry.getFileEntryId());
 		}
-
-		DLAppHelperThreadLocal.setEnabled(true);
 	}
 
 	public void deletePortletFileEntry(long fileEntryId)

--- a/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.portletfilerepository;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Repository;
+import com.liferay.portal.model.User;
+import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.RepositoryLocalServiceUtil;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.UserLocalServiceUtil;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PortletKeys;
+import com.liferay.portlet.documentlibrary.NoSuchFolderException;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
+import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.util.DLAppHelperThreadLocal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class PortletFileRepositoryImpl implements PortletFileRepository {
+
+	public void addPortletFileEntries(
+			long groupId, long userId, long folderId,
+			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
+			String portletId)
+		throws PortalException, SystemException {
+
+		for (int i = 0; i < inputStreamOVPs.size(); i++) {
+			ObjectValuePair<String, InputStream> inputStreamOVP =
+				inputStreamOVPs.get(i);
+
+			addPortletFileEntry(
+				groupId, userId, folderId, portletId, inputStreamOVP.getValue(),
+				inputStreamOVP.getKey());
+		}
+	}
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			File file, String fileName)
+		throws PortalException, SystemException {
+
+		if (Validator.isNull(fileName)) {
+			return;
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
+		long repositoryId = getPortletRepository(
+			groupId, portletId, serviceContext);
+
+		String contentType = MimeTypesUtil.getContentType(file);
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.addFileEntry(
+			userId, repositoryId, folderId, fileName, contentType, fileName,
+			StringPool.BLANK, StringPool.BLANK, file, serviceContext);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			InputStream inputStream, String fileName)
+		throws PortalException, SystemException {
+
+		if (inputStream == null) {
+			return;
+		}
+
+		long size = 0;
+
+		try {
+			byte[] bytes = FileUtil.getBytes(inputStream, -1, false);
+
+			size = bytes.length;
+		}
+		catch (IOException ioe) {
+			return;
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
+		long repositoryId = getPortletRepository(
+			groupId, portletId, serviceContext);
+
+		String contentType = MimeTypesUtil.getContentType(
+			inputStream, fileName);
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.addFileEntry(
+			userId, repositoryId, folderId, fileName, contentType, fileName,
+			StringPool.BLANK, StringPool.BLANK, inputStream, size,
+			serviceContext);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void deletePortletFileEntries(long groupId, long folderId)
+		throws PortalException, SystemException {
+
+		List<DLFileEntry> dlFileEntries =
+			DLFileEntryLocalServiceUtil.getFileEntries(
+				groupId, folderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		for (DLFileEntry dlFileEntry : dlFileEntries) {
+			deletePortletFileEntry(dlFileEntry.getFileEntryId());
+		}
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void deletePortletFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.deleteFileEntry(fileEntryId);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void deletePortletFileEntry(
+			long groupId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			groupId, folderId, fileName);
+
+		deletePortletFileEntry(fileEntry.getFileEntryId());
+	}
+
+	public long getFolder(
+			long userId, long repositoryId, long parentFolderId,
+			String folderName, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		Folder folder = null;
+
+		try {
+			folder = DLAppLocalServiceUtil.getFolder(
+				repositoryId, parentFolderId, folderName);
+		}
+		catch (NoSuchFolderException nsfe) {
+			folder = DLAppLocalServiceUtil.addFolder(
+				userId, repositoryId, parentFolderId, folderName,
+				StringPool.BLANK, serviceContext);
+		}
+
+		return folder.getFolderId();
+	}
+
+	public long getPortletRepository(
+			long groupId, String portletId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		Repository repository = RepositoryLocalServiceUtil.getRepository(
+			groupId, portletId);
+
+		if (repository != null) {
+			return repository.getRepositoryId();
+		}
+
+		Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+		User defaultUser = UserLocalServiceUtil.getDefaultUser(
+			group.getCompanyId());
+
+		long classNameId = PortalUtil.getClassNameId(
+			LiferayRepository.class.getName());
+
+		UnicodeProperties typeSettingsProperties = new UnicodeProperties(true);
+
+		return RepositoryLocalServiceUtil.addRepository(
+			defaultUser.getUserId(), groupId, classNameId,
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, PortletKeys.WIKI,
+			StringPool.BLANK, PortletKeys.WIKI, typeSettingsProperties,
+			DLFolderConstants.PORTLET_REPOSITORY, serviceContext);
+	}
+
+	public void movePortletFileEntryFromTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.restoreFileEntryFromTrash(userId, fileEntryId);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void movePortletFileEntryFromTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			groupId, folderId, fileName);
+
+		movePortletFileEntryFromTrash(userId, fileEntry.getFileEntryId());
+	}
+
+	public void movePortletFileEntryToTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLAppHelperThreadLocal.setEnabled(false);
+
+		DLAppLocalServiceUtil.moveFileEntryToTrash(userId, fileEntryId);
+
+		DLAppHelperThreadLocal.setEnabled(true);
+	}
+
+	public void movePortletFileEntryToTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		FileEntry fileEntry = DLAppLocalServiceUtil.getFileEntry(
+			groupId, folderId, fileName);
+
+		movePortletFileEntryToTrash(userId, fileEntry.getFileEntryId());
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -1505,6 +1505,10 @@
 		<finder name="GroupId" return-type="Collection">
 			<finder-column name="groupId" />
 		</finder>
+		<finder name="G_P" return-type="Repository" unique="true">
+			<finder-column name="groupId" />
+			<finder-column name="portletId" />
+		</finder>
 
 		<!-- References -->
 

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.RepositoryNameException;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
+import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 
 import java.util.Date;
 import java.util.List;
@@ -58,7 +59,7 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 	public long addRepository(
 			long userId, long groupId, long classNameId, long parentFolderId,
 			String name, String description, String portletId,
-			UnicodeProperties typeSettingsProperties,
+			UnicodeProperties typeSettingsProperties, int repositoryType,
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
@@ -84,7 +85,7 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 		repository.setDlFolderId(
 			getDLFolderId(
 				user, groupId, repositoryId, parentFolderId, name, description,
-				serviceContext));
+				repositoryType, serviceContext));
 
 		repositoryPersistence.update(repository, false);
 
@@ -102,6 +103,19 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 		}
 
 		return repositoryId;
+	}
+
+	public long addRepository(
+			long userId, long groupId, long classNameId, long parentFolderId,
+			String name, String description, String portletId,
+			UnicodeProperties typeSettingsProperties,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return addRepository(
+			userId, groupId, classNameId, parentFolderId, name, description,
+			portletId, typeSettingsProperties,
+			DLFolderConstants.REGULAR_REPOSITORY, serviceContext);
 	}
 
 	public void checkRepository(long repositoryId) throws SystemException {
@@ -230,6 +244,12 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 			repositoryEntryId, localRepositoryImpl);
 
 		return localRepositoryImpl;
+	}
+
+	public Repository getRepository(long groupId, String portletId)
+		throws SystemException {
+
+		return repositoryPersistence.fetchByG_P(groupId, portletId);
 	}
 
 	public com.liferay.portal.kernel.repository.Repository getRepositoryImpl(
@@ -421,7 +441,8 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 
 	protected long getDLFolderId(
 			User user, long groupId, long repositoryId, long parentFolderId,
-			String name, String description, ServiceContext serviceContext)
+			String name, String description, int repositoryType,
+			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
 		if (Validator.isNull(name)) {
@@ -430,7 +451,7 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 
 		DLFolder dlFolder = dlFolderLocalService.addFolder(
 			user.getUserId(), groupId, repositoryId, true, parentFolderId, name,
-			description, serviceContext);
+			description, repositoryType, serviceContext);
 
 		return dlFolder.getFolderId();
 	}

--- a/portal-impl/src/com/liferay/portal/service/persistence/RepositoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/RepositoryPersistenceImpl.java
@@ -146,6 +146,16 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 			RepositoryModelImpl.FINDER_CACHE_ENABLED, Long.class,
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
 			new String[] { Long.class.getName() });
+	public static final FinderPath FINDER_PATH_FETCH_BY_G_P = new FinderPath(RepositoryModelImpl.ENTITY_CACHE_ENABLED,
+			RepositoryModelImpl.FINDER_CACHE_ENABLED, RepositoryImpl.class,
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_P",
+			new String[] { Long.class.getName(), String.class.getName() },
+			RepositoryModelImpl.GROUPID_COLUMN_BITMASK |
+			RepositoryModelImpl.PORTLETID_COLUMN_BITMASK);
+	public static final FinderPath FINDER_PATH_COUNT_BY_G_P = new FinderPath(RepositoryModelImpl.ENTITY_CACHE_ENABLED,
+			RepositoryModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_P",
+			new String[] { Long.class.getName(), String.class.getName() });
 	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_ALL = new FinderPath(RepositoryModelImpl.ENTITY_CACHE_ENABLED,
 			RepositoryModelImpl.FINDER_CACHE_ENABLED, RepositoryImpl.class,
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findAll", new String[0]);
@@ -168,6 +178,13 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 		FinderCacheUtil.putResult(FINDER_PATH_FETCH_BY_UUID_G,
 			new Object[] {
 				repository.getUuid(), Long.valueOf(repository.getGroupId())
+			}, repository);
+
+		FinderCacheUtil.putResult(FINDER_PATH_FETCH_BY_G_P,
+			new Object[] {
+				Long.valueOf(repository.getGroupId()),
+				
+			repository.getPortletId()
 			}, repository);
 
 		repository.resetOriginalValues();
@@ -246,6 +263,13 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 		FinderCacheUtil.removeResult(FINDER_PATH_FETCH_BY_UUID_G,
 			new Object[] {
 				repository.getUuid(), Long.valueOf(repository.getGroupId())
+			});
+
+		FinderCacheUtil.removeResult(FINDER_PATH_FETCH_BY_G_P,
+			new Object[] {
+				Long.valueOf(repository.getGroupId()),
+				
+			repository.getPortletId()
 			});
 	}
 
@@ -451,6 +475,13 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 				new Object[] {
 					repository.getUuid(), Long.valueOf(repository.getGroupId())
 				}, repository);
+
+			FinderCacheUtil.putResult(FINDER_PATH_FETCH_BY_G_P,
+				new Object[] {
+					Long.valueOf(repository.getGroupId()),
+					
+				repository.getPortletId()
+				}, repository);
 		}
 		else {
 			if ((repositoryModelImpl.getColumnBitmask() &
@@ -468,6 +499,26 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 					new Object[] {
 						repository.getUuid(),
 						Long.valueOf(repository.getGroupId())
+					}, repository);
+			}
+
+			if ((repositoryModelImpl.getColumnBitmask() &
+					FINDER_PATH_FETCH_BY_G_P.getColumnBitmask()) != 0) {
+				Object[] args = new Object[] {
+						Long.valueOf(repositoryModelImpl.getOriginalGroupId()),
+						
+						repositoryModelImpl.getOriginalPortletId()
+					};
+
+				FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_G_P, args);
+
+				FinderCacheUtil.removeResult(FINDER_PATH_FETCH_BY_G_P, args);
+
+				FinderCacheUtil.putResult(FINDER_PATH_FETCH_BY_G_P,
+					new Object[] {
+						Long.valueOf(repository.getGroupId()),
+						
+					repository.getPortletId()
 					}, repository);
 			}
 		}
@@ -1956,6 +2007,167 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 	}
 
 	/**
+	 * Returns the repository where groupId = &#63; and portletId = &#63; or throws a {@link com.liferay.portal.NoSuchRepositoryException} if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param portletId the portlet ID
+	 * @return the matching repository
+	 * @throws com.liferay.portal.NoSuchRepositoryException if a matching repository could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public Repository findByG_P(long groupId, String portletId)
+		throws NoSuchRepositoryException, SystemException {
+		Repository repository = fetchByG_P(groupId, portletId);
+
+		if (repository == null) {
+			StringBundler msg = new StringBundler(6);
+
+			msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			msg.append("groupId=");
+			msg.append(groupId);
+
+			msg.append(", portletId=");
+			msg.append(portletId);
+
+			msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(msg.toString());
+			}
+
+			throw new NoSuchRepositoryException(msg.toString());
+		}
+
+		return repository;
+	}
+
+	/**
+	 * Returns the repository where groupId = &#63; and portletId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param portletId the portlet ID
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public Repository fetchByG_P(long groupId, String portletId)
+		throws SystemException {
+		return fetchByG_P(groupId, portletId, true);
+	}
+
+	/**
+	 * Returns the repository where groupId = &#63; and portletId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param portletId the portlet ID
+	 * @param retrieveFromCache whether to use the finder cache
+	 * @return the matching repository, or <code>null</code> if a matching repository could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public Repository fetchByG_P(long groupId, String portletId,
+		boolean retrieveFromCache) throws SystemException {
+		Object[] finderArgs = new Object[] { groupId, portletId };
+
+		Object result = null;
+
+		if (retrieveFromCache) {
+			result = FinderCacheUtil.getResult(FINDER_PATH_FETCH_BY_G_P,
+					finderArgs, this);
+		}
+
+		if (result instanceof Repository) {
+			Repository repository = (Repository)result;
+
+			if ((groupId != repository.getGroupId()) ||
+					!Validator.equals(portletId, repository.getPortletId())) {
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler query = new StringBundler(3);
+
+			query.append(_SQL_SELECT_REPOSITORY_WHERE);
+
+			query.append(_FINDER_COLUMN_G_P_GROUPID_2);
+
+			if (portletId == null) {
+				query.append(_FINDER_COLUMN_G_P_PORTLETID_1);
+			}
+			else {
+				if (portletId.equals(StringPool.BLANK)) {
+					query.append(_FINDER_COLUMN_G_P_PORTLETID_3);
+				}
+				else {
+					query.append(_FINDER_COLUMN_G_P_PORTLETID_2);
+				}
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(groupId);
+
+				if (portletId != null) {
+					qPos.add(portletId);
+				}
+
+				List<Repository> list = q.list();
+
+				result = list;
+
+				Repository repository = null;
+
+				if (list.isEmpty()) {
+					FinderCacheUtil.putResult(FINDER_PATH_FETCH_BY_G_P,
+						finderArgs, list);
+				}
+				else {
+					repository = list.get(0);
+
+					cacheResult(repository);
+
+					if ((repository.getGroupId() != groupId) ||
+							(repository.getPortletId() == null) ||
+							!repository.getPortletId().equals(portletId)) {
+						FinderCacheUtil.putResult(FINDER_PATH_FETCH_BY_G_P,
+							finderArgs, repository);
+					}
+				}
+
+				return repository;
+			}
+			catch (Exception e) {
+				throw processException(e);
+			}
+			finally {
+				if (result == null) {
+					FinderCacheUtil.removeResult(FINDER_PATH_FETCH_BY_G_P,
+						finderArgs);
+				}
+
+				closeSession(session);
+			}
+		}
+		else {
+			if (result instanceof List<?>) {
+				return null;
+			}
+			else {
+				return (Repository)result;
+			}
+		}
+	}
+
+	/**
 	 * Returns all the repositories.
 	 *
 	 * @return the repositories
@@ -2121,6 +2333,21 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 		for (Repository repository : findByGroupId(groupId)) {
 			remove(repository);
 		}
+	}
+
+	/**
+	 * Removes the repository where groupId = &#63; and portletId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param portletId the portlet ID
+	 * @return the repository that was removed
+	 * @throws SystemException if a system exception occurred
+	 */
+	public Repository removeByG_P(long groupId, String portletId)
+		throws NoSuchRepositoryException, SystemException {
+		Repository repository = findByG_P(groupId, portletId);
+
+		return remove(repository);
 	}
 
 	/**
@@ -2395,6 +2622,77 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 	}
 
 	/**
+	 * Returns the number of repositories where groupId = &#63; and portletId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param portletId the portlet ID
+	 * @return the number of matching repositories
+	 * @throws SystemException if a system exception occurred
+	 */
+	public int countByG_P(long groupId, String portletId)
+		throws SystemException {
+		Object[] finderArgs = new Object[] { groupId, portletId };
+
+		Long count = (Long)FinderCacheUtil.getResult(FINDER_PATH_COUNT_BY_G_P,
+				finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(3);
+
+			query.append(_SQL_COUNT_REPOSITORY_WHERE);
+
+			query.append(_FINDER_COLUMN_G_P_GROUPID_2);
+
+			if (portletId == null) {
+				query.append(_FINDER_COLUMN_G_P_PORTLETID_1);
+			}
+			else {
+				if (portletId.equals(StringPool.BLANK)) {
+					query.append(_FINDER_COLUMN_G_P_PORTLETID_3);
+				}
+				else {
+					query.append(_FINDER_COLUMN_G_P_PORTLETID_2);
+				}
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(groupId);
+
+				if (portletId != null) {
+					qPos.add(portletId);
+				}
+
+				count = (Long)q.uniqueResult();
+			}
+			catch (Exception e) {
+				throw processException(e);
+			}
+			finally {
+				if (count == null) {
+					count = Long.valueOf(0);
+				}
+
+				FinderCacheUtil.putResult(FINDER_PATH_COUNT_BY_G_P, finderArgs,
+					count);
+
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
 	 * Returns the number of repositories.
 	 *
 	 * @return the number of repositories
@@ -2611,6 +2909,10 @@ public class RepositoryPersistenceImpl extends BasePersistenceImpl<Repository>
 	private static final String _FINDER_COLUMN_UUID_C_UUID_3 = "(repository.uuid IS NULL OR repository.uuid = ?) AND ";
 	private static final String _FINDER_COLUMN_UUID_C_COMPANYID_2 = "repository.companyId = ?";
 	private static final String _FINDER_COLUMN_GROUPID_GROUPID_2 = "repository.groupId = ?";
+	private static final String _FINDER_COLUMN_G_P_GROUPID_2 = "repository.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_G_P_PORTLETID_1 = "repository.portletId IS NULL";
+	private static final String _FINDER_COLUMN_G_P_PORTLETID_2 = "repository.portletId = ?";
+	private static final String _FINDER_COLUMN_G_P_PORTLETID_3 = "(repository.portletId IS NULL OR repository.portletId = ?)";
 	private static final String _ORDER_BY_ENTITY_ALIAS = "repository.";
 	private static final String _NO_SUCH_ENTITY_WITH_PRIMARY_KEY = "No Repository exists with the primary key ";
 	private static final String _NO_SUCH_ENTITY_WITH_KEY = "No Repository exists with the key {";

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderCacheModel.java
@@ -34,7 +34,7 @@ import java.util.Date;
 public class DLFolderCacheModel implements CacheModel<DLFolder>, Serializable {
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(41);
+		StringBundler sb = new StringBundler(43);
 
 		sb.append("{uuid=");
 		sb.append(uuid);
@@ -54,6 +54,8 @@ public class DLFolderCacheModel implements CacheModel<DLFolder>, Serializable {
 		sb.append(modifiedDate);
 		sb.append(", repositoryId=");
 		sb.append(repositoryId);
+		sb.append(", repositoryType=");
+		sb.append(repositoryType);
 		sb.append(", mountPoint=");
 		sb.append(mountPoint);
 		sb.append(", parentFolderId=");
@@ -118,6 +120,7 @@ public class DLFolderCacheModel implements CacheModel<DLFolder>, Serializable {
 		}
 
 		dlFolderImpl.setRepositoryId(repositoryId);
+		dlFolderImpl.setRepositoryType(repositoryType);
 		dlFolderImpl.setMountPoint(mountPoint);
 		dlFolderImpl.setParentFolderId(parentFolderId);
 
@@ -175,6 +178,7 @@ public class DLFolderCacheModel implements CacheModel<DLFolder>, Serializable {
 	public long createDate;
 	public long modifiedDate;
 	public long repositoryId;
+	public int repositoryType;
 	public boolean mountPoint;
 	public long parentFolderId;
 	public String name;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
@@ -75,6 +75,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 			{ "createDate", Types.TIMESTAMP },
 			{ "modifiedDate", Types.TIMESTAMP },
 			{ "repositoryId", Types.BIGINT },
+			{ "repositoryType", Types.INTEGER },
 			{ "mountPoint", Types.BOOLEAN },
 			{ "parentFolderId", Types.BIGINT },
 			{ "name", Types.VARCHAR },
@@ -87,7 +88,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 			{ "statusByUserName", Types.VARCHAR },
 			{ "statusDate", Types.TIMESTAMP }
 		};
-	public static final String TABLE_SQL_CREATE = "create table DLFolder (uuid_ VARCHAR(75) null,folderId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,repositoryId LONG,mountPoint BOOLEAN,parentFolderId LONG,name VARCHAR(100) null,description STRING null,lastPostDate DATE null,defaultFileEntryTypeId LONG,overrideFileEntryTypes BOOLEAN,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
+	public static final String TABLE_SQL_CREATE = "create table DLFolder (uuid_ VARCHAR(75) null,folderId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,repositoryId LONG,repositoryType INTEGER,mountPoint BOOLEAN,parentFolderId LONG,name VARCHAR(100) null,description STRING null,lastPostDate DATE null,defaultFileEntryTypeId LONG,overrideFileEntryTypes BOOLEAN,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null)";
 	public static final String TABLE_SQL_DROP = "drop table DLFolder";
 	public static final String ORDER_BY_JPQL = " ORDER BY dlFolder.parentFolderId ASC, dlFolder.name ASC";
 	public static final String ORDER_BY_SQL = " ORDER BY DLFolder.parentFolderId ASC, DLFolder.name ASC";
@@ -109,8 +110,9 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 	public static long NAME_COLUMN_BITMASK = 8L;
 	public static long PARENTFOLDERID_COLUMN_BITMASK = 16L;
 	public static long REPOSITORYID_COLUMN_BITMASK = 32L;
-	public static long STATUS_COLUMN_BITMASK = 64L;
-	public static long UUID_COLUMN_BITMASK = 128L;
+	public static long REPOSITORYTYPE_COLUMN_BITMASK = 64L;
+	public static long STATUS_COLUMN_BITMASK = 128L;
+	public static long UUID_COLUMN_BITMASK = 256L;
 
 	/**
 	 * Converts the soap model instance into a normal model instance.
@@ -134,6 +136,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 		model.setCreateDate(soapModel.getCreateDate());
 		model.setModifiedDate(soapModel.getModifiedDate());
 		model.setRepositoryId(soapModel.getRepositoryId());
+		model.setRepositoryType(soapModel.getRepositoryType());
 		model.setMountPoint(soapModel.getMountPoint());
 		model.setParentFolderId(soapModel.getParentFolderId());
 		model.setName(soapModel.getName());
@@ -223,6 +226,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
 		attributes.put("repositoryId", getRepositoryId());
+		attributes.put("repositoryType", getRepositoryType());
 		attributes.put("mountPoint", getMountPoint());
 		attributes.put("parentFolderId", getParentFolderId());
 		attributes.put("name", getName());
@@ -292,6 +296,12 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 
 		if (repositoryId != null) {
 			setRepositoryId(repositoryId);
+		}
+
+		Integer repositoryType = (Integer)attributes.get("repositoryType");
+
+		if (repositoryType != null) {
+			setRepositoryType(repositoryType);
 		}
 
 		Boolean mountPoint = (Boolean)attributes.get("mountPoint");
@@ -504,6 +514,27 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 
 	public long getOriginalRepositoryId() {
 		return _originalRepositoryId;
+	}
+
+	@JSON
+	public int getRepositoryType() {
+		return _repositoryType;
+	}
+
+	public void setRepositoryType(int repositoryType) {
+		_columnBitmask |= REPOSITORYTYPE_COLUMN_BITMASK;
+
+		if (!_setOriginalRepositoryType) {
+			_setOriginalRepositoryType = true;
+
+			_originalRepositoryType = _repositoryType;
+		}
+
+		_repositoryType = repositoryType;
+	}
+
+	public int getOriginalRepositoryType() {
+		return _originalRepositoryType;
 	}
 
 	@JSON
@@ -812,6 +843,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 		dlFolderImpl.setCreateDate(getCreateDate());
 		dlFolderImpl.setModifiedDate(getModifiedDate());
 		dlFolderImpl.setRepositoryId(getRepositoryId());
+		dlFolderImpl.setRepositoryType(getRepositoryType());
 		dlFolderImpl.setMountPoint(getMountPoint());
 		dlFolderImpl.setParentFolderId(getParentFolderId());
 		dlFolderImpl.setName(getName());
@@ -904,6 +936,10 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 
 		dlFolderModelImpl._setOriginalRepositoryId = false;
 
+		dlFolderModelImpl._originalRepositoryType = dlFolderModelImpl._repositoryType;
+
+		dlFolderModelImpl._setOriginalRepositoryType = false;
+
 		dlFolderModelImpl._originalMountPoint = dlFolderModelImpl._mountPoint;
 
 		dlFolderModelImpl._setOriginalMountPoint = false;
@@ -969,6 +1005,8 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 
 		dlFolderCacheModel.repositoryId = getRepositoryId();
 
+		dlFolderCacheModel.repositoryType = getRepositoryType();
+
 		dlFolderCacheModel.mountPoint = getMountPoint();
 
 		dlFolderCacheModel.parentFolderId = getParentFolderId();
@@ -1028,7 +1066,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(41);
+		StringBundler sb = new StringBundler(43);
 
 		sb.append("{uuid=");
 		sb.append(getUuid());
@@ -1048,6 +1086,8 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 		sb.append(getModifiedDate());
 		sb.append(", repositoryId=");
 		sb.append(getRepositoryId());
+		sb.append(", repositoryType=");
+		sb.append(getRepositoryType());
 		sb.append(", mountPoint=");
 		sb.append(getMountPoint());
 		sb.append(", parentFolderId=");
@@ -1076,7 +1116,7 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 	}
 
 	public String toXmlString() {
-		StringBundler sb = new StringBundler(64);
+		StringBundler sb = new StringBundler(67);
 
 		sb.append("<model><model-name>");
 		sb.append("com.liferay.portlet.documentlibrary.model.DLFolder");
@@ -1117,6 +1157,10 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 		sb.append(
 			"<column><column-name>repositoryId</column-name><column-value><![CDATA[");
 		sb.append(getRepositoryId());
+		sb.append("]]></column-value></column>");
+		sb.append(
+			"<column><column-name>repositoryType</column-name><column-value><![CDATA[");
+		sb.append(getRepositoryType());
 		sb.append("]]></column-value></column>");
 		sb.append(
 			"<column><column-name>mountPoint</column-name><column-value><![CDATA[");
@@ -1189,6 +1233,9 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 	private long _repositoryId;
 	private long _originalRepositoryId;
 	private boolean _setOriginalRepositoryId;
+	private int _repositoryType;
+	private int _originalRepositoryType;
+	private boolean _setOriginalRepositoryType;
 	private boolean _mountPoint;
 	private boolean _originalMountPoint;
 	private boolean _setOriginalMountPoint;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -476,6 +476,7 @@
 		<!-- Other fields -->
 
 		<column name="repositoryId" type="long" />
+		<column name="repositoryType" type="int" />
 		<column name="mountPoint" type="boolean" />
 		<column name="parentFolderId" type="long" />
 		<column name="name" type="String" />
@@ -538,6 +539,12 @@
 			<finder-column name="mountPoint" />
 			<finder-column name="parentFolderId" />
 			<finder-column name="status" />
+		</finder>
+		<finder name="G_M_R_P" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="mountPoint" />
+			<finder-column name="repositoryType" />
+			<finder-column name="parentFolderId" />
 		</finder>
 
 		<!-- References -->

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
+import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
@@ -51,6 +52,7 @@ import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.model.DLSyncConstants;
 import com.liferay.portlet.documentlibrary.service.base.DLAppHelperLocalServiceBaseImpl;
 import com.liferay.portlet.documentlibrary.social.DLActivityKeys;
+import com.liferay.portlet.documentlibrary.util.DLAppHelperThreadLocal;
 import com.liferay.portlet.documentlibrary.util.DLProcessorRegistryUtil;
 import com.liferay.portlet.documentlibrary.util.comparator.FileVersionVersionComparator;
 import com.liferay.portlet.social.model.SocialActivityConstants;
@@ -77,17 +79,24 @@ public class DLAppHelperLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		updateAsset(
-			userId, fileEntry, fileVersion,
-			serviceContext.getAssetCategoryIds(),
-			serviceContext.getAssetTagNames(),
-			serviceContext.getAssetLinkEntryIds());
+		if (DLAppHelperThreadLocal.isEnabled()) {
+			updateAsset(
+				userId, fileEntry, fileVersion,
+				serviceContext.getAssetCategoryIds(),
+				serviceContext.getAssetTagNames(),
+				serviceContext.getAssetLinkEntryIds());
 
-		if (PropsValues.DL_FILE_ENTRY_COMMENTS_ENABLED) {
-			mbMessageLocalService.addDiscussionMessage(
-				fileEntry.getUserId(), fileEntry.getUserName(),
-				fileEntry.getGroupId(), DLFileEntryConstants.getClassName(),
-				fileEntry.getFileEntryId(), WorkflowConstants.ACTION_PUBLISH);
+			if (PropsValues.DL_FILE_ENTRY_COMMENTS_ENABLED) {
+				mbMessageLocalService.addDiscussionMessage(
+					fileEntry.getUserId(), fileEntry.getUserName(),
+					fileEntry.getGroupId(), DLFileEntryConstants.getClassName(),
+					fileEntry.getFileEntryId(),
+					WorkflowConstants.ACTION_PUBLISH);
+			}
+		}
+
+		if (!DLAppHelperThreadLocal.isEnabled()) {
+			WorkflowThreadLocal.setEnabled(false);
 		}
 
 		if (fileVersion instanceof LiferayFileVersion) {
@@ -105,7 +114,13 @@ public class DLAppHelperLocalServiceImpl
 				workflowContext);
 		}
 
-		registerDLProcessorCallback(fileEntry, null);
+		if (!DLAppHelperThreadLocal.isEnabled()) {
+			WorkflowThreadLocal.setEnabled(false);
+		}
+
+		if (DLAppHelperThreadLocal.isEnabled()) {
+			registerDLProcessorCallback(fileEntry, null);
+		}
 	}
 
 	public void addFolder(Folder folder, ServiceContext serviceContext)
@@ -209,49 +224,55 @@ public class DLAppHelperLocalServiceImpl
 	public void deleteFileEntry(FileEntry fileEntry)
 		throws PortalException, SystemException {
 
-		// Subscriptions
+		if (DLAppHelperThreadLocal.isEnabled()) {
 
-		subscriptionLocalService.deleteSubscriptions(
-			fileEntry.getCompanyId(), DLFileEntryConstants.getClassName(),
-			fileEntry.getFileEntryId());
+			// Subscriptions
 
-		// File previews
+			subscriptionLocalService.deleteSubscriptions(
+				fileEntry.getCompanyId(), DLFileEntryConstants.getClassName(),
+				fileEntry.getFileEntryId());
 
-		DLProcessorRegistryUtil.cleanUp(fileEntry);
+			// File previews
 
-		// File ranks
+			DLProcessorRegistryUtil.cleanUp(fileEntry);
 
-		dlFileRankLocalService.deleteFileRanksByFileEntryId(
-			fileEntry.getFileEntryId());
+			// File ranks
 
-		// File shortcuts
+			dlFileRankLocalService.deleteFileRanksByFileEntryId(
+				fileEntry.getFileEntryId());
 
-		dlFileShortcutLocalService.deleteFileShortcuts(
-			fileEntry.getFileEntryId());
+			// File shortcuts
 
-		// Sync
+			dlFileShortcutLocalService.deleteFileShortcuts(
+				fileEntry.getFileEntryId());
 
-		if (!isStagingGroup(fileEntry.getGroupId())) {
-			dlSyncLocalService.updateSync(
-				fileEntry.getFileEntryId(), fileEntry.getFolderId(),
-				fileEntry.getTitle(), fileEntry.getDescription(),
-				DLSyncConstants.EVENT_DELETE, fileEntry.getVersion());
+			// Sync
+
+			if (!isStagingGroup(fileEntry.getGroupId())) {
+				dlSyncLocalService.updateSync(
+					fileEntry.getFileEntryId(), fileEntry.getFolderId(),
+					fileEntry.getTitle(), fileEntry.getDescription(),
+					DLSyncConstants.EVENT_DELETE, fileEntry.getVersion());
+			}
+
+			// Asset
+
+			assetEntryLocalService.deleteEntry(
+				DLFileEntryConstants.getClassName(),
+				fileEntry.getFileEntryId());
+
+			// Message boards
+
+			mbMessageLocalService.deleteDiscussionMessages(
+				DLFileEntryConstants.getClassName(),
+				fileEntry.getFileEntryId());
+
+			// Ratings
+
+			ratingsStatsLocalService.deleteStats(
+				DLFileEntryConstants.getClassName(),
+				fileEntry.getFileEntryId());
 		}
-
-		// Asset
-
-		assetEntryLocalService.deleteEntry(
-			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
-
-		// Message boards
-
-		mbMessageLocalService.deleteDiscussionMessages(
-			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
-
-		// Ratings
-
-		ratingsStatsLocalService.deleteStats(
-			DLFileEntryConstants.getClassName(), fileEntry.getFileEntryId());
 
 		// Trash
 
@@ -388,6 +409,10 @@ public class DLAppHelperLocalServiceImpl
 				userId, fileEntry.getFileEntryId(), newFolderId,
 				serviceContext);
 
+			if (DLAppHelperThreadLocal.isEnabled()) {
+				return new LiferayFileEntry(dlFileEntry);
+			}
+
 			dlFileRankLocalService.enableFileRanks(fileEntry.getFileEntryId());
 
 			return new LiferayFileEntry(dlFileEntry);
@@ -396,6 +421,11 @@ public class DLAppHelperLocalServiceImpl
 			dlFileEntryLocalService.updateStatus(
 				userId, fileVersion.getFileVersionId(), fileVersion.getStatus(),
 				new HashMap<String, Serializable>(), serviceContext);
+
+			if (DLAppHelperThreadLocal.isEnabled()) {
+				return dlAppService.moveFileEntry(
+					fileEntry.getFileEntryId(), newFolderId, serviceContext);
+			}
 
 			// File rank
 
@@ -447,6 +477,10 @@ public class DLAppHelperLocalServiceImpl
 			userId, fileVersion.getFileVersionId(),
 			WorkflowConstants.STATUS_IN_TRASH, workflowContext,
 			new ServiceContext());
+
+		if (!DLAppHelperThreadLocal.isEnabled()) {
+			return fileEntry;
+		}
 
 		// File shortcut
 
@@ -611,6 +645,10 @@ public class DLAppHelperLocalServiceImpl
 		dlFileEntryLocalService.updateStatus(
 			userId, fileVersion.getFileVersionId(), trashEntry.getStatus(),
 			workflowContext, new ServiceContext());
+
+		if (!DLAppHelperThreadLocal.isEnabled()) {
+			return;
+		}
 
 		// File shortcut
 
@@ -788,6 +826,10 @@ public class DLAppHelperLocalServiceImpl
 			FileVersion destinationFileVersion, long assetClassPk)
 		throws PortalException, SystemException {
 
+		if (!DLAppHelperThreadLocal.isEnabled()) {
+			return;
+		}
+
 		boolean updateAsset = true;
 
 		if (fileEntry instanceof LiferayFileEntry &&
@@ -809,6 +851,10 @@ public class DLAppHelperLocalServiceImpl
 			long userId, FileEntry fileEntry, FileVersion sourceFileVersion,
 			FileVersion destinationFileVersion, ServiceContext serviceContext)
 		throws PortalException, SystemException {
+
+		if (DLAppHelperThreadLocal.isEnabled()) {
+			return;
+		}
 
 		updateAsset(
 			userId, fileEntry, destinationFileVersion,
@@ -835,6 +881,10 @@ public class DLAppHelperLocalServiceImpl
 			int oldStatus, int newStatus,
 			Map<String, Serializable> workflowContext)
 		throws PortalException, SystemException {
+
+		if (!DLAppHelperThreadLocal.isEnabled()) {
+			return;
+		}
 
 		if (newStatus == WorkflowConstants.STATUS_APPROVED) {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -668,6 +668,26 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 			toLocalRepository, serviceContext);
 	}
 
+	public FileEntry moveFileEntryToTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		LocalRepository localRepository = getLocalRepository(0, fileEntryId, 0);
+
+		FileEntry fileEntry = localRepository.getFileEntry(fileEntryId);
+
+		return dlAppHelperLocalService.moveFileEntryToTrash(userId, fileEntry);
+	}
+
+	public void restoreFileEntryFromTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		LocalRepository localRepository = getLocalRepository(0, fileEntryId, 0);
+
+		FileEntry fileEntry = localRepository.getFileEntry(fileEntryId);
+
+		dlAppHelperLocalService.restoreFileEntryFromTrash(userId, fileEntry);
+	}
+
 	/**
 	 * Updates the file entry's asset replacing its asset categories, tags, and
 	 * links.

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -59,7 +59,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 	public DLFolder addFolder(
 			long userId, long groupId, long repositoryId, boolean mountPoint,
 			long parentFolderId, String name, String description,
-			ServiceContext serviceContext)
+			int repositoryType, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
 		// Folder
@@ -81,6 +81,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 		dlFolder.setCreateDate(serviceContext.getCreateDate(now));
 		dlFolder.setModifiedDate(serviceContext.getModifiedDate(now));
 		dlFolder.setRepositoryId(repositoryId);
+		dlFolder.setRepositoryType(repositoryType);
 		dlFolder.setMountPoint(mountPoint);
 		dlFolder.setParentFolderId(parentFolderId);
 		dlFolder.setName(name);
@@ -127,6 +128,17 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 			new LiferayFolder(dlFolder), serviceContext);
 
 		return dlFolder;
+	}
+
+	public DLFolder addFolder(
+			long userId, long groupId, long repositoryId, boolean mountPoint,
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return addFolder(
+			userId, groupId, repositoryId, mountPoint, parentFolderId, name,
+			description, DLFolderConstants.REGULAR_REPOSITORY, serviceContext);
 	}
 
 	public void deleteAll(long groupId)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
+import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.model.impl.DLFolderImpl;
 import com.liferay.portlet.documentlibrary.service.base.DLFolderServiceBaseImpl;
 import com.liferay.portlet.documentlibrary.service.permission.DLFolderPermission;
@@ -280,8 +281,9 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			OrderByComparator obc)
 		throws SystemException {
 
-		return dlFolderPersistence.filterFindByG_M_P(
-			groupId, true, parentFolderId, start, end, obc);
+		return dlFolderPersistence.filterFindByG_M_R_P(
+			groupId, true, DLFolderConstants.REGULAR_REPOSITORY, parentFolderId,
+			start, end, obc);
 	}
 
 	public int getMountFoldersCount(long groupId, long parentFolderId)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderPersistenceImpl.java
@@ -326,6 +326,35 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 				Long.class.getName(), Boolean.class.getName(),
 				Long.class.getName(), Integer.class.getName()
 			});
+	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_BY_G_M_R_P = new FinderPath(DLFolderModelImpl.ENTITY_CACHE_ENABLED,
+			DLFolderModelImpl.FINDER_CACHE_ENABLED, DLFolderImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_M_R_P",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Long.class.getName(),
+				
+			"java.lang.Integer", "java.lang.Integer",
+				"com.liferay.portal.kernel.util.OrderByComparator"
+			});
+	public static final FinderPath FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_M_R_P =
+		new FinderPath(DLFolderModelImpl.ENTITY_CACHE_ENABLED,
+			DLFolderModelImpl.FINDER_CACHE_ENABLED, DLFolderImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_M_R_P",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Long.class.getName()
+			},
+			DLFolderModelImpl.GROUPID_COLUMN_BITMASK |
+			DLFolderModelImpl.MOUNTPOINT_COLUMN_BITMASK |
+			DLFolderModelImpl.REPOSITORYTYPE_COLUMN_BITMASK |
+			DLFolderModelImpl.PARENTFOLDERID_COLUMN_BITMASK);
+	public static final FinderPath FINDER_PATH_COUNT_BY_G_M_R_P = new FinderPath(DLFolderModelImpl.ENTITY_CACHE_ENABLED,
+			DLFolderModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_M_R_P",
+			new String[] {
+				Long.class.getName(), Boolean.class.getName(),
+				Integer.class.getName(), Long.class.getName()
+			});
 	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_ALL = new FinderPath(DLFolderModelImpl.ENTITY_CACHE_ENABLED,
 			DLFolderModelImpl.FINDER_CACHE_ENABLED, DLFolderImpl.class,
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findAll", new String[0]);
@@ -782,6 +811,31 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 				FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_M_P_S,
 					args);
 			}
+
+			if ((dlFolderModelImpl.getColumnBitmask() &
+					FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_M_R_P.getColumnBitmask()) != 0) {
+				Object[] args = new Object[] {
+						Long.valueOf(dlFolderModelImpl.getOriginalGroupId()),
+						Boolean.valueOf(dlFolderModelImpl.getOriginalMountPoint()),
+						Integer.valueOf(dlFolderModelImpl.getOriginalRepositoryType()),
+						Long.valueOf(dlFolderModelImpl.getOriginalParentFolderId())
+					};
+
+				FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_G_M_R_P, args);
+				FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_M_R_P,
+					args);
+
+				args = new Object[] {
+						Long.valueOf(dlFolderModelImpl.getGroupId()),
+						Boolean.valueOf(dlFolderModelImpl.getMountPoint()),
+						Integer.valueOf(dlFolderModelImpl.getRepositoryType()),
+						Long.valueOf(dlFolderModelImpl.getParentFolderId())
+					};
+
+				FinderCacheUtil.removeResult(FINDER_PATH_COUNT_BY_G_M_R_P, args);
+				FinderCacheUtil.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_M_R_P,
+					args);
+			}
 		}
 
 		EntityCacheUtil.putResult(DLFolderModelImpl.ENTITY_CACHE_ENABLED,
@@ -885,6 +939,7 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 		dlFolderImpl.setCreateDate(dlFolder.getCreateDate());
 		dlFolderImpl.setModifiedDate(dlFolder.getModifiedDate());
 		dlFolderImpl.setRepositoryId(dlFolder.getRepositoryId());
+		dlFolderImpl.setRepositoryType(dlFolder.getRepositoryType());
 		dlFolderImpl.setMountPoint(dlFolder.isMountPoint());
 		dlFolderImpl.setParentFolderId(dlFolder.getParentFolderId());
 		dlFolderImpl.setName(dlFolder.getName());
@@ -6929,6 +6984,833 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 	}
 
 	/**
+	 * Returns all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @return the matching document library folders
+	 * @throws SystemException if a system exception occurred
+	 */
+	public List<DLFolder> findByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId) throws SystemException {
+		return findByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param start the lower bound of the range of document library folders
+	 * @param end the upper bound of the range of document library folders (not inclusive)
+	 * @return the range of matching document library folders
+	 * @throws SystemException if a system exception occurred
+	 */
+	public List<DLFolder> findByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId, int start, int end)
+		throws SystemException {
+		return findByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param start the lower bound of the range of document library folders
+	 * @param end the upper bound of the range of document library folders (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library folders
+	 * @throws SystemException if a system exception occurred
+	 */
+	public List<DLFolder> findByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId, int start, int end,
+		OrderByComparator orderByComparator) throws SystemException {
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+			finderPath = FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_M_R_P;
+			finderArgs = new Object[] {
+					groupId, mountPoint, repositoryType, parentFolderId
+				};
+		}
+		else {
+			finderPath = FINDER_PATH_WITH_PAGINATION_FIND_BY_G_M_R_P;
+			finderArgs = new Object[] {
+					groupId, mountPoint, repositoryType, parentFolderId,
+					
+					start, end, orderByComparator
+				};
+		}
+
+		List<DLFolder> list = (List<DLFolder>)FinderCacheUtil.getResult(finderPath,
+				finderArgs, this);
+
+		if ((list != null) && !list.isEmpty()) {
+			for (DLFolder dlFolder : list) {
+				if ((groupId != dlFolder.getGroupId()) ||
+						(mountPoint != dlFolder.getMountPoint()) ||
+						(repositoryType != dlFolder.getRepositoryType()) ||
+						(parentFolderId != dlFolder.getParentFolderId())) {
+					list = null;
+
+					break;
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(6 +
+						(orderByComparator.getOrderByFields().length * 3));
+			}
+			else {
+				query = new StringBundler(6);
+			}
+
+			query.append(_SQL_SELECT_DLFOLDER_WHERE);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_GROUPID_2);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_MOUNTPOINT_2);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_REPOSITORYTYPE_2);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_PARENTFOLDERID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_ALIAS,
+					orderByComparator);
+			}
+
+			else {
+				query.append(DLFolderModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(groupId);
+
+				qPos.add(mountPoint);
+
+				qPos.add(repositoryType);
+
+				qPos.add(parentFolderId);
+
+				list = (List<DLFolder>)QueryUtil.list(q, getDialect(), start,
+						end);
+			}
+			catch (Exception e) {
+				throw processException(e);
+			}
+			finally {
+				if (list == null) {
+					FinderCacheUtil.removeResult(finderPath, finderArgs);
+				}
+				else {
+					cacheResult(list);
+
+					FinderCacheUtil.putResult(finderPath, finderArgs, list);
+				}
+
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library folder
+	 * @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a matching document library folder could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public DLFolder findByG_M_R_P_First(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId,
+		OrderByComparator orderByComparator)
+		throws NoSuchFolderException, SystemException {
+		DLFolder dlFolder = fetchByG_M_R_P_First(groupId, mountPoint,
+				repositoryType, parentFolderId, orderByComparator);
+
+		if (dlFolder != null) {
+			return dlFolder;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("groupId=");
+		msg.append(groupId);
+
+		msg.append(", mountPoint=");
+		msg.append(mountPoint);
+
+		msg.append(", repositoryType=");
+		msg.append(repositoryType);
+
+		msg.append(", parentFolderId=");
+		msg.append(parentFolderId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchFolderException(msg.toString());
+	}
+
+	/**
+	 * Returns the first document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library folder, or <code>null</code> if a matching document library folder could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public DLFolder fetchByG_M_R_P_First(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId,
+		OrderByComparator orderByComparator) throws SystemException {
+		List<DLFolder> list = findByG_M_R_P(groupId, mountPoint,
+				repositoryType, parentFolderId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library folder
+	 * @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a matching document library folder could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public DLFolder findByG_M_R_P_Last(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId,
+		OrderByComparator orderByComparator)
+		throws NoSuchFolderException, SystemException {
+		DLFolder dlFolder = fetchByG_M_R_P_Last(groupId, mountPoint,
+				repositoryType, parentFolderId, orderByComparator);
+
+		if (dlFolder != null) {
+			return dlFolder;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("groupId=");
+		msg.append(groupId);
+
+		msg.append(", mountPoint=");
+		msg.append(mountPoint);
+
+		msg.append(", repositoryType=");
+		msg.append(repositoryType);
+
+		msg.append(", parentFolderId=");
+		msg.append(parentFolderId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchFolderException(msg.toString());
+	}
+
+	/**
+	 * Returns the last document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library folder, or <code>null</code> if a matching document library folder could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public DLFolder fetchByG_M_R_P_Last(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId,
+		OrderByComparator orderByComparator) throws SystemException {
+		int count = countByG_M_R_P(groupId, mountPoint, repositoryType,
+				parentFolderId);
+
+		List<DLFolder> list = findByG_M_R_P(groupId, mountPoint,
+				repositoryType, parentFolderId, count - 1, count,
+				orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the document library folders before and after the current document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param folderId the primary key of the current document library folder
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next document library folder
+	 * @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a document library folder with the primary key could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public DLFolder[] findByG_M_R_P_PrevAndNext(long folderId, long groupId,
+		boolean mountPoint, int repositoryType, long parentFolderId,
+		OrderByComparator orderByComparator)
+		throws NoSuchFolderException, SystemException {
+		DLFolder dlFolder = findByPrimaryKey(folderId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			DLFolder[] array = new DLFolderImpl[3];
+
+			array[0] = getByG_M_R_P_PrevAndNext(session, dlFolder, groupId,
+					mountPoint, repositoryType, parentFolderId,
+					orderByComparator, true);
+
+			array[1] = dlFolder;
+
+			array[2] = getByG_M_R_P_PrevAndNext(session, dlFolder, groupId,
+					mountPoint, repositoryType, parentFolderId,
+					orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected DLFolder getByG_M_R_P_PrevAndNext(Session session,
+		DLFolder dlFolder, long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId,
+		OrderByComparator orderByComparator, boolean previous) {
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(6 +
+					(orderByComparator.getOrderByFields().length * 6));
+		}
+		else {
+			query = new StringBundler(3);
+		}
+
+		query.append(_SQL_SELECT_DLFOLDER_WHERE);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_GROUPID_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_MOUNTPOINT_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_REPOSITORYTYPE_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_PARENTFOLDERID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields = orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+
+		else {
+			query.append(DLFolderModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(groupId);
+
+		qPos.add(mountPoint);
+
+		qPos.add(repositoryType);
+
+		qPos.add(parentFolderId);
+
+		if (orderByComparator != null) {
+			Object[] values = orderByComparator.getOrderByConditionValues(dlFolder);
+
+			for (Object value : values) {
+				qPos.add(value);
+			}
+		}
+
+		List<DLFolder> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @return the matching document library folders that the user has permission to view
+	 * @throws SystemException if a system exception occurred
+	 */
+	public List<DLFolder> filterFindByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId) throws SystemException {
+		return filterFindByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param start the lower bound of the range of document library folders
+	 * @param end the upper bound of the range of document library folders (not inclusive)
+	 * @return the range of matching document library folders that the user has permission to view
+	 * @throws SystemException if a system exception occurred
+	 */
+	public List<DLFolder> filterFindByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId, int start, int end)
+		throws SystemException {
+		return filterFindByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library folders that the user has permissions to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param start the lower bound of the range of document library folders
+	 * @param end the upper bound of the range of document library folders (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library folders that the user has permission to view
+	 * @throws SystemException if a system exception occurred
+	 */
+	public List<DLFolder> filterFindByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId, int start, int end,
+		OrderByComparator orderByComparator) throws SystemException {
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_M_R_P(groupId, mountPoint, repositoryType,
+				parentFolderId, start, end, orderByComparator);
+		}
+
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(6 +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(6);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_DLFOLDER_WHERE);
+		}
+		else {
+			query.append(_FILTER_SQL_SELECT_DLFOLDER_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		query.append(_FINDER_COLUMN_G_M_R_P_GROUPID_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_MOUNTPOINT_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_REPOSITORYTYPE_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_PARENTFOLDERID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_DLFOLDER_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_ALIAS,
+					orderByComparator);
+			}
+			else {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_TABLE,
+					orderByComparator);
+			}
+		}
+
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				query.append(DLFolderModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				query.append(DLFolderModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(query.toString(),
+				DLFolder.class.getName(),
+				_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery q = session.createSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				q.addEntity(_FILTER_ENTITY_ALIAS, DLFolderImpl.class);
+			}
+			else {
+				q.addEntity(_FILTER_ENTITY_TABLE, DLFolderImpl.class);
+			}
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(groupId);
+
+			qPos.add(mountPoint);
+
+			qPos.add(repositoryType);
+
+			qPos.add(parentFolderId);
+
+			return (List<DLFolder>)QueryUtil.list(q, getDialect(), start, end);
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the document library folders before and after the current document library folder in the ordered set of document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param folderId the primary key of the current document library folder
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next document library folder
+	 * @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a document library folder with the primary key could not be found
+	 * @throws SystemException if a system exception occurred
+	 */
+	public DLFolder[] filterFindByG_M_R_P_PrevAndNext(long folderId,
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, OrderByComparator orderByComparator)
+		throws NoSuchFolderException, SystemException {
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_M_R_P_PrevAndNext(folderId, groupId, mountPoint,
+				repositoryType, parentFolderId, orderByComparator);
+		}
+
+		DLFolder dlFolder = findByPrimaryKey(folderId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			DLFolder[] array = new DLFolderImpl[3];
+
+			array[0] = filterGetByG_M_R_P_PrevAndNext(session, dlFolder,
+					groupId, mountPoint, repositoryType, parentFolderId,
+					orderByComparator, true);
+
+			array[1] = dlFolder;
+
+			array[2] = filterGetByG_M_R_P_PrevAndNext(session, dlFolder,
+					groupId, mountPoint, repositoryType, parentFolderId,
+					orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected DLFolder filterGetByG_M_R_P_PrevAndNext(Session session,
+		DLFolder dlFolder, long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId,
+		OrderByComparator orderByComparator, boolean previous) {
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(6 +
+					(orderByComparator.getOrderByFields().length * 6));
+		}
+		else {
+			query = new StringBundler(3);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_DLFOLDER_WHERE);
+		}
+		else {
+			query.append(_FILTER_SQL_SELECT_DLFOLDER_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		query.append(_FINDER_COLUMN_G_M_R_P_GROUPID_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_MOUNTPOINT_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_REPOSITORYTYPE_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_PARENTFOLDERID_2);
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			query.append(_FILTER_SQL_SELECT_DLFOLDER_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields = orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					query.append(_ORDER_BY_ENTITY_ALIAS);
+				}
+				else {
+					query.append(_ORDER_BY_ENTITY_TABLE);
+				}
+
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					query.append(_ORDER_BY_ENTITY_ALIAS);
+				}
+				else {
+					query.append(_ORDER_BY_ENTITY_TABLE);
+				}
+
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				query.append(DLFolderModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				query.append(DLFolderModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(query.toString(),
+				DLFolder.class.getName(),
+				_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		SQLQuery q = session.createSQLQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			q.addEntity(_FILTER_ENTITY_ALIAS, DLFolderImpl.class);
+		}
+		else {
+			q.addEntity(_FILTER_ENTITY_TABLE, DLFolderImpl.class);
+		}
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(groupId);
+
+		qPos.add(mountPoint);
+
+		qPos.add(repositoryType);
+
+		qPos.add(parentFolderId);
+
+		if (orderByComparator != null) {
+			Object[] values = orderByComparator.getOrderByConditionValues(dlFolder);
+
+			for (Object value : values) {
+				qPos.add(value);
+			}
+		}
+
+		List<DLFolder> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
 	 * Returns all the document library folders.
 	 *
 	 * @return the document library folders
@@ -7208,6 +8090,23 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 		long parentFolderId, int status) throws SystemException {
 		for (DLFolder dlFolder : findByG_M_P_S(groupId, mountPoint,
 				parentFolderId, status)) {
+			remove(dlFolder);
+		}
+	}
+
+	/**
+	 * Removes all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @throws SystemException if a system exception occurred
+	 */
+	public void removeByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId) throws SystemException {
+		for (DLFolder dlFolder : findByG_M_R_P(groupId, mountPoint,
+				repositoryType, parentFolderId)) {
 			remove(dlFolder);
 		}
 	}
@@ -8279,6 +9178,142 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 	}
 
 	/**
+	 * Returns the number of document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @return the number of matching document library folders
+	 * @throws SystemException if a system exception occurred
+	 */
+	public int countByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId) throws SystemException {
+		Object[] finderArgs = new Object[] {
+				groupId, mountPoint, repositoryType, parentFolderId
+			};
+
+		Long count = (Long)FinderCacheUtil.getResult(FINDER_PATH_COUNT_BY_G_M_R_P,
+				finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(5);
+
+			query.append(_SQL_COUNT_DLFOLDER_WHERE);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_GROUPID_2);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_MOUNTPOINT_2);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_REPOSITORYTYPE_2);
+
+			query.append(_FINDER_COLUMN_G_M_R_P_PARENTFOLDERID_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(groupId);
+
+				qPos.add(mountPoint);
+
+				qPos.add(repositoryType);
+
+				qPos.add(parentFolderId);
+
+				count = (Long)q.uniqueResult();
+			}
+			catch (Exception e) {
+				throw processException(e);
+			}
+			finally {
+				if (count == null) {
+					count = Long.valueOf(0);
+				}
+
+				FinderCacheUtil.putResult(FINDER_PATH_COUNT_BY_G_M_R_P,
+					finderArgs, count);
+
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param mountPoint the mount point
+	 * @param repositoryType the repository type
+	 * @param parentFolderId the parent folder ID
+	 * @return the number of matching document library folders that the user has permission to view
+	 * @throws SystemException if a system exception occurred
+	 */
+	public int filterCountByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId) throws SystemException {
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return countByG_M_R_P(groupId, mountPoint, repositoryType,
+				parentFolderId);
+		}
+
+		StringBundler query = new StringBundler(5);
+
+		query.append(_FILTER_SQL_COUNT_DLFOLDER_WHERE);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_GROUPID_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_MOUNTPOINT_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_REPOSITORYTYPE_2);
+
+		query.append(_FINDER_COLUMN_G_M_R_P_PARENTFOLDERID_2);
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(query.toString(),
+				DLFolder.class.getName(),
+				_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery q = session.createSQLQuery(sql);
+
+			q.addScalar(COUNT_COLUMN_NAME,
+				com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(groupId);
+
+			qPos.add(mountPoint);
+
+			qPos.add(repositoryType);
+
+			qPos.add(parentFolderId);
+
+			Long count = (Long)q.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
 	 * Returns the number of document library folders.
 	 *
 	 * @return the number of document library folders
@@ -9091,6 +10126,10 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 	private static final String _FINDER_COLUMN_G_M_P_S_MOUNTPOINT_2 = "dlFolder.mountPoint = ? AND ";
 	private static final String _FINDER_COLUMN_G_M_P_S_PARENTFOLDERID_2 = "dlFolder.parentFolderId = ? AND ";
 	private static final String _FINDER_COLUMN_G_M_P_S_STATUS_2 = "dlFolder.status = ?";
+	private static final String _FINDER_COLUMN_G_M_R_P_GROUPID_2 = "dlFolder.groupId = ? AND ";
+	private static final String _FINDER_COLUMN_G_M_R_P_MOUNTPOINT_2 = "dlFolder.mountPoint = ? AND ";
+	private static final String _FINDER_COLUMN_G_M_R_P_REPOSITORYTYPE_2 = "dlFolder.repositoryType = ? AND ";
+	private static final String _FINDER_COLUMN_G_M_R_P_PARENTFOLDERID_2 = "dlFolder.parentFolderId = ?";
 	private static final String _FILTER_ENTITY_TABLE_FILTER_PK_COLUMN = "dlFolder.folderId";
 	private static final String _FILTER_SQL_SELECT_DLFOLDER_WHERE = "SELECT DISTINCT {dlFolder.*} FROM DLFolder dlFolder WHERE ";
 	private static final String _FILTER_SQL_SELECT_DLFOLDER_NO_INLINE_DISTINCT_WHERE_1 =

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/RepositoryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/RepositoryPersistenceTest.java
@@ -303,6 +303,12 @@ public class RepositoryPersistenceTest {
 				existingRepositoryModelImpl.getOriginalUuid()));
 		Assert.assertEquals(existingRepositoryModelImpl.getGroupId(),
 			existingRepositoryModelImpl.getOriginalGroupId());
+
+		Assert.assertEquals(existingRepositoryModelImpl.getGroupId(),
+			existingRepositoryModelImpl.getOriginalGroupId());
+		Assert.assertTrue(Validator.equals(
+				existingRepositoryModelImpl.getPortletId(),
+				existingRepositoryModelImpl.getOriginalPortletId()));
 	}
 
 	protected Repository addRepository() throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/DLFolderPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/DLFolderPersistenceTest.java
@@ -126,6 +126,8 @@ public class DLFolderPersistenceTest {
 
 		newDLFolder.setRepositoryId(ServiceTestUtil.nextLong());
 
+		newDLFolder.setRepositoryType(ServiceTestUtil.nextInt());
+
 		newDLFolder.setMountPoint(ServiceTestUtil.randomBoolean());
 
 		newDLFolder.setParentFolderId(ServiceTestUtil.nextLong());
@@ -171,6 +173,8 @@ public class DLFolderPersistenceTest {
 			Time.getShortTimestamp(newDLFolder.getModifiedDate()));
 		Assert.assertEquals(existingDLFolder.getRepositoryId(),
 			newDLFolder.getRepositoryId());
+		Assert.assertEquals(existingDLFolder.getRepositoryType(),
+			newDLFolder.getRepositoryType());
 		Assert.assertEquals(existingDLFolder.getMountPoint(),
 			newDLFolder.getMountPoint());
 		Assert.assertEquals(existingDLFolder.getParentFolderId(),
@@ -358,6 +362,8 @@ public class DLFolderPersistenceTest {
 		dlFolder.setModifiedDate(ServiceTestUtil.nextDate());
 
 		dlFolder.setRepositoryId(ServiceTestUtil.nextLong());
+
+		dlFolder.setRepositoryType(ServiceTestUtil.nextInt());
 
 		dlFolder.setMountPoint(ServiceTestUtil.randomBoolean());
 

--- a/portal-service/src/com/liferay/portal/portletFileRepository/PortletFileRepository.java
+++ b/portal-service/src/com/liferay/portal/portletFileRepository/PortletFileRepository.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.portletfilerepository;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public interface PortletFileRepository {
+
+	public void addPortletFileEntries(
+			long groupId, long userId, long folderId,
+			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
+			String portletId)
+		throws PortalException, SystemException;
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			File file, String fileName)
+		throws PortalException, SystemException;
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			InputStream inputStream, String fileName)
+		throws PortalException, SystemException;
+
+	public void deletePortletFileEntries(long groupId, long folderId)
+		throws PortalException, SystemException;
+
+	public void deletePortletFileEntry(long fileEntryId)
+		throws PortalException, SystemException;
+
+	public void deletePortletFileEntry(
+			long groupId, long folderId, String fileName)
+		throws PortalException, SystemException;
+
+	public long getFolder(
+			long userId, long repositoryId, long parentFolderId,
+			String folderName, ServiceContext serviceContext)
+		throws PortalException, SystemException;
+
+	public long getPortletRepository(
+			long groupId, String portletId, ServiceContext serviceContext)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryFromTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryFromTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryToTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryToTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException;
+
+}

--- a/portal-service/src/com/liferay/portal/portletFileRepository/PortletFileRepositoryUtil.java
+++ b/portal-service/src/com/liferay/portal/portletFileRepository/PortletFileRepositoryUtil.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.portletfilerepository;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class PortletFileRepositoryUtil {
+
+	public static void addPortletFileEntries(
+			long groupId, long userId, long folderId,
+			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
+			String portletId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().addPortletFileEntries(
+			groupId, userId, folderId, inputStreamOVPs, portletId);
+	}
+
+	public static void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			File file, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().addPortletFileEntry(
+			groupId, userId, folderId, portletId, file, fileName);
+	}
+
+	public static void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			InputStream inputStream, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().addPortletFileEntry(
+			groupId, userId, folderId, portletId, inputStream, fileName);
+	}
+
+	public static void deletePortletFileEntries(long groupId, long folderId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().deletePortletFileEntries(groupId, folderId);
+	}
+
+	public static void deletePortletFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().deletePortletFileEntry(fileEntryId);
+	}
+
+	public static void deletePortletFileEntry(
+			long groupId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().deletePortletFileEntry(
+			groupId, folderId, fileName);
+	}
+
+	public static long getFolder(
+			long userId, long repositoryId, long parentFolderId,
+			String folderName, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return getPortletFileRepository().getFolder(
+			userId, repositoryId, parentFolderId, folderName, serviceContext);
+	}
+
+	public static PortletFileRepository getPortletFileRepository() {
+		PortalRuntimePermission.checkGetBeanProperty(
+			PortletFileRepositoryUtil.class);
+
+		return _portletFileRepository;
+	}
+
+	public static long getPortletRepository(
+			long groupId, String portletId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return getPortletFileRepository().getPortletRepository(
+			groupId, portletId, serviceContext);
+	}
+
+	public static void movePortletFileEntryFromTrash(
+			long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryFromTrash(
+			userId, fileEntryId);
+	}
+
+	public static void movePortletFileEntryFromTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryFromTrash(
+			groupId, userId, folderId, fileName);
+	}
+
+	public static void movePortletFileEntryToTrash(
+			long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryToTrash(
+			userId, fileEntryId);
+	}
+
+	public static void movePortletFileEntryToTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryToTrash(
+			groupId, userId, folderId, fileName);
+	}
+
+	public void setPortletFileRepository(
+		PortletFileRepository portletFileRepository) {
+
+		PortalRuntimePermission.checkSetBeanProperty(getClass());
+
+		_portletFileRepository = portletFileRepository;
+	}
+
+	private static PortletFileRepository _portletFileRepository;
+
+}

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.portletfilerepository;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public interface PortletFileRepository {
+
+	public void addPortletFileEntries(
+			long groupId, long userId, long folderId,
+			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
+			String portletId)
+		throws PortalException, SystemException;
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			File file, String fileName)
+		throws PortalException, SystemException;
+
+	public void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			InputStream inputStream, String fileName)
+		throws PortalException, SystemException;
+
+	public void deletePortletFileEntries(long groupId, long folderId)
+		throws PortalException, SystemException;
+
+	public void deletePortletFileEntry(long fileEntryId)
+		throws PortalException, SystemException;
+
+	public void deletePortletFileEntry(
+			long groupId, long folderId, String fileName)
+		throws PortalException, SystemException;
+
+	public long getFolder(
+			long userId, long repositoryId, long parentFolderId,
+			String folderName, ServiceContext serviceContext)
+		throws PortalException, SystemException;
+
+	public long getPortletRepository(
+			long groupId, String portletId, ServiceContext serviceContext)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryFromTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryFromTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryToTrash(long userId, long fileEntryId)
+		throws PortalException, SystemException;
+
+	public void movePortletFileEntryToTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException;
+
+}

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.portletfilerepository;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class PortletFileRepositoryUtil {
+
+	public static void addPortletFileEntries(
+			long groupId, long userId, long folderId,
+			List<ObjectValuePair<String, InputStream>> inputStreamOVPs,
+			String portletId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().addPortletFileEntries(
+			groupId, userId, folderId, inputStreamOVPs, portletId);
+	}
+
+	public static void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			File file, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().addPortletFileEntry(
+			groupId, userId, folderId, portletId, file, fileName);
+	}
+
+	public static void addPortletFileEntry(
+			long groupId, long userId, long folderId, String portletId,
+			InputStream inputStream, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().addPortletFileEntry(
+			groupId, userId, folderId, portletId, inputStream, fileName);
+	}
+
+	public static void deletePortletFileEntries(long groupId, long folderId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().deletePortletFileEntries(groupId, folderId);
+	}
+
+	public static void deletePortletFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().deletePortletFileEntry(fileEntryId);
+	}
+
+	public static void deletePortletFileEntry(
+			long groupId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().deletePortletFileEntry(
+			groupId, folderId, fileName);
+	}
+
+	public static long getFolder(
+			long userId, long repositoryId, long parentFolderId,
+			String folderName, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return getPortletFileRepository().getFolder(
+			userId, repositoryId, parentFolderId, folderName, serviceContext);
+	}
+
+	public static PortletFileRepository getPortletFileRepository() {
+		PortalRuntimePermission.checkGetBeanProperty(
+			PortletFileRepositoryUtil.class);
+
+		return _portletFileRepository;
+	}
+
+	public static long getPortletRepository(
+			long groupId, String portletId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return getPortletFileRepository().getPortletRepository(
+			groupId, portletId, serviceContext);
+	}
+
+	public static void movePortletFileEntryFromTrash(
+			long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryFromTrash(
+			userId, fileEntryId);
+	}
+
+	public static void movePortletFileEntryFromTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryFromTrash(
+			groupId, userId, folderId, fileName);
+	}
+
+	public static void movePortletFileEntryToTrash(
+			long userId, long fileEntryId)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryToTrash(
+			userId, fileEntryId);
+	}
+
+	public static void movePortletFileEntryToTrash(
+			long groupId, long userId, long folderId, String fileName)
+		throws PortalException, SystemException {
+
+		getPortletFileRepository().movePortletFileEntryToTrash(
+			groupId, userId, folderId, fileName);
+	}
+
+	public void setPortletFileRepository(
+		PortletFileRepository portletFileRepository) {
+
+		PortalRuntimePermission.checkSetBeanProperty(getClass());
+
+		_portletFileRepository = portletFileRepository;
+	}
+
+	private static PortletFileRepository _portletFileRepository;
+
+}

--- a/portal-service/src/com/liferay/portal/service/RepositoryLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryLocalService.java
@@ -258,6 +258,15 @@ public interface RepositoryLocalService extends BaseLocalService,
 		long parentFolderId, java.lang.String name,
 		java.lang.String description, java.lang.String portletId,
 		com.liferay.portal.kernel.util.UnicodeProperties typeSettingsProperties,
+		int repositoryType,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public long addRepository(long userId, long groupId, long classNameId,
+		long parentFolderId, java.lang.String name,
+		java.lang.String description, java.lang.String portletId,
+		com.liferay.portal.kernel.util.UnicodeProperties typeSettingsProperties,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
@@ -280,6 +289,11 @@ public interface RepositoryLocalService extends BaseLocalService,
 		long folderId, long fileEntryId, long fileVersionId)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public com.liferay.portal.model.Repository getRepository(long groupId,
+		java.lang.String portletId)
+		throws com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portal.kernel.repository.Repository getRepositoryImpl(

--- a/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceUtil.java
@@ -286,6 +286,20 @@ public class RepositoryLocalServiceUtil {
 		long classNameId, long parentFolderId, java.lang.String name,
 		java.lang.String description, java.lang.String portletId,
 		com.liferay.portal.kernel.util.UnicodeProperties typeSettingsProperties,
+		int repositoryType,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .addRepository(userId, groupId, classNameId, parentFolderId,
+			name, description, portletId, typeSettingsProperties,
+			repositoryType, serviceContext);
+	}
+
+	public static long addRepository(long userId, long groupId,
+		long classNameId, long parentFolderId, java.lang.String name,
+		java.lang.String description, java.lang.String portletId,
+		com.liferay.portal.kernel.util.UnicodeProperties typeSettingsProperties,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
@@ -318,6 +332,12 @@ public class RepositoryLocalServiceUtil {
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService()
 				   .getLocalRepositoryImpl(folderId, fileEntryId, fileVersionId);
+	}
+
+	public static com.liferay.portal.model.Repository getRepository(
+		long groupId, java.lang.String portletId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getService().getRepository(groupId, portletId);
 	}
 
 	public static com.liferay.portal.kernel.repository.Repository getRepositoryImpl(

--- a/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/RepositoryLocalServiceWrapper.java
@@ -279,6 +279,19 @@ public class RepositoryLocalServiceWrapper implements RepositoryLocalService,
 		long parentFolderId, java.lang.String name,
 		java.lang.String description, java.lang.String portletId,
 		com.liferay.portal.kernel.util.UnicodeProperties typeSettingsProperties,
+		int repositoryType,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _repositoryLocalService.addRepository(userId, groupId,
+			classNameId, parentFolderId, name, description, portletId,
+			typeSettingsProperties, repositoryType, serviceContext);
+	}
+
+	public long addRepository(long userId, long groupId, long classNameId,
+		long parentFolderId, java.lang.String name,
+		java.lang.String description, java.lang.String portletId,
+		com.liferay.portal.kernel.util.UnicodeProperties typeSettingsProperties,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
@@ -311,6 +324,12 @@ public class RepositoryLocalServiceWrapper implements RepositoryLocalService,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _repositoryLocalService.getLocalRepositoryImpl(folderId,
 			fileEntryId, fileVersionId);
+	}
+
+	public com.liferay.portal.model.Repository getRepository(long groupId,
+		java.lang.String portletId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return _repositoryLocalService.getRepository(groupId, portletId);
 	}
 
 	public com.liferay.portal.kernel.repository.Repository getRepositoryImpl(

--- a/portal-service/src/com/liferay/portal/service/persistence/RepositoryPersistence.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/RepositoryPersistence.java
@@ -503,6 +503,45 @@ public interface RepositoryPersistence extends BasePersistence<Repository> {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
+	* Returns the repository where groupId = &#63; and portletId = &#63; or throws a {@link com.liferay.portal.NoSuchRepositoryException} if it could not be found.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the matching repository
+	* @throws com.liferay.portal.NoSuchRepositoryException if a matching repository could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portal.model.Repository findByG_P(long groupId,
+		java.lang.String portletId)
+		throws com.liferay.portal.NoSuchRepositoryException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the repository where groupId = &#63; and portletId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the matching repository, or <code>null</code> if a matching repository could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portal.model.Repository fetchByG_P(long groupId,
+		java.lang.String portletId)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the repository where groupId = &#63; and portletId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @param retrieveFromCache whether to use the finder cache
+	* @return the matching repository, or <code>null</code> if a matching repository could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portal.model.Repository fetchByG_P(long groupId,
+		java.lang.String portletId, boolean retrieveFromCache)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
 	* Returns all the repositories.
 	*
 	* @return the repositories
@@ -587,6 +626,19 @@ public interface RepositoryPersistence extends BasePersistence<Repository> {
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
+	* Removes the repository where groupId = &#63; and portletId = &#63; from the database.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the repository that was removed
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portal.model.Repository removeByG_P(long groupId,
+		java.lang.String portletId)
+		throws com.liferay.portal.NoSuchRepositoryException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	/**
 	* Removes all the repositories from the database.
 	*
 	* @throws SystemException if a system exception occurred
@@ -634,6 +686,17 @@ public interface RepositoryPersistence extends BasePersistence<Repository> {
 	* @throws SystemException if a system exception occurred
 	*/
 	public int countByGroupId(long groupId)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the number of repositories where groupId = &#63; and portletId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the number of matching repositories
+	* @throws SystemException if a system exception occurred
+	*/
+	public int countByG_P(long groupId, java.lang.String portletId)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/persistence/RepositoryUtil.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/RepositoryUtil.java
@@ -657,6 +657,51 @@ public class RepositoryUtil {
 	}
 
 	/**
+	* Returns the repository where groupId = &#63; and portletId = &#63; or throws a {@link com.liferay.portal.NoSuchRepositoryException} if it could not be found.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the matching repository
+	* @throws com.liferay.portal.NoSuchRepositoryException if a matching repository could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portal.model.Repository findByG_P(long groupId,
+		java.lang.String portletId)
+		throws com.liferay.portal.NoSuchRepositoryException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence().findByG_P(groupId, portletId);
+	}
+
+	/**
+	* Returns the repository where groupId = &#63; and portletId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the matching repository, or <code>null</code> if a matching repository could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portal.model.Repository fetchByG_P(long groupId,
+		java.lang.String portletId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence().fetchByG_P(groupId, portletId);
+	}
+
+	/**
+	* Returns the repository where groupId = &#63; and portletId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @param retrieveFromCache whether to use the finder cache
+	* @return the matching repository, or <code>null</code> if a matching repository could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portal.model.Repository fetchByG_P(long groupId,
+		java.lang.String portletId, boolean retrieveFromCache)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence().fetchByG_P(groupId, portletId, retrieveFromCache);
+	}
+
+	/**
 	* Returns all the repositories.
 	*
 	* @return the repositories
@@ -755,6 +800,21 @@ public class RepositoryUtil {
 	}
 
 	/**
+	* Removes the repository where groupId = &#63; and portletId = &#63; from the database.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the repository that was removed
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portal.model.Repository removeByG_P(
+		long groupId, java.lang.String portletId)
+		throws com.liferay.portal.NoSuchRepositoryException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence().removeByG_P(groupId, portletId);
+	}
+
+	/**
 	* Removes all the repositories from the database.
 	*
 	* @throws SystemException if a system exception occurred
@@ -812,6 +872,19 @@ public class RepositoryUtil {
 	public static int countByGroupId(long groupId)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return getPersistence().countByGroupId(groupId);
+	}
+
+	/**
+	* Returns the number of repositories where groupId = &#63; and portletId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param portletId the portlet ID
+	* @return the number of matching repositories
+	* @throws SystemException if a system exception occurred
+	*/
+	public static int countByG_P(long groupId, java.lang.String portletId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence().countByG_P(groupId, portletId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderConstants.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderConstants.java
@@ -30,6 +30,10 @@ public class DLFolderConstants {
 
 	public static final long DEFAULT_PARENT_FOLDER_ID = 0;
 
+	public static final int PORTLET_REPOSITORY = 1;
+
+	public static final int REGULAR_REPOSITORY = 0;
+
 	public static String getClassName() {
 		return DLFolder.class.getName();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderModel.java
@@ -207,6 +207,20 @@ public interface DLFolderModel extends BaseModel<DLFolder>, GroupedModel,
 	public void setRepositoryId(long repositoryId);
 
 	/**
+	 * Returns the repository type of this document library folder.
+	 *
+	 * @return the repository type of this document library folder
+	 */
+	public int getRepositoryType();
+
+	/**
+	 * Sets the repository type of this document library folder.
+	 *
+	 * @param repositoryType the repository type of this document library folder
+	 */
+	public void setRepositoryType(int repositoryType);
+
+	/**
 	 * Returns the mount point of this document library folder.
 	 *
 	 * @return the mount point of this document library folder

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderSoap.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderSoap.java
@@ -40,6 +40,7 @@ public class DLFolderSoap implements Serializable {
 		soapModel.setCreateDate(model.getCreateDate());
 		soapModel.setModifiedDate(model.getModifiedDate());
 		soapModel.setRepositoryId(model.getRepositoryId());
+		soapModel.setRepositoryType(model.getRepositoryType());
 		soapModel.setMountPoint(model.getMountPoint());
 		soapModel.setParentFolderId(model.getParentFolderId());
 		soapModel.setName(model.getName());
@@ -175,6 +176,14 @@ public class DLFolderSoap implements Serializable {
 		_repositoryId = repositoryId;
 	}
 
+	public int getRepositoryType() {
+		return _repositoryType;
+	}
+
+	public void setRepositoryType(int repositoryType) {
+		_repositoryType = repositoryType;
+	}
+
 	public boolean getMountPoint() {
 		return _mountPoint;
 	}
@@ -280,6 +289,7 @@ public class DLFolderSoap implements Serializable {
 	private Date _createDate;
 	private Date _modifiedDate;
 	private long _repositoryId;
+	private int _repositoryType;
 	private boolean _mountPoint;
 	private long _parentFolderId;
 	private String _name;

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
@@ -54,6 +54,7 @@ public class DLFolderWrapper implements DLFolder, ModelWrapper<DLFolder> {
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
 		attributes.put("repositoryId", getRepositoryId());
+		attributes.put("repositoryType", getRepositoryType());
 		attributes.put("mountPoint", getMountPoint());
 		attributes.put("parentFolderId", getParentFolderId());
 		attributes.put("name", getName());
@@ -122,6 +123,12 @@ public class DLFolderWrapper implements DLFolder, ModelWrapper<DLFolder> {
 
 		if (repositoryId != null) {
 			setRepositoryId(repositoryId);
+		}
+
+		Integer repositoryType = (Integer)attributes.get("repositoryType");
+
+		if (repositoryType != null) {
+			setRepositoryType(repositoryType);
 		}
 
 		Boolean mountPoint = (Boolean)attributes.get("mountPoint");
@@ -391,6 +398,24 @@ public class DLFolderWrapper implements DLFolder, ModelWrapper<DLFolder> {
 	*/
 	public void setRepositoryId(long repositoryId) {
 		_dlFolder.setRepositoryId(repositoryId);
+	}
+
+	/**
+	* Returns the repository type of this document library folder.
+	*
+	* @return the repository type of this document library folder
+	*/
+	public int getRepositoryType() {
+		return _dlFolder.getRepositoryType();
+	}
+
+	/**
+	* Sets the repository type of this document library folder.
+	*
+	* @param repositoryType the repository type of this document library folder
+	*/
+	public void setRepositoryType(int repositoryType) {
+		_dlFolder.setRepositoryType(repositoryType);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppLocalService.java
@@ -493,6 +493,15 @@ public interface DLAppLocalService extends BaseLocalService {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
+	public com.liferay.portal.kernel.repository.model.FileEntry moveFileEntryToTrash(
+		long userId, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public void restoreFileEntryFromTrash(long userId, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	/**
 	* Updates the file entry's asset replacing its asset categories, tags, and
 	* links.

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppLocalServiceUtil.java
@@ -547,6 +547,19 @@ public class DLAppLocalServiceUtil {
 			serviceContext);
 	}
 
+	public static com.liferay.portal.kernel.repository.model.FileEntry moveFileEntryToTrash(
+		long userId, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService().moveFileEntryToTrash(userId, fileEntryId);
+	}
+
+	public static void restoreFileEntryFromTrash(long userId, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		getService().restoreFileEntryFromTrash(userId, fileEntryId);
+	}
+
 	/**
 	* Updates the file entry's asset replacing its asset categories, tags, and
 	* links.

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppLocalServiceWrapper.java
@@ -534,6 +534,19 @@ public class DLAppLocalServiceWrapper implements DLAppLocalService,
 			newFolderId, serviceContext);
 	}
 
+	public com.liferay.portal.kernel.repository.model.FileEntry moveFileEntryToTrash(
+		long userId, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _dlAppLocalService.moveFileEntryToTrash(userId, fileEntryId);
+	}
+
+	public void restoreFileEntryFromTrash(long userId, long fileEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		_dlAppLocalService.restoreFileEntryFromTrash(userId, fileEntryId);
+	}
+
 	/**
 	* Updates the file entry's asset replacing its asset categories, tags, and
 	* links.

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalService.java
@@ -261,6 +261,14 @@ public interface DLFolderLocalService extends BaseLocalService,
 	public com.liferay.portlet.documentlibrary.model.DLFolder addFolder(
 		long userId, long groupId, long repositoryId, boolean mountPoint,
 		long parentFolderId, java.lang.String name,
+		java.lang.String description, int repositoryType,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public com.liferay.portlet.documentlibrary.model.DLFolder addFolder(
+		long userId, long groupId, long repositoryId, boolean mountPoint,
+		long parentFolderId, java.lang.String name,
 		java.lang.String description,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceUtil.java
@@ -286,6 +286,18 @@ public class DLFolderLocalServiceUtil {
 	public static com.liferay.portlet.documentlibrary.model.DLFolder addFolder(
 		long userId, long groupId, long repositoryId, boolean mountPoint,
 		long parentFolderId, java.lang.String name,
+		java.lang.String description, int repositoryType,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .addFolder(userId, groupId, repositoryId, mountPoint,
+			parentFolderId, name, description, repositoryType, serviceContext);
+	}
+
+	public static com.liferay.portlet.documentlibrary.model.DLFolder addFolder(
+		long userId, long groupId, long repositoryId, boolean mountPoint,
+		long parentFolderId, java.lang.String name,
 		java.lang.String description,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLFolderLocalServiceWrapper.java
@@ -281,6 +281,18 @@ public class DLFolderLocalServiceWrapper implements DLFolderLocalService,
 	public com.liferay.portlet.documentlibrary.model.DLFolder addFolder(
 		long userId, long groupId, long repositoryId, boolean mountPoint,
 		long parentFolderId, java.lang.String name,
+		java.lang.String description, int repositoryType,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _dlFolderLocalService.addFolder(userId, groupId, repositoryId,
+			mountPoint, parentFolderId, name, description, repositoryType,
+			serviceContext);
+	}
+
+	public com.liferay.portlet.documentlibrary.model.DLFolder addFolder(
+		long userId, long groupId, long repositoryId, boolean mountPoint,
+		long parentFolderId, java.lang.String name,
 		java.lang.String description,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException,

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderPersistence.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderPersistence.java
@@ -1729,6 +1729,236 @@ public interface DLFolderPersistence extends BasePersistence<DLFolder> {
 			com.liferay.portlet.documentlibrary.NoSuchFolderException;
 
 	/**
+	* Returns all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> findByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns a range of all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @return the range of matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> findByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns an ordered range of all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> findByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the first document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portlet.documentlibrary.model.DLFolder findByG_M_R_P_First(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException;
+
+	/**
+	* Returns the first document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library folder, or <code>null</code> if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portlet.documentlibrary.model.DLFolder fetchByG_M_R_P_First(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the last document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portlet.documentlibrary.model.DLFolder findByG_M_R_P_Last(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException;
+
+	/**
+	* Returns the last document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library folder, or <code>null</code> if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portlet.documentlibrary.model.DLFolder fetchByG_M_R_P_Last(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the document library folders before and after the current document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param folderId the primary key of the current document library folder
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a document library folder with the primary key could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portlet.documentlibrary.model.DLFolder[] findByG_M_R_P_PrevAndNext(
+		long folderId, long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException;
+
+	/**
+	* Returns all the document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> filterFindByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns a range of all the document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @return the range of matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> filterFindByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns an ordered range of all the document library folders that the user has permissions to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> filterFindByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the document library folders before and after the current document library folder in the ordered set of document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param folderId the primary key of the current document library folder
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a document library folder with the primary key could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public com.liferay.portlet.documentlibrary.model.DLFolder[] filterFindByG_M_R_P_PrevAndNext(
+		long folderId, long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException;
+
+	/**
 	* Returns all the document library folders.
 	*
 	* @return the document library folders
@@ -1901,6 +2131,19 @@ public interface DLFolderPersistence extends BasePersistence<DLFolder> {
 	*/
 	public void removeByG_M_P_S(long groupId, boolean mountPoint,
 		long parentFolderId, int status)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Removes all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63; from the database.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @throws SystemException if a system exception occurred
+	*/
+	public void removeByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
@@ -2105,6 +2348,34 @@ public interface DLFolderPersistence extends BasePersistence<DLFolder> {
 	*/
 	public int filterCountByG_M_P_S(long groupId, boolean mountPoint,
 		long parentFolderId, int status)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the number of document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the number of matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public int countByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* Returns the number of document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the number of matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public int filterCountByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/persistence/DLFolderUtil.java
@@ -2126,6 +2126,284 @@ public class DLFolderUtil {
 	}
 
 	/**
+	* Returns all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> findByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .findByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId);
+	}
+
+	/**
+	* Returns a range of all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @return the range of matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> findByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .findByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, start, end);
+	}
+
+	/**
+	* Returns an ordered range of all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> findByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .findByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, start, end, orderByComparator);
+	}
+
+	/**
+	* Returns the first document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portlet.documentlibrary.model.DLFolder findByG_M_R_P_First(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException {
+		return getPersistence()
+				   .findByG_M_R_P_First(groupId, mountPoint, repositoryType,
+			parentFolderId, orderByComparator);
+	}
+
+	/**
+	* Returns the first document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library folder, or <code>null</code> if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portlet.documentlibrary.model.DLFolder fetchByG_M_R_P_First(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .fetchByG_M_R_P_First(groupId, mountPoint, repositoryType,
+			parentFolderId, orderByComparator);
+	}
+
+	/**
+	* Returns the last document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portlet.documentlibrary.model.DLFolder findByG_M_R_P_Last(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException {
+		return getPersistence()
+				   .findByG_M_R_P_Last(groupId, mountPoint, repositoryType,
+			parentFolderId, orderByComparator);
+	}
+
+	/**
+	* Returns the last document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library folder, or <code>null</code> if a matching document library folder could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portlet.documentlibrary.model.DLFolder fetchByG_M_R_P_Last(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .fetchByG_M_R_P_Last(groupId, mountPoint, repositoryType,
+			parentFolderId, orderByComparator);
+	}
+
+	/**
+	* Returns the document library folders before and after the current document library folder in the ordered set where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param folderId the primary key of the current document library folder
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a document library folder with the primary key could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portlet.documentlibrary.model.DLFolder[] findByG_M_R_P_PrevAndNext(
+		long folderId, long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException {
+		return getPersistence()
+				   .findByG_M_R_P_PrevAndNext(folderId, groupId, mountPoint,
+			repositoryType, parentFolderId, orderByComparator);
+	}
+
+	/**
+	* Returns all the document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> filterFindByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .filterFindByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId);
+	}
+
+	/**
+	* Returns a range of all the document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @return the range of matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> filterFindByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .filterFindByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, start, end);
+	}
+
+	/**
+	* Returns an ordered range of all the document library folders that the user has permissions to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full result set.
+	* </p>
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param start the lower bound of the range of document library folders
+	* @param end the upper bound of the range of document library folders (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public static java.util.List<com.liferay.portlet.documentlibrary.model.DLFolder> filterFindByG_M_R_P(
+		long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .filterFindByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId, start, end, orderByComparator);
+	}
+
+	/**
+	* Returns the document library folders before and after the current document library folder in the ordered set of document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param folderId the primary key of the current document library folder
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next document library folder
+	* @throws com.liferay.portlet.documentlibrary.NoSuchFolderException if a document library folder with the primary key could not be found
+	* @throws SystemException if a system exception occurred
+	*/
+	public static com.liferay.portlet.documentlibrary.model.DLFolder[] filterFindByG_M_R_P_PrevAndNext(
+		long folderId, long groupId, boolean mountPoint, int repositoryType,
+		long parentFolderId,
+		com.liferay.portal.kernel.util.OrderByComparator orderByComparator)
+		throws com.liferay.portal.kernel.exception.SystemException,
+			com.liferay.portlet.documentlibrary.NoSuchFolderException {
+		return getPersistence()
+				   .filterFindByG_M_R_P_PrevAndNext(folderId, groupId,
+			mountPoint, repositoryType, parentFolderId, orderByComparator);
+	}
+
+	/**
 	* Returns all the document library folders.
 	*
 	* @return the document library folders
@@ -2329,6 +2607,22 @@ public class DLFolderUtil {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		getPersistence()
 			.removeByG_M_P_S(groupId, mountPoint, parentFolderId, status);
+	}
+
+	/**
+	* Removes all the document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63; from the database.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @throws SystemException if a system exception occurred
+	*/
+	public static void removeByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		getPersistence()
+			.removeByG_M_R_P(groupId, mountPoint, repositoryType, parentFolderId);
 	}
 
 	/**
@@ -2574,6 +2868,42 @@ public class DLFolderUtil {
 		return getPersistence()
 				   .filterCountByG_M_P_S(groupId, mountPoint, parentFolderId,
 			status);
+	}
+
+	/**
+	* Returns the number of document library folders where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the number of matching document library folders
+	* @throws SystemException if a system exception occurred
+	*/
+	public static int countByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .countByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId);
+	}
+
+	/**
+	* Returns the number of document library folders that the user has permission to view where groupId = &#63; and mountPoint = &#63; and repositoryType = &#63; and parentFolderId = &#63;.
+	*
+	* @param groupId the group ID
+	* @param mountPoint the mount point
+	* @param repositoryType the repository type
+	* @param parentFolderId the parent folder ID
+	* @return the number of matching document library folders that the user has permission to view
+	* @throws SystemException if a system exception occurred
+	*/
+	public static int filterCountByG_M_R_P(long groupId, boolean mountPoint,
+		int repositoryType, long parentFolderId)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getPersistence()
+				   .filterCountByG_M_R_P(groupId, mountPoint, repositoryType,
+			parentFolderId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/DLAppHelperThreadLocal.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/DLAppHelperThreadLocal.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.util;
+
+import com.liferay.portal.kernel.util.AutoResetThreadLocal;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class DLAppHelperThreadLocal {
+
+	public static boolean isEnabled() {
+		return _enabled.get().booleanValue();
+	}
+
+	public static void setEnabled(boolean enabled) {
+		_enabled.set(enabled);
+	}
+
+	private static ThreadLocal<Boolean> _enabled =
+		new AutoResetThreadLocal<Boolean>(
+			DLAppHelperThreadLocal.class + "._enabled", true);
+
+}

--- a/sql/indexes.properties
+++ b/sql/indexes.properties
@@ -265,6 +265,7 @@ IX_95E9E44E=DLFileVersion.Uuid_C
 IX_A74DB14C=DLFolder.CompanyId
 IX_C6081B20=DLFolder.G_M_P
 IX_86893A06=DLFolder.G_M_P_S
+IX_8746B38=DLFolder.G_M_R_P
 IX_49C37475=DLFolder.G_P
 IX_902FD874=DLFolder.G_P_N
 IX_24946E5B=DLFolder.G_P_S
@@ -631,6 +632,7 @@ IX_16D87CA7=Region.CountryId
 
 IX_8BD6BCA7=Release_.ServletContextName
 
+IX_8AD39CEB=Repository.G_P
 IX_5253B1FA=Repository.GroupId
 IX_11641E26=Repository.UUID_G
 IX_74C17B04=Repository.Uuid

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -258,6 +258,7 @@ create index IX_A74DB14C on DLFolder (companyId);
 create index IX_F2EA1ACE on DLFolder (groupId);
 create index IX_C6081B20 on DLFolder (groupId, mountPoint, parentFolderId);
 create index IX_86893A06 on DLFolder (groupId, mountPoint, parentFolderId, status);
+create index IX_8746B38 on DLFolder (groupId, mountPoint, repositoryType, parentFolderId);
 create index IX_49C37475 on DLFolder (groupId, parentFolderId);
 create unique index IX_902FD874 on DLFolder (groupId, parentFolderId, name);
 create index IX_24946E5B on DLFolder (groupId, parentFolderId, status);
@@ -623,7 +624,9 @@ create unique index IX_A2635F5C on Region (countryId, regionCode);
 
 create index IX_8BD6BCA7 on Release_ (servletContextName);
 
+create unique index IX_521DA6AD on Repository (companyId, portletId);
 create index IX_5253B1FA on Repository (groupId);
+create unique index IX_8AD39CEB on Repository (groupId, portletId);
 create index IX_74C17B04 on Repository (uuid_);
 create index IX_F543EA4 on Repository (uuid_, companyId);
 create unique index IX_11641E26 on Repository (uuid_, groupId);

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -655,6 +655,7 @@ create table DLFolder (
 	createDate DATE null,
 	modifiedDate DATE null,
 	repositoryId LONG,
+	repositoryType INTEGER,
 	mountPoint BOOLEAN,
 	parentFolderId LONG,
 	name VARCHAR(100) null,

--- a/sql/update-6.1.1-6.2.0.sql
+++ b/sql/update-6.1.1-6.2.0.sql
@@ -248,6 +248,7 @@ alter table DLFolder add status INTEGER;
 alter table DLFolder add statusByUserId LONG;
 alter table DLFolder add statusByUserName VARCHAR(75) null;
 alter table DLFolder add statusDate DATE null;
+alter table DLFolder add repositoryType INTEGER;
 
 COMMIT_TRANSACTION;
 
@@ -255,6 +256,7 @@ update DLFolder set status = 0;
 update DLFolder set statusByUserId = userId;
 update DLFolder set statusByUserName = userName;
 update DLFolder set statusDate = modifiedDate;
+update DLFolder set repositoryType = 0;
 
 drop table Groups_Permissions;
 


### PR DESCRIPTION
Hey Brian,

We had a couple of questions about this pull.

First, we are not fully sure about the idea of having a threadlocal and disable it when calling DLApp from PortletFileRepository. The thing is that there are many things that are not needed, and after talking with @caorongjin he suggested that we should have something like this to disable everything that it's not needed for performance reasons.

The other thing is about the name of methods like GetFolder. The issue is that this method is not only getting a folder, but also creating it in case it doesn't exist. There are many other methods in the portal like this, called getXXXX or isXXXX, but it does more things, not only getting or checking.
What do you think about changing these methods name to something like getAddFolder?

Reviewed by @sergiogonzalez

@caorongjin
