### PR TITLE
LPS-29167

### DIFF
--- a/definitions/liferay-service-builder_6_2_0.dtd
+++ b/definitions/liferay-service-builder_6_2_0.dtd
@@ -296,6 +296,10 @@ different values for different locales. The default value is false.
 The json-enabled value specifies whether or not the column should be annotated
 for JSON serialization. By default, if the json-enabled value in the entity
 element is true, then the json-enabled value in the column element is true.
+
+The references-container-model and references-parent-container-model values
+specify whether the column is an id referencing a container or a parent
+container model.
 -->
 <!ATTLIST column
 	name CDATA #REQUIRED
@@ -313,6 +317,8 @@ element is true, then the json-enabled value in the column element is true.
 	lazy CDATA #IMPLIED
 	localized CDATA #IMPLIED
 	json-enabled CDATA #IMPLIED
+	references-container-model CDATA #IMPLIED
+	references-parent-container-model CDATA #IMPLIED
 >
 
 <!--

--- a/portal-impl/src/META-INF/portal-orm.xml
+++ b/portal-impl/src/META-INF/portal-orm.xml
@@ -2036,7 +2036,9 @@
 			<basic name="statusDate">
 				<temporal>TIMESTAMP</temporal>
 			</basic>
+			<transient name="containerModelId" />
 			<transient name="modelAttributes" />
+			<transient name="parentContainerModelId" />
 			<transient name="primaryKey" />
 			<transient name="primaryKeyObj" />
 			<transient name="statusByUserUuid" />

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/Entity.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/Entity.java
@@ -148,6 +148,18 @@ public class Entity {
 				}
 			}
 		}
+
+		if ((_columnList != null) && !_columnList.isEmpty()) {
+			for (EntityColumn col : _columnList) {
+				if (col.isContainerModelReference() ||
+					col.isParentContainerModelReference()) {
+
+					_containerModel = true;
+
+					break;
+				}
+			}
+		}
 	}
 
 	@Override
@@ -536,6 +548,10 @@ public class Entity {
 		return _cacheEnabled;
 	}
 
+	public boolean isContainerModel() {
+		return _containerModel;
+	}
+
 	public boolean isDefaultDataSource() {
 		if (_dataSource.equals(DEFAULT_DATA_SOURCE)) {
 			return true;
@@ -700,6 +716,7 @@ public class Entity {
 	private boolean _cacheEnabled;
 	private List<EntityColumn> _collectionList;
 	private List<EntityColumn> _columnList;
+	private boolean _containerModel;
 	private String _dataSource;
 	private String _finderClass;
 	private List<EntityColumn> _finderColumnsList;

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/EntityColumn.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/EntityColumn.java
@@ -28,7 +28,8 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 	public EntityColumn(String name) {
 		this(
 			name, null, null, false, false, false, null, null, null, true, true,
-			false, null, null, null, null, true, true, false, false);
+			false, null, null, null, null, true, true, false, false, false,
+			false);
 	}
 
 	public EntityColumn(
@@ -38,7 +39,8 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 		boolean orderByAscending, boolean orderColumn, String comparator,
 		String arrayableOperator, String idType, String idParam,
 		boolean convertNull, boolean lazy, boolean localized,
-		boolean jsonEnabled) {
+		boolean jsonEnabled, boolean referencesContainerModel,
+		boolean referencesParentContainerModel) {
 
 		_name = name;
 		_dbName = dbName;
@@ -62,6 +64,8 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 		_lazy = lazy;
 		_localized = localized;
 		_jsonEnabled = jsonEnabled;
+		_referencesContainerModel = referencesContainerModel;
+		_referencesParentContainerModel = referencesParentContainerModel;
 	}
 
 	public EntityColumn(
@@ -69,12 +73,14 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 		boolean accessor, boolean filterPrimary, String ejbName,
 		String mappingKey, String mappingTable, String idType, String idParam,
 		boolean convertNull, boolean lazy, boolean localized,
-		boolean jsonEnabled) {
+		boolean jsonEnabled, boolean referencesContainerModel,
+		boolean referencesParentContainerModel) {
 
 		this(
 			name, dbName, type, primary, accessor, filterPrimary, ejbName,
 			mappingKey, mappingTable, true, true, false, null, null, idType,
-			idParam, convertNull, lazy, localized, jsonEnabled);
+			idParam, convertNull, lazy, localized, jsonEnabled,
+			referencesContainerModel, referencesParentContainerModel);
 	}
 
 	@Override
@@ -84,7 +90,8 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 			isFilterPrimary(), getEJBName(), getMappingKey(), getMappingTable(),
 			isCaseSensitive(), isOrderByAscending(), isOrderColumn(),
 			getComparator(), getArrayableOperator(), getIdType(), getIdParam(),
-			isConvertNull(), isLazy(), isLocalized(), isJsonEnabled());
+			isConvertNull(), isLazy(), isLocalized(), isJsonEnabled(),
+			isContainerModelReference(), isParentContainerModelReference());
 	}
 
 	public int compareTo(EntityColumn entityColumn) {
@@ -239,6 +246,10 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 		}
 	}
 
+	public boolean isContainerModelReference() {
+		return _referencesContainerModel;
+	}
+
 	public boolean isConvertNull() {
 		return _convertNull;
 	}
@@ -277,6 +288,10 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 
 	public boolean isOrderColumn() {
 		return _orderColumn;
+	}
+
+	public boolean isParentContainerModelReference() {
+		return _referencesParentContainerModel;
 	}
 
 	public boolean isPrimary() {
@@ -340,6 +355,10 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 		_comparator = comparator;
 	}
 
+	public void setContainerModelReference(boolean referencesContainerModel) {
+		_referencesContainerModel = referencesContainerModel;
+	}
+
 	public void setConvertNull(boolean convertNull) {
 		_convertNull = convertNull;
 	}
@@ -374,6 +393,12 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 
 	public void setOrderColumn(boolean orderColumn) {
 		_orderColumn = orderColumn;
+	}
+
+	public void setParentContainerModelReference(
+		boolean referencesParentContainerModel) {
+
+		_referencesParentContainerModel = referencesParentContainerModel;
 	}
 
 	protected String convertComparatorToHtml(String comparator) {
@@ -422,6 +447,8 @@ public class EntityColumn implements Cloneable, Comparable<EntityColumn> {
 	private boolean _orderByAscending;
 	private boolean _orderColumn;
 	private boolean _primary;
+	private boolean _referencesContainerModel;
+	private boolean _referencesParentContainerModel;
 	private String _type;
 
 }

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -4554,11 +4554,17 @@ public class ServiceBuilder {
 				columnElement.attributeValue("localized"));
 			boolean colJsonEnabled = GetterUtil.getBoolean(
 				columnElement.attributeValue("json-enabled"), jsonEnabled);
+			boolean referencesContainerModel = GetterUtil.getBoolean(
+				columnElement.attributeValue("references-container-model"));
+			boolean referencesParentContainerModel = GetterUtil.getBoolean(
+				columnElement.attributeValue(
+					"references-parent-container-model"));
 
 			EntityColumn col = new EntityColumn(
 				columnName, columnDBName, columnType, primary, accessor,
 				filterPrimary, collectionEntity, mappingKey, mappingTable,
-				idType, idParam, convertNull, lazy, localized, colJsonEnabled);
+				idType, idParam, convertNull, lazy, localized, colJsonEnabled,
+				referencesContainerModel, referencesParentContainerModel);
 
 			if (primary) {
 				pkList.add(col);

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model.ftl
@@ -11,6 +11,7 @@ import com.liferay.portal.model.AttachedModel;
 import com.liferay.portal.model.AuditedModel;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.CacheModel;
+import com.liferay.portal.model.ContainerModel;
 import com.liferay.portal.model.GroupedModel;
 import com.liferay.portal.model.ResourcedModel;
 import com.liferay.portal.model.WorkflowedModel;
@@ -49,6 +50,10 @@ public interface ${entity.name}Model extends
 	</#if>
 
 	BaseModel<${entity.name}>
+
+	<#if entity.isContainerModel()>
+		, ContainerModel
+	</#if>
 
 	<#if entity.isGroupedModel()>
 		, GroupedModel
@@ -321,6 +326,49 @@ public interface ${entity.name}Model extends
 		 * @return <code>true</code> if this ${entity.humanName} is scheduled; <code>false</code> otherwise
 		 */
 		public boolean isScheduled();
+	</#if>
+
+	<#if entity.isContainerModel()>
+		<#if !entity.hasColumn("containerModelId")>
+			/**
+			 * Returns the container model id of this ${entity.humanName}.
+			 *
+			 * @return the container model id of this ${entity.humanName}
+			 */
+			public long getContainerModelId();
+
+			/**
+			 * Sets the container model id of this ${entity.humanName}.
+			 *
+			 * @param container model id of this ${entity.humanName}
+			 */
+			public void setContainerModelId(long containerModelId);
+		</#if>
+
+		<#if !entity.hasColumn("name")>
+			/**
+			 * Returns the name of this ${entity.humanName}.
+			 *
+			 * @return the name of this ${entity.humanName}
+			 */
+			public long getName();
+		</#if>
+
+		<#if !entity.hasColumn("parentContainerModelId")>
+			/**
+			 * Returns the parent container model id of this ${entity.humanName}.
+			 *
+			 * @return the parent container model id of this ${entity.humanName}
+			 */
+			public long getParentContainerModelId();
+
+			/**
+			 * Sets the parent container model id of this ${entity.humanName}.
+			 *
+			 * @param parent container model id of this ${entity.humanName}
+			 */
+			public void setParentContainerModelId(long parentContainerModelId);
+		</#if>
 	</#if>
 
 	<#--

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
@@ -626,6 +626,49 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 		}
 	</#list>
 
+	<#if entity.isContainerModel()>
+		<#assign hasParentContainerModelId = entity.hasColumn("parentContainerModelId")>
+
+		<#list entity.columnList as column>
+			<#if column.isContainerModelReference() && (column.name != "containerModelId")>
+				public long getContainerModelId() {
+					return get${column.methodName}();
+				}
+
+				public void setContainerModelId(long containerModelId) {
+					_${column.name} = containerModelId;
+				}
+			</#if>
+
+			<#if column.isParentContainerModelReference() && (column.name != "parentContainerModelId")>
+				<#assign hasParentContainerModelId = true>
+
+				public long getParentContainerModelId() {
+					return get${column.methodName}();
+				}
+
+				public void setParentContainerModelId(long parentContainerModelId) {
+					_${column.name} = parentContainerModelId;
+				}
+			</#if>
+		</#list>
+
+		<#if !hasParentContainerModelId>
+			public long getParentContainerModelId() {
+				return 0;
+			}
+
+			public void setParentContainerModelId(long parentContainerModelId) {
+			}
+		</#if>
+	</#if>
+
+	<#if (entity.isContainerModel() && !entity.hasColumn("name"))>
+		public String getName() {
+			return String.valueOf(getContainerModelId());
+		}
+	</#if>
+
 	<#if entity.isWorkflowEnabled()>
 		/**
 		 * @deprecated {@link #isApproved}

--- a/portal-impl/src/com/liferay/portal/util/WebKeys.java
+++ b/portal-impl/src/com/liferay/portal/util/WebKeys.java
@@ -434,6 +434,8 @@ public class WebKeys implements com.liferay.portal.kernel.util.WebKeys {
 
 	public static final String TRANSLATOR_TRANSLATION = "TRANSLATOR_TRANSLATION";
 
+	public static final String TRASH_DESTINATION_CONTAINER_MODEL = "TRASH_DESTINATION_CONTAINER_MODEL";
+
 	public static final String TRASH_ENTRY = "TRASH_ENTRY";
 
 	public static final String TREE_GROUP_ID = "TREE_GROUP_ID";

--- a/portal-impl/src/com/liferay/portlet/blogs/trash/BlogsEntryTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/trash/BlogsEntryTrashHandler.java
@@ -17,9 +17,11 @@ package com.liferay.portlet.blogs.trash;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.trash.BaseTrashHandler;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portlet.blogs.model.BlogsEntry;
 import com.liferay.portlet.blogs.service.BlogsEntryLocalServiceUtil;
 import com.liferay.portlet.blogs.service.BlogsEntryServiceUtil;
+import com.liferay.portlet.blogs.service.permission.BlogsPermission;
 
 /**
  * Represents the trash handler for blogs entries entity.
@@ -29,6 +31,13 @@ import com.liferay.portlet.blogs.service.BlogsEntryServiceUtil;
 public class BlogsEntryTrashHandler extends BaseTrashHandler {
 
 	public static final String CLASS_NAME = BlogsEntry.class.getName();
+
+	public void checkPermission(
+			PermissionChecker permissionChecker, long groupId, String actionId)
+		throws PortalException, SystemException {
+
+		BlogsPermission.check(permissionChecker, groupId, actionId);
+	}
 
 	/**
 	 * Deletes all blogs entries with the matching primary keys.

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderModelImpl.java
@@ -683,6 +683,22 @@ public class DLFolderModelImpl extends BaseModelImpl<DLFolder>
 		_statusDate = statusDate;
 	}
 
+	public long getContainerModelId() {
+		return getFolderId();
+	}
+
+	public void setContainerModelId(long containerModelId) {
+		_folderId = containerModelId;
+	}
+
+	public long getParentContainerModelId() {
+		return getParentFolderId();
+	}
+
+	public void setParentContainerModelId(long parentContainerModelId) {
+		_parentFolderId = parentContainerModelId;
+	}
+
 	/**
 	 * @deprecated {@link #isApproved}
 	 */

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE service-builder PUBLIC "-//Liferay//DTD Service Builder 6.1.0//EN" "http://www.liferay.com/dtd/liferay-service-builder_6_1_0.dtd">
+<!DOCTYPE service-builder PUBLIC "-//Liferay//DTD Service Builder 6.2.0//EN" "http://www.liferay.com/dtd/liferay-service-builder_6_2_0.dtd">
 
 <service-builder package-path="com.liferay.portlet.documentlibrary">
 	<namespace>DL</namespace>
@@ -459,7 +459,7 @@
 
 		<!-- PK fields -->
 
-		<column name="folderId" type="long" primary="true" />
+		<column name="folderId" type="long" primary="true" references-container-model="true"/>
 
 		<!-- Group instance -->
 
@@ -477,7 +477,7 @@
 
 		<column name="repositoryId" type="long" />
 		<column name="mountPoint" type="boolean" />
-		<column name="parentFolderId" type="long" />
+		<column name="parentFolderId" type="long" references-parent-container-model="true"/>
 		<column name="name" type="String" />
 		<column name="description" type="String" />
 		<column name="lastPostDate" type="Date" />

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLBaseTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLBaseTrashHandler.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.trash;
+
+import com.liferay.portal.InvalidRepositoryException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.trash.BaseTrashHandler;
+import com.liferay.portal.model.ContainerModel;
+import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.service.RepositoryServiceUtil;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.model.DLFileShortcut;
+import com.liferay.portlet.documentlibrary.model.DLFolder;
+import com.liferay.portlet.documentlibrary.service.DLFileShortcutLocalServiceUtil;
+import com.liferay.portlet.trash.model.TrashEntry;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Zsolt Berentey
+ */
+public abstract class DLBaseTrashHandler extends BaseTrashHandler {
+
+	@Override
+	public ContainerModel getContainerModel(long containerModelId)
+		throws PortalException, SystemException {
+
+		return (ContainerModel)getDLFolder(containerModelId);
+	}
+
+	@Override
+	public List<ContainerModel> getContainerModels(
+			long entryId, long parentContainerModelId, int start, int end)
+		throws PortalException, SystemException {
+
+		Repository repository = getRepository(entryId);
+
+		List<Folder> folders = repository.getFolders(
+			parentContainerModelId, false, start, end, null);
+
+		List<ContainerModel> containerModels = new ArrayList<ContainerModel>();
+
+		for (Folder folder : folders) {
+			containerModels.add((ContainerModel)folder.getModel());
+		}
+
+		return containerModels;
+	}
+
+	@Override
+	public int getContainerModelsCount(
+			long entryId, long parentContainerModelId)
+		throws PortalException, SystemException {
+
+		Repository repository = getRepository(entryId);
+
+		return repository.getFoldersCount(parentContainerModelId, false);
+	}
+
+	@Override
+	public String getRootContainerName() {
+		return "home";
+	}
+
+	protected DLFileEntry getDLFileEntry(long classPK)
+		throws PortalException, SystemException {
+
+		Repository repository = getRepository(0, classPK);
+
+		FileEntry fileEntry = repository.getFileEntry(classPK);
+
+		return (DLFileEntry)fileEntry.getModel();
+	}
+
+	protected DLFileShortcut getDLFileShortcut(long classPK)
+		throws PortalException, SystemException {
+
+		return DLFileShortcutLocalServiceUtil.getDLFileShortcut(classPK);
+	}
+
+	protected DLFolder getDLFolder(long classPK)
+		throws PortalException, SystemException {
+
+		Repository repository = getRepository(classPK, 0);
+
+		Folder folder = repository.getFolder(classPK);
+
+		return (DLFolder)folder.getModel();
+	}
+
+	protected Repository getRepository(long entryId)
+		throws PortalException, SystemException {
+
+		TrashEntry entry = getEntry(entryId);
+
+		String className = entry.getClassName();
+
+		if (className.equals(DLFolder.class.getName())) {
+			return getRepository(entry.getClassPK(), 0);
+		}
+
+		return getRepository(0, entry.getClassPK());
+	}
+
+	protected Repository getRepository(long folderId, long fileEntryid)
+		throws PortalException, SystemException {
+
+		Repository repository = RepositoryServiceUtil.getRepositoryImpl(
+			folderId, fileEntryid, 0);
+
+		if (!(repository instanceof LiferayRepository)) {
+			throw new InvalidRepositoryException(
+				"Repository " + repository.getRepositoryId() +
+					" does not support trash operations");
+		}
+
+		return repository;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.trash.BaseTrashHandler;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.repository.liferayrepository.LiferayRepository;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.RepositoryServiceUtil;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
@@ -30,8 +31,10 @@ import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLAppServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileVersionLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.permission.DLPermission;
 import com.liferay.portlet.documentlibrary.util.DLUtil;
 import com.liferay.portlet.trash.DuplicateEntryException;
+import com.liferay.portlet.trash.TrashEntryConstants;
 import com.liferay.portlet.trash.model.TrashEntry;
 import com.liferay.portlet.trash.util.TrashUtil;
 
@@ -42,13 +45,15 @@ import javax.portlet.PortletRequest;
  *
  * @author Alexander Chow
  * @author Manuel de la Peña
+ * @author Zsolt Berentey
  */
 public class DLFileEntryTrashHandler extends BaseTrashHandler {
 
 	public static final String CLASS_NAME = DLFileEntry.class.getName();
 
 	@Override
-	public void checkDuplicateTrashEntry(TrashEntry trashEntry, String newName)
+	public void checkDuplicateTrashEntry(
+			TrashEntry trashEntry, long containerId, String newName)
 		throws PortalException, SystemException {
 
 		DLFileEntry dlFileEntry = getDLFileEntry(trashEntry.getClassPK());
@@ -61,10 +66,18 @@ public class DLFileEntryTrashHandler extends BaseTrashHandler {
 
 		String originalTitle = TrashUtil.stripTrashNamespace(restoredTitle);
 
+		if (restoredTitle.indexOf(StringPool.FORWARD_SLASH) > 0) {
+			originalTitle = restoredTitle.substring(
+				0, restoredTitle.indexOf(StringPool.FORWARD_SLASH));
+		}
+
+		if (containerId == TrashEntryConstants.DEFAULT_CONTAINER_ID) {
+			containerId = dlFileEntry.getFolderId();
+		}
+
 		DLFileEntry duplicateDLFileEntry =
 			DLFileEntryLocalServiceUtil.fetchFileEntry(
-				dlFileEntry.getGroupId(), dlFileEntry.getFolderId(),
-				originalTitle);
+				dlFileEntry.getGroupId(), containerId, originalTitle);
 
 		if (duplicateDLFileEntry != null) {
 			DuplicateEntryException dee = new DuplicateEntryException();
@@ -75,6 +88,13 @@ public class DLFileEntryTrashHandler extends BaseTrashHandler {
 
 			throw dee;
 		}
+	}
+
+	public void checkPermission(
+			PermissionChecker permissionChecker, long groupId, String actionId)
+		throws PortalException, SystemException {
+
+		DLPermission.check(permissionChecker, groupId, actionId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
@@ -14,16 +14,12 @@
 
 package com.liferay.portlet.documentlibrary.trash;
 
-import com.liferay.portal.InvalidRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.repository.Repository;
-import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.trash.BaseTrashHandler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.repository.liferayrepository.LiferayRepository;
 import com.liferay.portal.security.permission.PermissionChecker;
-import com.liferay.portal.service.RepositoryServiceUtil;
+import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
@@ -47,7 +43,7 @@ import javax.portlet.PortletRequest;
  * @author Manuel de la Peña
  * @author Zsolt Berentey
  */
-public class DLFileEntryTrashHandler extends BaseTrashHandler {
+public class DLFileEntryTrashHandler extends DLBaseTrashHandler {
 
 	public static final String CLASS_NAME = DLFileEntry.class.getName();
 
@@ -168,6 +164,24 @@ public class DLFileEntryTrashHandler extends BaseTrashHandler {
 		return false;
 	}
 
+	@Override
+	public boolean isRestorable(long classPK)
+		throws PortalException, SystemException {
+
+		DLFileEntry dlFileEntry = getDLFileEntry(classPK);
+
+		return !dlFileEntry.isInTrashFolder();
+	}
+
+	@Override
+	public void moveTrashEntry(
+			long classPK, long containerId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		DLAppServiceUtil.moveFileEntryFromTrash(
+			classPK, containerId, serviceContext);
+	}
+
 	/**
 	 * Restores all file entries with the matching primary keys.
 	 *
@@ -198,23 +212,6 @@ public class DLFileEntryTrashHandler extends BaseTrashHandler {
 		dlFileVersion.setTitle(name);
 
 		DLFileVersionLocalServiceUtil.updateDLFileVersion(dlFileVersion, false);
-	}
-
-	protected DLFileEntry getDLFileEntry(long classPK)
-		throws PortalException, SystemException {
-
-		Repository repository = RepositoryServiceUtil.getRepositoryImpl(
-			0, classPK, 0);
-
-		if (!(repository instanceof LiferayRepository)) {
-			throw new InvalidRepositoryException(
-				"Repository " + repository.getRepositoryId() +
-					" does not support trash operations");
-		}
-
-		FileEntry fileEntry = repository.getFileEntry(classPK);
-
-		return (DLFileEntry)fileEntry.getModel();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
@@ -18,10 +18,12 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.trash.BaseTrashHandler;
 import com.liferay.portal.kernel.trash.TrashRenderer;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portlet.documentlibrary.model.DLFileShortcut;
 import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLAppServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileShortcutLocalServiceUtil;
+import com.liferay.portlet.documentlibrary.service.permission.DLPermission;
 import com.liferay.portlet.documentlibrary.util.DLUtil;
 
 import javax.portlet.PortletRequest;
@@ -37,6 +39,13 @@ public class DLFileShortcutTrashHandler extends BaseTrashHandler {
 	 * The class name of the file shortcut entity.
 	 */
 	public static final String CLASS_NAME = DLFileShortcut.class.getName();
+
+	public void checkPermission(
+			PermissionChecker permissionChecker, long groupId, String actionId)
+		throws PortalException, SystemException {
+
+		DLPermission.check(permissionChecker, groupId, actionId);
+	}
 
 	/**
 	 * Deletes all file shortcuts with the matching primary keys.

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
@@ -16,9 +16,9 @@ package com.liferay.portlet.documentlibrary.trash;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.trash.BaseTrashHandler;
 import com.liferay.portal.kernel.trash.TrashRenderer;
 import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.model.DLFileShortcut;
 import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLAppServiceUtil;
@@ -33,7 +33,7 @@ import javax.portlet.PortletRequest;
  *
  * @author Zsolt Berentey
  */
-public class DLFileShortcutTrashHandler extends BaseTrashHandler {
+public class DLFileShortcutTrashHandler extends DLBaseTrashHandler {
 
 	/**
 	 * The class name of the file shortcut entity.
@@ -135,6 +135,24 @@ public class DLFileShortcutTrashHandler extends BaseTrashHandler {
 		}
 
 		return false;
+	}
+
+	@Override
+	public boolean isRestorable(long classPK)
+		throws PortalException, SystemException {
+
+		DLFileShortcut dlFileShortcut = getDLFileShortcut(classPK);
+
+		return !dlFileShortcut.isInTrashFolder();
+	}
+
+	@Override
+	public void moveTrashEntry(
+			long classPK, long containerId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		DLAppServiceUtil.moveFileShortcutFromTrash(
+			classPK, containerId, serviceContext);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandler.java
@@ -14,17 +14,14 @@
 
 package com.liferay.portlet.documentlibrary.trash;
 
-import com.liferay.portal.InvalidRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.trash.BaseTrashHandler;
 import com.liferay.portal.kernel.trash.TrashRenderer;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.repository.liferayrepository.LiferayRepository;
 import com.liferay.portal.security.permission.PermissionChecker;
-import com.liferay.portal.service.RepositoryServiceUtil;
+import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLAppServiceUtil;
@@ -45,7 +42,7 @@ import javax.portlet.PortletRequest;
  * @author Alexander Chow
  * @author Zsolt Berentey
  */
-public class DLFolderTrashHandler extends BaseTrashHandler {
+public class DLFolderTrashHandler extends DLBaseTrashHandler {
 
 	public static final String CLASS_NAME = DLFolder.class.getName();
 
@@ -179,6 +176,24 @@ public class DLFolderTrashHandler extends BaseTrashHandler {
 		return false;
 	}
 
+	@Override
+	public boolean isRestorable(long classPK)
+		throws PortalException, SystemException {
+
+		DLFolder dlFolder = getDLFolder(classPK);
+
+		return !dlFolder.isInTrashFolder();
+	}
+
+	@Override
+	public void moveTrashEntry(
+			long classPK, long containerId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		DLAppServiceUtil.moveFolderFromTrash(
+			classPK, containerId, serviceContext);
+	}
+
 	/**
 	 * Restores all folders with the matching primary keys.
 	 *
@@ -203,23 +218,6 @@ public class DLFolderTrashHandler extends BaseTrashHandler {
 		dlFolder.setName(name);
 
 		DLFolderLocalServiceUtil.updateDLFolder(dlFolder, false);
-	}
-
-	protected DLFolder getDLFolder(long classPK)
-		throws PortalException, SystemException {
-
-		Repository repository = RepositoryServiceUtil.getRepositoryImpl(
-			classPK, 0, 0);
-
-		if (!(repository instanceof LiferayRepository)) {
-			throw new InvalidRepositoryException(
-				"Repository " + repository.getRepositoryId() +
-					" does not support trash operations");
-		}
-
-		Folder folder = repository.getFolder(classPK);
-
-		return (DLFolder)folder.getModel();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/messageboards/trash/MBThreadTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/trash/MBThreadTrashHandler.java
@@ -21,9 +21,11 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.model.CompanyConstants;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portlet.documentlibrary.NoSuchDirectoryException;
 import com.liferay.portlet.documentlibrary.store.DLStoreUtil;
 import com.liferay.portlet.messageboards.model.MBThread;
+import com.liferay.portlet.messageboards.service.permission.MBPermission;
 import com.liferay.portlet.trash.util.TrashUtil;
 
 import java.util.Date;
@@ -36,6 +38,13 @@ import java.util.Date;
 public class MBThreadTrashHandler extends BaseTrashHandler {
 
 	public static final String CLASS_NAME = MBThread.class.getName();
+
+	public void checkPermission(
+			PermissionChecker permissionChecker, long groupId, String actionId)
+		throws PortalException, SystemException {
+
+		MBPermission.check(permissionChecker, groupId, actionId);
+	}
 
 	/**
 	 * Deletes trash attachments from all the message boards messages from a

--- a/portal-impl/src/com/liferay/portlet/trash/action/EditEntryAction.java
+++ b/portal-impl/src/com/liferay/portlet/trash/action/EditEntryAction.java
@@ -29,10 +29,13 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceContextFactory;
 import com.liferay.portal.struts.PortletAction;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.WebKeys;
 import com.liferay.portlet.trash.DuplicateEntryException;
+import com.liferay.portlet.trash.TrashEntryConstants;
 import com.liferay.portlet.trash.model.TrashEntry;
 import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
 import com.liferay.portlet.trash.service.TrashEntryServiceUtil;
@@ -95,6 +98,9 @@ public class EditEntryAction extends PortletAction {
 			else if (cmd.equals(Constants.EMPTY_TRASH)) {
 				emptyTrash(actionRequest);
 			}
+			else if (cmd.equals(Constants.MOVE)) {
+				entries = moveEntry(actionRequest);
+			}
 			else if (cmd.equals(Constants.RENAME)) {
 				entries = restoreRename(actionRequest);
 			}
@@ -104,14 +110,14 @@ public class EditEntryAction extends PortletAction {
 			else if (cmd.equals(Constants.OVERRIDE)) {
 				entries = restoreOverride(actionRequest);
 			}
-			else if (cmd.equals("checkEntry")) {
+			else if (cmd.equals(Constants.CHECK_ENTRY)) {
 				checkEntry(actionRequest, actionResponse);
 
 				return;
 			}
 
 			if (cmd.equals(Constants.RENAME) || cmd.equals(Constants.RESTORE) ||
-				cmd.equals(Constants.OVERRIDE)) {
+				cmd.equals(Constants.OVERRIDE) || cmd.equals(Constants.MOVE)) {
 
 				addRestoreData(
 					(LiferayPortletConfig)portletConfig, actionRequest,
@@ -199,7 +205,8 @@ public class EditEntryAction extends PortletAction {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
 		try {
-			trashHandler.checkDuplicateTrashEntry(entry, newName);
+			trashHandler.checkDuplicateTrashEntry(
+				entry, TrashEntryConstants.DEFAULT_CONTAINER_ID, newName);
 
 			jsonObject.put("success", true);
 		}
@@ -245,6 +252,29 @@ public class EditEntryAction extends PortletAction {
 		TrashEntryServiceUtil.deleteEntries(themeDisplay.getScopeGroupId());
 	}
 
+	protected TrashEntry[] moveEntry(ActionRequest actionRequest)
+		throws Exception {
+
+		long containerId = ParamUtil.getLong(actionRequest, "containerId");
+		long entryId = ParamUtil.getLong(actionRequest, "entryId");
+
+		TrashEntry entry = TrashEntryLocalServiceUtil.getTrashEntry(entryId);
+
+		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
+			entry.getClassName());
+
+		trashHandler.checkDuplicateTrashEntry(
+			entry, containerId, StringPool.BLANK);
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			entry.getClassName(), actionRequest);
+
+		trashHandler.moveTrashEntry(
+			entry.getClassPK(), containerId, serviceContext);
+
+		return new TrashEntry[] {entry};
+	}
+
 	protected TrashEntry[] restoreEntries(ActionRequest actionRequest)
 		throws Exception {
 
@@ -275,7 +305,8 @@ public class EditEntryAction extends PortletAction {
 		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
 			entry.getClassName());
 
-		trashHandler.checkDuplicateTrashEntry(entry, StringPool.BLANK);
+		trashHandler.checkDuplicateTrashEntry(
+			entry, TrashEntryConstants.DEFAULT_CONTAINER_ID, StringPool.BLANK);
 
 		trashHandler.restoreTrashEntry(entry.getClassPK());
 

--- a/portal-impl/src/com/liferay/portlet/trash/action/SelectContainerAction.java
+++ b/portal-impl/src/com/liferay/portlet/trash/action/SelectContainerAction.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.trash.action;
+
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.trash.TrashHandler;
+import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.model.ContainerModel;
+import com.liferay.portal.security.auth.PrincipalException;
+import com.liferay.portal.security.permission.ActionKeys;
+import com.liferay.portal.struts.PortletAction;
+import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.WebKeys;
+
+import javax.portlet.PortletConfig;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+
+/**
+ * @author Zsolt Berentey
+ */
+public class SelectContainerAction extends PortletAction {
+
+	@Override
+	public ActionForward render(
+			ActionMapping mapping, ActionForm form, PortletConfig portletConfig,
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		try {
+			String className = ParamUtil.getString(
+				renderRequest, "entryClassName");
+
+			TrashHandler trashHandler =
+				TrashHandlerRegistryUtil.getTrashHandler(className);
+
+			ContainerModel containerModel = null;
+
+			long containerModelId = ParamUtil.getLong(
+				renderRequest, "containerModelId");
+
+			if (containerModelId > 0) {
+				containerModel = trashHandler.getContainerModel(
+					containerModelId);
+			}
+			else {
+				trashHandler.checkPermission(
+					themeDisplay.getPermissionChecker(),
+					themeDisplay.getScopeGroupId(), ActionKeys.VIEW);
+			}
+
+			renderRequest.setAttribute(
+				WebKeys.TRASH_DESTINATION_CONTAINER_MODEL, containerModel);
+		}
+		catch (Exception e) {
+			if (e instanceof PrincipalException) {
+				SessionErrors.add(renderRequest, e.getClass());
+
+				return mapping.findForward("portlet.trash.error");
+			}
+			else {
+				throw e;
+			}
+		}
+
+		return mapping.findForward(
+			getForward(renderRequest, "portlet.trash.select_container"));
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/wiki/trash/WikiNodeTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/trash/WikiNodeTrashHandler.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.trash.BaseTrashHandler;
 import com.liferay.portal.kernel.trash.TrashRenderer;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portlet.trash.DuplicateEntryException;
 import com.liferay.portlet.trash.model.TrashEntry;
 import com.liferay.portlet.trash.util.TrashUtil;
@@ -26,6 +27,7 @@ import com.liferay.portlet.wiki.asset.WikiNodeTrashRenderer;
 import com.liferay.portlet.wiki.model.WikiNode;
 import com.liferay.portlet.wiki.service.WikiNodeLocalServiceUtil;
 import com.liferay.portlet.wiki.service.WikiNodeServiceUtil;
+import com.liferay.portlet.wiki.service.permission.WikiPermission;
 /*
  * @author Eudaldo Alonso
  */
@@ -34,7 +36,8 @@ public class WikiNodeTrashHandler extends BaseTrashHandler {
 	public static final String CLASS_NAME = WikiNode.class.getName();
 
 	@Override
-	public void checkDuplicateTrashEntry(TrashEntry trashEntry, String newName)
+	public void checkDuplicateTrashEntry(
+			TrashEntry trashEntry, long containerId, String newName)
 		throws PortalException, SystemException {
 
 		WikiNode node = WikiNodeLocalServiceUtil.getNode(
@@ -60,6 +63,13 @@ public class WikiNodeTrashHandler extends BaseTrashHandler {
 
 			throw dee;
 		}
+	}
+
+	public void checkPermission(
+			PermissionChecker permissionChecker, long groupId, String actionId)
+		throws PortalException, SystemException {
+
+		WikiPermission.check(permissionChecker, groupId, actionId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/wiki/trash/WikiPageTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/trash/WikiPageTrashHandler.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.CompanyConstants;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.LayoutConstants;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portlet.PortletURLFactoryUtil;
@@ -40,6 +41,7 @@ import com.liferay.portlet.wiki.model.WikiPageResource;
 import com.liferay.portlet.wiki.service.WikiPageLocalServiceUtil;
 import com.liferay.portlet.wiki.service.WikiPageResourceLocalServiceUtil;
 import com.liferay.portlet.wiki.service.WikiPageServiceUtil;
+import com.liferay.portlet.wiki.service.permission.WikiPermission;
 
 import java.util.Date;
 
@@ -53,7 +55,8 @@ public class WikiPageTrashHandler extends BaseTrashHandler {
 	public static final String CLASS_NAME = WikiPage.class.getName();
 
 	@Override
-	public void checkDuplicateTrashEntry(TrashEntry trashEntry, String newName)
+	public void checkDuplicateTrashEntry(
+			TrashEntry trashEntry, long containerId, String newName)
 		throws PortalException, SystemException {
 
 		WikiPage page = WikiPageLocalServiceUtil.getPage(
@@ -68,7 +71,7 @@ public class WikiPageTrashHandler extends BaseTrashHandler {
 		String originalTitle = TrashUtil.stripTrashNamespace(restoredTitle);
 
 		WikiPage duplicatePage = WikiPageLocalServiceUtil.fetchPage(
-			page.getNodeId(), originalTitle, page.getVersion());
+			containerId, originalTitle, page.getVersion());
 
 		if (duplicatePage != null) {
 			DuplicateEntryException dee = new DuplicateEntryException();
@@ -79,6 +82,13 @@ public class WikiPageTrashHandler extends BaseTrashHandler {
 
 			throw dee;
 		}
+	}
+
+	public void checkPermission(
+			PermissionChecker permissionChecker, long groupId, String actionId)
+		throws PortalException, SystemException {
+
+		WikiPermission.check(permissionChecker, groupId, actionId);
 	}
 
 	/**

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -423,6 +423,10 @@ action.VIEW_USER=View User
 ## Messages
 ##
 
+choose-this-destination=Choose This Destination
+container=Container
+num-of-subcontainers=# of Subcontainers
+select-destination=Select Destination
 1-day=1 Day
 1-minute=1 Minute
 1-month=1 Month

--- a/portal-service/src/com/liferay/portal/kernel/trash/BaseTrashHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/trash/BaseTrashHandler.java
@@ -16,14 +16,20 @@ package com.liferay.portal.kernel.trash;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.ContainerModel;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.asset.AssetRendererFactoryRegistryUtil;
 import com.liferay.portlet.asset.model.AssetRenderer;
 import com.liferay.portlet.asset.model.AssetRendererFactory;
 import com.liferay.portlet.trash.model.TrashEntry;
+import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
 
 import java.util.Date;
+import java.util.List;
 
 import javax.portlet.PortletRequest;
 
@@ -49,7 +55,8 @@ import javax.portlet.PortletRequest;
 public abstract class BaseTrashHandler implements TrashHandler {
 
 	@SuppressWarnings("unused")
-	public void checkDuplicateTrashEntry(TrashEntry trashEntry, String newName)
+	public void checkDuplicateTrashEntry(
+			TrashEntry trashEntry, long containerId, String newName)
 		throws PortalException, SystemException {
 	}
 
@@ -76,6 +83,26 @@ public abstract class BaseTrashHandler implements TrashHandler {
 		deleteTrashEntries(new long[] {classPK}, checkPermission);
 	}
 
+	public ContainerModel getContainerModel(long containerModelId)
+		throws PortalException, SystemException {
+
+		return null;
+	}
+
+	public List<ContainerModel> getContainerModels(
+			long entryId, long parentContainerModelId, int start, int end)
+		throws PortalException, SystemException {
+
+		return null;
+	}
+
+	public int getContainerModelsCount(
+			long entryId, long parentContainerModelId)
+		throws PortalException, SystemException {
+
+		return 0;
+	}
+
 	public String getDeleteMessage() {
 		return "deleted-in-x";
 	}
@@ -91,6 +118,10 @@ public abstract class BaseTrashHandler implements TrashHandler {
 	public String getRestoreMessage(PortletRequest portletRequest, long classPK)
 		throws PortalException, SystemException {
 
+		return StringPool.BLANK;
+	}
+
+	public String getRootContainerName() {
 		return StringPool.BLANK;
 	}
 
@@ -111,6 +142,26 @@ public abstract class BaseTrashHandler implements TrashHandler {
 		return null;
 	}
 
+	public boolean isRestorable(long classPK)
+		throws PortalException, SystemException {
+
+		return true;
+	}
+
+	public void moveTrashEntry(
+			long classPK, long containerId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		if (isRestorable(classPK)) {
+			restoreTrashEntry(classPK);
+		}
+
+		_log.error("moveTrashEntry() is not implemented in " +
+			getClass().getName());
+
+		throw new SystemException();
+	}
+
 	public void restoreTrashEntry(long classPK)
 		throws PortalException, SystemException {
 
@@ -126,5 +177,14 @@ public abstract class BaseTrashHandler implements TrashHandler {
 		return AssetRendererFactoryRegistryUtil.
 			getAssetRendererFactoryByClassName(getClassName());
 	}
+
+	protected TrashEntry getEntry(long entryId)
+		throws PortalException, SystemException {
+
+		return TrashEntryLocalServiceUtil.getEntry(entryId);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseTrashHandler.class);
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/trash/TrashHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/trash/TrashHandler.java
@@ -16,10 +16,14 @@ package com.liferay.portal.kernel.trash;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.model.ContainerModel;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.trash.model.TrashEntry;
 
 import java.util.Date;
+import java.util.List;
 
 import javax.portlet.PortletRequest;
 
@@ -57,8 +61,13 @@ import javax.portlet.PortletRequest;
  */
 public interface TrashHandler {
 
-	public void checkDuplicateTrashEntry(TrashEntry trashEntry, String newName)
+	public void checkDuplicateTrashEntry(
+			TrashEntry trashEntry, long containerId, String newName)
 		throws PortalException, SystemException;
+
+	public void checkPermission(
+		PermissionChecker permissionChecker, long groupId, String actionId)
+	throws PortalException, SystemException;
 
 	/**
 	 * Deletes all trash attachments from a group that were deleted after a
@@ -116,6 +125,16 @@ public interface TrashHandler {
 	 */
 	public String getClassName();
 
+	public ContainerModel getContainerModel(long containerId)
+		throws PortalException, SystemException;
+
+	public List<ContainerModel> getContainerModels(
+			long entryId, long containerId, int start, int end)
+		throws PortalException, SystemException;
+
+	public int getContainerModelsCount(long entryId, long containerId)
+		throws PortalException, SystemException;
+
 	public String getDeleteMessage();
 
 	public String getRestoreLink(PortletRequest portletRequest, long classPK)
@@ -123,6 +142,8 @@ public interface TrashHandler {
 
 	public String getRestoreMessage(PortletRequest portletRequest, long classPK)
 		throws PortalException, SystemException;
+
+	public String getRootContainerName();
 
 	/**
 	 * Returns the trash renderer associated to the trash entry.
@@ -137,6 +158,13 @@ public interface TrashHandler {
 		throws PortalException, SystemException;
 
 	public boolean isInTrash(long classPK)
+		throws PortalException, SystemException;
+
+	public boolean isRestorable(long classPK)
+		throws PortalException, SystemException;
+
+	public void moveTrashEntry(
+			long classPK, long containerId, ServiceContext serviceContext)
 		throws PortalException, SystemException;
 
 	/**

--- a/portal-service/src/com/liferay/portal/kernel/util/Constants.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Constants.java
@@ -35,6 +35,8 @@ public interface Constants {
 
 	public static final String CANCEL_CHECKOUT = "cancel_checkout";
 
+	public static final String CHECK_ENTRY = "check_entry";
+
 	public static final String CHECKIN = "checkin";
 
 	public static final String CHECKOUT = "checkout";

--- a/portal-service/src/com/liferay/portal/model/ContainerModel.java
+++ b/portal-service/src/com/liferay/portal/model/ContainerModel.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.model;
+
+/**
+ * @author Zsolt Berentey
+ */
+public interface ContainerModel {
+
+	public long getContainerModelId();
+
+	public String getName();
+
+	public long getParentContainerModelId();
+
+	public void setContainerModelId(long containerModelId);
+
+	public void setParentContainerModelId(long parentContainerModelId);
+
+}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderModel.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderModel.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.CacheModel;
+import com.liferay.portal.model.ContainerModel;
 import com.liferay.portal.model.GroupedModel;
 import com.liferay.portal.model.WorkflowedModel;
 import com.liferay.portal.service.ServiceContext;
@@ -41,8 +42,8 @@ import java.util.Date;
  * @see com.liferay.portlet.documentlibrary.model.impl.DLFolderModelImpl
  * @generated
  */
-public interface DLFolderModel extends BaseModel<DLFolder>, GroupedModel,
-	WorkflowedModel {
+public interface DLFolderModel extends BaseModel<DLFolder>, ContainerModel,
+	GroupedModel, WorkflowedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:
 	 *
@@ -459,6 +460,34 @@ public interface DLFolderModel extends BaseModel<DLFolder>, GroupedModel,
 	 * @return <code>true</code> if this document library folder is scheduled; <code>false</code> otherwise
 	 */
 	public boolean isScheduled();
+
+	/**
+	 * Returns the container model id of this document library folder.
+	 *
+	 * @return the container model id of this document library folder
+	 */
+	public long getContainerModelId();
+
+	/**
+	 * Sets the container model id of this document library folder.
+	 *
+	 * @param container model id of this document library folder
+	 */
+	public void setContainerModelId(long containerModelId);
+
+	/**
+	 * Returns the parent container model id of this document library folder.
+	 *
+	 * @return the parent container model id of this document library folder
+	 */
+	public long getParentContainerModelId();
+
+	/**
+	 * Sets the parent container model id of this document library folder.
+	 *
+	 * @param parent container model id of this document library folder
+	 */
+	public void setParentContainerModelId(long parentContainerModelId);
 
 	public boolean isNew();
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
@@ -717,6 +717,42 @@ public class DLFolderWrapper implements DLFolder, ModelWrapper<DLFolder> {
 		return _dlFolder.isScheduled();
 	}
 
+	/**
+	* Returns the container model id of this document library folder.
+	*
+	* @return the container model id of this document library folder
+	*/
+	public long getContainerModelId() {
+		return _dlFolder.getContainerModelId();
+	}
+
+	/**
+	* Sets the container model id of this document library folder.
+	*
+	* @param container model id of this document library folder
+	*/
+	public void setContainerModelId(long containerModelId) {
+		_dlFolder.setContainerModelId(containerModelId);
+	}
+
+	/**
+	* Returns the parent container model id of this document library folder.
+	*
+	* @return the parent container model id of this document library folder
+	*/
+	public long getParentContainerModelId() {
+		return _dlFolder.getParentContainerModelId();
+	}
+
+	/**
+	* Sets the parent container model id of this document library folder.
+	*
+	* @param parent container model id of this document library folder
+	*/
+	public void setParentContainerModelId(long parentContainerModelId) {
+		_dlFolder.setParentContainerModelId(parentContainerModelId);
+	}
+
 	public boolean isNew() {
 		return _dlFolder.isNew();
 	}

--- a/portal-service/src/com/liferay/portlet/trash/TrashEntryConstants.java
+++ b/portal-service/src/com/liferay/portlet/trash/TrashEntryConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.trash;
+
+/**
+ * @author Zsolt Berentey
+ */
+public class TrashEntryConstants {
+
+	public static final int DEFAULT_CONTAINER_ID = -1;
+
+}

--- a/portal-web/docroot/WEB-INF/struts-config.xml
+++ b/portal-web/docroot/WEB-INF/struts-config.xml
@@ -1937,6 +1937,11 @@
 
 		<action path="/trash/restore_entry" forward="portlet.trash.restore_entry" />
 
+		<action path="/trash/select_container" type="com.liferay.portlet.trash.action.SelectContainerAction">
+			<forward name="portlet.trash.error" path="portlet.trash.error" />
+			<forward name="portlet.trash.select_container" path="portlet.trash.select_container" />
+		</action>
+
 		<action path="/trash/view" forward="portlet.trash.view" />
 
 		<action path="/trash/view_content" forward="portlet.trash.view_content" />

--- a/portal-web/docroot/WEB-INF/tiles-defs.xml
+++ b/portal-web/docroot/WEB-INF/tiles-defs.xml
@@ -1581,6 +1581,10 @@
 		<put name="portlet_content" value="/portlet/trash/restore_entry.jsp" />
 	</definition>
 
+	<definition name="portlet.trash.select_container" extends="portlet.trash">
+		<put name="portlet_content" value="/portlet/trash/select_container.jsp" />
+	</definition>
+
 	<definition name="portlet.trash.view" extends="portlet.trash">
 		<put name="portlet_content" value="/portlet/trash/view.jsp" />
 	</definition>

--- a/portal-web/docroot/html/portlet/trash/action/restore.jspf
+++ b/portal-web/docroot/html/portlet/trash/action/restore.jspf
@@ -16,17 +16,26 @@
 
 <%
 TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(entry.getClassName());
-
-TrashRenderer trashRenderer = trashHandler.getTrashRenderer(entry.getClassPK());
-
-String restorePath = trashRenderer.getRestorePath(renderRequest);
 %>
 
 <c:choose>
-	<c:when test="<%= Validator.isNotNull(restorePath) %>">
-		<liferay-util:include page="<%= restorePath %>" portletId="<%= trashRenderer.getPortletId() %>">
-			<liferay-util:param name="showHeader" value="<%= Boolean.FALSE.toString() %>" />
-		</liferay-util:include>
+	<c:when test="<%= !trashHandler.isRestorable(entry.getClassPK()) %>">
+		<portlet:renderURL var="moveURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+			<portlet:param name="struts_action" value="/trash/select_container" />
+			<portlet:param name="entryId" value="<%= String.valueOf(entry.getEntryId()) %>" />
+			<portlet:param name="entryClassName" value="<%= entry.getClassName() %>" />
+		</portlet:renderURL>
+
+		<%
+		String taglibOpenWindow = "var dialogWindow = window.open('" + moveURL + "','folder', 'directories=no,height=640,location=no,menubar=no,resizable=yes,scrollbars=yes,status=no,toolbar=no,width=680'); void(''); dialogWindow.focus();";
+		%>
+
+		<liferay-ui:icon
+			image="submit"
+			message="move"
+			onClick="<%= taglibOpenWindow %>"
+			url="javascript:;"
+		/>
 	</c:when>
 	<c:otherwise>
 		<portlet:actionURL var="restoreEntryURL">

--- a/portal-web/docroot/html/portlet/trash/select_container.jsp
+++ b/portal-web/docroot/html/portlet/trash/select_container.jsp
@@ -1,0 +1,183 @@
+<%--
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/portlet/trash/init.jsp" %>
+
+<%
+long containerModelId = 0;
+long entryId = ParamUtil.getLong(request, "entryId");
+String className = ParamUtil.getString(request, "entryClassName");
+
+TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(className);
+
+ContainerModel containerModel = (ContainerModel)request.getAttribute(WebKeys.TRASH_DESTINATION_CONTAINER_MODEL);
+
+if (containerModel != null) {
+	containerModelId = containerModel.getContainerModelId();
+
+	List<Tuple> tuples = new ArrayList<Tuple>();
+
+	tuples.add(new Tuple(containerModel.getContainerModelId(), containerModel.getName()));
+
+	ContainerModel curContainerModel = containerModel;
+
+	while (curContainerModel.getParentContainerModelId() > 0) {
+		curContainerModel = trashHandler.getContainerModel(curContainerModel.getParentContainerModelId());
+
+		tuples.add(0, new Tuple(curContainerModel.getContainerModelId(), curContainerModel.getName()));
+	}
+
+	tuples.add(0, new Tuple(0L, LanguageUtil.get(pageContext, trashHandler.getRootContainerName())));
+
+	for (Tuple tuple : tuples) {
+		long curContainerId = (Long)tuple.getObject(0);
+
+		PortletURL containerURL = renderResponse.createRenderURL();
+
+		containerURL.setParameter("struts_action", "/trash/select_container");
+		containerURL.setParameter("containerModelId", String.valueOf(curContainerId));
+		containerURL.setParameter("entryId", String.valueOf(entryId));
+		containerURL.setParameter("entryClassName", className);
+
+		if (curContainerId == containerModel.getContainerModelId()) {
+			PortalUtil.addPortletBreadcrumbEntry(request, String.valueOf(tuple.getObject(1)), null);
+		}
+		else {
+			PortalUtil.addPortletBreadcrumbEntry(request, String.valueOf(tuple.getObject(1)), containerURL.toString());
+		}
+	}
+}
+else {
+	PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(pageContext, trashHandler.getRootContainerName()), null);
+}
+%>
+
+<aui:form method="post" name="fm">
+	<liferay-ui:header
+		title="select-destination"
+	/>
+
+	<liferay-ui:breadcrumb showGuestGroup="<%= false %>" showLayout="<%= false %>" showParentGroups="<%= false %>" />
+
+	<%
+	PortletURL portletURL = renderResponse.createRenderURL();
+
+	portletURL.setParameter("struts_action", "/trash/select_container");
+	portletURL.setParameter("containerModelId", String.valueOf(containerModelId));
+	portletURL.setParameter("entryId", String.valueOf(entryId));
+	portletURL.setParameter("entryClassName", className);
+
+	List<String> headerNames = new ArrayList<String>();
+
+	headerNames.add("container");
+	headerNames.add("num-of-subcontainers");
+	headerNames.add(StringPool.BLANK);
+	%>
+
+	<liferay-ui:search-container
+		searchContainer="<%= new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, null) %>"
+	>
+
+		<liferay-ui:search-container-results>
+
+			<%
+			pageContext.setAttribute("results", trashHandler.getContainerModels(entryId, containerModelId, searchContainer.getStart(), searchContainer.getEnd()));
+			pageContext.setAttribute("total", trashHandler.getContainerModelsCount(entryId, containerModelId));
+			%>
+
+		</liferay-ui:search-container-results>
+
+		<liferay-ui:search-container-row
+			className="com.liferay.portal.model.ContainerModel"
+			keyProperty="containerModelId"
+			modelVar="curContainerModel"
+		>
+
+			<%
+			PortletURL rowURL = renderResponse.createRenderURL();
+
+			rowURL.setParameter("struts_action", "/trash/select_container");
+			rowURL.setParameter("containerModelId", String.valueOf(curContainerModel.getContainerModelId()));
+			rowURL.setParameter("entryId", String.valueOf(entryId));
+			rowURL.setParameter("entryClassName", className);
+			%>
+
+			<liferay-ui:search-container-column-text
+				name="container"
+			>
+				<c:choose>
+					<c:when test="<%= curContainerModel.getContainerModelId() > 0 %>">
+
+						<%
+						TrashHandler containerTrashHandler = TrashHandlerRegistryUtil.getTrashHandler(((BaseModel)curContainerModel).getModelClassName());
+
+						TrashRenderer containerTrashRenderer = containerTrashHandler.getTrashRenderer(curContainerModel.getContainerModelId());
+						%>
+
+						<liferay-ui:icon label="<%= true %>" message="<%= curContainerModel.getName() %>" src="<%= containerTrashRenderer.getIconPath(renderRequest) %>" url="<%= rowURL.toString() %>" />
+					</c:when>
+					<c:otherwise>
+						<%=curContainerModel.getName() %>
+					</c:otherwise>
+				</c:choose>
+			</liferay-ui:search-container-column-text>
+
+			<liferay-ui:search-container-column-text
+				name="num-of-subcontainers"
+				value="<%= String.valueOf(trashHandler.getContainerModelsCount(entryId, curContainerModel.getContainerModelId())) %>"
+			/>
+
+			<c:choose>
+				<c:when test="<%= rowURL != null %>">
+
+					<%
+					StringBuilder sb = new StringBuilder();
+
+					sb.append("opener.");
+					sb.append(renderResponse.getNamespace());
+					sb.append("selectContainer(");
+					sb.append(entryId);
+					sb.append(", ");
+					sb.append(curContainerModel.getContainerModelId());
+					sb.append("); window.close();");
+					%>
+
+					<liferay-ui:search-container-column-button
+						align="right"
+						href="<%= sb.toString() %>"
+						name="choose"
+					/>
+				</c:when>
+				<c:otherwise>
+					<liferay-ui:search-container-column-text> </liferay-ui:search-container-column-text>
+				</c:otherwise>
+			</c:choose>
+		</liferay-ui:search-container-row>
+
+		<aui:button-row>
+
+			<%
+			String taglibSelectOnClick = "opener." + renderResponse.getNamespace() + "selectContainer("+ entryId + ", " + containerModelId + "); window.close();";
+			%>
+
+			<aui:button onClick="<%= taglibSelectOnClick %>" value="choose-this-destination" />
+		</aui:button-row>
+
+		<div class="separator"><!-- --></div>
+
+		<liferay-ui:search-iterator />
+	</liferay-ui:search-container>
+</aui:form>

--- a/portal-web/docroot/html/portlet/trash/view.jsp
+++ b/portal-web/docroot/html/portlet/trash/view.jsp
@@ -271,14 +271,34 @@ portletURL.setParameter("tabs1", tabs1);
 	<liferay-ui:search-iterator type='<%= aproximate ? "more" : "regular" %>' />
 </liferay-ui:search-container>
 
+<portlet:actionURL var="moveEntryURL">
+	<portlet:param name="struts_action" value="/trash/edit_entry" />
+</portlet:actionURL>
+
+<aui:form action="<%= moveEntryURL.toString() %>" method="post" name="fm1">
+	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.MOVE %>" />
+	<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
+	<aui:input name="entryId" type="hidden" value="" />
+	<aui:input name="containerId" type="hidden" value="" />
+</aui:form>
+
 <aui:script use="liferay-trash">
 	new Liferay.Portlet.Trash(
 		{
-			checkEntryURL: '<portlet:actionURL><portlet:param name="<%= Constants.CMD %>" value="checkEntry" /><portlet:param name="struts_action" value="/trash/edit_entry" /></portlet:actionURL>',
+			checkEntryURL: '<portlet:actionURL><portlet:param name="<%= Constants.CMD %>" value="<%= Constants.CHECK_ENTRY %>" /><portlet:param name="struts_action" value="/trash/edit_entry" /></portlet:actionURL>',
 			namespace: '<portlet:namespace />',
 			restoreEntryURL: '<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="struts_action" value="/trash/restore_entry" /><portlet:param name="redirect" value="<%= currentURL %>" /></portlet:renderURL>'
 		}
 	);
+</aui:script>
+
+<aui:script>
+	function <portlet:namespace />selectContainer(entryId, containerId) {
+		document.<portlet:namespace />fm1.<portlet:namespace />entryId.value = entryId;
+		document.<portlet:namespace />fm1.<portlet:namespace />containerId.value = containerId;
+
+		submitForm(document.<portlet:namespace />fm1);
+	}
 </aui:script>
 
 <%

--- a/portal-web/docroot/html/portlet/trash/view.jsp
+++ b/portal-web/docroot/html/portlet/trash/view.jsp
@@ -278,8 +278,8 @@ portletURL.setParameter("tabs1", tabs1);
 <aui:form action="<%= moveEntryURL.toString() %>" method="post" name="fm1">
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.MOVE %>" />
 	<aui:input name="redirect" type="hidden" value="<%= portletURL.toString() %>" />
-	<aui:input name="entryId" type="hidden" value="" />
-	<aui:input name="containerId" type="hidden" value="" />
+	<aui:input name="entryId" type="hidden" />
+	<aui:input name="containerId" type="hidden" />
 </aui:form>
 
 <aui:script use="liferay-trash">


### PR DESCRIPTION
- I can find more than 100 references to container Id. shouldn't it be containerModelId? Not sure....
- Users will find weird the word "Container" in the UI. I think we should change this. We have 3 options:
  - Use a better one (I like destination, but I don't like subdestination)
  - Use destination for all of them (avoid using subdestinations)
  - Make the name part of the framework. "getContainerModelName" By default it is folder, but it could be "node" in the wiki.
