### PR TITLE
LPS-30733 [RESENT] Use referer URL to redirect after password update

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
@@ -97,17 +97,17 @@ public class UpdatePasswordAction extends Action {
 		try {
 			updatePassword(request, response, themeDisplay, ticket);
 
-			String redirectURL = ParamUtil.getString(request, WebKeys.REFERER);
+			String redirect = ParamUtil.getString(request, WebKeys.REFERER);
 
-			if (Validator.isNull(redirectURL)) {
+			if (Validator.isNull(redirect)) {
 				PortletURL portletURL = new PortletURLImpl(
 					request, PortletKeys.LOGIN, themeDisplay.getPlid(),
 					PortletRequest.RENDER_PHASE);
 
-				redirectURL = portletURL.toString();
+				redirect = portletURL.toString();
 			}
 
-			response.sendRedirect(redirectURL);
+			response.sendRedirect(redirect);
 
 			return null;
 		}

--- a/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
@@ -97,11 +97,17 @@ public class UpdatePasswordAction extends Action {
 		try {
 			updatePassword(request, response, themeDisplay, ticket);
 
-			PortletURL portletURL = new PortletURLImpl(
-				request, PortletKeys.LOGIN, themeDisplay.getPlid(),
-				PortletRequest.RENDER_PHASE);
+			String redirectURL = ParamUtil.getString(request, WebKeys.REFERER);
 
-			response.sendRedirect(portletURL.toString());
+			if (Validator.isNull(redirectURL)) {
+				PortletURL portletURL = new PortletURLImpl(
+					request, PortletKeys.LOGIN, themeDisplay.getPlid(),
+					PortletRequest.RENDER_PHASE);
+
+				redirectURL = portletURL.toString();
+			}
+
+			response.sendRedirect(redirectURL);
 
 			return null;
 		}


### PR DESCRIPTION
Brian: Why don't we use the "redirect" parameter? Why are we using the REFERER constant?

Eduardo: We use the referer param because it's the one set at the update_password.jsp. The redirect parameter is empty.
