### PR TITLE
LPS-30824 It is better to use "==" to test Class' equality, because we n...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/MethodKey.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/MethodKey.java
@@ -68,7 +68,7 @@ public class MethodKey implements Externalizable {
 
 		MethodKey methodKey = (MethodKey)obj;
 
-		if (Validator.equals(_declaringClass, methodKey._declaringClass) &&
+		if ((_declaringClass == methodKey._declaringClass) &&
 			Validator.equals(_methodName, methodKey._methodName) &&
 			Arrays.equals(_parameterTypes, methodKey._parameterTypes)) {
 


### PR DESCRIPTION
...eed to ensure they are from the exact same ClassLoader and ClassLoader maintains an unique singleton cache for Classes. "==" is more clear to express this.
