### PR TITLE
LPS-30940 Injection with cdn_host parameter

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1145,6 +1145,8 @@ public class PortalImpl implements Portal {
 	public String getCDNHost(HttpServletRequest request)
 		throws PortalException, SystemException {
 
+		boolean cdnEnabled = ParamUtil.getBoolean(request, "cdn_enabled", true);
+
 		String cdnHost = null;
 
 		Company company = getCompany(request);
@@ -1156,9 +1158,7 @@ public class PortalImpl implements Portal {
 			cdnHost = getCDNHostHttp(company.getCompanyId());
 		}
 
-		cdnHost = ParamUtil.getString(request, "cdn_host", cdnHost);
-
-		if (Validator.isUrl(cdnHost)) {
+		if (cdnEnabled && Validator.isUrl(cdnHost)) {
 			return cdnHost;
 		}
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5684,17 +5684,17 @@
 
     #
     # Set the hostname that will be used to serve static content via a CDN for
-    # requests made over the HTTP protocol. This property can be overridden
-    # dynamically at runtime by setting the URL parameter "cdn_host". The value
-    # must always include the full protocol.
+    # requests made over the HTTP protocol. This property can be disabled
+    # dynamically at runtime by setting the URL parameter "cdn_enabled" to "0".
+    # The value must always include the full protocol.
     #
     cdn.host.http=
 
     #
     # Set the hostname that will be used to serve static content via a CDN for
-    # requests made over the HTTPS protocol. This property can be overridden
-    # dynamically at runtime by setting the URL parameter "cdn_host". The value
-    # must always include the full protocol.
+    # requests made over the HTTPS protocol. This property can be disabled
+    # dynamically at runtime by setting the URL parameter "cdn_enabled" to "0".
+    # The value must always include the full protocol.
     #
     cdn.host.https=
 


### PR DESCRIPTION
It seems like your idea to use the "cdn_enabled" parameter should work given my understanding of your use case. You can set this URL parameter during runtime to "0" and all the URL will use the default, which should be www.liferay.com in this case.

If you set the host to other values, I'll need to come up with another solution. (May also need to IM you for more details on your use case.)
