### PR TITLE
LPS-30870 Make RSS logic consistent (we will apply more changes later) Please read description -->

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1417,6 +1417,10 @@ public class PropsValues {
 
 	public static final int RSS_CONNECTION_TIMEOUT = GetterUtil.getInteger(PropsUtil.get(PropsKeys.RSS_CONNECTION_TIMEOUT));
 
+	public static String RSS_FEED_TYPE_DEFAULT = PropsUtil.get(PropsKeys.RSS_FEED_TYPE_DEFAULT);
+
+	public static String[] RSS_FEED_TYPES = PropsUtil.getArray(PropsKeys.RSS_FEED_TYPES);
+
 	public static boolean RSS_FEEDS_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.RSS_FEEDS_ENABLED));
 
 	public static final String SANDBOX_DEPLOY_DIR = PropsUtil.get(PropsKeys.SANDBOX_DEPLOY_DIR);

--- a/portal-impl/src/com/liferay/portlet/blogs/action/RSSAction.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/action/RSSAction.java
@@ -50,7 +50,7 @@ public class RSSAction extends com.liferay.portal.struts.RSSAction {
 		int max = ParamUtil.getInteger(
 			request, "max", SearchContainer.DEFAULT_DELTA);
 		String type = ParamUtil.getString(
-			request, "type", RSSUtil.TYPE_DEFAULT);
+			request, "type", RSSUtil.FORMAT_DEFAULT);
 		double version = ParamUtil.getDouble(
 			request, "version", RSSUtil.VERSION_DEFAULT);
 		String displayStyle = ParamUtil.getString(

--- a/portal-impl/src/com/liferay/portlet/journal/action/EditFeedAction.java
+++ b/portal-impl/src/com/liferay/portlet/journal/action/EditFeedAction.java
@@ -16,9 +16,7 @@ package com.liferay.portlet.journal.action;
 
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.PrincipalException;
@@ -165,28 +163,11 @@ public class EditFeedAction extends PortletAction {
 			actionRequest, "targetPortletId");
 		String contentField = ParamUtil.getString(
 			actionRequest, "contentField");
+		String feedType = ParamUtil.getString(
+			actionRequest, "feedType", RSSUtil.FEED_TYPE_DEFAULT);
 
-		String feedType = RSSUtil.TYPE_DEFAULT;
-		double feedVersion = RSSUtil.VERSION_DEFAULT;
-
-		String feedTypeAndVersion = ParamUtil.getString(
-			actionRequest, "feedTypeAndVersion");
-
-		if (Validator.isNotNull(feedTypeAndVersion)) {
-			String[] parts = feedTypeAndVersion.split(StringPool.COLON);
-
-			try {
-				feedType = parts[0];
-				feedVersion = GetterUtil.getDouble(parts[1]);
-			}
-			catch (Exception e) {
-			}
-		}
-		else {
-			feedType = ParamUtil.getString(actionRequest, "feedType", feedType);
-			feedVersion = ParamUtil.getDouble(
-				actionRequest, "feedVersion", feedVersion);
-		}
+		String feedFormat = RSSUtil.getFeedTypeFormat(feedType);
+		double feedVersion = RSSUtil.getFeedTypeVersion(feedType);
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			JournalFeed.class.getName(), actionRequest);
@@ -199,7 +180,7 @@ public class EditFeedAction extends PortletAction {
 				groupId, feedId, autoFeedId, name, description, type,
 				structureId, templateId, rendererTemplateId, delta, orderByCol,
 				orderByType, targetLayoutFriendlyUrl, targetPortletId,
-				contentField, feedType, feedVersion, serviceContext);
+				contentField, feedFormat, feedVersion, serviceContext);
 		}
 		else {
 
@@ -209,7 +190,7 @@ public class EditFeedAction extends PortletAction {
 				groupId, feedId, name, description, type, structureId,
 				templateId, rendererTemplateId, delta, orderByCol, orderByType,
 				targetLayoutFriendlyUrl, targetPortletId, contentField,
-				feedType, feedVersion, serviceContext);
+				feedFormat, feedVersion, serviceContext);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFeedLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFeedLocalServiceImpl.java
@@ -101,7 +101,7 @@ public class JournalFeedLocalServiceImpl
 		feed.setContentField(contentField);
 
 		if (Validator.isNull(feedType)) {
-			feed.setFeedType(RSSUtil.TYPE_DEFAULT);
+			feed.setFeedType(RSSUtil.FORMAT_DEFAULT);
 			feed.setFeedVersion(RSSUtil.VERSION_DEFAULT);
 		}
 		else {

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFeedLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFeedLocalServiceImpl.java
@@ -308,7 +308,7 @@ public class JournalFeedLocalServiceImpl
 		feed.setContentField(contentField);
 
 		if (Validator.isNull(feedType)) {
-			feed.setFeedType(RSSUtil.TYPE_DEFAULT);
+			feed.setFeedType(RSSUtil.FORMAT_DEFAULT);
 			feed.setFeedVersion(RSSUtil.VERSION_DEFAULT);
 		}
 		else {

--- a/portal-impl/src/com/liferay/portlet/messageboards/action/RSSAction.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/action/RSSAction.java
@@ -44,7 +44,7 @@ public class RSSAction extends com.liferay.portal.struts.RSSAction {
 		int max = ParamUtil.getInteger(
 			request, "max", SearchContainer.DEFAULT_DELTA);
 		String type = ParamUtil.getString(
-			request, "type", RSSUtil.TYPE_DEFAULT);
+			request, "type", RSSUtil.FORMAT_DEFAULT);
 		double version = ParamUtil.getDouble(
 			request, "version", RSSUtil.VERSION_DEFAULT);
 		String displayStyle = ParamUtil.getString(

--- a/portal-impl/src/com/liferay/portlet/wiki/action/RSSAction.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/action/RSSAction.java
@@ -51,7 +51,7 @@ public class RSSAction extends com.liferay.portal.struts.RSSAction {
 		int max = ParamUtil.getInteger(
 			request, "max", SearchContainer.DEFAULT_DELTA);
 		String type = ParamUtil.getString(
-			request, "type", RSSUtil.TYPE_DEFAULT);
+			request, "type", RSSUtil.FORMAT_DEFAULT);
 		double version = ParamUtil.getDouble(
 			request, "version", RSSUtil.VERSION_DEFAULT);
 		String displayStyle = ParamUtil.getString(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6675,20 +6675,17 @@
 ##
 
     #
-	# Set the default feed type. The supported types are a subset of those
-    # defined for SyndFeed in the ROME project: atom_1.0,rss_1.0 and rss_2.0.
+    # Set the default feed type from the feed types defined in rss.feed.types
     #
-    # See http://rometools.jira.com
-	#
     rss.feed.type.default=atom_1.0
 
-	#
-	# Enter a list of comma separated values with the feed types. The supported
-    # types are a subset of those defined for SyndFeed in the ROME project:
-    # atom_1.0,rss_1.0 and rss_2.0.
+    #
+    # Enter a list of comma separated values with the feed types. The supported
+    # types should be a subset of those defined for SyndFeed in the ROME
+    # project: atom_1.0,rss_1.0 and rss_2.0.
     #
     # See http://rometools.jira.com
-	#
+    #
     rss.feed.types=atom_1.0,rss_1.0,rss_2.0
 
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6675,6 +6675,23 @@
 ##
 
     #
+	# Set the default feed type. The supported types are a subset of those
+    # defined for SyndFeed in the ROME project: atom_1.0,rss_1.0 and rss_2.0.
+    #
+    # See http://rometools.jira.com
+	#
+    rss.feed.type.default=atom_1.0
+
+	#
+	# Enter a list of comma separated values with the feed types. The supported
+    # types are a subset of those defined for SyndFeed in the ROME project:
+    # atom_1.0,rss_1.0 and rss_2.0.
+    #
+    # See http://rometools.jira.com
+	#
+    rss.feed.types=atom_1.0,rss_1.0,rss_2.0
+
+    #
     # Set this to true to enable RSS feeds.
     #
     rss.feeds.enabled=true

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1893,6 +1893,10 @@ public interface PropsKeys {
 
 	public static final String RSS_CONNECTION_TIMEOUT = "rss.connection.timeout";
 
+	public static final String RSS_FEED_TYPE_DEFAULT = "rss.feed.type.default";
+
+	public static final String RSS_FEED_TYPES = "rss.feed.types";
+
 	public static final String RSS_FEEDS_ENABLED = "rss.feeds.enabled";
 
 	public static final String SANDBOX_DEPLOY_DIR = "sandbox.deploy.dir";

--- a/portal-web/docroot/html/portlet/blogs/view_entries.jspf
+++ b/portal-web/docroot/html/portlet/blogs/view_entries.jspf
@@ -110,12 +110,12 @@ ResourceURL rssURL = liferayPortletResponse.createResourceURL();
 rssURL.setCacheability(ResourceURL.FULL);
 rssURL.setParameter("struts_action", "/blogs/rss");
 
-if ((rssDelta != SearchContainer.DEFAULT_DELTA) || !rssFormatType.equals(RSSUtil.TYPE_DEFAULT) || (rssFormatVersion != RSSUtil.VERSION_DEFAULT) || !rssDisplayStyle.equals(RSSUtil.DISPLAY_STYLE_FULL_CONTENT)) {
+if ((rssDelta != SearchContainer.DEFAULT_DELTA) || !rssFormatType.equals(RSSUtil.FORMAT_DEFAULT) || (rssFormatVersion != RSSUtil.VERSION_DEFAULT) || !rssDisplayStyle.equals(RSSUtil.DISPLAY_STYLE_FULL_CONTENT)) {
 	if (rssDelta != SearchContainer.DEFAULT_DELTA) {
 		rssURL.setParameter("max", String.valueOf(rssDelta));
 	}
 
-	if (!rssFormatType.equals(RSSUtil.TYPE_DEFAULT)) {
+	if (!rssFormatType.equals(RSSUtil.FORMAT_DEFAULT)) {
 		rssURL.setParameter("type", rssFormatType);
 	}
 

--- a/portal-web/docroot/html/portlet/journal/edit_feed.jsp
+++ b/portal-web/docroot/html/portlet/journal/edit_feed.jsp
@@ -83,8 +83,10 @@ if (Validator.isNull(contentField) || ((structure == null) && !contentField.equa
 	contentField = JournalFeedConstants.WEB_CONTENT_DESCRIPTION;
 }
 
-String feedType = BeanParamUtil.getString(feed, request, "feedType", RSSUtil.TYPE_DEFAULT);
+String feedFormat = BeanParamUtil.getString(feed, request, "feedType", RSSUtil.FORMAT_DEFAULT);
 double feedVersion = BeanParamUtil.getDouble(feed, request, "feedVersion", RSSUtil.VERSION_DEFAULT);
+
+String feedType = RSSUtil.getFeedType(feedFormat, feedVersion);
 
 ResourceURL feedURL = null;
 
@@ -305,23 +307,13 @@ if (feed != null) {
 					</c:if>
 				</aui:select>
 
-				<aui:select label="feed-type" name="feedTypeAndVersion">
+				<aui:select label="feed-type" name="feedType">
 
 					<%
-					for (int i = 4; i < RSSUtil.RSS_VERSIONS.length; i++) {
+					for (String curFeedType : RSSUtil.FEED_TYPES) {
 					%>
 
-						<aui:option label="<%= LanguageUtil.get(pageContext, RSSUtil.RSS) + StringPool.SPACE + RSSUtil.RSS_VERSIONS[i] %>" selected="<%= feedType.equals(RSSUtil.RSS) && (feedVersion == RSSUtil.RSS_VERSIONS[i]) %>" value="<%= RSSUtil.RSS + StringPool.COLON + RSSUtil.RSS_VERSIONS[i]%>" />
-
-					<%
-					}
-					%>
-
-					<%
-					for (int i = 1; i < RSSUtil.ATOM_VERSIONS.length; i++) {
-					%>
-
-						<aui:option label="<%= LanguageUtil.get(pageContext, RSSUtil.ATOM) + StringPool.SPACE + RSSUtil.ATOM_VERSIONS[i] %>" selected="<%= feedType.equals(RSSUtil.ATOM) && (feedVersion == RSSUtil.ATOM_VERSIONS[i]) %>" value="<%= RSSUtil.ATOM + StringPool.COLON + RSSUtil.ATOM_VERSIONS[i]%>" />
+						<aui:option label="<%= RSSUtil.getFeedTypeName(curFeedType) %>" selected="<%= feedType.equals(curFeedType) %>" useModelValue="<%= false %>" value="<%= curFeedType %>" />
 
 					<%
 					}

--- a/portal-web/docroot/html/portlet/message_boards/init.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/init.jsp
@@ -122,12 +122,12 @@ ResourceURL rssURL = liferayPortletResponse.createResourceURL();
 rssURL.setCacheability(ResourceURL.FULL);
 rssURL.setParameter("struts_action", "/message_boards/rss");
 
-if ((rssDelta != SearchContainer.DEFAULT_DELTA) || !rssFormatType.equals(RSSUtil.TYPE_DEFAULT) || (rssFormatVersion != RSSUtil.VERSION_DEFAULT) || !rssDisplayStyle.equals(RSSUtil.DISPLAY_STYLE_FULL_CONTENT)) {
+if ((rssDelta != SearchContainer.DEFAULT_DELTA) || !rssFormatType.equals(RSSUtil.FORMAT_DEFAULT) || (rssFormatVersion != RSSUtil.VERSION_DEFAULT) || !rssDisplayStyle.equals(RSSUtil.DISPLAY_STYLE_FULL_CONTENT)) {
 	if (rssDelta != SearchContainer.DEFAULT_DELTA) {
 		rssURL.setParameter("max", String.valueOf(rssDelta));
 	}
 
-	if (!rssFormatType.equals(RSSUtil.TYPE_DEFAULT)) {
+	if (!rssFormatType.equals(RSSUtil.FORMAT_DEFAULT)) {
 		rssURL.setParameter("type", rssFormatType);
 	}
 

--- a/util-java/src/com/liferay/util/RSSUtil.java
+++ b/util-java/src/com/liferay/util/RSSUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import com.sun.syndication.feed.synd.SyndContent;
 import com.sun.syndication.feed.synd.SyndEntry;
@@ -89,7 +90,7 @@ public class RSSUtil {
 	}
 
 	public static String getFeedTypeFormat(String feedType) {
-		if (feedType != null) {
+		if (Validator.isNotNull(feedType)) {
 			String[] parts = StringUtil.split(feedType, StringPool.UNDERLINE);
 
 			if (parts.length == 2) {
@@ -115,7 +116,7 @@ public class RSSUtil {
 	}
 
 	public static double getFeedTypeVersion(String feedType) {
-		if (feedType != null) {
+		if (Validator.isNotNull(feedType)) {
 			String[] parts = StringUtil.split(feedType, StringPool.UNDERLINE);
 
 			if (parts.length == 2) {
@@ -128,7 +129,7 @@ public class RSSUtil {
 
 	public static String getFormatType(String format) {
 		if (format == null) {
-			return TYPE_DEFAULT;
+			return FORMAT_DEFAULT;
 		}
 
 		int x = format.indexOf(ATOM);
@@ -143,7 +144,7 @@ public class RSSUtil {
 			return RSS;
 		}
 
-		return TYPE_DEFAULT;
+		return FORMAT_DEFAULT;
 	}
 
 	public static double getFormatVersion(String format) {


### PR DESCRIPTION
FeedType is now: FeedFormat + FeedVersion (this is also consistent with ROME standard)

@brianchandotcom, we needed to use useModelValue=false becuase the column in feed entity is called feedType when it actually refers to a feedFormat. do you want us to rename the entity column?
