### PR TITLE
LPS-26761 Adding model-data-handlers to portlets --> REQUIERES ANT BUILD-SERVICE-PORTAL

### DIFF
--- a/definitions/liferay-portlet-app_6_2_0.dtd
+++ b/definitions/liferay-portlet-app_6_2_0.dtd
@@ -17,7 +17,7 @@ The portlet element contains the declarative data of a portlet.
 parent-struts-path?, configuration-path?, configuration-action-class?,
 indexer-class*, open-search-class?, scheduler-entry*, portlet-url-class?,
 friendly-url-mapper-class?, friendly-url-mapping?, friendly-url-routes?,
-url-encoder-class?, portlet-data-handler-class?,
+url-encoder-class?, portlet-data-handler-class?, model-data-handler-class*,
 portlet-display-template-handler?, portlet-layout-listener-class?,
 poller-processor-class?, pop-message-listener-class?,
 social-activity-interpreter-class?, social-request-interpreter-class?,
@@ -242,6 +242,13 @@ http://docs.liferay.com/portal/6.2/javadocs/portal-impl/com/liferay/portlet/jour
 http://docs.liferay.com/portal/6.2/javadocs/portal-service/com/liferay/portal/kernel/lar/PortletDataHandler.html
 -->
 <!ELEMENT portlet-data-handler-class (#PCDATA)>
+
+<!--
+The model-data-handler-class value must be a class that implements
+com.liferay.portal.kernel.lar.StagedModelDatahandler and is called to handle
+export and import functionalities for a staged modelled entity.
+-->
+<!ELEMENT model-data-handler-class (#PCDATA)>
 
 <!--
 The portlet-layout-listener-class value must be a class that implements

--- a/portal-impl/src/META-INF/staging-spring.xml
+++ b/portal-impl/src/META-INF/staging-spring.xml
@@ -16,4 +16,9 @@
 		<aop:advisor advice-ref="com.liferay.portal.service.impl.LayoutSetLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.LayoutSetLocalService)" />
 		<aop:advisor advice-ref="com.liferay.portal.service.impl.PortletPreferencesLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.PortletPreferencesLocalService)" />
 	</aop:config>
+
+	<bean id="com.liferay.portal.kernel.lar.StagedModelDataHandlerRegistry" class="com.liferay.portal.lar.StagedModelDataHandlerRegistryImpl" />
+	<bean id="com.liferay.portal.kernel.lar.StagedModelDataHandlerRegistryUtil" class="com.liferay.portal.kernel.lar.StagedModelDataHandlerRegistryUtil">
+		<property name="stagedModelDataHandlerRegistry" ref="com.liferay.portal.kernel.lar.StagedModelDataHandlerRegistry" />
+	</bean>
 </beans>

--- a/portal-impl/src/com/liferay/portal/lar/StagedModelDataHandlerRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/StagedModelDataHandlerRegistryImpl.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar;
+
+import com.liferay.portal.kernel.lar.StagedModelDataHandler;
+import com.liferay.portal.kernel.lar.StagedModelDataHandlerImpl;
+import com.liferay.portal.kernel.lar.StagedModelDataHandlerRegistry;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Mate Thurzo
+ */
+public class StagedModelDataHandlerRegistryImpl
+	implements StagedModelDataHandlerRegistry {
+
+	public StagedModelDataHandler getStagedModelDataHandler(String className) {
+		if (Validator.isNull(className) ||
+			!_stagedModelDataHandlers.containsKey(className)) {
+
+			return null;
+		}
+
+		return _stagedModelDataHandlers.get(className);
+	}
+
+	public List<StagedModelDataHandler> getStagedModelDataHandlerList() {
+		return ListUtil.fromMapValues(_stagedModelDataHandlers);
+	}
+
+	public Map<String, StagedModelDataHandler> getStagedModelDataHandlers() {
+		return _stagedModelDataHandlers;
+	}
+
+	public void register(StagedModelDataHandler stagedModelDataHandler) {
+		if (stagedModelDataHandler == null) {
+			return;
+		}
+
+		String stagedModelClassName = getStagedModelClassName(
+			stagedModelDataHandler);
+
+		_stagedModelDataHandlers.put(
+			stagedModelClassName, stagedModelDataHandler);
+	}
+
+	public void unregister(StagedModelDataHandler stagedModelDataHandler) {
+		if (stagedModelDataHandler == null) {
+			return;
+		}
+
+		String stagedModelClassName = getStagedModelClassName(
+			stagedModelDataHandler);
+
+		if (stagedModelClassName == null) {
+			return;
+		}
+
+		if (!_stagedModelDataHandlers.containsKey(stagedModelClassName)) {
+			return;
+		}
+
+		_stagedModelDataHandlers.remove(stagedModelClassName);
+	}
+
+	protected String getStagedModelClassName(
+		StagedModelDataHandler stagedModelDataHandler) {
+
+		Class clazz = stagedModelDataHandler.getClass();
+
+		Class superClazz = clazz.getSuperclass();
+
+		if ((superClazz == null) ||
+			!superClazz.getName().equals(
+				StagedModelDataHandlerImpl.class.getName())) {
+
+			return null;
+		}
+
+		ParameterizedType type =
+			(ParameterizedType)clazz.getGenericSuperclass();
+
+		Type[] actualTypeArgs = type.getActualTypeArguments();
+
+		if ((actualTypeArgs != null) && (actualTypeArgs.length > 0)) {
+			return ((Class)actualTypeArgs[0]).getName();
+		}
+
+		return null;
+	}
+
+	private Map<String, StagedModelDataHandler> _stagedModelDataHandlers =
+		new HashMap<String, StagedModelDataHandler>();
+
+}

--- a/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
@@ -1000,6 +1000,10 @@ public class PortletImpl extends PortletBaseImpl {
 		return _maximizeHelp;
 	}
 
+	public List<String> getModelDataHandlerClasses() {
+		return _modelDataHandlerClasses;
+	}
+
 	/**
 	 * Returns the name of the open search class of the portlet.
 	 *
@@ -2735,6 +2739,12 @@ public class PortletImpl extends PortletBaseImpl {
 		_maximizeHelp = maximizeHelp;
 	}
 
+	public void setModelDataHandlerClasses(
+		List<String> modelDataHandlerClasses) {
+
+		_modelDataHandlerClasses = modelDataHandlerClasses;
+	}
+
 	/**
 	 * Sets the name of the open search class of the portlet.
 	 *
@@ -3574,6 +3584,8 @@ public class PortletImpl extends PortletBaseImpl {
 	 * user goes into the help mode.
 	 */
 	private boolean _maximizeHelp;
+
+	private List<String> _modelDataHandlerClasses;
 
 	/**
 	 * The name of the open search class of the portlet.

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -1317,10 +1317,22 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 			GetterUtil.getString(
 				portletElement.elementText("url-encoder-class"),
 				portletModel.getURLEncoderClass()));
+
 		portletModel.setPortletDataHandlerClass(
 			GetterUtil.getString(
 				portletElement.elementText("portlet-data-handler-class"),
 				portletModel.getPortletDataHandlerClass()));
+
+		List<String> modelDataHandlerClasses = new ArrayList<String>();
+
+		for (Element modelDataHandlerClassElement :
+				portletElement.elements("model-data-handler-class")) {
+
+			modelDataHandlerClasses.add(modelDataHandlerClassElement.getText());
+		}
+
+		portletModel.setModelDataHandlerClasses(modelDataHandlerClasses);
+
 		portletModel.setPortletDisplayTemplateHandlerClass(
 			GetterUtil.getString(
 				portletElement.elementText("portlet-display-template-handler"),

--- a/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
+++ b/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
@@ -18,6 +18,8 @@ import com.liferay.portal.dao.shard.ShardPollerProcessorWrapper;
 import com.liferay.portal.kernel.atom.AtomCollectionAdapter;
 import com.liferay.portal.kernel.atom.AtomCollectionAdapterRegistryUtil;
 import com.liferay.portal.kernel.lar.PortletDataHandler;
+import com.liferay.portal.kernel.lar.StagedModelDataHandler;
+import com.liferay.portal.kernel.lar.StagedModelDataHandlerRegistryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.poller.PollerProcessor;
@@ -148,6 +150,21 @@ public class PortletBagFactory {
 
 		PortletDataHandler portletDataHandlerInstance = newPortletDataHandler(
 			portlet);
+
+		List<StagedModelDataHandler> modelDataHandlerInstances =
+			new ArrayList<StagedModelDataHandler>();
+
+		for (String modelDataHandlerClass :
+				portlet.getModelDataHandlerClasses()) {
+
+			StagedModelDataHandler modelDataHandler =
+				(StagedModelDataHandler)newInstance(
+					StagedModelDataHandler.class, modelDataHandlerClass);
+
+			modelDataHandlerInstances.add(modelDataHandler);
+
+			StagedModelDataHandlerRegistryUtil.register(modelDataHandler);
+		}
 
 		PortletDisplayTemplateHandler portletDisplayTemplateHandlerInstance =
 			newPortletDisplayTemplateHandler(portlet);
@@ -317,7 +334,8 @@ public class PortletBagFactory {
 			portlet.getPortletId(), _servletContext, portletInstance,
 			configurationActionInstance, indexerInstances, openSearchInstance,
 			friendlyURLMapperInstance, urlEncoderInstance,
-			portletDataHandlerInstance, portletDisplayTemplateHandlerInstance,
+			portletDataHandlerInstance, modelDataHandlerInstances,
+			portletDisplayTemplateHandlerInstance,
 			portletLayoutListenerInstance, pollerProcessorInstance,
 			popMessageListenerInstance, socialActivityInterpreterInstance,
 			socialRequestInterpreterInstance, webDAVStorageInstance,

--- a/portal-impl/src/com/liferay/portlet/PortletBagImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletBagImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portlet;
 
 import com.liferay.portal.kernel.atom.AtomCollectionAdapter;
 import com.liferay.portal.kernel.lar.PortletDataHandler;
+import com.liferay.portal.kernel.lar.StagedModelDataHandler;
 import com.liferay.portal.kernel.poller.PollerProcessor;
 import com.liferay.portal.kernel.pop.MessageListener;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
@@ -61,6 +62,7 @@ public class PortletBagImpl implements PortletBag {
 		FriendlyURLMapper friendlyURLMapperInstance,
 		URLEncoder urlEncoderInstance,
 		PortletDataHandler portletDataHandlerInstance,
+		List<StagedModelDataHandler> modelDataHandlerInstances,
 		PortletDisplayTemplateHandler portletDisplayTemplateHandlerInstance,
 		PortletLayoutListener portletLayoutListenerInstance,
 		PollerProcessor pollerProcessorInstance,
@@ -87,6 +89,7 @@ public class PortletBagImpl implements PortletBag {
 		_friendlyURLMapperInstance = friendlyURLMapperInstance;
 		_urlEncoderInstance = urlEncoderInstance;
 		_portletDataHandlerInstance = portletDataHandlerInstance;
+		_modelDataHandlerInstances = modelDataHandlerInstances;
 		_portletDisplayTemplateHandlerInstance =
 			portletDisplayTemplateHandlerInstance;
 		_portletLayoutListenerInstance = portletLayoutListenerInstance;
@@ -114,6 +117,7 @@ public class PortletBagImpl implements PortletBag {
 			getConfigurationActionInstance(), getIndexerInstances(),
 			getOpenSearchInstance(), getFriendlyURLMapperInstance(),
 			getURLEncoderInstance(), getPortletDataHandlerInstance(),
+			getModelDataHandlerInstances(),
 			getPortletDisplayTemplateHandlerInstance(),
 			getPortletLayoutListenerInstance(), getPollerProcessorInstance(),
 			getPopMessageListenerInstance(),
@@ -154,6 +158,10 @@ public class PortletBagImpl implements PortletBag {
 
 	public List<Indexer> getIndexerInstances() {
 		return _indexerInstances;
+	}
+
+	public List<StagedModelDataHandler> getModelDataHandlerInstances() {
+		return _modelDataHandlerInstances;
 	}
 
 	public OpenSearch getOpenSearchInstance() {
@@ -265,6 +273,7 @@ public class PortletBagImpl implements PortletBag {
 	private List<CustomAttributesDisplay> _customAttributesDisplayInstances;
 	private FriendlyURLMapper _friendlyURLMapperInstance;
 	private List<Indexer> _indexerInstances;
+	private List<StagedModelDataHandler> _modelDataHandlerInstances;
 	private OpenSearch _openSearchInstance;
 	private PermissionPropagator _permissionPropagatorInstance;
 	private PollerProcessor _pollerProcessorInstance;

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerRegistry.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerRegistry.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Mate Thurzo
+ */
+public interface StagedModelDataHandlerRegistry {
+
+	public StagedModelDataHandler getStagedModelDataHandler(String className);
+
+	public List<StagedModelDataHandler> getStagedModelDataHandlerList();
+
+	public Map<String, StagedModelDataHandler> getStagedModelDataHandlers();
+
+	public void register(StagedModelDataHandler stagedModelDataHandler);
+
+	public void unregister(StagedModelDataHandler stagedModelDataHandler);
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerRegistryUtil.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Mate Thurzo
+ */
+public class StagedModelDataHandlerRegistryUtil {
+
+	public static StagedModelDataHandler getStagedModelDataHandler(
+		String className) {
+
+		return getStagedModelDataHandlerRegistry().getStagedModelDataHandler(
+			className);
+	}
+
+	public static List<StagedModelDataHandler> getStagedModelDataHandlerList() {
+		return getStagedModelDataHandlerRegistry().
+			getStagedModelDataHandlerList();
+	}
+
+	public static StagedModelDataHandlerRegistry
+		getStagedModelDataHandlerRegistry() {
+
+		return _stagedModelDataHandlerRegistry;
+	}
+
+	public static Map<String, StagedModelDataHandler>
+		getStagedModelDataHandlers() {
+
+		return getStagedModelDataHandlerRegistry().getStagedModelDataHandlers();
+	}
+
+	public static void register(StagedModelDataHandler stagedModelDataHandler) {
+		getStagedModelDataHandlerRegistry().register(stagedModelDataHandler);
+	}
+
+	public static void unregister(
+		StagedModelDataHandler stagedModelDataHandler) {
+
+		getStagedModelDataHandlerRegistry().unregister(stagedModelDataHandler);
+	}
+
+	public void setStagedModelDataHandlerRegistry(
+		StagedModelDataHandlerRegistry stagedModelDataHandlerRegistry) {
+
+		_stagedModelDataHandlerRegistry = stagedModelDataHandlerRegistry;
+	}
+
+	private static StagedModelDataHandlerRegistry
+		_stagedModelDataHandlerRegistry;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/portlet/PortletBag.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/PortletBag.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.portlet;
 
 import com.liferay.portal.kernel.atom.AtomCollectionAdapter;
 import com.liferay.portal.kernel.lar.PortletDataHandler;
+import com.liferay.portal.kernel.lar.StagedModelDataHandler;
 import com.liferay.portal.kernel.poller.PollerProcessor;
 import com.liferay.portal.kernel.pop.MessageListener;
 import com.liferay.portal.kernel.portletdisplaytemplate.PortletDisplayTemplateHandler;
@@ -63,6 +64,8 @@ public interface PortletBag extends Cloneable {
 	public FriendlyURLMapper getFriendlyURLMapperInstance();
 
 	public List<Indexer> getIndexerInstances();
+
+	public List<StagedModelDataHandler> getModelDataHandlerInstances();
 
 	public OpenSearch getOpenSearchInstance();
 


### PR DESCRIPTION
This pull is missing ant build-service-portal to compile. We wanted to avoid having conflicts with the autogenerated files.
