### PR TITLE
LPS-31186

### DIFF
--- a/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Converter;
+import com.liferay.portal.kernel.util.PreloadClassLoader;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -32,6 +33,7 @@ import java.io.InputStream;
 import java.net.URL;
 
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -53,13 +55,21 @@ import org.springframework.orm.hibernate3.LocalSessionFactoryBean;
  */
 public class PortalHibernateConfiguration extends LocalSessionFactoryBean {
 
+	public static final String[] PRELOAD_CLASS_NAMES = {
+		"javassist.util.proxy.MethodHandler",
+		"javassist.util.proxy.ProxyObject",
+		"javassist.util.proxy.RuntimeSupport",
+		"org.hibernate.proxy.HibernateProxy",
+		"org.hibernate.proxy.LazyInitializer"
+	};
+
 	@Override
 	public SessionFactory buildSessionFactory() throws Exception {
 		ProxyFactory.classLoaderProvider =
 			new ProxyFactory.ClassLoaderProvider() {
 
 				public ClassLoader get(ProxyFactory proxyFactory) {
-					return PACLClassLoaderUtil.getContextClassLoader();
+					return _createProxyFactoryClassLoader();
 				}
 
 			};
@@ -227,6 +237,34 @@ public class PortalHibernateConfiguration extends LocalSessionFactoryBean {
 
 	protected void setDB(Dialect dialect) {
 		DBFactoryUtil.setDB(dialect);
+	}
+
+	private ClassLoader _createProxyFactoryClassLoader() {
+		ClassLoader contextClassLoader =
+			PACLClassLoaderUtil.getContextClassLoader();
+		ClassLoader portalClassLoader =
+			PACLClassLoaderUtil.getPortalClassLoader();
+
+		if (contextClassLoader == portalClassLoader) {
+			return contextClassLoader;
+		}
+		else {
+			Map<String, Class<?>> classMap = new HashMap<String, Class<?>>();
+
+			try {
+				for (String className : PRELOAD_CLASS_NAMES) {
+					Class<?> hibernateProxyClass = portalClassLoader.loadClass(
+						className);
+
+					classMap.put(className, hibernateProxyClass);
+				}
+			}
+			catch (ClassNotFoundException cnfe) {
+				throw new RuntimeException(cnfe);
+			}
+
+			return new PreloadClassLoader(contextClassLoader, classMap);
+		}
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/test/unit/com/liferay/portal/hibernate/HibernateCompatibilityTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/hibernate/HibernateCompatibilityTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.hibernate;
+
+import com.liferay.portal.spring.hibernate.PortalHibernateConfiguration;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class HibernateCompatibilityTest {
+
+	@Test
+	public void assertPreloadClassesExistence() {
+		for (String className :
+				PortalHibernateConfiguration.PRELOAD_CLASS_NAMES) {
+
+			try {
+				Class.forName(className);
+			}
+			catch (ClassNotFoundException cnfe) {
+				Assert.fail(cnfe.getMessage());
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Add the unit test to verify classes existence.

But this does not really provide much protection, there is still plenty chance that hibernate or javassist's internal changes break plugins with hibernate.
