### PR TITLE
LPS-30413

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1165,6 +1165,8 @@ public class PropsValues {
 
 	public static final boolean OPEN_ID_AUTH_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.OPEN_ID_AUTH_ENABLED));
 
+	public static final String[] OPEN_ID_HOST_TYPES = PropsUtil.getArray(PropsKeys.OPEN_ID_HOST_TYPES);
+
 	public static final boolean OPEN_SSO_AUTH_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.OPEN_SSO_AUTH_ENABLED));
 
 	public static final String OPEN_SSO_EMAIL_ADDRESS_ATTR = PropsUtil.get(PropsKeys.OPEN_SSO_EMAIL_ADDRESS_ATTR);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1165,7 +1165,7 @@ public class PropsValues {
 
 	public static final boolean OPEN_ID_AUTH_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.OPEN_ID_AUTH_ENABLED));
 
-	public static final String[] OPEN_ID_HOST_TYPES = PropsUtil.getArray(PropsKeys.OPEN_ID_HOST_TYPES);
+	public static final String[] OPEN_ID_PROVIDERS = PropsUtil.getArray(PropsKeys.OPEN_ID_PROVIDERS);
 
 	public static final boolean OPEN_SSO_AUTH_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.OPEN_SSO_AUTH_ENABLED));
 

--- a/portal-impl/src/com/liferay/portlet/login/action/OpenIdAction.java
+++ b/portal-impl/src/com/liferay/portlet/login/action/OpenIdAction.java
@@ -233,7 +233,7 @@ public class OpenIdAction extends PortletAction {
 				SRegResponse sregResp = (SRegResponse)ext;
 
 				String fullName = GetterUtil.getString(
-					sregResp.getAttributeValue("fullname"));
+					sregResp.getAttributeValue(_REQ_RESP_ATTR_FULLNAME));
 
 				String[] names = splitName(fullName);
 
@@ -242,7 +242,7 @@ public class OpenIdAction extends PortletAction {
 					lastName = names[1];
 				}
 
-				emailAddress = sregResp.getAttributeValue("email");
+				emailAddress = sregResp.getAttributeValue(_REQ_RESP_ATTR_EMAIL);
 			}
 		}
 
@@ -256,7 +256,8 @@ public class OpenIdAction extends PortletAction {
 				URL endpoint = discovered.getOPEndpoint();
 
 				if (isYahooOpenId(endpoint)) {
-					String fullName = fetchResp.getAttributeValue("fullname");
+					String fullName = fetchResp.getAttributeValue(
+						_REQ_RESP_ATTR_FULLNAME);
 
 					String[] names = splitName(fullName);
 
@@ -272,23 +273,25 @@ public class OpenIdAction extends PortletAction {
 
 					if (Validator.isNull(emailAddress)) {
 						emailAddress = getFirstValue(
-							fetchResp.getAttributeValues("email"));
+							fetchResp.getAttributeValues(_REQ_RESP_ATTR_EMAIL));
 					}
 				}
 				else {
 					if (Validator.isNull(firstName)) {
 						firstName = getFirstValue(
-							fetchResp.getAttributeValues("firstName"));
+							fetchResp.getAttributeValues(
+								_REQ_RESP_ATTR_FIRSTNAME));
 					}
 
 					if (Validator.isNull(lastName)) {
 						lastName = getFirstValue(
-							fetchResp.getAttributeValues("lastName"));
+							fetchResp.getAttributeValues(
+								_REQ_RESP_ATTR_LASTNAME));
 					}
 
 					if (Validator.isNull(emailAddress)) {
 						emailAddress = getFirstValue(
-							fetchResp.getAttributeValues("email"));
+							fetchResp.getAttributeValues(_REQ_RESP_ATTR_EMAIL));
 					}
 				}
 			}
@@ -422,32 +425,32 @@ public class OpenIdAction extends PortletAction {
 					openIdProvider = "yahoo";
 
 					fetch.addAttribute(
-						"email",
+						_REQ_RESP_ATTR_EMAIL,
 						PropsUtil.get(
 							PropsKeys.OPEN_ID_AX_TYPE_EMAIL,
 							new Filter(openIdProvider)), true);
 
 					fetch.addAttribute(
-						"fullname",
+						_REQ_RESP_ATTR_FULLNAME,
 						PropsUtil.get(
 							PropsKeys.OPEN_ID_AX_TYPE_FULL_NAME,
 								new Filter(openIdProvider)), true);
 				}
 				else {
 					fetch.addAttribute(
-						"email",
+						_REQ_RESP_ATTR_EMAIL,
 						PropsUtil.get(
 							PropsKeys.OPEN_ID_AX_TYPE_EMAIL,
 							new Filter(openIdProvider)), true);
 
 					fetch.addAttribute(
-						"firstName",
+						_REQ_RESP_ATTR_FIRSTNAME,
 						PropsUtil.get(
 							PropsKeys.OPEN_ID_AX_TYPE_FIRST_NAME,
 							new Filter(openIdProvider)), true);
 
 					fetch.addAttribute(
-						"lastName",
+						_REQ_RESP_ATTR_LASTNAME,
 						PropsUtil.get(
 							PropsKeys.OPEN_ID_AX_TYPE_LAST_NAME,
 							new Filter(openIdProvider)), true);
@@ -457,8 +460,8 @@ public class OpenIdAction extends PortletAction {
 
 				SRegRequest sregRequest = SRegRequest.createFetchRequest();
 
-				sregRequest.addAttribute("fullname", true);
-				sregRequest.addAttribute("email", true);
+				sregRequest.addAttribute(_REQ_RESP_ATTR_FULLNAME, true);
+				sregRequest.addAttribute(_REQ_RESP_ATTR_EMAIL, true);
 
 				authRequest.addExtension(sregRequest);
 			}
@@ -487,6 +490,11 @@ public class OpenIdAction extends PortletAction {
 	}
 
 	private static final boolean _CHECK_METHOD_ON_PROCESS_ACTION = false;
+
+	private static final String _REQ_RESP_ATTR_EMAIL = "email";
+	private static final String _REQ_RESP_ATTR_FIRSTNAME = "firstName";
+	private static final String _REQ_RESP_ATTR_FULLNAME = "fullname";
+	private static final String _REQ_RESP_ATTR_LASTNAME = "lastName";
 
 	private static final String _YAHOO_OPEN_ID_HOST =
 		"open.login.yahooapis.com";

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3195,6 +3195,10 @@
     #
     open.id.auth.enabled=true
 
+	open.id.host.types=yahoo
+
+	open.id.host[yahoo]=open.login.yahooapis.com
+
     open.id.ax.type.email[default]=http://schema.openid.net/contact/email
     open.id.ax.type.first.name[default]=http://schema.openid.net/namePerson/first
     open.id.ax.type.last.name[default]=http://schema.openid.net/namePerson/last

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3195,6 +3195,13 @@
     #
     open.id.auth.enabled=true
 
+    open.id.ax.type.email[default]=http://schema.openid.net/contact/email
+    open.id.ax.type.first.name[default]=http://schema.openid.net/namePerson/first
+    open.id.ax.type.last.name[default]=http://schema.openid.net/namePerson/last
+
+    open.id.ax.type.email[yahoo]=http://axschema.org/contact/email
+    open.id.ax.type.full.name[yahoo]=http://axschema.org/namePerson
+
 ##
 ## OpenSSO
 ##

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3199,6 +3199,9 @@
 
 	open.id.host[yahoo]=open.login.yahooapis.com
 
+	open.id.ax.types[default]=email,firstName,lastName
+	open.id.ax.types[yahoo]=email,fullname
+
     open.id.ax.type.email[default]=http://schema.openid.net/contact/email
     open.id.ax.type.first.name[default]=http://schema.openid.net/namePerson/first
     open.id.ax.type.last.name[default]=http://schema.openid.net/namePerson/last

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3195,19 +3195,18 @@
     #
     open.id.auth.enabled=true
 
-	open.id.host.types=yahoo
+    open.id.providers=yahoo
 
-	open.id.host[yahoo]=open.login.yahooapis.com
+    open.id.url[yahoo]=open.login.yahooapis.com
 
-	open.id.ax.types[default]=email,firstName,lastName
-	open.id.ax.types[yahoo]=email,fullname
-
+    open.id.ax.schema[default]=email,firstname,lastname
     open.id.ax.type.email[default]=http://schema.openid.net/contact/email
-    open.id.ax.type.first.name[default]=http://schema.openid.net/namePerson/first
-    open.id.ax.type.last.name[default]=http://schema.openid.net/namePerson/last
+    open.id.ax.type.firstname[default]=http://schema.openid.net/namePerson/first
+    open.id.ax.type.lastname[default]=http://schema.openid.net/namePerson/last
 
+    open.id.ax.schema[yahoo]=email,fullname
     open.id.ax.type.email[yahoo]=http://axschema.org/contact/email
-    open.id.ax.type.full.name[yahoo]=http://axschema.org/namePerson
+    open.id.ax.type.fullname[yahoo]=http://axschema.org/namePerson
 
 ##
 ## OpenSSO

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1615,19 +1615,19 @@ public interface PropsKeys {
 
 	public static final String OPEN_ID_AUTH_ENABLED = "open.id.auth.enabled";
 
+	public static final String OPEN_ID_AX_SCHEMA = "open.id.ax.schema";
+
 	public static final String OPEN_ID_AX_TYPE_EMAIL = "open.id.ax.type.email";
 
-	public static final String OPEN_ID_AX_TYPE_FIRST_NAME = "open.id.ax.type.first.name";
+	public static final String OPEN_ID_AX_TYPE_FIRST_NAME = "open.id.ax.type.firstname";
 
-	public static final String OPEN_ID_AX_TYPE_FULL_NAME = "open.id.ax.type.full.name";
+	public static final String OPEN_ID_AX_TYPE_FULL_NAME = "open.id.ax.type.fullname";
 
-	public static final String OPEN_ID_AX_TYPE_LAST_NAME = "open.id.ax.type.last.name";
+	public static final String OPEN_ID_AX_TYPE_LAST_NAME = "open.id.ax.type.lastname";
 
-	public static final String OPEN_ID_AX_TYPES = "open.id.ax.types";
+	public static final String OPEN_ID_PROVIDERS = "open.id.providers";
 
-	public static final String OPEN_ID_HOST = "open.id.host";
-
-	public static final String OPEN_ID_HOST_TYPES = "open.id.host.types";
+	public static final String OPEN_ID_URL = "open.id.url";
 
 	public static final String OPEN_SSO_AUTH_ENABLED = "open.sso.auth.enabled";
 

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1623,6 +1623,10 @@ public interface PropsKeys {
 
 	public static final String OPEN_ID_AX_TYPE_LAST_NAME = "open.id.ax.type.last.name";
 
+	public static final String OPEN_ID_HOST = "open.id.host";
+
+	public static final String OPEN_ID_HOST_TYPES = "open.id.host.types";
+
 	public static final String OPEN_SSO_AUTH_ENABLED = "open.sso.auth.enabled";
 
 	public static final String OPEN_SSO_EMAIL_ADDRESS_ATTR = "open.sso.email.address.attr";

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1615,6 +1615,14 @@ public interface PropsKeys {
 
 	public static final String OPEN_ID_AUTH_ENABLED = "open.id.auth.enabled";
 
+	public static final String OPEN_ID_AX_TYPE_EMAIL = "open.id.ax.type.email";
+
+	public static final String OPEN_ID_AX_TYPE_FIRST_NAME = "open.id.ax.type.first.name";
+
+	public static final String OPEN_ID_AX_TYPE_FULL_NAME = "open.id.ax.type.full.name";
+
+	public static final String OPEN_ID_AX_TYPE_LAST_NAME = "open.id.ax.type.last.name";
+
 	public static final String OPEN_SSO_AUTH_ENABLED = "open.sso.auth.enabled";
 
 	public static final String OPEN_SSO_EMAIL_ADDRESS_ATTR = "open.sso.email.address.attr";

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1623,6 +1623,8 @@ public interface PropsKeys {
 
 	public static final String OPEN_ID_AX_TYPE_LAST_NAME = "open.id.ax.type.last.name";
 
+	public static final String OPEN_ID_AX_TYPES = "open.id.ax.types";
+
 	public static final String OPEN_ID_HOST = "open.id.host";
 
 	public static final String OPEN_ID_HOST_TYPES = "open.id.host.types";


### PR DESCRIPTION
Hey Brian, I have changed the names of the ax type in the portal.properties so that we can use them to create the keys to get the individual type URIs. Technically if we kept the big if in the sendRequest we could use anything but it seemed a nice trade off. Simple Reg attribute names are unfortunately fixed.
