### PR TITLE
LPS-31813 Run junit test methods in alphabetizing order

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/test/AbstractIntegrationJUnitTestRunner.java
+++ b/portal-service/src/com/liferay/portal/kernel/test/AbstractIntegrationJUnitTestRunner.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.test;
 
+import org.junit.runner.manipulation.Sorter;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -37,6 +38,8 @@ public abstract class AbstractIntegrationJUnitTestRunner
 		}
 
 		_testContextHandler = new TestContextHandler(clazz);
+
+		sort(new Sorter(new AlphabetizingDescriptionComparator()));
 	}
 
 	public abstract void initApplicationContext();

--- a/portal-service/src/com/liferay/portal/kernel/test/AlphabetizingDescriptionComparator.java
+++ b/portal-service/src/com/liferay/portal/kernel/test/AlphabetizingDescriptionComparator.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.test;
+
+import java.util.Comparator;
+
+import org.junit.runner.Description;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class AlphabetizingDescriptionComparator
+	implements Comparator<Description> {
+
+	public int compare(Description description1, Description description2) {
+		return description1.getDisplayName().compareTo(
+			description2.getDisplayName());
+	}
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/test/NewClassLoaderJUnitTestRunner.java
+++ b/portal-service/src/com/liferay/portal/kernel/test/NewClassLoaderJUnitTestRunner.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.runner.manipulation.Sorter;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -45,6 +46,8 @@ public class NewClassLoaderJUnitTestRunner extends BlockJUnit4ClassRunner {
 		throws InitializationError {
 
 		super(clazz);
+
+		sort(new Sorter(new AlphabetizingDescriptionComparator()));
 	}
 
 	protected ClassLoader createClassLoader(FrameworkMethod frameworkMethod) {

--- a/portal-service/src/com/liferay/portal/kernel/test/NewJVMJUnitTestRunner.java
+++ b/portal-service/src/com/liferay/portal/kernel/test/NewJVMJUnitTestRunner.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Future;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.runner.manipulation.Sorter;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -50,6 +51,8 @@ public class NewJVMJUnitTestRunner extends BlockJUnit4ClassRunner {
 		super(clazz);
 
 		_classPath = ClassPathUtil.getJVMClassPath(false);
+
+		sort(new Sorter(new AlphabetizingDescriptionComparator()));
 	}
 
 	protected static void attachProcess(String message) {


### PR DESCRIPTION
Please read the description on the ticket.
I am not sure what is the best way to notify people to fix their tests.
A possible aggressive way is to reverse the comparing order in AlphabetizingDescriptionComparator by default, to force those tests to fail, then ask QA to notify the author(please don't let qa come back to me, I am not breaking the tests, I am just exposing a long exist issue.)

For a very long time, Spanish office is asking people to run the integration test before commit code, but the thing is without this fix no one out side Spanish office can actually use those tests, somehow they are using a special jdk version that not returning methods in random order. While most other people are seeing random errors.
