### PR TITLE
LPS-31896 system.properties - limit use of "##" for section headings

### DIFF
--- a/portal-impl/src/system.properties
+++ b/portal-impl/src/system.properties
@@ -1,21 +1,21 @@
-##
-## Start your application server with the system property
-## "system.properties.load" set to true to load the external file called
-## system.properties. This is given as a convenient way to ensure all properties
-## are set for deployment. When the server starts, the portal will load
-## system.properties and then system-ext.properties.
-##
-## Start your application server with the system property
-## "system.properties.final" set to true if the properties of system.properties
-## override all similar command line properties. If set to false, the properties
-## of system.properties will be set if and only if those properties are not
-## currently set.
-##
-## Some application servers require you to set the "file.encoding" and
-## "user.timezone" on startup regardless of system.properties because the
-## application server reads these properties before system.properties is ever
-## loaded.
-##
+#
+# Start your application server with the system property
+# "system.properties.load" set to true to load the external file called
+# system.properties. This is given as a convenient way to ensure all properties
+# are set for deployment. When the server starts, the portal will load
+# system.properties and then system-ext.properties.
+#
+# Start your application server with the system property
+# "system.properties.final" set to true if the properties of system.properties
+# override all similar command line properties. If set to false, the properties
+# of system.properties will be set if and only if those properties are not
+# currently set.
+#
+# Some application servers require you to set the "file.encoding" and
+# "user.timezone" on startup regardless of system.properties because the
+# application server reads these properties before system.properties is ever
+# loaded.
+#
 
 ##
 ## Java


### PR DESCRIPTION
Please propagate to 6.1.x or let me know. Thanks!
