### PR TITLE
LPS-31448 rename updateStatuses/updateStatus --> updateChildrenStatus

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -979,7 +979,7 @@ public class DLAppHelperLocalServiceImpl
 		}
 	}
 
-	public void updateStatuses(
+	public void updateChildStatus(
 			User user, List<Object> dlFileEntriesAndDLFolders, int status)
 		throws PortalException, SystemException {
 
@@ -1110,7 +1110,7 @@ public class DLAppHelperLocalServiceImpl
 							dlFolder.getGroupId(), dlFolder.getFolderId(), null,
 							false, queryDefinition);
 
-				updateStatuses(
+				updateChildStatus(
 					user, foldersAndFileEntriesAndFileShortcuts, status);
 			}
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -639,7 +639,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 			getFoldersAndFileEntriesAndFileShortcuts(
 				dlFolder.getGroupId(), folderId, null, false, queryDefinition);
 
-		dlAppHelperLocalService.updateStatuses(
+		dlAppHelperLocalService.updateChildrenStatus(
 			user, foldersAndFileEntriesAndFileShortcuts, status);
 
 		// Trash

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBCategoryLocalServiceImpl.java
@@ -642,43 +642,8 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 		return category;
 	}
 
-	public MBCategory updateStatus(long userId, long categoryId, int status)
-		throws PortalException, SystemException {
-
-		// Category
-
-		User user = userPersistence.findByPrimaryKey(userId);
-
-		MBCategory category = mbCategoryPersistence.findByPrimaryKey(
-			categoryId);
-
-		category.setStatus(status);
-		category.setStatusByUserId(user.getUserId());
-		category.setStatusByUserName(user.getFullName());
-		category.setStatusDate(new Date());
-
-		mbCategoryPersistence.update(category);
-
-		// Categories and threads
-
-		List<Object> categoriesAndThreads = getCategoriesAndThreads(
-			category.getGroupId(), categoryId);
-
-		updateChildStatus(user, categoriesAndThreads, status);
-
-		// Trash
-
-		if (status == WorkflowConstants.STATUS_IN_TRASH) {
-			trashEntryLocalService.addTrashEntry(
-				userId, category.getGroupId(), MBCategory.class.getName(),
-				categoryId, WorkflowConstants.STATUS_APPROVED, null, null);
-		}
-
-		return category;
-	}
-
-	public void updateChildStatus(
-			User user, List<Object> categoriesAndThreads, int status)
+	public void updateChildrenStatus(
+		User user, List<Object> categoriesAndThreads, int status)
 		throws PortalException, SystemException {
 
 		for (Object object : categoriesAndThreads) {
@@ -701,13 +666,48 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 					continue;
 				}
 
-				updateChildStatus(
+				updateChildrenStatus(
 					user,
 					getCategoriesAndThreads(
 						category.getGroupId(), category.getCategoryId()),
 					status);
 			}
 		}
+	}
+
+	public MBCategory updateStatus(long userId, long categoryId, int status)
+		throws PortalException, SystemException {
+
+		// Category
+
+		User user = userPersistence.findByPrimaryKey(userId);
+
+		MBCategory category = mbCategoryPersistence.findByPrimaryKey(
+			categoryId);
+
+		category.setStatus(status);
+		category.setStatusByUserId(user.getUserId());
+		category.setStatusByUserName(user.getFullName());
+		category.setStatusDate(new Date());
+
+		mbCategoryPersistence.update(category);
+
+		// Categories and threads
+
+		List<Object> categoriesAndThreads = getCategoriesAndThreads(
+			category.getGroupId(), categoryId);
+
+		updateChildrenStatus(user, categoriesAndThreads, status);
+
+		// Trash
+
+		if (status == WorkflowConstants.STATUS_IN_TRASH) {
+			trashEntryLocalService.addTrashEntry(
+				userId, category.getGroupId(), MBCategory.class.getName(),
+				categoryId, WorkflowConstants.STATUS_APPROVED, null, null);
+		}
+
+		return category;
 	}
 
 	protected long getParentCategoryId(long groupId, long parentCategoryId)

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBCategoryLocalServiceImpl.java
@@ -664,7 +664,7 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 		List<Object> categoriesAndThreads = getCategoriesAndThreads(
 			category.getGroupId(), categoryId);
 
-		updateStatuses(user, categoriesAndThreads, status);
+		updateChildStatus(user, categoriesAndThreads, status);
 
 		// Trash
 
@@ -677,7 +677,7 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 		return category;
 	}
 
-	public void updateStatuses(
+	public void updateChildStatus(
 			User user, List<Object> categoriesAndThreads, int status)
 		throws PortalException, SystemException {
 
@@ -701,7 +701,7 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 					continue;
 				}
 
-				updateStatuses(
+				updateChildStatus(
 					user,
 					getCategoriesAndThreads(
 						category.getGroupId(), category.getCategoryId()),

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
@@ -871,7 +871,7 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 			// Messages
 
-			updateStatus(threadId, status);
+			updateChildStatus(threadId, status);
 
 			if (thread.getCategoryId() !=
 					MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) {
@@ -933,7 +933,7 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 			}
 		}
 		else {
-			updateStatus(threadId, status);
+			updateChildStatus(threadId, status);
 		}
 
 		return thread;
@@ -986,7 +986,7 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 		return messagesMoved;
 	}
 
-	protected void updateStatus(long threadId, int status)
+	protected void updateChildStatus(long threadId, int status)
 		throws PortalException, SystemException {
 
 		List<MBMessage> messages = mbMessageLocalService.getThreadMessages(
@@ -997,11 +997,11 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 				continue;
 			}
 
-			updateStatus(message, status);
+			updateChildStatus(message, status);
 		}
 	}
 
-	protected void updateStatus(MBMessage message, int status)
+	protected void updateChildStatus(MBMessage message, int status)
 		throws PortalException, SystemException {
 
 		if (status == WorkflowConstants.STATUS_IN_TRASH) {

--- a/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiNodeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiNodeLocalServiceImpl.java
@@ -433,7 +433,7 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 
 		// Pages
 
-		updateStatus(node.getNodeId(), status);
+		updateChildStatus(node.getNodeId(), status);
 
 		// Trash
 
@@ -515,17 +515,17 @@ public class WikiNodeLocalServiceImpl extends WikiNodeLocalServiceBaseImpl {
 		return wikiImporter;
 	}
 
-	protected void updateStatus(long nodeId, int status)
+	protected void updateChildStatus(long nodeId, int status)
 		throws PortalException, SystemException {
 
 		List<WikiPage> pages = wikiPagePersistence.findByNodeId(nodeId);
 
 		for (WikiPage page : pages) {
-			updateStatus(page, status);
+			updateChildStatus(page, status);
 		}
 	}
 
-	protected void updateStatus(WikiPage page, int status)
+	protected void updateChildStatus(WikiPage page, int status)
 		throws PortalException, SystemException {
 
 		if (status == WorkflowConstants.STATUS_IN_TRASH) {

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalService.java
@@ -236,6 +236,11 @@ public interface DLAppHelperLocalService extends BaseLocalService {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
+	public void updateChildrenStatus(com.liferay.portal.model.User user,
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	public void updateFileEntry(long userId,
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry,
 		com.liferay.portal.kernel.repository.model.FileVersion sourceFileVersion,
@@ -263,11 +268,6 @@ public interface DLAppHelperLocalService extends BaseLocalService {
 		com.liferay.portal.kernel.repository.model.FileVersion latestFileVersion,
 		int oldStatus, int newStatus,
 		java.util.Map<java.lang.String, java.io.Serializable> workflowContext)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
-	public void updateStatuses(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 }

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceUtil.java
@@ -292,6 +292,15 @@ public class DLAppHelperLocalServiceUtil {
 			assetCategoryIds, assetTagNames, assetLinkEntryIds);
 	}
 
+	public static void updateChildrenStatus(
+		com.liferay.portal.model.User user,
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		getService()
+			.updateChildrenStatus(user, dlFileEntriesAndDLFolders, status);
+	}
+
 	public static void updateFileEntry(long userId,
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry,
 		com.liferay.portal.kernel.repository.model.FileVersion sourceFileVersion,
@@ -334,13 +343,6 @@ public class DLAppHelperLocalServiceUtil {
 		getService()
 			.updateStatus(userId, fileEntry, latestFileVersion, oldStatus,
 			newStatus, workflowContext);
-	}
-
-	public static void updateStatuses(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		getService().updateStatuses(user, dlFileEntriesAndDLFolders, status);
 	}
 
 	public static DLAppHelperLocalService getService() {

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceWrapper.java
@@ -288,6 +288,14 @@ public class DLAppHelperLocalServiceWrapper implements DLAppHelperLocalService,
 			fileVersion, assetCategoryIds, assetTagNames, assetLinkEntryIds);
 	}
 
+	public void updateChildrenStatus(com.liferay.portal.model.User user,
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		_dlAppHelperLocalService.updateChildrenStatus(user,
+			dlFileEntriesAndDLFolders, status);
+	}
+
 	public void updateFileEntry(long userId,
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry,
 		com.liferay.portal.kernel.repository.model.FileVersion sourceFileVersion,
@@ -327,14 +335,6 @@ public class DLAppHelperLocalServiceWrapper implements DLAppHelperLocalService,
 			com.liferay.portal.kernel.exception.SystemException {
 		_dlAppHelperLocalService.updateStatus(userId, fileEntry,
 			latestFileVersion, oldStatus, newStatus, workflowContext);
-	}
-
-	public void updateStatuses(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		_dlAppHelperLocalService.updateStatuses(user,
-			dlFileEntriesAndDLFolders, status);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalService.java
@@ -443,13 +443,13 @@ public interface MBCategoryLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
-	public com.liferay.portlet.messageboards.model.MBCategory updateStatus(
-		long userId, long categoryId, int status)
+	public void updateChildrenStatus(com.liferay.portal.model.User user,
+		java.util.List<java.lang.Object> categoriesAndThreads, int status)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
-	public void updateStatuses(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> categoriesAndThreads, int status)
+	public com.liferay.portlet.messageboards.model.MBCategory updateStatus(
+		long userId, long categoryId, int status)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 }

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceUtil.java
@@ -549,18 +549,19 @@ public class MBCategoryLocalServiceUtil {
 			mailingListActive, mergeWithParentCategory, serviceContext);
 	}
 
+	public static void updateChildrenStatus(
+		com.liferay.portal.model.User user,
+		java.util.List<java.lang.Object> categoriesAndThreads, int status)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		getService().updateChildrenStatus(user, categoriesAndThreads, status);
+	}
+
 	public static com.liferay.portlet.messageboards.model.MBCategory updateStatus(
 		long userId, long categoryId, int status)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService().updateStatus(userId, categoryId, status);
-	}
-
-	public static void updateStatuses(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> categoriesAndThreads, int status)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		getService().updateStatuses(user, categoriesAndThreads, status);
 	}
 
 	public static MBCategoryLocalService getService() {

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBCategoryLocalServiceWrapper.java
@@ -548,19 +548,19 @@ public class MBCategoryLocalServiceWrapper implements MBCategoryLocalService,
 			serviceContext);
 	}
 
+	public void updateChildrenStatus(com.liferay.portal.model.User user,
+		java.util.List<java.lang.Object> categoriesAndThreads, int status)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		_mbCategoryLocalService.updateChildrenStatus(user,
+			categoriesAndThreads, status);
+	}
+
 	public com.liferay.portlet.messageboards.model.MBCategory updateStatus(
 		long userId, long categoryId, int status)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _mbCategoryLocalService.updateStatus(userId, categoryId, status);
-	}
-
-	public void updateStatuses(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> categoriesAndThreads, int status)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		_mbCategoryLocalService.updateStatuses(user, categoriesAndThreads,
-			status);
 	}
 
 	/**


### PR DESCRIPTION
Hi Brian, we had tried to keep the following convention:
- updateStatus --> updates the status of an entity
- updateStatuses --> updates the status of the children

In your last source formating, you renamed an updateStatuses to updateStatus and we felt that this was very unconsistent but at the same time unclear, so we have decided to make it more obvious, renaming these methods to:
- updateStatus --> updates the status of an entity
- updateChildrenStauts --> updates the status of the children
