### PR TITLE
LPS-31440 Documents in trash shouldn't appear in Documents and Media Display

### DIFF
--- a/portal-web/docroot/html/portlet/document_library_display/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/view.jsp
@@ -234,8 +234,8 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 				%>
 
 				<liferay-ui:search-container-results
-					results="<%= DLAppServiceUtil.getGroupFileEntries(repositoryId, groupFileEntriesUserId, defaultFolderId, searchContainer.getStart(), searchContainer.getEnd()) %>"
-					total="<%= DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupFileEntriesUserId, defaultFolderId) %>"
+					results="<%= DLAppServiceUtil.getGroupFileEntries(repositoryId, groupFileEntriesUserId, folderId, null, status, searchContainer.getStart(), searchContainer.getEnd(), null) %>"
+					total="<%= DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupFileEntriesUserId, folderId, null, status) %>"
 				/>
 
 				<liferay-ui:search-container-row

--- a/portal-web/docroot/html/portlet/document_library_display/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/view.jsp
@@ -234,8 +234,8 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 				%>
 
 				<liferay-ui:search-container-results
-					results="<%= DLAppServiceUtil.getGroupFileEntries(repositoryId, groupFileEntriesUserId, folderId, null, status, searchContainer.getStart(), searchContainer.getEnd(), null) %>"
-					total="<%= DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupFileEntriesUserId, folderId, null, status) %>"
+					results="<%= DLAppServiceUtil.getGroupFileEntries(repositoryId, groupFileEntriesUserId, defaultFolderId, null, status, searchContainer.getStart(), searchContainer.getEnd(), null) %>"
+					total="<%= DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupFileEntriesUserId, defaultFolderId, null, status) %>"
 				/>
 
 				<liferay-ui:search-container-row


### PR DESCRIPTION
Same logic as in view_entries.jsp

``` java
        results = DLAppServiceUtil.getGroupFileEntries(repositoryId, groupFileEntriesUserId, folderId, null, status, entryStart, entryEnd, null);
        total = DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupFileEntriesUserId, folderId, null, status);

```
