### PR TITLE
LPS-31379 Edit option shouldn't be enabled in trashed messages.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadImpl.java
@@ -109,6 +109,10 @@ public class MBThreadImpl extends MBThreadBaseImpl {
 
 	public boolean isLocked() {
 		try {
+			if (isInTrash() || isInTrashContainer()) {
+				return true;
+			}
+
 			return LockLocalServiceUtil.isLocked(
 				MBThread.class.getName(), getThreadId());
 		}


### PR DESCRIPTION
A Thread in trash or in a trashed Category will be considered as locked.
