### PR TITLE
LPS-32059 Fix broken loop control flow

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/LockLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/LockLocalServiceTest.java
@@ -142,34 +142,43 @@ public class LockLocalServiceTest {
 						// to unlock many times because some databases like SQL
 						// Server may randomly choke and rollback an unlock.
 
-						boolean reacquireLock = false;
-
 						while (true) {
 							try {
 								LockLocalServiceUtil.unlock(
 									_className, _key, _owner, false);
 
 								if (++count >= _requiredSuccessCount) {
-									reacquireLock = true;
+
+									// The test is done, quit this test thread
+
+									return;
+								}
+								else {
+
+									// Need more iteration
 
 									break;
 								}
-
-								break;
 							}
 							catch (SystemException se) {
 								if (_isExpectedException(se)) {
+
+									// Failed to unlock by expected exception,
+									// retry
+
 									continue;
 								}
+								else {
 
-								_systemException = se;
+									// Failed to unlock by unexpected exception,
+									// record the exception and quit this test
+									// thread.
 
-								break;
+									_systemException = se;
+
+									return;
+								}
 							}
-						}
-
-						if (reacquireLock) {
-							continue;
 						}
 					}
 				}


### PR DESCRIPTION
Ok, this is a special case. Because there is no post processing logic in the bottom of the outter loop, so we can directly do a return inside the inner loop. This can eliminate both the "break label" and control variable.

Just to confirm, are we supposed to never use "break label"? Because there will be more complex cases, where break label will be the only clean solution. The "break label" is basically a simplified version of goto for Java, much safer than goto, and of course much less powerful. Should we always prefer control variable over break label?
