### PR TITLE
LPS-16393 Remove the harsh testing, this could break on a heavy loaded machine.

### DIFF
--- a/portal-service/test/unit/com/liferay/portal/kernel/io/CharPipeTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/io/CharPipeTest.java
@@ -572,9 +572,6 @@ public class CharPipeTest extends TestCase {
 
 			assertTrue(timestampAfterSkip1 >= timestampBeforeWrite);
 			assertTrue(timestampAfterSkip2 >= timestampAfterSkip1);
-			assertTrue(
-				(timestampAfterSkip1 - timestampBeforeWrite) >=
-					(timestampAfterSkip2 - timestampAfterSkip1));
 		}
 
 		charPipe.close();


### PR DESCRIPTION
The assert was trying to say a synchronized exchange is slower than a direct taken, which is true in normal case.

But apparently the jenkins server does not agree. If some random load kicks in while the code is doing direct taken, it could be even slower than a synchronized exchange.

It is not necessary to this point, so just simply remove the assert.
