### PR TITLE
LPS-31579 Remove unused/unnecessary restore paths

### DIFF
--- a/portal-web/docroot/WEB-INF/struts-config.xml
+++ b/portal-web/docroot/WEB-INF/struts-config.xml
@@ -528,10 +528,6 @@
 			<forward name="portlet.document_library.error" path="portlet.document_library.error" />
 		</action>
 
-		<action path="/document_library/restore_entry" type="com.liferay.portlet.trash.action.EditEntryAction">
-			<forward name="portlet.document_library.view" path="portlet.document_library.view" />
-		</action>
-
 		<action path="/document_library/search" type="com.liferay.portlet.documentlibrary.action.SearchAction">
 			<forward name="portlet.document_library.view" path="portlet.document_library.view" />
 		</action>
@@ -2137,14 +2133,6 @@
 
 		<action path="/wiki/restore_entry" forward="portlet.trash.restore_entry" />
 
-		<action path="/wiki/restore_node" type="com.liferay.portlet.wiki.action.EditNodeAction">
-			<forward name="portlet.wiki.error" path="portlet.wiki.error" />
-		</action>
-
-		<action path="/wiki/restore_page" type="com.liferay.portlet.wiki.action.EditPageAction">
-			<forward name="portlet.wiki.error" path="portlet.wiki.error" />
-		</action>
-
 		<action path="/wiki/restore_page_attachment" type="com.liferay.portlet.trash.action.EditEntryAction">
 			<forward name="portlet.trash.view" path="portlet.wiki.view_page_attachments" />
 		</action>
@@ -2289,14 +2277,6 @@
 
 		<action path="/wiki_admin/restore_entry" forward="portlet.trash.restore_entry" />
 
-		<action path="/wiki_admin/restore_node" type="com.liferay.portlet.wiki.action.EditNodeAction">
-			<forward name="portlet.wiki.error" path="portlet.wiki.error" />
-		</action>
-
-		<action path="/wiki_admin/restore_page" type="com.liferay.portlet.wiki.action.EditPageAction">
-			<forward name="portlet.wiki.error" path="portlet.wiki.error" />
-		</action>
-
 		<action path="/wiki_admin/restore_page_attachment" type="com.liferay.portlet.trash.action.EditEntryAction">
 			<forward name="portlet.trash.view" path="portlet.wiki.view_page_attachments" />
 		</action>
@@ -2418,14 +2398,6 @@
 		</action>
 
 		<action path="/wiki_display/restore_entry" forward="portlet.trash.restore_entry" />
-
-		<action path="/wiki_display/restore_node" type="com.liferay.portlet.wiki.action.EditNodeAction">
-			<forward name="portlet.wiki.error" path="portlet.wiki.error" />
-		</action>
-
-		<action path="/wiki_display/restore_page" type="com.liferay.portlet.wiki.action.EditPageAction">
-			<forward name="portlet.wiki.error" path="portlet.wiki.error" />
-		</action>
 
 		<action path="/wiki_display/restore_page_attachment" type="com.liferay.portlet.trash.action.EditEntryAction">
 			<forward name="portlet.trash.view" path="portlet.wiki.view_page_attachments" />

--- a/portal-web/docroot/html/portlet/wiki/view_all_pages.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view_all_pages.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/portlet/wiki/init.jsp" %>
 
 <portlet:actionURL var="undoTrashURL">
-	<portlet:param name="struts_action" value="/wiki/restore_page" />
+	<portlet:param name="struts_action" value="/wiki/edit_page" />
 	<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
 </portlet:actionURL>
 

--- a/portal-web/docroot/html/portlet/wiki/view_nodes.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view_nodes.jsp
@@ -40,7 +40,7 @@ searchContainer.setResults(results);
 %>
 
 <portlet:actionURL var="undoTrashURL">
-	<portlet:param name="struts_action" value="/wiki/restore_node" />
+	<portlet:param name="struts_action" value="/wiki/edit_node" />
 	<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
 </portlet:actionURL>
 


### PR DESCRIPTION
Hey Brian,

Probably you remember that after reviewing LPS-29174 we decided to standarize the struts paths for restoring trashed entries, because the current ones were confusing. Currently there are no written rules for the naming and structure of struts paths and action classes in the Peer Reviews Checklist, so I've extracted some here:
- The [portlet_struts_path]/edit_entry paths are used for those actions which are common to more than one entity within the same portlet. The EditEntryAction class contains those common actions. The set of common actions depends of the GUI design: In portlets with a general toolbar, like D&M and WCM, many actions are common. In other cases, like Message Boards, only the restore action is common so far. And in other, like the Wiki, there are no common actions (and thus, no edit_entry path). This might change if we extend the same GUI design in D&M and WCM to all portlets. 
- The [portlet_struts_path]/restore_entry paths are used to forward to the restore_entry.jsp view in case an attachment document is duplicated. We need a path for every portlet using attachments based in the Document Library (so far Wiki and Message Boards).
- The [portlet_struts_path]/restore_[entity]_attachments paths define the action class for restoring attachments: trash.action.EditEntryAction. Once more we need a path for every portlet using attachments.

I removed some paths that were unnused or unnecessary (see my commit). For all others, though we initially considered renaming the restore_\* paths to edit_trash_entry_*, giving the above described rules I'm not sure whether that solution will be better in terms of semantic and simplicity. What do you think? 

Thanks

@juliocamarero We could add these rules to the Peer Reviews Checklist once we close this ticket.
