### PR TITLE
LPS-32067 Re-add, else it will fail on service classes in plugins

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
+++ b/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
@@ -788,6 +788,10 @@ public class JavadocFormatter {
 		}
 
 		if (pos == -1) {
+			pos = fileName.indexOf("service/");
+		}
+
+		if (pos == -1) {
 			throw new RuntimeException(fileName);
 		}
 


### PR DESCRIPTION
Good catch by @shinnlok . The formatter needs to check the service/ directory for limiting on plugin service classes.
