### PR TITLE
LPS-32362 Declare supported classNames in FolderSearcher (we assume this feature is not supported in plugins for now)

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/search/FolderSearcher.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/FolderSearcher.java
@@ -14,6 +14,10 @@
 
 package com.liferay.portal.kernel.search;
 
+import com.liferay.portlet.bookmarks.model.BookmarksFolder;
+import com.liferay.portlet.documentlibrary.model.DLFolder;
+import com.liferay.portlet.journal.model.JournalFolder;
+
 import java.util.Locale;
 
 import javax.portlet.PortletURL;
@@ -22,6 +26,10 @@ import javax.portlet.PortletURL;
  * @author Eduardo Garcia
  */
 public class FolderSearcher extends BaseIndexer {
+
+	public static final String[] CLASS_NAMES = {
+		BookmarksFolder.class.getName(), DLFolder.class.getName(),
+		JournalFolder.class.getName()};
 
 	public static Indexer getInstance() {
 		return new FolderSearcher();
@@ -33,7 +41,7 @@ public class FolderSearcher extends BaseIndexer {
 	}
 
 	public String[] getClassNames() {
-		return null;
+		return CLASS_NAMES;
 	}
 
 	@Override


### PR DESCRIPTION
Hey Brian, we are accepting that for now, we don't allow plugins to show their folders in this facet. We will do this in another iteration. Explanation by Eduardo below:

by @JorgeFerrer:
The key here is that adding support for this for folders has an small cost
and it's something we need. But adding support for plugins requires a more
complex infrastructure that would cost easily ten times more. But we don't
even know if it will be really needed/desired. So we went ahead with the
simpler design and can expand it later if using this from plugins is really
needed.

by @epgarcia:
While the FacetSearcher fully overrides the BaseIndexer.createFullQuery method, the FolderSearcher simply extends it. Thus, if FolderSearcher.getClassNames returns null, a NullPointerException will be thrown by the BaseIndexer.createFullQuery method. It is assumed that currently only folders of the declared classNames will be supported, since for them the classPK is unique (they use the same counter). This means this feature is not yet supported for folder entities created in plugins.
