### PR TITLE
LPS-32678

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -2868,7 +2868,49 @@ public class StringUtil {
 	 *         trailing whitespace removed
 	 */
 	public static String trim(String s) {
-		return trim(s, null);
+		if (s == null) {
+			return null;
+		}
+
+		if (s.length() == 0) {
+			return s;
+		}
+
+		int len = s.length();
+		int x = len;
+
+		for (int i = 0; i < len; i++) {
+			char c = s.charAt(i);
+
+			if (!Character.isWhitespace(c)) {
+				x = i;
+
+				break;
+			}
+		}
+
+		if (x == len) {
+			return StringPool.BLANK;
+		}
+
+		int y = x + 1;
+
+		for (int i = len - 1; i > x; i--) {
+			char c = s.charAt(i);
+
+			if (!Character.isWhitespace(c)) {
+				y = i + 1;
+
+				break;
+			}
+		}
+
+		if ((x == 0) && (y == len)) {
+			return s;
+		}
+		else {
+			return s.substring(x, y);
+		}
 	}
 
 	/**
@@ -2911,43 +2953,48 @@ public class StringUtil {
 			return null;
 		}
 
-		char[] chars = s.toCharArray();
+		if (s.length() == 0) {
+			return s;
+		}
 
-		int len = chars.length;
+		if ((exceptions == null) || (exceptions.length == 0)) {
+			return trim(s);
+		}
 
-		int x = 0;
-		int y = chars.length;
+		int len = s.length();
+		int x = len;
 
 		for (int i = 0; i < len; i++) {
-			char c = chars[i];
+			char c = s.charAt(i);
 
-			if (_isTrimable(c, exceptions)) {
-				x = i + 1;
-			}
-			else {
+			if (!_isTrimable(c, exceptions)) {
+				x = i;
+
 				break;
 			}
 		}
 
-		for (int i = len - 1; i >= 0; i--) {
-			char c = chars[i];
-
-			if (_isTrimable(c, exceptions)) {
-				y = i;
-			}
-			else {
-				break;
-			}
-		}
-
-		if (x > y) {
+		if (x == len) {
 			return StringPool.BLANK;
 		}
-		else if ((x != 0) || (y != len)) {
-			return s.substring(x, y);
+
+		int y = x + 1;
+
+		for (int i = len - 1; i > x; i--) {
+			char c = s.charAt(i);
+
+			if (!_isTrimable(c, exceptions)) {
+				y = i + 1;
+
+				break;
+			}
+		}
+
+		if ((x == 0) && (y == len)) {
+			return s;
 		}
 		else {
-			return s;
+			return s.substring(x, y);
 		}
 	}
 
@@ -2959,7 +3006,36 @@ public class StringUtil {
 	 *         whitespace removed
 	 */
 	public static String trimLeading(String s) {
-		return trimLeading(s, null);
+		if (s == null) {
+			return null;
+		}
+
+		if (s.length() == 0) {
+			return s;
+		}
+
+		int len = s.length();
+		int x = len;
+
+		for (int i = 0; i < len; i++) {
+			char c = s.charAt(i);
+
+			if (!Character.isWhitespace(c)) {
+				x = i;
+
+				break;
+			}
+		}
+
+		if (x == len) {
+			return StringPool.BLANK;
+		}
+		else if (x == 0) {
+			return s;
+		}
+		else {
+			return s.substring(x);
+		}
 	}
 
 	/**
@@ -2991,29 +3067,35 @@ public class StringUtil {
 			return null;
 		}
 
-		char[] chars = s.toCharArray();
+		if (s.length() == 0) {
+			return s;
+		}
 
-		int len = chars.length;
+		if ((exceptions == null) || (exceptions.length == 0)) {
+			return trimLeading(s);
+		}
 
-		int x = 0;
-		int y = chars.length;
+		int len = s.length();
+		int x = len;
 
 		for (int i = 0; i < len; i++) {
-			char c = chars[i];
+			char c = s.charAt(i);
 
-			if (_isTrimable(c, exceptions)) {
-				x = i + 1;
-			}
-			else {
+			if (!_isTrimable(c, exceptions)) {
+				x = i;
+
 				break;
 			}
 		}
 
-		if ((x != 0) || (y != len)) {
-			return s.substring(x, y);
+		if (x == len) {
+			return StringPool.BLANK;
+		}
+		else if (x == 0) {
+			return s;
 		}
 		else {
-			return s;
+			return s.substring(x);
 		}
 	}
 
@@ -3025,7 +3107,36 @@ public class StringUtil {
 	 *         whitespace removed
 	 */
 	public static String trimTrailing(String s) {
-		return trimTrailing(s, null);
+		if (s == null) {
+			return null;
+		}
+
+		if (s.length() == 0) {
+			return s;
+		}
+
+		int len = s.length();
+		int y = 0;
+
+		for (int i = len - 1; i >= 0; i--) {
+			char c = s.charAt(i);
+
+			if (!Character.isWhitespace(c)) {
+				y = i + 1;
+
+				break;
+			}
+		}
+
+		if (y == 0) {
+			return StringPool.BLANK;
+		}
+		else if (y == len) {
+			return s;
+		}
+		else {
+			return s.substring(0, y);
+		}
 	}
 
 	/**
@@ -3057,29 +3168,35 @@ public class StringUtil {
 			return null;
 		}
 
-		char[] chars = s.toCharArray();
+		if (s.length() == 0) {
+			return s;
+		}
 
-		int len = chars.length;
+		if ((exceptions == null) || (exceptions.length == 0)) {
+			return trimTrailing(s);
+		}
 
-		int x = 0;
-		int y = chars.length;
+		int len = s.length();
+		int y = 0;
 
 		for (int i = len - 1; i >= 0; i--) {
-			char c = chars[i];
+			char c = s.charAt(i);
 
-			if (_isTrimable(c, exceptions)) {
-				y = i;
-			}
-			else {
+			if (!_isTrimable(c, exceptions)) {
+				y = i + 1;
+
 				break;
 			}
 		}
 
-		if ((x != 0) || (y != len)) {
-			return s.substring(x, y);
+		if (y == 0) {
+			return StringPool.BLANK;
+		}
+		else if (y == len) {
+			return s;
 		}
 		else {
-			return s;
+			return s.substring(0, y);
 		}
 	}
 
@@ -3223,11 +3340,9 @@ public class StringUtil {
 	 *         to any of the exception characters; <code>true</code> otherwise
 	 */
 	private static boolean _isTrimable(char c, char[] exceptions) {
-		if ((exceptions != null) && (exceptions.length > 0)) {
-			for (char exception : exceptions) {
-				if (c == exception) {
-					return false;
-				}
+		for (char exception : exceptions) {
+			if (c == exception) {
+				return false;
 			}
 		}
 

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -2940,7 +2940,10 @@ public class StringUtil {
 			}
 		}
 
-		if ((x != 0) || (y != len)) {
+		if (x > y) {
+			return StringPool.BLANK;
+		}
+		else if ((x != 0) || (y != len)) {
 			return s.substring(x, y);
 		}
 		else {

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
@@ -200,4 +200,348 @@ public class StringUtilTest extends TestCase {
 		assertEquals("abcd", StringUtil.strip(" a b  c   d", ' '));
 	}
 
+	public void testTrim() {
+
+		// 1) Null String
+
+		assertNull(StringUtil.trim(null));
+
+		// 2) Blank String
+
+		assertSame(StringPool.BLANK, StringUtil.trim(StringPool.BLANK));
+
+		// 3) Spaces String
+
+		String spacesString = " \t\r\n";
+
+		assertSame(StringPool.BLANK, StringUtil.trim(spacesString));
+
+		// 4) Not trimable
+
+		String testString = "a";
+
+		assertSame(testString, StringUtil.trim(testString));
+
+		testString = "ab";
+
+		assertSame(testString, StringUtil.trim(testString));
+
+		// 5) Leading spaces
+
+		String leadingSpacesString = " \t\r\n" + testString;
+
+		assertEquals(testString, StringUtil.trim(leadingSpacesString));
+
+		// 6) Trailing spaces
+
+		String trailingSpacesString = testString + " \t\r\n";
+
+		assertEquals(testString, StringUtil.trim(trailingSpacesString));
+
+		// 7) Surrounding spaces
+
+		String surroundingSpacesString = " \t\r\n" + testString + " \t\r\n";
+
+		assertEquals(testString, StringUtil.trim(surroundingSpacesString));
+	}
+
+	public void testTrimLeading() {
+
+		// 1) Null String
+
+		assertNull(StringUtil.trimLeading(null));
+
+		// 2) Blank String
+
+		assertSame(StringPool.BLANK, StringUtil.trimLeading(StringPool.BLANK));
+
+		// 3) Spaces String
+
+		String spacesString = " \t\r\n";
+
+		assertSame(StringPool.BLANK, StringUtil.trimLeading(spacesString));
+
+		// 4) Not trimable
+
+		String testString = "a";
+
+		assertSame(testString, StringUtil.trimLeading(testString));
+
+		testString = "ab";
+
+		assertSame(testString, StringUtil.trimLeading(testString));
+
+		// 5) Leading spaces
+
+		String leadingSpacesString = " \t\r\n" + testString;
+
+		assertEquals(testString, StringUtil.trimLeading(leadingSpacesString));
+
+		// 6) Trailing spaces
+
+		String trailingSpacesString = testString + " \t\r\n";
+
+		assertSame(
+			trailingSpacesString, StringUtil.trimLeading(trailingSpacesString));
+
+		// 7) Surrounding spaces
+
+		String surroundingSpacesString = " \t\r\n" + testString + " \t\r\n";
+
+		assertEquals(
+			testString + " \t\r\n",
+			StringUtil.trimLeading(surroundingSpacesString));
+	}
+
+	public void testTrimLeadingWithExceptions() {
+
+		// 1) Null String
+
+		assertNull(StringUtil.trimLeading(null, null));
+
+		// 2) Null exceptions
+
+		assertSame(StringPool.BLANK, StringUtil.trimLeading(" ", null));
+
+		// 3) Zero exceptions
+
+		assertSame(StringPool.BLANK, StringUtil.trimLeading(" ", new char[0]));
+
+		char[] exceptions = {'\t', '\r'};
+
+		// 4) Blank String
+
+		assertSame(
+			StringPool.BLANK,
+			StringUtil.trimLeading(StringPool.BLANK, exceptions));
+
+		// 5) Spaces String
+
+		String spacesString = " \t\r\n";
+
+		assertEquals(
+			"\t\r\n", StringUtil.trimLeading(spacesString, exceptions));
+
+		// 6) Not trimable
+
+		String testString = "\t";
+
+		assertSame(testString, StringUtil.trimLeading(testString, exceptions));
+
+		testString = "\t\r";
+
+		assertSame(testString, StringUtil.trimLeading(testString, exceptions));
+
+		// 7) All trimable
+
+		assertSame(StringPool.BLANK, StringUtil.trimLeading(" \n", exceptions));
+
+		// 8) Leading spaces
+
+		String leadingSpacesString = " \t\r\n" + testString;
+
+		assertEquals(
+			"\t\r\n" + testString,
+			StringUtil.trimLeading(leadingSpacesString, exceptions));
+
+		// 9) Trailing spaces
+
+		String trailingSpacesString = testString + " \t\r\n";
+
+		assertSame(
+			trailingSpacesString,
+			StringUtil.trimLeading(trailingSpacesString, exceptions));
+
+		// 10) Surrounding spaces
+
+		String surroundingSpacesString = " \t\r\n" + testString + " \t\r\n";
+
+		assertEquals(
+			"\t\r\n" + testString + " \t\r\n",
+			StringUtil.trimLeading(surroundingSpacesString, exceptions));
+	}
+
+	public void testTrimTrailing() {
+
+		// 1) Null String
+
+		assertNull(StringUtil.trimTrailing(null));
+
+		// 2) Blank String
+
+		assertSame(StringPool.BLANK, StringUtil.trimTrailing(StringPool.BLANK));
+
+		// 3) Spaces String
+
+		String spacesString = " \t\r\n";
+
+		assertSame(StringPool.BLANK, StringUtil.trimTrailing(spacesString));
+
+		// 4) Not trimable
+
+		String testString = "a";
+
+		assertSame(testString, StringUtil.trimTrailing(testString));
+
+		testString = "ab";
+
+		assertSame(testString, StringUtil.trimTrailing(testString));
+
+		// 5) Leading spaces
+
+		String leadingSpacesString = " \t\r\n" + testString;
+
+		assertSame(
+			leadingSpacesString, StringUtil.trimTrailing(leadingSpacesString));
+
+		// 6) Trailing spaces
+
+		String trailingSpacesString = testString + " \t\r\n";
+
+		assertEquals(testString, StringUtil.trimTrailing(trailingSpacesString));
+
+		// 7) Surrounding spaces
+
+		String surroundingSpacesString = " \t\r\n" + testString + " \t\r\n";
+
+		assertEquals(
+			" \t\r\n" + testString,
+			StringUtil.trimTrailing(surroundingSpacesString));
+	}
+
+	public void testTrimTrailingWithExceptions() {
+
+		// 1) Null String
+
+		assertNull(StringUtil.trimTrailing(null, null));
+
+		// 2) Null exceptions
+
+		assertSame(StringPool.BLANK, StringUtil.trimTrailing(" ", null));
+
+		// 3) Zero exceptions
+
+		assertSame(StringPool.BLANK, StringUtil.trimTrailing(" ", new char[0]));
+
+		char[] exceptions = {'\t', '\r'};
+
+		// 4) Blank String
+
+		assertSame(
+			StringPool.BLANK,
+			StringUtil.trimTrailing(StringPool.BLANK, exceptions));
+
+		// 5) Spaces String
+
+		String spacesString = " \t\r\n";
+
+		assertEquals(
+			" \t\r", StringUtil.trimTrailing(spacesString, exceptions));
+
+		// 6) Not trimable
+
+		String testString = "\t";
+
+		assertSame(testString, StringUtil.trimTrailing(testString, exceptions));
+
+		testString = "\t\r";
+
+		assertSame(testString, StringUtil.trimTrailing(testString, exceptions));
+
+		// 7) All trimable
+
+		assertSame(
+			StringPool.BLANK, StringUtil.trimTrailing(" \n", exceptions));
+
+		// 8) Leading spaces
+
+		String leadingSpacesString = " \t\r\n" + testString;
+
+		assertSame(
+			leadingSpacesString,
+			StringUtil.trimTrailing(leadingSpacesString, exceptions));
+
+		// 9) Trailing spaces
+
+		String trailingSpacesString = testString + " \t\r\n";
+
+		assertEquals(
+			testString + " \t\r",
+			StringUtil.trimTrailing(trailingSpacesString, exceptions));
+
+		// 10) Surrounding spaces
+
+		String surroundingSpacesString = " \t\r\n" + testString + " \t\r\n";
+
+		assertEquals(
+			" \t\r\n" + testString + " \t\r",
+			StringUtil.trimTrailing(surroundingSpacesString, exceptions));
+	}
+
+	public void testTrimWithExceptions() {
+
+		// 1) Null String
+
+		assertNull(StringUtil.trim(null, null));
+
+		// 2) Null exceptions
+
+		assertSame(StringPool.BLANK, StringUtil.trim(" ", null));
+
+		// 3) Zero exceptions
+
+		assertSame(StringPool.BLANK, StringUtil.trim(" ", new char[0]));
+
+		char[] exceptions = {'\t', '\r'};
+
+		// 4) Blank String
+
+		assertSame(
+			StringPool.BLANK, StringUtil.trim(StringPool.BLANK, exceptions));
+
+		// 5) Spaces String
+
+		String spacesString = " \t\r\n";
+
+		assertEquals("\t\r", StringUtil.trim(spacesString, exceptions));
+
+		// 6) Not trimable
+
+		String testString = "\t";
+
+		assertSame(testString, StringUtil.trim(testString, exceptions));
+
+		testString = "\t\r";
+
+		assertSame(testString, StringUtil.trim(testString, exceptions));
+
+		// 7) All trimable
+
+		assertSame(StringPool.BLANK, StringUtil.trim(" \n", exceptions));
+
+		// 8) Leading spaces
+
+		String leadingSpacesString = " \t\r\n" + testString;
+
+		assertEquals(
+			"\t\r\n" + testString,
+			StringUtil.trim(leadingSpacesString, exceptions));
+
+		// 9) Trailing spaces
+
+		String trailingSpacesString = testString + " \t\r\n";
+
+		assertEquals(
+			testString + " \t\r",
+			StringUtil.trim(trailingSpacesString, exceptions));
+
+		// 10) Surrounding spaces
+
+		String surroundingSpacesString = " \t\r\n" + testString + " \t\r\n";
+
+		assertEquals(
+			"\t\r\n" + testString + " \t\r",
+			StringUtil.trim(surroundingSpacesString, exceptions));
+	}
+
 }


### PR DESCRIPTION
@brianchandotcom @hhuijser

I rewrote all those trim*() methods.

Right now the trim with exceptions fall back to the simple trim, not the other way around.
Since the simple trim are used much more often than those exception ones, we should convert complex case to simple case on special condition, rather than generalize the simple case to complex case to reduce duplicate code.

For utility class like this, we should spend more man power to do it right once(duplicate code is not a problem, as they should be very stable, very unlikely to be changed in the future), then everyone else can use it with a good performance.
