### PR TITLE
LPS-32502 OSGi components should end up in the osgi/portal folder. Extract the path to a common build file.

### DIFF
--- a/osgi/bootstrap/src/com/liferay/osgi/bootstrap/ModuleFrameworkImpl.java
+++ b/osgi/bootstrap/src/com/liferay/osgi/bootstrap/ModuleFrameworkImpl.java
@@ -782,7 +782,7 @@ public class ModuleFrameworkImpl
 				return;
 			}
 
-			if (_hasLazyActivationPolicy(bundle)) {
+			if (!start && _hasLazyActivationPolicy(bundle)) {
 				lazyActivationBundles.add(bundle);
 
 				return;

--- a/osgi/modules/build-module.xml
+++ b/osgi/modules/build-module.xml
@@ -4,4 +4,6 @@
 	<property name="project.dir" value="../../.." />
 
 	<import file="../../build-common-java.xml" />
+
+	<property name="deploy.dir" value="${liferay.home}/data/osgi/portal" />
 </project>

--- a/osgi/modules/log-bridge/build.xml
+++ b/osgi/modules/log-bridge/build.xml
@@ -3,6 +3,5 @@
 <project name="log-bridge" basedir="." default="compile">
 	<import file="../build-module.xml" />
 
-	<property name="deploy.dir" value="${app.server.lib.portal.dir}" />
 	<property name="jar.file" value="${ant.project.name}" />
 </project>


### PR DESCRIPTION
If a module needs to be deployed to a different path it should be override the deploy.dir variable in its build.xml file
