### PR TITLE
LPS-32726 Generate build.number in machine-friendly way (avoid formatting)

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/props.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/props.ftl
@@ -13,7 +13,7 @@
 ##
 
     build.namespace=${portletShortName}
-    build.number=${buildNumber}
+    build.number=${buildNumber?c}
     build.date=${currentTimeMillis?c}
     build.auto.upgrade=true
 


### PR DESCRIPTION
Hey Brian,

This is a small fix in one of the service builder dependencies. We would like to omit formatting for the build.number attribute.

Thanks,

Máté
