### PR TITLE
LPS-32529 - Again with explanation...

### DIFF
--- a/portal-web/docroot/html/portlet/search/facets/asset_tags.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/asset_tags.jsp
@@ -77,7 +77,7 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 						Liferay.Search.tokenList.add(
 							{
 								clearFields: '<%= UnicodeFormatter.toString(renderResponse.getNamespace() + facet.getFieldName()) %>',
-								text: '<%= UnicodeFormatter.toString(termCollector.getTerm()) %>'
+								text: '<%= UnicodeFormatter.toString(HtmlUtil.escape(termCollector.getTerm())) %>'
 							}
 						);
 					</aui:script>

--- a/portal-web/docroot/html/portlet/search/facets/folders.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/folders.jsp
@@ -69,7 +69,7 @@ SearchContext searchContext = SearchContextFactory.getInstance(request);
 						{
 							clearFields: '<%= UnicodeFormatter.toString(renderResponse.getNamespace() + facet.getFieldName()) %>',
 							fieldValues: '<%= curFolderId %>',
-							text: '<%= UnicodeFormatter.toString(title.getValue()) %>'
+							text: '<%= UnicodeFormatter.toString(HtmlUtil.escape(title.getValue())) %>'
 						}
 					);
 				</aui:script>

--- a/portal-web/docroot/html/portlet/search/facets/scopes.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/scopes.jsp
@@ -50,7 +50,7 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 					Liferay.Search.tokenList.add(
 						{
 							fieldValues: '<%= UnicodeFormatter.toString(renderResponse.getNamespace() + facet.getFieldName() + "|0") %>',
-							text: '<%= UnicodeFormatter.toString(group.getDescriptiveName(locale)) %>'
+							text: '<%= UnicodeFormatter.toString(HtmlUtil.escape(group.getDescriptiveName(locale))) %>'
 						}
 					);
 				</aui:script>
@@ -63,7 +63,7 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 			%>
 
 			<li class="facet-value <%= groupId == curGroupId ? "current-term" : StringPool.BLANK %>">
-				<a data-value="<%= curGroupId %>" href="javascript:;"><%= group.getDescriptiveName(locale) %></a>
+				<a data-value="<%= curGroupId %>" href="javascript:;"><%= HtmlUtil.escape(group.getDescriptiveName(locale)) %></a>
 
 				<c:if test="<%= showAssetCount %>">
 					<span class="frequency">(<%= termCollector.getFrequency() %>)</span>

--- a/portal-web/docroot/html/portlet/search/facets/term_list.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/term_list.jsp
@@ -43,7 +43,7 @@ int maxTerms = dataJSONObject.getInt("maxTerms");
 					Liferay.Search.tokenList.add(
 						{
 							clearFields: '<%= UnicodeFormatter.toString(renderResponse.getNamespace() + facet.getFieldName()) %>',
-							text: '<%= UnicodeFormatter.toString(termCollector.getTerm()) %>'
+							text: '<%= UnicodeFormatter.toString(HtmlUtil.escape(termCollector.getTerm())) %>'
 						}
 					);
 				</aui:script>

--- a/portal-web/docroot/html/portlet/search/facets/term_list.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/term_list.jsp
@@ -56,7 +56,7 @@ int maxTerms = dataJSONObject.getInt("maxTerms");
 		%>
 
 			<li class="facet-value <%= fieldParam.equals(termCollector.getTerm()) ? "current-term" : StringPool.BLANK %>">
-				<a data-value="<%= termCollector.getTerm() %>" href="javascript:;"><%= termCollector.getTerm() %></a> <span class="frequency">(<%= termCollector.getFrequency() %>)</span>
+				<a data-value="<%= HtmlUtil.escapeAttribute(termCollector.getTerm()) %>" href="javascript:;"><%= HtmlUtil.escape(termCollector.getTerm()) %></a> <span class="frequency">(<%= termCollector.getFrequency() %>)</span>
 			</li>
 
 		<%

--- a/portal-web/docroot/html/portlet/search/facets/users.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/users.jsp
@@ -50,7 +50,7 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 					Liferay.Search.tokenList.add(
 						{
 							clearFields: '<%= UnicodeFormatter.toString(renderResponse.getNamespace() + facet.getFieldName()) %>',
-							text: '<%= UnicodeFormatter.toString(curUser.getFullName()) %>'
+							text: '<%= UnicodeFormatter.toString(HtmlUtil.escape(curUser.getFullName())) %>'
 						}
 					);
 				</aui:script>


### PR DESCRIPTION
Hi Brian,

UnicodeFormatter doesn't "HTML" escape. We need to escape the content because while using UnicodeFormatter prevents XSS, it preserves the html, so when we actually write it to the output stream, it becomes valid html and so the browser doesn't display it. Html escape changes the characters "<" is not the same as < even if they are displayed the same.

The customer actually complained about not seeing what he entered and not about it being an XSS...
