### PR TITLE
Page Objects (Add Base java files into the portalweb2 folder)

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb2/util/SeleniumUtil.java
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/SeleniumUtil.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portalweb2.util;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class SeleniumUtil {
+}

--- a/portal-web/test/functional/com/liferay/portalweb2/util/blocks/action/BaseAction.java
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/blocks/action/BaseAction.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portalweb2.util.blocks.action;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class BaseAction {
+}

--- a/portal-web/test/functional/com/liferay/portalweb2/util/blocks/function/BaseFunction.java
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/blocks/function/BaseFunction.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portalweb2.util.blocks.function;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class BaseFunction {
+}

--- a/portal-web/test/functional/com/liferay/portalweb2/util/blocks/macro/BaseMacro.java
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/blocks/macro/BaseMacro.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portalweb2.util.blocks.macro;
+
+/**
+ * @author Michael Hashimoto
+ */
+public class BaseMacro {
+}

--- a/portal-web/test/functional/com/liferay/portalweb2/util/liferayselenium/LiferaySelenium.java
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/liferayselenium/LiferaySelenium.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portalweb2.util.liferayselenium;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public interface LiferaySelenium {
+}

--- a/portal-web/test/functional/com/liferay/portalweb2/util/testcase/BaseTestCase.java
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/testcase/BaseTestCase.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portalweb2.util.testcase;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class BaseTestCase {
+}

--- a/portal-web/test/functional/com/liferay/portalweb2/util/testsuite/BaseTestSuite.java
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/testsuite/BaseTestSuite.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-2012 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portalweb2.util.testsuite;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class BaseTestSuite {
+}


### PR DESCRIPTION
http://issues.liferay.com/browse/LIFEREAYQA-3912

Projected changes once we move over completely:

```
portalweb2/util/*.java  <==  portalweb/portal/util/*.java
portalweb2/util/blocks/action/BaseAction.java  <==  (New Folders)
portalweb2/util/blocks/function/BaseFunction.java  <==  (New Folders)
portalweb2/util/blocks/macro/BaseMacro.java  <==  (New Folders)
portalweb2/util/liferayselenium/*.java  <==  portalweb/portal/util/liferayselenium/*.java
portalweb2/util/testcase/BaseTestCase.java  <==  portalweb/portal/BaseTestCase
portalweb2/util/testsuite/BaseTestSuite.java  <==  portalweb/portal/BaseTestSuite
```
