### PR TITLE
LPS-32830 rename callback as eventName

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/select_organization.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/select_organization.jsp
@@ -17,13 +17,13 @@
 <%@ include file="/html/portlet/users_admin/init.jsp" %>
 
 <%
-String callback = ParamUtil.getString(request, "callback", "selectOrganization");
+String eventName = ParamUtil.getString(request, "eventName", "selectOrganization");
 String target = ParamUtil.getString(request, "target");
 
 PortletURL portletURL = renderResponse.createRenderURL();
 
 portletURL.setParameter("struts_action", "/users_admin/select_organization");
-portletURL.setParameter("callback", callback);
+portletURL.setParameter("eventName", eventName);
 
 if (Validator.isNotNull(target)) {
 	portletURL.setParameter("target", target);
@@ -152,7 +152,7 @@ if (Validator.isNotNull(target)) {
 		function(event) {
 			var result = Util.getAttributes(event.currentTarget, 'data-');
 
-			Util.getOpener().Liferay.fire('<portlet:namespace /><%= callback %>', result);
+			Util.getOpener().Liferay.fire('<portlet:namespace /><%= eventName %>', result);
 
 			Util.getWindow().close();
 		},


### PR DESCRIPTION
Hey Brian, in this new pattern this variable is not a callback anymore but an eventName. I think we should keep the names different because otherwise users will understand that a callback is a function called back whereas an event is something you have to listen to.

We are going to apply this new patter to all the select_xxx.jsp next week. This was just the prototype to see if Nate and you liked it.

thanks!
