### PR TITLE
LPS-31950 fix language keys for new Wiki UI

### DIFF
--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -418,6 +418,7 @@ action.VIEW_USER=View User
 ## Messages
 ##
 
+select-version=Select Version
 1-day=1 Day
 1-minute=1 Minute
 1-month=1 Month
@@ -554,15 +555,16 @@ activity-tasks-review-proposal={0} reviewed proposal from {1}.
 activity-tasks-update-entry-for={0} updated a task for {1}.
 activity-tasks-update-entry={0} updated a task.
 activity-twitter-add-status={0} tweeted.
-activity-wiki-add-attachment={0} added the attachment {1}.
+activity-wiki-add-the-attachment={0} added the attachment {1}.
 activity-wiki-add-comment-in={1} commented on a wiki page, {2}, in {0}.
 activity-wiki-add-comment={1} commented on a wiki page, {2}.
 activity-wiki-add-page-in={1} wrote a new wiki page, {2}, in {0}.
-activity-wiki-add-page={1} wrote a new wiki page, {2}.
-activity-wiki-delete-attachment={0} removed the attachment {1}.
-activity-wiki-restore-attachment={0} restored the attachment {1}.
+activity-wiki-remove-the-attachment={0} removed the attachment {1}.
+activity-wiki-restore-the-attachment={0} restored the attachment {1}.
 activity-wiki-update-page-in={1} updated a wiki page, {2}, in {0}.
 activity-wiki-update-page={1} updated a wiki page, {2}.
+activity-wiki-update-the-page-to-version={0} updated the page to version {1}.
+activity-wiki-add-the-page={0} added the page {1}.
 activity=Activity
 actual-duration=Actual Duration
 actual-end-date=Actual End Date

--- a/portal-web/docroot/html/portlet/wiki/view_page_activities.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view_page_activities.jsp
@@ -117,21 +117,21 @@ iteratorURL.setParameter("nodeId", String.valueOf(node.getNodeId()));
 								<liferay-ui:icon
 									image="clip"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "activity-wiki-add-attachment", new Object[] {socialActivityUser.getFullName(), attachmentTitle}) %>'
+									message='<%= LanguageUtil.format(pageContext, "activity-wiki-add-the-attachment", new Object[] {socialActivityUser.getFullName(), attachmentTitle}) %>'
 								/>
 							</c:when>
 							<c:when test="<%= socialActivity.getType() == SocialActivityConstants.TYPE_MOVE_ATTACHMENT_TO_TRASH %>">
 								<liferay-ui:icon
 									image="delete_attachment"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "activity-wiki-delete-attachment", new Object[] {socialActivityUser.getFullName(), attachmentTitle}) %>'
+									message='<%= LanguageUtil.format(pageContext, "activity-wiki-remove-the-attachment", new Object[] {socialActivityUser.getFullName(), attachmentTitle}) %>'
 								/>
 							</c:when>
 							<c:when test="<%= socialActivity.getType() == SocialActivityConstants.TYPE_RESTORE_ATTACHMENT_FROM_TRASH %>">
 								<liferay-ui:icon
 									image="undo"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "activity-wiki-restore-attachment", new Object[] {socialActivityUser.getFullName(), attachmentTitle}) %>'
+									message='<%= LanguageUtil.format(pageContext, "activity-wiki-restore-the-attachment", new Object[] {socialActivityUser.getFullName(), attachmentTitle}) %>'
 								/>
 							</c:when>
 						</c:choose>
@@ -161,7 +161,7 @@ iteratorURL.setParameter("nodeId", String.valueOf(node.getNodeId()));
 								<liferay-ui:icon
 									image="add_article"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "activity-wiki-add-page", new Object[] {StringPool.BLANK, socialActivityUser.getFullName(), pageTitleLink}) %>'
+									message='<%= LanguageUtil.format(pageContext, "activity-wiki-add-the-page", new Object[] {socialActivityUser.getFullName(), pageTitleLink}) %>'
 								/>
 							</c:when >
 							<c:when test="<%= socialActivity.getType() == WikiActivityKeys.UPDATE_PAGE %>">
@@ -172,7 +172,7 @@ iteratorURL.setParameter("nodeId", String.valueOf(node.getNodeId()));
 								<liferay-ui:icon
 									image="edit"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "activity-wiki-update-page", new Object[] {socialActivityUser.getFullName(), pageTitleLink}) %>'
+									message='<%= LanguageUtil.format(pageContext, "activity-wiki-update-the-page-to-version", new Object[] {socialActivityUser.getFullName(), pageTitleLink}) %>'
 								/>
 
 								<c:if test="<%= socialActivityWikiPage.getStatus() != WorkflowConstants.STATUS_APPROVED %>">


### PR DESCRIPTION
Since we are using these Language keys for the new UI showing activities for a specific page (we need the article 'THE' to make sense instead of the generic a/an). We also need restore instead delete since they are different actions. Right now, we don't log delete actions but we want to do it. This action is just for REMOVING, not for DELETING (they have a different meaining, something removed can be restored)
