### PR TITLE
LPS-31893 Always add XML elements for non-void return values

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
+++ b/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
@@ -531,6 +531,8 @@ public class JavadocFormatter {
 			return;
 		}
 
+		Element returnElement = methodElement.addElement("return");
+
 		DocletTag[] returnDocletTags = javaMethod.getTagsByName("return");
 
 		String comment = StringPool.BLANK;
@@ -544,8 +546,6 @@ public class JavadocFormatter {
 		comment = _trimMultilineText(comment);
 
 		if (Validator.isNotNull(comment)) {
-			Element returnElement = methodElement.addElement("return");
-
 			Element commentElement = returnElement.addElement("comment");
 
 			commentElement.addCDATA(comment);


### PR DESCRIPTION
The XML element representing the non-void return value aids the formatter's update mode in determining whether to insert missing @return stubs for methods that have partial Javadoc specified.
