### PR TITLE
master-bc-405

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3479,9 +3479,7 @@ file.
 								<isset property="skip.delete-liferay-home" />
 							</not>
 							<then>
-								<delete dir="${user.home}/liferay" includeemptydirs="true">
-									<exclude name="**/osgi/**" />
-								</delete>
+								<delete dir="${user.home}/liferay" />
 							</then>
 						</if>
 
@@ -3540,6 +3538,10 @@ file.
 				</if>
 			</else>
 		</if>
+
+		<copy todir="${user.home}/liferay/data/osgi">
+			<fileset dir="${app.server.parent.dir}/data/osgi" />
+		</copy>
 	</target>
 
 	<target name="rebuild-database-db2">

--- a/build-test.xml
+++ b/build-test.xml
@@ -3479,7 +3479,9 @@ file.
 								<isset property="skip.delete-liferay-home" />
 							</not>
 							<then>
-								<delete dir="${user.home}/liferay" />
+								<delete dir="${user.home}/liferay" includeemptydirs="true">
+									<exclude name="**/osgi/**" />
+								</delete>
 							</then>
 						</if>
 


### PR DESCRIPTION
http://issues.liferay.com/browse/LIFERAYQA-4132

Current automation tests are failing because they set the home folder to C:/Users/Liferay, but unless the osgi folder in the data folder that is created when running "ant all" is in the home folder, a NPE will show up (http://issues.liferay.com/browse/LPS-32912). We previously thought this was a regression, but we've learned that it isn't one. This NPE causes the evaluateLog test to fail, which in turn causes the smoke test to fail. Because of this, all downstream projects in Hudson for 6.2.x haven't been running. These commits tell the script to move the osgi folder to the home folder location at the end of "rebuild-database". Let us know if you'd rather us do this a different way.
