### PR TITLE
LPS-33204 JavadocFormatter default mode prerserves named param and throw...

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
+++ b/portal-impl/src/com/liferay/portal/tools/JavadocFormatter.java
@@ -256,7 +256,7 @@ public class JavadocFormatter {
 		boolean publicAccess) {
 
 		List<String> allTagNames = new ArrayList<String>();
-		List<String> commonTagNamesWithComments = new ArrayList<String>();
+		List<String> commonTagNamesWithCommentsOrNames = new ArrayList<String>();
 		List<String> customTagNames = new ArrayList<String>();
 
 		for (String tagName : tagNames) {
@@ -280,7 +280,16 @@ public class JavadocFormatter {
 					tagName.equals("throws")) {
 
 					if (Validator.isNotNull(comment)) {
-						commonTagNamesWithComments.add(tagName);
+						commonTagNamesWithCommentsOrNames.add(tagName);
+					}
+					else if (tagName.equals("param") ||
+							 tagName.equals("throws")) {
+
+						Element namedElement = element.element("named");
+
+						if (Boolean.parseBoolean(namedElement.getText())) {
+							commonTagNamesWithCommentsOrNames.add(tagName);
+						}
 					}
 				}
 				else {
@@ -299,16 +308,16 @@ public class JavadocFormatter {
 			maxTagNameLengthTags.addAll(allTagNames);
 		}
 		else if (_updateJavadocs) {
-			if (!commonTagNamesWithComments.isEmpty()) {
+			if (!commonTagNamesWithCommentsOrNames.isEmpty()) {
 				maxTagNameLengthTags.addAll(allTagNames);
 			}
 			else {
-				maxTagNameLengthTags.addAll(commonTagNamesWithComments);
+				maxTagNameLengthTags.addAll(commonTagNamesWithCommentsOrNames);
 				maxTagNameLengthTags.addAll(customTagNames);
 			}
 		}
 		else {
-			maxTagNameLengthTags.addAll(commonTagNamesWithComments);
+			maxTagNameLengthTags.addAll(commonTagNamesWithCommentsOrNames);
 			maxTagNameLengthTags.addAll(customTagNames);
 		}
 
@@ -377,7 +386,7 @@ public class JavadocFormatter {
 
 							sb.append(comment);
 						}
-						else if (!commonTagNamesWithComments.isEmpty()) {
+						else if (!commonTagNamesWithCommentsOrNames.isEmpty()) {
 
 							// Write out all tags
 
@@ -406,9 +415,24 @@ public class JavadocFormatter {
 
 							sb.append(comment);
 						}
+						if (tagName.equals("param") ||
+							tagName.equals("throws")) {
+
+							Element namedElement = element.element("named");
+
+							if (Boolean.parseBoolean(namedElement.getText())) {
+								elementName = element.elementText("name");
+
+								comment = _assembleTagComment(
+									tagName, elementName, comment, indent,
+									tagNameIndent);
+
+								sb.append(comment);
+							}
+						}
 						else {
 
-							// Skip empty common tag name
+							// Skip empty common tag
 
 						}
 					}
@@ -490,9 +514,13 @@ public class JavadocFormatter {
 		DocUtil.add(paramElement, "name", name);
 		DocUtil.add(paramElement, "type", _getTypeValue(javaParameter));
 
+		boolean named = false;
 		if (value != null) {
+			named = true;
 			value = value.substring(name.length());
 		}
+
+		DocUtil.add(paramElement, "named", Boolean.toString(named));
 
 		value = _trimMultilineText(value);
 
@@ -580,9 +608,13 @@ public class JavadocFormatter {
 		DocUtil.add(throwsElement, "name", name);
 		DocUtil.add(throwsElement, "type", exceptionType.getValue());
 
+		boolean named = false;
 		if (value != null) {
+			named = true;
 			value = value.substring(name.length());
 		}
+
+		DocUtil.add(throwsElement, "named", Boolean.toString(named));
 
 		value = _trimMultilineText(value);
 


### PR DESCRIPTION
...s tags

This is part I of the fix for this issue. I'll follow up with the fix commit with respect to the returns tag. Thanks.
