### PR TITLE
LPS-33306 support for excluding tests from the configuration

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -792,6 +792,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 							<exclude name="**/DLAppServiceSoapTest.class" />
 							<exclude name="**/UserServiceHttpTest.class" />
 							<exclude name="**/UserServiceSoapTest.class" />
+							<exclude name="${junit.test.exclude.regex}" />
 							<exclude name="${test.excludes}" />
 						</fileset>
 					</batchtest>

--- a/build.properties
+++ b/build.properties
@@ -57,6 +57,7 @@
     junit.halt.on.failure=false
     junit.java.mx=1024m
     junit.java.maxpermsize=256m
+    junit.test.exclude.regex=
 
 ##
 ## Module Framework


### PR DESCRIPTION
(we are going to disable TransactionInterceptorTest for our integration server until @migue and @shuyangzhou can identify why it fails randomly)
