### PR TITLE
LPS-33273 Renamed wiki page can cause NoSuchPageException when moved to Recycle Bin

### DIFF
--- a/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -1216,6 +1216,15 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			wikiPagePersistence.update(versionPage);
 		}
 
+		List<WikiPage> redirectPages = wikiPagePersistence.findByN_R(
+			page.getNodeId(), page.getTitle());
+
+		for (WikiPage redirectPage : redirectPages) {
+			redirectPage.setRedirectTitle(trashTitle);
+
+			wikiPagePersistence.update(redirectPage);
+		}
+
 		WikiPageResource pageResource =
 			wikiPageResourcePersistence.fetchByPrimaryKey(
 				page.getResourcePrimKey());
@@ -1279,10 +1288,6 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 		String title = TrashUtil.getOriginalTitle(page.getTitle());
 
-		page.setTitle(title);
-
-		wikiPagePersistence.update(page);
-
 		List<WikiPage> versionPages = wikiPagePersistence.findByR_N_H(
 			page.getResourcePrimKey(), page.getNodeId(), false);
 
@@ -1292,6 +1297,15 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			wikiPagePersistence.update(versionPage);
 		}
 
+		List<WikiPage> redirectPages = wikiPagePersistence.findByN_R(
+			page.getNodeId(), page.getTitle());
+
+		for (WikiPage redirectPage : redirectPages) {
+			redirectPage.setRedirectTitle(title);
+
+			wikiPagePersistence.update(redirectPage);
+		}
+
 		WikiPageResource pageResource =
 			wikiPageResourcePersistence.fetchByPrimaryKey(
 				page.getResourcePrimKey());
@@ -1299,6 +1313,10 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		pageResource.setTitle(title);
 
 		wikiPageResourcePersistence.update(pageResource);
+
+		page.setTitle(title);
+
+		wikiPagePersistence.update(page);
 
 		TrashEntry trashEntry = trashEntryLocalService.getEntry(
 			WikiPage.class.getName(), page.getResourcePrimKey());

--- a/portal-impl/test/integration/com/liferay/portlet/journal/service/persistence/JournalFolderFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/service/persistence/JournalFolderFinderTest.java
@@ -85,7 +85,7 @@ public class JournalFolderFinderTest {
 		queryDefinition.setStatus(WorkflowConstants.STATUS_IN_TRASH);
 
 		Assert.assertEquals(
-			2,
+			1,
 			JournalFolderFinderUtil.countF_A_ByG_F(
 				_group.getGroupId(), _folder1.getFolderId(), queryDefinition));
 
@@ -130,7 +130,7 @@ public class JournalFolderFinderTest {
 		results = JournalFolderFinderUtil.findF_A_ByG_F(
 			_group.getGroupId(), _folder1.getFolderId(), queryDefinition);
 
-		Assert.assertEquals(2, results.size());
+		Assert.assertEquals(1, results.size());
 
 		for (Object result : results) {
 			if (result instanceof JournalFolder) {


### PR DESCRIPTION
@ealonso you may want to have a look at this.
