### PR TITLE
LPS-33400

### DIFF
--- a/portal-impl/src/com/liferay/portlet/social/model/impl/SocialActivityInterpreterImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/model/impl/SocialActivityInterpreterImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.social.model.impl;
 
 import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portlet.social.model.SocialActivity;
 import com.liferay.portlet.social.model.SocialActivityFeedEntry;
 import com.liferay.portlet.social.model.SocialActivityInterpreter;
@@ -67,6 +68,12 @@ public class SocialActivityInterpreterImpl
 		SocialActivity activity, ServiceContext serviceContext) {
 
 		return _activityInterpreter.interpret(activity, serviceContext);
+	}
+
+	public SocialActivityFeedEntry interpret(
+		SocialActivity activity, ThemeDisplay themeDisplay) {
+
+		return _activityInterpreter.interpret(activity, themeDisplay);
 	}
 
 	public SocialActivityFeedEntry interpret(

--- a/portal-service/src/com/liferay/portlet/social/model/BaseSocialActivityInterpreter.java
+++ b/portal-service/src/com/liferay/portlet/social/model/BaseSocialActivityInterpreter.java
@@ -62,6 +62,19 @@ public abstract class BaseSocialActivityInterpreter
 	}
 
 	public SocialActivityFeedEntry interpret(
+		SocialActivity activity, ThemeDisplay themeDisplay) {
+
+		try {
+			return doInterpret(activity, themeDisplay);
+		}
+		catch (Exception e) {
+			_log.error("Unable to interpret activity", e);
+		}
+
+		return null;
+	}
+
+	public SocialActivityFeedEntry interpret(
 		SocialActivitySet activitySet, ServiceContext serviceContext) {
 
 		try {

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivityInterpreter.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivityInterpreter.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.social.model;
 
 import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.theme.ThemeDisplay;
 
 /**
  * @author Brian Wing Shun Chan
@@ -27,6 +28,9 @@ public interface SocialActivityInterpreter {
 
 	public SocialActivityFeedEntry interpret(
 		SocialActivity activity, ServiceContext serviceContext);
+
+	public SocialActivityFeedEntry interpret(
+		SocialActivity activity, ThemeDisplay themeDisplay);
 
 	public SocialActivityFeedEntry interpret(
 		SocialActivitySet activitySet, ServiceContext serviceContext);

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityInterpreterLocalService.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityInterpreterLocalService.java
@@ -72,6 +72,10 @@ public interface SocialActivityInterpreterLocalService extends BaseLocalService 
 	public void deleteActivityInterpreter(
 		com.liferay.portlet.social.model.SocialActivityInterpreter activityInterpreter);
 
+	public com.liferay.portlet.social.model.SocialActivityFeedEntry interpret(
+		com.liferay.portlet.social.model.SocialActivity activity,
+		com.liferay.portal.theme.ThemeDisplay themeDisplay);
+
 	/**
 	* Creates a human readable activity feed entry for the activity using an
 	* available compatible activity interpreter.

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityInterpreterLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityInterpreterLocalServiceUtil.java
@@ -75,6 +75,12 @@ public class SocialActivityInterpreterLocalServiceUtil {
 		getService().deleteActivityInterpreter(activityInterpreter);
 	}
 
+	public static com.liferay.portlet.social.model.SocialActivityFeedEntry interpret(
+		com.liferay.portlet.social.model.SocialActivity activity,
+		com.liferay.portal.theme.ThemeDisplay themeDisplay) {
+		return getService().interpret(activity, themeDisplay);
+	}
+
 	/**
 	* Creates a human readable activity feed entry for the activity using an
 	* available compatible activity interpreter.

--- a/portal-service/src/com/liferay/portlet/social/service/SocialActivityInterpreterLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/social/service/SocialActivityInterpreterLocalServiceWrapper.java
@@ -71,6 +71,13 @@ public class SocialActivityInterpreterLocalServiceWrapper
 		_socialActivityInterpreterLocalService.deleteActivityInterpreter(activityInterpreter);
 	}
 
+	public com.liferay.portlet.social.model.SocialActivityFeedEntry interpret(
+		com.liferay.portlet.social.model.SocialActivity activity,
+		com.liferay.portal.theme.ThemeDisplay themeDisplay) {
+		return _socialActivityInterpreterLocalService.interpret(activity,
+			themeDisplay);
+	}
+
 	/**
 	* Creates a human readable activity feed entry for the activity using an
 	* available compatible activity interpreter.


### PR DESCRIPTION
Hey Brian,

In LPS-33320, we made Activity Interpreters backward compatible, but the local service is not.

I know you mentioned you kinda wanted it to break if the interpreter is being called wrong.  However, in the Open Social portlet - LiferayActivityService.java, it doesn't seem like we can create the serviceContext.

Feels like a lot of duplicated code, but might be the best way to fix this for now.  Let me know if we should be doing something different.  Thanks.
