### PR TITLE
LPS-33443 javadoc deprecations

### DIFF
--- a/portal-impl/src/com/liferay/portal/cache/ehcache/ModifiableEhcacheWrapper.java
+++ b/portal-impl/src/com/liferay/portal/cache/ehcache/ModifiableEhcacheWrapper.java
@@ -331,7 +331,7 @@ public class ModifiableEhcacheWrapper implements Ehcache {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public boolean isClusterCoherent() {
 		return _ehcache.isClusterCoherent();
@@ -374,7 +374,7 @@ public class ModifiableEhcacheWrapper implements Ehcache {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public boolean isNodeCoherent() {
 		return _ehcache.isNodeCoherent();
@@ -636,7 +636,7 @@ public class ModifiableEhcacheWrapper implements Ehcache {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void setNodeCoherent(boolean nodeCoherent)
 		throws UnsupportedOperationException {
@@ -705,7 +705,7 @@ public class ModifiableEhcacheWrapper implements Ehcache {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void waitUntilClusterCoherent()
 		throws UnsupportedOperationException {

--- a/portal-impl/src/com/liferay/portal/cache/ehcache/RMICacheManagerPeerProviderFactory.java
+++ b/portal-impl/src/com/liferay/portal/cache/ehcache/RMICacheManagerPeerProviderFactory.java
@@ -16,7 +16,8 @@ package com.liferay.portal.cache.ehcache;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link LiferayCacheManagerPeerProviderFactory}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             LiferayCacheManagerPeerProviderFactory}
  */
 public class RMICacheManagerPeerProviderFactory
 	extends LiferayCacheManagerPeerProviderFactory {

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/util/DataSourceFactoryBean.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/util/DataSourceFactoryBean.java
@@ -16,7 +16,8 @@ package com.liferay.portal.dao.jdbc.util;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.dao.jdbc.spring.DataSourceFactoryBean}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.dao.jdbc.spring.DataSourceFactoryBean}
  */
 public class DataSourceFactoryBean
 	extends com.liferay.portal.dao.jdbc.spring.DataSourceFactoryBean {

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SessionImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SessionImpl.java
@@ -144,7 +144,7 @@ public class SessionImpl implements Session {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	@NotPrivileged
 	public Object get(Class<?> clazz, Serializable id, LockMode lockMode)

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1879,7 +1879,7 @@ public class ServicePreAction extends Action {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	protected boolean isViewableCommunity(
 			User user, long groupId, boolean privateLayout,
@@ -1891,7 +1891,7 @@ public class ServicePreAction extends Action {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	protected boolean isViewableGroup(
 			User user, long groupId, boolean privateLayout, long layoutId,

--- a/portal-impl/src/com/liferay/portal/messaging/LayoutsLocalPublisherMessageListener.java
+++ b/portal-impl/src/com/liferay/portal/messaging/LayoutsLocalPublisherMessageListener.java
@@ -52,7 +52,7 @@ public class LayoutsLocalPublisherMessageListener
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public LayoutsLocalPublisherMessageListener(
 		SingleDestinationMessageSender statusSender,

--- a/portal-impl/src/com/liferay/portal/messaging/LayoutsRemotePublisherMessageListener.java
+++ b/portal-impl/src/com/liferay/portal/messaging/LayoutsRemotePublisherMessageListener.java
@@ -51,7 +51,7 @@ public class LayoutsRemotePublisherMessageListener
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public LayoutsRemotePublisherMessageListener(
 		SingleDestinationMessageSender statusSender,

--- a/portal-impl/src/com/liferay/portal/model/impl/ThemeImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/ThemeImpl.java
@@ -55,7 +55,7 @@ import javax.servlet.ServletContext;
 public class ThemeImpl extends PluginBaseImpl implements Theme {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static String getDefaultRegularThemeId() {
 		return PortalUtil.getJsSafePortletId(
@@ -72,7 +72,7 @@ public class ThemeImpl extends PluginBaseImpl implements Theme {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static String getDefaultWapThemeId() {
 		return PortalUtil.getJsSafePortletId(PropsValues.DEFAULT_WAP_THEME_ID);

--- a/portal-impl/src/com/liferay/portal/monitoring/statistics/service/ServiceMonitorAdvice.java
+++ b/portal-impl/src/com/liferay/portal/monitoring/statistics/service/ServiceMonitorAdvice.java
@@ -35,7 +35,7 @@ import org.aopalliance.intercept.MethodInvocation;
 public class ServiceMonitorAdvice extends ChainableMethodAdvice {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static ServiceMonitorAdvice getInstance() {
 		return new ServiceMonitorAdvice();

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -1204,7 +1204,7 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	protected static final String RESULTS_SEPARATOR = "_RESULTS_SEPARATOR_";
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -503,7 +503,8 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	/**
-	 * @deprecated {@link #getRoles(long, Group, String, int[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getRoles(long, Group,
+	 *             String, int[])}
 	 */
 	public List<Role> getRoles(
 			long companyId, Group group, String modelResource)

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdEncryptor.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdEncryptor.java
@@ -54,7 +54,7 @@ public class PwdEncryptor {
 	public static final String TYPE_BCRYPT = "BCRYPT";
 
 	/**
-	 * @deprecated {@link #TYPE_UFC_CRYPT}
+	 * @deprecated As of 6.1.0, replaced by {@link #TYPE_UFC_CRYPT}
 	 */
 	public static final String TYPE_CRYPT = "CRYPT";
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -223,7 +223,7 @@ public class PasswordPolicyLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public PasswordPolicy getPasswordPolicy(
 			long companyId, long organizationId, long locationId)

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -206,7 +206,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated {@link #clonePortlet(String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #clonePortlet(String)}
 	 */
 	@Skip
 	public Portlet clonePortlet(long companyId, String portletId) {

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -271,7 +271,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	 * @throws     PortalException if any one of the users could not be found or
 	 *             if a portal exception occurred
 	 * @throws     SystemException if a system exception occurred
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void copyUserGroupLayouts(long userGroupId, long[] userIds)
 		throws PortalException, SystemException {
@@ -306,7 +306,7 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	 * @throws     PortalException if a user with the primary key could not be
 	 *             found or if a portal exception occurred
 	 * @throws     SystemException if a system exception occurred
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void copyUserGroupLayouts(long[] userGroupIds, long userId)
 		throws PortalException, SystemException {

--- a/portal-impl/src/com/liferay/portal/servlet/FacebookServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/FacebookServlet.java
@@ -16,7 +16,8 @@ package com.liferay.portal.servlet;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.facebook.FacebookServlet}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.facebook.FacebookServlet}
  */
 public class FacebookServlet
 	extends com.liferay.portal.facebook.FacebookServlet {

--- a/portal-impl/src/com/liferay/portal/servlet/PortalSessionContext.java
+++ b/portal-impl/src/com/liferay/portal/servlet/PortalSessionContext.java
@@ -16,7 +16,8 @@ package com.liferay.portal.servlet;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.servlet.PortalSessionContext}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.servlet.PortalSessionContext}
  */
 public class PortalSessionContext
 	extends com.liferay.portal.kernel.servlet.PortalSessionContext {

--- a/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java
+++ b/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java
@@ -131,7 +131,7 @@ public class SharedSessionWrapper implements HttpSession {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public javax.servlet.http.HttpSessionContext getSessionContext() {
 		HttpSession session = getSessionDelegate();

--- a/portal-impl/src/com/liferay/portal/spring/annotation/PortalTransactionAnnotationParser.java
+++ b/portal-impl/src/com/liferay/portal/spring/annotation/PortalTransactionAnnotationParser.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.interceptor.TransactionAttribute;
 /**
  * @author     Michael Young
  * @author     Shuyang Zhou
- * @deprecated
+ * @deprecated As of 6.1.0
  */
 public class PortalTransactionAnnotationParser
 	implements TransactionAnnotationParser, Serializable {

--- a/portal-impl/src/com/liferay/portal/spring/transaction/TransactionInterceptor.java
+++ b/portal-impl/src/com/liferay/portal/spring/transaction/TransactionInterceptor.java
@@ -102,7 +102,7 @@ public class TransactionInterceptor implements MethodInterceptor {
 	}
 
 	/**
-	 * @deprecated {@link
+	 * @deprecated As of 6.1.0, replaced by {@link
 	 *             #setPlatformTransactionManager(PlatformTransactionManager)}
 	 */
 	public void setTransactionManager(

--- a/portal-impl/src/com/liferay/portal/struts/LastPath.java
+++ b/portal-impl/src/com/liferay/portal/struts/LastPath.java
@@ -18,7 +18,8 @@ import java.util.Map;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.struts.LastPath}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.struts.LastPath}
  */
 public class LastPath extends com.liferay.portal.kernel.struts.LastPath {
 

--- a/portal-impl/src/com/liferay/portal/tools/sql/DBUtil.java
+++ b/portal-impl/src/com/liferay/portal/tools/sql/DBUtil.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
 /**
  * @author     Alexander Chow
  * @author     Ganesh Ram
- * @deprecated
+ * @deprecated As of 6.1.0
  */
 public abstract class DBUtil implements DB {
 

--- a/portal-impl/src/com/liferay/portal/upload/LiferayFileUpload.java
+++ b/portal-impl/src/com/liferay/portal/upload/LiferayFileUpload.java
@@ -58,7 +58,7 @@ public class LiferayFileUpload extends ServletFileUpload {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	@Override
 	@SuppressWarnings("rawtypes")

--- a/portal-impl/src/com/liferay/portal/util/ContentTypeUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/ContentTypeUtil.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.util.MimeTypesUtil;
 
 /**
  * @author     Alexander Chow
- * @deprecated {@link MimeTypesUtil}
+ * @deprecated As of 6.1.0, replaced by {@link MimeTypesUtil}
  */
 public class ContentTypeUtil {
 

--- a/portal-impl/src/com/liferay/portal/util/FacebookConnectUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/FacebookConnectUtil.java
@@ -16,7 +16,8 @@ package com.liferay.portal.util;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.facebook.FacebookConnectUtil}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.facebook.FacebookConnectUtil}
  */
 public class FacebookConnectUtil
 	extends com.liferay.portal.kernel.facebook.FacebookConnectUtil {

--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -380,7 +380,8 @@ public class HttpImpl implements Http {
 	}
 
 	/**
-	 * @deprecated {@link #getHostConfiguration(String)}
+	 * @deprecated As of 6.1.0, replaced by {@link
+	 *             #getHostConfiguration(String)}
 	 */
 	public HostConfiguration getHostConfig(String location) throws IOException {
 		return getHostConfiguration(location);

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1140,7 +1140,7 @@ public class PortalImpl implements Portal {
 	}
 
 	/**
-	 * @deprecated {@link #getCDNHost(boolean)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getCDNHost(boolean)}
 	 */
 	public String getCDNHost() {
 		long companyId = CompanyThreadLocal.getCompanyId();
@@ -3070,7 +3070,7 @@ public class PortalImpl implements Portal {
 	}
 
 	/**
-	 * @deprecated {@link #getPortalPort(boolean)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getPortalPort(boolean)}
 	 */
 	public int getPortalPort() {
 		return _portalPort.get();
@@ -3212,7 +3212,8 @@ public class PortalImpl implements Portal {
 	}
 
 	/**
-	 * @deprecated {@link #getPortletBreadcrumbs(HttpServletRequest)}
+	 * @deprecated As of 6.1.0, replaced by {@link
+	 *             #getPortletBreadcrumbs(HttpServletRequest)}
 	 */
 	public List<BreadcrumbEntry> getPortletBreadcrumbList(
 		HttpServletRequest request) {

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesWrapper.java
@@ -72,7 +72,7 @@ public class PortletPreferencesWrapper
 	}
 
 	/**
-	 * @deprecated {@link #getPortletPreferencesImpl}
+	 * @deprecated As of 6.1.0, replaced by {@link #getPortletPreferencesImpl}
 	 */
 	public PortletPreferencesImpl getPreferencesImpl() {
 		return getPortletPreferencesImpl();

--- a/portal-impl/src/com/liferay/portlet/PortletServletRequest.java
+++ b/portal-impl/src/com/liferay/portlet/PortletServletRequest.java
@@ -442,7 +442,7 @@ public class PortletServletRequest extends HttpServletRequestWrapper {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	@Override
 	public boolean isRequestedSessionIdFromUrl() {

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceSoap.java
@@ -69,7 +69,7 @@ import java.util.Map;
  */
 public class AssetVocabularyServiceSoap {
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static com.liferay.portlet.asset.model.AssetVocabularySoap addVocabulary(
 		java.lang.String[] titleMapLanguageIds,
@@ -369,7 +369,7 @@ public class AssetVocabularyServiceSoap {
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static com.liferay.portlet.asset.model.AssetVocabularySoap updateVocabulary(
 		long vocabularyId, java.lang.String[] titleMapLanguageIds,

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -51,7 +51,7 @@ public class AssetVocabularyLocalServiceImpl
 	extends AssetVocabularyLocalServiceBaseImpl {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public AssetVocabulary addVocabulary(
 			long userId, Map<Locale, String> titleMap,
@@ -331,7 +331,7 @@ public class AssetVocabularyLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public AssetVocabulary updateVocabulary(
 			long vocabularyId, Map<Locale, String> titleMap,

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -48,7 +48,7 @@ import java.util.Map;
 public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public AssetVocabulary addVocabulary(
 			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
@@ -251,7 +251,7 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public AssetVocabulary updateVocabulary(
 			long vocabularyId, Map<Locale, String> titleMap,

--- a/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsEntryModelImpl.java
@@ -738,7 +738,7 @@ public class BlogsEntryModelImpl extends BaseModelImpl<BlogsEntry>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/model/impl/BlogsEntryModelImpl.java
@@ -738,7 +738,7 @@ public class BlogsEntryModelImpl extends BaseModelImpl<BlogsEntry>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsLocalPublisherMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsLocalPublisherMessageListener.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.messaging.sender.SingleDestinationMessageSender
 
 /**
  * @author     Bruno Farache
- * @deprecated {@link
+ * @deprecated As of 6.1.0, replaced by {@link
  *             com.liferay.portal.messaging.LayoutsLocalPublisherMessageListener}
  */
 public class LayoutsLocalPublisherMessageListener
@@ -29,7 +29,7 @@ public class LayoutsLocalPublisherMessageListener
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public LayoutsLocalPublisherMessageListener(
 		SingleDestinationMessageSender statusSender,

--- a/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsLocalPublisherRequest.java
+++ b/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsLocalPublisherRequest.java
@@ -19,7 +19,8 @@ import java.util.Map;
 
 /**
  * @author     Bruno Farache
- * @deprecated {@link com.liferay.portal.messaging.LayoutsLocalPublisherRequest}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.messaging.LayoutsLocalPublisherRequest}
  */
 public class LayoutsLocalPublisherRequest
 	extends com.liferay.portal.messaging.LayoutsLocalPublisherRequest {

--- a/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsRemotePublisherMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsRemotePublisherMessageListener.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.messaging.sender.SingleDestinationMessageSender
 
 /**
  * @author     Bruno Farache
- * @deprecated {@link
+ * @deprecated As of 6.1.0, replaced by {@link
  *             com.liferay.portal.messaging.LayoutsRemotePublisherMessageListener}
  */
 public class LayoutsRemotePublisherMessageListener
@@ -29,7 +29,7 @@ public class LayoutsRemotePublisherMessageListener
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public LayoutsRemotePublisherMessageListener(
 		SingleDestinationMessageSender statusSender,

--- a/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsRemotePublisherRequest.java
+++ b/portal-impl/src/com/liferay/portlet/communities/messaging/LayoutsRemotePublisherRequest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 /**
  * @author     Bruno Farache
- * @deprecated {@link
+ * @deprecated As of 6.1.0, replaced by {@link
  *             com.liferay.portal.messaging.LayoutsRemotePublisherRequest}
  */
 public class LayoutsRemotePublisherRequest

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutModelImpl.java
@@ -575,7 +575,7 @@ public class DLFileShortcutModelImpl extends BaseModelImpl<DLFileShortcut>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutModelImpl.java
@@ -575,7 +575,7 @@ public class DLFileShortcutModelImpl extends BaseModelImpl<DLFileShortcut>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
@@ -796,7 +796,7 @@ public class DLFileVersionModelImpl extends BaseModelImpl<DLFileVersion>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionModelImpl.java
@@ -796,7 +796,7 @@ public class DLFileVersionModelImpl extends BaseModelImpl<DLFileVersion>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordVersionModelImpl.java
@@ -430,7 +430,7 @@ public class DDLRecordVersionModelImpl extends BaseModelImpl<DDLRecordVersion>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordVersionModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/model/impl/DDLRecordVersionModelImpl.java
@@ -430,7 +430,7 @@ public class DDLRecordVersionModelImpl extends BaseModelImpl<DDLRecordVersion>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoRowLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoRowLocalServiceImpl.java
@@ -200,7 +200,8 @@ public class ExpandoRowLocalServiceImpl extends ExpandoRowLocalServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated {@link #getRows(long, String, String, int, int)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getRows(long, String,
+	 *             String, int, int)}
 	 */
 	public List<ExpandoRow> getRows(
 			String className, String tableName, int start, int end)
@@ -239,7 +240,8 @@ public class ExpandoRowLocalServiceImpl extends ExpandoRowLocalServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated {@link #getRowsCount(long, String, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getRowsCount(long, String,
+	 *             String)}
 	 */
 	public int getRowsCount(String className, String tableName)
 		throws SystemException {

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoTableLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoTableLocalServiceImpl.java
@@ -67,7 +67,8 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addTable(long, long, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #addTable(long, long,
+	 *             String)}
 	 */
 	public ExpandoTable addTable(long classNameId, String name)
 		throws PortalException, SystemException {
@@ -86,7 +87,8 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addTable(long, String, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #addTable(long, String,
+	 *             String)}
 	 */
 	public ExpandoTable addTable(String className, String name)
 		throws PortalException, SystemException {
@@ -221,7 +223,8 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getTable(long, long, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getTable(long, long,
+	 *             String)}
 	 */
 	public ExpandoTable getTable(long classNameId, String name)
 		throws PortalException, SystemException {
@@ -240,7 +243,8 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getTable(long, String, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getTable(long, String,
+	 *             String)}
 	 */
 	public ExpandoTable getTable(String className, String name)
 		throws PortalException, SystemException {

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoValueLocalServiceImpl.java
@@ -594,8 +594,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             boolean[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, boolean[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -609,8 +609,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             boolean[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, boolean[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -624,7 +624,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, Date[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -638,7 +639,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, Date[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -652,8 +654,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             double[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, double[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -667,8 +669,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             double[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, double[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -682,8 +684,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             float[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, float[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -697,8 +699,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             float[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, float[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -712,7 +714,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, int[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -726,7 +729,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, int[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -740,7 +744,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, long[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -754,7 +759,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, long[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -768,7 +774,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long, Object)}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, Object)}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -782,8 +789,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             short[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, short[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -797,8 +804,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             short[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, short[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -812,8 +819,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             String[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, String[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -827,8 +834,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #addValue(long, String, String, String, long,
-	 *             String[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	 *             String, String, long, String[])}
 	 */
 	public ExpandoValue addValue(
 			String className, String tableName, String columnName, long classPK,
@@ -1168,8 +1175,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getColumnValues(long, String, String, String, String,
-	 *             int, int)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getColumnValues(long,
+	 *             String, String, String, String, int, int)}
 	 */
 	public List<ExpandoValue> getColumnValues(
 			String className, String tableName, String columnName, String data,
@@ -1247,8 +1254,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getColumnValuesCount(long, String, String, String,
-	 *             String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getColumnValuesCount(long,
+	 *             String, String, String, String)}
 	 */
 	public int getColumnValuesCount(
 			String className, String tableName, String columnName, String data)
@@ -1618,7 +1625,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long)}
 	 */
 	public Serializable getData(
 			String className, String tableName, String columnName, long classPK)
@@ -1631,8 +1639,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long,
-	 *             boolean[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, boolean[])}
 	 */
 	public boolean getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1646,8 +1654,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long,
-	 *             boolean[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, boolean[])}
 	 */
 	public boolean[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1661,7 +1669,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, Date[])}
 	 */
 	public Date getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1675,7 +1684,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, Date[])}
 	 */
 	public Date[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1689,8 +1699,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long,
-	 *             double[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, double[])}
 	 */
 	public double getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1704,8 +1714,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long,
-	 *             double[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, double[])}
 	 */
 	public double[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1719,7 +1729,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, float[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, float[])}
 	 */
 	public float getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1733,7 +1744,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, float[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, float[])}
 	 */
 	public float[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1747,7 +1759,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, int[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, int[])}
 	 */
 	public int getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1761,7 +1774,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, int[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, int[])}
 	 */
 	public int[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1775,7 +1789,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, long[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, long[])}
 	 */
 	public long getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1789,7 +1804,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, long[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, long[])}
 	 */
 	public long[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1803,7 +1819,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, short[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, short[])}
 	 */
 	public short getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1817,7 +1834,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long, short[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, short[])}
 	 */
 	public short[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1831,8 +1849,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long,
-	 *             String[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, String[])}
 	 */
 	public String getData(
 			String className, String tableName, String columnName, long classPK,
@@ -1846,8 +1864,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getData(long, String, String, String, long,
-	 *             String[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	 *             String, String, long, String[])}
 	 */
 	public String[] getData(
 			String className, String tableName, String columnName, long classPK,
@@ -2008,7 +2026,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getValue(long, long, String, String, long)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getValue(long, long, String,
+	 *             String, long)}
 	 */
 	public ExpandoValue getValue(
 			long classNameId, String tableName, String columnName, long classPK)
@@ -2032,7 +2051,8 @@ public class ExpandoValueLocalServiceImpl
 	}
 
 	/**
-	 * @deprecated {@link #getValue(long, String, String, String, long)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getValue(long, String,
+	 *             String, String, long)}
 	 */
 	public ExpandoValue getValue(
 			String className, String tableName, String columnName, long classPK)

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
@@ -1214,7 +1214,7 @@ public class JournalArticleModelImpl extends BaseModelImpl<JournalArticle>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalArticleModelImpl.java
@@ -1214,7 +1214,7 @@ public class JournalArticleModelImpl extends BaseModelImpl<JournalArticle>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMessageModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMessageModelImpl.java
@@ -837,7 +837,7 @@ public class MBMessageModelImpl extends BaseModelImpl<MBMessage>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMessageModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBMessageModelImpl.java
@@ -837,7 +837,7 @@ public class MBMessageModelImpl extends BaseModelImpl<MBMessage>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadModelImpl.java
@@ -564,7 +564,7 @@ public class MBThreadModelImpl extends BaseModelImpl<MBThread>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/model/impl/MBThreadModelImpl.java
@@ -564,7 +564,7 @@ public class MBThreadModelImpl extends BaseModelImpl<MBThread>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageModelImpl.java
@@ -808,7 +808,7 @@ public class WikiPageModelImpl extends BaseModelImpl<WikiPage>
 	}
 
 	/**
-	 * @deprecated {@link #isApproved}
+	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/model/impl/WikiPageModelImpl.java
@@ -808,7 +808,7 @@ public class WikiPageModelImpl extends BaseModelImpl<WikiPage>
 	}
 
 	/**
-	 * @deprecated As of 6.1.0, replaced by {@link #isApproved}
+	 * @deprecated {@link #isApproved}
 	 */
 	public boolean getApproved() {
 		return isApproved();

--- a/portal-service/src/com/liferay/portal/PortalException.java
+++ b/portal-service/src/com/liferay/portal/PortalException.java
@@ -16,7 +16,8 @@ package com.liferay.portal;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.exception.PortalException}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.exception.PortalException}
  */
 public class PortalException
 	extends com.liferay.portal.kernel.exception.PortalException {

--- a/portal-service/src/com/liferay/portal/SystemException.java
+++ b/portal-service/src/com/liferay/portal/SystemException.java
@@ -16,7 +16,8 @@ package com.liferay.portal;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.exception.SystemException}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.exception.SystemException}
  */
 public class SystemException
 	extends com.liferay.portal.kernel.exception.SystemException {

--- a/portal-service/src/com/liferay/portal/kernel/bean/ContextClassLoaderBeanHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/bean/ContextClassLoaderBeanHandler.java
@@ -18,7 +18,7 @@ import java.lang.Object;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated
+ * @deprecated As of 6.1.0
  */
 public class ContextClassLoaderBeanHandler extends ClassLoaderBeanHandler {
 

--- a/portal-service/src/com/liferay/portal/kernel/cache/CacheKVP.java
+++ b/portal-service/src/com/liferay/portal/kernel/cache/CacheKVP.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated
+ * @deprecated As of 6.1.0
  */
 @Deprecated
 public class CacheKVP implements Serializable {

--- a/portal-service/src/com/liferay/portal/kernel/dao/orm/FinderCacheUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/orm/FinderCacheUtil.java
@@ -48,7 +48,7 @@ public class FinderCacheUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static Object getResult(
 		String className, String methodName, String[] params, Object[] args,
@@ -66,7 +66,7 @@ public class FinderCacheUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void putResult(
 		boolean classNameCacheEnabled, String className, String methodName,

--- a/portal-service/src/com/liferay/portal/kernel/jmx/RegistryAwareMBeanServer.java
+++ b/portal-service/src/com/liferay/portal/kernel/jmx/RegistryAwareMBeanServer.java
@@ -112,7 +112,7 @@ public class RegistryAwareMBeanServer implements MBeanServer {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public ObjectInputStream deserialize(ObjectName objectName, byte[] data)
 		throws InstanceNotFoundException, OperationsException {
@@ -123,7 +123,7 @@ public class RegistryAwareMBeanServer implements MBeanServer {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public ObjectInputStream deserialize(String className, byte[] data)
 		throws OperationsException, ReflectionException {
@@ -132,7 +132,7 @@ public class RegistryAwareMBeanServer implements MBeanServer {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public ObjectInputStream deserialize(
 			String className, ObjectName loaderObjectName, byte[] data)

--- a/portal-service/src/com/liferay/portal/kernel/messaging/BaseAsyncDestination.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/BaseAsyncDestination.java
@@ -46,14 +46,14 @@ public abstract class BaseAsyncDestination extends BaseDestination {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public BaseAsyncDestination(String name) {
 		this(name, _WORKERS_CORE_SIZE, _WORKERS_MAX_SIZE);
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public BaseAsyncDestination(
 		String name, int workersCoreSize, int workersMaxSize) {

--- a/portal-service/src/com/liferay/portal/kernel/messaging/BaseMessageStatusMessageListener.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/BaseMessageStatusMessageListener.java
@@ -30,7 +30,7 @@ public abstract class BaseMessageStatusMessageListener
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public BaseMessageStatusMessageListener(
 		SingleDestinationMessageSender statusSender,

--- a/portal-service/src/com/liferay/portal/kernel/messaging/BridgingMessageListener.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/BridgingMessageListener.java
@@ -25,7 +25,7 @@ public class BridgingMessageListener implements MessageListener {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public BridgingMessageListener(
 		SingleDestinationMessageSender singleDestinationMessageSender) {

--- a/portal-service/src/com/liferay/portal/kernel/messaging/DestinationNames.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/DestinationNames.java
@@ -24,7 +24,7 @@ public interface DestinationNames {
 	public static final String AUDIT = "liferay/audit";
 
 	/**
-	 * @deprecated {@link #SUBSCRIPTION_SENDER}
+	 * @deprecated As of 6.1.0, replaced by {@link #SUBSCRIPTION_SENDER}
 	 */
 	public static final String BLOGS = "liferay/blogs";
 
@@ -67,7 +67,7 @@ public interface DestinationNames {
 		"liferay/ip_geocoder/response";
 
 	/**
-	 * @deprecated {@link #SUBSCRIPTION_SENDER}
+	 * @deprecated As of 6.1.0, replaced by {@link #SUBSCRIPTION_SENDER}
 	 */
 	public static final String JOURNAL = "liferay/journal";
 
@@ -86,7 +86,7 @@ public interface DestinationNames {
 	public static final String MARKETPLACE = "liferay/marketplace";
 
 	/**
-	 * @deprecated {@link #SUBSCRIPTION_SENDER}
+	 * @deprecated As of 6.1.0, replaced by {@link #SUBSCRIPTION_SENDER}
 	 */
 	public static final String MESSAGE_BOARDS = "liferay/message_boards";
 
@@ -134,7 +134,7 @@ public interface DestinationNames {
 	public static final String TEST_TRANSACTION = "liferay/test_transaction";
 
 	/**
-	 * @deprecated {@link #SUBSCRIPTION_SENDER}
+	 * @deprecated As of 6.1.0, replaced by {@link #SUBSCRIPTION_SENDER}
 	 */
 	public static final String WIKI = "liferay/wiki";
 

--- a/portal-service/src/com/liferay/portal/kernel/messaging/GlobalDestinationEventListener.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/GlobalDestinationEventListener.java
@@ -29,7 +29,7 @@ public class GlobalDestinationEventListener
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public GlobalDestinationEventListener(
 		MessageListener messageListener, List<String> ignoredDestinations) {

--- a/portal-service/src/com/liferay/portal/kernel/messaging/ParallelDestination.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/ParallelDestination.java
@@ -37,14 +37,14 @@ public class ParallelDestination extends BaseAsyncDestination {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public ParallelDestination(String name) {
 		super(name);
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public ParallelDestination(
 		String name, int workersCoreSize, int workersMaxSize) {

--- a/portal-service/src/com/liferay/portal/kernel/messaging/SerialDestination.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/SerialDestination.java
@@ -41,7 +41,7 @@ public class SerialDestination extends BaseAsyncDestination {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public SerialDestination(String name) {
 		super(name, _WORKERS_CORE_SIZE, _WORKERS_MAX_SIZE);

--- a/portal-service/src/com/liferay/portal/kernel/messaging/config/AbstractMessagingConfigurator.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/config/AbstractMessagingConfigurator.java
@@ -140,7 +140,7 @@ public abstract class AbstractMessagingConfigurator
 	}
 
 	/**
-	 * @deprecated {@link #afterPropertiesSet}
+	 * @deprecated As of 6.1.0, replaced by {@link #afterPropertiesSet}
 	 */
 	public void init() {
 		afterPropertiesSet();

--- a/portal-service/src/com/liferay/portal/kernel/messaging/jmx/JMXMessageListener.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/jmx/JMXMessageListener.java
@@ -116,7 +116,7 @@ public class JMXMessageListener extends BaseDestinationEventListener {
 	}
 
 	/**
-	 * @deprecated {@link #afterPropertiesSet}
+	 * @deprecated As of 6.1.0, replaced by {@link #afterPropertiesSet}
 	 */
 	public void init() throws Exception {
 		afterPropertiesSet();

--- a/portal-service/src/com/liferay/portal/kernel/messaging/sender/DefaultSingleDestinationMessageSender.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/sender/DefaultSingleDestinationMessageSender.java
@@ -26,7 +26,7 @@ public class DefaultSingleDestinationMessageSender
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public DefaultSingleDestinationMessageSender(
 		String destinationName, MessageSender messageSender) {

--- a/portal-service/src/com/liferay/portal/kernel/messaging/sender/DefaultSingleDestinationSynchronousMessageSender.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/sender/DefaultSingleDestinationSynchronousMessageSender.java
@@ -27,7 +27,7 @@ public class DefaultSingleDestinationSynchronousMessageSender
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public DefaultSingleDestinationSynchronousMessageSender(
 		String destinationName,

--- a/portal-service/src/com/liferay/portal/kernel/messaging/sender/DefaultSynchronousMessageSender.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/sender/DefaultSynchronousMessageSender.java
@@ -34,7 +34,7 @@ public class DefaultSynchronousMessageSender
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public DefaultSynchronousMessageSender(
 		MessageBus messageBus, PortalUUID portalUUID, long timeout) {

--- a/portal-service/src/com/liferay/portal/kernel/portlet/BaseConfigurationAction.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/BaseConfigurationAction.java
@@ -17,7 +17,7 @@ package com.liferay.portal.kernel.portlet;
 /**
  * @author     Brian Wing Shun Chan
  * @author     Julio Camarero
- * @deprecated {@link DefaultConfigurationAction}
+ * @deprecated As of 6.1.0, replaced by {@link DefaultConfigurationAction}
  */
 public class BaseConfigurationAction extends DefaultConfigurationAction {
 }

--- a/portal-service/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
@@ -50,7 +50,7 @@ import javax.servlet.http.HttpServletRequest;
 public class PortletResponseUtil {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			MimeResponse mimeResponse, String fileName, byte[] bytes)
@@ -60,7 +60,7 @@ public class PortletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			MimeResponse mimeResponse, String fileName, byte[] bytes,
@@ -71,7 +71,7 @@ public class PortletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			MimeResponse mimeResponse, String fileName, InputStream is)
@@ -81,7 +81,7 @@ public class PortletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			MimeResponse mimeResponse, String fileName, InputStream is,
@@ -92,7 +92,7 @@ public class PortletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			MimeResponse mimeResponse, String fileName, InputStream is,

--- a/portal-service/src/com/liferay/portal/kernel/search/BaseOpenSearchImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseOpenSearchImpl.java
@@ -268,7 +268,7 @@ public abstract class BaseOpenSearchImpl implements OpenSearch {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	protected Object[] addSearchResults(
 		String keywords, int startPage, int itemsPerPage, int total, int start,

--- a/portal-service/src/com/liferay/portal/kernel/search/Document.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Document.java
@@ -103,12 +103,12 @@ public interface Document extends Cloneable, Serializable {
 	public void addLocalizedText(String name, Map<Locale, String> values);
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void addModifiedDate();
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void addModifiedDate(Date modifiedDate);
 

--- a/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -299,14 +299,14 @@ public class DocumentImpl implements Document {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void addModifiedDate() {
 		addModifiedDate(new Date());
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void addModifiedDate(Date modifiedDate) {
 		addDate(Field.MODIFIED, modifiedDate);

--- a/portal-service/src/com/liferay/portal/kernel/search/Field.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Field.java
@@ -77,7 +77,7 @@ public class Field implements Serializable {
 	};
 
 	/**
-	 * @deprecated {@link #MODIFIED_DATE}
+	 * @deprecated As of 6.1.0, replaced by {@link #MODIFIED_DATE}
 	 */
 	public static final String MODIFIED = "modified";
 
@@ -146,7 +146,7 @@ public class Field implements Serializable {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public Field(String name, String value, boolean tokenized) {
 		this(name, value);
@@ -160,7 +160,7 @@ public class Field implements Serializable {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public Field(String name, String[] values, boolean tokenized) {
 		this(name, values);
@@ -169,7 +169,7 @@ public class Field implements Serializable {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public Field(String name, String[] values, boolean tokenized, float boost) {
 		this(name, values);

--- a/portal-service/src/com/liferay/portal/kernel/search/Sort.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Sort.java
@@ -23,6 +23,9 @@ import java.io.Serializable;
  */
 public class Sort implements Serializable {
 
+	/**
+	 * @deprecated As of 6.1.0
+	 */
 	@Deprecated
 	public static final int AUTO_TYPE = 2;
 

--- a/portal-service/src/com/liferay/portal/kernel/servlet/HttpSessionWrapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/HttpSessionWrapper.java
@@ -57,21 +57,21 @@ public class HttpSessionWrapper implements HttpSession {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public javax.servlet.http.HttpSessionContext getSessionContext() {
 		return _session.getSessionContext();
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public Object getValue(String name) {
 		return _session.getValue(name);
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public String[] getValueNames() {
 		return _session.getValueNames();
@@ -90,7 +90,7 @@ public class HttpSessionWrapper implements HttpSession {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void putValue(String name, Object value) {
 		_session.putValue(name, value);
@@ -101,7 +101,7 @@ public class HttpSessionWrapper implements HttpSession {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void removeValue(String name) {
 		_session.removeValue(name);

--- a/portal-service/src/com/liferay/portal/kernel/servlet/PageContextWrapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/PageContextWrapper.java
@@ -93,7 +93,7 @@ public class PageContextWrapper extends PageContext {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	@Override
 	public javax.servlet.jsp.el.ExpressionEvaluator getExpressionEvaluator() {
@@ -136,7 +136,7 @@ public class PageContextWrapper extends PageContext {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	@Override
 	public javax.servlet.jsp.el.VariableResolver getVariableResolver() {

--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -169,7 +169,7 @@ public class ServletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			HttpServletResponse response, String fileName, byte[] bytes)
@@ -179,7 +179,7 @@ public class ServletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			HttpServletResponse response, String fileName, byte[] bytes,
@@ -190,7 +190,7 @@ public class ServletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			HttpServletResponse response, String fileName, InputStream is)
@@ -200,7 +200,7 @@ public class ServletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			HttpServletResponse response, String fileName, InputStream is,
@@ -211,7 +211,7 @@ public class ServletResponseUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void sendFile(
 			HttpServletResponse response, String fileName, InputStream is,

--- a/portal-service/src/com/liferay/portal/kernel/util/ClassLoaderProxy.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/ClassLoaderProxy.java
@@ -77,7 +77,7 @@ public class ClassLoaderProxy {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public Object invoke(String methodName, Object[] args) throws Throwable {
 		Thread currentThread = Thread.currentThread();

--- a/portal-service/src/com/liferay/portal/kernel/util/ConcurrentHashSet.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/ConcurrentHashSet.java
@@ -18,7 +18,8 @@ import java.util.Set;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.concurrent.ConcurrentHashSet}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.concurrent.ConcurrentHashSet}
  */
 public class ConcurrentHashSet<E>
 	extends com.liferay.portal.kernel.concurrent.ConcurrentHashSet<E> {

--- a/portal-service/src/com/liferay/portal/kernel/util/Database.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Database.java
@@ -23,7 +23,8 @@ import javax.naming.NamingException;
 /**
  * @author     Ganesh Ram
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.dao.db.DB}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.dao.db.DB}
  */
 public interface Database {
 

--- a/portal-service/src/com/liferay/portal/kernel/util/DatabaseUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/DatabaseUtil.java
@@ -26,7 +26,7 @@ import javax.naming.NamingException;
 /**
  * @author     Ganesh Ram
  * @author     Brian Wing Shun Chan
- * @deprecated {@link DBFactoryUtil}
+ * @deprecated As of 6.1.0, replaced by {@link DBFactoryUtil}
  */
 public class DatabaseUtil {
 

--- a/portal-service/src/com/liferay/portal/kernel/util/NotificationThreadLocal.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/NotificationThreadLocal.java
@@ -24,7 +24,7 @@ public class NotificationThreadLocal {
 	}
 
 	/**
-	 * @deprecated {@link #isEnabled}
+	 * @deprecated As of 6.1.0, replaced by {@link #isEnabled}
 	 */
 	public static boolean isNotificationEnabled() {
 		return isEnabled();
@@ -35,7 +35,7 @@ public class NotificationThreadLocal {
 	}
 
 	/**
-	 * @deprecated {@link #setEnabled(boolean)}
+	 * @deprecated As of 6.1.0, replaced by {@link #setEnabled(boolean)}
 	 */
 	public static void setNotificationEnabled(boolean notificationEnabled) {
 		setEnabled(notificationEnabled);

--- a/portal-service/src/com/liferay/portal/kernel/util/PortalInitable.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PortalInitable.java
@@ -16,7 +16,7 @@ package com.liferay.portal.kernel.util;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link PortalLifecycle}
+ * @deprecated As of 6.1.0, replaced by {@link PortalLifecycle}
  */
 public interface PortalInitable {
 

--- a/portal-service/src/com/liferay/portal/kernel/util/PortalInitableUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PortalInitableUtil.java
@@ -19,7 +19,7 @@ import java.util.Vector;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link PortalLifecycleUtil}
+ * @deprecated As of 6.1.0, replaced by {@link PortalLifecycleUtil}
  */
 public class PortalInitableUtil {
 

--- a/portal-service/src/com/liferay/portal/kernel/util/PrettyDateFormat.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PrettyDateFormat.java
@@ -39,7 +39,7 @@ public class PrettyDateFormat extends DateFormat {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public PrettyDateFormat(long companyId, Locale locale, TimeZone timeZone) {
 		this(locale, timeZone);

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -586,14 +586,14 @@ public class StringUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static String highlight(String s, String keywords) {
 		return highlight(s, keywords, "<span class=\"highlight\">", "</span>");
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static String highlight(
 		String s, String keywords, String highlight1, String highlight2) {

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil_IW.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil_IW.java
@@ -106,7 +106,7 @@ public class StringUtil_IW {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public java.lang.String highlight(java.lang.String s,
 		java.lang.String keywords) {
@@ -114,7 +114,7 @@ public class StringUtil_IW {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public java.lang.String highlight(java.lang.String s,
 		java.lang.String keywords, java.lang.String highlight1,

--- a/portal-service/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -64,12 +64,12 @@ public interface WebKeys {
 	public static final String LAYOUTS = "LAYOUTS";
 
 	/**
-	 * @deprecated {@link #VISITED_GROUP_ID_PREVIOUS}
+	 * @deprecated As of 6.1.0, replaced by {@link #VISITED_GROUP_ID_PREVIOUS}
 	 */
 	public static final String LIFERAY_SHARED_VISITED_GROUP_ID_PREVIOUS = "LIFERAY_SHARED_VISITED_GROUP_ID_PREVIOUS";
 
 	/**
-	 * @deprecated {@link #VISITED_GROUP_ID_RECENT}
+	 * @deprecated As of 6.1.0, replaced by {@link #VISITED_GROUP_ID_RECENT}
 	 */
 	public static final String LIFERAY_SHARED_VISITED_GROUP_ID_RECENT = "LIFERAY_SHARED_VISITED_GROUP_ID_RECENT";
 

--- a/portal-service/src/com/liferay/portal/model/Location.java
+++ b/portal-service/src/com/liferay/portal/model/Location.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated
+ * @deprecated As of 6.1.0
  */
 public interface Location extends Serializable {
 }

--- a/portal-service/src/com/liferay/portal/security/permission/ResourceActions.java
+++ b/portal-service/src/com/liferay/portal/security/permission/ResourceActions.java
@@ -133,7 +133,8 @@ public interface ResourceActions {
 		String portletResource, String modelResource);
 
 	/**
-	 * @deprecated {@link #getRoles(long, Group, String, int[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getRoles(long, Group,
+	 *             String, int[])}
 	 */
 	public List<Role> getRoles(
 			long companyId, Group group, String modelResource)

--- a/portal-service/src/com/liferay/portal/security/permission/ResourceActionsUtil.java
+++ b/portal-service/src/com/liferay/portal/security/permission/ResourceActionsUtil.java
@@ -35,25 +35,26 @@ import javax.servlet.jsp.PageContext;
 public class ResourceActionsUtil {
 
 	/**
-	 * @deprecated {@link ResourceActions#ACTION_NAME_PREFIX}
+	 * @deprecated As of 6.1.0, replaced by {@link #getActionNamePrefix}
 	 */
 	public static final String ACTION_NAME_PREFIX =
 		ResourceActions.ACTION_NAME_PREFIX;
 
 	/**
-	 * @deprecated {@link ResourceActions#MODEL_RESOURCE_NAME_PREFIX}
+	 * @deprecated As of 6.1.0, replaced by {@link #getModelResourceNamePrefix}
 	 */
 	public static final String MODEL_RESOURCE_NAME_PREFIX =
 		ResourceActions.MODEL_RESOURCE_NAME_PREFIX;
 
 	/**
-	 * @deprecated {@link ResourceActions#ORGANIZATION_MODEL_RESOURCES}
+	 * @deprecated As of 6.1.0, replaced by {@link
+	 *             #getOrganizationModelResources}
 	 */
 	public static final String[] ORGANIZATION_MODEL_RESOURCES =
 		ResourceActions.ORGANIZATION_MODEL_RESOURCES;
 
 	/**
-	 * @deprecated {@link ResourceActions#PORTAL_MODEL_RESOURCES}
+	 * @deprecated As of 6.1.0, replaced by {@link #getPortalModelResources}
 	 */
 	public static final String[] PORTAL_MODEL_RESOURCES =
 		ResourceActions.PORTAL_MODEL_RESOURCES;
@@ -223,7 +224,8 @@ public class ResourceActionsUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getRoles(long, Group, String, int[])}
+	 * @deprecated As of 6.1.0, replaced by {@link #getRoles(long, Group,
+	 *             String, int[])}
 	 */
 	public static List<Role> getRoles(
 			long companyId, Group group, String modelResource)
@@ -245,7 +247,7 @@ public class ResourceActionsUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void init() {
 	}

--- a/portal-service/src/com/liferay/portal/service/PasswordPolicyLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/PasswordPolicyLocalService.java
@@ -269,7 +269,7 @@ public interface PasswordPolicyLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portal.model.PasswordPolicy getPasswordPolicy(

--- a/portal-service/src/com/liferay/portal/service/PasswordPolicyLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/PasswordPolicyLocalServiceUtil.java
@@ -312,7 +312,7 @@ public class PasswordPolicyLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static com.liferay.portal.model.PasswordPolicy getPasswordPolicy(
 		long companyId, long organizationId, long locationId)

--- a/portal-service/src/com/liferay/portal/service/PasswordPolicyLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/PasswordPolicyLocalServiceWrapper.java
@@ -306,7 +306,7 @@ public class PasswordPolicyLocalServiceWrapper
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portal.model.PasswordPolicy getPasswordPolicy(
 		long companyId, long organizationId, long locationId)

--- a/portal-service/src/com/liferay/portal/service/PortletLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/PortletLocalService.java
@@ -239,7 +239,7 @@ public interface PortletLocalService extends BaseLocalService,
 	public void clearCompanyPortletsPool();
 
 	/**
-	* @deprecated {@link #clonePortlet(String)}
+	* @deprecated As of 6.1.0, replaced by {@link #clonePortlet(String)}
 	*/
 	public com.liferay.portal.model.Portlet clonePortlet(long companyId,
 		java.lang.String portletId);

--- a/portal-service/src/com/liferay/portal/service/PortletLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/PortletLocalServiceUtil.java
@@ -274,7 +274,7 @@ public class PortletLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #clonePortlet(String)}
+	* @deprecated As of 6.1.0, replaced by {@link #clonePortlet(String)}
 	*/
 	public static com.liferay.portal.model.Portlet clonePortlet(
 		long companyId, java.lang.String portletId) {

--- a/portal-service/src/com/liferay/portal/service/PortletLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/PortletLocalServiceWrapper.java
@@ -265,7 +265,7 @@ public class PortletLocalServiceWrapper implements PortletLocalService,
 	}
 
 	/**
-	* @deprecated {@link #clonePortlet(String)}
+	* @deprecated As of 6.1.0, replaced by {@link #clonePortlet(String)}
 	*/
 	public com.liferay.portal.model.Portlet clonePortlet(long companyId,
 		java.lang.String portletId) {

--- a/portal-service/src/com/liferay/portal/service/UserGroupLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/UserGroupLocalService.java
@@ -339,7 +339,7 @@ public interface UserGroupLocalService extends BaseLocalService,
 	* @throws PortalException if any one of the users could not be found or
 	if a portal exception occurred
 	* @throws SystemException if a system exception occurred
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public void copyUserGroupLayouts(long userGroupId, long[] userIds)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -353,7 +353,7 @@ public interface UserGroupLocalService extends BaseLocalService,
 	* @throws PortalException if a user with the primary key could not be
 	found or if a portal exception occurred
 	* @throws SystemException if a system exception occurred
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public void copyUserGroupLayouts(long[] userGroupIds, long userId)
 		throws com.liferay.portal.kernel.exception.PortalException,

--- a/portal-service/src/com/liferay/portal/service/UserGroupLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/UserGroupLocalServiceUtil.java
@@ -383,7 +383,7 @@ public class UserGroupLocalServiceUtil {
 	* @throws PortalException if any one of the users could not be found or
 	if a portal exception occurred
 	* @throws SystemException if a system exception occurred
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static void copyUserGroupLayouts(long userGroupId, long[] userIds)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -399,7 +399,7 @@ public class UserGroupLocalServiceUtil {
 	* @throws PortalException if a user with the primary key could not be
 	found or if a portal exception occurred
 	* @throws SystemException if a system exception occurred
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static void copyUserGroupLayouts(long[] userGroupIds, long userId)
 		throws com.liferay.portal.kernel.exception.PortalException,

--- a/portal-service/src/com/liferay/portal/service/UserGroupLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/UserGroupLocalServiceWrapper.java
@@ -372,7 +372,7 @@ public class UserGroupLocalServiceWrapper implements UserGroupLocalService,
 	* @throws PortalException if any one of the users could not be found or
 	if a portal exception occurred
 	* @throws SystemException if a system exception occurred
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public void copyUserGroupLayouts(long userGroupId, long[] userIds)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -388,7 +388,7 @@ public class UserGroupLocalServiceWrapper implements UserGroupLocalService,
 	* @throws PortalException if a user with the primary key could not be
 	found or if a portal exception occurred
 	* @throws SystemException if a system exception occurred
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public void copyUserGroupLayouts(long[] userGroupIds, long userId)
 		throws com.liferay.portal.kernel.exception.PortalException,

--- a/portal-service/src/com/liferay/portal/service/permission/UserPermission.java
+++ b/portal-service/src/com/liferay/portal/service/permission/UserPermission.java
@@ -23,7 +23,7 @@ import com.liferay.portal.security.permission.PermissionChecker;
 public interface UserPermission {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public void check(
 			PermissionChecker permissionChecker, long userId,
@@ -40,7 +40,7 @@ public interface UserPermission {
 		throws PrincipalException;
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public boolean contains(
 		PermissionChecker permissionChecker, long userId, long organizationId,

--- a/portal-service/src/com/liferay/portal/service/permission/UserPermissionUtil.java
+++ b/portal-service/src/com/liferay/portal/service/permission/UserPermissionUtil.java
@@ -24,7 +24,7 @@ import com.liferay.portal.security.permission.PermissionChecker;
 public class UserPermissionUtil {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void check(
 			PermissionChecker permissionChecker, long userId,
@@ -53,7 +53,7 @@ public class UserPermissionUtil {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static boolean contains(
 		PermissionChecker permissionChecker, long userId, long organizationId,

--- a/portal-service/src/com/liferay/portal/util/PortalUtil.java
+++ b/portal-service/src/com/liferay/portal/util/PortalUtil.java
@@ -267,7 +267,7 @@ public class PortalUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getCDNHost(boolean)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getCDNHost(boolean)}
 	 */
 	public static String getCDNHost() {
 		return getPortal().getCDNHost();
@@ -444,7 +444,7 @@ public class PortalUtil {
 	}
 
 	/**
-	 * @deprecated {@link DBFactoryUtil#getDB()}
+	 * @deprecated As of 6.1.0, replaced by {@link DBFactoryUtil#getDB()}
 	 */
 	public static DB getDB() {
 		return DBFactoryUtil.getDB();
@@ -787,7 +787,8 @@ public class PortalUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getBaseModel(ResourcePermission)}
+	 * @deprecated As of 6.1.0, replaced by {@link
+	 *             #getBaseModel(ResourcePermission)}
 	 */
 	public static BaseModel<?> getModel(ResourcePermission resourcePermission)
 		throws PortalException, SystemException {
@@ -796,7 +797,8 @@ public class PortalUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getBaseModel(String, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getBaseModel(String,
+	 *             String)}
 	 */
 	public static BaseModel<?> getModel(String modelName, String primKey)
 		throws PortalException, SystemException {
@@ -896,7 +898,7 @@ public class PortalUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getPortalPort(boolean)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getPortalPort(boolean)}
 	 */
 	public static int getPortalPort() {
 		return getPortal().getPortalPort();
@@ -963,7 +965,8 @@ public class PortalUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getPortletBreadcrumbs(HttpServletRequest)}
+	 * @deprecated As of 6.1.0, replaced by {@link
+	 *             #getPortletBreadcrumbs(HttpServletRequest)}
 	 */
 	public static List<BreadcrumbEntry> getPortletBreadcrumbList(
 		HttpServletRequest request) {
@@ -1592,7 +1595,7 @@ public class PortalUtil {
 	}
 
 	/**
-	 * @deprecated {@link DB#runSQL(String)}
+	 * @deprecated As of 6.1.0, replaced by {@link DB#runSQL(String)}
 	 */
 	public static void runSQL(String sql) throws IOException, SQLException {
 		DBFactoryUtil.getDB().runSQL(sql);

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalService.java
@@ -246,7 +246,7 @@ public interface AssetVocabularyLocalService extends BaseLocalService,
 	public void setBeanIdentifier(java.lang.String beanIdentifier);
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary addVocabulary(
 		long userId,
@@ -351,7 +351,7 @@ public interface AssetVocabularyLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary updateVocabulary(
 		long vocabularyId,

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceUtil.java
@@ -269,7 +269,7 @@ public class AssetVocabularyLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static com.liferay.portlet.asset.model.AssetVocabulary addVocabulary(
 		long userId,
@@ -408,7 +408,7 @@ public class AssetVocabularyLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static com.liferay.portlet.asset.model.AssetVocabulary updateVocabulary(
 		long vocabularyId,

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceWrapper.java
@@ -267,7 +267,7 @@ public class AssetVocabularyLocalServiceWrapper
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary addVocabulary(
 		long userId,
@@ -405,7 +405,7 @@ public class AssetVocabularyLocalServiceWrapper
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary updateVocabulary(
 		long vocabularyId,

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyService.java
@@ -62,7 +62,7 @@ public interface AssetVocabularyService extends BaseService {
 	public void setBeanIdentifier(java.lang.String beanIdentifier);
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary addVocabulary(
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
@@ -171,7 +171,7 @@ public interface AssetVocabularyService extends BaseService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary updateVocabulary(
 		long vocabularyId,

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceUtil.java
@@ -56,7 +56,7 @@ public class AssetVocabularyServiceUtil {
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static com.liferay.portlet.asset.model.AssetVocabulary addVocabulary(
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
@@ -196,7 +196,7 @@ public class AssetVocabularyServiceUtil {
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public static com.liferay.portlet.asset.model.AssetVocabulary updateVocabulary(
 		long vocabularyId,

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceWrapper.java
@@ -51,7 +51,7 @@ public class AssetVocabularyServiceWrapper implements AssetVocabularyService,
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary addVocabulary(
 		java.util.Map<java.util.Locale, java.lang.String> titleMap,
@@ -190,7 +190,7 @@ public class AssetVocabularyServiceWrapper implements AssetVocabularyService,
 	}
 
 	/**
-	* @deprecated
+	* @deprecated As of 6.1.0
 	*/
 	public com.liferay.portlet.asset.model.AssetVocabulary updateVocabulary(
 		long vocabularyId,

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoRowLocalService.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoRowLocalService.java
@@ -313,7 +313,8 @@ public interface ExpandoRowLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getRows(long, String, String, int, int)}
+	* @deprecated As of 6.1.0, replaced by {@link #getRows(long, String,
+	String, int, int)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.expando.model.ExpandoRow> getRows(
@@ -335,7 +336,8 @@ public interface ExpandoRowLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getRowsCount(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getRowsCount(long, String,
+	String)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getRowsCount(java.lang.String className,

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoRowLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoRowLocalServiceUtil.java
@@ -364,7 +364,8 @@ public class ExpandoRowLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getRows(long, String, String, int, int)}
+	* @deprecated As of 6.1.0, replaced by {@link #getRows(long, String,
+	String, int, int)}
 	*/
 	public static java.util.List<com.liferay.portlet.expando.model.ExpandoRow> getRows(
 		java.lang.String className, java.lang.String tableName, int start,
@@ -390,7 +391,8 @@ public class ExpandoRowLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getRowsCount(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getRowsCount(long, String,
+	String)}
 	*/
 	public static int getRowsCount(java.lang.String className,
 		java.lang.String tableName)

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoRowLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoRowLocalServiceWrapper.java
@@ -363,7 +363,8 @@ public class ExpandoRowLocalServiceWrapper implements ExpandoRowLocalService,
 	}
 
 	/**
-	* @deprecated {@link #getRows(long, String, String, int, int)}
+	* @deprecated As of 6.1.0, replaced by {@link #getRows(long, String,
+	String, int, int)}
 	*/
 	public java.util.List<com.liferay.portlet.expando.model.ExpandoRow> getRows(
 		java.lang.String className, java.lang.String tableName, int start,
@@ -391,7 +392,8 @@ public class ExpandoRowLocalServiceWrapper implements ExpandoRowLocalService,
 	}
 
 	/**
-	* @deprecated {@link #getRowsCount(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getRowsCount(long, String,
+	String)}
 	*/
 	public int getRowsCount(java.lang.String className,
 		java.lang.String tableName)

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoTableLocalService.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoTableLocalService.java
@@ -246,7 +246,8 @@ public interface ExpandoTableLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addTable(long, long, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #addTable(long, long,
+	String)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoTable addTable(
 		long classNameId, java.lang.String name)
@@ -259,7 +260,8 @@ public interface ExpandoTableLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addTable(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #addTable(long, String,
+	String)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoTable addTable(
 		java.lang.String className, java.lang.String name)
@@ -329,7 +331,8 @@ public interface ExpandoTableLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getTable(long, long, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getTable(long, long,
+	String)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.expando.model.ExpandoTable getTable(
@@ -344,7 +347,8 @@ public interface ExpandoTableLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getTable(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getTable(long, String,
+	String)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.expando.model.ExpandoTable getTable(

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoTableLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoTableLocalServiceUtil.java
@@ -274,7 +274,8 @@ public class ExpandoTableLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addTable(long, long, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #addTable(long, long,
+	String)}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoTable addTable(
 		long classNameId, java.lang.String name)
@@ -291,7 +292,8 @@ public class ExpandoTableLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addTable(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #addTable(long, String,
+	String)}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoTable addTable(
 		java.lang.String className, java.lang.String name)
@@ -383,7 +385,8 @@ public class ExpandoTableLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getTable(long, long, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getTable(long, long,
+	String)}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoTable getTable(
 		long classNameId, java.lang.String name)
@@ -400,7 +403,8 @@ public class ExpandoTableLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getTable(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getTable(long, String,
+	String)}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoTable getTable(
 		java.lang.String className, java.lang.String name)

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoTableLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoTableLocalServiceWrapper.java
@@ -269,7 +269,8 @@ public class ExpandoTableLocalServiceWrapper implements ExpandoTableLocalService
 	}
 
 	/**
-	* @deprecated {@link #addTable(long, long, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #addTable(long, long,
+	String)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoTable addTable(
 		long classNameId, java.lang.String name)
@@ -286,7 +287,8 @@ public class ExpandoTableLocalServiceWrapper implements ExpandoTableLocalService
 	}
 
 	/**
-	* @deprecated {@link #addTable(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #addTable(long, String,
+	String)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoTable addTable(
 		java.lang.String className, java.lang.String name)
@@ -378,7 +380,8 @@ public class ExpandoTableLocalServiceWrapper implements ExpandoTableLocalService
 	}
 
 	/**
-	* @deprecated {@link #getTable(long, long, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getTable(long, long,
+	String)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoTable getTable(
 		long classNameId, java.lang.String name)
@@ -395,7 +398,8 @@ public class ExpandoTableLocalServiceWrapper implements ExpandoTableLocalService
 	}
 
 	/**
-	* @deprecated {@link #getTable(long, String, String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getTable(long, String,
+	String)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoTable getTable(
 		java.lang.String className, java.lang.String name)

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoValueLocalService.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoValueLocalService.java
@@ -359,8 +359,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, boolean[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -369,8 +369,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, boolean[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -379,7 +379,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Date[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -388,7 +389,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Date[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -397,8 +399,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, double[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -407,8 +409,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, double[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -417,8 +419,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, float[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -427,8 +429,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, float[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -437,7 +439,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, int[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -446,7 +449,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, int[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -455,7 +459,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, long[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -464,7 +469,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, long[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -473,7 +479,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Object)}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Object)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -482,8 +489,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, short[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -492,8 +499,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, short[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -502,8 +509,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, String[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -512,8 +519,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, String[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -606,8 +613,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getColumnValues(long, String, String, String, String,
-	int, int)}
+	* @deprecated As of 6.1.0, replaced by {@link #getColumnValues(long,
+	String, String, String, String, int, int)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.expando.model.ExpandoValue> getColumnValues(
@@ -642,8 +649,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getColumnValuesCount(long, String, String, String,
-	String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getColumnValuesCount(long,
+	String, String, String, String)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getColumnValuesCount(java.lang.String className,
@@ -802,7 +809,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.io.Serializable getData(java.lang.String className,
@@ -811,8 +819,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, boolean[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public boolean getData(java.lang.String className,
@@ -822,8 +830,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, boolean[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public boolean[] getData(java.lang.String className,
@@ -833,7 +841,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, Date[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.Date getData(java.lang.String className,
@@ -843,7 +852,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, Date[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.Date[] getData(java.lang.String className,
@@ -853,8 +863,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, double[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public double getData(java.lang.String className,
@@ -864,8 +874,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, double[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public double[] getData(java.lang.String className,
@@ -875,7 +885,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, float[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public float getData(java.lang.String className,
@@ -885,7 +896,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, float[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public float[] getData(java.lang.String className,
@@ -895,7 +907,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, int[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getData(java.lang.String className, java.lang.String tableName,
@@ -904,7 +917,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, int[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int[] getData(java.lang.String className,
@@ -914,7 +928,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, long[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public long getData(java.lang.String className, java.lang.String tableName,
@@ -923,7 +938,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, long[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public long[] getData(java.lang.String className,
@@ -933,7 +949,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, short[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public short getData(java.lang.String className,
@@ -943,7 +960,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, short[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public short[] getData(java.lang.String className,
@@ -953,8 +971,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, String[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.lang.String getData(java.lang.String className,
@@ -964,8 +982,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, String[])}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.lang.String[] getData(java.lang.String className,
@@ -1054,7 +1072,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getValue(long, long, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getValue(long, long, String,
+	String, long)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.expando.model.ExpandoValue getValue(
@@ -1069,7 +1088,8 @@ public interface ExpandoValueLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated {@link #getValue(long, String, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getValue(long, String,
+	String, String, long)}
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.expando.model.ExpandoValue getValue(

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoValueLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoValueLocalServiceUtil.java
@@ -464,8 +464,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, boolean[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -477,8 +477,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, boolean[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -490,7 +490,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Date[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -502,7 +503,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Date[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -514,8 +516,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, double[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -527,8 +529,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, double[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -540,8 +542,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, float[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -553,8 +555,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, float[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -566,7 +568,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, int[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -578,7 +581,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, int[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -590,7 +594,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, long[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -602,7 +607,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, long[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -614,7 +620,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Object)}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Object)}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -626,8 +633,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, short[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -639,8 +646,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, short[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -652,8 +659,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, String[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -665,8 +672,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, String[])}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -805,8 +812,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getColumnValues(long, String, String, String, String,
-	int, int)}
+	* @deprecated As of 6.1.0, replaced by {@link #getColumnValues(long,
+	String, String, String, String, int, int)}
 	*/
 	public static java.util.List<com.liferay.portlet.expando.model.ExpandoValue> getColumnValues(
 		java.lang.String className, java.lang.String tableName,
@@ -858,8 +865,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getColumnValuesCount(long, String, String, String,
-	String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getColumnValuesCount(long,
+	String, String, String, String)}
 	*/
 	public static int getColumnValuesCount(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName,
@@ -1082,7 +1089,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long)}
 	*/
 	public static java.io.Serializable getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK)
@@ -1092,8 +1100,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, boolean[])}
 	*/
 	public static boolean getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1106,8 +1114,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, boolean[])}
 	*/
 	public static boolean[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1120,7 +1128,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, Date[])}
 	*/
 	public static java.util.Date getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1133,7 +1142,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, Date[])}
 	*/
 	public static java.util.Date[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1146,8 +1156,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, double[])}
 	*/
 	public static double getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1160,8 +1170,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, double[])}
 	*/
 	public static double[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1174,7 +1184,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, float[])}
 	*/
 	public static float getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1187,7 +1198,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, float[])}
 	*/
 	public static float[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1200,7 +1212,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, int[])}
 	*/
 	public static int getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1213,7 +1226,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, int[])}
 	*/
 	public static int[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1226,7 +1240,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, long[])}
 	*/
 	public static long getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1239,7 +1254,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, long[])}
 	*/
 	public static long[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1252,7 +1268,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, short[])}
 	*/
 	public static short getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1265,7 +1282,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, short[])}
 	*/
 	public static short[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1278,8 +1296,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, String[])}
 	*/
 	public static java.lang.String getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1292,8 +1310,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, String[])}
 	*/
 	public static java.lang.String[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1417,7 +1435,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getValue(long, long, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getValue(long, long, String,
+	String, long)}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue getValue(
 		long classNameId, java.lang.String tableName,
@@ -1436,7 +1455,8 @@ public class ExpandoValueLocalServiceUtil {
 	}
 
 	/**
-	* @deprecated {@link #getValue(long, String, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getValue(long, String,
+	String, String, long)}
 	*/
 	public static com.liferay.portlet.expando.model.ExpandoValue getValue(
 		java.lang.String className, java.lang.String tableName,

--- a/portal-service/src/com/liferay/portlet/expando/service/ExpandoValueLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/expando/service/ExpandoValueLocalServiceWrapper.java
@@ -439,8 +439,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, boolean[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -452,8 +452,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, boolean[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -465,7 +465,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Date[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -477,7 +478,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Date[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -489,8 +491,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, double[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -502,8 +504,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, double[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -515,8 +517,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, float[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -528,8 +530,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, float[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -541,7 +543,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, int[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -553,7 +556,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, int[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -565,7 +569,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, long[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -577,7 +582,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, long[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -589,7 +595,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long, Object)}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, Object)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -601,8 +608,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, short[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -614,8 +621,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, short[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -627,8 +634,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, String[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -640,8 +647,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #addValue(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #addValue(long, String,
+	String, String, long, String[])}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue addValue(
 		java.lang.String className, java.lang.String tableName,
@@ -777,8 +784,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getColumnValues(long, String, String, String, String,
-	int, int)}
+	* @deprecated As of 6.1.0, replaced by {@link #getColumnValues(long,
+	String, String, String, String, int, int)}
 	*/
 	public java.util.List<com.liferay.portlet.expando.model.ExpandoValue> getColumnValues(
 		java.lang.String className, java.lang.String tableName,
@@ -824,8 +831,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getColumnValuesCount(long, String, String, String,
-	String)}
+	* @deprecated As of 6.1.0, replaced by {@link #getColumnValuesCount(long,
+	String, String, String, String)}
 	*/
 	public int getColumnValuesCount(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName,
@@ -1028,7 +1035,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long)}
 	*/
 	public java.io.Serializable getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK)
@@ -1039,8 +1047,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, boolean[])}
 	*/
 	public boolean getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1052,8 +1060,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	boolean[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, boolean[])}
 	*/
 	public boolean[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1065,7 +1073,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, Date[])}
 	*/
 	public java.util.Date getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1077,7 +1086,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, Date[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, Date[])}
 	*/
 	public java.util.Date[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1089,8 +1099,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, double[])}
 	*/
 	public double getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1102,8 +1112,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	double[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, double[])}
 	*/
 	public double[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1115,7 +1125,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, float[])}
 	*/
 	public float getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1127,7 +1138,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, float[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, float[])}
 	*/
 	public float[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1139,7 +1151,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, int[])}
 	*/
 	public int getData(java.lang.String className, java.lang.String tableName,
 		java.lang.String columnName, long classPK, int defaultData)
@@ -1150,7 +1163,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, int[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, int[])}
 	*/
 	public int[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1162,7 +1176,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, long[])}
 	*/
 	public long getData(java.lang.String className, java.lang.String tableName,
 		java.lang.String columnName, long classPK, long defaultData)
@@ -1173,7 +1188,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, long[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, long[])}
 	*/
 	public long[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1185,7 +1201,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, short[])}
 	*/
 	public short getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1197,7 +1214,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long, short[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, short[])}
 	*/
 	public short[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1209,8 +1227,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, String[])}
 	*/
 	public java.lang.String getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1222,8 +1240,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getData(long, String, String, String, long,
-	String[])}
+	* @deprecated As of 6.1.0, replaced by {@link #getData(long, String,
+	String, String, long, String[])}
 	*/
 	public java.lang.String[] getData(java.lang.String className,
 		java.lang.String tableName, java.lang.String columnName, long classPK,
@@ -1338,7 +1356,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getValue(long, long, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getValue(long, long, String,
+	String, long)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue getValue(
 		long classNameId, java.lang.String tableName,
@@ -1357,7 +1376,8 @@ public class ExpandoValueLocalServiceWrapper implements ExpandoValueLocalService
 	}
 
 	/**
-	* @deprecated {@link #getValue(long, String, String, String, long)}
+	* @deprecated As of 6.1.0, replaced by {@link #getValue(long, String,
+	String, String, long)}
 	*/
 	public com.liferay.portlet.expando.model.ExpandoValue getValue(
 		java.lang.String className, java.lang.String tableName,

--- a/portal-service/src/com/liferay/portlet/expando/util/ExpandoBridgeFactoryUtil.java
+++ b/portal-service/src/com/liferay/portlet/expando/util/ExpandoBridgeFactoryUtil.java
@@ -37,7 +37,8 @@ public class ExpandoBridgeFactoryUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getExpandoBridge(long, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getExpandoBridge(long,
+	 *             String)}
 	 */
 	public static ExpandoBridge getExpandoBridge(String className) {
 		long companyId = CompanyThreadLocal.getCompanyId();
@@ -46,7 +47,8 @@ public class ExpandoBridgeFactoryUtil {
 	}
 
 	/**
-	 * @deprecated {@link #getExpandoBridge(long, String, long)}
+	 * @deprecated As of 6.1.0, replaced by {@link #getExpandoBridge(long,
+	 *             String, long)}
 	 */
 	public static ExpandoBridge getExpandoBridge(
 		String className, long classPK) {

--- a/util-java/src/com/liferay/util/License.java
+++ b/util-java/src/com/liferay/util/License.java
@@ -16,7 +16,8 @@ package com.liferay.util;
 
 /**
  * @author     Jorge Ferrer
- * @deprecated {@link com.liferay.portal.kernel.plugin.License}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.plugin.License}
  */
 public class License extends com.liferay.portal.kernel.plugin.License {
 }

--- a/util-java/src/com/liferay/util/LocalizationUtil.java
+++ b/util-java/src/com/liferay/util/LocalizationUtil.java
@@ -16,7 +16,8 @@ package com.liferay.util;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.util.LocalizationUtil}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.util.LocalizationUtil}
  */
 public class LocalizationUtil
 	extends com.liferay.portal.kernel.util.LocalizationUtil {

--- a/util-java/src/com/liferay/util/ResourceBundleUtil.java
+++ b/util-java/src/com/liferay/util/ResourceBundleUtil.java
@@ -16,7 +16,8 @@ package com.liferay.util;
 
 /**
  * @author     Neil Griffin
- * @deprecated {@link com.liferay.portal.kernel.util.ResourceBundleUtil}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.util.ResourceBundleUtil}
  */
 public class ResourceBundleUtil
 	extends com.liferay.portal.kernel.util.ResourceBundleUtil {

--- a/util-java/src/com/liferay/util/Screenshot.java
+++ b/util-java/src/com/liferay/util/Screenshot.java
@@ -16,7 +16,8 @@ package com.liferay.util;
 
 /**
  * @author     Jorge Ferrer
- * @deprecated {@link com.liferay.portal.kernel.plugin.Screenshot}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.plugin.Screenshot}
  */
 public class Screenshot extends com.liferay.portal.kernel.plugin.Screenshot {
 }

--- a/util-java/src/com/liferay/util/Version.java
+++ b/util-java/src/com/liferay/util/Version.java
@@ -16,7 +16,8 @@ package com.liferay.util;
 
 /**
  * @author     Jorge Ferrer
- * @deprecated {@link com.liferay.portal.kernel.plugin.Version}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.plugin.Version}
  */
 public class Version extends com.liferay.portal.kernel.plugin.Version {
 

--- a/util-java/src/com/liferay/util/json/JSONFactoryUtil.java
+++ b/util-java/src/com/liferay/util/json/JSONFactoryUtil.java
@@ -16,7 +16,8 @@ package com.liferay.util.json;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated {@link com.liferay.portal.kernel.json.JSONFactoryUtil}
+ * @deprecated As of 6.1.0, replaced by {@link
+ *             com.liferay.portal.kernel.json.JSONFactoryUtil}
  */
 public class JSONFactoryUtil
 	extends com.liferay.portal.kernel.json.JSONFactoryUtil {

--- a/util-java/src/com/liferay/util/servlet/NullSession.java
+++ b/util-java/src/com/liferay/util/servlet/NullSession.java
@@ -73,7 +73,7 @@ public class NullSession implements HttpSession {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public javax.servlet.http.HttpSessionContext getSessionContext() {
 		return null;

--- a/util-taglib/src/com/liferay/taglib/ui/ToggleValueTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/ToggleValueTag.java
@@ -29,7 +29,7 @@ import javax.servlet.jsp.tagext.TagSupport;
 public class ToggleValueTag extends TagSupport {
 
 	/**
-	 * @deprecated
+	 * @deprecated As of 6.1.0
 	 */
 	public static void doTag(
 			String id, PageContext pageContext, HttpServletRequest request)

--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
@@ -48,9 +48,9 @@ public interface VelocityTaglib {
 		throws Exception;
 
 	/**
-	 * @deprecated {@link #actionURL(String, String, Boolean, Boolean, Boolean,
-	 *             String, long, long, String, Boolean, Boolean, long, long,
-	 *             Boolean, String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #actionURL(String, String,
+	 *             Boolean, Boolean, Boolean, String, long, long, String,
+	 *             Boolean, Boolean, long, long, Boolean, String)}
 	 */
 	public void actionURL(
 			String windowState, String portletMode, Boolean secure,
@@ -207,12 +207,12 @@ public interface VelocityTaglib {
 	public void metaTags() throws Exception;
 
 	/**
-	 * @deprecated {@link #mySites}
+	 * @deprecated As of 6.1.0, replaced by {@link #mySites}
 	 */
 	public void myPlaces() throws Exception;
 
 	/**
-	 * @deprecated {@link #mySites(int)}
+	 * @deprecated As of 6.1.0, replaced by {@link #mySites(int)}
 	 */
 	public void myPlaces(int max) throws Exception;
 
@@ -256,9 +256,9 @@ public interface VelocityTaglib {
 		throws Exception;
 
 	/**
-	 * @deprecated {@link #renderURL(String, String, Boolean, Boolean, Boolean,
-	 *             long, long, String, Boolean, Boolean, long, long, Boolean,
-	 *             String)}
+	 * @deprecated As of 6.1.0, replaced by {@link #renderURL(String, String,
+	 *             Boolean, Boolean, Boolean, long, long, String, Boolean,
+	 *             Boolean, long, long, Boolean, String)}
 	 */
 	public void renderURL(
 			String windowState, String portletMode, Boolean secure,


### PR DESCRIPTION
@hhuijser - Hi guys. I went back to 6.1.0-ga1 to add the version information to the deprecatations and then rebased just those comments into trunk.

All remaining deprecations that don't already have version information can get tagged as 6.2.0 deprecations. If you have any concerns, please see LPS-33443 for the steps I took. Thanks.
