### PR TITLE
Revert "LPS-32054 Source formatting"

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java
@@ -55,7 +55,7 @@ public class I18nServlet extends HttpServlet {
 	}
 
 	public static void setLanguageIds(Element root) {
-		_languageIds.clear();
+		_languageIds = new HashSet<String>();
 
 		List<Element> rootElements = root.elements("servlet-mapping");
 
@@ -168,6 +168,6 @@ public class I18nServlet extends HttpServlet {
 
 	private static Log _log = LogFactoryUtil.getLog(I18nServlet.class);
 
-	private static Set<String> _languageIds = new HashSet<String>();
+	private static Set<String> _languageIds;
 
 }

--- a/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
@@ -52,7 +52,7 @@ public class I18nFilter extends BasePortalFilter {
 	}
 
 	public static void setLanguageIds(Set<String> languageIds) {
-		_languageIds.clear();
+		_languageIds = new HashSet<String>();
 
 		for (String languageId : languageIds) {
 			languageId = languageId.substring(1);
@@ -261,6 +261,6 @@ public class I18nFilter extends BasePortalFilter {
 
 	private static Log _log = LogFactoryUtil.getLog(I18nFilter.class);
 
-	private static Set<String> _languageIds = new HashSet<String>();
+	private static Set<String> _languageIds;
 
 }


### PR DESCRIPTION
This reverts commit aa0d32f7b88705d81570484fff0efe93011f97ea.

@rotty3000

Ray's original commit was correct. Those setLanguageIds() are repeatly being called during test, if we reuse the set , we will do clear on the unmodifiable wrapper.
