### PR TITLE
LPS-31965 Support order by in Asset Search --> PLEASE read description

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -363,6 +363,7 @@ public class AssetUtil {
 		searchContext.setClassTypeIds(assetEntryQuery.getClassTypeIds());
 		searchContext.setEnd(end);
 		searchContext.setGroupIds(assetEntryQuery.getGroupIds());
+		searchContext.setSorts(getSorts(assetEntryQuery));
 		searchContext.setStart(start);
 
 		return assetSearcher.search(searchContext);
@@ -452,6 +453,46 @@ public class AssetUtil {
 
 			return new String(textCharArray);
 		}
+	}
+
+	protected static Sort getSort(String orderByType, String sortField) {
+		if (Validator.isNull(orderByType)) {
+			orderByType = "asc";
+		}
+
+		int sortType = Sort.STRING_TYPE;
+
+		if (sortField.equals("createDate") ||
+			sortField.equals("expirationDate") ||
+			sortField.equals("modifiedDate") ||
+			sortField.equals("publishDate")) {
+
+			sortType= Sort.LONG_TYPE;
+		}
+		else if (sortField.equals("priority") || sortField.equals("ratings")) {
+			sortType= Sort.DOUBLE_TYPE;
+		}
+		else if (sortField.equals("viewCount")) {
+			sortType= Sort.INT_TYPE;
+		}
+
+		return new Sort(
+			"asset_" + sortField, sortType,
+			!orderByType.equalsIgnoreCase("asc"));
+	}
+
+	protected static Sort[] getSorts(AssetEntryQuery assetEntryQuery)
+		throws Exception {
+
+		Sort sort1 = getSort(
+			assetEntryQuery.getOrderByType1(),
+			assetEntryQuery.getOrderByCol1());
+
+		Sort sort2 = getSort(
+			assetEntryQuery.getOrderByType2(),
+			assetEntryQuery.getOrderByCol2());
+
+		return new Sort[] {sort1, sort2};
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(AssetUtil.class);

--- a/portal-impl/src/com/liferay/portlet/blogs/util/BlogsIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/util/BlogsIndexer.java
@@ -117,6 +117,9 @@ public class BlogsIndexer extends BaseIndexer {
 		document.addDate(Field.MODIFIED_DATE, entry.getDisplayDate());
 		document.addText(Field.TITLE, entry.getTitle());
 
+		addAssetFields(
+			document, BlogsEntry.class.getName(), entry.getEntryId());
+
 		return document;
 	}
 

--- a/portal-impl/src/com/liferay/portlet/bookmarks/util/BookmarksEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/util/BookmarksEntryIndexer.java
@@ -127,6 +127,9 @@ public class BookmarksEntryIndexer extends BaseIndexer {
 		document.addText(Field.TITLE, entry.getName());
 		document.addText(Field.URL, entry.getUrl());
 
+		addAssetFields(
+			document, BookmarksEntry.class.getName(), entry.getEntryId());
+
 		if (!entry.isInTrash() && entry.isInTrashContainer()) {
 			BookmarksFolder folder = entry.getTrashContainer();
 

--- a/portal-impl/src/com/liferay/portlet/bookmarks/util/BookmarksFolderIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/util/BookmarksFolderIndexer.java
@@ -125,6 +125,9 @@ public class BookmarksFolderIndexer extends BaseIndexer {
 		document.addKeyword(Field.FOLDER_ID, folder.getParentFolderId());
 		document.addText(Field.TITLE, folder.getName());
 
+		addAssetFields(
+			document, BookmarksFolder.class.getName(), folder.getFolderId());
+
 		if (!folder.isInTrash() && folder.isInTrashContainer()) {
 			BookmarksFolder trashedFolder = folder.getTrashContainer();
 

--- a/portal-impl/src/com/liferay/portlet/calendar/util/CalIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/calendar/util/CalIndexer.java
@@ -75,6 +75,8 @@ public class CalIndexer extends BaseIndexer {
 		document.addText(Field.TITLE, event.getTitle());
 		document.addKeyword(Field.TYPE, event.getType());
 
+		addAssetFields(document, CalEvent.class.getName(), event.getEventId());
+
 		return document;
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -414,6 +414,10 @@ public class DLFileEntryIndexer extends BaseIndexer {
 				}
 			}
 
+			addAssetFields(
+				document, DLFileEntry.class.getName(),
+				dlFileEntry.getFileEntryId());
+
 			if (!dlFileVersion.isInTrash() &&
 				dlFileVersion.isInTrashContainer()) {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFolderIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFolderIndexer.java
@@ -130,6 +130,9 @@ public class DLFolderIndexer extends BaseIndexer {
 			Field.HIDDEN, (dlFolder.isHidden() || dlFolder.isInHiddenFolder()));
 		document.addText(Field.TITLE, dlFolder.getName());
 
+		addAssetFields(
+			document, DLFolder.class.getName(), dlFolder.getFolderId());
+
 		if (!dlFolder.isInTrash() && dlFolder.isInTrashContainer()) {
 			DLFolder trashedFolder = dlFolder.getTrashContainer();
 

--- a/portal-impl/src/com/liferay/portlet/journal/util/JournalArticleIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/JournalArticleIndexer.java
@@ -330,6 +330,10 @@ public class JournalArticleIndexer extends BaseIndexer {
 
 		addDDMStructureAttributes(document, article);
 
+		addAssetFields(
+			document, JournalArticle.class.getName(),
+			article.getResourcePrimKey());
+
 		if (!article.isInTrash() && article.isInTrashContainer()) {
 			JournalFolder folder = article.getTrashContainer();
 

--- a/portal-impl/src/com/liferay/portlet/journal/util/JournalFolderIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/JournalFolderIndexer.java
@@ -124,6 +124,9 @@ public class JournalFolderIndexer extends BaseIndexer {
 		document.addKeyword(Field.FOLDER_ID, folder.getParentFolderId());
 		document.addText(Field.TITLE, folder.getName());
 
+		addAssetFields(
+			document, JournalFolder.class.getName(), folder.getFolderId());
+
 		if (!folder.isInTrash() && folder.isInTrashContainer()) {
 			JournalFolder trashedFolder = folder.getTrashContainer();
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/util/MBMessageIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/util/MBMessageIndexer.java
@@ -282,6 +282,9 @@ public class MBMessageIndexer extends BaseIndexer {
 			}
 		}
 
+		addAssetFields(
+			document, message.getWorkflowClassName(), message.getMessageId());
+
 		if (!message.isInTrash() && message.isInTrashThread()) {
 			addTrashFields(
 				document, MBThread.class.getName(), message.getThreadId(), null,

--- a/portal-impl/src/com/liferay/portlet/wiki/util/WikiPageIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/util/WikiPageIndexer.java
@@ -227,6 +227,9 @@ public class WikiPageIndexer extends BaseIndexer {
 		document.addKeyword(Field.NODE_ID, page.getNodeId());
 		document.addText(Field.TITLE, page.getTitle());
 
+		addAssetFields(
+			document, WikiPage.class.getName(), page.getResourcePrimKey());
+
 		if (!page.isInTrash() && page.isInTrashContainer()) {
 			addTrashFields(
 				document, WikiNode.class.getName(), page.getNodeId(), null,

--- a/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -65,8 +65,10 @@ import com.liferay.portal.service.ServiceContextThreadLocal;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.asset.model.AssetCategory;
+import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.model.AssetTag;
 import com.liferay.portlet.asset.service.AssetCategoryLocalServiceUtil;
+import com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil;
 import com.liferay.portlet.asset.service.AssetTagLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
@@ -76,6 +78,8 @@ import com.liferay.portlet.expando.model.ExpandoColumnConstants;
 import com.liferay.portlet.expando.util.ExpandoBridgeFactoryUtil;
 import com.liferay.portlet.expando.util.ExpandoBridgeIndexerUtil;
 import com.liferay.portlet.messageboards.model.MBMessage;
+import com.liferay.portlet.ratings.model.RatingsStats;
+import com.liferay.portlet.ratings.service.RatingsStatsLocalServiceUtil;
 import com.liferay.portlet.trash.model.TrashEntry;
 import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
 
@@ -476,6 +480,35 @@ public abstract class BaseIndexer implements Indexer {
 
 		_indexerPostProcessors = indexerPostProcessorsList.toArray(
 			new IndexerPostProcessor[indexerPostProcessorsList.size()]);
+	}
+
+	protected void addAssetFields(
+			Document document, String className, long classPK)
+		throws Exception {
+
+		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+			className, classPK);
+
+		if (assetEntry == null) {
+			return;
+		}
+
+		Locale defaultLocale = LocaleUtil.getDefault();
+
+		document.addDate("asset_createDate", assetEntry.getCreateDate());
+		document.addDate(
+			"asset_expirationDate", assetEntry.getExpirationDate());
+		document.addDate("asset_modifiedDate", assetEntry.getModifiedDate());
+		document.addNumber("asset_priority", assetEntry.getPriority());
+		document.addDate("asset_publishDate", assetEntry.getPublishDate());
+
+		RatingsStats ratingsStats = RatingsStatsLocalServiceUtil.getStats(
+			className, classPK);
+
+		document.addNumber("asset_ratings", ratingsStats.getAverageScore());
+
+		document.addKeyword("asset_title", assetEntry.getTitle(defaultLocale));
+		document.addNumber("asset_viewCount", assetEntry.getViewCount());
 	}
 
 	/**


### PR DESCRIPTION
Brian, we are not sure about the pattern in BaseIndexer when using the "asset_" prefix, but we found several isssues that we are fixing when doing it in this way:
- if we use the field "title" it won't work since that one contains the localized title. We are working on supporting ordering by localized title, but that requieres more changes. Using "asset_title" now will support ordering the title in the default locale.
- createDate and modifiedDate are already indexed for auditedModels, but we are indexing them here to make sure we index for all the assets even if they are not auditedModels, because if one asset is missing, then lucen doesn't order anything.
