### PR TITLE
LPS-33626 XML without prolog is valid

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/Validator.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Validator.java
@@ -1307,7 +1307,11 @@ public class Validator {
 	 *         <code>false</code> otherwise
 	 */
 	public static boolean isXml(String s) {
-		if (s.startsWith(_XML_BEGIN) || s.startsWith(_XML_EMPTY)) {
+		s = s.trim();
+
+		if (s.startsWith(StringPool.LESS_THAN) &&
+			s.endsWith(StringPool.GREATER_THAN)) {
+
 			return true;
 		}
 		else {
@@ -1337,10 +1341,6 @@ public class Validator {
 	private static final String _VARIABLE_TERM_BEGIN = "[$";
 
 	private static final String _VARIABLE_TERM_END = "$]";
-
-	private static final String _XML_BEGIN = "<?xml";
-
-	private static final String _XML_EMPTY = "<root />";
 
 	private static Pattern _emailAddressPattern = Pattern.compile(
 		"[\\w!#$%&'*+/=?^_`{|}~-]+(?:\\.[\\w!#$%&'*+/=?^_`{|}~-]+)*@" +


### PR DESCRIPTION
Importing currently throws npe due to the following:
1. document.formattedString() -> element.formattedString() in DataHandlers = no more prolog
2. portletDataContext.setImportDataRootElement(rootElement) is not set because it's not recognized as valid xml
3. Element rootElement = portletDataContext.getImportDataRootElement(); is null causing rootElement.element() to throw NPE
