### PR TITLE
LPS-32851 Initial tests for Membership Polices --> please read comments

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -525,25 +525,13 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 			birthdayMonth, birthdayDay, birthdayYear, jobTitle, groupIds,
 			organizationIds, roleIds, userGroupIds, sendEmail, serviceContext);
 
-		if (groupIds != null) {
-			SiteMembershipPolicyUtil.propagateMembership(
-				new long[] {user.getUserId()}, groupIds, null);
-		}
+		checkMembership(
+			new long[] {user.getUserId()}, organizationIds, roleIds, groupIds,
+			userGroupIds);
 
-		if (organizationIds != null) {
-			OrganizationMembershipPolicyUtil.propagateMembership(
-				new long[] {user.getUserId()}, organizationIds, null);
-		}
-
-		if (roleIds != null) {
-			RoleMembershipPolicyUtil.propagateRoles(
-				new long[] {user.getUserId()}, roleIds, null);
-		}
-
-		if (userGroupIds != null) {
-			UserGroupMembershipPolicyUtil.propagateMembership(
-				new long[] {user.getUserId()}, userGroupIds, null);
-		}
+		propagateMembership(
+			new long[]{user.getUserId()}, organizationIds, roleIds, groupIds,
+			userGroupIds);
 
 		return user;
 	}
@@ -2204,6 +2192,30 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 		return groupIds;
 	}
 
+	protected void checkMembership(
+			long[] userIds, long[] organizationIds, long[] roleIds,
+			long[] groupIds, long[] userGroupIds)
+		throws PortalException, SystemException {
+
+		if (organizationIds != null) {
+			OrganizationMembershipPolicyUtil.checkMembership(
+				userIds, organizationIds, null);
+		}
+
+		if (roleIds != null) {
+			RoleMembershipPolicyUtil.checkRoles(userIds, roleIds, null);
+		}
+
+		if (groupIds != null) {
+			SiteMembershipPolicyUtil.checkMembership(userIds, groupIds, null);
+		}
+
+		if (userGroupIds != null) {
+			UserGroupMembershipPolicyUtil.checkMembership(
+				userIds, userGroupIds, null);
+		}
+	}
+
 	protected long[] checkOrganizations(long userId, long[] organizationIds)
 		throws PortalException, SystemException {
 
@@ -2439,6 +2451,32 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 		}
 
 		return userGroupRoles;
+	}
+
+	protected void propagateMembership(
+			long[] userIds, long[] organizationIds, long[] roleIds,
+			long[] groupIds, long[] userGroupIds)
+		throws PortalException, SystemException {
+
+		if (organizationIds != null) {
+			OrganizationMembershipPolicyUtil.propagateMembership(
+				userIds, organizationIds, null);
+		}
+
+		if (roleIds != null) {
+			RoleMembershipPolicyUtil.propagateRoles(userIds, roleIds, null);
+		}
+
+		if (groupIds != null) {
+			SiteMembershipPolicyUtil.propagateMembership(
+				userIds, groupIds, null);
+		}
+
+		if (userGroupIds != null) {
+
+			UserGroupMembershipPolicyUtil.propagateMembership(
+				userIds, userGroupIds, null);
+		}
 	}
 
 	protected void updateAnnouncementsDeliveries(

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/BaseSiteMembershipPolicyTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/BaseSiteMembershipPolicyTestCase.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.membershippolicy;
+
+import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.User;
+import com.liferay.portal.security.membershippolicy.util.RoleTestUtil;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.service.UserLocalServiceUtil;
+import com.liferay.portal.test.EnvironmentExecutionTestListener;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.TransactionalExecutionTestListener;
+import com.liferay.portal.util.GroupTestUtil;
+import com.liferay.portal.util.UserTestUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roberto Díaz
+ */
+@ExecutionTestListeners(
+	listeners = {
+		EnvironmentExecutionTestListener.class,
+		TransactionalExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public abstract class BaseSiteMembershipPolicyTestCase {
+
+	public static int currentGroups(int i) {
+		return i;
+	}
+
+	public static long[] getForbiddenRoleIds() {
+		return _forbiddenRoleIds;
+	}
+
+	public static long[] getForbiddenSiteIds() {
+		return _forbiddenSiteIds;
+	}
+
+	public static Group getGroup() {
+		return _group;
+	}
+
+	public static boolean getPropagateMembershipMethodFlag() {
+		return _propagateMembershipMethodFlag;
+	}
+
+	public static boolean getPropagateRolesMethodFlag() {
+		return _propagateRolesMethodFlag;
+	}
+
+	public static long[] getRequiredRoleIds() {
+		return _requiredRoleIds;
+	}
+
+	public static long[] getRequiredSiteIds() {
+		return _requiredSiteIds;
+	}
+
+	public static long[] getStandardRoleIds() {
+		return _standardRoleIds;
+	}
+
+	public static long[] getStandardSiteIds() {
+		return _standardSiteIds;
+	}
+
+	public static long[] getUserIds() {
+		return _userIds;
+	}
+
+	public static boolean getVerifyMethodFlag() {
+		return _verifyMethodFlag;
+	}
+
+	public static void setGroup(Group group) {
+		_group = group;
+	}
+
+	public static void setPropagateMembershipMethodFlag(
+		boolean propagateMembershipMethodFlag) {
+
+		_propagateMembershipMethodFlag = propagateMembershipMethodFlag;
+	}
+
+	public static void setPropagateRolesMethodFlag(
+		boolean propagateRolesMethodFlag) {
+
+		_propagateRolesMethodFlag = propagateRolesMethodFlag;
+	}
+
+	public static void setVerifyMethodFlag(boolean verifyMethodFlag) {
+		_verifyMethodFlag = verifyMethodFlag;
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		FinderCacheUtil.clearCache();
+
+		setGroup(GroupTestUtil.addGroup());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupLocalServiceUtil.deleteGroup(getGroup());
+	}
+
+	protected static int addedUsers(int i) {
+		return i;
+	}
+
+	protected ServiceContext _getServiceContext() throws Exception {
+		return ServiceTestUtil.getServiceContext();
+	}
+
+	protected void addForbiddenRoles() throws Exception {
+		_forbiddenRoleIds[0] = RoleTestUtil.addGroupRole(_group.getGroupId());
+		_forbiddenRoleIds[1] = RoleTestUtil.addGroupRole(_group.getGroupId());
+	}
+
+	protected void addForbiddenSites() throws Exception {
+		Group forbiddenSite1 = GroupTestUtil.addGroup(
+			ServiceTestUtil.randomString());
+		_forbiddenSiteIds[0] = forbiddenSite1.getGroupId();
+
+		Group forbiddenSite2 = GroupTestUtil.addGroup(
+			ServiceTestUtil.randomString());
+		_forbiddenSiteIds[1] = forbiddenSite2.getGroupId();
+	}
+
+	protected void addRequiredRoles() throws Exception {
+		_requiredRoleIds[0] = RoleTestUtil.addGroupRole(_group.getGroupId());
+		_requiredRoleIds[1] = RoleTestUtil.addGroupRole(_group.getGroupId());
+	}
+
+	protected void addRequiredSites() throws Exception {
+		Group requiredSite1 = GroupTestUtil.addGroup(
+			ServiceTestUtil.randomString());
+		_requiredSiteIds[0] = requiredSite1.getGroupId();
+
+		Group requiredSite2 = GroupTestUtil.addGroup(
+			ServiceTestUtil.randomString());
+		_requiredSiteIds[1] = requiredSite2.getGroupId();
+	}
+
+	protected void addStandardRoles() throws Exception {
+		_standardRoleIds[0] = RoleTestUtil.addGroupRole(_group.getGroupId());
+		_standardRoleIds[1] = RoleTestUtil.addGroupRole(_group.getGroupId());
+	}
+
+	protected void addStandardSites() throws Exception {
+		Group standardSite1 = GroupTestUtil.addGroup(
+			ServiceTestUtil.randomString());
+		_standardSiteIds[0] = standardSite1.getGroupId();
+
+		Group standardSite2 = GroupTestUtil.addGroup(
+			ServiceTestUtil.randomString());
+		_standardSiteIds[1] = standardSite2.getGroupId();
+	}
+
+	protected void addUsers() throws Exception {
+		User user1= UserTestUtil.addUser(
+			ServiceTestUtil.randomString(), _group.getGroupId());
+		_userIds[0] = user1.getUserId();
+
+		User user2 = UserTestUtil.addUser(
+			ServiceTestUtil.randomString(), _group.getGroupId());
+		_userIds[1] = user2.getUserId();
+	}
+
+	protected User getUser() throws Exception {
+		return UserLocalServiceUtil.getUser(getUserIds()[0]);
+	}
+
+	private static long[] _forbiddenRoleIds = new long[2];
+	private static long[] _forbiddenSiteIds = new long[2];
+	private static Group _group;
+	private static boolean _propagateMembershipMethodFlag = false;
+	private static boolean _propagateRolesMethodFlag = false;
+	private static long[] _requiredRoleIds = new long[2];
+	private static long[] _requiredSiteIds = new long[2];
+	private static long[] _standardRoleIds = new long[2];
+	private static long[] _standardSiteIds = new long[2];
+	private static long[] _userIds = new long[2];
+	private static boolean _verifyMethodFlag;
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/BaseSiteMembershipPolicyTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/BaseSiteMembershipPolicyTestCase.java
@@ -20,17 +20,13 @@ import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.membershippolicy.util.RoleTestUtil;
-import com.liferay.portal.service.GroupLocalServiceUtil;
-import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
-import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
 import com.liferay.portal.test.TransactionalExecutionTestListener;
 import com.liferay.portal.util.GroupTestUtil;
 import com.liferay.portal.util.UserTestUtil;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
@@ -46,20 +42,12 @@ import org.junit.runner.RunWith;
 @Transactional
 public abstract class BaseSiteMembershipPolicyTestCase {
 
-	public static int currentGroups(int i) {
-		return i;
-	}
-
 	public static long[] getForbiddenRoleIds() {
 		return _forbiddenRoleIds;
 	}
 
 	public static long[] getForbiddenSiteIds() {
 		return _forbiddenSiteIds;
-	}
-
-	public static Group getGroup() {
-		return _group;
 	}
 
 	public static boolean getPropagateMembershipMethodFlag() {
@@ -94,10 +82,6 @@ public abstract class BaseSiteMembershipPolicyTestCase {
 		return _verifyMethodFlag;
 	}
 
-	public static void setGroup(Group group) {
-		_group = group;
-	}
-
 	public static void setPropagateMembershipMethodFlag(
 		boolean propagateMembershipMethodFlag) {
 
@@ -117,29 +101,16 @@ public abstract class BaseSiteMembershipPolicyTestCase {
 	@Before
 	public void setUp() throws Exception {
 		FinderCacheUtil.clearCache();
-
-		setGroup(GroupTestUtil.addGroup());
 	}
 
-	@After
-	public void tearDown() throws Exception {
-		GroupLocalServiceUtil.deleteGroup(getGroup());
-	}
-
-	protected static int addedUsers(int i) {
-		return i;
-	}
-
-	protected ServiceContext _getServiceContext() throws Exception {
-		return ServiceTestUtil.getServiceContext();
-	}
-
-	protected void addForbiddenRoles() throws Exception {
+	protected long[] addForbiddenRoles() throws Exception {
 		_forbiddenRoleIds[0] = RoleTestUtil.addGroupRole(_group.getGroupId());
 		_forbiddenRoleIds[1] = RoleTestUtil.addGroupRole(_group.getGroupId());
+
+		return _forbiddenRoleIds;
 	}
 
-	protected void addForbiddenSites() throws Exception {
+	protected long[] addForbiddenSites() throws Exception {
 		Group forbiddenSite1 = GroupTestUtil.addGroup(
 			ServiceTestUtil.randomString());
 		_forbiddenSiteIds[0] = forbiddenSite1.getGroupId();
@@ -147,14 +118,18 @@ public abstract class BaseSiteMembershipPolicyTestCase {
 		Group forbiddenSite2 = GroupTestUtil.addGroup(
 			ServiceTestUtil.randomString());
 		_forbiddenSiteIds[1] = forbiddenSite2.getGroupId();
+
+		return _forbiddenSiteIds;
 	}
 
-	protected void addRequiredRoles() throws Exception {
+	protected long[] addRequiredRoles() throws Exception {
 		_requiredRoleIds[0] = RoleTestUtil.addGroupRole(_group.getGroupId());
 		_requiredRoleIds[1] = RoleTestUtil.addGroupRole(_group.getGroupId());
+
+		return _requiredRoleIds;
 	}
 
-	protected void addRequiredSites() throws Exception {
+	protected long[] addRequiredSites() throws Exception {
 		Group requiredSite1 = GroupTestUtil.addGroup(
 			ServiceTestUtil.randomString());
 		_requiredSiteIds[0] = requiredSite1.getGroupId();
@@ -162,14 +137,18 @@ public abstract class BaseSiteMembershipPolicyTestCase {
 		Group requiredSite2 = GroupTestUtil.addGroup(
 			ServiceTestUtil.randomString());
 		_requiredSiteIds[1] = requiredSite2.getGroupId();
+
+		return _requiredSiteIds;
 	}
 
-	protected void addStandardRoles() throws Exception {
+	protected long[] addStandardRoles() throws Exception {
 		_standardRoleIds[0] = RoleTestUtil.addGroupRole(_group.getGroupId());
 		_standardRoleIds[1] = RoleTestUtil.addGroupRole(_group.getGroupId());
+
+		return _standardRoleIds;
 	}
 
-	protected void addStandardSites() throws Exception {
+	protected long[] addStandardSites() throws Exception {
 		Group standardSite1 = GroupTestUtil.addGroup(
 			ServiceTestUtil.randomString());
 		_standardSiteIds[0] = standardSite1.getGroupId();
@@ -177,9 +156,11 @@ public abstract class BaseSiteMembershipPolicyTestCase {
 		Group standardSite2 = GroupTestUtil.addGroup(
 			ServiceTestUtil.randomString());
 		_standardSiteIds[1] = standardSite2.getGroupId();
+
+		return _standardSiteIds;
 	}
 
-	protected void addUsers() throws Exception {
+	protected long[] addUsers() throws Exception {
 		User user1= UserTestUtil.addUser(
 			ServiceTestUtil.randomString(), _group.getGroupId());
 		_userIds[0] = user1.getUserId();
@@ -187,10 +168,8 @@ public abstract class BaseSiteMembershipPolicyTestCase {
 		User user2 = UserTestUtil.addUser(
 			ServiceTestUtil.randomString(), _group.getGroupId());
 		_userIds[1] = user2.getUserId();
-	}
 
-	protected User getUser() throws Exception {
-		return UserLocalServiceUtil.getUser(getUserIds()[0]);
+		return _userIds;
 	}
 
 	private static long[] _forbiddenRoleIds = new long[2];

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyBaseImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyBaseImplTest.java
@@ -14,13 +14,7 @@
 
 package com.liferay.portal.security.membershippolicy;
 
-import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
-import com.liferay.portal.service.GroupLocalServiceUtil;
-import com.liferay.portal.util.GroupTestUtil;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -29,116 +23,88 @@ import org.junit.Test;
 public class SiteMembershipPolicyBaseImplTest
 	extends BaseSiteMembershipPolicyTestCase {
 
-	@Before
-	public void setUp() throws Exception {
-		FinderCacheUtil.clearCache();
-
-		setGroup(GroupTestUtil.addGroup());
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		GroupLocalServiceUtil.deleteGroup(getGroup());
-	}
-
 	@Test
-	public void testIsMembershipAllowedReturnFalseInCheckException()
-		throws Exception {
-
-		addUsers();
-		addForbiddenSites();
-
-		Assert.assertFalse(
-			SiteMembershipPolicyUtil.isMembershipAllowed(
-				getUserIds()[0], getForbiddenSiteIds()[0]));
-	}
-
-	@Test
-	public void testIsMembershipAllowedReturnTrueInCheckPass()
-		throws Exception {
-
-		addUsers();
-		addStandardSites();
+	public void testIsMembershipAllowed() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
 
 		Assert.assertTrue(
 			SiteMembershipPolicyUtil.isMembershipAllowed(
-				getUserIds()[0], getStandardSiteIds()[0]));
+				userIds[0], standardSiteIds[0]));
 	}
 
 	@Test
-	public void testIsMembershipRequiredReturnFalseInCheckPass()
-		throws Exception {
+	public void testIsMembershipNotAllowed() throws Exception {
+		long[] userIds = addUsers();
+		long[] forbiddenSiteIds = addForbiddenSites();
 
-		addUsers();
-		addStandardSites();
+		Assert.assertFalse(
+			SiteMembershipPolicyUtil.isMembershipAllowed(
+				userIds[0], forbiddenSiteIds[0]));
+	}
+
+	@Test
+	public void testIsMembershipNotRequired() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
 
 		Assert.assertFalse(
 			SiteMembershipPolicyUtil.isMembershipRequired(
-				getUserIds()[0], getStandardSiteIds()[0]));
+				userIds[0], standardSiteIds[0]));
 	}
 
 	@Test
-	public void testIsMembershipRequiredReturnTrueInCheckException()
-		throws Exception {
-
-		addUsers();
-		addRequiredSites();
+	public void testIsMembershipRequired() throws Exception {
+		long[] userIds = addUsers();
+		long[] requiredSiteIds = addRequiredSites();
 
 		Assert.assertTrue(
 			SiteMembershipPolicyUtil.isMembershipRequired(
-				getUserIds()[0], getRequiredSiteIds()[0]));
+				userIds[0], requiredSiteIds[0]));
 	}
 
 	@Test
-	public void testIsRoleAllowedReturnFalseInCheckException()
-		throws Exception {
-
-		addUsers();
-		addStandardSites();
-		addForbiddenRoles();
-
-		Assert.assertFalse(
-			SiteMembershipPolicyUtil.isRoleAllowed(
-				getUserIds()[0], getForbiddenSiteIds()[0],
-				getForbiddenRoleIds()[0]));
-	}
-
-	@Test
-	public void testIsRoleAllowedReturnTrueInCheckPass() throws Exception {
-		addUsers();
-		addStandardSites();
-		addStandardRoles();
+	public void testIsRoleAllowed() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
+		long[] standardRoleIds = addStandardRoles();
 
 		Assert.assertTrue(
 			SiteMembershipPolicyUtil.isRoleAllowed(
-				getUserIds()[0], getStandardSiteIds()[0],
-				getStandardRoleIds()[0]));
+				userIds[0], standardSiteIds[0], standardRoleIds[0]));
 	}
 
 	@Test
-	public void testIsRoleRequiredReturnFalseInCheckPass() throws Exception {
-		addUsers();
-		addStandardSites();
-		addStandardRoles();
+	public void testIsRoleNotAllowed() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
+		long[] forbiddenRoleIds = addForbiddenRoles();
+
+		Assert.assertFalse(
+			SiteMembershipPolicyUtil.isRoleAllowed(
+				userIds[0], standardSiteIds[0], forbiddenRoleIds[0]));
+	}
+
+	@Test
+	public void testIsRoleNotRequired() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
+		long[] standardRoleIds = addStandardRoles();
 
 		Assert.assertFalse(
 			SiteMembershipPolicyUtil.isRoleRequired(
-				getUserIds()[0], getStandardSiteIds()[0],
-				getStandardRoleIds()[0]));
+				userIds[0], standardSiteIds[0], standardRoleIds[0]));
 	}
 
 	@Test
-	public void testIsRoleRequiredReturnTrueInCheckException()
-		throws Exception {
-
-		addUsers();
-		addStandardSites();
-		addRequiredRoles();
+	public void testIsRoleRequired() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
+		long[] requiredRoleIds = addRequiredRoles();
 
 		Assert.assertTrue(
 			SiteMembershipPolicyUtil.isRoleRequired(
-				getUserIds()[0], getRequiredSiteIds()[0],
-				getRequiredRoleIds()[0]));
+				userIds[0], standardSiteIds[0], requiredRoleIds[0]));
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyBaseImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyBaseImplTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.membershippolicy;
+
+import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.util.GroupTestUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Roberto Díaz
+ */
+public class SiteMembershipPolicyBaseImplTest
+	extends BaseSiteMembershipPolicyTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		FinderCacheUtil.clearCache();
+
+		setGroup(GroupTestUtil.addGroup());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupLocalServiceUtil.deleteGroup(getGroup());
+	}
+
+	@Test
+	public void testIsMembershipAllowedReturnFalseInCheckException()
+		throws Exception {
+
+		addUsers();
+		addForbiddenSites();
+
+		Assert.assertFalse(
+			SiteMembershipPolicyUtil.isMembershipAllowed(
+				getUserIds()[0], getForbiddenSiteIds()[0]));
+	}
+
+	@Test
+	public void testIsMembershipAllowedReturnTrueInCheckPass()
+		throws Exception {
+
+		addUsers();
+		addStandardSites();
+
+		Assert.assertTrue(
+			SiteMembershipPolicyUtil.isMembershipAllowed(
+				getUserIds()[0], getStandardSiteIds()[0]));
+	}
+
+	@Test
+	public void testIsMembershipRequiredReturnFalseInCheckPass()
+		throws Exception {
+
+		addUsers();
+		addStandardSites();
+
+		Assert.assertFalse(
+			SiteMembershipPolicyUtil.isMembershipRequired(
+				getUserIds()[0], getStandardSiteIds()[0]));
+	}
+
+	@Test
+	public void testIsMembershipRequiredReturnTrueInCheckException()
+		throws Exception {
+
+		addUsers();
+		addRequiredSites();
+
+		Assert.assertTrue(
+			SiteMembershipPolicyUtil.isMembershipRequired(
+				getUserIds()[0], getRequiredSiteIds()[0]));
+	}
+
+	@Test
+	public void testIsRoleAllowedReturnFalseInCheckException()
+		throws Exception {
+
+		addUsers();
+		addStandardSites();
+		addForbiddenRoles();
+
+		Assert.assertFalse(
+			SiteMembershipPolicyUtil.isRoleAllowed(
+				getUserIds()[0], getForbiddenSiteIds()[0],
+				getForbiddenRoleIds()[0]));
+	}
+
+	@Test
+	public void testIsRoleAllowedReturnTrueInCheckPass() throws Exception {
+		addUsers();
+		addStandardSites();
+		addStandardRoles();
+
+		Assert.assertTrue(
+			SiteMembershipPolicyUtil.isRoleAllowed(
+				getUserIds()[0], getStandardSiteIds()[0],
+				getStandardRoleIds()[0]));
+	}
+
+	@Test
+	public void testIsRoleRequiredReturnFalseInCheckPass() throws Exception {
+		addUsers();
+		addStandardSites();
+		addStandardRoles();
+
+		Assert.assertFalse(
+			SiteMembershipPolicyUtil.isRoleRequired(
+				getUserIds()[0], getStandardSiteIds()[0],
+				getStandardRoleIds()[0]));
+	}
+
+	@Test
+	public void testIsRoleRequiredReturnTrueInCheckException()
+		throws Exception {
+
+		addUsers();
+		addStandardSites();
+		addRequiredRoles();
+
+		Assert.assertTrue(
+			SiteMembershipPolicyUtil.isRoleRequired(
+				getUserIds()[0], getRequiredSiteIds()[0],
+				getRequiredRoleIds()[0]));
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyMembershipsTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyMembershipsTest.java
@@ -20,12 +20,12 @@ import com.liferay.portal.model.User;
 import com.liferay.portal.model.UserGroupRole;
 import com.liferay.portal.security.membershippolicy.util.MembershipPolicyTestUtil;
 import com.liferay.portal.service.GroupServiceUtil;
-import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
 import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.service.UserServiceUtil;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,375 +36,245 @@ import org.junit.Test;
 public class SiteMembershipPolicyMembershipsTest
 	extends BaseSiteMembershipPolicyTestCase {
 
-	@Test
-	public void testCountGroupUsersWhenAddForbiddenSitesToUser()
-		throws Exception {
-
-		addUsers();
-		addForbiddenSites();
-
-		int expectedUsersInFirstForbiddenGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[0]);
-
-		int expectedUsersInSecondForbiddenGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[1]);
-
-		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
-
-		try {
-			MembershipPolicyTestUtil.updateUser(
-				user, null, null, getForbiddenSiteIds(), null,
-				Collections.<UserGroupRole>emptyList());
-		}
-		catch (Exception e) {
-			if (!(e instanceof MembershipPolicyException)) {
-				Assert.fail("Exception Throwing :" + e.getClass().getName());
-			}
-		}
-
-		int currentUsersInFirstForbiddenGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[0]);
-
-		int currentUsersInSecondForbiddenGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[1]);
-
-		Assert.assertEquals(
-			expectedUsersInFirstForbiddenGroupCount,
-			currentUsersInFirstForbiddenGroupCount);
-
-		Assert.assertEquals(
-			expectedUsersInSecondForbiddenGroupCount,
-			currentUsersInSecondForbiddenGroupCount);
-	}
-
-	@Test
-	public void testCountGroupUsersWhenAddRequiredSitesToUser()
-		throws Exception {
-
-		addUsers();
-		addRequiredSites();
-
-		int expectedUsersInFirstRequiredGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(
-				getRequiredSiteIds()[0]) + addedUsers(1);
-
-		int expectedUsersInSecondRequiredGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(
-				getRequiredSiteIds()[1]) + addedUsers(1);
-
-		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, getRequiredSiteIds(), null,
-			Collections.<UserGroupRole>emptyList());
-
-		int currentUsersInFirstRequiredGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[0]);
-
-		int currentUsersInSecondRequiredGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[1]);
-
-		Assert.assertEquals(
-			expectedUsersInFirstRequiredGroupCount,
-			currentUsersInFirstRequiredGroupCount);
-
-		Assert.assertEquals(
-			expectedUsersInSecondRequiredGroupCount,
-			currentUsersInSecondRequiredGroupCount);
-	}
-
-	@Test
-	public void testCountGroupUsersWhenAddUsersToRequiredSite()
-		throws Exception {
-
-		addUsers();
-		addRequiredSites();
-
-		int expectedUserGroupCountInRequiredSite =
-			UserLocalServiceUtil.getGroupUsersCount(
-				getRequiredSiteIds()[0]) + addedUsers(2);
-
-		try {
-			UserServiceUtil.addGroupUsers(
-				getRequiredSiteIds()[0], getUserIds(), _getServiceContext());
-		}
-		catch (Exception e) {
-			if (e instanceof MembershipPolicyException) {
-				Assert.fail("MembershipPolicyException was throw");
-			}
-			else {
-				Assert.fail(
-					"Unexpected Exception throw: " + e.getClass().getName());
-			}
-		}
-
-		int currentUserGroupCountInRequiredSite =
-			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[0]);
-
-		Assert.assertEquals(
-			expectedUserGroupCountInRequiredSite,
-			currentUserGroupCountInRequiredSite);
-		Assert.assertTrue(getPropagateMembershipMethodFlag());
-	}
-
-	@Test
-	public void testCountGroupUsersWhenAddUserToRequiredSite()
-		throws Exception {
-
-		addUsers();
-		addRequiredSites();
-
-		int expectedGroupUsersInRequiredSite =
-			UserLocalServiceUtil.getGroupUsersCount(
-				getRequiredSiteIds()[0]) + addedUsers(1);
-
-		UserServiceUtil.addGroupUsers(
-			getRequiredSiteIds()[0], new long[]{getUserIds()[0]},
-			_getServiceContext());
-
-		int currentGroupUsersInRequiredSite =
-			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[0]);
-
-		Assert.assertEquals(
-			expectedGroupUsersInRequiredSite, currentGroupUsersInRequiredSite);
-		Assert.assertTrue(getPropagateMembershipMethodFlag());
-	}
-
 	@Test(expected = MembershipPolicyException.class)
-	public void testExceptionThrowWhenAddForbiddenSitesToUser()
-		throws Exception {
-
-		addUsers();
-		addForbiddenSites();
-
-		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, getForbiddenSiteIds(), null,
-			Collections.<UserGroupRole>emptyList());
+	public void testAddUserToForbiddenSites() throws Exception {
+		MembershipPolicyTestUtil.addUser(null, null, addForbiddenSites(), null);
 	}
 
-	@Test(expected = MembershipPolicyException.class)
-	public void testExceptionThrowWhenAddForbiddenSiteToUser()
-		throws Exception {
+	public void testAddUserToRequiredSites() throws Exception {
+		long[] requiredSiteIds = addRequiredSites();
 
-		addUsers();
-		addForbiddenSites();
-
-		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, getForbiddenSiteIds(), null,
-			Collections.<UserGroupRole>emptyList());
-	}
-
-	@Test(expected = MembershipPolicyException.class)
-	public void testExceptionThrowWhenAddUsersToForbiddenSite()
-		throws Exception {
-
-		addUsers();
-		addForbiddenSites();
-
-		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
-
-		UserServiceUtil.addGroupUsers(
-			getForbiddenSiteIds()[0], getUserIds(), serviceContext);
-	}
-
-	@Test(expected = MembershipPolicyException.class)
-	public void testExceptionThrowWhenAddUserToForbiddenSite()
-		throws Exception {
-
-		addUsers();
-		addForbiddenSites();
-
-		UserServiceUtil.addGroupUsers(
-			getForbiddenSiteIds()[0], new long[]{getUserIds()[0]},
-			_getServiceContext());
-	}
-
-	@Test(expected = MembershipPolicyException.class)
-	public void testExceptionThrowWhenCreatingUserWithForbiddenSites()
-		throws Exception {
-
-		addForbiddenSites();
+		int initialUserGroupCount = UserLocalServiceUtil.getGroupUsersCount(
+			requiredSiteIds[0]);
 
 		MembershipPolicyTestUtil.addUser(
-			null, null, getForbiddenSiteIds(), null);
+			null, null, new long[] {requiredSiteIds[0]}, null);
+
+		Assert.assertEquals(
+			initialUserGroupCount + 1,
+			UserLocalServiceUtil.getGroupUsersCount(requiredSiteIds[0]));
 	}
 
 	@Test(expected = MembershipPolicyException.class)
-	public void testExceptionThrowWhenRemoveUsersFromRequiredSite()
+	public void testAssignUsersToForbiddenSite() throws Exception {
+		long[] forbiddenSiteIds = addForbiddenSites();
+
+		UserServiceUtil.addGroupUsers(
+			forbiddenSiteIds[0], addUsers(),
+			ServiceTestUtil.getServiceContext());
+	}
+
+	@Test
+	public void testAssignUsersToRequiredSite() throws Exception {
+		long[] requiredSiteIds = addRequiredSites();
+
+		int initialUserGroupCountInRequiredSite =
+			UserLocalServiceUtil.getGroupUsersCount(requiredSiteIds[0]);
+
+		UserServiceUtil.addGroupUsers(
+			requiredSiteIds[0], addUsers(),
+			ServiceTestUtil.getServiceContext());
+
+		Assert.assertEquals(
+			initialUserGroupCountInRequiredSite + 2,
+			UserLocalServiceUtil.getGroupUsersCount(requiredSiteIds[0]));
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testAssignUserToForbiddenSites() throws Exception {
+		long[] userIds = addUsers();
+
+		User user = UserLocalServiceUtil.getUser(userIds[0]);
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, addForbiddenSites(), null,
+			Collections.<UserGroupRole>emptyList());
+	}
+
+	@Test
+	public void testAssignUserToRequiredSites() throws Exception {
+		long[] userIds = addUsers();
+		long[] requiredSiteIds = addRequiredSites();
+
+		int initialUserGroupCount = UserLocalServiceUtil.getGroupUsersCount(
+			requiredSiteIds[0]);
+
+		User user = UserLocalServiceUtil.getUser(userIds[0]);
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, new long[]{requiredSiteIds[0]}, null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertEquals(
+			initialUserGroupCount + 1,
+			UserLocalServiceUtil.getGroupUsersCount(requiredSiteIds[0]));
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testPropagateWhenAddingUserToRequiredSites() throws Exception {
+		MembershipPolicyTestUtil.addUser(null, null, addRequiredSites(), null);
+
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testPropagateWhenAssigningUsersToRequiredSite()
 		throws Exception {
 
-		addRequiredSites();
+		long[] requiredSiteIds = addRequiredSites();
+
+		UserServiceUtil.addGroupUsers(
+			requiredSiteIds[0], addUsers(),
+			ServiceTestUtil.getServiceContext());
+
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testPropagateWhenAssigningUserToRequiredSites()
+		throws Exception {
+
+		long[] userIds = addUsers();
+
+		User user = UserLocalServiceUtil.getUser(userIds[0]);
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, addRequiredSites(), null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testUnassignUserFromRequiredSites() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
+		long[] requiredSiteIds = addRequiredSites();
+
+		User user = UserLocalServiceUtil.getUser(userIds[0]);
+
+		// Users always have the personal site
+
+		List<Group> groups =  user.getGroups();
+
+		Assert.assertEquals(1, groups.size());
+
+		long[] userGroupIds = ArrayUtil.append(
+			standardSiteIds, requiredSiteIds, new long[] {user.getGroupId()});
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, userGroupIds, null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertEquals(userGroupIds.length, user.getGroups().size());
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, requiredSiteIds, null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertEquals(requiredSiteIds.length, user.getGroups().size());
+	}
+
+	@Test
+	public void testUnassignUserFromSites() throws Exception {
+		long[] userIds = addUsers();
+		long[] standardSiteIds = addStandardSites();
+		long[] requiredSiteIds = addRequiredSites();
+
+		User user = UserLocalServiceUtil.getUser(userIds[0]);
+
+		// Users always have the personal site
+
+		List<Group> groups =  user.getGroups();
+
+		Assert.assertEquals(1, groups.size());
+
+		long[] userGroupIds = ArrayUtil.append(
+			standardSiteIds, requiredSiteIds, new long[] {user.getGroupId()});
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, userGroupIds, null,
+			Collections.<UserGroupRole>emptyList());
+
+		groups =  user.getGroups();
+
+		Assert.assertEquals(userGroupIds.length, groups.size());
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, standardSiteIds, null,
+			Collections.<UserGroupRole>emptyList());
+
+		// We have removed the user from her personal site but the required
+		// sites are kept
+
+		groups =  user.getGroups();
+
+		Assert.assertEquals(userGroupIds.length - 1, groups.size());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testUnassignUsersFromRequiredSite() throws Exception {
+		long[] requiredSiteIds = addRequiredSites();
 
 		User user = MembershipPolicyTestUtil.addUser(
-			null, null, getRequiredSiteIds(), null);
+			null, null, requiredSiteIds, null);
 
 		UserServiceUtil.unsetGroupUsers(
-			getRequiredSiteIds()[0], new long[]{user.getUserId()},
-			_getServiceContext());
+			requiredSiteIds[0], new long[]{user.getUserId()},
+			ServiceTestUtil.getServiceContext());
 	}
 
 	@Test
-	public void testLaunchPropagationWhenAddUsersToRequiredSite()
-		throws Exception {
+	public void testUnassignUsersFromSite() throws Exception {
+		long[] standardSiteIds = addStandardSites();
 
-		addUsers();
-		addRequiredSites();
+		User user = MembershipPolicyTestUtil.addUser(
+			null, null, standardSiteIds, null);
 
-		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
+		int initialUserGroupCount = UserLocalServiceUtil.getGroupUsersCount(
+			standardSiteIds[0]);
 
-		UserServiceUtil.addGroupUsers(
-			getRequiredSiteIds()[0], getUserIds(), serviceContext);
+		UserServiceUtil.unsetGroupUsers(
+			standardSiteIds[0], new long[]{user.getUserId()},
+			ServiceTestUtil.getServiceContext());
 
+		Assert.assertEquals(
+			initialUserGroupCount - 1,
+			UserLocalServiceUtil.getGroupUsersCount(standardSiteIds[0]));
 		Assert.assertTrue(getPropagateMembershipMethodFlag());
 	}
 
 	@Test
-	public void testLaunchPropagationWhenCreateUserWithRequiredSites()
-		throws Exception {
-
-		addRequiredSites();
-
-		MembershipPolicyTestUtil.addUser(
-			null, null, getRequiredSiteIds(), null);
-
-		Assert.assertTrue(getPropagateMembershipMethodFlag());
-	}
-
-	@Test
-	public void testLaunchVerificationWhenAddGroup() throws Exception {
+	public void testVerifyWhenAddingGroup() throws Exception {
 		MembershipPolicyTestUtil.addGroup();
 
 		Assert.assertTrue(getVerifyMethodFlag());
 	}
 
 	@Test
-	public void testSuccessfulUnsetGroupUsersWhenRemoveUserFromStandardSite()
-		throws Exception {
-
-		addStandardSites();
-
-		User user = MembershipPolicyTestUtil.addUser(
-			null, null, getStandardSiteIds(), null);
-
-		int expectedUserGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(
-				getStandardSiteIds()[0]) - 1;
-
-		UserServiceUtil.unsetGroupUsers(
-			getStandardSiteIds()[0], new long[]{user.getUserId()},
-			_getServiceContext());
-
-		int currentUserGroupCount = UserLocalServiceUtil.getGroupUsersCount(
-			getStandardSiteIds()[0]);
-
-		Assert.assertEquals(expectedUserGroupCount, currentUserGroupCount);
-		Assert.assertTrue(getPropagateMembershipMethodFlag());
-	}
-
-	@Test
-	public void testUpdateGroupLaunchVerification() throws Exception {
+	public void testVerifyWhenUpdatingGroup() throws Exception {
 		Group group = MembershipPolicyTestUtil.addGroup();
 
 		GroupServiceUtil.updateGroup(
-			group.getGroupId(), group.getParentGroupId(), "TestSiteNewName",
-			group.getDescription(), group.getType(), group.getFriendlyURL(),
-			group.isActive(), _getServiceContext());
+			group.getGroupId(), group.getParentGroupId(),
+			ServiceTestUtil.randomString(), group.getDescription(),
+			group.getType(), group.getFriendlyURL(), group.isActive(),
+			ServiceTestUtil.getServiceContext());
 
 		Assert.assertTrue(getVerifyMethodFlag());
 	}
 
 	@Test
-	public void testUpdateGroupTypeSettingsLaunchVerification()
-		throws Exception {
-
+	public void testVerifyWhenUpdatingGroupTypeSettings() throws Exception {
 		Group group = MembershipPolicyTestUtil.addGroup();
 
 		String typeSettings = ServiceTestUtil.randomString(50);
+
 		GroupServiceUtil.updateGroup(group.getGroupId(), typeSettings);
 
 		Assert.assertTrue(getVerifyMethodFlag());
-	}
-
-	@Test
-	public void testUserGrouCountWhenUpdateSitesFromUser() throws Exception {
-		addUsers();
-		addStandardSites();
-		addRequiredSites();
-
-		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
-
-		Assert.assertEquals(currentGroups(1), user.getGroups().size());
-
-		long[] userGroupIds = ArrayUtil.append(
-			getStandardSiteIds(), getRequiredSiteIds(), user.getGroupIds());
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, userGroupIds, null,
-			Collections.<UserGroupRole>emptyList());
-
-		Assert.assertEquals(currentGroups(5), user.getGroups().size());
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, getRequiredSiteIds(), null,
-			Collections.<UserGroupRole>emptyList());
-
-		Assert.assertEquals(currentGroups(2), user.getGroups().size());
-	}
-
-	@Test
-	public void testUserGroupCountWhenAddRequiredSiteOnUserUpdate()
-		throws Exception {
-
-		addUsers();
-		addRequiredSites();
-
-		int expectedUserGroupCount =
-			UserLocalServiceUtil.getGroupUsersCount(
-				getRequiredSiteIds()[0]) + addedUsers(1);
-
-		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, new long[] {getRequiredSiteIds()[0]}, null,
-			Collections.<UserGroupRole>emptyList());
-
-		int currentUserGroupCount = UserLocalServiceUtil.getGroupUsersCount(
-			getRequiredSiteIds()[0]);
-
-		Assert.assertEquals(expectedUserGroupCount, currentUserGroupCount);
-		Assert.assertTrue(getPropagateMembershipMethodFlag());
-	}
-
-	@Test
-	public void testUserGroupCountWhenWhenDeleteRequiredSitesInUserUpdate()
-		throws Exception {
-
-		addUsers();
-		addStandardSites();
-		addRequiredSites();
-
-		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
-
-		Assert.assertEquals(currentGroups(1), user.getGroups().size());
-
-		long[] userGroupIds = ArrayUtil.append(
-			getStandardSiteIds(), getRequiredSiteIds(), user.getGroupIds());
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, userGroupIds, null,
-			Collections.<UserGroupRole>emptyList());
-
-		Assert.assertEquals(currentGroups(5), user.getGroups().size());
-
-		MembershipPolicyTestUtil.updateUser(
-			user, null, null, getStandardSiteIds(), null,
-			Collections.<UserGroupRole>emptyList());
-
-		Assert.assertEquals(currentGroups(4), user.getGroups().size());
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyMembershipsTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyMembershipsTest.java
@@ -1,0 +1,410 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.membershippolicy;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.User;
+import com.liferay.portal.model.UserGroupRole;
+import com.liferay.portal.security.membershippolicy.util.MembershipPolicyTestUtil;
+import com.liferay.portal.service.GroupServiceUtil;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.service.UserLocalServiceUtil;
+import com.liferay.portal.service.UserServiceUtil;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Roberto Díaz
+ */
+public class SiteMembershipPolicyMembershipsTest
+	extends BaseSiteMembershipPolicyTestCase {
+
+	@Test
+	public void testCountGroupUsersWhenAddForbiddenSitesToUser()
+		throws Exception {
+
+		addUsers();
+		addForbiddenSites();
+
+		int expectedUsersInFirstForbiddenGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[0]);
+
+		int expectedUsersInSecondForbiddenGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[1]);
+
+		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
+
+		try {
+			MembershipPolicyTestUtil.updateUser(
+				user, null, null, getForbiddenSiteIds(), null,
+				Collections.<UserGroupRole>emptyList());
+		}
+		catch (Exception e) {
+			if (!(e instanceof MembershipPolicyException)) {
+				Assert.fail("Exception Throwing :" + e.getClass().getName());
+			}
+		}
+
+		int currentUsersInFirstForbiddenGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[0]);
+
+		int currentUsersInSecondForbiddenGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(getForbiddenSiteIds()[1]);
+
+		Assert.assertEquals(
+			expectedUsersInFirstForbiddenGroupCount,
+			currentUsersInFirstForbiddenGroupCount);
+
+		Assert.assertEquals(
+			expectedUsersInSecondForbiddenGroupCount,
+			currentUsersInSecondForbiddenGroupCount);
+	}
+
+	@Test
+	public void testCountGroupUsersWhenAddRequiredSitesToUser()
+		throws Exception {
+
+		addUsers();
+		addRequiredSites();
+
+		int expectedUsersInFirstRequiredGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(
+				getRequiredSiteIds()[0]) + addedUsers(1);
+
+		int expectedUsersInSecondRequiredGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(
+				getRequiredSiteIds()[1]) + addedUsers(1);
+
+		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, getRequiredSiteIds(), null,
+			Collections.<UserGroupRole>emptyList());
+
+		int currentUsersInFirstRequiredGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[0]);
+
+		int currentUsersInSecondRequiredGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[1]);
+
+		Assert.assertEquals(
+			expectedUsersInFirstRequiredGroupCount,
+			currentUsersInFirstRequiredGroupCount);
+
+		Assert.assertEquals(
+			expectedUsersInSecondRequiredGroupCount,
+			currentUsersInSecondRequiredGroupCount);
+	}
+
+	@Test
+	public void testCountGroupUsersWhenAddUsersToRequiredSite()
+		throws Exception {
+
+		addUsers();
+		addRequiredSites();
+
+		int expectedUserGroupCountInRequiredSite =
+			UserLocalServiceUtil.getGroupUsersCount(
+				getRequiredSiteIds()[0]) + addedUsers(2);
+
+		try {
+			UserServiceUtil.addGroupUsers(
+				getRequiredSiteIds()[0], getUserIds(), _getServiceContext());
+		}
+		catch (Exception e) {
+			if (e instanceof MembershipPolicyException) {
+				Assert.fail("MembershipPolicyException was throw");
+			}
+			else {
+				Assert.fail(
+					"Unexpected Exception throw: " + e.getClass().getName());
+			}
+		}
+
+		int currentUserGroupCountInRequiredSite =
+			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[0]);
+
+		Assert.assertEquals(
+			expectedUserGroupCountInRequiredSite,
+			currentUserGroupCountInRequiredSite);
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testCountGroupUsersWhenAddUserToRequiredSite()
+		throws Exception {
+
+		addUsers();
+		addRequiredSites();
+
+		int expectedGroupUsersInRequiredSite =
+			UserLocalServiceUtil.getGroupUsersCount(
+				getRequiredSiteIds()[0]) + addedUsers(1);
+
+		UserServiceUtil.addGroupUsers(
+			getRequiredSiteIds()[0], new long[]{getUserIds()[0]},
+			_getServiceContext());
+
+		int currentGroupUsersInRequiredSite =
+			UserLocalServiceUtil.getGroupUsersCount(getRequiredSiteIds()[0]);
+
+		Assert.assertEquals(
+			expectedGroupUsersInRequiredSite, currentGroupUsersInRequiredSite);
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowWhenAddForbiddenSitesToUser()
+		throws Exception {
+
+		addUsers();
+		addForbiddenSites();
+
+		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, getForbiddenSiteIds(), null,
+			Collections.<UserGroupRole>emptyList());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowWhenAddForbiddenSiteToUser()
+		throws Exception {
+
+		addUsers();
+		addForbiddenSites();
+
+		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, getForbiddenSiteIds(), null,
+			Collections.<UserGroupRole>emptyList());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowWhenAddUsersToForbiddenSite()
+		throws Exception {
+
+		addUsers();
+		addForbiddenSites();
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
+
+		UserServiceUtil.addGroupUsers(
+			getForbiddenSiteIds()[0], getUserIds(), serviceContext);
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowWhenAddUserToForbiddenSite()
+		throws Exception {
+
+		addUsers();
+		addForbiddenSites();
+
+		UserServiceUtil.addGroupUsers(
+			getForbiddenSiteIds()[0], new long[]{getUserIds()[0]},
+			_getServiceContext());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowWhenCreatingUserWithForbiddenSites()
+		throws Exception {
+
+		addForbiddenSites();
+
+		MembershipPolicyTestUtil.addUser(
+			null, null, getForbiddenSiteIds(), null);
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowWhenRemoveUsersFromRequiredSite()
+		throws Exception {
+
+		addRequiredSites();
+
+		User user = MembershipPolicyTestUtil.addUser(
+			null, null, getRequiredSiteIds(), null);
+
+		UserServiceUtil.unsetGroupUsers(
+			getRequiredSiteIds()[0], new long[]{user.getUserId()},
+			_getServiceContext());
+	}
+
+	@Test
+	public void testLaunchPropagationWhenAddUsersToRequiredSite()
+		throws Exception {
+
+		addUsers();
+		addRequiredSites();
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
+
+		UserServiceUtil.addGroupUsers(
+			getRequiredSiteIds()[0], getUserIds(), serviceContext);
+
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testLaunchPropagationWhenCreateUserWithRequiredSites()
+		throws Exception {
+
+		addRequiredSites();
+
+		MembershipPolicyTestUtil.addUser(
+			null, null, getRequiredSiteIds(), null);
+
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testLaunchVerificationWhenAddGroup() throws Exception {
+		MembershipPolicyTestUtil.addGroup();
+
+		Assert.assertTrue(getVerifyMethodFlag());
+	}
+
+	@Test
+	public void testSuccessfulUnsetGroupUsersWhenRemoveUserFromStandardSite()
+		throws Exception {
+
+		addStandardSites();
+
+		User user = MembershipPolicyTestUtil.addUser(
+			null, null, getStandardSiteIds(), null);
+
+		int expectedUserGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(
+				getStandardSiteIds()[0]) - 1;
+
+		UserServiceUtil.unsetGroupUsers(
+			getStandardSiteIds()[0], new long[]{user.getUserId()},
+			_getServiceContext());
+
+		int currentUserGroupCount = UserLocalServiceUtil.getGroupUsersCount(
+			getStandardSiteIds()[0]);
+
+		Assert.assertEquals(expectedUserGroupCount, currentUserGroupCount);
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testUpdateGroupLaunchVerification() throws Exception {
+		Group group = MembershipPolicyTestUtil.addGroup();
+
+		GroupServiceUtil.updateGroup(
+			group.getGroupId(), group.getParentGroupId(), "TestSiteNewName",
+			group.getDescription(), group.getType(), group.getFriendlyURL(),
+			group.isActive(), _getServiceContext());
+
+		Assert.assertTrue(getVerifyMethodFlag());
+	}
+
+	@Test
+	public void testUpdateGroupTypeSettingsLaunchVerification()
+		throws Exception {
+
+		Group group = MembershipPolicyTestUtil.addGroup();
+
+		String typeSettings = ServiceTestUtil.randomString(50);
+		GroupServiceUtil.updateGroup(group.getGroupId(), typeSettings);
+
+		Assert.assertTrue(getVerifyMethodFlag());
+	}
+
+	@Test
+	public void testUserGrouCountWhenUpdateSitesFromUser() throws Exception {
+		addUsers();
+		addStandardSites();
+		addRequiredSites();
+
+		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
+
+		Assert.assertEquals(currentGroups(1), user.getGroups().size());
+
+		long[] userGroupIds = ArrayUtil.append(
+			getStandardSiteIds(), getRequiredSiteIds(), user.getGroupIds());
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, userGroupIds, null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertEquals(currentGroups(5), user.getGroups().size());
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, getRequiredSiteIds(), null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertEquals(currentGroups(2), user.getGroups().size());
+	}
+
+	@Test
+	public void testUserGroupCountWhenAddRequiredSiteOnUserUpdate()
+		throws Exception {
+
+		addUsers();
+		addRequiredSites();
+
+		int expectedUserGroupCount =
+			UserLocalServiceUtil.getGroupUsersCount(
+				getRequiredSiteIds()[0]) + addedUsers(1);
+
+		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, new long[] {getRequiredSiteIds()[0]}, null,
+			Collections.<UserGroupRole>emptyList());
+
+		int currentUserGroupCount = UserLocalServiceUtil.getGroupUsersCount(
+			getRequiredSiteIds()[0]);
+
+		Assert.assertEquals(expectedUserGroupCount, currentUserGroupCount);
+		Assert.assertTrue(getPropagateMembershipMethodFlag());
+	}
+
+	@Test
+	public void testUserGroupCountWhenWhenDeleteRequiredSitesInUserUpdate()
+		throws Exception {
+
+		addUsers();
+		addStandardSites();
+		addRequiredSites();
+
+		User user = UserLocalServiceUtil.getUser(getUserIds()[0]);
+
+		Assert.assertEquals(currentGroups(1), user.getGroups().size());
+
+		long[] userGroupIds = ArrayUtil.append(
+			getStandardSiteIds(), getRequiredSiteIds(), user.getGroupIds());
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, userGroupIds, null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertEquals(currentGroups(5), user.getGroups().size());
+
+		MembershipPolicyTestUtil.updateUser(
+			user, null, null, getStandardSiteIds(), null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertEquals(currentGroups(4), user.getGroups().size());
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyRolesTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/SiteMembershipPolicyRolesTest.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.membershippolicy;
+
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.User;
+import com.liferay.portal.model.UserGroupRole;
+import com.liferay.portal.security.membershippolicy.util.MembershipPolicyTestUtil;
+import com.liferay.portal.service.UserGroupRoleLocalServiceUtil;
+import com.liferay.portal.service.UserGroupRoleServiceUtil;
+import com.liferay.portal.service.persistence.UserGroupRolePK;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Roberto Díaz
+ */
+public class SiteMembershipPolicyRolesTest
+	extends BaseSiteMembershipPolicyTestCase {
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowingWhenAddUsersToForbiddenSiteRole()
+		throws Exception {
+
+		addUsers();
+		addForbiddenRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.addUserGroupRoles(
+			getUserIds(), group.getGroupId(), getForbiddenRoleIds()[0]);
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowingWhenAddUserToForbiddenSiteRoles()
+		throws Exception {
+
+		addUsers();
+		addForbiddenRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.addUserGroupRoles(
+			getUserIds()[0], group.getGroupId(), getForbiddenRoleIds());
+
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowingWhenDeleteUserFromRequiredSiteRoles()
+		throws Exception {
+
+		addUsers();
+		addRequiredRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.deleteUserGroupRoles(
+			getUserIds()[0], group.getGroupId(), getRequiredRoleIds());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowingWhenDeleteUsersFromRequiredSiteRole()
+		throws Exception {
+
+		addUsers();
+		addRequiredRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.deleteUserGroupRoles(
+			getUserIds(), group.getGroupId(), getRequiredRoleIds()[0]);
+	}
+
+	@Test
+	public void testExceptionThrowWhenDeleteUsersFromStandardSiteRole()
+		throws Exception {
+
+		addUsers();
+		addStandardRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.deleteUserGroupRoles(
+			getUserIds(), group.getGroupId(), getStandardRoleIds()[0]);
+
+		Assert.assertTrue(getPropagateRolesMethodFlag());
+	}
+
+	@Test(expected = MembershipPolicyException.class)
+	public void testExceptionThrowWhenSetForbiddenSiteRoleToUser()
+		throws Exception {
+
+		addUsers();
+		addForbiddenRoles();
+
+		Group group = getGroup();
+
+		UserGroupRolePK userGroupRolePK = new UserGroupRolePK(
+			getUserIds()[0], group.getGroupId(), getForbiddenRoleIds()[0]);
+
+		List<UserGroupRole> userGroupRoleList = new ArrayList<UserGroupRole>();
+
+		UserGroupRole userGroupRole =
+			UserGroupRoleLocalServiceUtil.createUserGroupRole(userGroupRolePK);
+
+		userGroupRoleList.add(userGroupRole);
+
+		MembershipPolicyTestUtil.updateUser(
+			getUser(), null, null, null, null, userGroupRoleList);
+	}
+
+	@Test
+	public void testPropagationLaunchWhenAddUsersToStandardSiteRole()
+		throws Exception {
+
+		addUsers();
+		addStandardRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.addUserGroupRoles(
+			getUserIds(), group.getGroupId(), getStandardRoleIds()[0]);
+
+		Assert.assertTrue(getPropagateRolesMethodFlag());
+	}
+
+	@Test
+	public void testPropagationLaunchWhenAddUserToStandardSiteRoles()
+		throws Exception {
+
+		addUsers();
+		addStandardRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.addUserGroupRoles(
+			getUserIds()[0], group.getGroupId(), getStandardRoleIds());
+
+		Assert.assertTrue(getPropagateRolesMethodFlag());
+	}
+
+	@Test
+	public void testPropagationLaunchWhenDeletingUserFromStandardSiteRoles()
+		throws Exception {
+
+		addUsers();
+		addStandardRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.deleteUserGroupRoles(
+			getUserIds()[0], group.getGroupId(), getStandardRoleIds());
+
+		Assert.assertTrue(getPropagateRolesMethodFlag());
+	}
+
+	@Test
+	public void testPropagationLaunchWhenSetStandardSiteRoleToUser()
+		throws Exception {
+
+		addUsers();
+		addStandardRoles();
+
+		Group group = getGroup();
+
+		UserGroupRolePK userGroupRolePK = new UserGroupRolePK(
+			getUserIds()[0], group.getGroupId(), getStandardRoleIds()[0]);
+
+		List<UserGroupRole> userGroupRoleList = new ArrayList<UserGroupRole>();
+
+		UserGroupRole userGroupRole =
+			UserGroupRoleLocalServiceUtil.createUserGroupRole(userGroupRolePK);
+
+		userGroupRoleList.add(userGroupRole);
+
+		MembershipPolicyTestUtil.updateUser(
+			getUser(), null, null, null, null, userGroupRoleList);
+
+		Assert.assertTrue(getPropagateRolesMethodFlag());
+	}
+
+	@Test
+	public void testPropagationLaunchWhenUnsetStandardSiteRoleFromUser()
+		throws Exception {
+
+		addUsers();
+		addStandardRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.addUserGroupRoles(
+			getUser().getUserId(), group.getGroupId(), getStandardRoleIds());
+
+		MembershipPolicyTestUtil.updateUser(
+			getUser(), null, null, null, null,
+			Collections.<UserGroupRole>emptyList());
+
+		Assert.assertTrue(getPropagateRolesMethodFlag());
+	}
+
+	@Test
+	public void testUserRoleCountWhenUnsetRequiredSiteRoleFromUser()
+		throws Exception {
+
+		addUsers();
+		addRequiredRoles();
+
+		Group group = getGroup();
+
+		UserGroupRoleServiceUtil.addUserGroupRoles(
+			getUserIds()[0], group.getGroupId(), getRequiredRoleIds());
+
+		User user = getUser();
+
+		List<UserGroupRole> expectedUserGroupRoles =
+			UserGroupRoleLocalServiceUtil.getUserGroupRoles(user.getUserId());
+
+		int expectedUserGroupRolesCount = expectedUserGroupRoles.size();
+
+		List<UserGroupRole> emptyNonAbstractList =
+			new ArrayList<UserGroupRole>();
+
+		MembershipPolicyTestUtil.updateUser(
+			getUser(), null, null, null, null, emptyNonAbstractList);
+
+		List<UserGroupRole> currentUserGroupRoles =
+			UserGroupRoleLocalServiceUtil.getUserGroupRoles(user.getUserId());
+
+		int currentUserGroupRolesCount = currentUserGroupRoles.size();
+
+		Assert.assertEquals(expectedUserGroupRoles, currentUserGroupRoles);
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/membershippolicysamples/SiteMembershipPolicyTestImpl.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/membershippolicysamples/SiteMembershipPolicyTestImpl.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.membershippolicy.membershippolicysamples;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Role;
+import com.liferay.portal.model.UserGroupRole;
+import com.liferay.portal.security.membershippolicy.BaseSiteMembershipPolicy;
+import com.liferay.portal.security.membershippolicy.BaseSiteMembershipPolicyTestCase;
+import com.liferay.portal.security.membershippolicy.MembershipPolicyException;
+import com.liferay.portlet.asset.model.AssetCategory;
+import com.liferay.portlet.asset.model.AssetTag;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+
+/**
+ * @author Roberto Díaz
+ */
+public class SiteMembershipPolicyTestImpl extends BaseSiteMembershipPolicy {
+
+	public void checkMembership(
+			long[] userIds, long[] addGroupIds, long[] removeGroupIds)
+		throws PortalException, SystemException {
+
+		for (long forbiddenGroupId : getForbiddenGroupIds()) {
+			if (forbiddenGroupId == 0) {
+				continue;
+			}
+
+			if (ArrayUtil.contains(addGroupIds, forbiddenGroupId)) {
+				throw new MembershipPolicyException(
+					MembershipPolicyException.SITE_MEMBERSHIP_NOT_ALLOWED);
+			}
+		}
+
+		for (long requiredGroupId : getRequiredGroupIds()) {
+			if (requiredGroupId == 0) {
+				continue;
+			}
+
+			if (ArrayUtil.contains(removeGroupIds, requiredGroupId)) {
+				throw new MembershipPolicyException(
+					MembershipPolicyException.SITE_MEMBERSHIP_REQUIRED);
+			}
+		}
+	}
+
+	public void checkRoles(
+			List<UserGroupRole> addUserGroupRoles,
+			List<UserGroupRole> removeUserGroupRoles)
+		throws PortalException, SystemException {
+
+		long[] addUserGroupRoleIds = new long[2];
+		long[] removeUserGroupRoleIds = new long[2];
+
+		if ((addUserGroupRoles != null) && !addUserGroupRoles.isEmpty()) {
+			for (UserGroupRole addUserGroupRole : addUserGroupRoles) {
+				addUserGroupRoleIds[0] = addUserGroupRole.getRoleId();
+			}
+		}
+
+		if ((removeUserGroupRoles != null) && !removeUserGroupRoles.isEmpty()) {
+			for (UserGroupRole removeUserGroupRole : removeUserGroupRoles) {
+				removeUserGroupRoleIds[0] = removeUserGroupRole.getRoleId();
+			}
+		}
+
+		for (long forbiddenGroupRoleId : getForbiddenGroupRoleIds()) {
+			if (forbiddenGroupRoleId == 0) {
+				continue;
+			}
+
+			if (ArrayUtil.contains(addUserGroupRoleIds, forbiddenGroupRoleId)) {
+				throw new MembershipPolicyException(
+					MembershipPolicyException.ROLE_MEMBERSHIP_NOT_ALLOWED);
+			}
+		}
+
+		for (long requiredGroupRoleId : getRequiredGroupRoleIds()) {
+			if (requiredGroupRoleId == 0) {
+				continue;
+			}
+
+			if (ArrayUtil.contains(
+					removeUserGroupRoleIds, requiredGroupRoleId)) {
+
+				throw new MembershipPolicyException(
+					MembershipPolicyException.ROLE_MEMBERSHIP_REQUIRED);
+			}
+		}
+	}
+
+	public void propagateMembership(
+			long[] userIds, long[] addGroupIds, long[] removeGroupIds)
+		throws PortalException, SystemException {
+
+		BaseSiteMembershipPolicyTestCase.setPropagateMembershipMethodFlag(true);
+	}
+
+	public void propagateRoles(
+			List<UserGroupRole> addUserGroupRoles,
+			List<UserGroupRole> removeUserGroupRoles)
+		throws PortalException, SystemException {
+
+		BaseSiteMembershipPolicyTestCase.setPropagateRolesMethodFlag(true);
+	}
+
+	public void verifyPolicy() throws PortalException, SystemException {
+		BaseSiteMembershipPolicyTestCase.setVerifyMethodFlag(true);
+	}
+
+	@Override
+	public void verifyPolicy(Group group)
+		throws PortalException, SystemException {
+
+		verifyPolicy();
+	}
+
+	public void verifyPolicy(
+			Group group, Group oldGroup, List<AssetCategory> oldAssetCategories,
+			List<AssetTag> oldAssetTags,
+			Map<String, Serializable> oldExpandoAttributes,
+			String oldTypeSettings)
+		throws PortalException, SystemException {
+
+		Assert.assertNotNull(group);
+		Assert.assertNotNull(oldGroup);
+
+		if (oldTypeSettings == null) {
+			Assert.assertNotNull(oldAssetCategories);
+			Assert.assertNotNull(oldAssetTags);
+			Assert.assertNotNull(oldExpandoAttributes);
+		}
+		else {
+			Assert.assertNull(oldAssetCategories);
+			Assert.assertNull(oldAssetTags);
+			Assert.assertNull(oldExpandoAttributes);
+		}
+
+		verifyPolicy(group);
+	}
+
+	public void verifyPolicy(Role role)
+		throws PortalException, SystemException {
+
+		verifyPolicy();
+	}
+
+	public void verifyPolicy(
+			Role role, Role oldRole, Map<String,
+			Serializable> oldExpandoAttributes)
+		throws PortalException, SystemException {
+
+		Assert.assertNotNull(role);
+		Assert.assertNotNull(oldRole);
+		Assert.assertNotNull(oldExpandoAttributes);
+
+		verifyPolicy(role);
+	}
+
+	protected long[] getForbiddenGroupIds() {
+		return BaseSiteMembershipPolicyTestCase.getForbiddenSiteIds();
+	}
+
+	protected long[] getForbiddenGroupRoleIds() {
+		return BaseSiteMembershipPolicyTestCase.getForbiddenRoleIds();
+	}
+
+	protected long[] getRequiredGroupIds() {
+		return BaseSiteMembershipPolicyTestCase.getRequiredSiteIds();
+	}
+
+	protected long[] getRequiredGroupRoleIds() {
+		return BaseSiteMembershipPolicyTestCase.getRequiredRoleIds();
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/membershippolicysamples/SiteMembershipPolicyTestImpl.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/membershippolicysamples/SiteMembershipPolicyTestImpl.java
@@ -42,7 +42,9 @@ public class SiteMembershipPolicyTestImpl extends BaseSiteMembershipPolicy {
 			long[] userIds, long[] addGroupIds, long[] removeGroupIds)
 		throws PortalException, SystemException {
 
-		for (long forbiddenGroupId : getForbiddenGroupIds()) {
+		for (long forbiddenGroupId :
+				BaseSiteMembershipPolicyTestCase.getForbiddenSiteIds()) {
+
 			if (forbiddenGroupId == 0) {
 				continue;
 			}
@@ -53,7 +55,9 @@ public class SiteMembershipPolicyTestImpl extends BaseSiteMembershipPolicy {
 			}
 		}
 
-		for (long requiredGroupId : getRequiredGroupIds()) {
+		for (long requiredGroupId :
+				BaseSiteMembershipPolicyTestCase.getRequiredSiteIds()) {
+
 			if (requiredGroupId == 0) {
 				continue;
 			}
@@ -85,7 +89,9 @@ public class SiteMembershipPolicyTestImpl extends BaseSiteMembershipPolicy {
 			}
 		}
 
-		for (long forbiddenGroupRoleId : getForbiddenGroupRoleIds()) {
+		for (long forbiddenGroupRoleId :
+				BaseSiteMembershipPolicyTestCase.getForbiddenRoleIds()) {
+
 			if (forbiddenGroupRoleId == 0) {
 				continue;
 			}
@@ -96,7 +102,9 @@ public class SiteMembershipPolicyTestImpl extends BaseSiteMembershipPolicy {
 			}
 		}
 
-		for (long requiredGroupRoleId : getRequiredGroupRoleIds()) {
+		for (long requiredGroupRoleId :
+				BaseSiteMembershipPolicyTestCase.getRequiredRoleIds()) {
+
 			if (requiredGroupRoleId == 0) {
 				continue;
 			}
@@ -176,22 +184,6 @@ public class SiteMembershipPolicyTestImpl extends BaseSiteMembershipPolicy {
 		Assert.assertNotNull(oldExpandoAttributes);
 
 		verifyPolicy(role);
-	}
-
-	protected long[] getForbiddenGroupIds() {
-		return BaseSiteMembershipPolicyTestCase.getForbiddenSiteIds();
-	}
-
-	protected long[] getForbiddenGroupRoleIds() {
-		return BaseSiteMembershipPolicyTestCase.getForbiddenRoleIds();
-	}
-
-	protected long[] getRequiredGroupIds() {
-		return BaseSiteMembershipPolicyTestCase.getRequiredSiteIds();
-	}
-
-	protected long[] getRequiredGroupRoleIds() {
-		return BaseSiteMembershipPolicyTestCase.getRequiredRoleIds();
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/util/MembershipPolicyTestUtil.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/util/MembershipPolicyTestUtil.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.membershippolicy.util;
+
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Address;
+import com.liferay.portal.model.EmailAddress;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.GroupConstants;
+import com.liferay.portal.model.Phone;
+import com.liferay.portal.model.User;
+import com.liferay.portal.model.UserGroupRole;
+import com.liferay.portal.model.Website;
+import com.liferay.portal.service.GroupServiceUtil;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.service.UserServiceUtil;
+import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.announcements.model.AnnouncementsDelivery;
+import com.liferay.portlet.asset.model.AssetCategory;
+import com.liferay.portlet.asset.model.AssetTag;
+import com.liferay.portlet.asset.model.AssetVocabulary;
+import com.liferay.portlet.asset.service.AssetCategoryLocalServiceUtil;
+import com.liferay.portlet.asset.service.AssetTagLocalServiceUtil;
+import com.liferay.portlet.asset.service.AssetVocabularyLocalServiceUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Roberto Díaz
+ */
+public class MembershipPolicyTestUtil {
+
+	// All these methods are not using UserTestUtil.java or GroupTestUtil.java
+	// because we need to call the Remote Service in order to verify the
+	// Membership Policies
+
+	public static Group addGroup() throws Exception {
+		String name = ServiceTestUtil.randomString();
+		String friendlyURL =
+			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name);
+
+		return GroupServiceUtil.addGroup(
+			GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			GroupConstants.DEFAULT_LIVE_GROUP_ID, name, "This is a test group",
+			GroupConstants.TYPE_SITE_OPEN, friendlyURL, true, true,
+			populateServiceContext());
+	}
+
+	public static User addUser(
+			long[] organizationIds, long[] roleIds, long[] siteIds,
+			long[] userGroupIds)
+		throws Exception {
+
+		boolean autoPassword = true;
+		String password1 = StringPool.BLANK;
+		String password2 = StringPool.BLANK;
+		boolean autoScreenName = true;
+		String screenName = StringPool.BLANK;
+		String emailAddress =
+			"UserServiceTest." + ServiceTestUtil.nextLong() + "@liferay.com";
+		long facebookId = 0;
+		String openId = StringPool.BLANK;
+		Locale locale = LocaleUtil.getDefault();
+		String firstName = "UserServiceTest";
+		String middleName = StringPool.BLANK;
+		String lastName = "UserServiceTest";
+		int prefixId = 0;
+		int suffixId = 0;
+		boolean male = true;
+		int birthdayMonth = Calendar.JANUARY;
+		int birthdayDay = 1;
+		int birthdayYear = 1970;
+		String jobTitle = StringPool.BLANK;
+		boolean sendMail = false;
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		return UserServiceUtil.addUser(
+			TestPropsValues.getCompanyId(), autoPassword, password1, password2,
+			autoScreenName, screenName, emailAddress, facebookId, openId,
+			locale, firstName, middleName, lastName, prefixId, suffixId, male,
+			birthdayMonth, birthdayDay, birthdayYear, jobTitle, siteIds,
+			organizationIds, roleIds, userGroupIds, sendMail, serviceContext);
+	}
+
+	public static void updateUser(
+			User user, long[] organizationIds, long[] roleIds, long[] siteIds,
+			long[] userGroupIds, List<UserGroupRole> userGroupRoles)
+		throws Exception {
+
+		long userId = user.getUserId();
+		String oldPassword = user.getPassword();
+		String newPassword1 = ServiceTestUtil.randomString();
+		String newPassword2 = newPassword1;
+		boolean passwordReset = true;
+		String reminderQueryQuestion = ServiceTestUtil.randomString();
+		String reminderQueryAnswer = ServiceTestUtil.randomString();
+
+		String screenName = ServiceTestUtil.randomString();
+		String emailAddress =
+			"UserServiceTest." + ServiceTestUtil.nextLong() + "@liferay.com";
+		long facebookId = 0;
+		String openId = StringPool.BLANK;
+		String languageId = LocaleUtil.toLanguageId(Locale.getDefault());
+		String timeZoneId = ServiceTestUtil.randomString();
+		String greeting = ServiceTestUtil.randomString();
+		String comments = ServiceTestUtil.randomString();
+		String firstName = "UserServiceTest";
+		String middleName = StringPool.BLANK;
+		String lastName = "UserServiceTest";
+		int prefixId = 0;
+		int suffixId = 0;
+		boolean male = true;
+		int birthdayMonth = Calendar.JANUARY;
+		int birthdayDay = 1;
+		int birthdayYear = 1970;
+		String jobTitle = StringPool.BLANK;
+		String smsSn =
+			"UserServiceTestSmsSn." + ServiceTestUtil.nextInt() +
+				"@liferay.com";
+		String aimSn = ServiceTestUtil.randomString();
+		String facebookSn = ServiceTestUtil.randomString();
+		String icqSn = ServiceTestUtil.randomString();
+		String jabberSn = ServiceTestUtil.randomString();
+		String msnSn =
+			"UserServiceTestMsnSn." + ServiceTestUtil.nextInt() +
+				"@liferay.com";
+		String mySpaceSn = ServiceTestUtil.randomString();
+		String skypeSn = ServiceTestUtil.randomString();
+		String twitterSn = ServiceTestUtil.randomString();
+		String ymSn = ServiceTestUtil.randomString();
+
+		List<Address> addresses = new ArrayList<Address>();
+		List<EmailAddress> emailAddresses = new ArrayList<EmailAddress>();
+		List<Phone> phones = new ArrayList<Phone>();
+		List<Website> websites = new ArrayList<Website>();
+		List<AnnouncementsDelivery> announcementsDelivers =
+			new ArrayList<AnnouncementsDelivery>();
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		UserServiceUtil.updateUser(
+			userId, oldPassword, newPassword1, newPassword2, passwordReset,
+			reminderQueryQuestion, reminderQueryAnswer, screenName,
+			emailAddress, facebookId, openId, languageId, timeZoneId, greeting,
+			comments, firstName, middleName, lastName, prefixId, suffixId, male,
+			birthdayMonth, birthdayDay, birthdayYear, smsSn, aimSn, facebookSn,
+			icqSn, jabberSn, msnSn, mySpaceSn, skypeSn, twitterSn, ymSn,
+			jobTitle, siteIds, organizationIds, roleIds, userGroupRoles,
+			userGroupIds, addresses, emailAddresses, phones, websites,
+			announcementsDelivers, serviceContext);
+	}
+
+	protected static Map<String, Serializable> addExpandoMap() {
+		Map<String, Serializable> expandoMap =
+			new HashMap<String, Serializable>();
+
+		expandoMap.put("key1", "value1");
+		expandoMap.put("key2", "value2");
+		expandoMap.put("key3", "value3");
+		expandoMap.put("key4", "value4");
+
+		return expandoMap;
+	}
+
+	protected static ServiceContext populateServiceContext() throws Exception {
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+
+		AssetTag tag = AssetTagLocalServiceUtil.addTag(
+			TestPropsValues.getUserId(), ServiceTestUtil.randomString(), null,
+			new ServiceContext());
+
+		serviceContext.setAssetTagNames(new String[]{tag.getName()});
+
+		AssetVocabulary vocabulary =
+			AssetVocabularyLocalServiceUtil.addVocabulary(
+				TestPropsValues.getUserId(), ServiceTestUtil.randomString(),
+				new ServiceContext());
+
+		AssetCategory category = AssetCategoryLocalServiceUtil.addCategory(
+			TestPropsValues.getUserId(), ServiceTestUtil.randomString(),
+			vocabulary.getVocabularyId(), serviceContext);
+
+		serviceContext.setAssetCategoryIds(
+			new long[]{category.getCategoryId()});
+
+		serviceContext.setExpandoBridgeAttributes(addExpandoMap());
+
+		return serviceContext;
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/util/RoleTestUtil.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/membershippolicy/util/RoleTestUtil.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.membershippolicy.util;
+
+import com.liferay.portal.model.Role;
+import com.liferay.portal.model.RoleConstants;
+import com.liferay.portal.service.RoleLocalServiceUtil;
+import com.liferay.portal.service.ServiceTestUtil;
+
+/**
+ * @author Roberto Díaz
+ */
+public class RoleTestUtil {
+
+	public static long addGroupRole(long groupId) throws Exception {
+		Role role = ServiceTestUtil.addRole(
+			"TestRole", RoleConstants.TYPE_SITE);
+
+		RoleLocalServiceUtil.addGroupRole(groupId, role.getRoleId());
+
+		return role.getRoleId();
+	}
+
+}

--- a/portal-impl/test/portal-test.properties
+++ b/portal-impl/test/portal-test.properties
@@ -15,3 +15,5 @@ dl.file.entry.processors.trigger.synchronously=true
 
 journal.transformer.regex.pattern.0=beta.sample.com
 journal.transformer.regex.replacement.0=production.sample.com
+
+membership.policy.sites=com.liferay.portal.security.membershippolicy.membershippolicysamples.SiteMembershipPolicyTestImpl

--- a/portal-service/src/com/liferay/portal/security/membershippolicy/BaseSiteMembershipPolicy.java
+++ b/portal-service/src/com/liferay/portal/security/membershippolicy/BaseSiteMembershipPolicy.java
@@ -158,7 +158,7 @@ public abstract class BaseSiteMembershipPolicy implements SiteMembershipPolicy {
 			userId, groupId, roleId);
 
 		UserGroupRole userGroupRole =
-			UserGroupRoleLocalServiceUtil.getUserGroupRole(userGroupRolePK);
+			UserGroupRoleLocalServiceUtil.createUserGroupRole(userGroupRolePK);
 
 		userGroupRoles.add(userGroupRole);
 


### PR DESCRIPTION
Hi Brian, we have added a Membership Policy for Sites and then 3 tests:
- one for the baseMembership Policy
- one for checking the memberships of sites
- one for checking the roles in sites

Once you validate the pattern we will keep adding tests for Organization Membership Policies, User Groups, and Roles.
