### PR TITLE
LPS-33805 Path parameter from StagedModelDataHandler --> please read comments

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -658,8 +658,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 		StagedModel stagedModel, String namespace) {
 
 		return createServiceContext(
-			StagedModelPathUtil.getPath(stagedModel), (ClassedModel)stagedModel,
-			namespace);
+			StagedModelPathUtil.getPath(stagedModel), stagedModel, namespace);
 	}
 
 	public ServiceContext createServiceContext(

--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.lar.PortletDataContextListener;
 import com.liferay.portal.kernel.lar.PortletDataException;
 import com.liferay.portal.kernel.lar.PortletDataHandlerControl;
 import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.portal.kernel.lar.StagedModelPathUtil;
 import com.liferay.portal.kernel.lar.UserIdStrategy;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -52,6 +53,7 @@ import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.ResourcedModel;
 import com.liferay.portal.model.Role;
 import com.liferay.portal.model.RoleConstants;
+import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.model.Team;
 import com.liferay.portal.model.impl.LockImpl;
 import com.liferay.portal.security.permission.ResourceActionsUtil;
@@ -650,6 +652,14 @@ public class PortletDataContextImpl implements PortletDataContext {
 		Element element, ClassedModel classedModel, String namespace) {
 
 		return createServiceContext(element, null, classedModel, namespace);
+	}
+
+	public ServiceContext createServiceContext(
+		StagedModel stagedModel, String namespace) {
+
+		return createServiceContext(
+			StagedModelPathUtil.getPath(stagedModel), (ClassedModel)stagedModel,
+			namespace);
 	}
 
 	public ServiceContext createServiceContext(

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceLocalServiceImpl.java
@@ -143,15 +143,13 @@ public class ResourceLocalServiceImpl extends ResourceLocalServiceBaseImpl {
 			AuditedModel auditedModel, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		ClassedModel classedModel = (ClassedModel)auditedModel;
-
 		if (serviceContext.isAddGroupPermissions() ||
 			serviceContext.isAddGuestPermissions()) {
 
 			addResources(
 				auditedModel.getCompanyId(), getGroupId(auditedModel),
-				auditedModel.getUserId(), classedModel.getModelClassName(),
-				String.valueOf(classedModel.getPrimaryKeyObj()), false,
+				auditedModel.getUserId(), auditedModel.getModelClassName(),
+				String.valueOf(auditedModel.getPrimaryKeyObj()), false,
 				serviceContext.isAddGroupPermissions(),
 				serviceContext.isAddGuestPermissions(),
 				getPermissionedModel(auditedModel));
@@ -159,13 +157,13 @@ public class ResourceLocalServiceImpl extends ResourceLocalServiceBaseImpl {
 		else {
 			if (serviceContext.isDeriveDefaultPermissions()) {
 				serviceContext.deriveDefaultPermissions(
-					getGroupId(auditedModel), classedModel.getModelClassName());
+					getGroupId(auditedModel), auditedModel.getModelClassName());
 			}
 
 			addModelResources(
 				auditedModel.getCompanyId(), getGroupId(auditedModel),
-				auditedModel.getUserId(), classedModel.getModelClassName(),
-				String.valueOf(classedModel.getPrimaryKeyObj()),
+				auditedModel.getUserId(), auditedModel.getModelClassName(),
+				String.valueOf(auditedModel.getPrimaryKeyObj()),
 				serviceContext.getGroupPermissions(),
 				serviceContext.getGuestPermissions(),
 				getPermissionedModel(auditedModel));

--- a/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksEntryStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksEntryStagedModelDataHandler.java
@@ -67,7 +67,7 @@ public class BookmarksEntryStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			BookmarksEntry entry)
 		throws Exception {
 
@@ -91,14 +91,14 @@ public class BookmarksEntryStagedModelDataHandler
 					parentFolderPath);
 
 			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, element, parentFolderPath, parentFolder);
+				portletDataContext, element, parentFolder);
 
 			folderId = MapUtil.getLong(
 				folderIds, entry.getFolderId(), entry.getFolderId());
 		}
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, entry, BookmarksPortletDataHandler.NAMESPACE);
+			entry, BookmarksPortletDataHandler.NAMESPACE);
 
 		BookmarksEntry importedEntry = null;
 

--- a/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksFolderStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksFolderStagedModelDataHandler.java
@@ -63,7 +63,7 @@ public class BookmarksFolderStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			BookmarksFolder folder)
 		throws Exception {
 
@@ -88,8 +88,7 @@ public class BookmarksFolderStagedModelDataHandler
 				(BookmarksFolder)portletDataContext.getZipEntryAsObject(
 					parentFolderPath);
 
-			importStagedModel(
-				portletDataContext, element, parentFolderPath, parentFolder);
+			importStagedModel(portletDataContext, element, parentFolder);
 
 			parentFolderId = MapUtil.getLong(
 				folderIds, folder.getParentFolderId(),
@@ -97,7 +96,7 @@ public class BookmarksFolderStagedModelDataHandler
 		}
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, folder, BookmarksPortletDataHandler.NAMESPACE);
+			folder, BookmarksPortletDataHandler.NAMESPACE);
 
 		BookmarksFolder importedFolder = null;
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/lar/DDLRecordSetStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/lar/DDLRecordSetStagedModelDataHandler.java
@@ -76,7 +76,7 @@ public class DDLRecordSetStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			DDLRecordSet recordSet)
 		throws Exception {
 
@@ -103,7 +103,7 @@ public class DDLRecordSetStagedModelDataHandler
 			recordSet.getDDMStructureId());
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, recordSet, DDLPortletDataHandler.NAMESPACE);
+			recordSet, DDLPortletDataHandler.NAMESPACE);
 
 		DDLRecordSet importedRecordSet = null;
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMStructureStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMStructureStagedModelDataHandler.java
@@ -67,7 +67,7 @@ public class DDMStructureStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			DDMStructure structure)
 		throws Exception {
 
@@ -80,7 +80,7 @@ public class DDMStructureStagedModelDataHandler
 				DDMStructure.class);
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, structure, DDMPortletDataHandler.NAMESPACE);
+			structure, DDMPortletDataHandler.NAMESPACE);
 
 		DDMStructure importedStructure = null;
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMTemplateStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/lar/DDMTemplateStagedModelDataHandler.java
@@ -162,7 +162,7 @@ public class DDMTemplateStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			DDMTemplate template)
 		throws Exception {
 
@@ -202,7 +202,7 @@ public class DDMTemplateStagedModelDataHandler
 		}
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			element, template, DDMPortletDataHandler.NAMESPACE);
+			template, DDMPortletDataHandler.NAMESPACE);
 
 		DDMTemplate importedTemplate = null;
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/lar/MBBanStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/lar/MBBanStagedModelDataHandler.java
@@ -56,8 +56,7 @@ public class MBBanStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
-			MBBan ban)
+			PortletDataContext portletDataContext, Element element, MBBan ban)
 		throws Exception {
 
 		User user = UserUtil.fetchByUuid_C_First(

--- a/portal-impl/src/com/liferay/portlet/messageboards/lar/MBCategoryStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/lar/MBCategoryStagedModelDataHandler.java
@@ -70,7 +70,7 @@ public class MBCategoryStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			MBCategory category)
 		throws Exception {
 
@@ -117,8 +117,7 @@ public class MBCategoryStagedModelDataHandler
 					parentCategoryPath);
 
 			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, element, parentCategoryPath,
-				parentCategory);
+				portletDataContext, element, parentCategory);
 
 			parentCategoryId = MapUtil.getLong(
 				categoryIds, category.getParentCategoryId(),
@@ -126,7 +125,7 @@ public class MBCategoryStagedModelDataHandler
 		}
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, category, MBPortletDataHandler.NAMESPACE);
+			category, MBPortletDataHandler.NAMESPACE);
 
 		MBCategory importedCategory = null;
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/lar/MBMessageStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/lar/MBMessageStagedModelDataHandler.java
@@ -118,7 +118,7 @@ public class MBMessageStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			MBMessage message)
 		throws Exception {
 
@@ -175,7 +175,7 @@ public class MBMessageStagedModelDataHandler
 						categoryPath);
 
 				StagedModelDataHandlerUtil.importStagedModel(
-					portletDataContext, element, categoryPath, category);
+					portletDataContext, element, category);
 
 				parentCategoryId = MapUtil.getLong(
 					categoryIds, message.getCategoryId(),

--- a/portal-impl/src/com/liferay/portlet/messageboards/lar/MBThreadFlagStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/lar/MBThreadFlagStagedModelDataHandler.java
@@ -86,7 +86,7 @@ public class MBThreadFlagStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			MBThreadFlag threadFlag)
 		throws Exception {
 
@@ -108,7 +108,7 @@ public class MBThreadFlagStagedModelDataHandler
 				getZipEntryAsObject(rootMessagePath);
 
 			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, element, rootMessagePath, rootMessage);
+				portletDataContext, element, rootMessage);
 
 			threadId = MapUtil.getLong(
 				threadIds, threadFlag.getThreadId(), threadFlag.getThreadId());

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRActionStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRActionStagedModelDataHandler.java
@@ -101,7 +101,7 @@ public class MDRActionStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			MDRAction action)
 		throws Exception {
 
@@ -114,8 +114,7 @@ public class MDRActionStagedModelDataHandler
 				ruleGroupInstancePath);
 
 		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, element, ruleGroupInstancePath,
-			ruleGroupInstance);
+			portletDataContext, element, ruleGroupInstance);
 
 		Map<Long, Long> ruleGroupInstanceIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -126,7 +125,7 @@ public class MDRActionStagedModelDataHandler
 			action.getRuleGroupInstanceId());
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			element, action, MDRPortletDataHandler.NAMESPACE);
+			action, MDRPortletDataHandler.NAMESPACE);
 
 		serviceContext.setUserId(
 			portletDataContext.getUserId(action.getUserUuid()));

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRRuleGroupInstanceStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRRuleGroupInstanceStagedModelDataHandler.java
@@ -86,7 +86,7 @@ public class MDRRuleGroupInstanceStagedModelDataHandler
 	@Override
 	protected void doImportStagedModel(
 			PortletDataContext portletDataContext,
-			Element ruleGroupInstanceElement, String path,
+			Element ruleGroupInstanceElement,
 			MDRRuleGroupInstance ruleGroupInstance)
 		throws Exception {
 
@@ -101,8 +101,7 @@ public class MDRRuleGroupInstanceStagedModelDataHandler
 			(MDRRuleGroup)portletDataContext.getZipEntryAsObject(ruleGroupPath);
 
 		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, ruleGroupInstanceElement, ruleGroupPath,
-			ruleGroup);
+			portletDataContext, ruleGroupInstanceElement, ruleGroup);
 
 		Map<Long, Long> ruleGroupIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -151,8 +150,7 @@ public class MDRRuleGroupInstanceStagedModelDataHandler
 		}
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			ruleGroupInstanceElement, ruleGroupInstance,
-			MDRPortletDataHandler.NAMESPACE);
+			ruleGroupInstance, MDRPortletDataHandler.NAMESPACE);
 
 		serviceContext.setUserId(userId);
 

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRRuleGroupStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRRuleGroupStagedModelDataHandler.java
@@ -52,13 +52,13 @@ public class MDRRuleGroupStagedModelDataHandler
 	@Override
 	protected void doImportStagedModel(
 			PortletDataContext portletDataContext, Element ruleGroupElement,
-			String path, MDRRuleGroup ruleGroup)
+			MDRRuleGroup ruleGroup)
 		throws Exception {
 
 		long userId = portletDataContext.getUserId(ruleGroup.getUserUuid());
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			ruleGroupElement, ruleGroup, MDRPortletDataHandler.NAMESPACE);
+			ruleGroup, MDRPortletDataHandler.NAMESPACE);
 
 		serviceContext.setUserId(userId);
 

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRRuleStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/lar/MDRRuleStagedModelDataHandler.java
@@ -65,7 +65,7 @@ public class MDRRuleStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			MDRRule rule)
 		throws Exception {
 
@@ -77,7 +77,7 @@ public class MDRRuleStagedModelDataHandler
 			(MDRRuleGroup)portletDataContext.getZipEntryAsObject(ruleGroupPath);
 
 		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, element, ruleGroupPath, ruleGroup);
+			portletDataContext, element, ruleGroup);
 
 		Map<Long, Long> ruleGroupIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -87,7 +87,7 @@ public class MDRRuleStagedModelDataHandler
 			ruleGroupIds, rule.getRuleGroupId(), rule.getRuleGroupId());
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			element, rule, MDRPortletDataHandler.NAMESPACE);
+			rule, MDRPortletDataHandler.NAMESPACE);
 
 		serviceContext.setUserId(
 			portletDataContext.getUserId(rule.getUserUuid()));

--- a/portal-impl/src/com/liferay/portlet/polls/lar/PollsChoiceStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/polls/lar/PollsChoiceStagedModelDataHandler.java
@@ -65,7 +65,7 @@ public class PollsChoiceStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			PollsChoice choice)
 		throws Exception {
 
@@ -79,7 +79,7 @@ public class PollsChoiceStagedModelDataHandler
 			(PollsQuestion)portletDataContext.getZipEntryAsObject(questionPath);
 
 		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, element, questionPath, question);
+			portletDataContext, element, question);
 
 		Map<Long, Long> questionIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -91,7 +91,7 @@ public class PollsChoiceStagedModelDataHandler
 		PollsChoice importedChoice = null;
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, choice, PollsPortletDataHandler.NAMESPACE);
+			choice, PollsPortletDataHandler.NAMESPACE);
 
 		if (portletDataContext.isDataStrategyMirror()) {
 			PollsChoice existingChoice = PollsChoiceFinderUtil.fetchByUUID_G(

--- a/portal-impl/src/com/liferay/portlet/polls/lar/PollsQuestionStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/polls/lar/PollsQuestionStagedModelDataHandler.java
@@ -55,7 +55,7 @@ public class PollsQuestionStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			PollsQuestion question)
 		throws Exception {
 
@@ -88,7 +88,7 @@ public class PollsQuestionStagedModelDataHandler
 		}
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, question, PollsPortletDataHandler.NAMESPACE);
+			question, PollsPortletDataHandler.NAMESPACE);
 
 		PollsQuestion importedQuestion = null;
 

--- a/portal-impl/src/com/liferay/portlet/polls/lar/PollsVoteStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/polls/lar/PollsVoteStagedModelDataHandler.java
@@ -66,7 +66,7 @@ public class PollsVoteStagedModelDataHandler
 
 	@Override
 	protected void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			PollsVote vote)
 		throws Exception {
 
@@ -78,7 +78,7 @@ public class PollsVoteStagedModelDataHandler
 			(PollsChoice)portletDataContext.getZipEntryAsObject(choicePath);
 
 		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, element, choicePath, choice);
+			portletDataContext, element, choice);
 
 		Map<Long, Long> questionIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -95,7 +95,7 @@ public class PollsVoteStagedModelDataHandler
 			choiceIds, vote.getChoiceId(), vote.getChoiceId());
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
-			path, vote, PollsPortletDataHandler.NAMESPACE);
+			vote, PollsPortletDataHandler.NAMESPACE);
 
 		serviceContext.setCreateDate(vote.getVoteDate());
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
@@ -56,16 +56,18 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 	public abstract String getClassName();
 
 	public void importStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			T stagedModel)
 		throws PortletDataException {
+
+		String path = StagedModelPathUtil.getPath(stagedModel);
 
 		if (portletDataContext.isPathProcessed(path)) {
 			return;
 		}
 
 		try {
-			doImportStagedModel(portletDataContext, element, path, stagedModel);
+			doImportStagedModel(portletDataContext, element, stagedModel);
 		}
 		catch (Exception e) {
 			throw new PortletDataException(e);
@@ -78,7 +80,7 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 		throws Exception;
 
 	protected abstract void doImportStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			T stagedModel)
 		throws Exception;
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/PortletDataContext.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/PortletDataContext.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.zip.ZipReader;
 import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.model.ClassedModel;
 import com.liferay.portal.model.Lock;
+import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.expando.model.ExpandoColumn;
 import com.liferay.portlet.messageboards.model.MBMessage;
@@ -118,6 +119,9 @@ public interface PortletDataContext extends Serializable {
 
 	public ServiceContext createServiceContext(
 		Element element, ClassedModel classedModel, String namespace);
+
+	public ServiceContext createServiceContext(
+		StagedModel stagedModel, String namespace);
 
 	public ServiceContext createServiceContext(
 		String path, ClassedModel classedModel, String namespace);

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandler.java
@@ -36,7 +36,7 @@ public interface StagedModelDataHandler<T extends StagedModel> {
 	public String getClassName();
 
 	public void importStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			T stagedModel)
 		throws PortletDataException;
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
@@ -56,11 +56,11 @@ public class StagedModelDataHandlerUtil {
 		StagedModel stagedModel =
 			(StagedModel)portletDataContext.getZipEntryAsObject(element, path);
 
-		importStagedModel(portletDataContext, element, path, stagedModel);
+		importStagedModel(portletDataContext, element, stagedModel);
 	}
 
 	public static <T extends StagedModel> void importStagedModel(
-			PortletDataContext portletDataContext, Element element, String path,
+			PortletDataContext portletDataContext, Element element,
 			T stagedModel)
 		throws PortletDataException {
 
@@ -68,7 +68,7 @@ public class StagedModelDataHandlerUtil {
 			_getStagedModelDataHandler(stagedModel);
 
 		stagedModelDataHandler.importStagedModel(
-			portletDataContext, element, path, stagedModel);
+			portletDataContext, element, stagedModel);
 	}
 
 	private static <T extends StagedModel> StagedModelDataHandler<T>

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelPathUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelPathUtil.java
@@ -16,7 +16,6 @@ package com.liferay.portal.kernel.lar;
 
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.model.ClassedModel;
 import com.liferay.portal.model.StagedModel;
 
 import java.io.Serializable;
@@ -49,11 +48,9 @@ public class StagedModelPathUtil {
 	public static String getPath(
 		StagedModel stagedModel, String dependentFileName) {
 
-		ClassedModel classedModel = (ClassedModel)stagedModel;
-
 		return getPath(
-			stagedModel.getGroupId(), classedModel.getModelClassName(),
-			classedModel.getPrimaryKeyObj(), dependentFileName);
+			stagedModel.getGroupId(), stagedModel.getModelClassName(),
+			stagedModel.getPrimaryKeyObj(), dependentFileName);
 	}
 
 	protected static String getPath(

--- a/portal-service/src/com/liferay/portal/model/AuditedModel.java
+++ b/portal-service/src/com/liferay/portal/model/AuditedModel.java
@@ -21,7 +21,7 @@ import java.util.Date;
 /**
  * @author Brian Wing Shun Chan
  */
-public interface AuditedModel {
+public interface AuditedModel extends ClassedModel {
 
 	public long getCompanyId();
 


### PR DESCRIPTION
Hey Brian,

This change set has been reviewed by Mike Han (@mhan810) as well. He had only one concern, casting the StagedModel to ClassedModel, since the StagedModel is not extending the ClassedModel (nor the AuditedModel or GroupedModel).

As we discussed all entities that will be StagedModels are implicitly be ClassedModels too according to how the service builder works (model.ftl) although this is still a risk for class casting problems. We've agreed to eliminate this risk, and based on our conversation with Mike, I've added two new commits to the PR changing the AuditedModel to explicitly extend ClassedModel (will affect GroupedModel and StagedModel eventually).
The reason I haven't merged the commits together is to keep track of why it has been changed.

Thanks,

Máté

cc-ing also: @KocsisDaniel
