### PR TITLE
LPS-33811 Adding empty element --> please read description

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/seleniumbuilder/SeleniumBuilderFileUtil.java
+++ b/portal-impl/src/com/liferay/portal/tools/seleniumbuilder/SeleniumBuilderFileUtil.java
@@ -32,6 +32,7 @@ import com.liferay.portal.tools.servicebuilder.ServiceBuilder;
 
 import java.io.File;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -300,7 +301,8 @@ public class SeleniumBuilderFileUtil {
 		}
 		else if (errorCode == 1001) {
 			throw new IllegalArgumentException(
-				prefix + "Missing child elements in " + suffix);
+				prefix + "Missing (" + StringUtil.merge(array, "|") +
+					") child element in " + suffix);
 		}
 		else if (errorCode == 1002) {
 			throw new IllegalArgumentException(
@@ -351,7 +353,9 @@ public class SeleniumBuilderFileUtil {
 		List<Element> elements = commandElement.elements();
 
 		if (elements.isEmpty()) {
-			throwValidationException(1001, fileName, commandElement);
+			throwValidationException(
+				1001, fileName, commandElement,
+				allowedCommandChildElementNames);
 		}
 
 		for (Element element : elements) {
@@ -556,7 +560,8 @@ public class SeleniumBuilderFileUtil {
 		List<Element> elements = rootElement.elements();
 
 		if (elements.isEmpty()) {
-			throwValidationException(1001, fileName, rootElement);
+			throwValidationException(
+				1001, fileName, rootElement, new String[] {"command"});
 		}
 
 		for (Element element : elements) {
@@ -585,12 +590,12 @@ public class SeleniumBuilderFileUtil {
 
 		List<Element> elements = ifElement.elements();
 
-		if (elements.isEmpty()) {
-			throwValidationException(1001, fileName, ifElement);
-		}
+		Set<String> elementNames = new HashSet<String>();
 
 		for (Element element : elements) {
 			String elementName = element.getName();
+
+			elementNames.add(elementName);
 
 			if (elementName.equals("condition")) {
 				validateExecuteElement(
@@ -607,6 +612,13 @@ public class SeleniumBuilderFileUtil {
 				throwValidationException(1002, fileName, element, elementName);
 			}
 		}
+
+		if (!elementNames.contains("condition") ||
+			!elementNames.contains("then")) {
+
+			throwValidationException(
+				1001, fileName, ifElement, new String[] {"condition", "then"});
+		}
 	}
 
 	protected void validateMacroDocument(String fileName, Element rootElement) {
@@ -617,7 +629,8 @@ public class SeleniumBuilderFileUtil {
 		List<Element> elements = rootElement.elements();
 
 		if (elements.isEmpty()) {
-			throwValidationException(1001, fileName, rootElement);
+			throwValidationException(
+				1001, fileName, rootElement, new String[] {"command", "var"});
 		}
 
 		for (Element element : elements) {
@@ -709,12 +722,12 @@ public class SeleniumBuilderFileUtil {
 
 		List<Element> elements = whileElement.elements();
 
-		if (elements.isEmpty()) {
-			throwValidationException(1001, fileName, whileElement);
-		}
+		Set<String> elementNames = new HashSet<String>();
 
 		for (Element element : elements) {
 			String elementName = element.getName();
+
+			elementNames.add(elementName);
 
 			if (elementName.equals("condition")) {
 				validateExecuteElement(
@@ -730,6 +743,14 @@ public class SeleniumBuilderFileUtil {
 			else {
 				throwValidationException(1002, fileName, element, elementName);
 			}
+		}
+
+		if (!elementNames.contains("condition") ||
+			!elementNames.contains("then")) {
+
+			throwValidationException(
+				1001, fileName, whileElement,
+				new String[] {"condition", "then"});
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/xml/EmptyElementImpl.java
+++ b/portal-impl/src/com/liferay/portal/xml/EmptyElementImpl.java
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.xml;
+
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.xml.Attribute;
+import com.liferay.portal.kernel.xml.CDATA;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.EmptyElement;
+import com.liferay.portal.kernel.xml.Entity;
+import com.liferay.portal.kernel.xml.Namespace;
+import com.liferay.portal.kernel.xml.Node;
+import com.liferay.portal.kernel.xml.QName;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.kernel.xml.Text;
+
+import java.io.IOException;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.collections.iterators.EmptyIterator;
+
+/**
+ * @author Mate Thurzo
+ */
+public class EmptyElementImpl extends ElementImpl implements EmptyElement {
+
+	public EmptyElementImpl(org.dom4j.Element element) {
+		super(element);
+	}
+
+	@Override
+	public List<Namespace> additionalNamespaces() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Attribute attribute(int index) {
+		return null;
+	}
+
+	@Override
+	public Attribute attribute(QName qName) {
+		return null;
+	}
+
+	@Override
+	public Attribute attribute(String name) {
+		return null;
+	}
+
+	@Override
+	public int attributeCount() {
+		return 0;
+	}
+
+	@Override
+	public Iterator<Attribute> attributeIterator() {
+		return EmptyIterator.INSTANCE;
+	}
+
+	@Override
+	public List<Attribute> attributes() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String attributeValue(QName qName) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String attributeValue(QName qName, String defaultValue) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String attributeValue(String name) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String attributeValue(String name, String defaultValue) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public Element createCopy() {
+		return SAXReaderUtil.emptyElement();
+	}
+
+	@Override
+	public Element createCopy(QName qName) {
+		return SAXReaderUtil.emptyElement();
+	}
+
+	@Override
+	public Element createCopy(String name) {
+		return SAXReaderUtil.emptyElement();
+	}
+
+	@Override
+	public List<Namespace> declaredNamespaces() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Element element(QName qName) {
+		return SAXReaderUtil.emptyElement();
+	}
+
+	@Override
+	public Element element(String name) {
+		return SAXReaderUtil.emptyElement();
+	}
+
+	@Override
+	public Iterator<Element> elementIterator() {
+		return EmptyIterator.RESETTABLE_INSTANCE;
+	}
+
+	@Override
+	public Iterator<Element> elementIterator(QName qName) {
+		return EmptyIterator.RESETTABLE_INSTANCE;
+	}
+
+	@Override
+	public Iterator<Element> elementIterator(String name) {
+		return EmptyIterator.RESETTABLE_INSTANCE;
+	}
+
+	@Override
+	public List<Element> elements() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Element> elements(QName qName) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<Element> elements(String name) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String elementText(QName qName) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String elementText(String name) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String elementTextTrim(QName qName) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String elementTextTrim(String name) {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String formattedString() throws IOException {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String formattedString(String indent) throws IOException {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String formattedString(String indent, boolean expandEmptyElements)
+		throws IOException {
+
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public Object getData() {
+		return null;
+	}
+
+	@Override
+	public Namespace getNamespace() {
+		return null;
+	}
+
+	@Override
+	public Namespace getNamespaceForPrefix(String prefix) {
+		return null;
+	}
+
+	@Override
+	public Namespace getNamespaceForURI(String uri) {
+		return null;
+	}
+
+	@Override
+	public String getNamespacePrefix() {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public List<Namespace> getNamespacesForURI(String uri) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String getNamespaceURI() {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public String getTextTrim() {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public org.dom4j.Element getWrappedElement() {
+		return (org.dom4j.Element)SAXReaderUtil.emptyElement();
+	}
+
+	@Override
+	public Node getXPathResult(int index) {
+		return null;
+	}
+
+	@Override
+	public boolean hasMixedContent() {
+		return false;
+	}
+
+	@Override
+	public boolean isRootElement() {
+		return false;
+	}
+
+	@Override
+	public boolean isTextOnly() {
+		return false;
+	}
+
+	@Override
+	public boolean remove(Attribute attribute) {
+		return false;
+	}
+
+	@Override
+	public boolean remove(CDATA cdata) {
+		return false;
+	}
+
+	@Override
+	public boolean remove(Entity entity) {
+		return false;
+	}
+
+	@Override
+	public boolean remove(Namespace namespace) {
+		return false;
+	}
+
+	@Override
+	public boolean remove(Text text) {
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return StringPool.BLANK;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/xml/SAXReaderImpl.java
+++ b/portal-impl/src/com/liferay/portal/xml/SAXReaderImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.xml.Attribute;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.DocumentException;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.EmptyElement;
 import com.liferay.portal.kernel.xml.Entity;
 import com.liferay.portal.kernel.xml.Namespace;
 import com.liferay.portal.kernel.xml.Node;
@@ -314,6 +315,10 @@ public class SAXReaderImpl implements SAXReader {
 		return createXPath(xPathExpression, namespaceContextMap);
 	}
 
+	public Element emptyElement() {
+		return _EMPTY_ELEMENT;
+	}
+
 	public Document read(File file) throws DocumentException {
 		return read(file, false);
 	}
@@ -516,6 +521,9 @@ public class SAXReaderImpl implements SAXReader {
 
 		return reader;
 	}
+
+	private static final Element _EMPTY_ELEMENT = new EmptyElementImpl(
+		DocumentHelper.createElement(EmptyElement.EMPTY_ELEMENT_NAME));
 
 	private static final String _FEATURES_DYNAMIC =
 		"http://apache.org/xml/features/validation/dynamic";

--- a/portal-impl/test/integration/com/liferay/portal/tools/seleniumbuilder/SeleniumBuilderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/tools/seleniumbuilder/SeleniumBuilderTest.java
@@ -41,7 +41,7 @@ public class SeleniumBuilderTest {
 	public void testFunctionCommandElement1001() throws Exception {
 		test(
 			"FunctionCommandElement1001.function",
-			"Error 1001: Missing child elements in " + _DIR_NAME +
+			"Error 1001: Missing (execute|if) child element in " + _DIR_NAME +
 				"/FunctionCommandElement1001.function:2");
 	}
 
@@ -89,7 +89,7 @@ public class SeleniumBuilderTest {
 	public void testFunctionDefinitionElement1001() throws Exception {
 		test(
 			"FunctionDefinitionElement1001.function",
-			"Error 1001: Missing child elements in " + _DIR_NAME +
+			"Error 1001: Missing (command) child element in " + _DIR_NAME +
 				"/FunctionDefinitionElement1001.function:1");
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/tools/seleniumbuilder/dependencies/Function.function
+++ b/portal-impl/test/integration/com/liferay/portal/tools/seleniumbuilder/dependencies/Function.function
@@ -6,10 +6,6 @@
 
 		<if>
 			<condition function="Function#isFunction" />
-		</if>
-
-		<if>
-			<condition function="Function#isFunction" />
 			<then>
 				<execute function="function" />
 			</then>

--- a/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/util/DDMXMLImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/util/DDMXMLImplTest.java
@@ -53,7 +53,7 @@ public class DDMXMLImplTest extends PowerMockito {
 		when(
 			SAXReaderUtil.getSAXReader()
 		).thenReturn(
-			_saxReader
+			SAXReaderImpl.getInstance()
 		);
 
 		spy(DDMXMLUtil.class);
@@ -178,7 +178,5 @@ public class DDMXMLImplTest extends PowerMockito {
 	}
 
 	private DDMXMLImpl _ddmXML = new DDMXMLImpl();
-
-	private SAXReaderImpl _saxReader = new SAXReaderImpl();
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/xml/EmptyElement.java
+++ b/portal-service/src/com/liferay/portal/kernel/xml/EmptyElement.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.xml;
+
+/**
+ * @author Mate Thurzo
+ */
+public interface EmptyElement extends Element {
+
+	public static final String EMPTY_ELEMENT_NAME = "EMPTY-ELEMENT";
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/xml/SAXReader.java
+++ b/portal-service/src/com/liferay/portal/kernel/xml/SAXReader.java
@@ -71,6 +71,8 @@ public interface SAXReader {
 	public XPath createXPath(
 		String xPathExpression, String prefix, String namespace);
 
+	public Element emptyElement();
+
 	public Document read(File file) throws DocumentException;
 
 	public Document read(File file, boolean validate)

--- a/portal-service/src/com/liferay/portal/kernel/xml/SAXReaderUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/xml/SAXReaderUtil.java
@@ -115,6 +115,10 @@ public class SAXReaderUtil {
 		return getSAXReader().createXPath(xPathExpression, prefix, namespace);
 	}
 
+	public static Element emptyElement() {
+		return getSAXReader().emptyElement();
+	}
+
 	public static SAXReader getSAXReader() {
 		PortalRuntimePermission.checkGetBeanProperty(SAXReaderUtil.class);
 


### PR DESCRIPTION
Hey Brian,

I'm splitting up the commits for this ticket what originally Mike Han sent you: https://github.com/brianchandotcom/liferay-portal/pull/9963

Mike already reviewed these changes.

This is the first batch, I hope this would help you review the changes more easily.

In this PR I'm adding an empty element feature to our XML handling. The empty element is similar to the Collections.emptyList() concept, it will prevent the environment to fail with an NPE but we can still check for this special case because we have a named class for it.

The empty element does not mean that and element name is empty like this: <>.

Instead it will be used when we don't find an element (actual usages will come in the next PRs):

<pre><code>
Element element = rootElement.element("test");

if (element == null) {
   return SAXReaderUtil.emptyElement();
}
</code></pre>


Thanks,

Máté

cc: @KocsisDaniel
