### PR TITLE
LPS-33621 Add a property to define the "profile" friendly url for users

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.util.Digester;
 import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -67,6 +68,7 @@ import com.liferay.portal.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.service.WebsiteLocalServiceUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.Portal;
+import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
 
@@ -183,6 +185,18 @@ public class UserImpl extends UserBaseImpl {
 			return StringPool.BLANK;
 		}
 
+		String profileFriendlyURL = getProfileFriendlyURL();
+
+		if (Validator.isNotNull(profileFriendlyURL)) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(portalURL);
+			sb.append(PortalUtil.getPathContext());
+			sb.append(profileFriendlyURL);
+
+			return sb.toString();
+		}
+
 		Group group = getGroup();
 
 		int publicLayoutsPageCount = group.getPublicLayoutsPageCount();
@@ -297,14 +311,14 @@ public class UserImpl extends UserBaseImpl {
 		return getContact().getMale();
 	}
 
-	public List<Group> getMySites() throws PortalException, SystemException {
-		return getMySites(null, false, QueryUtil.ALL_POS);
-	}
-
 	public List<Group> getMySites(boolean includeControlPanel, int max)
 		throws PortalException, SystemException {
 
 		return getMySites(null, includeControlPanel, max);
+	}
+
+	public List<Group> getMySites() throws PortalException, SystemException {
+		return getMySites(null, false, QueryUtil.ALL_POS);
 	}
 
 	public List<Group> getMySites(int max)
@@ -351,10 +365,6 @@ public class UserImpl extends UserBaseImpl {
 		return getMySites(classNames, false, max);
 	}
 
-	public long[] getOrganizationIds() throws PortalException, SystemException {
-		return getOrganizationIds(false);
-	}
-
 	public long[] getOrganizationIds(boolean includeAdministrative)
 		throws PortalException, SystemException {
 
@@ -372,10 +382,8 @@ public class UserImpl extends UserBaseImpl {
 		return organizationIds;
 	}
 
-	public List<Organization> getOrganizations()
-		throws PortalException, SystemException {
-
-		return getOrganizations(false);
+	public long[] getOrganizationIds() throws PortalException, SystemException {
+		return getOrganizationIds(false);
 	}
 
 	public List<Organization> getOrganizations(boolean includeAdministrative)
@@ -383,6 +391,12 @@ public class UserImpl extends UserBaseImpl {
 
 		return OrganizationLocalServiceUtil.getUserOrganizations(
 			getUserId(), includeAdministrative);
+	}
+
+	public List<Organization> getOrganizations()
+		throws PortalException, SystemException {
+
+		return getOrganizations(false);
 	}
 
 	public boolean getPasswordModified() {
@@ -533,10 +547,6 @@ public class UserImpl extends UserBaseImpl {
 			getCompanyId(), Contact.class.getName(), getContactId());
 	}
 
-	public boolean hasCompanyMx() throws PortalException, SystemException {
-		return hasCompanyMx(getEmailAddress());
-	}
-
 	public boolean hasCompanyMx(String emailAddress)
 		throws PortalException, SystemException {
 
@@ -548,6 +558,10 @@ public class UserImpl extends UserBaseImpl {
 			getCompanyId());
 
 		return company.hasCompanyMx(emailAddress);
+	}
+
+	public boolean hasCompanyMx() throws PortalException, SystemException {
+		return hasCompanyMx(getEmailAddress());
 	}
 
 	public boolean hasMySites() throws PortalException, SystemException {
@@ -640,6 +654,19 @@ public class UserImpl extends UserBaseImpl {
 		_timeZone = TimeZoneUtil.getTimeZone(timeZoneId);
 
 		super.setTimeZoneId(timeZoneId);
+	}
+
+	protected String getProfileFriendlyURL() {
+		if (Validator.isNull(PropsValues.USERS_PROFILE_FRIENDLY_URL)) {
+			return null;
+		}
+
+		return StringUtil.replace(
+			PropsValues.USERS_PROFILE_FRIENDLY_URL,
+			new String[] {"${liferay:userId}", "${liferay:userScreenName}"},
+			new String[] {
+				String.valueOf(getUserId()), HtmlUtil.escapeURL(getScreenName())
+			});
 	}
 
 	private Locale _locale;

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -311,14 +311,14 @@ public class UserImpl extends UserBaseImpl {
 		return getContact().getMale();
 	}
 
+	public List<Group> getMySites() throws PortalException, SystemException {
+		return getMySites(null, false, QueryUtil.ALL_POS);
+	}
+
 	public List<Group> getMySites(boolean includeControlPanel, int max)
 		throws PortalException, SystemException {
 
 		return getMySites(null, includeControlPanel, max);
-	}
-
-	public List<Group> getMySites() throws PortalException, SystemException {
-		return getMySites(null, false, QueryUtil.ALL_POS);
 	}
 
 	public List<Group> getMySites(int max)
@@ -365,6 +365,10 @@ public class UserImpl extends UserBaseImpl {
 		return getMySites(classNames, false, max);
 	}
 
+	public long[] getOrganizationIds() throws PortalException, SystemException {
+		return getOrganizationIds(false);
+	}
+
 	public long[] getOrganizationIds(boolean includeAdministrative)
 		throws PortalException, SystemException {
 
@@ -382,8 +386,10 @@ public class UserImpl extends UserBaseImpl {
 		return organizationIds;
 	}
 
-	public long[] getOrganizationIds() throws PortalException, SystemException {
-		return getOrganizationIds(false);
+	public List<Organization> getOrganizations()
+		throws PortalException, SystemException {
+
+		return getOrganizations(false);
 	}
 
 	public List<Organization> getOrganizations(boolean includeAdministrative)
@@ -391,12 +397,6 @@ public class UserImpl extends UserBaseImpl {
 
 		return OrganizationLocalServiceUtil.getUserOrganizations(
 			getUserId(), includeAdministrative);
-	}
-
-	public List<Organization> getOrganizations()
-		throws PortalException, SystemException {
-
-		return getOrganizations(false);
 	}
 
 	public boolean getPasswordModified() {
@@ -547,6 +547,10 @@ public class UserImpl extends UserBaseImpl {
 			getCompanyId(), Contact.class.getName(), getContactId());
 	}
 
+	public boolean hasCompanyMx() throws PortalException, SystemException {
+		return hasCompanyMx(getEmailAddress());
+	}
+
 	public boolean hasCompanyMx(String emailAddress)
 		throws PortalException, SystemException {
 
@@ -558,10 +562,6 @@ public class UserImpl extends UserBaseImpl {
 			getCompanyId());
 
 		return company.hasCompanyMx(emailAddress);
-	}
-
-	public boolean hasCompanyMx() throws PortalException, SystemException {
-		return hasCompanyMx(getEmailAddress());
 	}
 
 	public boolean hasMySites() throws PortalException, SystemException {

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1776,6 +1776,8 @@ public class PropsValues {
 
 	public static final String[] USERS_LIST_VIEWS = PropsUtil.getArray(PropsKeys.USERS_LIST_VIEWS);
 
+	public static final String USERS_PROFILE_FRIENDLY_URL = PropsUtil.get(PropsKeys.USERS_PROFILE_FRIENDLY_URL);
+
 	public static final boolean USERS_REMINDER_QUERIES_CUSTOM_QUESTION_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.USERS_REMINDER_QUERIES_CUSTOM_QUESTION_ENABLED));
 
 	public static final boolean USERS_REMINDER_QUERIES_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.USERS_REMINDER_QUERIES_ENABLED));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -2019,6 +2019,15 @@
     #
     users.export.csv.fields=fullName,emailAddress
 
+	#
+	# Set the friendly URL to a user's profile page. If none is specified, the
+	# portal will query the user's public first page at runtime.
+	#
+	# The following variables can be used: ${liferay:userId},
+	# ${liferay:userScreenName}
+	#
+	#users.profile.friendly.url=/web/${liferay:userScreenName}/profile
+
 ##
 ## Groups and Roles
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2399,6 +2399,8 @@ public interface PropsKeys {
 
 	public static final String USERS_LIST_VIEWS = "users.list.views";
 
+	public static final String USERS_PROFILE_FRIENDLY_URL = "users.profile.friendly.url";
+
 	public static final String USERS_REMINDER_QUERIES_CUSTOM_QUESTION_ENABLED = "users.reminder.queries.custom.question.enabled";
 
 	public static final String USERS_REMINDER_QUERIES_ENABLED = "users.reminder.queries.enabled";


### PR DESCRIPTION
Hey Brian, this will be used to replace the "hardcoded" /profile in social-networking.

We added this property to make the solution very flexible instead of just reduce it to the friendlyURL of the layout. This would allow to generate complex urls to porlets or even to have parameters.
