### PR TITLE
LPS-34212 containsregexp is matching the file content, not the file name...

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -843,9 +843,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 							<exclude name="**/UserServiceHttpTest.class" />
 							<exclude name="**/UserServiceSoapTest.class" />
 							<exclude name="${test.excludes}" />
-							<not>
-								<containsregexp expression="${junit.test.excludes}" />
-							</not>
+							<filename regex="${junit.test.excludes}" negate="true" />
 						</fileset>
 					</batchtest>
 				</junit>

--- a/build.properties
+++ b/build.properties
@@ -60,7 +60,7 @@
     junit.halt.on.failure=false
     junit.java.mx=1024m
     junit.java.maxpermsize=256m
-    junit.test.excludes=
+    junit.test.excludes=(?!)
 
 ##
 ## Module Framework


### PR DESCRIPTION
..., it sLPS-34212 containsregexp is matching the file content, not the file name, it should use filename. Besides, since we are doing an exclude, by default we need to provide a regex that matches everything, then negative of it means not excluding anything.hould use filename. Besides, since we are doing an exclude, by default we need to provide a regex that matches everything.
