### PR TITLE
LPS-34419 JRuby causing perm space memory leaking

### DIFF
--- a/portal-impl/src/com/liferay/portal/scripting/ruby/RubyExecutor.java
+++ b/portal-impl/src/com/liferay/portal/scripting/ruby/RubyExecutor.java
@@ -63,7 +63,7 @@ public class RubyExecutor extends BaseScriptingExecutor {
 		}
 
 		_scriptingContainer = new ScriptingContainer(
-			LocalContextScope.THREADSAFE);
+			LocalContextScope.CONCURRENT);
 
 		LocalContextProvider localContextProvider =
 			_scriptingContainer.getProvider();


### PR DESCRIPTION
@amosfong

This is the most obvious perm space memory leaking on our production servers, but not necessarily to be the only one. Please patch the server with this, if we run out of perm space again, do another heap dump. I will look for further leakings.
