### PR TITLE
Lps 34537

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -83,7 +83,9 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+
 import java.lang.reflect.Constructor;
+
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -93,6 +95,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -106,6 +109,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.dom4j.DocumentException;
+
 import org.springframework.context.support.AbstractApplicationContext;
 
 /**
@@ -332,15 +336,27 @@ public class ServiceBuilder {
 	public static void reenterableMain(String[] args) throws Exception {
 		Properties properties = new Properties(System.getProperties());
 
-		URL[] jvmUrls = ClassPathUtil.getClassPathURLs(ClassPathUtil.getJVMClassPath(true));
-		URL[] parentUrls = ((URLClassLoader)Thread.currentThread().getContextClassLoader()).getURLs();
+		URL[] jvmClassPathURLs = ClassPathUtil.getClassPathURLs(
+			ClassPathUtil.getJVMClassPath(true));
 
-		URL[] mergedUrls = new URL[jvmUrls.length + parentUrls.length];
+		Thread currentThread = Thread.currentThread();
 
-		System.arraycopy( jvmUrls, 0, mergedUrls, 0, jvmUrls.length );
-		System.arraycopy( parentUrls, 0, mergedUrls, jvmUrls.length, parentUrls.length );
+		Set<URL> contextClassPathURLs = ClassPathUtil.getClassPathURLs(
+			currentThread.getContextClassLoader());
 
-		ClassLoader classLoader = new URLClassLoader(mergedUrls, null );
+		Class<ServiceBuilder> serviceBuilderClass = ServiceBuilder.class;
+
+		Set<URL> literalClassPathURLs = ClassPathUtil.getClassPathURLs(
+			serviceBuilderClass.getClassLoader());
+
+		Set<URL> mergedURLs = new LinkedHashSet<URL>();
+
+		mergedURLs.addAll(literalClassPathURLs);
+		mergedURLs.addAll(contextClassPathURLs);
+		mergedURLs.addAll(Arrays.asList(jvmClassPathURLs));
+
+		ClassLoader classLoader = new URLClassLoader(
+			mergedURLs.toArray(new URL[mergedURLs.size()]), null);
 
 		class ReenterableCallable implements Callable<Void> {
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -14,13 +14,16 @@
 
 package com.liferay.portal.tools.servicebuilder;
 
+import com.liferay.portal.bean.BeanLocatorImpl;
 import com.liferay.portal.freemarker.FreeMarkerUtil;
+import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.db.IndexMetadataFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
+import com.liferay.portal.kernel.process.ClassPathUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ArrayUtil_IW;
 import com.liferay.portal.kernel.util.CharPool;
@@ -80,6 +83,9 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.net.URLClassLoader;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,10 +100,13 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.dom4j.DocumentException;
+import org.springframework.context.support.AbstractApplicationContext;
 
 /**
  * @author Brian Wing Shun Chan
@@ -318,6 +327,71 @@ public class ServiceBuilder {
 		}
 
 		Introspector.flushCaches();
+	}
+
+	public static void reenterableMain(String[] args) throws Exception {
+		Properties properties = new Properties(System.getProperties());
+
+		URL[] jvmUrls = ClassPathUtil.getClassPathURLs(ClassPathUtil.getJVMClassPath(true));
+		URL[] parentUrls = ((URLClassLoader)Thread.currentThread().getContextClassLoader()).getURLs();
+
+		URL[] mergedUrls = new URL[jvmUrls.length + parentUrls.length];
+
+		System.arraycopy( jvmUrls, 0, mergedUrls, 0, jvmUrls.length );
+		System.arraycopy( parentUrls, 0, mergedUrls, jvmUrls.length, parentUrls.length );
+
+		ClassLoader classLoader = new URLClassLoader(mergedUrls, null );
+
+		class ReenterableCallable implements Callable<Void> {
+
+			public ReenterableCallable(String[] args) {
+				_args = args;
+			}
+
+			@Override
+			public Void call() throws Exception {
+				main(_args);
+
+				BeanLocatorImpl beanLocatorImpl =
+					(BeanLocatorImpl)PortalBeanLocatorUtil.getBeanLocator();
+
+				AbstractApplicationContext abstractApplicationContext =
+					(AbstractApplicationContext)
+						beanLocatorImpl.getApplicationContext();
+
+				abstractApplicationContext.close();
+
+				return null;
+			}
+
+			private final String[] _args;
+
+		}
+
+		Class<? extends Callable<Void>> reenterableCallableClass =
+			(Class<? extends Callable<Void>>)classLoader.loadClass(
+				ReenterableCallable.class.getName());
+
+		Constructor<? extends Callable<Void>> constructor =
+			reenterableCallableClass.getConstructor(String[].class);
+
+		constructor.setAccessible(true);
+
+		FutureTask<Void> mainFutureTask = new FutureTask<Void>(
+			constructor.newInstance(new Object[]{args}));
+
+		Thread invokerThread = new Thread(mainFutureTask);
+
+		invokerThread.setContextClassLoader(classLoader);
+		invokerThread.setDaemon(true);
+
+		invokerThread.start();
+
+		mainFutureTask.get();
+
+		invokerThread.join();
+
+		System.setProperties(properties);
 	}
 
 	public static String toHumanName(String name) {

--- a/portal-service/src/com/liferay/portal/kernel/process/ClassPathUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/ClassPathUtil.java
@@ -32,11 +32,12 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.net.URLConnection;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -46,12 +47,28 @@ import javax.servlet.ServletException;
  */
 public class ClassPathUtil {
 
+	public static Set<URL> getClassPathURLs(ClassLoader classLoader) {
+		Set<URL> urls = new LinkedHashSet<URL>();
+
+		while (classLoader != null) {
+			if (classLoader instanceof URLClassLoader) {
+				URLClassLoader urlClassLoader = (URLClassLoader)classLoader;
+
+				urls.addAll(Arrays.asList(urlClassLoader.getURLs()));
+			}
+
+			classLoader = classLoader.getParent();
+		}
+
+		return urls;
+	}
+
 	public static URL[] getClassPathURLs(String classPath)
 		throws MalformedURLException {
 
 		String[] paths = StringUtil.split(classPath, File.pathSeparatorChar);
 
-		List<URL> urls = new ArrayList<URL>();
+		Set<URL> urls = new LinkedHashSet<URL>();
 
 		for (String path : paths) {
 			File file = new File(path);


### PR DESCRIPTION
@gamerson
I added ClassLoader hierarchic searching and including literal class path urls. 
This is not really needed for your case, but for a more complex case which context classloader could be different from literal classloader and they could both have a hierarchic. This can make the most complex case still working.

@brianchandotcom
Brian, you don't have to merge this, if you still feel this is too complex. Greg can keep this in the maven support project.
The only reason I prefer this approach, is just it can prevent most future changes breaking this feature as it treats servicebuilder as a black box. And the invoker does not need to worry about an ahead of time initialization for Spring, as we can always destroy everything properly.
