### PR TITLE
LPS-33340 Source formatting

### DIFF
--- a/portal-impl/src/com/liferay/portal/json/UnmodifiableJSONObjectImpl.java
+++ b/portal-impl/src/com/liferay/portal/json/UnmodifiableJSONObjectImpl.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
-import edu.emory.mathcs.backport.java.util.Collections;
+import java.util.Collections;
 
 import java.util.Date;
 import java.util.Iterator;


### PR DESCRIPTION
I think we should remove concurrent.jar, it is quite annoying to have it in the class path. I don't think currently we have any libs depend on it.

Or at least we should add a source formatter scanning warning for importing from that jar.
