### PR TITLE
LPS-30322 Undo some source formtting for performance and threadsafty purposes

### DIFF
--- a/portal-impl/src/com/liferay/portal/resiliency/spi/SPIRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/resiliency/spi/SPIRegistryImpl.java
@@ -162,15 +162,16 @@ public class SPIRegistryImpl implements SPIRegistry {
 
 	private static Log _log = LogFactoryUtil.getLog(SPIRegistryImpl.class);
 
-	private Set<String> _excludedPortletIds = new ConcurrentHashSet<String>();
-	private Lock _lock = new ReentrantLock();
-	private Map<SPI, String[]> _portletIds =
+	private final Set<String> _excludedPortletIds =
+		new ConcurrentHashSet<String>();
+	private final Lock _lock = new ReentrantLock();
+	private final Map<SPI, String[]> _portletIds =
 		new ConcurrentHashMap<SPI, String[]>();
-	private Map<String, SPI> _portletSPIs =
+	private final Map<String, SPI> _portletSPIs =
 		new ConcurrentHashMap<String, SPI>();
-	private Map<SPI, String[]> _servletContextNames =
+	private final Map<SPI, String[]> _servletContextNames =
 		new ConcurrentHashMap<SPI, String[]>();
-	private Map<String, SPI> _servletContextSPIs =
+	private final Map<String, SPI> _servletContextSPIs =
 		new ConcurrentHashMap<String, SPI>();
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
@@ -385,10 +385,6 @@ public class MPIHelperUtil {
 				return true;
 			}
 
-			if (!(obj instanceof SPIKey)) {
-				return false;
-			}
-
 			SPIKey clusterNode = (SPIKey)obj;
 
 			if (Validator.equals(
@@ -403,9 +399,7 @@ public class MPIHelperUtil {
 
 		@Override
 		public int hashCode() {
-			String string = toString();
-
-			return string.hashCode();
+			return _spiProviderName.hashCode() * 11 + _spiId.hashCode();
 		}
 
 		@Override
@@ -413,8 +407,8 @@ public class MPIHelperUtil {
 			return _spiProviderName.concat(StringPool.POUND).concat(_spiId);
 		}
 
-		private String _spiId;
-		private String _spiProviderName;
+		private final String _spiId;
+		private final String _spiProviderName;
 
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIConfiguration.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIConfiguration.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.kernel.resiliency.spi;
 
 import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Document;
@@ -51,28 +50,35 @@ public class SPIConfiguration implements Serializable {
 
 		Element rootElement = document.getRootElement();
 
-		String id = rootElement.elementText("id");
-		String javaExecutable = rootElement.elementText("javaExecutable");
-		String jvmArguments = rootElement.elementText("jvmArguments");
-		String spiAgentClassName = rootElement.elementText("spiAgentClassName");
-		int connectorPort = Integer.parseInt(
-			rootElement.elementText("connectorPort"));
-		String baseDir = rootElement.elementText("baseDir");
-		String[] portletIds = StringUtil.split(
-			rootElement.elementText("portletIds"));
-		String[] servletContextNames = StringUtil.split(
-			rootElement.elementText("servletContextNames"));
-		long pingInterval = GetterUtil.getLong(
-			rootElement.elementText("pingInterval"));
-		long registerTimeout = GetterUtil.getLong(
-			rootElement.elementText("registerTimeout"));
-		long shutdownTimeout = GetterUtil.getLong(
-			rootElement.elementText("shutdownTimeout"));
+		try {
+			String id = rootElement.elementText("id");
+			String javaExecutable = rootElement.elementText("javaExecutable");
+			String jvmArguments = rootElement.elementText("jvmArguments");
+			String spiAgentClassName = rootElement.elementText(
+				"spiAgentClassName");
+			int connectorPort = Integer.parseInt(
+				rootElement.elementText("connectorPort"));
+			String baseDir = rootElement.elementText("baseDir");
+			String[] portletIds = StringUtil.split(
+				rootElement.elementText("portletIds"));
+			String[] servletContextNames = StringUtil.split(
+				rootElement.elementText("servletContextNames"));
+			long pingInterval = Long.parseLong(
+				rootElement.elementText("pingInterval"));
+			long registerTimeout = Long.parseLong(
+				rootElement.elementText("registerTimeout"));
+			long shutdownTimeout = Long.parseLong(
+				rootElement.elementText("shutdownTimeout"));
 
-		return new SPIConfiguration(
-			id, javaExecutable, jvmArguments, spiAgentClassName, connectorPort,
-			baseDir, portletIds, servletContextNames, pingInterval,
-			registerTimeout, shutdownTimeout);
+			return new SPIConfiguration(
+				id, javaExecutable, jvmArguments, spiAgentClassName,
+				connectorPort, baseDir, portletIds, servletContextNames,
+				pingInterval, registerTimeout, shutdownTimeout);
+		}
+		catch (NumberFormatException nfe) {
+			throw new DocumentException(
+				"Unable to parse xml to SPIConfiguration", nfe);
+		}
 	}
 
 	public SPIConfiguration(
@@ -203,16 +209,16 @@ public class SPIConfiguration implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private String _baseDir;
-	private int _connectorPort;
-	private String _javaExecutable;
-	private String _jvmArguments;
-	private long _pingInterval;
-	private String[] _portletIds;
-	private long _registerTimeout;
-	private String[] _servletContextNames;
-	private long _shutdownTimeout;
-	private String _spiAgentClassName;
-	private String _spiId;
+	private final String _baseDir;
+	private final int _connectorPort;
+	private final String _javaExecutable;
+	private final String _jvmArguments;
+	private final long _pingInterval;
+	private final String[] _portletIds;
+	private final long _registerTimeout;
+	private final String[] _servletContextNames;
+	private final long _shutdownTimeout;
+	private final String _spiAgentClassName;
+	private final String _spiId;
 
 }


### PR DESCRIPTION
Hey Brian,

Those finals are required for threadsafty.
SPIConfiguration.fromXMLString() needs to call Long.parseLong() in order to throw out NumberFormatException on bad xml content, it can not silently convert bad setting to default 0.
SPIKey is private class, not possible to be used outside of MPIHelperUtil, no need to do the instanceof checking. Calculating hashcode bases toString() is no good, it forces us to create the temp toString() objects.
