### PR TITLE
LPS-30322 Use 11 as it is a good prime number that is not too small(like...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
@@ -403,9 +403,7 @@ public class MPIHelperUtil {
 
 		@Override
 		public int hashCode() {
-			String string = toString();
-
-			return string.hashCode();
+			return _spiProviderName.hashCode() * 11 + _spiId.hashCode();
 		}
 
 		@Override


### PR DESCRIPTION
... 2, 3, 7) to provide a decent even hash LPS-30322 Use 11 as it is a good prime number that is not too small(like 2, 3, 7) to provide an uneven hash, or too big to cause a heavy calculation
