### PR TITLE
LPS-30322 "private static class .*Key" does not need the instanceof for ...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtil.java
@@ -381,19 +381,11 @@ public class MPIHelperUtil {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (this == obj) {
-				return true;
-			}
-
-			if (!(obj instanceof SPIKey)) {
-				return false;
-			}
-
-			SPIKey clusterNode = (SPIKey)obj;
+			SPIKey spiKey = (SPIKey)obj;
 
 			if (Validator.equals(
-					_spiProviderName, clusterNode._spiProviderName) &&
-				Validator.equals(_spiId, clusterNode._spiId)) {
+					_spiProviderName, spiKey._spiProviderName) &&
+				Validator.equals(_spiId, spiKey._spiId)) {
 
 				return true;
 			}


### PR DESCRIPTION
...performance reason, don't copy this pattern to public hash key classes, source formatter checking will be added for this.
