### PR TITLE
LPS-34899 Disable Security Manager when TCK is enabled

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/lang/SecurityManagerUtil.java
+++ b/portal-impl/src/com/liferay/portal/security/lang/SecurityManagerUtil.java
@@ -38,8 +38,14 @@ public class SecurityManagerUtil {
 			return;
 		}
 
-		_portalSecurityManagerStrategy = PortalSecurityManagerStrategy.parse(
-			PropsValues.PORTAL_SECURITY_MANAGER_STRATEGY);
+		if (!PropsValues.TCK_URL) {
+			_portalSecurityManagerStrategy =
+				PortalSecurityManagerStrategy.parse(
+					PropsValues.PORTAL_SECURITY_MANAGER_STRATEGY);
+		}
+		else {
+			_portalSecurityManagerStrategy = PortalSecurityManagerStrategy.NONE;
+		}
 
 		if ((_portalSecurityManagerStrategy ==
 				PortalSecurityManagerStrategy.LIFERAY) ||


### PR DESCRIPTION
There's a bug with PACL so this won't work until http://issues.liferay.com/browse/LPS-34936 is merged (currently under Ray's review), however the patch can safely be merged.
