### PR TITLE
Lps 33946 mdr rules

### DIFF
--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -29,12 +29,14 @@ import com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup;
 import com.liferay.portlet.mobiledevicerules.service.base.MDRRuleGroupLocalServiceBaseImpl;
 
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 /**
  * @author Edward C. Han
+ * @author Manuel de la Peña
  */
 public class MDRRuleGroupLocalServiceImpl
 	extends MDRRuleGroupLocalServiceBaseImpl {
@@ -178,32 +180,38 @@ public class MDRRuleGroupLocalServiceImpl
 	}
 
 	public List<MDRRuleGroup> search(
-			long groupId, String name, boolean andOperator, int start, int end)
+			long groupId, String name, LinkedHashMap<String, Object> params,
+			boolean andOperator, int start, int end)
 		throws SystemException {
 
 		return mdrRuleGroupFinder.findByG_N(
-			groupId, name, andOperator, start, end);
+			groupId, name, params, andOperator, start, end);
 	}
 
 	public List<MDRRuleGroup> searchByKeywords(
-			long groupId, String keywords, boolean andOperator, int start,
-			int end)
+			long groupId, String keywords, LinkedHashMap<String, Object> params,
+			boolean andOperator, int start, int end)
 		throws SystemException {
 
-		return mdrRuleGroupFinder.findByKeywords(groupId, keywords, start, end);
+		return mdrRuleGroupFinder.findByKeywords(
+			groupId, keywords, params, start, end);
 	}
 
 	public int searchByKeywordsCount(
-			long groupId, String keywords, boolean andOperator)
+			long groupId, String keywords, LinkedHashMap<String, Object> params,
+			boolean andOperator)
 		throws SystemException {
 
-		return mdrRuleGroupFinder.countByKeywords(groupId, keywords);
+		return mdrRuleGroupFinder.countByKeywords(groupId, params, keywords);
 	}
 
-	public int searchCount(long groupId, String name, boolean andOperator)
+	public int searchCount(
+			long groupId, String name, LinkedHashMap<String, Object> params,
+			boolean andOperator)
 		throws SystemException {
 
-		return mdrRuleGroupFinder.countByG_N(groupId, name, andOperator);
+		return mdrRuleGroupFinder.countByG_N(
+			groupId, name, params, andOperator);
 	}
 
 	public MDRRuleGroup updateRuleGroup(

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -187,8 +187,13 @@ public class MDRRuleGroupLocalServiceImpl
 			long groupId, String name, boolean andOperator, int start, int end)
 		throws SystemException {
 
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
 		return mdrRuleGroupFinder.findByG_N(
-			groupId, name, andOperator, start, end);
+			groupId, name, params, andOperator, start, end);
 	}
 
 	public List<MDRRuleGroup> search(
@@ -209,8 +214,13 @@ public class MDRRuleGroupLocalServiceImpl
 			int end)
 		throws SystemException {
 
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
 		return mdrRuleGroupFinder.findByKeywords(
-			groupId, keywords, start, end);
+			groupId, keywords, params, start, end);
 	}
 
 	public List<MDRRuleGroup> searchByKeywords(
@@ -230,7 +240,12 @@ public class MDRRuleGroupLocalServiceImpl
 			long groupId, String keywords, boolean andOperator)
 		throws SystemException {
 
-		return mdrRuleGroupFinder.countByKeywords(groupId, keywords);
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
+		return mdrRuleGroupFinder.countByKeywords(groupId, keywords, params);
 	}
 
 	public int searchByKeywordsCount(
@@ -238,7 +253,7 @@ public class MDRRuleGroupLocalServiceImpl
 			boolean andOperator)
 		throws SystemException {
 
-		return mdrRuleGroupFinder.countByKeywords(groupId, params, keywords);
+		return mdrRuleGroupFinder.countByKeywords(groupId, keywords, params);
 	}
 
 	/**
@@ -248,7 +263,13 @@ public class MDRRuleGroupLocalServiceImpl
 	public int searchCount(long groupId, String name, boolean andOperator)
 		throws SystemException {
 
-		return mdrRuleGroupFinder.countByG_N(groupId, name, andOperator);
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
+		return mdrRuleGroupFinder.countByG_N(
+			groupId, name, params, andOperator);
 	}
 
 	public int searchCount(

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -179,6 +179,10 @@ public class MDRRuleGroupLocalServiceImpl
 		return mdrRuleGroupPersistence.countByGroupId(groupId);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #search(long, String,
+	 *             java.util.LinkedHashMap, boolean, int, int)}
+	 */
 	public List<MDRRuleGroup> search(
 			long groupId, String name, boolean andOperator, int start, int end)
 		throws SystemException {
@@ -196,6 +200,10 @@ public class MDRRuleGroupLocalServiceImpl
 			groupId, name, params, andOperator, start, end);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #searchByKeywords(long,
+	 *             String, java.util.LinkedHashMap, boolean, int, int)}
+	 */
 	public List<MDRRuleGroup> searchByKeywords(
 			long groupId, String keywords, boolean andOperator, int start,
 			int end)
@@ -214,6 +222,10 @@ public class MDRRuleGroupLocalServiceImpl
 			groupId, keywords, params, start, end);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #searchByKeywordsCount(long,
+	 *             String, java.util.LinkedHashMap, boolean)}
+	 */
 	public int searchByKeywordsCount(
 			long groupId, String keywords, boolean andOperator)
 		throws SystemException {
@@ -229,6 +241,10 @@ public class MDRRuleGroupLocalServiceImpl
 		return mdrRuleGroupFinder.countByKeywords(groupId, params, keywords);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #searchCount(long,
+	 *             String, java.util.LinkedHashMap, boolean)}
+	 */
 	public int searchCount(long groupId, String name, boolean andOperator)
 		throws SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -180,12 +180,29 @@ public class MDRRuleGroupLocalServiceImpl
 	}
 
 	public List<MDRRuleGroup> search(
+			long groupId, String name, boolean andOperator, int start, int end)
+		throws SystemException {
+
+		return mdrRuleGroupFinder.findByG_N(
+			groupId, name, andOperator, start, end);
+	}
+
+	public List<MDRRuleGroup> search(
 			long groupId, String name, LinkedHashMap<String, Object> params,
 			boolean andOperator, int start, int end)
 		throws SystemException {
 
 		return mdrRuleGroupFinder.findByG_N(
 			groupId, name, params, andOperator, start, end);
+	}
+
+	public List<MDRRuleGroup> searchByKeywords(
+			long groupId, String keywords, boolean andOperator, int start,
+			int end)
+		throws SystemException {
+
+		return mdrRuleGroupFinder.findByKeywords(
+			groupId, keywords, start, end);
 	}
 
 	public List<MDRRuleGroup> searchByKeywords(
@@ -198,11 +215,24 @@ public class MDRRuleGroupLocalServiceImpl
 	}
 
 	public int searchByKeywordsCount(
+			long groupId, String keywords, boolean andOperator)
+		throws SystemException {
+
+		return mdrRuleGroupFinder.countByKeywords(groupId, keywords);
+	}
+
+	public int searchByKeywordsCount(
 			long groupId, String keywords, LinkedHashMap<String, Object> params,
 			boolean andOperator)
 		throws SystemException {
 
 		return mdrRuleGroupFinder.countByKeywords(groupId, params, keywords);
+	}
+
+	public int searchCount(long groupId, String name, boolean andOperator)
+		throws SystemException {
+
+		return mdrRuleGroupFinder.countByG_N(groupId, name, andOperator);
 	}
 
 	public int searchCount(

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
@@ -54,22 +54,8 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	public static final String FIND_BY_G_N =
 		MDRRuleGroupFinder.class.getName() + ".findByG_N";
 
-	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #countByKeywords(long,
-	 *             java.util.LinkedHashMap, String)}
-	 */
-	public int countByKeywords(long groupId, String keywords)
-		throws SystemException {
-
-		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
-
-		params.put("includeGlobalScope", true);
-
-		return countByKeywords(groupId, params, keywords);
-	}
-
 	public int countByKeywords(
-			long groupId, LinkedHashMap<String, Object> params, String keywords)
+			long groupId, String keywords, LinkedHashMap<String, Object> params)
 		throws SystemException {
 
 		String[] names = null;
@@ -85,40 +71,12 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return countByG_N(groupId, names, params, andOperator);
 	}
 
-	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #countByG_N(long, String,
-	 *             java.util.LinkedHashMap, boolean)}
-	 */
-	public int countByG_N(long groupId, String name, boolean andOperator)
-		throws SystemException {
-
-		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
-
-		params.put("includeGlobalScope", true);
-
-		return countByG_N(groupId, name, params, andOperator);
-	}
-
 	public int countByG_N(
 			long groupId, String name, LinkedHashMap<String, Object> params,
 			boolean andOperator)
 		throws SystemException {
 
 		String[] names = CustomSQLUtil.keywords(name);
-
-		return countByG_N(groupId, names, params, andOperator);
-	}
-
-	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #countByG_N(long, String[],
-	 *             java.util.LinkedHashMap, boolean)}
-	 */
-	public int countByG_N(long groupId, String[] names, boolean andOperator)
-		throws SystemException {
-
-		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
-
-		params.put("includeGlobalScope", true);
 
 		return countByG_N(groupId, names, params, andOperator);
 	}
@@ -179,7 +137,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 			qPos.add(groupId);
 
-			setParameterValues(qPos, params1);
+			setParams(qPos, params1);
 
 			qPos.add(names, 2);
 
@@ -203,21 +161,6 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		}
 	}
 
-	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #findByKeywords(long, String,
-	 *             java.util.LinkedHashMap, int, int)}
-	 */
-	public List<MDRRuleGroup> findByKeywords(
-			long groupId, String keywords, int start, int end)
-		throws SystemException {
-
-		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
-
-		params.put("includeGlobalScope", true);
-
-		return findByKeywords(groupId, keywords, params, start, end);
-	}
-
 	public List<MDRRuleGroup> findByKeywords(
 			long groupId, String keywords, LinkedHashMap<String, Object> params,
 			int start, int end)
@@ -236,21 +179,6 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return findByG_N(groupId, names, params, andOperator, start, end);
 	}
 
-	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #findByG_N(long, String,
-	 *             java.util.LinkedHashMap, boolean)}
-	 */
-	public List<MDRRuleGroup> findByG_N(
-			long groupId, String name, boolean andOperator)
-		throws SystemException {
-
-		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
-
-		params.put("includeGlobalScope", true);
-
-		return findByG_N(groupId, name, params, andOperator);
-	}
-
 	public List<MDRRuleGroup> findByG_N(
 			long groupId, String name, LinkedHashMap<String, Object> params,
 			boolean andOperator)
@@ -261,45 +189,12 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			QueryUtil.ALL_POS);
 	}
 
-	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #findByG_N(long, String,
-	 *             java.util.LinkedHashMap, boolean, int, int)}
-	 */
-	public List<MDRRuleGroup> findByG_N(
-			long groupId, String name, boolean andOperator, int start, int end)
-		throws SystemException {
-
-		LinkedHashMap<String, Object> params =
-			new LinkedHashMap<String, Object>();
-
-		params.put("includeGlobalScope", true);
-
-		return findByG_N(groupId, name, params, andOperator, start, end);
-	}
-
 	public List<MDRRuleGroup> findByG_N(
 			long groupId, String name, LinkedHashMap<String, Object> params,
 			boolean andOperator, int start, int end)
 		throws SystemException {
 
 		String[] names = CustomSQLUtil.keywords(name);
-
-		return findByG_N(groupId, names, params, andOperator, start, end);
-	}
-
-	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #findByG_N(long, String,
-	 *             java.util.LinkedHashMap, boolean, int, int)}
-	 */
-	public List<MDRRuleGroup> findByG_N(
-			long groupId, String[] names, boolean andOperator, int start,
-			int end)
-		throws SystemException {
-
-		LinkedHashMap<String, Object> params =
-			new LinkedHashMap<String, Object>();
-
-		params.put("includeGlobalScope", true);
 
 		return findByG_N(groupId, names, params, andOperator, start, end);
 	}
@@ -360,7 +255,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 			qPos.add(groupId);
 
-			setParameterValues(qPos, params1);
+			setParams(qPos, params1);
 
 			qPos.add(names, 2);
 
@@ -378,11 +273,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	protected String getGroupIdComparator(
 		LinkedHashMap<String, Object> params) {
 
-		if ((params == null) || params.isEmpty()) {
-			return "(groupId = ?)";
-		}
-
-		StringBundler sb = new StringBundler(params.size());
+		StringBundler sb = new StringBundler(5);
 
 		for (Map.Entry<String, Object> entry : params.entrySet()) {
 			String key = entry.getKey();
@@ -432,7 +323,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return resultSQL;
 	}
 
-	protected void setParameterValues(
+	protected void setParams(
 			QueryPos qPos, LinkedHashMap<String, Object> params)
 		throws PortalException, SystemException {
 
@@ -444,7 +335,6 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			String key = entry.getKey();
 
 			if (key.equals("includeGlobalScope")) {
-
 				boolean includeGlobalScope = (Boolean)entry.getValue();
 
 				if (includeGlobalScope) {
@@ -458,57 +348,14 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 					qPos.add(globalGroup.getGroupId());
 				}
 			}
-			else {
-				Object value = entry.getValue();
-
-				if (value instanceof Integer) {
-					Integer valueInteger = (Integer)value;
-
-					if (Validator.isNotNull(valueInteger)) {
-						qPos.add(valueInteger);
-					}
-				}
-				else if (value instanceof Long) {
-					Long valueLong = (Long)value;
-
-					if (Validator.isNotNull(valueLong)) {
-						qPos.add(valueLong);
-					}
-				}
-				else if (value instanceof String) {
-					String valueString = (String)value;
-
-					if (Validator.isNotNull(valueString)) {
-						qPos.add(valueString);
-					}
-				}
-			}
 		}
 	}
 
 	private String _buildSQLKey(LinkedHashMap<String, Object> param1) {
-
 		StringBundler sb = new StringBundler(param1.size() + 1);
 
 		for (Map.Entry<String, Object> entry : param1.entrySet()) {
-			String key = entry.getKey();
-
-			Object value = entry.getValue();
-
-			if (value instanceof List<?>) {
-				List<Object> values = (List<Object>)value;
-
-				if (!values.isEmpty()) {
-					for (int i = 0; i < values.size(); i++) {
-						sb.append(key);
-						sb.append(StringPool.DASH);
-						sb.append(i);
-					}
-				}
-			}
-			else {
-				sb.append(key);
-			}
+			sb.append(entry.getKey());
 		}
 
 		return sb.toString();

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
@@ -92,20 +92,14 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			params = _emptyLinkedHashMap;
 		}
 
-		LinkedHashMap<String, Object> params1 = params;
-
 		Session session = null;
 
 		try {
 			session = openSession();
 
-			String sql = null;
+			String cacheKey = _buildCacheKey(COUNT_BY_G_N, params);
 
-			if (params1.size() > 0) {
-				String sqlKey = _buildSQLKey(params1);
-
-				sql = _countByG_NCache.get(sqlKey);
-			}
+			String sql = _countByG_NCache.get(cacheKey);
 
 			if (sql == null) {
 				String countByG_N = CustomSQLUtil.get(COUNT_BY_G_N);
@@ -113,16 +107,13 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 				StringBundler sb = new StringBundler();
 
 				sb.append(StringPool.OPEN_PARENTHESIS);
-				sb.append(replaceGroupIdComparator(countByG_N, params1));
+				sb.append(
+					replaceGroupIdComparator(countByG_N, cacheKey, params));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 
-				if (params1.size() > 0) {
-					String sqlKey = _buildSQLKey(params1);
-
-					_countByG_NCache.put(sqlKey, sb.toString());
-				}
-
 				sql = sb.toString();
+
+				_countByG_NCache.put(cacheKey, sql);
 			}
 
 			sql = CustomSQLUtil.replaceKeywords(
@@ -137,7 +128,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 			qPos.add(groupId);
 
-			setParams(qPos, params1);
+			setParams(qPos, params);
 
 			qPos.add(names, 2);
 
@@ -210,20 +201,14 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			params = _emptyLinkedHashMap;
 		}
 
-		LinkedHashMap<String, Object> params1 = params;
-
 		Session session = null;
 
 		try {
 			session = openSession();
 
-			String sql = null;
+			String cacheKey = _buildCacheKey(FIND_BY_G_N, params);
 
-			if (params1.size() > 0) {
-				String sqlKey = _buildSQLKey(params1);
-
-				sql = _findByG_NCache.get(sqlKey);
-			}
+			String sql = _findByG_NCache.get(cacheKey);
 
 			if (sql == null) {
 				String findByG_N = CustomSQLUtil.get(FIND_BY_G_N);
@@ -231,16 +216,13 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 				StringBundler sb = new StringBundler();
 
 				sb.append(StringPool.OPEN_PARENTHESIS);
-				sb.append(replaceGroupIdComparator(findByG_N, params1));
+				sb.append(
+					replaceGroupIdComparator(findByG_N, cacheKey, params));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 
-				if (params1.size() > 0) {
-					String sqlKey = _buildSQLKey(params1);
-
-					_findByG_NCache.put(sqlKey, sb.toString());
-				}
-
 				sql = sb.toString();
+
+				_findByG_NCache.put(cacheKey, sql);
 			}
 
 			sql = CustomSQLUtil.replaceKeywords(
@@ -255,7 +237,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 			qPos.add(groupId);
 
-			setParams(qPos, params1);
+			setParams(qPos, params);
 
 			qPos.add(names, 2);
 
@@ -270,8 +252,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		}
 	}
 
-	protected String getGroupIdComparator(
-		LinkedHashMap<String, Object> params) {
+	protected String getGroupIdComparator(Map<String, Object> params) {
 
 		StringBundler sb = new StringBundler(5);
 
@@ -296,7 +277,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	}
 
 	protected String replaceGroupIdComparator(
-		String sql, LinkedHashMap<String, Object> params) {
+		String sql, String cacheKey, Map<String, Object> params) {
 
 		if (params.isEmpty()) {
 			return StringUtil.replace(
@@ -308,8 +289,6 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 					"(groupId = ?)"
 				});
 		}
-
-		String cacheKey = _getCacheKey(sql, params);
 
 		String resultSQL = _replaceWhereSQLCache.get(cacheKey);
 
@@ -323,8 +302,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return resultSQL;
 	}
 
-	protected void setParams(
-			QueryPos qPos, LinkedHashMap<String, Object> params)
+	protected void setParams(QueryPos qPos, Map<String, Object> params)
 		throws PortalException, SystemException {
 
 		if ((params == null) || params.isEmpty()) {
@@ -351,23 +329,16 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		}
 	}
 
-	private String _buildSQLKey(LinkedHashMap<String, Object> param1) {
-		StringBundler sb = new StringBundler(param1.size() + 1);
+	private String _buildCacheKey(
+		String keyPrefix, Map<String, Object> param1) {
+
+		StringBundler sb = new StringBundler(param1.size() + 2);
+
+		sb.append(keyPrefix);
 
 		for (Map.Entry<String, Object> entry : param1.entrySet()) {
 			sb.append(entry.getKey());
 		}
-
-		return sb.toString();
-	}
-
-	private String _getCacheKey(
-		String sql, LinkedHashMap<String, Object> params) {
-
-		StringBundler sb = new StringBundler();
-
-		sb.append(sql);
-		sb.append(_buildSQLKey(params));
 
 		return sb.toString();
 	}

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
@@ -19,20 +19,31 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.Type;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.Company;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.security.auth.CompanyThreadLocal;
+import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup;
 import com.liferay.portlet.mobiledevicerules.model.impl.MDRRuleGroupImpl;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Edward Han
  * @author Eduardo Lundgren
+ * @author Manuel de la Peña
  */
 public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	implements MDRRuleGroupFinder {
@@ -43,7 +54,8 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	public static final String FIND_BY_G_N =
 		MDRRuleGroupFinder.class.getName() + ".findByG_N";
 
-	public int countByKeywords(long groupId, String keywords)
+	public int countByKeywords(
+			long groupId, LinkedHashMap<String, Object> params, String keywords)
 		throws SystemException {
 
 		String[] names = null;
@@ -56,28 +68,62 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			andOperator = true;
 		}
 
-		return countByG_N(groupId, names, andOperator);
+		return countByG_N(groupId, names, params, andOperator);
 	}
 
-	public int countByG_N(long groupId, String name, boolean andOperator)
+	public int countByG_N(
+			long groupId, String name, LinkedHashMap<String, Object> params,
+			boolean andOperator)
 		throws SystemException {
 
 		String[] names = CustomSQLUtil.keywords(name);
 
-		return countByG_N(groupId, names, andOperator);
+		return countByG_N(groupId, names, params, andOperator);
 	}
 
-	public int countByG_N(long groupId, String[] names, boolean andOperator)
+	public int countByG_N(
+			long groupId, String[] names, LinkedHashMap<String, Object> params,
+			boolean andOperator)
 		throws SystemException {
 
 		names = CustomSQLUtil.keywords(names);
+
+		if (params == null) {
+			params = _emptyLinkedHashMap;
+		}
+
+		LinkedHashMap<String, Object> params1 = params;
 
 		Session session = null;
 
 		try {
 			session = openSession();
 
-			String sql = CustomSQLUtil.get(COUNT_BY_G_N);
+			String sql = null;
+
+			if (params1.size() > 0) {
+				String sqlKey = _buildSQLKey(params1);
+
+				sql = _countByG_NCache.get(sqlKey);
+			}
+
+			if (sql == null) {
+				String countByG_N = CustomSQLUtil.get(COUNT_BY_G_N);
+
+				StringBundler sb = new StringBundler();
+
+				sb.append(StringPool.OPEN_PARENTHESIS);
+				sb.append(replaceGroupIdComparator(countByG_N, params1));
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+
+				if (params1.size() > 0) {
+					String sqlKey = _buildSQLKey(params1);
+
+					_countByG_NCache.put(sqlKey, sb.toString());
+				}
+
+				sql = sb.toString();
+			}
 
 			sql = CustomSQLUtil.replaceKeywords(
 				sql, "lower(name)", StringPool.LIKE, true, names);
@@ -90,6 +136,9 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			QueryPos qPos = QueryPos.getInstance(q);
 
 			qPos.add(groupId);
+
+			setParameterValues(qPos, params1);
+
 			qPos.add(names, 2);
 
 			Iterator<Long> itr = q.iterate();
@@ -113,7 +162,8 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	}
 
 	public List<MDRRuleGroup> findByKeywords(
-			long groupId, String keywords, int start, int end)
+			long groupId, String keywords, LinkedHashMap<String, Object> params,
+			int start, int end)
 		throws SystemException {
 
 		String[] names = null;
@@ -126,39 +176,72 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			andOperator = true;
 		}
 
-		return findByG_N(groupId, names, andOperator, start, end);
+		return findByG_N(groupId, names, params, andOperator, start, end);
 	}
 
 	public List<MDRRuleGroup> findByG_N(
-			long groupId, String name, boolean andOperator)
+			long groupId, String name, LinkedHashMap<String, Object> params,
+			boolean andOperator)
 		throws SystemException {
 
 		return findByG_N(
-			groupId, name, andOperator, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			groupId, name, params, andOperator, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS);
 	}
 
 	public List<MDRRuleGroup> findByG_N(
-			long groupId, String name, boolean andOperator, int start, int end)
+			long groupId, String name, LinkedHashMap<String, Object> params,
+			boolean andOperator, int start, int end)
 		throws SystemException {
 
 		String[] names = CustomSQLUtil.keywords(name);
 
-		return findByG_N(groupId, names, andOperator, start, end);
+		return findByG_N(groupId, names, params, andOperator, start, end);
 	}
 
 	public List<MDRRuleGroup> findByG_N(
-			long groupId, String[] names, boolean andOperator, int start,
-			int end)
+			long groupId, String[] names, LinkedHashMap<String, Object> params,
+			boolean andOperator, int start, int end)
 		throws SystemException {
 
 		names = CustomSQLUtil.keywords(names);
+
+		if (params == null) {
+			params = _emptyLinkedHashMap;
+		}
+
+		LinkedHashMap<String, Object> params1 = params;
 
 		Session session = null;
 
 		try {
 			session = openSession();
 
-			String sql = CustomSQLUtil.get(FIND_BY_G_N);
+			String sql = null;
+
+			if (params1.size() > 0) {
+				String sqlKey = _buildSQLKey(params1);
+
+				sql = _findByG_NCache.get(sqlKey);
+			}
+
+			if (sql == null) {
+				String findByG_N = CustomSQLUtil.get(FIND_BY_G_N);
+
+				StringBundler sb = new StringBundler();
+
+				sb.append(StringPool.OPEN_PARENTHESIS);
+				sb.append(replaceGroupIdComparator(findByG_N, params1));
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+
+				if (params1.size() > 0) {
+					String sqlKey = _buildSQLKey(params1);
+
+					_findByG_NCache.put(sqlKey, sb.toString());
+				}
+
+				sql = sb.toString();
+			}
 
 			sql = CustomSQLUtil.replaceKeywords(
 				sql, "lower(name)", StringPool.LIKE, true, names);
@@ -171,6 +254,9 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			QueryPos qPos = QueryPos.getInstance(q);
 
 			qPos.add(groupId);
+
+			setParameterValues(qPos, params1);
+
 			qPos.add(names, 2);
 
 			return (List<MDRRuleGroup>)QueryUtil.list(
@@ -183,5 +269,164 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			closeSession(session);
 		}
 	}
+
+	protected String getGroupIdComparator(
+		LinkedHashMap<String, Object> params) {
+
+		if ((params == null) || params.isEmpty()) {
+			return "(groupId = ?)";
+		}
+
+		StringBundler sb = new StringBundler(params.size());
+
+		for (Map.Entry<String, Object> entry : params.entrySet()) {
+			String key = entry.getKey();
+
+			if (key.equals("includeGlobalScope")) {
+				boolean includeGlobalScope = (Boolean)entry.getValue();
+
+				sb.append(StringPool.OPEN_PARENTHESIS);
+				sb.append("(groupId = ?)");
+
+				if (includeGlobalScope) {
+					sb.append(" OR ");
+					sb.append("(groupId = ?)");
+					sb.append(StringPool.CLOSE_PARENTHESIS);
+				}
+			}
+		}
+
+		return sb.toString();
+	}
+
+	protected String replaceGroupIdComparator(
+		String sql, LinkedHashMap<String, Object> params) {
+
+		if (params.isEmpty()) {
+			return StringUtil.replace(
+				sql,
+				new String[] {
+					"[$GROUP_ID$]"
+				},
+				new String[] {
+					"(groupId = ?)"
+				});
+		}
+
+		String cacheKey = _getCacheKey(sql, params);
+
+		String resultSQL = _replaceWhereSQLCache.get(cacheKey);
+
+		if (resultSQL == null) {
+			resultSQL = StringUtil.replace(
+				sql, "[$GROUP_ID$]", getGroupIdComparator(params));
+
+			_replaceWhereSQLCache.put(cacheKey, resultSQL);
+		}
+
+		return resultSQL;
+	}
+
+	protected void setParameterValues(
+			QueryPos qPos, LinkedHashMap<String, Object> params)
+		throws SystemException, PortalException {
+
+		if ((params == null) || params.isEmpty()) {
+			return;
+		}
+
+		for (Map.Entry<String, Object> entry : params.entrySet()) {
+			String key = entry.getKey();
+
+			if (key.equals("includeGlobalScope")) {
+
+				boolean includeGlobalScope = (Boolean)entry.getValue();
+
+				if (includeGlobalScope) {
+					long currentCompanyId = CompanyThreadLocal.getCompanyId();
+
+					Company company = CompanyLocalServiceUtil.getCompany(
+						currentCompanyId);
+
+					Group globalGroup = company.getGroup();
+
+					qPos.add(globalGroup.getGroupId());
+				}
+			}
+			else {
+				Object value = entry.getValue();
+
+				if (value instanceof Integer) {
+					Integer valueInteger = (Integer)value;
+
+					if (Validator.isNotNull(valueInteger)) {
+						qPos.add(valueInteger);
+					}
+				}
+				else if (value instanceof Long) {
+					Long valueLong = (Long)value;
+
+					if (Validator.isNotNull(valueLong)) {
+						qPos.add(valueLong);
+					}
+				}
+				else if (value instanceof String) {
+					String valueString = (String)value;
+
+					if (Validator.isNotNull(valueString)) {
+						qPos.add(valueString);
+					}
+				}
+			}
+		}
+	}
+
+	private String _buildSQLKey(LinkedHashMap<String, Object> param1) {
+
+		StringBundler sb = new StringBundler(param1.size() + 1);
+
+		for (Map.Entry<String, Object> entry : param1.entrySet()) {
+			String key = entry.getKey();
+
+			Object value = entry.getValue();
+
+			if (value instanceof List<?>) {
+				List<Object> values = (List<Object>)value;
+
+				if (!values.isEmpty()) {
+					for (int i = 0; i < values.size(); i++) {
+						sb.append(key);
+						sb.append(StringPool.DASH);
+						sb.append(i);
+					}
+				}
+			}
+			else {
+				sb.append(key);
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private String _getCacheKey(
+		String sql, LinkedHashMap<String, Object> params) {
+
+		StringBundler sb = new StringBundler();
+
+		sb.append(sql);
+		sb.append(_buildSQLKey(params));
+
+		return sb.toString();
+	}
+
+	private Map<String, String> _countByG_NCache =
+		new ConcurrentHashMap<String, String>();
+	private LinkedHashMap<String, Object> _emptyLinkedHashMap =
+		new LinkedHashMap<String, Object>(0);
+	private Map<String, String> _findByG_NCache =
+		new ConcurrentHashMap<String, String>();
+	private Map<String, String> _replaceWhereSQLCache =
+		new ConcurrentHashMap<String, String>();
 
 }

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
@@ -54,6 +54,10 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	public static final String FIND_BY_G_N =
 		MDRRuleGroupFinder.class.getName() + ".findByG_N";
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #countByKeywords(long,
+	 *             java.util.LinkedHashMap, String)}
+	 */
 	public int countByKeywords(long groupId, String keywords)
 		throws SystemException {
 
@@ -81,6 +85,10 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return countByG_N(groupId, names, params, andOperator);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #countByG_N(long, String,
+	 *             java.util.LinkedHashMap, boolean)}
+	 */
 	public int countByG_N(long groupId, String name, boolean andOperator)
 		throws SystemException {
 
@@ -101,6 +109,10 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return countByG_N(groupId, names, params, andOperator);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #countByG_N(long, String[],
+	 *             java.util.LinkedHashMap, boolean)}
+	 */
 	public int countByG_N(long groupId, String[] names, boolean andOperator)
 		throws SystemException {
 
@@ -191,6 +203,10 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		}
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #findByKeywords(long, String,
+	 *             java.util.LinkedHashMap, int, int)}
+	 */
 	public List<MDRRuleGroup> findByKeywords(
 			long groupId, String keywords, int start, int end)
 		throws SystemException {
@@ -220,6 +236,10 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return findByG_N(groupId, names, params, andOperator, start, end);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #findByG_N(long, String,
+	 *             java.util.LinkedHashMap, boolean)}
+	 */
 	public List<MDRRuleGroup> findByG_N(
 			long groupId, String name, boolean andOperator)
 		throws SystemException {
@@ -241,6 +261,10 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 			QueryUtil.ALL_POS);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #findByG_N(long, String,
+	 *             java.util.LinkedHashMap, boolean, int, int)}
+	 */
 	public List<MDRRuleGroup> findByG_N(
 			long groupId, String name, boolean andOperator, int start, int end)
 		throws SystemException {
@@ -263,6 +287,10 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return findByG_N(groupId, names, params, andOperator, start, end);
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #findByG_N(long, String,
+	 *             java.util.LinkedHashMap, boolean, int, int)}
+	 */
 	public List<MDRRuleGroup> findByG_N(
 			long groupId, String[] names, boolean andOperator, int start,
 			int end)

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
@@ -99,7 +99,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 			String cacheKey = _buildCacheKey(COUNT_BY_G_N, params);
 
-			String sql = _countByG_NCache.get(cacheKey);
+			String sql = _countByG_NSQLCache.get(cacheKey);
 
 			if (sql == null) {
 				String countByG_N = CustomSQLUtil.get(COUNT_BY_G_N);
@@ -113,7 +113,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 				sql = sb.toString();
 
-				_countByG_NCache.put(cacheKey, sql);
+				_countByG_NSQLCache.put(cacheKey, sql);
 			}
 
 			sql = CustomSQLUtil.replaceKeywords(
@@ -208,7 +208,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 			String cacheKey = _buildCacheKey(FIND_BY_G_N, params);
 
-			String sql = _findByG_NCache.get(cacheKey);
+			String sql = _findByG_NSQLCache.get(cacheKey);
 
 			if (sql == null) {
 				String findByG_N = CustomSQLUtil.get(FIND_BY_G_N);
@@ -222,7 +222,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 				sql = sb.toString();
 
-				_findByG_NCache.put(cacheKey, sql);
+				_findByG_NSQLCache.put(cacheKey, sql);
 			}
 
 			sql = CustomSQLUtil.replaceKeywords(
@@ -343,11 +343,11 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return sb.toString();
 	}
 
-	private Map<String, String> _countByG_NCache =
+	private Map<String, String> _countByG_NSQLCache =
 		new ConcurrentHashMap<String, String>();
 	private LinkedHashMap<String, Object> _emptyLinkedHashMap =
 		new LinkedHashMap<String, Object>(0);
-	private Map<String, String> _findByG_NCache =
+	private Map<String, String> _findByG_NSQLCache =
 		new ConcurrentHashMap<String, String>();
 	private Map<String, String> _replaceWhereSQLCache =
 		new ConcurrentHashMap<String, String>();

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderImpl.java
@@ -54,6 +54,16 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	public static final String FIND_BY_G_N =
 		MDRRuleGroupFinder.class.getName() + ".findByG_N";
 
+	public int countByKeywords(long groupId, String keywords)
+		throws SystemException {
+
+		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
+		return countByKeywords(groupId, params, keywords);
+	}
+
 	public int countByKeywords(
 			long groupId, LinkedHashMap<String, Object> params, String keywords)
 		throws SystemException {
@@ -71,12 +81,32 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 		return countByG_N(groupId, names, params, andOperator);
 	}
 
+	public int countByG_N(long groupId, String name, boolean andOperator)
+		throws SystemException {
+
+		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
+		return countByG_N(groupId, name, params, andOperator);
+	}
+
 	public int countByG_N(
 			long groupId, String name, LinkedHashMap<String, Object> params,
 			boolean andOperator)
 		throws SystemException {
 
 		String[] names = CustomSQLUtil.keywords(name);
+
+		return countByG_N(groupId, names, params, andOperator);
+	}
+
+	public int countByG_N(long groupId, String[] names, boolean andOperator)
+		throws SystemException {
+
+		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
 
 		return countByG_N(groupId, names, params, andOperator);
 	}
@@ -162,6 +192,17 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	}
 
 	public List<MDRRuleGroup> findByKeywords(
+			long groupId, String keywords, int start, int end)
+		throws SystemException {
+
+		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
+		return findByKeywords(groupId, keywords, params, start, end);
+	}
+
+	public List<MDRRuleGroup> findByKeywords(
 			long groupId, String keywords, LinkedHashMap<String, Object> params,
 			int start, int end)
 		throws SystemException {
@@ -180,6 +221,17 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	}
 
 	public List<MDRRuleGroup> findByG_N(
+			long groupId, String name, boolean andOperator)
+		throws SystemException {
+
+		LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
+		return findByG_N(groupId, name, params, andOperator);
+	}
+
+	public List<MDRRuleGroup> findByG_N(
 			long groupId, String name, LinkedHashMap<String, Object> params,
 			boolean andOperator)
 		throws SystemException {
@@ -190,11 +242,36 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 	}
 
 	public List<MDRRuleGroup> findByG_N(
+			long groupId, String name, boolean andOperator, int start, int end)
+		throws SystemException {
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
+
+		return findByG_N(groupId, name, params, andOperator, start, end);
+	}
+
+	public List<MDRRuleGroup> findByG_N(
 			long groupId, String name, LinkedHashMap<String, Object> params,
 			boolean andOperator, int start, int end)
 		throws SystemException {
 
 		String[] names = CustomSQLUtil.keywords(name);
+
+		return findByG_N(groupId, names, params, andOperator, start, end);
+	}
+
+	public List<MDRRuleGroup> findByG_N(
+			long groupId, String[] names, boolean andOperator, int start,
+			int end)
+		throws SystemException {
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("includeGlobalScope", true);
 
 		return findByG_N(groupId, names, params, andOperator, start, end);
 	}
@@ -329,7 +406,7 @@ public class MDRRuleGroupFinderImpl extends BasePersistenceImpl<MDRRuleGroup>
 
 	protected void setParameterValues(
 			QueryPos qPos, LinkedHashMap<String, Object> params)
-		throws SystemException, PortalException {
+		throws PortalException, SystemException {
 
 		if ((params == null) || params.isEmpty()) {
 			return;

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -152,7 +152,6 @@ javax.portlet.title.173=Recent Content
 javax.portlet.title.174=Site Memberships
 javax.portlet.title.175=Related Assets
 javax.portlet.title.176=License Manager
-javax.portlet.title.177=Mobile Device Rules
 javax.portlet.title.178=Mobile Device Rules
 javax.portlet.title.179=Social Activity
 javax.portlet.title.180=User Statistics

--- a/portal-impl/src/custom-sql/mobiledevicerules.xml
+++ b/portal-impl/src/custom-sql/mobiledevicerules.xml
@@ -8,7 +8,7 @@
 			FROM
 				MDRRuleGroup
 			WHERE
-				(groupId = ?) AND
+				[$GROUP_ID$] AND
 				(lower(name) LIKE ? [$AND_OR_NULL_CHECK$])
 		]]>
 	</sql>
@@ -19,7 +19,7 @@
 			FROM
 				MDRRuleGroup
 			WHERE
-				(groupId = ?) AND
+				[$GROUP_ID$] AND
 				(lower(name) LIKE ? [$AND_OR_NULL_CHECK$])
 			ORDER BY
 				MDRRuleGroup.name DESC

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -514,7 +514,7 @@
     # Set a list of comma delimited portlet ids that will bypass the security
     # check set in the property "portlet.add.default.resource.check.enabled".
     #
-    portlet.add.default.resource.check.whitelist=3,56_INSTANCE_0000,58,82,86,87,88,103,113,145,164,166,170,177
+    portlet.add.default.resource.check.whitelist=3,56_INSTANCE_0000,58,82,86,87,88,103,113,145,164,166,170
 
     #
     # Input a list of comma delimited struts actions that will bypass the

--- a/portal-impl/src/resource-actions/mobiledevicerules.xml
+++ b/portal-impl/src/resource-actions/mobiledevicerules.xml
@@ -3,7 +3,7 @@
 
 <resource-action-mapping>
 	<portlet-resource>
-		<portlet-name>177</portlet-name>
+		<portlet-name>178</portlet-name>
 		<permissions>
 			<supports>
 				<action-key>CONFIGURATION</action-key>
@@ -22,7 +22,7 @@
 	<model-resource>
 		<model-name>com.liferay.portlet.mobiledevicerules</model-name>
 		<portlet-ref>
-			<portlet-name>177</portlet-name>
+			<portlet-name>178</portlet-name>
 		</portlet-ref>
 		<permissions>
 			<supports>
@@ -46,7 +46,7 @@
 	<model-resource>
 		<model-name>com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup</model-name>
 		<portlet-ref>
-			<portlet-name>177</portlet-name>
+			<portlet-name>178</portlet-name>
 		</portlet-ref>
 		<permissions>
 			<supports>
@@ -67,7 +67,7 @@
 	<model-resource>
 		<model-name>com.liferay.portlet.mobiledevicerules.model.MDRRuleGroupInstance</model-name>
 		<portlet-ref>
-			<portlet-name>177</portlet-name>
+			<portlet-name>178</portlet-name>
 		</portlet-ref>
 		<permissions>
 			<supports>

--- a/portal-impl/test/integration/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.mobiledevicerules.service;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Company;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.service.CompanyLocalServiceUtil;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.MainServletExecutionTestListener;
+import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
+import com.liferay.portal.util.GroupTestUtil;
+import com.liferay.portal.util.LayoutTestUtil;
+import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup;
+import com.liferay.portlet.mobiledevicerules.util.MDRTestUtil;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Manuel de la Peña
+ */
+@ExecutionTestListeners(
+	listeners = {
+		MainServletExecutionTestListener.class,
+		TransactionalCallbackAwareExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class MDRRuleGroupLocalServiceTest {
+
+	@Before
+	public void setUp() throws Exception {
+		Company company = CompanyLocalServiceUtil.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_globalGroup = company.getGroup();
+
+		_globalRuleGroup = MDRTestUtil.addRuleGroup(_globalGroup.getGroupId());
+	}
+
+	@Test
+	public void testSelectGlobalMDRRulesNotPresent() throws Exception {
+		testSelectableMDRRuleGroups(false);
+	}
+
+	@Test
+	public void testSelectGlobalMDRRulesPresent() throws Exception {
+		testSelectableMDRRuleGroups(true);
+	}
+
+	protected void testSelectableMDRRuleGroups(boolean includeGlobalGroup)
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addLayout(
+			group.getGroupId(), ServiceTestUtil.randomString());
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		if (includeGlobalGroup) {
+			params.put("includeGlobalScope", true);
+		}
+
+		List<MDRRuleGroup> ruleGroups =
+			MDRRuleGroupLocalServiceUtil.searchByKeywords(
+				layout.getGroupId(), StringPool.BLANK, params, false,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		if (includeGlobalGroup) {
+			Assert.assertTrue(ruleGroups.contains(_globalRuleGroup));
+		}
+		else {
+			Assert.assertFalse(ruleGroups.contains(_globalRuleGroup));
+		}
+	}
+
+	private Group _globalGroup;
+	private MDRRuleGroup _globalRuleGroup;
+
+}

--- a/portal-impl/test/integration/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceTest.java
@@ -57,9 +57,9 @@ public class MDRRuleGroupLocalServiceTest {
 		Company company = CompanyLocalServiceUtil.getCompany(
 			TestPropsValues.getCompanyId());
 
-		_globalGroup = company.getGroup();
+		Group companyGroup = company.getGroup();
 
-		_globalRuleGroup = MDRTestUtil.addRuleGroup(_globalGroup.getGroupId());
+		_companyRuleGroup = MDRTestUtil.addRuleGroup(companyGroup.getGroupId());
 	}
 
 	@Test
@@ -93,14 +93,13 @@ public class MDRRuleGroupLocalServiceTest {
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		if (includeGlobalGroup) {
-			Assert.assertTrue(ruleGroups.contains(_globalRuleGroup));
+			Assert.assertTrue(ruleGroups.contains(_companyRuleGroup));
 		}
 		else {
-			Assert.assertFalse(ruleGroups.contains(_globalRuleGroup));
+			Assert.assertFalse(ruleGroups.contains(_companyRuleGroup));
 		}
 	}
 
-	private Group _globalGroup;
-	private MDRRuleGroup _globalRuleGroup;
+	private MDRRuleGroup _companyRuleGroup;
 
 }

--- a/portal-service/src/com/liferay/portal/util/PortletKeys.java
+++ b/portal-service/src/com/liferay/portal/util/PortletKeys.java
@@ -120,8 +120,6 @@ public class PortletKeys {
 
 	public static final String MESSAGE_BOARDS_ADMIN = "162";
 
-	public static final String MOBILE_DEVICE_GLOBAL_ADMIN = "177";
-
 	public static final String MOBILE_DEVICE_SITE_ADMIN = "178";
 
 	public static final String MONITORING = "131";

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalService.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalService.java
@@ -299,11 +299,26 @@ public interface MDRRuleGroupLocalService extends BaseLocalService,
 	public int getRuleGroupsCount(long groupId)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #search(long, String,
+	java.util.LinkedHashMap, boolean, int, int)}
+	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> search(
 		long groupId, java.lang.String name, boolean andOperator, int start,
 		int end) throws com.liferay.portal.kernel.exception.SystemException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> search(
+		long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchByKeywords(long,
+	String, java.util.LinkedHashMap, boolean, int, int)}
+	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> searchByKeywords(
 		long groupId, java.lang.String keywords, boolean andOperator,
@@ -311,12 +326,39 @@ public interface MDRRuleGroupLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> searchByKeywords(
+		long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchByKeywordsCount(long,
+	String, java.util.LinkedHashMap, boolean)}
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int searchByKeywordsCount(long groupId, java.lang.String keywords,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchByKeywordsCount(long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchCount(long,
+	String, java.util.LinkedHashMap, boolean)}
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int searchCount(long groupId, java.lang.String name,
+		boolean andOperator)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceUtil.java
@@ -343,12 +343,29 @@ public class MDRRuleGroupLocalServiceUtil {
 		return getService().getRuleGroupsCount(groupId);
 	}
 
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #search(long, String,
+	java.util.LinkedHashMap, boolean, int, int)}
+	*/
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> search(
 		long groupId, java.lang.String name, boolean andOperator, int start,
 		int end) throws com.liferay.portal.kernel.exception.SystemException {
 		return getService().search(groupId, name, andOperator, start, end);
 	}
 
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> search(
+		long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .search(groupId, name, params, andOperator, start, end);
+	}
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchByKeywords(long,
+	String, java.util.LinkedHashMap, boolean, int, int)}
+	*/
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> searchByKeywords(
 		long groupId, java.lang.String keywords, boolean andOperator,
 		int start, int end)
@@ -357,16 +374,50 @@ public class MDRRuleGroupLocalServiceUtil {
 				   .searchByKeywords(groupId, keywords, andOperator, start, end);
 	}
 
+	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> searchByKeywords(
+		long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .searchByKeywords(groupId, keywords, params, andOperator,
+			start, end);
+	}
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchByKeywordsCount(long,
+	String, java.util.LinkedHashMap, boolean)}
+	*/
 	public static int searchByKeywordsCount(long groupId,
 		java.lang.String keywords, boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return getService().searchByKeywordsCount(groupId, keywords, andOperator);
 	}
 
+	public static int searchByKeywordsCount(long groupId,
+		java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .searchByKeywordsCount(groupId, keywords, params, andOperator);
+	}
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchCount(long,
+	String, java.util.LinkedHashMap, boolean)}
+	*/
 	public static int searchCount(long groupId, java.lang.String name,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return getService().searchCount(groupId, name, andOperator);
+	}
+
+	public static int searchCount(long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getService().searchCount(groupId, name, params, andOperator);
 	}
 
 	public static com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup updateRuleGroup(

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/MDRRuleGroupLocalServiceWrapper.java
@@ -337,6 +337,10 @@ public class MDRRuleGroupLocalServiceWrapper implements MDRRuleGroupLocalService
 		return _mdrRuleGroupLocalService.getRuleGroupsCount(groupId);
 	}
 
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #search(long, String,
+	java.util.LinkedHashMap, boolean, int, int)}
+	*/
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> search(
 		long groupId, java.lang.String name, boolean andOperator, int start,
 		int end) throws com.liferay.portal.kernel.exception.SystemException {
@@ -344,6 +348,19 @@ public class MDRRuleGroupLocalServiceWrapper implements MDRRuleGroupLocalService
 			start, end);
 	}
 
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> search(
+		long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return _mdrRuleGroupLocalService.search(groupId, name, params,
+			andOperator, start, end);
+	}
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchByKeywords(long,
+	String, java.util.LinkedHashMap, boolean, int, int)}
+	*/
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> searchByKeywords(
 		long groupId, java.lang.String keywords, boolean andOperator,
 		int start, int end)
@@ -352,6 +369,19 @@ public class MDRRuleGroupLocalServiceWrapper implements MDRRuleGroupLocalService
 			andOperator, start, end);
 	}
 
+	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> searchByKeywords(
+		long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return _mdrRuleGroupLocalService.searchByKeywords(groupId, keywords,
+			params, andOperator, start, end);
+	}
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchByKeywordsCount(long,
+	String, java.util.LinkedHashMap, boolean)}
+	*/
 	public int searchByKeywordsCount(long groupId, java.lang.String keywords,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException {
@@ -359,10 +389,30 @@ public class MDRRuleGroupLocalServiceWrapper implements MDRRuleGroupLocalService
 			keywords, andOperator);
 	}
 
+	public int searchByKeywordsCount(long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return _mdrRuleGroupLocalService.searchByKeywordsCount(groupId,
+			keywords, params, andOperator);
+	}
+
+	/**
+	* @deprecated As of 6.2.0, replaced by {@link #searchCount(long,
+	String, java.util.LinkedHashMap, boolean)}
+	*/
 	public int searchCount(long groupId, java.lang.String name,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return _mdrRuleGroupLocalService.searchCount(groupId, name, andOperator);
+	}
+
+	public int searchCount(long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return _mdrRuleGroupLocalService.searchCount(groupId, name, params,
+			andOperator);
 	}
 
 	public com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup updateRuleGroup(

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinder.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinder.java
@@ -18,30 +18,41 @@ package com.liferay.portlet.mobiledevicerules.service.persistence;
  * @author Edward C. Han
  */
 public interface MDRRuleGroupFinder {
-	public int countByKeywords(long groupId, java.lang.String keywords)
+	public int countByKeywords(long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	public int countByG_N(long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	public int countByG_N(long groupId, java.lang.String[] names,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByKeywords(
-		long groupId, java.lang.String keywords, int start, int end)
+		long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByG_N(
-		long groupId, java.lang.String name, boolean andOperator)
+		long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByG_N(
-		long groupId, java.lang.String name, boolean andOperator, int start,
-		int end) throws com.liferay.portal.kernel.exception.SystemException;
+		long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
 
 	public java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByG_N(
-		long groupId, java.lang.String[] names, boolean andOperator, int start,
-		int end) throws com.liferay.portal.kernel.exception.SystemException;
+		long groupId, java.lang.String[] names,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
 }

--- a/portal-service/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderUtil.java
+++ b/portal-service/src/com/liferay/portlet/mobiledevicerules/service/persistence/MDRRuleGroupFinderUtil.java
@@ -21,45 +21,58 @@ import com.liferay.portal.kernel.util.ReferenceRegistry;
  * @author Edward C. Han
  */
 public class MDRRuleGroupFinderUtil {
-	public static int countByKeywords(long groupId, java.lang.String keywords)
+	public static int countByKeywords(long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params)
 		throws com.liferay.portal.kernel.exception.SystemException {
-		return getFinder().countByKeywords(groupId, keywords);
+		return getFinder().countByKeywords(groupId, keywords, params);
 	}
 
 	public static int countByG_N(long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException {
-		return getFinder().countByG_N(groupId, name, andOperator);
+		return getFinder().countByG_N(groupId, name, params, andOperator);
 	}
 
 	public static int countByG_N(long groupId, java.lang.String[] names,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
 		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException {
-		return getFinder().countByG_N(groupId, names, andOperator);
+		return getFinder().countByG_N(groupId, names, params, andOperator);
 	}
 
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByKeywords(
-		long groupId, java.lang.String keywords, int start, int end)
+		long groupId, java.lang.String keywords,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		int start, int end)
 		throws com.liferay.portal.kernel.exception.SystemException {
-		return getFinder().findByKeywords(groupId, keywords, start, end);
+		return getFinder().findByKeywords(groupId, keywords, params, start, end);
 	}
 
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByG_N(
-		long groupId, java.lang.String name, boolean andOperator)
+		long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator)
 		throws com.liferay.portal.kernel.exception.SystemException {
-		return getFinder().findByG_N(groupId, name, andOperator);
+		return getFinder().findByG_N(groupId, name, params, andOperator);
 	}
 
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByG_N(
-		long groupId, java.lang.String name, boolean andOperator, int start,
-		int end) throws com.liferay.portal.kernel.exception.SystemException {
-		return getFinder().findByG_N(groupId, name, andOperator, start, end);
+		long groupId, java.lang.String name,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getFinder()
+				   .findByG_N(groupId, name, params, andOperator, start, end);
 	}
 
 	public static java.util.List<com.liferay.portlet.mobiledevicerules.model.MDRRuleGroup> findByG_N(
-		long groupId, java.lang.String[] names, boolean andOperator, int start,
-		int end) throws com.liferay.portal.kernel.exception.SystemException {
-		return getFinder().findByG_N(groupId, names, andOperator, start, end);
+		long groupId, java.lang.String[] names,
+		java.util.LinkedHashMap<java.lang.String, java.lang.Object> params,
+		boolean andOperator, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getFinder()
+				   .findByG_N(groupId, names, params, andOperator, start, end);
 	}
 
 	public static MDRRuleGroupFinder getFinder() {

--- a/portal-web/docroot/WEB-INF/liferay-display.xml
+++ b/portal-web/docroot/WEB-INF/liferay-display.xml
@@ -86,7 +86,6 @@
 		<portlet id="173" />
 		<portlet id="174" />
 		<portlet id="176" />
-		<portlet id="177" />
 		<portlet id="178" />
 		<portlet id="179" />
 		<portlet id="182" />

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1945,20 +1945,6 @@
 		<css-class-wrapper>license-manager</css-class-wrapper>
 	</portlet>
 	<portlet>
-		<portlet-name>177</portlet-name>
-		<icon>/html/icons/default.png</icon>
-		<struts-path>mobile_device_rules</struts-path>
-		<portlet-url-class>com.liferay.portal.struts.StrutsActionPortletURL</portlet-url-class>
-		<control-panel-entry-category>configuration</control-panel-entry-category>
-		<control-panel-entry-weight>3.0</control-panel-entry-weight>
-		<use-default-template>false</use-default-template>
-		<private-request-attributes>false</private-request-attributes>
-		<private-session-attributes>false</private-session-attributes>
-		<render-weight>50</render-weight>
-		<header-portlet-css>/html/portlet/mobile_device_rules/css/main.css</header-portlet-css>
-		<css-class-wrapper>mobile-device-rules</css-class-wrapper>
-	</portlet>
-	<portlet>
 		<portlet-name>178</portlet-name>
 		<icon>/html/icons/default.png</icon>
 		<parent-struts-path>mobile_device_rules</parent-struts-path>

--- a/portal-web/docroot/WEB-INF/portlet-custom.xml
+++ b/portal-web/docroot/WEB-INF/portlet-custom.xml
@@ -3090,30 +3090,6 @@
 		</security-role-ref>
 	</portlet>
 	<portlet>
-		<portlet-name>177</portlet-name>
-		<display-name>Mobile Device Rules</display-name>
-		<portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
-		<init-param>
-			<name>template-path</name>
-			<value>/html/portlet/mobile_device_rules/</value>
-		</init-param>
-		<init-param>
-			<name>view-action</name>
-			<value>/mobile_device_rules/view</value>
-		</init-param>
-		<expiration-cache>0</expiration-cache>
-		<supports>
-			<mime-type>text/html</mime-type>
-		</supports>
-		<resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-		<security-role-ref>
-			<role-name>power-user</role-name>
-		</security-role-ref>
-		<security-role-ref>
-			<role-name>user</role-name>
-		</security-role-ref>
-	</portlet>
-	<portlet>
 		<portlet-name>178</portlet-name>
 		<display-name>Mobile Device Rules</display-name>
 		<portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>

--- a/portal-web/docroot/html/portlet/mobile_device_rules/rule_group_search_results.jspf
+++ b/portal-web/docroot/html/portlet/mobile_device_rules/rule_group_search_results.jspf
@@ -15,13 +15,17 @@
 --%>
 
 <%
+LinkedHashMap<String, Object> params = new LinkedHashMap<String, Object>();
+
+params.put("includeGlobalScope", true);
+
 if (Validator.isNotNull(searchTerms.getName())) {
-	results = MDRRuleGroupLocalServiceUtil.search(searchTerms.getGroupId(), searchTerms.getName(), searchTerms.isAndOperator(), searchContainer.getStart(), searchContainer.getEnd());
-	total = MDRRuleGroupLocalServiceUtil.searchCount(searchTerms.getGroupId(), searchTerms.getName(), searchTerms.isAndOperator());
+	results = MDRRuleGroupLocalServiceUtil.search(searchTerms.getGroupId(), searchTerms.getName(), params, searchTerms.isAndOperator(), searchContainer.getStart(), searchContainer.getEnd());
+	total = MDRRuleGroupLocalServiceUtil.searchCount(searchTerms.getGroupId(), searchTerms.getName(), params, searchTerms.isAndOperator());
 }
 else {
-	results = MDRRuleGroupLocalServiceUtil.searchByKeywords(searchTerms.getGroupId(), searchTerms.getKeywords(), searchTerms.isAndOperator(), searchContainer.getStart(), searchContainer.getEnd());
-	total = MDRRuleGroupLocalServiceUtil.searchByKeywordsCount(searchTerms.getGroupId(), searchTerms.getKeywords(), searchTerms.isAndOperator());
+	results = MDRRuleGroupLocalServiceUtil.searchByKeywords(searchTerms.getGroupId(), searchTerms.getKeywords(), params, searchTerms.isAndOperator(), searchContainer.getStart(), searchContainer.getEnd());
+	total = MDRRuleGroupLocalServiceUtil.searchByKeywordsCount(searchTerms.getGroupId(), searchTerms.getKeywords(), params, searchTerms.isAndOperator());
 }
 
 pageContext.setAttribute("results", results);


### PR DESCRIPTION
Brian, I'm resending this PR (you already reviewed): https://github.com/brianchandotcom/liferay-portal/pull/10634

These are my changes:

1.) Let's get rid of the SQL caching, I think it's not necessary and makes it hard to read. I only add them in after the fact if performance tests show they actually make a difference.

I've cached the SQL because a user could want to retrieve rules including or not glabal scoped rules: sometimes the query will include global groupId, sometimes not.

2.) But if you were to add them, they ought to follow the format in GroupFinderImpl (String findByX_Y_SQL, not jsut String findByX_Y).

Done, variables have been renamed following the pattern

3.) The test is in the wrong package.

Done, I missed package name and now tests are in *.service package.
