### PR TITLE
LPS-35558

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java
+++ b/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java
@@ -155,7 +155,15 @@ public class SharedSessionWrapper implements HttpSession {
 
 	@Override
 	public int hashCode() {
-		return _portalSession.hashCode() ^ _portletSession.hashCode();
+		if (_portletSession == null) {
+
+			// LPS-35558
+
+			return _portalSession.hashCode();
+		}
+		else {
+			return _portalSession.hashCode() ^ _portletSession.hashCode();
+		}
 	}
 
 	public void invalidate() {


### PR DESCRIPTION
NullPointerException in SharedSessionWrapper.hashCode() when WAR plugin portlets utilize Weld on JBoss AS
