### PR TITLE
LPS-35567 resending pull with explanation --> read description please

### DIFF
--- a/portal-web/docroot/html/js/editor/ckeditor.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor.jsp
@@ -52,12 +52,17 @@ String fileBrowserParams = marshallParams(fileBrowserParamsMap);
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:cssClass"));
 String cssClasses = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:cssClasses"));
 String editorImpl = (String)request.getAttribute("liferay-ui:input-editor:editorImpl");
+String languageId = (String)request.getAttribute("liferay-ui:input-editor:languageId");
 String name = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:name"));
 String initMethod = (String)request.getAttribute("liferay-ui:input-editor:initMethod");
 boolean inlineEdit = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-editor:inlineEdit"));
 String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:inlineEditSaveURL"));
 
 String onChangeMethod = (String)request.getAttribute("liferay-ui:input-editor:onChangeMethod");
+
+if (Validator.isNull(languageId)) {
+	languageId = HttpUtil.encodeURL(LocaleUtil.toLanguageId(locale));
+}
 
 if (Validator.isNotNull(onChangeMethod)) {
 	onChangeMethod = namespace + onChangeMethod;
@@ -226,7 +231,7 @@ if (inlineEdit && (inlineEditSaveURL != null)) {
 
 			'<%= name %>',
 			{
-				customConfig: '<%= PortalUtil.getPathContext() %>/html/js/editor/ckeditor/<%= HtmlUtil.escapeJS(ckEditorConfigFileName) %>?p_l_id=<%= plid %>&p_p_id=<%= HttpUtil.encodeURL(portletId) %>&p_main_path=<%= HttpUtil.encodeURL(mainPath) %>&doAsUserId=<%= HttpUtil.encodeURL(doAsUserId) %>&doAsGroupId=<%= HttpUtil.encodeURL(String.valueOf(doAsGroupId)) %>&cssPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeCss()) %>&cssClasses=<%= HttpUtil.encodeURL(cssClasses) %>&imagesPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeImages()) %>&languageId=<%= HttpUtil.encodeURL(LocaleUtil.toLanguageId(locale)) %>&resizable=<%= resizable %>&inlineEdit=<%= inlineEdit %><%= configParams %>',
+				customConfig: '<%= PortalUtil.getPathContext() %>/html/js/editor/ckeditor/<%= HtmlUtil.escapeJS(ckEditorConfigFileName) %>?p_l_id=<%= plid %>&p_p_id=<%= HttpUtil.encodeURL(portletId) %>&p_main_path=<%= HttpUtil.encodeURL(mainPath) %>&doAsUserId=<%= HttpUtil.encodeURL(doAsUserId) %>&doAsGroupId=<%= HttpUtil.encodeURL(String.valueOf(doAsGroupId)) %>&cssPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeCss()) %>&cssClasses=<%= HttpUtil.encodeURL(cssClasses) %>&imagesPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeImages()) %>&languageId=<%= languageId %>&resizable=<%= resizable %>&inlineEdit=<%= inlineEdit %><%= configParams %>',
 				filebrowserBrowseUrl: '<%= PortalUtil.getPathContext() %>/html/js/editor/ckeditor/editor/filemanager/browser/liferay/browser.html?Connector=<%= connectorURL %><%= fileBrowserParams %>',
 				filebrowserUploadUrl: null,
 				toolbar: '<%= TextFormatter.format(HtmlUtil.escapeJS(toolbarSet), TextFormatter.M) %>'

--- a/portal-web/docroot/html/js/editor/ckeditor.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor.jsp
@@ -50,6 +50,11 @@ String configParams = marshallParams(configParamsMap);
 String fileBrowserParams = marshallParams(fileBrowserParamsMap);
 
 String contentsLanguageId = (String)request.getAttribute("liferay-ui:input-editor:contentsLanguageId");
+
+if (Validator.isNull(contentsLanguageId)) {
+	contentsLanguageId = HttpUtil.encodeURL(LocaleUtil.toLanguageId(locale));
+}
+
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:cssClass"));
 String cssClasses = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:cssClasses"));
 String editorImpl = (String)request.getAttribute("liferay-ui:input-editor:editorImpl");
@@ -59,10 +64,6 @@ boolean inlineEdit = GetterUtil.getBoolean((String)request.getAttribute("liferay
 String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:inlineEditSaveURL"));
 
 String onChangeMethod = (String)request.getAttribute("liferay-ui:input-editor:onChangeMethod");
-
-if (Validator.isNull(contentsLanguageId)) {
-	contentsLanguageId = HttpUtil.encodeURL(LocaleUtil.toLanguageId(locale));
-}
 
 if (Validator.isNotNull(onChangeMethod)) {
 	onChangeMethod = namespace + onChangeMethod;

--- a/portal-web/docroot/html/js/editor/ckeditor.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor.jsp
@@ -49,10 +49,10 @@ Map<String, String> fileBrowserParamsMap = (Map<String, String>)request.getAttri
 String configParams = marshallParams(configParamsMap);
 String fileBrowserParams = marshallParams(fileBrowserParamsMap);
 
+String contentsLanguageId = (String)request.getAttribute("liferay-ui:input-editor:contentsLanguageId");
 String cssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:cssClass"));
 String cssClasses = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:cssClasses"));
 String editorImpl = (String)request.getAttribute("liferay-ui:input-editor:editorImpl");
-String languageId = (String)request.getAttribute("liferay-ui:input-editor:languageId");
 String name = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:name"));
 String initMethod = (String)request.getAttribute("liferay-ui:input-editor:initMethod");
 boolean inlineEdit = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-editor:inlineEdit"));
@@ -60,8 +60,8 @@ String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute("li
 
 String onChangeMethod = (String)request.getAttribute("liferay-ui:input-editor:onChangeMethod");
 
-if (Validator.isNull(languageId)) {
-	languageId = HttpUtil.encodeURL(LocaleUtil.toLanguageId(locale));
+if (Validator.isNull(contentsLanguageId)) {
+	contentsLanguageId = HttpUtil.encodeURL(LocaleUtil.toLanguageId(locale));
 }
 
 if (Validator.isNotNull(onChangeMethod)) {
@@ -231,7 +231,7 @@ if (inlineEdit && (inlineEditSaveURL != null)) {
 
 			'<%= name %>',
 			{
-				customConfig: '<%= PortalUtil.getPathContext() %>/html/js/editor/ckeditor/<%= HtmlUtil.escapeJS(ckEditorConfigFileName) %>?p_l_id=<%= plid %>&p_p_id=<%= HttpUtil.encodeURL(portletId) %>&p_main_path=<%= HttpUtil.encodeURL(mainPath) %>&doAsUserId=<%= HttpUtil.encodeURL(doAsUserId) %>&doAsGroupId=<%= HttpUtil.encodeURL(String.valueOf(doAsGroupId)) %>&cssPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeCss()) %>&cssClasses=<%= HttpUtil.encodeURL(cssClasses) %>&imagesPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeImages()) %>&languageId=<%= languageId %>&resizable=<%= resizable %>&inlineEdit=<%= inlineEdit %><%= configParams %>',
+				customConfig: '<%= PortalUtil.getPathContext() %>/html/js/editor/ckeditor/<%= HtmlUtil.escapeJS(ckEditorConfigFileName) %>?p_l_id=<%= plid %>&p_p_id=<%= HttpUtil.encodeURL(portletId) %>&p_main_path=<%= HttpUtil.encodeURL(mainPath) %>&doAsUserId=<%= HttpUtil.encodeURL(doAsUserId) %>&doAsGroupId=<%= HttpUtil.encodeURL(String.valueOf(doAsGroupId)) %>&cssPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeCss()) %>&cssClasses=<%= HttpUtil.encodeURL(cssClasses) %>&imagesPath=<%= HttpUtil.encodeURL(themeDisplay.getPathThemeImages()) %>&languageId=<%= HttpUtil.encodeURL(LocaleUtil.toLanguageId(locale)) %>&contentsLanguageId=<%= contentsLanguageId %>&resizable=<%= resizable %>&inlineEdit=<%= inlineEdit %><%= configParams %>',
 				filebrowserBrowseUrl: '<%= PortalUtil.getPathContext() %>/html/js/editor/ckeditor/editor/filemanager/browser/liferay/browser.html?Connector=<%= connectorURL %><%= fileBrowserParams %>',
 				filebrowserUploadUrl: null,
 				toolbar: '<%= TextFormatter.format(HtmlUtil.escapeJS(toolbarSet), TextFormatter.M) %>'

--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
@@ -35,6 +35,8 @@ boolean resizable = ParamUtil.getBoolean(request, "resizable");
 Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);
 String contentsLanguageDir = LanguageUtil.get(contentsLocale, "lang.dir");
 
+// LPS-35567
+
 languageId = languageId.replace("iw_", "he_");
 contentsLanguageId = contentsLanguageId.replace("iw_", "he_");
 

--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
@@ -16,9 +16,13 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.ContentTypes" %>
 <%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %>
+<%@ page import="com.liferay.portal.kernel.util.LocaleUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.ParamUtil" %>
+
+<%@ page import="java.util.Locale" %>
 
 <%
 String cssPath = ParamUtil.getString(request, "cssPath");
@@ -26,6 +30,11 @@ String cssClasses = ParamUtil.getString(request, "cssClasses");
 boolean inlineEdit = ParamUtil.getBoolean(request, "inlineEdit");
 String languageId = ParamUtil.getString(request, "languageId");
 boolean resizable = ParamUtil.getBoolean(request, "resizable");
+
+Locale locale = LocaleUtil.fromLanguageId(languageId);
+String languageDir = LanguageUtil.get(locale, "lang.dir");
+
+languageId = languageId.replace("iw_", "he_");
 
 response.setContentType(ContentTypes.TEXT_JAVASCRIPT);
 %>
@@ -67,6 +76,10 @@ CKEDITOR.config.bodyClass = 'html-editor <%= HtmlUtil.escapeJS(cssClasses) %>';
 CKEDITOR.config.closeNoticeTimeout = 8000;
 
 CKEDITOR.config.contentsCss = '<%= HtmlUtil.escapeJS(cssPath) %>/main.css';
+
+CKEDITOR.config.contentsLangDirection = '<%= HtmlUtil.escapeJS(languageDir) %>';
+
+CKEDITOR.config.contentsLanguage = '<%= HtmlUtil.escapeJS(languageId) %>';
 
 CKEDITOR.config.entities = false;
 

--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
@@ -25,16 +25,18 @@
 <%@ page import="java.util.Locale" %>
 
 <%
+String contentsLanguageId = ParamUtil.getString(request, "contentsLanguageId");
 String cssPath = ParamUtil.getString(request, "cssPath");
 String cssClasses = ParamUtil.getString(request, "cssClasses");
 boolean inlineEdit = ParamUtil.getBoolean(request, "inlineEdit");
 String languageId = ParamUtil.getString(request, "languageId");
 boolean resizable = ParamUtil.getBoolean(request, "resizable");
 
-Locale locale = LocaleUtil.fromLanguageId(languageId);
-String languageDir = LanguageUtil.get(locale, "lang.dir");
+Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);
+String contentsLanguageDir = LanguageUtil.get(contentsLocale, "lang.dir");
 
 languageId = languageId.replace("iw_", "he_");
+contentsLanguageId = contentsLanguageId.replace("iw_", "he_");
 
 response.setContentType(ContentTypes.TEXT_JAVASCRIPT);
 %>
@@ -77,9 +79,9 @@ CKEDITOR.config.closeNoticeTimeout = 8000;
 
 CKEDITOR.config.contentsCss = '<%= HtmlUtil.escapeJS(cssPath) %>/main.css';
 
-CKEDITOR.config.contentsLangDirection = '<%= HtmlUtil.escapeJS(languageDir) %>';
+CKEDITOR.config.contentsLangDirection = '<%= HtmlUtil.escapeJS(contentsLanguageDir) %>';
 
-CKEDITOR.config.contentsLanguage = '<%= HtmlUtil.escapeJS(languageId) %>';
+CKEDITOR.config.contentsLanguage = '<%= HtmlUtil.escapeJS(contentsLanguageId) %>';
 
 CKEDITOR.config.entities = false;
 

--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_bbcode.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_bbcode.jsp
@@ -16,19 +16,30 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
 <%@ page import="com.liferay.portal.kernel.parsers.bbcode.BBCodeTranslatorUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %>
+<%@ page import="com.liferay.portal.kernel.util.LocaleUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.ParamUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.StringUtil" %>
 <%@ page import="com.liferay.portlet.messageboards.model.MBThreadConstants" %>
 
+<%@ page import="java.util.Locale" %>
+
 <%
+String contentsLanguageId = ParamUtil.getString(request, "contentsLanguageId");
 String cssPath = ParamUtil.getString(request, "cssPath");
 String cssClasses = ParamUtil.getString(request, "cssClasses");
 String imagesPath = ParamUtil.getString(request, "imagesPath");
 String languageId = ParamUtil.getString(request, "languageId");
 String emoticonsPath = ParamUtil.getString(request, "emoticonsPath");
 boolean resizable = ParamUtil.getBoolean(request, "resizable");
+
+Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);
+String contentsLanguageDir = LanguageUtil.get(contentsLocale, "lang.dir");
+
+languageId = languageId.replace("iw_", "he_");
+contentsLanguageId = contentsLanguageId.replace("iw_", "he_");
 %>
 
 CKEDITOR.config.height = 265;
@@ -63,6 +74,10 @@ CKEDITOR.config.toolbar_bbcode = [
 CKEDITOR.config.bodyClass = 'html-editor <%= HtmlUtil.escapeJS(cssClasses) %>';
 
 CKEDITOR.config.contentsCss = '<%= HtmlUtil.escapeJS(cssPath) %>/main.css';
+
+CKEDITOR.config.contentsLangDirection = '<%= HtmlUtil.escapeJS(contentsLanguageDir) %>';
+
+CKEDITOR.config.contentsLanguage = '<%= HtmlUtil.escapeJS(contentsLanguageId) %>';
 
 CKEDITOR.config.enterMode = CKEDITOR.ENTER_BR;
 

--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_bbcode.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_bbcode.jsp
@@ -38,6 +38,8 @@ boolean resizable = ParamUtil.getBoolean(request, "resizable");
 Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);
 String contentsLanguageDir = LanguageUtil.get(contentsLocale, "lang.dir");
 
+// LPS-35567
+
 languageId = languageId.replace("iw_", "he_");
 contentsLanguageId = contentsLanguageId.replace("iw_", "he_");
 %>

--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
@@ -16,10 +16,15 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %>
+<%@ page import="com.liferay.portal.kernel.util.LocaleUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.ParamUtil" %>
 
+<%@ page import="java.util.Locale" %>
+
 <%
+String contentsLanguageId = ParamUtil.getString(request, "contentsLanguageId");
 String cssPath = ParamUtil.getString(request, "cssPath");
 String cssClasses = ParamUtil.getString(request, "cssClasses");
 String languageId = ParamUtil.getString(request, "languageId");
@@ -32,11 +37,21 @@ String linkButtonBar = "['Link', 'Unlink']";
 if (wikiPageResourcePrimKey > 0) {
 	linkButtonBar = "['Link', 'Unlink', 'Image']";
 }
+
+Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);
+String contentsLanguageDir = LanguageUtil.get(contentsLocale, "lang.dir");
+
+languageId = languageId.replace("iw_", "he_");
+contentsLanguageId = contentsLanguageId.replace("iw_", "he_");
 %>
 
 CKEDITOR.config.attachmentURLPrefix = '<%= HtmlUtil.escapeJS(attachmentURLPrefix) %>';
 
 CKEDITOR.config.bodyClass = 'html-editor <%= HtmlUtil.escapeJS(cssClasses) %>';
+
+CKEDITOR.config.contentsLangDirection = '<%= HtmlUtil.escapeJS(contentsLanguageDir) %>';
+
+CKEDITOR.config.contentsLanguage = '<%= HtmlUtil.escapeJS(contentsLanguageId) %>';
 
 CKEDITOR.config.decodeLinks = true;
 

--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig_creole.jsp
@@ -41,6 +41,8 @@ if (wikiPageResourcePrimKey > 0) {
 Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);
 String contentsLanguageDir = LanguageUtil.get(contentsLocale, "lang.dir");
 
+// LPS-35567
+
 languageId = languageId.replace("iw_", "he_");
 contentsLanguageId = contentsLanguageId.replace("iw_", "he_");
 %>

--- a/portal-web/docroot/html/portlet/journal/article/content.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/content.jsp
@@ -88,10 +88,10 @@ String languageId = (String)request.getAttribute("edit_article.jsp-languageId");
 String defaultLanguageId = (String)request.getAttribute("edit_article.jsp-defaultLanguageId");
 String toLanguageId = (String)request.getAttribute("edit_article.jsp-toLanguageId");
 
-String editorLanguageId = defaultLanguageId;
+String contentsLanguageId = defaultLanguageId;
 
 if (Validator.isNotNull(toLanguageId)) {
-	editorLanguageId = toLanguageId;
+	contentsLanguageId = toLanguageId;
 }
 
 String content = null;
@@ -523,7 +523,7 @@ if (Validator.isNotNull(content)) {
 										</label>
 
 										<div class="journal-article-component-container">
-											<liferay-ui:input-editor editorImpl="<%= EDITOR_WYSIWYG_IMPL_KEY %>" languageId="<%= editorLanguageId %>" name='<%= renderResponse.getNamespace() + "structure_el_TextAreaField_content" %>' toolbarSet="liferay-article" width="100%" />
+											<liferay-ui:input-editor contentsLanguageId="<%= contentsLanguageId %>" editorImpl="<%= EDITOR_WYSIWYG_IMPL_KEY %>" name='<%= renderResponse.getNamespace() + "structure_el_TextAreaField_content" %>' toolbarSet="liferay-article" width="100%" />
 										</div>
 
 										<aui:input cssClass="journal-article-localized-checkbox" label="localizable" name="localized" type="hidden" value="<%= true %>" />

--- a/portal-web/docroot/html/portlet/journal/article/content.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/content.jsp
@@ -88,6 +88,12 @@ String languageId = (String)request.getAttribute("edit_article.jsp-languageId");
 String defaultLanguageId = (String)request.getAttribute("edit_article.jsp-defaultLanguageId");
 String toLanguageId = (String)request.getAttribute("edit_article.jsp-toLanguageId");
 
+String editorLanguageId = defaultLanguageId;
+
+if (Validator.isNotNull(toLanguageId)) {
+	editorLanguageId = toLanguageId;
+}
+
 String content = null;
 
 boolean preselectCurrentLayout = false;
@@ -517,7 +523,7 @@ if (Validator.isNotNull(content)) {
 										</label>
 
 										<div class="journal-article-component-container">
-											<liferay-ui:input-editor editorImpl="<%= EDITOR_WYSIWYG_IMPL_KEY %>" name='<%= renderResponse.getNamespace() + "structure_el_TextAreaField_content" %>' toolbarSet="liferay-article" width="100%" />
+											<liferay-ui:input-editor editorImpl="<%= EDITOR_WYSIWYG_IMPL_KEY %>" languageId="<%= editorLanguageId %>" name='<%= renderResponse.getNamespace() + "structure_el_TextAreaField_content" %>' toolbarSet="liferay-article" width="100%" />
 										</div>
 
 										<aui:input cssClass="journal-article-localized-checkbox" label="localizable" name="localized" type="hidden" value="<%= true %>" />

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1590,6 +1590,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>contentsLanguageId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1621,11 +1626,6 @@
 		</attribute>
 		<attribute>
 			<name>initMethod</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
-			<name>languageId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1625,6 +1625,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>languageId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>name</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
@@ -142,7 +142,6 @@ public class InputEditorTag extends IncludeTag {
 			"liferay-ui:input-editor:inlineEdit", String.valueOf(_inlineEdit));
 		request.setAttribute(
 			"liferay-ui:input-editor:inlineEditSaveURL", _inlineEditSaveURL);
-		request.setAttribute("liferay-ui:input-editor:contentsLanguageId", _contentsLanguageId);		
 		request.setAttribute("liferay-ui:input-editor:name", _name);
 		request.setAttribute(
 			"liferay-ui:input-editor:onChangeMethod", _onChangeMethod);

--- a/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
@@ -60,6 +60,10 @@ public class InputEditorTag extends IncludeTag {
 		_inlineEditSaveURL = inlineEditSaveURL;
 	}
 
+	public void setLanguageId(String languageId) {
+		_languageId = languageId;
+	}
+
 	public void setName(String name) {
 		_name = name;
 	}
@@ -94,6 +98,7 @@ public class InputEditorTag extends IncludeTag {
 		_initMethod = "initEditor";
 		_inlineEdit = false;
 		_inlineEditSaveURL = null;
+		_languageId = null;
 		_name = "editor";
 		_onChangeMethod = null;
 		_page = null;
@@ -135,6 +140,7 @@ public class InputEditorTag extends IncludeTag {
 			"liferay-ui:input-editor:inlineEdit", String.valueOf(_inlineEdit));
 		request.setAttribute(
 			"liferay-ui:input-editor:inlineEditSaveURL", _inlineEditSaveURL);
+		request.setAttribute("liferay-ui:input-editor:languageId", _languageId);		
 		request.setAttribute("liferay-ui:input-editor:name", _name);
 		request.setAttribute(
 			"liferay-ui:input-editor:onChangeMethod", _onChangeMethod);
@@ -155,6 +161,7 @@ public class InputEditorTag extends IncludeTag {
 	private String _initMethod = "initEditor";
 	private boolean _inlineEdit;
 	private String _inlineEditSaveURL;
+	private String _languageId;
 	private String _name = "editor";
 	private String _onChangeMethod;
 	private String _page;

--- a/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
@@ -32,6 +32,10 @@ public class InputEditorTag extends IncludeTag {
 		_configParams = configParams;
 	}
 
+	public void setContentsLanguageId(String contentsLanguageId) {
+		_contentsLanguageId = contentsLanguageId;
+	}
+
 	public void setCssClass(String cssClass) {
 		_cssClass = cssClass;
 	}
@@ -58,10 +62,6 @@ public class InputEditorTag extends IncludeTag {
 
 	public void setInlineEditSaveURL(String inlineEditSaveURL) {
 		_inlineEditSaveURL = inlineEditSaveURL;
-	}
-
-	public void setLanguageId(String languageId) {
-		_languageId = languageId;
 	}
 
 	public void setName(String name) {
@@ -91,6 +91,7 @@ public class InputEditorTag extends IncludeTag {
 	@Override
 	protected void cleanUp() {
 		_configParams = null;
+		_contentsLanguageId = null;
 		_cssClass = null;
 		_editorImpl = null;
 		_fileBrowserParams = null;
@@ -98,7 +99,6 @@ public class InputEditorTag extends IncludeTag {
 		_initMethod = "initEditor";
 		_inlineEdit = false;
 		_inlineEditSaveURL = null;
-		_languageId = null;
 		_name = "editor";
 		_onChangeMethod = null;
 		_page = null;
@@ -129,6 +129,8 @@ public class InputEditorTag extends IncludeTag {
 
 		request.setAttribute(
 			"liferay-ui:input-editor:configParams", _configParams);
+		request.setAttribute(
+			"liferay-ui:input-editor:contentsLanguageId", _contentsLanguageId);
 		request.setAttribute("liferay-ui:input-editor:cssClass", _cssClass);
 		request.setAttribute("liferay-ui:input-editor:cssClasses", cssClasses);
 		request.setAttribute("liferay-ui:input-editor:editorImpl", editorImpl);
@@ -140,7 +142,7 @@ public class InputEditorTag extends IncludeTag {
 			"liferay-ui:input-editor:inlineEdit", String.valueOf(_inlineEdit));
 		request.setAttribute(
 			"liferay-ui:input-editor:inlineEditSaveURL", _inlineEditSaveURL);
-		request.setAttribute("liferay-ui:input-editor:languageId", _languageId);		
+		request.setAttribute("liferay-ui:input-editor:contentsLanguageId", _contentsLanguageId);		
 		request.setAttribute("liferay-ui:input-editor:name", _name);
 		request.setAttribute(
 			"liferay-ui:input-editor:onChangeMethod", _onChangeMethod);
@@ -155,13 +157,13 @@ public class InputEditorTag extends IncludeTag {
 
 	private Map<String, String> _configParams;
 	private String _cssClass;
+	private String _contentsLanguageId;
 	private String _editorImpl;
 	private Map<String, String> _fileBrowserParams;
 	private String _height;
 	private String _initMethod = "initEditor";
 	private boolean _inlineEdit;
 	private String _inlineEditSaveURL;
-	private String _languageId;
 	private String _name = "editor";
 	private String _onChangeMethod;
 	private String _page;


### PR DESCRIPTION
From Brian:

I think the logic is wrong:

Locale contentsLocale = LocaleUtil.fromLanguageId(contentsLanguageId);
String contentsLanguageDir = LanguageUtil.get(contentsLocale, "lang.dir");

// LPS-35567

languageId = languageId.replace("iw_", "he_");
contentsLanguageId = contentsLanguageId.replace("iw_", "he_");

Why are we replacing the contentsLanguageId after we get the contentsLocale object. Shouldn't it be before?

Please resend.

Thx.

---

Answer:

Hi Brian, the logic is right for this reason:
- In liferay, we don't have the locale he for hebrew, we have the iw (as stated by the ISO we follow). In the last year, a new ISO has declared HE as the new languageId, but leaving IW working too (for backwards compatibility). 
- the version of ckeditor we are using is not following this strictly, since they only support he for hebrew.

For this reason, we need to obtain the liferay locale using IW (as we do everywhere in the portal), BUT for ckeditor, we need to pass the value HE
