### PR TITLE
LPS-35708 Enable monitoring-spring.xml by default to avoid configuration exceptions when listening liferay/monitoring channel 

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -759,7 +759,7 @@
         #META-INF/dynamic-data-source-spring.xml,\
         #META-INF/shard-data-source-spring.xml,\
         #META-INF/memcached-spring.xml,\
-        #META-INF/monitoring-spring.xml,\
+        META-INF/monitoring-spring.xml,\
         \
         classpath*:META-INF/ext-spring.xml
 


### PR DESCRIPTION
Best Regards

@igorbeslic 
