### PR TITLE
LPS-35669 Revert source formating --> Read description

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
@@ -339,7 +339,7 @@ if (endDateTime > 0) {
 									long exportModelCount = portletDataHandler.getExportModelCount(manifestSummary);
 								%>
 
-									<c:if test="<%= exportModelCount > 0 %>">
+									<c:if test="<%= exportModelCount != 0 %>">
 										<li>
 											<aui:input checked="<%= portletDataHandler.isPublishToLiveByDefault() %>" label='<%= portletTitle + (exportModelCount > 0 ? " (" + exportModelCount + ")" : StringPool.BLANK) %>' name="<%= PortletDataHandlerKeys.PORTLET_DATA + StringPool.UNDERLINE + portlet.getPortletId() %>" type="checkbox" />
 


### PR DESCRIPTION
If the modelCount is -1, it means the portletDataHandler isn't implementing the summary modelcount, therefore, we still want to display all the controls (backwards compatibility). If the modelCount is 0, it is implemented but there is nothing to export.
