### PR TITLE
LPS-30321 Programly ensure Hibernate query cache and second level cache ...

### DIFF
--- a/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.resiliency.spi.SPIUtil;
 import com.liferay.portal.kernel.util.Converter;
 import com.liferay.portal.kernel.util.PreloadClassLoader;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -128,7 +129,15 @@ public class PortalHibernateConfiguration extends LocalSessionFactoryBean {
 				}
 			}
 
-			configuration.setProperties(PropsUtil.getProperties());
+			Properties properties = PropsUtil.getProperties();
+
+			if (SPIUtil.isSPI()) {
+				properties.put("hibernate.cache.use_query_cache", "false");
+				properties.put(
+					"hibernate.cache.use_second_level_cache", "false");
+			}
+
+			configuration.setProperties(properties);
 
 			if (Validator.isNull(PropsValues.HIBERNATE_DIALECT)) {
 				Dialect dialect = determineDialect();

--- a/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_line_length_exclusions.properties
+++ b/portal-impl/src/com/liferay/portal/tools/dependencies/source_formatter_line_length_exclusions.properties
@@ -3,7 +3,7 @@
 #
 portal-impl/src/com/liferay/portal/parsers/creole/parser/Creole10Lexer.java
 portal-impl/src/com/liferay/portal/parsers/creole/parser/Creole10Parser.java
-portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java@245=true
+portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java@254=true
 portal-impl/src/com/liferay/portal/spring/transaction/TransactionInterceptorFactoryBean.java@41=true
 portal-impl/src/com/liferay/portal/tools/LangBuilder.java@440=true
 portal-impl/src/com/liferay/portal/tools/LangBuilder.java@446=true


### PR DESCRIPTION
...is off for SPIs, this is required due to EasyConfig's bug that does not allow overwriting grouped properties over system properties
