### PR TITLE
LPS-27398 The broken test could be caused by losing milliseconds on the ...

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/auth/JAASTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/auth/JAASTest.java
@@ -374,7 +374,7 @@ public class JAASTest extends MainServletExecutionTestListener {
 
 			_user = UserLocalServiceUtil.getUser(_user.getUserId());
 
-			Assert.assertTrue(lastLoginDate.before(_user.getLastLoginDate()));
+			Assert.assertFalse(lastLoginDate.after(_user.getLastLoginDate()));
 		}
 		finally {
 			EventsProcessorUtil.unregisterEvent(


### PR DESCRIPTION
...Date fetched back from DB?
