### PR TITLE
LPS-36114 Disable automatic template reloading

### DIFF
--- a/portal-impl/src/com/liferay/portal/freemarker/FreeMarkerUtil.java
+++ b/portal-impl/src/com/liferay/portal/freemarker/FreeMarkerUtil.java
@@ -57,6 +57,7 @@ public class FreeMarkerUtil {
 		_configuration.setObjectWrapper(new DefaultObjectWrapper());
 		_configuration.setTemplateLoader(
 			new ClassTemplateLoader(FreeMarkerUtil.class, StringPool.SLASH));
+		_configuration.setTemplateUpdateDelay(Integer.MAX_VALUE);
 
 		return _configuration;
 	}


### PR DESCRIPTION
Technically, a better solution would be applying LiferayTemplateCache to the Configuration as FreeMarkerManager does. Because our LiferayTemplateCache is more efficient than the default TemplateCache.

However, currently there is a PACL wrapper inside LiferayTemplateCache which will slow things a lot, and it is totally unneeded for tools.

So later when I optimize off the PACL wrapper, we may consider to inject our LiferayTemplateCache for tools' Configuration. But for now, this is the most simple and efficient solution.
