### PR TITLE
LPS-35937 Read description

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
@@ -17,15 +17,19 @@ package com.liferay.portal.servlet;
 import com.liferay.portal.NoSuchLayoutException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.LayoutFriendlyURL;
 import com.liferay.portal.model.LayoutFriendlyURLComposite;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.LayoutFriendlyURLLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextFactory;
 import com.liferay.portal.service.ServiceContextThreadLocal;
@@ -38,6 +42,7 @@ import com.liferay.portal.util.WebKeys;
 import java.io.IOException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -276,7 +281,15 @@ public class FriendlyURLServlet extends HttpServlet {
 
 			friendlyURL = layoutFriendlyURLComposite.getFriendlyURL();
 
+			pos = friendlyURL.indexOf(Portal.FRIENDLY_URL_SEPARATOR);
+
+			if (pos != -1) {
+				friendlyURL = friendlyURL.substring(0, pos);
+			}
+
 			if (!friendlyURL.startsWith(layout.getFriendlyURL(locale))) {
+				setAlternativeLayoutFriendlyURL(request, layout, friendlyURL);
+
 				String redirect = PortalUtil.getLocalizedFriendlyURL(
 					request, layout, locale);
 
@@ -285,6 +298,35 @@ public class FriendlyURLServlet extends HttpServlet {
 		}
 
 		return new Object[] {actualURL, Boolean.FALSE};
+	}
+
+	protected void setAlternativeLayoutFriendlyURL(
+			HttpServletRequest request, Layout layout, String friendlyURL)
+		throws Exception {
+
+		List<LayoutFriendlyURL> layoutFriendlyURLs =
+			LayoutFriendlyURLLocalServiceUtil.getLayoutFriendlyURLs(
+				layout.getPlid(), friendlyURL, 0, 1);
+
+		if (layoutFriendlyURLs.isEmpty()) {
+			return;
+		}
+
+		LayoutFriendlyURL layoutFriendlyURL = layoutFriendlyURLs.get(0);
+
+		Locale locale = LocaleUtil.fromLanguageId(
+			layoutFriendlyURL.getLanguageId());
+
+		String alternativeLayoutFriendlyURL =
+			PortalUtil.getLocalizedFriendlyURL(request, layout, locale);
+
+		SessionMessages.add(
+			request, "alternativeLayoutFriendlyURL",
+			alternativeLayoutFriendlyURL);
+
+		SessionMessages.add(
+			request, SessionMessages.KEY_PORTAL_MESSAGES_JSP_PATH,
+			"/html/common/themes/layout_friendly_url_redirect.jsp");
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(FriendlyURLServlet.class);

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -425,6 +425,8 @@ action.VIEW_USER=View User
 ## Messages
 ##
 
+you-have-been-redirected-to-the-following-url-x=You have been redirected to the following url: {0}
+click-in-the-following-link-if-you-want-to-dismiss-this-redirect-and-access-the-original-url-x=Click in the following link if you want to dismiss this redirect and access the original url {0}
 1-day=1 Day
 1-minute=1 Minute
 1-month=1 Month

--- a/portal-service/src/com/liferay/portal/kernel/servlet/SessionMessages.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/SessionMessages.java
@@ -33,6 +33,24 @@ import javax.servlet.http.HttpSession;
  */
 public class SessionMessages {
 
+	public static final String KEY_PORTAL_MESSAGES_ANIMATION =
+		"portalMessagesAnimation";
+
+	public static final String KEY_PORTAL_MESSAGES_CSS_CLASS =
+		"portalMessagesCssClass";
+
+	public static final String KEY_PORTAL_MESSAGES_JSP_PATH =
+		"portalMessagesJSPPath";
+
+	public static final String KEY_PORTAL_MESSAGES_MESSAGE =
+		"portalMessagesMessage";
+
+	public static final String KEY_PORTAL_MESSAGES_PORTLET_ID =
+		"portalMessagesPortletId";
+
+	public static final String KEY_PORTAL_MESSAGES_TIMEOUT =
+		"portalMessagesTimeout";
+
 	public static final String KEY_SUFFIX_CLOSE_REDIRECT = ".closeRedirect";
 
 	public static final String KEY_SUFFIX_DELETE_SUCCESS_DATA =

--- a/portal-web/docroot/html/common/themes/layout_friendly_url_redirect.jsp
+++ b/portal-web/docroot/html/common/themes/layout_friendly_url_redirect.jsp
@@ -1,0 +1,45 @@
+<%--
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/common/init.jsp" %>
+
+<%
+String alternativeLayoutFriendlyURL = GetterUtil.getString(SessionMessages.get(request, "alternativeLayoutFriendlyURL"));
+%>
+
+<c:if test="<%= Validator.isNotNull(alternativeLayoutFriendlyURL) %>">
+	<button class="close" type="button">&times;</button>
+
+	<liferay-util:buffer var="redirectedLink">
+		<aui:a href="<%= PortalUtil.getCurrentCompleteURL(request) %>">
+			<%= PortalUtil.getCurrentCompleteURL(request) %>
+		</aui:a>
+	</liferay-util:buffer>
+
+	<p class="redirected-to-message">
+		<liferay-ui:message arguments="<%= redirectedLink %>" key="you-have-been-redirected-to-the-following-url-x" />
+	</p>
+
+	<liferay-util:buffer var="originalLink">
+		<aui:a href="<%= alternativeLayoutFriendlyURL %>">
+			<liferay-ui:message key="link" />
+		</aui:a>
+	</liferay-util:buffer>
+
+	<p class="original-url">
+		<liferay-ui:message arguments="<%= originalLink %>" key="click-in-the-following-link-if-you-want-to-dismiss-this-redirect-and-access-the-original-url-x" />
+	</p>
+</c:if>

--- a/portal-web/docroot/html/common/themes/top_messages.jsp
+++ b/portal-web/docroot/html/common/themes/top_messages.jsp
@@ -26,3 +26,51 @@
 		</c:if>
 	</div>
 </c:if>
+
+<%
+String jspPath = GetterUtil.getString(SessionMessages.get(request, SessionMessages.KEY_PORTAL_MESSAGES_JSP_PATH));
+String message = GetterUtil.getString(SessionMessages.get(request, SessionMessages.KEY_PORTAL_MESSAGES_MESSAGE));
+
+if (Validator.isNotNull(jspPath) || Validator.isNotNull(message)) {
+	String cssClass = GetterUtil.getString(SessionMessages.get(request, SessionMessages.KEY_PORTAL_MESSAGES_CSS_CLASS), "alert-info");
+	String portletId = GetterUtil.getString(SessionMessages.get(request, SessionMessages.KEY_PORTAL_MESSAGES_PORTLET_ID));
+	int timeout = GetterUtil.getInteger(SessionMessages.get(request, SessionMessages.KEY_PORTAL_MESSAGES_TIMEOUT), 10000);
+	boolean useAnimation = GetterUtil.getBoolean(SessionMessages.get(request, SessionMessages.KEY_PORTAL_MESSAGES_ANIMATION), true);
+%>
+
+	<div class="hide <%= cssClass %>" id="portalMessageContainer">
+		<c:choose>
+			<c:when test="<%= Validator.isNotNull(jspPath) %>">
+				<liferay-util:include page="<%= jspPath %>" portletId="<%= portletId %>" />
+			</c:when>
+			<c:otherwise>
+				<liferay-ui:message key="<%= message %>" /><button type="button" class="close">&times;</button>
+			</c:otherwise>
+		</c:choose>
+	</div>
+
+	<aui:script use="liferay-notice">
+		var portalMessageContainer = A.one('#portalMessageContainer');
+
+		var banner = new Liferay.Notice(
+			{
+				animationConfig:
+					{
+						duration: 2,
+						top: '0px'
+					},
+				closeText: false,
+				content: portalMessageContainer.html(),
+				noticeClass: 'hide taglib-portal-message <%= cssClass %>',
+				timeout: <%= timeout %>,
+				toggleText: false,
+				useAnimation: <%= useAnimation %>
+			}
+		);
+
+		banner.show();
+	</aui:script>
+
+<%
+}
+%>

--- a/portal-web/docroot/html/js/liferay/modules.js
+++ b/portal-web/docroot/html/js/liferay/modules.js
@@ -421,7 +421,8 @@ window.YUI_config = {
 				'liferay-notice': {
 					path: 'notice.js',
 					requires: [
-						'aui-base'
+						'aui-base',
+						'transition'
 					]
 				},
 				'liferay-node': {

--- a/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
+++ b/portal-web/docroot/html/themes/classic/_diffs/css/custom.css
@@ -85,6 +85,17 @@
 		margin-bottom: 6px;
 	}
 
+	.redirected-to-message {
+		margin-right: 10px;
+
+		a {
+			background: #ecfbff;
+			border: 1px solid #ade5fa;
+			color: #8d8d8d;
+			padding: 5px;
+		}
+	}
+
 	/* ---------- Main navigation ---------- */
 
 	#navigation {


### PR DESCRIPTION
Hey Brian,

I have sent the pull as you suggested with SessionMessages and without using PortalUtil.addPortalMessage. I didn't include "requestProcessed" yet but I will include in next commits.

The issue with this approach of SessionMessages is that it won't work when used from external plugins (see https://github.com/brianchandotcom/liferay-plugins/pull/1639) because the session attributes are not shared between the portal and the plugin.

"requestProcessed" message works because it's consumed from portlet_messages.jspf and it has renderRequest

``` java
(String)SessionMessages.get(renderRequest, "requestProcessed");
```

but we are using it from top_messages.jsp and we only have request there so we cannot retrieve the values of the session sent by an external portlet.

``` java
GetterUtil.getString(SessionMessages.get(request, SessionMessages.KEY_PORTAL_MESSAGES_JSP_PATH))
```

Should we use LIFERAY_SHARED attributes as in here https://github.com/sergiogonzalez/liferay-portal/commit/b708c0011217aa010e3c904db0529d673a80d2e7 ?
