### PR TITLE
LPS-34567 Site template page import causes ConstraintViolation

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -797,10 +797,16 @@ public class LayoutImporter {
 			UnicodeProperties settingsProperties =
 				layoutSet.getSettingsProperties();
 
-			settingsProperties.setProperty(
-				Sites.LAST_MERGE_TIME, String.valueOf(lastMergeTime));
+			String mergeFailFriendlyURLLayouts =
+				settingsProperties.getProperty(
+					Sites.MERGE_FAIL_FRIENDLY_URL_LAYOUTS);
 
-			LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet);
+			if (Validator.isNull(mergeFailFriendlyURLLayouts)) {
+				settingsProperties.setProperty(
+					Sites.LAST_MERGE_TIME, String.valueOf(lastMergeTime));
+
+				LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet);
+			}
 		}
 
 		zipReader.close();

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -64,6 +64,7 @@ import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.service.ResourceLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceContextThreadLocal;
+import com.liferay.portal.service.persistence.LayoutFriendlyURLUtil;
 import com.liferay.portal.service.persistence.LayoutRevisionUtil;
 import com.liferay.portal.service.persistence.LayoutUtil;
 import com.liferay.portal.util.PropsValues;
@@ -315,6 +316,20 @@ public class LayoutStagedModelDataHandler
 
 			if (SitesUtil.isLayoutModifiedSinceLastMerge(existingLayout)) {
 				newLayoutsMap.put(oldLayoutId, existingLayout);
+
+				return;
+			}
+
+			LayoutFriendlyURL layoutFriendlyURL =
+				LayoutFriendlyURLUtil.fetchByG_P_F_First(
+					groupId, privateLayout, friendlyURL, null);
+
+			if ((layoutFriendlyURL != null) && (existingLayout == null)) {
+				Layout mergeFailFriendlyURLLayout = LayoutUtil.findByPrimaryKey(
+					layoutFriendlyURL.getPlid());
+
+				SitesUtil.addMergeFailFriendlyURLLayout(
+					mergeFailFriendlyURLLayout);
 
 				return;
 			}

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -425,6 +425,8 @@ action.VIEW_USER=View User
 ## Messages
 ##
 
+modify-the-friendly-url-of-the-pages-to-allow-the-propagation-of-the-pages-from-the-site-template=Modify the friendly url of the pages to allow the propagation of the pages from the site template.
+some-pages-from-the-site-template-cannot-be-propagated-because-their-friendly-urls-are-in-conflict-with-the-following-pages=Some pages from the site template cannot be propagated because their friendly urls are in conflict with the following pages.
 1-day=1 Day
 1-minute=1 Minute
 1-month=1 Month

--- a/portal-service/src/com/liferay/portlet/sites/util/Sites.java
+++ b/portal-service/src/com/liferay/portlet/sites/util/Sites.java
@@ -68,6 +68,12 @@ public interface Sites {
 
 	public static final String MERGE_FAIL_COUNT = "merge-fail-count";
 
+	public static final String MERGE_FAIL_FRIENDLY_URL_LAYOUTS =
+		"merge-fail-friendly-url-layouts";
+
+	public void addMergeFailFriendlyURLLayout(Layout layout)
+		throws PortalException, SystemException;
+
 	public void addPortletBreadcrumbEntries(
 			Group group, HttpServletRequest request,
 			RenderResponse renderResponse)
@@ -130,6 +136,9 @@ public interface Sites {
 	public int getMergeFailCount(LayoutSetPrototype layoutSetPrototype)
 		throws PortalException, SystemException;
 
+	public List<Layout> getMergeFailFriendlyURLLayouts(LayoutSet layoutSet)
+		throws PortalException, SystemException;
+
 	public void importLayoutSetPrototype(
 			LayoutSetPrototype layoutSetPrototype, InputStream inputStream,
 			ServiceContext serviceContext)
@@ -184,6 +193,9 @@ public interface Sites {
 	 */
 	public void mergeLayoutSetProtypeLayouts(Group group, LayoutSet layoutSet)
 		throws Exception;
+
+	public void removeMergeFailFriendlyURLLayouts(LayoutSet layoutSet)
+		throws PortalException, SystemException;
 
 	public void resetPrototype(Layout layout)
 		throws PortalException, SystemException;

--- a/portal-service/src/com/liferay/portlet/sites/util/SitesUtil.java
+++ b/portal-service/src/com/liferay/portlet/sites/util/SitesUtil.java
@@ -49,6 +49,12 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SitesUtil {
 
+	public static void addMergeFailFriendlyURLLayout(Layout layout)
+		throws PortalException, SystemException {
+
+		getSites().addMergeFailFriendlyURLLayout(layout);
+	}
+
 	public static void addPortletBreadcrumbEntries(
 			Group group, HttpServletRequest request,
 			RenderResponse renderResponse)
@@ -166,6 +172,13 @@ public class SitesUtil {
 		return getSites().getMergeFailCount(layoutSetPrototype);
 	}
 
+	public static List<Layout> getMergeFailFriendlyURLLayouts(
+			LayoutSet layoutSet)
+		throws PortalException, SystemException {
+
+		return getSites().getMergeFailFriendlyURLLayouts(layoutSet);
+	}
+
 	public static Sites getSites() {
 		PortalRuntimePermission.checkGetBeanProperty(SitesUtil.class);
 
@@ -272,6 +285,12 @@ public class SitesUtil {
 		throws Exception {
 
 		getSites().mergeLayoutSetProtypeLayouts(group, layoutSet);
+	}
+
+	public static void removeMergeFailFriendlyURLLayouts(LayoutSet layoutSet)
+		throws PortalException, SystemException {
+
+		getSites().removeMergeFailFriendlyURLLayouts(layoutSet);
 	}
 
 	public static void resetPrototype(Layout layout)

--- a/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
@@ -241,6 +241,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 
 													<%
 													request.setAttribute("edit_layout_set_prototype.jsp-groupId", String.valueOf(group.getGroupId()));
+													request.setAttribute("edit_layout_set_prototype.jsp-layoutSet", publicLayoutSet);
 													request.setAttribute("edit_layout_set_prototype.jsp-layoutSetPrototype", publicLayoutSetPrototype);
 													request.setAttribute("edit_layout_set_prototype.jsp-redirect", currentURL);
 													%>
@@ -324,8 +325,8 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 
 													<%
 													request.setAttribute("edit_layout_set_prototype.jsp-groupId", String.valueOf(group.getGroupId()));
+													request.setAttribute("edit_layout_set_prototype.jsp-layoutSet", privateLayoutSet);
 													request.setAttribute("edit_layout_set_prototype.jsp-layoutSetPrototype", privateLayoutSetPrototype);
-													request.setAttribute("edit_layout_set_prototype.jsp-privateLayoutSet", String.valueOf(true));
 													request.setAttribute("edit_layout_set_prototype.jsp-redirect", currentURL);
 													%>
 


### PR DESCRIPTION
Hey Brian,

These are the required changes in master. I've also sent you the backport for ee-6.1.x brianchandotcom/liferay-portal-ee/pull/1472. The main differences are:
- Part of the affected logic in LayoutImporter has been moved to LayoutStagedModelDataHandler.
- Using LayoutFriendlyURLUtil to check conflicts in any existing translations. Notice that the same layout might have the same friendlyURL for different translations, but the same friendlyURL cannot be used in other layout for any of its languages. 
- merge_alert.jsp already existed in 6.2.x so code has been combined with the existing one. 

Thanks

@lipusz 
@akos
