### PR TITLE
LPS-36412 Reading patch.level to identify what fix packs had been instal...

### DIFF
--- a/portal-impl/src/com/liferay/portal/patcher/PatcherImpl.java
+++ b/portal-impl/src/com/liferay/portal/patcher/PatcherImpl.java
@@ -116,6 +116,20 @@ public class PatcherImpl implements Patcher {
 	}
 
 	@Override
+	public String[] getPatchLevel() {
+		if (_patchLevel != null) {
+			return _patchLevel;
+		}
+
+		Properties properties = getProperties();
+
+		_patchLevel = StringUtil.split(
+			properties.getProperty(PROPERTY_PATCH_LEVEL));
+
+		return _patchLevel;
+	}
+
+	@Override
 	public Properties getProperties() {
 		if (_properties != null) {
 			return _properties;
@@ -165,6 +179,7 @@ public class PatcherImpl implements Patcher {
 	private static String[] _fixedIssueKeys;
 	private static String[] _installedPatchNames;
 	private static File _patchDirectory;
+	private static String[] _patchLevel;
 	private static Properties _properties;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/patcher/Patcher.java
+++ b/portal-service/src/com/liferay/portal/kernel/patcher/Patcher.java
@@ -32,6 +32,8 @@ public interface Patcher {
 
 	public static final String PROPERTY_PATCH_DIRECTORY = "patch.directory";
 
+	public static final String PROPERTY_PATCH_LEVEL = "patch.level";
+
 	public boolean applyPatch(File patchFile);
 
 	public String[] getFixedIssues();
@@ -39,6 +41,8 @@ public interface Patcher {
 	public String[] getInstalledPatches();
 
 	public File getPatchDirectory();
+
+	public String[] getPatchLevel();
 
 	public Properties getProperties();
 

--- a/portal-service/src/com/liferay/portal/kernel/patcher/PatcherUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/patcher/PatcherUtil.java
@@ -48,6 +48,10 @@ public class PatcherUtil {
 		return _patcher;
 	}
 
+	public static String[] getPatchLevel() {
+		return getPatcher().getPatchLevel();
+	}
+
 	public static Properties getProperties() {
 		return getPatcher().getProperties();
 	}


### PR DESCRIPTION
Hi Brian,

This new API would help us what fix packs are available and installed. When hotfix-1234 contains core-5, web-content-1 and one extra LPE, only the hotfix-1234 would be installed by the patching-tool while all of the core-5 and web-content-1 fixes would be available.

The patcher APIs would return the following values in this scenario:
getInstalledPatches(): hotfix-1234
getFixedIssues(): LPE-123,LPE-124,LPE...
getPatchLevel():core-5,web-content-1,hotfix-1234
