### PR TITLE
LPS-36481

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -811,10 +811,12 @@ public class PortletURLImpl
 			return;
 		}
 
-		sb.append("p_p_auth");
-		sb.append(StringPool.EQUAL);
-		sb.append(processValue(key, actualPortletAuthenticationToken));
-		sb.append(StringPool.AMPERSAND);
+		if (_portlet.isAddDefaultResource()) {
+			sb.append("p_p_auth");
+			sb.append(StringPool.EQUAL);
+			sb.append(processValue(key, actualPortletAuthenticationToken));
+			sb.append(StringPool.AMPERSAND);
+		}
 	}
 
 	protected void clearCache() {


### PR DESCRIPTION
The p_p_auth parameter is unnecessarily added to URLs for portlets that have add-default-resource=false
