### PR TITLE
LPS-36588

### DIFF
--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -272,16 +272,6 @@
 					<arg line="${arg.line}" />
 				</java>
 
-				<replace file="docroot/html/js/editor/ckeditor/dev/builder/release/ckeditor/skins/kama/editor.css">
-					<replacetoken><![CDATA[overflow:hidden}.cke_resizer{]]></replacetoken>
-					<replacevalue><![CDATA[overflow:hidden}.cke_top{white-space:normal}.cke_resizer{]]></replacevalue>
-				</replace>
-
-				<replace file="docroot/html/js/editor/ckeditor/dev/builder/release/ckeditor/skins/moono/editor.css">
-					<replacetoken><![CDATA[.cke_top{border-bottom:1px solid #b6b6b6;padding:6px 8px 2px;-moz-box-shadow:0 1px 0 #fff inset;]]></replacetoken>
-					<replacevalue><![CDATA[.cke_top{border-bottom:1px solid #b6b6b6;padding:6px 8px 2px;white-space:normal;-moz-box-shadow:0 1px 0 #fff inset;]]></replacevalue>
-				</replace>
-
 				<move
 					file="docroot/html/js/editor/ckeditor/dev/builder/release/ckeditor"
 					preservelastmodified="true"


### PR DESCRIPTION
We don't patch ckeditor through the build anymore after: https://issues.liferay.com/browse/LPS-34197

@HSchueler I was told you were responsible for maintaining our ckeditor branch. Can you add this patch to it and take care of the other two instances

``` xml
<replace file="docroot/html/js/editor/ckeditor/plugins/wysiwygarea/plugin.js">
<replace file="docroot/html/js/editor/ckeditor/plugins/link/dialogs/link.js">
```

Thanks!
