### PR TITLE
LPS-37726 Move the back link in headers from the far right to the left of the text

### DIFF
--- a/portal-impl/src/com/liferay/portlet/rolesadmin/action/EditRolePermissionsAction.java
+++ b/portal-impl/src/com/liferay/portlet/rolesadmin/action/EditRolePermissionsAction.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;

--- a/portal-web/docroot/html/css/taglib/header.css
+++ b/portal-web/docroot/html/css/taglib/header.css
@@ -7,7 +7,7 @@
 	}
 
 	.header-back-to a {
-		float: right;
+		float: left;
 		padding: 1em 0.2em;
 	}
 }

--- a/portal-web/docroot/html/portal/layout/view/control_panel.jsp
+++ b/portal-web/docroot/html/portal/layout/view/control_panel.jsp
@@ -163,7 +163,7 @@ request.setAttribute("control_panel.jsp-ppid", ppid);
 											%>
 
 											<a class="control-panel-back-link" href="<%= backURL %>" title="<liferay-ui:message key="back" />">
-												<i class="control-panel-back-icon icon-circle-arrow-left"></i>
+												<i class="control-panel-back-icon icon-chevron-left"></i>
 
 												<span class="control-panel-back-text">
 													<liferay-ui:message key="back" />

--- a/portal-web/docroot/html/taglib/ui/header/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/header/page.jsp
@@ -17,15 +17,6 @@
 <%@ include file="/html/taglib/ui/header/init.jsp" %>
 
 <%
-if (Validator.isNotNull(backLabel)) {
-	if (!backLabel.startsWith("&laquo; ")) {
-		backLabel = "&laquo; ".concat(LanguageUtil.format(pageContext, "back-to-x", HtmlUtil.escape(backLabel)));
-	}
-}
-else {
-	backLabel = "&laquo; ".concat(LanguageUtil.get(pageContext, "back"));
-}
-
 if (Validator.isNotNull(backURL) && !backURL.equals("javascript:history.go(-1);")) {
 	backURL = HtmlUtil.escapeHREF(PortalUtil.escapeRedirect(backURL));
 }
@@ -36,7 +27,7 @@ String headerTitle = (localizeTitle) ? LanguageUtil.get(pageContext, title) : ti
 <div class="taglib-header <%= cssClass %>">
 	<c:if test="<%= showBackURL && Validator.isNotNull(backURL) %>">
 		<span class="header-back-to">
-			<a href="<%= backURL %>" id="<%= namespace %>TabsBack"><%= backLabel %></a>
+			<a class="icon-chevron-left" href="<%= backURL %>" id="<%= namespace %>TabsBack" title="<%= backLabel %>">&nbsp;</a>
 		</span>
 	</c:if>
 


### PR DESCRIPTION
/cc @juliocamarero @natecavanaugh
