### PR TITLE
LPS-37400 Filters should use full cache key generator

### DIFF
--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -80,16 +80,16 @@
 					<bean class="com.liferay.portal.cache.key.HashCodeCacheKeyGenerator" />
 				</entry>
 				<entry key="com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilter">
-					<bean class="com.liferay.portal.cache.key.HashCodeCacheKeyGenerator" />
+					<bean class="com.liferay.portal.cache.key.SimpleCacheKeyGenerator" />
 				</entry>
-				<entry key="com.liferay.portal.language.LanguageResources">
-					<bean class="com.liferay.portal.cache.key.HashCodeCacheKeyGenerator" />
+				<entry key="com.liferay.portal.servlet.filters.aggregate.AggregateFilter">
+					<bean class="com.liferay.portal.cache.key.SimpleCacheKeyGenerator" />
 				</entry>
-				<entry key="com.liferay.portal.servlet.ComboServlet">
-					<bean class="com.liferay.portal.cache.key.HashCodeCacheKeyGenerator" />
+				<entry key="com.liferay.portal.servlet.filters.dynamiccss.DynamicCSSFilter">
+					<bean class="com.liferay.portal.cache.key.SimpleCacheKeyGenerator" />
 				</entry>
 				<entry key="com.liferay.portal.servlet.filters.strip.StripFilter">
-					<bean class="com.liferay.portal.cache.key.HashCodeCacheKeyGenerator" />
+					<bean class="com.liferay.portal.cache.key.SimpleCacheKeyGenerator" />
 				</entry>
 			</map>
 		</property>

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -94,7 +94,7 @@
 			</map>
 		</property>
 		<property name="defaultCacheKeyGenerator">
-			<bean class="com.liferay.portal.cache.key.HashCodeCacheKeyGenerator" />
+			<bean class="com.liferay.portal.cache.key.SimpleCacheKeyGenerator" />
 		</property>
 	</bean>
 	<bean id="com.liferay.portal.kernel.captcha.CaptchaUtil" class="com.liferay.portal.kernel.captcha.CaptchaUtil">


### PR DESCRIPTION
@topolik
Tomas, since I don't see you are applying my suggested fix, I went ahead made this commit.

It should fix the problem completely, without adding the SecureRandom and the new generator.

Please understand your previous SecureHashCodeCacheKeyGenerator solution is less safer than full cache key(which is 100% guaranteed safe), not matter how secure the seed is, hash is still hash, it will eventually conflict with something.

cc @rotty3000
