### PR TITLE
LPS-31785 Fix annotation removing comma after last listener

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/search/lucene/LuceneIndexSearcherTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/search/lucene/LuceneIndexSearcherTest.java
@@ -45,11 +45,10 @@ import org.junit.runner.RunWith;
 /**
  * @author Roberto Díaz
  */
-
 @ExecutionTestListeners(
 	listeners = {
 		EnvironmentExecutionTestListener.class,
-		SynchronousDestinationExecutionTestListener.class,
+		SynchronousDestinationExecutionTestListener.class
 	})
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
 @Sync


### PR DESCRIPTION
This was causing the JavadocFormatter to crash. I'll inform Roberto.
