### PR TITLE
LPS-33227 - Site Selector in Asset Publisher doesn't work properly when there are more than one asset publisher in the page

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/select_organization.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/select_organization.jsp
@@ -137,7 +137,7 @@ if (Validator.isNotNull(target)) {
 					Map<String, Object> data = new HashMap<String, Object>();
 
 					data.put("groupid", organization.getGroupId());
-					data.put("name", HtmlUtil.escape((organization.getName()));
+					data.put("name", HtmlUtil.escape((organization.getName())));
 					data.put("organizationid", organization.getOrganizationId());
 					data.put("type", LanguageUtil.get(pageContext, organization.getType()));
 					%>


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-33227.

Please let me know if you have any questions.  Thanks!
