### PR TITLE
LPS-38399 Tests

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.service;
 import com.liferay.portal.GroupParentException;
 import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -41,6 +42,7 @@ import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.GroupTestUtil;
 import com.liferay.portal.util.LayoutTestUtil;
+import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portal.util.UserTestUtil;
 import com.liferay.portlet.asset.service.AssetTagLocalServiceUtil;
@@ -51,6 +53,7 @@ import com.liferay.portlet.blogs.util.BlogsTestUtil;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -452,6 +455,20 @@ public class GroupServiceTest {
 	}
 
 	@Test
+	public void testInheritLocalesByDefault() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Assert.assertTrue(LanguageUtil.isInheritLocales(group.getGroupId()));
+
+		Locale[] portalAvailableLocales = LanguageUtil.getAvailableLocales();
+
+		Locale[] groupAvailableLocales = LanguageUtil.getAvailableLocales(
+			group.getGroupId());
+
+		Assert.assertArrayEquals(portalAvailableLocales, groupAvailableLocales);
+	}
+
+	@Test
 	public void testScopes() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 
@@ -592,6 +609,37 @@ public class GroupServiceTest {
 		Assert.assertFalse(group111.isRoot());
 		Assert.assertEquals(group1.getGroupId(), group11.getParentGroupId());
 		Assert.assertEquals(group11.getGroupId(), group111.getParentGroupId());
+	}
+
+	@Test
+	public void testUpdateAvailableLocales() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		Locale[] availableLocales = new Locale[] {enLocale, esLocale, deLocale};
+
+		group = GroupTestUtil.updateDisplaySettings(
+			group.getGroupId(), availableLocales, null);
+
+		Assert.assertArrayEquals(
+			availableLocales,
+			LanguageUtil.getAvailableLocales(group.getGroupId()));
+	}
+
+	@Test
+	public void testUpdateDefaultLocale() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Locale esLocale = new Locale("es", "ES");
+
+		group = GroupTestUtil.updateDisplaySettings(
+			group.getGroupId(), null, esLocale);
+
+		Assert.assertEquals(
+			esLocale, PortalUtil.getSiteDefaultLocale(group.getGroupId()));
 	}
 
 	@Test

--- a/portal-impl/test/integration/com/liferay/portal/service/LayoutFriendlyURLServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/LayoutFriendlyURLServiceTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service;
+
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.LayoutFriendlyURL;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.MainServletExecutionTestListener;
+import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
+import com.liferay.portal.util.GroupTestUtil;
+import com.liferay.portal.util.LayoutTestUtil;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.testng.Assert;
+
+/**
+ * @author Sergio González
+ */
+@ExecutionTestListeners(
+	listeners = {
+		MainServletExecutionTestListener.class,
+		TransactionalCallbackAwareExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class LayoutFriendlyURLServiceTest {
+
+	@Test
+	public void testLocalizedSiteAddLayoutFriendlyURLs() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		Locale[] availableLocales = new Locale[] {enLocale, esLocale};
+
+		group = GroupTestUtil.updateDisplaySettings(
+			group.getGroupId(), availableLocales, esLocale);
+
+		String name = ServiceTestUtil.randomString();
+
+		Map<Locale, String> nameMap = new HashMap<Locale, String>();
+
+		nameMap.put(enLocale, name);
+		nameMap.put(esLocale, name);
+		nameMap.put(deLocale, name);
+
+		Map<Locale, String> friendlyURLMap = new HashMap<Locale, String>();
+
+		friendlyURLMap.put(enLocale, "/englishurl");
+		friendlyURLMap.put(esLocale, "/spanishurl");
+		friendlyURLMap.put(deLocale, "/germanurl");
+
+		Layout layout = LayoutTestUtil.addLayout(
+			group.getGroupId(), false, nameMap, friendlyURLMap);
+
+		List<LayoutFriendlyURL> layoutFriendlyURLs =
+			LayoutFriendlyURLLocalServiceUtil.getLayoutFriendlyURLs(
+				layout.getPlid());
+
+		Assert.assertEquals(availableLocales.length, layoutFriendlyURLs.size());
+
+		String[] availableLanguageIds = LocaleUtil.toLanguageIds(
+			availableLocales);
+
+		for (LayoutFriendlyURL layoutFriendlyURL : layoutFriendlyURLs) {
+			if (!ArrayUtil.contains(
+					availableLanguageIds, layoutFriendlyURL.getLanguageId())) {
+
+				Assert.fail();
+			}
+		}
+	}
+
+	@Test
+	public void testLocalizedSiteFetchLayoutFriendlyURL() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		Locale[] availableLocales = new Locale[] {enLocale, esLocale};
+
+		Locale defaultLocale = esLocale;
+
+		group = GroupTestUtil.updateDisplaySettings(
+			group.getGroupId(), availableLocales, defaultLocale);
+
+		String name = ServiceTestUtil.randomString();
+
+		Map<Locale, String> nameMap = new HashMap<Locale, String>();
+
+		nameMap.put(enLocale, name);
+		nameMap.put(esLocale, name);
+
+		Map<Locale, String> friendlyURLMap = new HashMap<Locale, String>();
+
+		friendlyURLMap.put(enLocale, "/englishurl");
+		friendlyURLMap.put(esLocale, "/spanishurl");
+
+		Layout layout = LayoutTestUtil.addLayout(
+			group.getGroupId(), false, nameMap, friendlyURLMap);
+
+		LocaleThreadLocal.setSiteDefaultLocale(defaultLocale);
+
+		LayoutFriendlyURL layoutFriendlyURL =
+			LayoutFriendlyURLLocalServiceUtil.fetchLayoutFriendlyURL(
+				layout.getPlid(), LocaleUtil.toLanguageId(deLocale), true);
+
+		Assert.assertEquals("/spanishurl", layoutFriendlyURL.getFriendlyURL());
+		Assert.assertEquals(
+			LocaleUtil.toLanguageId(defaultLocale),
+			layoutFriendlyURL.getLanguageId());
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/service/LayoutFriendlyURLServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/LayoutFriendlyURLServiceTest.java
@@ -128,16 +128,23 @@ public class LayoutFriendlyURLServiceTest {
 		Layout layout = LayoutTestUtil.addLayout(
 			group.getGroupId(), false, nameMap, friendlyURLMap);
 
-		LocaleThreadLocal.setSiteDefaultLocale(defaultLocale);
+		Locale locale = LocaleThreadLocal.getSiteDefaultLocale();
 
-		LayoutFriendlyURL layoutFriendlyURL =
-			LayoutFriendlyURLLocalServiceUtil.fetchLayoutFriendlyURL(
-				layout.getPlid(), LocaleUtil.toLanguageId(deLocale), true);
+		try {
+			LocaleThreadLocal.setSiteDefaultLocale(defaultLocale);
 
-		Assert.assertEquals("/spanishurl", layoutFriendlyURL.getFriendlyURL());
-		Assert.assertEquals(
-			LocaleUtil.toLanguageId(defaultLocale),
-			layoutFriendlyURL.getLanguageId());
+			LayoutFriendlyURL layoutFriendlyURL =
+				LayoutFriendlyURLLocalServiceUtil.fetchLayoutFriendlyURL(
+					layout.getPlid(), LocaleUtil.toLanguageId(deLocale), true);
+
+			Assert.assertEquals("/spanishurl", layoutFriendlyURL.getFriendlyURL());
+			Assert.assertEquals(
+				LocaleUtil.toLanguageId(defaultLocale),
+				layoutFriendlyURL.getLanguageId());
+		}
+		finally {
+			LocaleThreadLocal.setSiteDefaultLocale(locale);
+		}
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/util/GroupTestUtil.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/GroupTestUtil.java
@@ -14,10 +14,15 @@
 
 package com.liferay.portal.util;
 
+import com.liferay.portal.kernel.cache.Lifecycle;
+import com.liferay.portal.kernel.cache.ThreadLocalCacheManager;
 import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.GroupConstants;
 import com.liferay.portal.model.Layout;
@@ -26,6 +31,7 @@ import com.liferay.portal.service.GroupServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -150,6 +156,40 @@ public class GroupTestUtil {
 		StagingUtil.enableLocalStaging(
 			TestPropsValues.getUserId(), group, group, false, false,
 			serviceContext);
+	}
+
+	public static Group updateDisplaySettings(
+			long groupId, Locale[] availableLocales, Locale defaultLocale)
+		throws Exception {
+
+		UnicodeProperties typeSettingsProperties = new UnicodeProperties();
+
+		boolean inheritLocales = false;
+
+		if ((availableLocales == null) && (defaultLocale == null)) {
+			inheritLocales = true;
+		}
+
+		typeSettingsProperties.put(
+			"inheritLocales", String.valueOf(inheritLocales));
+
+		if (availableLocales != null) {
+			typeSettingsProperties.put(
+				com.liferay.portal.kernel.util.PropsKeys.LOCALES,
+				StringUtil.merge(LocaleUtil.toLanguageIds(availableLocales)));
+		}
+
+		if (defaultLocale != null) {
+			typeSettingsProperties.put(
+				"languageId", LocaleUtil.toLanguageId(defaultLocale));
+		}
+
+		Group group = GroupLocalServiceUtil.updateGroup(
+			groupId, typeSettingsProperties.toString());
+
+		ThreadLocalCacheManager.clearAll(Lifecycle.REQUEST);
+
+		return group;
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/util/PortalImplGetAlternateURLTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/PortalImplGetAlternateURLTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Company;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.service.CompanyLocalServiceUtil;
+import com.liferay.portal.test.EnvironmentExecutionTestListener;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.TransactionalExecutionTestListener;
+import com.liferay.portal.theme.ThemeDisplay;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Sergio González
+ */
+@ExecutionTestListeners(
+	listeners = {
+		EnvironmentExecutionTestListener.class,
+		TransactionalExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class PortalImplGetAlternateURLTest {
+
+	@Test
+	public void testCustomPortalLocaleAlternateURL() throws Exception {
+		Locale esLocale = new Locale("es", "ES");
+
+		testAlternateURL(null, null, esLocale, "/es");
+	}
+
+	@Test
+	public void testDefaultPortalLocaleAlternateURL() throws Exception {
+		testAlternateURL(null, null, Locale.US, StringPool.BLANK);
+	}
+
+	@Test
+	public void testLocalizedSiteCustomSiteLocaleAlternateURL()
+		throws Exception {
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		testAlternateURL(
+			new Locale[] {enLocale, esLocale, deLocale}, esLocale, enLocale,
+			"/en");
+	}
+
+	@Test
+	public void testLocalizedSiteDefaultSiteLocaleAlternateURL()
+		throws Exception {
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		testAlternateURL(
+			new Locale[] {enLocale, esLocale, deLocale}, esLocale, esLocale,
+			StringPool.BLANK);
+	}
+
+	protected String generateURL(
+		String languageId, String groupFriendlyURL, String layoutFriendlyURL) {
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append("http://localhost");
+		sb.append(languageId);
+		sb.append(PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING);
+		sb.append(groupFriendlyURL);
+		sb.append(layoutFriendlyURL);
+
+		return sb.toString();
+	}
+
+	protected ThemeDisplay initThemeDisplay(Group group) throws Exception {
+		Company company = CompanyLocalServiceUtil.getCompany(
+			TestPropsValues.getCompanyId());
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLayoutSet(group.getPublicLayoutSet());
+		themeDisplay.setCompany(company);
+
+		return themeDisplay;
+	}
+
+	protected void testAlternateURL(
+			Locale[] groupAvailableLocales, Locale groupDefaultLocale,
+			Locale alternateLocale, String expectedI18nPath)
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		group = GroupTestUtil.updateDisplaySettings(
+			group.getGroupId(), groupAvailableLocales, groupDefaultLocale);
+
+		Layout layout = LayoutTestUtil.addLayout(
+			group.getGroupId(), "welcome", false);
+
+		String canonicalURL = generateURL(
+			StringPool.BLANK, group.getFriendlyURL(), layout.getFriendlyURL());
+
+		ThemeDisplay themeDisplay = initThemeDisplay(group);
+
+		String alternateURL = PortalUtil.getAlternateURL(
+			canonicalURL, themeDisplay, alternateLocale, layout);
+
+		String expectedURL = generateURL(
+			expectedI18nPath, group.getFriendlyURL(), layout.getFriendlyURL());
+
+		Assert.assertEquals(expectedURL, alternateURL);
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/util/PortalImplGetCanonicalURLTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/PortalImplGetCanonicalURLTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Company;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.service.CompanyLocalServiceUtil;
+import com.liferay.portal.test.EnvironmentExecutionTestListener;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.TransactionalExecutionTestListener;
+import com.liferay.portal.theme.ThemeDisplay;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Sergio González
+ */
+@ExecutionTestListeners(
+	listeners = {
+		EnvironmentExecutionTestListener.class,
+		TransactionalExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class PortalImplGetCanonicalURLTest {
+
+	@Test
+	public void testCustomPortalLocaleCanonicalURL() throws Exception {
+		testCanonicalURL(null, null, "/es", "/home");
+	}
+
+	@Test
+	public void testDefaultPortalLocaleCanonicalURL() throws Exception {
+		testCanonicalURL(null, null, "/en", "/home");
+	}
+
+	@Test
+	public void testLocalizedSiteCustomSiteLocaleCanonicalURL()
+		throws Exception {
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		testCanonicalURL(
+			new Locale[] {enLocale, esLocale, deLocale}, esLocale, "/en",
+			"/casa");
+	}
+
+	@Test
+	public void testLocalizedSiteDefaultSiteLocaleCanonicalURL()
+		throws Exception {
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		testCanonicalURL(
+			new Locale[] {enLocale, esLocale, deLocale}, esLocale, "/es",
+			"/casa");
+	}
+
+	protected String generateURL(
+		String languageId, String groupFriendlyURL, String layoutFriendlyURL) {
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append("http://localhost");
+		sb.append(languageId);
+		sb.append(PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING);
+		sb.append(groupFriendlyURL);
+		sb.append(layoutFriendlyURL);
+
+		return sb.toString();
+	}
+
+	protected ThemeDisplay initThemeDisplay(Group group) throws Exception {
+		Company company = CompanyLocalServiceUtil.getCompany(
+			TestPropsValues.getCompanyId());
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(company);
+		themeDisplay.setLayoutSet(group.getPublicLayoutSet());
+		themeDisplay.setServerPort(80);
+		themeDisplay.setSiteGroupId(group.getGroupId());
+
+		return themeDisplay;
+	}
+
+	protected void testCanonicalURL(
+			Locale[] groupAvailableLocales, Locale groupDefaultLocale,
+			String i18nPath, String expectedFriendlyURL)
+		throws Exception {
+
+		Group group = GroupTestUtil.addGroup();
+
+		group = GroupTestUtil.updateDisplaySettings(
+			group.getGroupId(), groupAvailableLocales, groupDefaultLocale);
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		Map<Locale, String> nameMap = new HashMap<Locale, String>();
+
+		nameMap.put(enLocale, "Home");
+		nameMap.put(esLocale, "Casa");
+		nameMap.put(deLocale, "Zuhause");
+
+		Map<Locale, String> friendlyURLMap = new HashMap<Locale, String>();
+
+		friendlyURLMap.put(enLocale, "/home");
+		friendlyURLMap.put(esLocale, "/casa");
+		friendlyURLMap.put(deLocale, "/zuhause");
+
+		Layout layout = LayoutTestUtil.addLayout(
+			group.getGroupId(), false, nameMap, friendlyURLMap);
+
+		String completeURL = generateURL(
+			i18nPath, group.getFriendlyURL(), layout.getFriendlyURL());
+
+		ThemeDisplay themeDisplay = initThemeDisplay(group);
+
+		String alternateURL = PortalUtil.getCanonicalURL(
+			completeURL, themeDisplay, layout, true);
+
+		String expectedURL = generateURL(
+			StringPool.BLANK, group.getFriendlyURL(), expectedFriendlyURL);
+
+		Assert.assertEquals(expectedURL, alternateURL);
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetVocabularyServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetVocabularyServiceTest.java
@@ -33,7 +33,9 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,6 +50,16 @@ import org.junit.runner.RunWith;
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
 @Transactional
 public class AssetVocabularyServiceTest {
+
+	@Before
+	public void setUp() {
+		_locale = LocaleThreadLocal.getSiteDefaultLocale();
+	}
+
+	@After
+	public void tearDown() {
+		LocaleThreadLocal.setSiteDefaultLocale(_locale);
+	}
 
 	@Test
 	public void testLocalizedSiteAddDefaultVocabulary() throws Exception {
@@ -138,5 +150,7 @@ public class AssetVocabularyServiceTest {
 
 		Assert.assertEquals(title, assetVocabulary.getName());
 	}
+
+	private Locale _locale;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetVocabularyServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetVocabularyServiceTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.asset.service;
+
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.MainServletExecutionTestListener;
+import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
+import com.liferay.portal.util.GroupTestUtil;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.asset.model.AssetVocabulary;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Sergio González
+ */
+@ExecutionTestListeners(
+	listeners = {
+		MainServletExecutionTestListener.class,
+		TransactionalCallbackAwareExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class AssetVocabularyServiceTest {
+
+	@Test
+	public void testLocalizedSiteAddDefaultVocabulary() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
+
+		AssetVocabulary assetVocabulary =
+			AssetVocabularyLocalServiceUtil.addDefaultVocabulary(
+				group.getGroupId());
+
+		Assert.assertEquals(
+			PropsValues.ASSET_VOCABULARY_DEFAULT,
+			assetVocabulary.getTitle(Locale.US, true));
+	}
+
+	@Test
+	public void testLocalizedSiteAddLocalizedVocabulary() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Locale enLocale = Locale.US;
+		Locale esLocale = new Locale("es", "ES");
+		Locale deLocale = new Locale("de", "DE");
+
+		LocaleThreadLocal.setSiteDefaultLocale(esLocale);
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
+			group.getGroupId());
+
+		String title = ServiceTestUtil.randomString();
+
+		Map<Locale, String> titleMap = new HashMap<Locale, String>();
+
+		String englishTitle = title + "_US";
+		String spanishTitle = title + "_ES";
+
+		titleMap.put(enLocale, englishTitle);
+		titleMap.put(esLocale, spanishTitle);
+
+		String description = ServiceTestUtil.randomString();
+
+		Map<Locale, String> descriptionMap = new HashMap<Locale, String>();
+
+		String englishDescription = description + "_US";
+		String spanishDescription = description + "_ES";
+
+		descriptionMap.put(enLocale, englishDescription);
+		descriptionMap.put(esLocale, spanishDescription);
+
+		AssetVocabulary assetVocabulary =
+			AssetVocabularyLocalServiceUtil.addVocabulary(
+				TestPropsValues.getUserId(), StringPool.BLANK, titleMap,
+				descriptionMap, StringPool.BLANK, serviceContext);
+
+		Assert.assertEquals(spanishTitle, assetVocabulary.getName());
+
+		Assert.assertEquals(
+			englishTitle, assetVocabulary.getTitle(enLocale, true));
+		Assert.assertEquals(
+			spanishTitle, assetVocabulary.getTitle(esLocale, true));
+		Assert.assertEquals(
+			spanishTitle, assetVocabulary.getTitle(deLocale, true));
+
+		Assert.assertEquals(
+			englishDescription, assetVocabulary.getDescription(enLocale, true));
+		Assert.assertEquals(
+			spanishDescription, assetVocabulary.getDescription(esLocale, true));
+		Assert.assertEquals(
+			spanishDescription, assetVocabulary.getDescription(deLocale, true));
+	}
+
+	@Test
+	public void testLocalizedSiteAddVocabulary() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
+			group.getGroupId());
+
+		String title = ServiceTestUtil.randomString();
+
+		AssetVocabulary assetVocabulary =
+			AssetVocabularyLocalServiceUtil.addVocabulary(
+				TestPropsValues.getUserId(), title, serviceContext);
+
+		Assert.assertEquals(title, assetVocabulary.getTitle(Locale.US, true));
+
+		Assert.assertEquals(title, assetVocabulary.getName());
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeServiceTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Group;
@@ -39,6 +40,7 @@ import com.liferay.portlet.documentlibrary.model.DLFileEntryType;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryTypeConstants;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
+import com.liferay.portlet.dynamicdatamapping.util.DDMStructureTestUtil;
 
 import java.util.List;
 import java.util.Locale;
@@ -152,6 +154,34 @@ public class DLFileEntryTypeServiceTest {
 	}
 
 	@Test
+	@Transactional
+	public void testLocalizedSiteAddFileEntryType() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
+			group.getGroupId());
+
+		LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			DLFileEntry.class.getName(), new Locale[] {new Locale("es", "ES")},
+			new Locale("es", "ES"));
+
+		String name = ServiceTestUtil.randomString();
+		String description = ServiceTestUtil.randomString();
+
+		DLFileEntryType dlFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+				TestPropsValues.getUserId(), group.getGroupId(), name,
+				description, new long[] {ddmStructure.getStructureId()},
+				serviceContext);
+
+		Assert.assertEquals(name, dlFileEntryType.getName(Locale.US, true));
+		Assert.assertEquals(
+			description, dlFileEntryType.getDescription(Locale.US, true));
+	}
+
+	@Test
 	public void testCheckDefaultFileEntryTypes() throws Exception {
 		Assert.assertNotNull(
 			DLFileEntryTypeConstants.NAME_BASIC_DOCUMENT + " cannot be null",
@@ -214,6 +244,45 @@ public class DLFileEntryTypeServiceTest {
 		fileEntry = DLAppServiceUtil.getFileEntry(fileEntry.getFileEntryId());
 
 		assertFileEntryType(fileEntry, _basicDocumentDLFileEntryType);
+	}
+
+	@Test
+	@Transactional
+	public void testLocalizedSiteUpdateFileEntryType() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
+			group.getGroupId());
+
+		LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			DLFileEntry.class.getName(), new Locale[] {new Locale("es", "ES")},
+			new Locale("es", "ES"));
+
+		String name = ServiceTestUtil.randomString();
+		String description = ServiceTestUtil.randomString();
+
+		DLFileEntryType dlFileEntryType =
+			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+				TestPropsValues.getUserId(), group.getGroupId(), name,
+				description, new long[] {ddmStructure.getStructureId()},
+				serviceContext);
+
+		name = ServiceTestUtil.randomString();
+		description = ServiceTestUtil.randomString();
+
+		DLFileEntryTypeLocalServiceUtil.updateFileEntryType(
+			TestPropsValues.getUserId(), dlFileEntryType.getFileEntryTypeId(),
+			name, description, new long[] {ddmStructure.getStructureId()},
+			serviceContext);
+
+		dlFileEntryType = DLFileEntryTypeLocalServiceUtil.getFileEntryType(
+			dlFileEntryType.getFileEntryTypeId());
+
+		Assert.assertEquals(name, dlFileEntryType.getName(Locale.US, true));
+		Assert.assertEquals(
+			description, dlFileEntryType.getDescription(Locale.US, true));
 	}
 
 	protected void assertFileEntryType(

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLFileEntryTypeServiceTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.events.SimpleAction;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -32,6 +33,7 @@ import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
 import com.liferay.portal.util.GroupTestUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.TestPropsValues;
@@ -54,7 +56,11 @@ import org.junit.runner.RunWith;
 /**
  * @author Alexander Chow
  */
-@ExecutionTestListeners(listeners = {EnvironmentExecutionTestListener.class})
+@ExecutionTestListeners(
+	listeners = {
+		EnvironmentExecutionTestListener.class,
+		TransactionalCallbackAwareExecutionTestListener.class
+	})
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
 public class DLFileEntryTypeServiceTest {
 
@@ -161,24 +167,31 @@ public class DLFileEntryTypeServiceTest {
 		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
 			group.getGroupId());
 
-		LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
+		Locale locale = LocaleThreadLocal.getSiteDefaultLocale();
 
-		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
-			DLFileEntry.class.getName(), new Locale[] {new Locale("es", "ES")},
-			new Locale("es", "ES"));
+		try {
+			LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
 
-		String name = ServiceTestUtil.randomString();
-		String description = ServiceTestUtil.randomString();
+			DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+				DLFileEntry.class.getName(),
+				new Locale[] {new Locale("es", "ES")}, new Locale("es", "ES"));
 
-		DLFileEntryType dlFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
-				TestPropsValues.getUserId(), group.getGroupId(), name,
-				description, new long[] {ddmStructure.getStructureId()},
-				serviceContext);
+			String name = ServiceTestUtil.randomString();
+			String description = ServiceTestUtil.randomString();
 
-		Assert.assertEquals(name, dlFileEntryType.getName(Locale.US, true));
-		Assert.assertEquals(
-			description, dlFileEntryType.getDescription(Locale.US, true));
+			DLFileEntryType dlFileEntryType =
+				DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+					TestPropsValues.getUserId(), group.getGroupId(), name,
+					description, new long[] {ddmStructure.getStructureId()},
+					serviceContext);
+
+			Assert.assertEquals(name, dlFileEntryType.getName(Locale.US, true));
+			Assert.assertEquals(
+				description, dlFileEntryType.getDescription(Locale.US, true));
+		}
+		finally {
+			LocaleThreadLocal.setSiteDefaultLocale(locale);
+		}
 	}
 
 	@Test
@@ -254,35 +267,42 @@ public class DLFileEntryTypeServiceTest {
 		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
 			group.getGroupId());
 
-		LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
+		Locale locale = LocaleThreadLocal.getSiteDefaultLocale();
 
-		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
-			DLFileEntry.class.getName(), new Locale[] {new Locale("es", "ES")},
-			new Locale("es", "ES"));
+		try {
+			LocaleThreadLocal.setSiteDefaultLocale(new Locale("es", "ES"));
 
-		String name = ServiceTestUtil.randomString();
-		String description = ServiceTestUtil.randomString();
+			DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+				DLFileEntry.class.getName(),
+				new Locale[] {new Locale("es", "ES")}, new Locale("es", "ES"));
 
-		DLFileEntryType dlFileEntryType =
-			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
-				TestPropsValues.getUserId(), group.getGroupId(), name,
-				description, new long[] {ddmStructure.getStructureId()},
-				serviceContext);
+			String name = ServiceTestUtil.randomString();
+			String description = ServiceTestUtil.randomString();
 
-		name = ServiceTestUtil.randomString();
-		description = ServiceTestUtil.randomString();
+			DLFileEntryType dlFileEntryType =
+				DLFileEntryTypeLocalServiceUtil.addFileEntryType(
+					TestPropsValues.getUserId(), group.getGroupId(), name,
+					description, new long[] {ddmStructure.getStructureId()},
+					serviceContext);
 
-		DLFileEntryTypeLocalServiceUtil.updateFileEntryType(
-			TestPropsValues.getUserId(), dlFileEntryType.getFileEntryTypeId(),
-			name, description, new long[] {ddmStructure.getStructureId()},
-			serviceContext);
+			name = ServiceTestUtil.randomString();
+			description = ServiceTestUtil.randomString();
 
-		dlFileEntryType = DLFileEntryTypeLocalServiceUtil.getFileEntryType(
-			dlFileEntryType.getFileEntryTypeId());
+			DLFileEntryTypeLocalServiceUtil.updateFileEntryType(
+				TestPropsValues.getUserId(),
+				dlFileEntryType.getFileEntryTypeId(), name, description,
+				new long[] {ddmStructure.getStructureId()}, serviceContext);
 
-		Assert.assertEquals(name, dlFileEntryType.getName(Locale.US, true));
-		Assert.assertEquals(
-			description, dlFileEntryType.getDescription(Locale.US, true));
+			dlFileEntryType = DLFileEntryTypeLocalServiceUtil.getFileEntryType(
+				dlFileEntryType.getFileEntryTypeId());
+
+			Assert.assertEquals(name, dlFileEntryType.getName(Locale.US, true));
+			Assert.assertEquals(
+				description, dlFileEntryType.getDescription(Locale.US, true));
+		}
+		finally {
+			LocaleThreadLocal.setSiteDefaultLocale(locale);
+		}
 	}
 
 	protected void assertFileEntryType(

--- a/portal-impl/test/integration/com/liferay/portlet/dynamicdatamapping/util/DDMStructureTestUtil.java
+++ b/portal-impl/test/integration/com/liferay/portlet/dynamicdatamapping/util/DDMStructureTestUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.dynamicdatamapping.util;
 
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
@@ -101,7 +102,19 @@ public class DDMStructureTestUtil {
 		throws Exception {
 
 		return addStructure(
-			TestPropsValues.getGroupId(), className, 0, getSampleStructureXSD(),
+			TestPropsValues.getGroupId(), className, 0,
+			getSampleStructureXSD(
+				"name", new Locale[] {Locale.US}, defaultLocale),
+			defaultLocale, ServiceTestUtil.getServiceContext());
+	}
+
+	public static DDMStructure addStructure(
+			String className, Locale[] availableLocales, Locale defaultLocale)
+		throws Exception {
+
+		return addStructure(
+			TestPropsValues.getGroupId(), className, 0,
+			getSampleStructureXSD("name", availableLocales, defaultLocale),
 			defaultLocale, ServiceTestUtil.getServiceContext());
 	}
 
@@ -154,7 +167,14 @@ public class DDMStructureTestUtil {
 	}
 
 	public static String getSampleStructureXSD(String name) {
-		Document document = createDocumentStructure();
+		return getSampleStructureXSD(name, new Locale[] {Locale.US}, Locale.US);
+	}
+
+	public static String getSampleStructureXSD(
+		String name, Locale[] availableLocales, Locale defaultLocale) {
+
+		Document document = createDocumentStructure(
+			availableLocales, defaultLocale);
 
 		Element rootElement = document.getRootElement();
 
@@ -170,7 +190,8 @@ public class DDMStructureTestUtil {
 
 		Element metaDataElement = dynamicElementElement.addElement("meta-data");
 
-		metaDataElement.addAttribute("locale", "en_US");
+		metaDataElement.addAttribute(
+			"locale", LocaleUtil.toLanguageId(defaultLocale));
 
 		Element labelElement = metaDataElement.addElement("entry");
 
@@ -202,13 +223,18 @@ public class DDMStructureTestUtil {
 		return document;
 	}
 
-	protected static Document createDocumentStructure() {
+	protected static Document createDocumentStructure(
+		Locale[] availableLocales, Locale defaultLocale) {
+
 		Document document = SAXReaderUtil.createDocument();
 
 		Element rootElement = document.addElement("root");
 
-		rootElement.addAttribute("available-locales", "en_US");
-		rootElement.addAttribute("default-locale", "en_US");
+		rootElement.addAttribute(
+			"available-locales",
+			StringUtil.merge(LocaleUtil.toLanguageIds(availableLocales)));
+		rootElement.addAttribute(
+			"default-locale", LocaleUtil.toLanguageId(defaultLocale));
 
 		return document;
 	}


### PR DESCRIPTION
Hey Brian,

In every test we are using LocaleThreadLocal.setSiteDefaultLocale we are always applying the original site locale when the test is over. 

We do this by try/finally if this only applies to certain tests in the class. In AssetVocabularyServiceTest this applies to all the tests, so instead of using try/finally y set this logic in setUp/tearDown methods because this way the logic is encapsulated.

If you think it's better to have them with try/finally everywhere I can change it. 

Thanks!
