### PR TITLE
LRDOCS-701: Remove liferay-faces.tld dependency from build.xml

### DIFF
--- a/util-taglib/build.xml
+++ b/util-taglib/build.xml
@@ -104,7 +104,6 @@
 		>
 			<arg line="-d ${doc.taglibs.dir}" />
 			<arg value="${project.dir}/util-taglib/src/META-INF/aui.tld" />
-			<arg value="${project.dir}/util-taglib/src/META-INF/liferay-faces.tld" />
 			<arg value="${project.dir}/util-taglib/src/META-INF/liferay-portlet-ext.tld" />
 			<arg value="${project.dir}/util-taglib/src/META-INF/liferay-portlet.tld" />
 			<arg value="${project.dir}/util-taglib/src/META-INF/liferay-security.tld" />


### PR DESCRIPTION
Since the .tld is no longer in portal, it should no longer be a build dependency. The dependency was preventing the taglib docs from being built.

@codyhoag
