### PR TITLE
LPS-38967 Hide default success message in site templates list when adding or updating a site template

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsetprototypes/action/EditLayoutSetPrototypeAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsetprototypes/action/EditLayoutSetPrototypeAction.java
@@ -88,6 +88,8 @@ public class EditLayoutSetPrototypeAction extends PortletAction {
 						actionResponse, siteThemeDisplay,
 						PortletKeys.SITE_TEMPLATE_SETTINGS);
 
+				hideDefaultSuccessMessage(portletConfig, actionRequest);
+
 				redirect = siteAdministrationURL.toString();
 			}
 			else if (cmd.equals(Constants.DELETE)) {


### PR DESCRIPTION
Same behavior as when adding/updating a site.
