### PR TITLE
LPS-30522

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -900,12 +900,6 @@
     hibernate.cache.use_structured_entries=false
 
     #
-    # Uncomment these properties to disable Hibernate caching.
-    #
-    #hibernate.cache.use_query_cache=false
-    #hibernate.cache.use_second_level_cache=false
-
-    #
     # Set the JDBC batch size to improve performance.
     #
     # If you're using Hypersonic, you SHOULD set the batch size to 0 as a


### PR DESCRIPTION
VerifyProperties is not necessary as we are modifying the default value of the properties (and adding to portal-legacy-6.1.properties), not changing/removing it.
