### PR TITLE
LPS-38712

### DIFF
--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_organizations.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_organizations.jsp
@@ -195,8 +195,6 @@ searchContainer.setEmptyResultsMessage(emptyResultsMessage);
 					<a href="<%= viewOrganizationsURL %>"><liferay-ui:message key="view-more" /> &raquo;</a>
 				</c:if>
 			</liferay-ui:panel>
-
-			<div class="separator"><!-- --></div>
 		</c:when>
 		<c:when test='<%= !tabs1.equals("summary") %>'>
 			<c:if test="<%= total > searchContainer.getDelta() %>">

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_user_groups.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_user_groups.jsp
@@ -188,8 +188,6 @@ userGroupSearch.setEmptyResultsMessage(emptyResultsMessage);
 					<a href="<%= viewUserGroupsURL %>"><liferay-ui:message key="view-more" /> &raquo;</a>
 				</c:if>
 			</liferay-ui:panel>
-
-			<div class="separator"><!-- --></div>
 		</c:when>
 		<c:when test='<%= !tabs1.equals("summary") %>'>
 			<c:if test="<%= total > userGroupSearch.getDelta() %>">

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_users.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_users.jsp
@@ -256,8 +256,6 @@ searchContainer.setEmptyResultsMessage(emptyResultsMessage);
 					<a href="<%= viewUsersURL %>"><liferay-ui:message key="view-more" /> &raquo;</a>
 				</c:if>
 			</liferay-ui:panel>
-
-			<div class="separator"><!-- --></div>
 		</c:when>
 		<c:when test='<%= !tabs1.equals("summary") %>'>
 			<c:if test="<%= total > searchContainer.getDelta() %>">


### PR DESCRIPTION
Hey Brian, after investigating why we need to remove this one and not the others, this goes back to 2011, with a change from Jorge in commit 8fad2cc 'LPS-16331 Improve usability of Site Member Management'. Basically, the separator used to be separating the search container from a button under it, but as of that commit, it was just the bottom most element, so this one is safe tto remove. Thanks!
