### PR TITLE
LPS-38576 Autodeployment of plugins in development --> please read description

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -100,6 +100,18 @@
     os.windows=Windows 95,Windows 98,Windows NT,Windows 2000,Windows 2003,Windows XP,Windows Vista,Windows 7
 
 ##
+## Plugins
+##
+
+    plugins.sdk.path=../plugins
+
+    #
+    # This property cannot be overwritten. Use plugins.to.deploy.custom instead
+    #
+    plugins.to.deploy=calendar-portlet,marketplace-portlet,resources-importer-web
+    plugins.to.deploy.custom=
+
+##
 ## Proxy
 ##
 

--- a/build.xml
+++ b/build.xml
@@ -379,7 +379,7 @@ ${app.server.tomcat.dir}, then run "ant -buildfile build-dist.xml unzip-tomcat".
 				<copy todir="${app.server.lib.global.dir}">
 					<fileset
 						dir="lib/development"
-						includes="saxpath.jar"
+						includes="junit.jar,saxpath.jar"
 					/>
 				</copy>
 			</then>

--- a/build.xml
+++ b/build.xml
@@ -553,12 +553,11 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 			<length string="${plugin.path}" trim="true" when="greater" length="0" />
 			<then>
 				<echo>Deploying plugin ${plugin.name}</echo>
+
 				<java classname="org.apache.tools.ant.launch.Launcher" fork="true" failonerror="true" dir="${plugin.path}" timeout="4000000" taskname="deploy">
 					<classpath>
 						<fileset dir="${ant.home}" includes="lib/**/*.jar" />
 					</classpath>
-					<arg value="-buildfile"/>
-					<arg file="${plugin.path}/build.xml"/>
 				</java>
 			</then>
 			<else>
@@ -570,7 +569,7 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 	<target name="deploy-plugins">
 		<foreach list="calendar-portlet,marketplace-portlet,resources-importer-web" delimiter="," target="deploy-plugin" param="plugin.name" />
 
-				<foreach list="${plugins.to.deploy.custom}" delimiter="," target="deploy-plugin" param="plugin.name" />
+		<foreach list="${plugins.to.deploy.custom}" delimiter="," target="deploy-plugin" param="plugin.name" />
 	</target>
 
 	<target name="deploy-properties">

--- a/build.xml
+++ b/build.xml
@@ -355,7 +355,7 @@ ${app.server.tomcat.dir}, then run "ant -buildfile build-dist.xml unzip-tomcat".
 				<copy todir="${app.server.lib.global.dir}">
 					<fileset
 						dir="lib/development"
-						includes="activation.jar,jta.jar,mail.jar,persistence.jar"
+						includes="activation.jar,junit.jar,jta.jar,mail.jar,persistence.jar"
 					/>
 				</copy>
 			</then>

--- a/build.xml
+++ b/build.xml
@@ -537,7 +537,35 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 			</then>
 		</if>
 
+		<foreach list="calendar-portlet,marketplace-portlet,resources-importer-web" delimiter="," target="deploy-plugin" param="plugin.name" />
+		<foreach list="${plugins.to.deploy.custom}" delimiter="," target="deploy-plugin" param="plugin.name" />
+
 		<antcall target="print-current-time" />
+	</target>
+
+	<target name="deploy-plugin">
+		<first id="plugin.path.type">
+			<dirset dir="${plugins.sdk.path}" includes="**/${plugin.name}" />
+		</first>
+
+		<var name="plugin.path" value="${toString:plugin.path.type}" />
+
+		<if>
+			<length string="${plugin.path}" trim="true" when="greater" length="0" />
+			<then>
+				<echo>Deploying plugin ${plugin.name}</echo>
+				<java classname="org.apache.tools.ant.launch.Launcher" fork="true" failonerror="true" dir="${plugin.path}" timeout="4000000" taskname="deploy">
+					<classpath>
+						<fileset dir="${ant.home}" includes="lib/**/*.jar" />
+					</classpath>
+					<arg value="-buildfile"/>
+					<arg file="${plugin.path}/build.xml"/>
+				</java>
+			</then>
+			<else>
+				<echo>Could not find a plugin with name: ${plugin.name}</echo>
+			</else>
+		</if>
 	</target>
 
 	<target name="deploy-properties">

--- a/build.xml
+++ b/build.xml
@@ -537,8 +537,7 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 			</then>
 		</if>
 
-		<foreach list="calendar-portlet,marketplace-portlet,resources-importer-web" delimiter="," target="deploy-plugin" param="plugin.name" />
-		<foreach list="${plugins.to.deploy.custom}" delimiter="," target="deploy-plugin" param="plugin.name" />
+		<antcall target="deploy-plugins" />
 
 		<antcall target="print-current-time" />
 	</target>
@@ -566,6 +565,12 @@ print AdminControl.invoke(appManager, 'startApplication', 'liferay-portal')
 				<echo>Could not find a plugin with name: ${plugin.name}</echo>
 			</else>
 		</if>
+	</target>
+
+	<target name="deploy-plugins">
+		<foreach list="calendar-portlet,marketplace-portlet,resources-importer-web" delimiter="," target="deploy-plugin" param="plugin.name" />
+
+				<foreach list="${plugins.to.deploy.custom}" delimiter="," target="deploy-plugin" param="plugin.name" />
 	</target>
 
 	<target name="deploy-properties">

--- a/portal-impl/src/com/liferay/portal/service/permission/UserGroupRolePermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/UserGroupRolePermissionImpl.java
@@ -17,13 +17,10 @@ package com.liferay.portal.service.permission;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.model.Group;
-import com.liferay.portal.model.Role;
-import com.liferay.portal.model.RoleConstants;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.GroupLocalServiceUtil;
-import com.liferay.portal.service.RoleLocalServiceUtil;
 
 /**
  * @author Brian Wing Shun Chan
@@ -47,22 +44,6 @@ public class UserGroupRolePermissionImpl implements UserGroupRolePermission {
 		throws PortalException, SystemException {
 
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
-
-		Role role = RoleLocalServiceUtil.getRole(roleId);
-
-		if (role.getType() == RoleConstants.TYPE_REGULAR) {
-			return false;
-		}
-		else if ((role.getType() == RoleConstants.TYPE_ORGANIZATION) &&
-				 !group.isOrganization()) {
-
-			return false;
-		}
-		else if ((role.getType() == RoleConstants.TYPE_SITE) &&
-				 group.isOrganization()) {
-
-			return false;
-		}
 
 		if (permissionChecker.isGroupOwner(groupId) ||
 			GroupPermissionUtil.contains(


### PR DESCRIPTION
Hi Brian, we have the feeling this is different to what you achieved with LPS-39277. Yours ensure that some plugins are always bundled, but the WAR must be provided in advanced (it won't be generated based on the latest sources).

This pull is for developers, so that every time they do ant deploy, not only the portal is deployed, but also some plugins are compiled and deployed (using the standard mechanism, they can be removed afterwards)... this is made to ensure the plugins are always compiling too.

cc @csierra @jorgeFerrer
