### PR TITLE
LPS-39328 Prevent NoSuchGroupException in search portlet

### DIFF
--- a/portal-web/docroot/html/portlet/search/facets/scopes.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/scopes.jsp
@@ -47,7 +47,11 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 
 			long curGroupId = GetterUtil.getInteger(termCollector.getTerm());
 
-			Group group = GroupLocalServiceUtil.getGroup(curGroupId);
+			Group group = GroupLocalServiceUtil.fetchGroup(curGroupId);
+
+			if (group == null) {
+				continue;
+			}
 		%>
 
 			<c:if test="<%= groupId == curGroupId %>">


### PR DESCRIPTION
Hi Brian,

When src formatting solr I ran into a NoSuchGroupException because the termCollector returns a curGroupId = 0. @mhan810 told me to add this fix.
