### PR TITLE
LPS-39178 Asset Link Behaviour is not working for portlets on pages in User Groups' Site Template

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/FindAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/FindAction.java
@@ -134,6 +134,36 @@ public abstract class FindAction extends Action {
 		}
 	}
 
+	protected Object[] fetchPlidAndPortletId(
+			PermissionChecker permissionChecker, long groupId)
+		throws Exception {
+
+		for (String portletId : _portletIds) {
+			long plid = PortalUtil.getPlidFromPortletId(groupId, portletId);
+
+			if (plid == LayoutConstants.DEFAULT_PLID) {
+				continue;
+			}
+
+			Layout layout = LayoutLocalServiceUtil.getLayout(plid);
+
+			if (!LayoutPermissionUtil.contains(
+					permissionChecker, layout, ActionKeys.VIEW)) {
+
+				continue;
+			}
+
+			LayoutTypePortlet layoutTypePortlet =
+				(LayoutTypePortlet)layout.getLayoutType();
+
+			portletId = getPortletId(layoutTypePortlet, portletId);
+
+			return new Object[] {plid, portletId};
+		}
+
+		throw new NoSuchLayoutException();
+	}
+
 	protected abstract long getGroupId(long primaryKey) throws Exception;
 
 	protected Object[] getPlidAndPortletId(
@@ -186,30 +216,7 @@ public abstract class FindAction extends Action {
 			}
 		}
 
-		for (String portletId : _portletIds) {
-			plid = PortalUtil.getPlidFromPortletId(groupId, portletId);
-
-			if (plid == LayoutConstants.DEFAULT_PLID) {
-				continue;
-			}
-
-			Layout layout = LayoutLocalServiceUtil.getLayout(plid);
-
-			if (!LayoutPermissionUtil.contains(
-					permissionChecker, layout, ActionKeys.VIEW)) {
-
-				continue;
-			}
-
-			LayoutTypePortlet layoutTypePortlet =
-				(LayoutTypePortlet)layout.getLayoutType();
-
-			portletId = getPortletId(layoutTypePortlet, portletId);
-
-			return new Object[] {plid, portletId};
-		}
-
-		throw new NoSuchLayoutException();
+		return fetchPlidAndPortletId(permissionChecker, groupId);
 	}
 
 	protected String getPortletId(

--- a/portal-impl/src/com/liferay/portal/struts/FindAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/FindAction.java
@@ -80,7 +80,7 @@ public abstract class FindAction extends Action {
 
 			plid = (Long)plidAndPortletId[0];
 
-			setSourceGroup(request, plid, primaryKey);
+			setTargetGroup(request, plid, primaryKey);
 
 			String portletId = (String)plidAndPortletId[1];
 
@@ -277,7 +277,7 @@ public abstract class FindAction extends Action {
 			getPrimaryKeyParameterName(), String.valueOf(primaryKey));
 	}
 
-	protected void setSourceGroup(
+	protected void setTargetGroup(
 			HttpServletRequest request, long plid, long primaryKey)
 		throws Exception {
 
@@ -299,9 +299,9 @@ public abstract class FindAction extends Action {
 			return;
 		}
 
-		Group sourceGroup = GroupLocalServiceUtil.getGroup(entityGroupId);
+		Group targetGroup = GroupLocalServiceUtil.getGroup(entityGroupId);
 
-		layout = new VirtualLayout(layout, sourceGroup);
+		layout = new VirtualLayout(layout, targetGroup);
 
 		request.setAttribute(WebKeys.LAYOUT, layout);
 	}

--- a/portal-impl/src/com/liferay/portal/struts/FindAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/FindAction.java
@@ -80,9 +80,9 @@ public abstract class FindAction extends Action {
 
 			plid = (Long)plidAndPortletId[0];
 
-			String portletId = (String)plidAndPortletId[1];
-
 			setSourceGroup(request, plid, primaryKey);
+
+			String portletId = (String)plidAndPortletId[1];
 
 			PortletURL portletURL = PortletURLFactoryUtil.create(
 				request, portletId, plid, PortletRequest.RENDER_PHASE);
@@ -281,25 +281,25 @@ public abstract class FindAction extends Action {
 			HttpServletRequest request, long plid, long primaryKey)
 		throws Exception {
 
-		Layout layout = LayoutLocalServiceUtil.getLayout(plid);
-
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		PermissionChecker permissionChecker =
 			themeDisplay.getPermissionChecker();
 
-		long sourceGroupId = getGroupId(primaryKey);
+		long entityGroupId = getGroupId(primaryKey);
 
-		if ((sourceGroupId == layout.getGroupId()) ||
-			(layout.getPrivateLayout() &&
-			 !SitesUtil.isUserGroupLayoutSetViewable(
-				permissionChecker, layout.getGroup()))) {
+		Layout layout = LayoutLocalServiceUtil.getLayout(plid);
+
+		if ((entityGroupId == layout.getGroupId()) ||
+			(layout.isPrivateLayout() &&
+				!SitesUtil.isUserGroupLayoutSetViewable(
+					permissionChecker, layout.getGroup()))) {
 
 			return;
 		}
 
-		Group sourceGroup = GroupLocalServiceUtil.getGroup(sourceGroupId);
+		Group sourceGroup = GroupLocalServiceUtil.getGroup(entityGroupId);
 
 		layout = new VirtualLayout(layout, sourceGroup);
 

--- a/portal-impl/test/integration/com/liferay/portal/lar/AssetPublisherExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/AssetPublisherExportImportTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.PortletConstants;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
@@ -73,8 +74,10 @@ public class AssetPublisherExportImportTest
 	extends BasePortletExportImportTestCase {
 
 	@Override
-	public String getPortletId() {
-		return PortletKeys.ASSET_PUBLISHER;
+	public String getPortletId() throws Exception {
+		return PortletKeys.ASSET_PUBLISHER +
+			PortletConstants.INSTANCE_SEPARATOR +
+			ServiceTestUtil.randomString();
 	}
 
 	@Test

--- a/portal-impl/test/integration/com/liferay/portal/lar/BasePortletExportImportTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/BasePortletExportImportTestCase.java
@@ -64,7 +64,7 @@ public class BasePortletExportImportTestCase extends BaseExportImportTestCase {
 		return null;
 	}
 
-	public String getPortletId() {
+	public String getPortletId() throws Exception {
 		return null;
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/struts/FindActionTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/struts/FindActionTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.struts;
+
+import com.liferay.portal.NoSuchLayoutException;
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.PortletConstants;
+import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.service.ServiceTestUtil;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.MainServletExecutionTestListener;
+import com.liferay.portal.test.TransactionalCallbackAwareExecutionTestListener;
+import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.GroupTestUtil;
+import com.liferay.portal.util.LayoutTestUtil;
+import com.liferay.portal.util.PortletKeys;
+import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.blogs.model.BlogsEntry;
+import com.liferay.portlet.blogs.util.BlogsTestUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Julio Camarero
+ * @author Laszlo Csontos
+ * @author Eduardo Garcia
+ */
+@ExecutionTestListeners(
+	listeners = {
+		MainServletExecutionTestListener.class,
+		TransactionalCallbackAwareExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+public class FindActionTest {
+
+	@Test
+	public void testGetPlidAndPortletIdViewInContext() throws Exception {
+		createPages(true);
+
+		Object[] plidAndPorltetId = FindAction.getPlidAndPortletId(
+			createThemeDisplay(), _blogsEntry.getGroupId(), _asset.getPlid(),
+			_portletIds);
+
+		Assert.assertEquals(_blog.getPlid(), plidAndPorltetId[0]);
+		Assert.assertEquals(PortletKeys.BLOGS, plidAndPorltetId[1]);
+	}
+
+	@Test
+	public void testGetPlidAndPortletIdWhenPortletDoesNotExist()
+		throws Exception {
+
+		createPages(false);
+
+		try {
+			FindAction.getPlidAndPortletId(
+				createThemeDisplay(), _blogsEntry.getGroupId(),
+				_asset.getPlid(), _portletIds);
+
+			Assert.fail("The page should have not be found");
+		}
+		catch (NoSuchLayoutException nsle) {
+		}
+	}
+
+	protected void createPages(boolean portletExists) throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_blog = LayoutTestUtil.addLayout(_group.getGroupId(), "blog");
+		_asset = LayoutTestUtil.addLayout(_group.getGroupId(), "asset");
+
+		if (portletExists) {
+			LayoutTestUtil.addPortletToLayout(_blog, PortletKeys.BLOGS);
+		}
+
+		Map<String, String[]> preferenceMap = new HashMap<String, String[]>();
+
+		preferenceMap.put("assetLinkBehavior", new String[] {"viewInPortlet"});
+
+		_assetPublisherPortletId =
+			PortletKeys.ASSET_PUBLISHER + PortletConstants.INSTANCE_SEPARATOR +
+			ServiceTestUtil.randomString();
+
+		LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), _asset, _assetPublisherPortletId,
+			"column-1", preferenceMap);
+
+		_blogsEntry = BlogsTestUtil.addEntry(
+			TestPropsValues.getUserId(), _group, true);
+	}
+
+	protected ThemeDisplay createThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+
+		PermissionChecker permissionChecker =
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser());
+
+		themeDisplay.setPermissionChecker(permissionChecker);
+
+		return themeDisplay;
+	}
+
+	private Layout _asset;
+	private String _assetPublisherPortletId;
+	private Layout _blog;
+	private BlogsEntry _blogsEntry;
+	private Group _group;
+	private String[] _portletIds = {
+		PortletKeys.BLOGS_ADMIN, PortletKeys.BLOGS,
+		PortletKeys.BLOGS_AGGREGATOR};
+
+}


### PR DESCRIPTION
Hey Brian,

You were right at your comment in brianchandotcom/liferay-portal#13535. As of LPS-23509 it must be checked that primaryKey > 0 to prevent exceptions. The second call to getGroupId() was therefore not only redundant but may also cause errors. I made sure the bug is still solved after performing this change.

Thanks!
