### PR TITLE
LPS-39634 Prevent any action over pages in Live other than view and delete

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -509,6 +509,7 @@ public class ServicePreAction extends Action {
 		LayoutSet layoutSet = null;
 
 		boolean hasCustomizeLayoutPermission = false;
+		boolean hasDeleteLayoutPermission = false;
 		boolean hasUpdateLayoutPermission = false;
 
 		boolean customizedView = SessionParamUtil.getBoolean(
@@ -518,6 +519,8 @@ public class ServicePreAction extends Action {
 			if (!layout.isTypeControlPanel()) {
 				hasCustomizeLayoutPermission = LayoutPermissionUtil.contains(
 					permissionChecker, layout, ActionKeys.CUSTOMIZE);
+				hasDeleteLayoutPermission = LayoutPermissionUtil.contains(
+					permissionChecker, layout, ActionKeys.DELETE);
 				hasUpdateLayoutPermission = LayoutPermissionUtil.contains(
 					permissionChecker, layout, ActionKeys.UPDATE);
 			}
@@ -820,7 +823,7 @@ public class ServicePreAction extends Action {
 
 		themeDisplay.setShowHomeIcon(true);
 		themeDisplay.setShowMyAccountIcon(signedIn);
-		themeDisplay.setShowPageSettingsIcon(false);
+		themeDisplay.setShowPageSettingsIcon(hasDeleteLayoutPermission);
 		themeDisplay.setShowPortalIcon(true);
 		themeDisplay.setShowSignInIcon(!signedIn);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetServiceImpl.java
@@ -82,7 +82,7 @@ public class LayoutSetServiceImpl extends LayoutSetServiceBaseImpl {
 		throws PortalException, SystemException {
 
 		GroupPermissionUtil.check(
-			getPermissionChecker(), groupId, ActionKeys.UPDATE);
+			getPermissionChecker(), groupId, ActionKeys.MANAGE_LAYOUTS);
 
 		layoutSetLocalService.updateLogo(groupId, privateLayout, logo, bytes);
 	}
@@ -93,7 +93,7 @@ public class LayoutSetServiceImpl extends LayoutSetServiceBaseImpl {
 		throws PortalException, SystemException {
 
 		GroupPermissionUtil.check(
-			getPermissionChecker(), groupId, ActionKeys.UPDATE);
+			getPermissionChecker(), groupId, ActionKeys.MANAGE_LAYOUTS);
 
 		layoutSetLocalService.updateLogo(groupId, privateLayout, logo, file);
 	}
@@ -114,7 +114,7 @@ public class LayoutSetServiceImpl extends LayoutSetServiceBaseImpl {
 		throws PortalException, SystemException {
 
 		GroupPermissionUtil.check(
-			getPermissionChecker(), groupId, ActionKeys.UPDATE);
+			getPermissionChecker(), groupId, ActionKeys.MANAGE_LAYOUTS);
 
 		layoutSetLocalService.updateLogo(
 			groupId, privateLayout, logo, inputStream, cleanUpStream);
@@ -127,7 +127,7 @@ public class LayoutSetServiceImpl extends LayoutSetServiceBaseImpl {
 		throws PortalException, SystemException {
 
 		GroupPermissionUtil.check(
-			getPermissionChecker(), groupId, ActionKeys.UPDATE);
+			getPermissionChecker(), groupId, ActionKeys.MANAGE_LAYOUTS);
 
 		pluginSettingLocalService.checkPermission(
 			getUserId(), themeId, Plugin.TYPE_THEME);
@@ -142,7 +142,7 @@ public class LayoutSetServiceImpl extends LayoutSetServiceBaseImpl {
 		throws PortalException, SystemException {
 
 		GroupPermissionUtil.check(
-			getPermissionChecker(), groupId, ActionKeys.UPDATE);
+			getPermissionChecker(), groupId, ActionKeys.MANAGE_LAYOUTS);
 
 		return layoutSetLocalService.updateSettings(
 			groupId, privateLayout, settings);

--- a/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/GroupPermissionImpl.java
@@ -88,6 +88,13 @@ public class GroupPermissionImpl implements GroupPermission {
 			}
 		}
 
+		if ((actionId.equals(ActionKeys.ADD_LAYOUT) ||
+			 actionId.equals(ActionKeys.MANAGE_LAYOUTS)) &&
+			group.hasLocalOrRemoteStagingGroup()) {
+
+			return false;
+		}
+
 		if (actionId.equals(ActionKeys.ADD_COMMUNITY) &&
 			permissionChecker.hasPermission(
 				groupId, Group.class.getName(), groupId,

--- a/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.service.permission;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.staging.permission.StagingPermissionUtil;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutConstants;
@@ -85,6 +86,14 @@ public class LayoutPermissionImpl implements LayoutPermission {
 			PermissionChecker permissionChecker, Layout layout,
 			boolean checkViewableGroup, String actionId)
 		throws PortalException, SystemException {
+
+		Boolean hasPermission = StagingPermissionUtil.hasPermission(
+			permissionChecker, layout.getGroup(), Layout.class.getName(),
+			layout.getGroupId(), null, actionId);
+
+		if (hasPermission != null) {
+			return hasPermission.booleanValue();
+		}
 
 		return containsWithViewableGroup(
 			permissionChecker, layout, checkViewableGroup, actionId);

--- a/portal-impl/src/com/liferay/portal/staging/permission/StagingPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/permission/StagingPermissionImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
 import com.liferay.portal.kernel.staging.permission.StagingPermission;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.PermissionChecker;
@@ -73,7 +74,7 @@ public class StagingPermissionImpl implements StagingPermission {
 		if (!actionId.equals(ActionKeys.VIEW) &&
 			!actionId.equals(ActionKeys.DELETE) &&
 			group.hasLocalOrRemoteStagingGroup() &&
-			group.isStagedPortlet(portletId)) {
+			(Validator.isNull(portletId) || group.isStagedPortlet(portletId))) {
 
 			return false;
 		}

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -117,16 +117,16 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 
 <aui:nav-bar>
 	<aui:nav id="layoutsNav">
-		<c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.ADD_LAYOUT) && (!selGroup.hasStagingGroup() || selGroup.isStagingGroup()) && showAddAction %>">
+		<c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.ADD_LAYOUT) && showAddAction %>">
 			<aui:nav-item data-value="add-child-page" iconClass="icon-plus" label="add-child-page" />
 		</c:if>
-		<c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.PERMISSIONS) && (!selGroup.hasStagingGroup() || selGroup.isStagingGroup()) %>">
+		<c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.PERMISSIONS) %>">
 			<aui:nav-item data-value="permissions" iconClass="icon-lock" label="permissions" />
 		</c:if>
 		<c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.DELETE) %>">
 			<aui:nav-item data-value="delete" iconClass="icon-remove" label="delete" />
 		</c:if>
-		<c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, selLayout, ActionKeys.UPDATE) && (!selGroup.hasStagingGroup() || selGroup.isStagingGroup()) %>">
+		<c:if test="<%= LayoutPermissionUtil.contains(permissionChecker, selLayout, ActionKeys.UPDATE) %>">
 			<aui:nav-item data-value="copy-applications" iconClass="icon-list-alt" label="copy-applications" />
 		</c:if>
 	</aui:nav>

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -197,7 +197,7 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 					</div>
 				</c:if>
 
-				<c:if test="<%= selGroup.hasStagingGroup() && !selGroup.isStagingGroup() %>">
+				<c:if test="<%= selGroup.hasLocalOrRemoteStagingGroup() && !selGroup.isStagingGroup() %>">
 					<div class="alert alert-block">
 						<liferay-ui:message key="changes-are-immediately-available-to-end-users" />
 					</div>
@@ -340,15 +340,13 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 				</aui:script>
 			</c:if>
 
-			<c:if test="<%= !selGroup.hasStagingGroup() || selGroup.isStagingGroup() %>">
-				<liferay-ui:form-navigator
-					categoryNames="<%= _CATEGORY_NAMES %>"
-					categorySections="<%= categorySections %>"
-					displayStyle="<%= displayStyle %>"
-					jspPath="/html/portlet/layouts_admin/layout/"
-					showButtons="<%= (selLayout.getGroupId() == groupId) && SitesUtil.isLayoutUpdateable(selLayout) && LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.UPDATE) %>"
-				/>
-			</c:if>
+			<liferay-ui:form-navigator
+				categoryNames="<%= _CATEGORY_NAMES %>"
+				categorySections="<%= categorySections %>"
+				displayStyle="<%= displayStyle %>"
+				jspPath="/html/portlet/layouts_admin/layout/"
+				showButtons="<%= (selLayout.getGroupId() == groupId) && SitesUtil.isLayoutUpdateable(selLayout) && LayoutPermissionUtil.contains(permissionChecker, selPlid, ActionKeys.UPDATE) %>"
+			/>
 		</c:otherwise>
 	</c:choose>
 </aui:form>

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
@@ -135,7 +135,7 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 		categoryNames="<%= _CATEGORY_NAMES %>"
 		categorySections="<%= categorySections %>"
 		jspPath="/html/portlet/layouts_admin/layout_set/"
-		showButtons="<%= GroupPermissionUtil.contains(permissionChecker, liveGroupId, ActionKeys.UPDATE) && SitesUtil.isLayoutSetPrototypeUpdateable(selLayoutSet) %>"
+		showButtons="<%= GroupPermissionUtil.contains(permissionChecker, liveGroupId, ActionKeys.MANAGE_LAYOUTS) && SitesUtil.isLayoutSetPrototypeUpdateable(selLayoutSet) %>"
 	/>
 </aui:form>
 

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
@@ -119,6 +119,10 @@ if ((group != null) && group.isCompany()) {
 	miscellaneousSections = new String[0];
 }
 
+if (group.hasLocalOrRemoteStagingGroup()) {
+	advancedSections = ArrayUtil.remove(advancedSections, "staging");
+}
+
 String[][] categorySections = {mainSections, seoSections, advancedSections, miscellaneousSections};
 %>
 


### PR DESCRIPTION
@JorgeFerrer, @mhan810

There are two type of actions in the LayoutSetService: the ones that are executed from Site Administration > Site Pages (update Logo, update Look and Feel, update Settings) and the ones that are executed from Site Administration > Configuration (update virtualHost, update layoutSetLinkEnabled). For all of them, the update permission in the group was being checked. As part of my solution for this task, I've changed the permission checked for the first type of actions to Manage Layouts. This way, a site admin cannot perform changes under Site Administration > Site Pages but he can perform them under Site Administration > Configuration.
