### PR TITLE
LPS-39782 Move @Skip processing to its own advice to fully support runtime plug/unplug ability

### DIFF
--- a/portal-impl/src/META-INF/base-spring.xml
+++ b/portal-impl/src/META-INF/base-spring.xml
@@ -29,7 +29,10 @@
 		<property name="dataSource" ref="liferayDataSource" />
 		<property name="sessionFactory" ref="liferaySessionFactory" />
 	</bean>
-	<bean id="serviceAdvice" class="com.liferay.portal.security.ac.AccessControlAdvice">
+	<bean id="serviceAdvice" class="com.liferay.portal.spring.aop.SkipAdvice">
+		<property name="nextMethodInterceptor" ref="accessControlAdvice" />
+	</bean>
+	<bean id="accessControlAdvice" class="com.liferay.portal.security.ac.AccessControlAdvice">
 		<property name="accessControlAdvisor">
 			<bean class="com.liferay.portal.security.ac.AccessControlAdvisorImpl" />
 		</property>

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -336,6 +336,7 @@
 				<entry key="com.liferay.portal.security.pacl.PACLAdvice" value="nextMethodInterceptor" />
 				<entry key="com.liferay.portal.spring.aop.ServiceBeanAutoProxyCreator" value="beanMatcher,methodInterceptor" />
 				<entry key="com.liferay.portal.spring.aop.ServiceBeanMatcher" value="" />
+				<entry key="com.liferay.portal.spring.aop.SkipAdvice" value="nextMethodInterceptor" />
 				<entry key="com.liferay.portal.spring.bean.BeanReferenceAnnotationBeanPostProcessor" value="" />
 				<entry key="com.liferay.portal.spring.context.PortletBeanFactoryCleaner" value="" />
 				<entry key="com.liferay.portal.spring.context.PortletBeanFactoryPostProcessor" value="" />

--- a/portal-impl/src/com/liferay/portal/spring/aop/ServiceBeanAopProxy.java
+++ b/portal-impl/src/com/liferay/portal/spring/aop/ServiceBeanAopProxy.java
@@ -16,7 +16,6 @@ package com.liferay.portal.spring.aop;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.spring.aop.Skip;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 
@@ -28,7 +27,6 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -172,16 +170,7 @@ public class ServiceBeanAopProxy implements AopProxy, InvocationHandler {
 				new ServiceBeanMethodInvocation(
 					target, targetClass, method, arguments);
 
-			Skip skip = ServiceBeanAopCacheManager.getAnnotation(
-				serviceBeanMethodInvocation, Skip.class, null);
-
-			if (skip != null) {
-				serviceBeanMethodInvocation.setMethodInterceptors(
-					Collections.<MethodInterceptor>emptyList());
-			}
-			else {
-				_setMethodInterceptors(serviceBeanMethodInvocation);
-			}
+			_setMethodInterceptors(serviceBeanMethodInvocation);
 
 			return serviceBeanMethodInvocation.proceed();
 		}

--- a/portal-impl/src/com/liferay/portal/spring/aop/ServiceBeanAutoProxyCreator.java
+++ b/portal-impl/src/com/liferay/portal/spring/aop/ServiceBeanAutoProxyCreator.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.spring.aop;
 
-import com.liferay.portal.kernel.spring.aop.Skip;
-
 import java.util.Map;
 
 import org.aopalliance.intercept.MethodInterceptor;
@@ -37,9 +35,6 @@ public class ServiceBeanAutoProxyCreator
 
 	public ServiceBeanAutoProxyCreator() {
 		_serviceBeanAopCacheManager = new ServiceBeanAopCacheManager();
-
-		_serviceBeanAopCacheManager.registerAnnotationChainableMethodAdvice(
-			Skip.class, null);
 	}
 
 	public void afterPropertiesSet() {

--- a/portal-impl/src/com/liferay/portal/spring/aop/SkipAdvice.java
+++ b/portal-impl/src/com/liferay/portal/spring/aop/SkipAdvice.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.spring.aop;
+
+import com.liferay.portal.kernel.spring.aop.Skip;
+
+import java.lang.annotation.Annotation;
+
+import java.util.Collections;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class SkipAdvice extends AnnotationChainableMethodAdvice<Skip> {
+
+	@Override
+	public Object before(MethodInvocation methodInvocation) throws Throwable {
+		Skip skip = findAnnotation(methodInvocation);
+
+		if (skip != _nullSkip) {
+			MethodInterceptorsBag methodInterceptorsBag =
+				serviceBeanAopCacheManager.getMethodInterceptorsBag(
+					methodInvocation);
+
+			MethodInterceptorsBag newMethodInterceptorsBag =
+				new MethodInterceptorsBag(
+					methodInterceptorsBag.getClassLevelMethodInterceptors(),
+					Collections.<MethodInterceptor>emptyList());
+
+			serviceBeanAopCacheManager.putMethodInterceptorsBag(
+				methodInvocation, newMethodInterceptorsBag);
+
+			ServiceBeanMethodInvocation serviceBeanMethodInvocation =
+				(ServiceBeanMethodInvocation)methodInvocation;
+
+			serviceBeanMethodInvocation.setMethodInterceptors(
+				Collections.<MethodInterceptor>emptyList());
+		}
+
+		return null;
+	}
+
+	@Override
+	public Skip getNullAnnotation() {
+		return _nullSkip;
+	}
+
+	private static Skip _nullSkip = new Skip() {
+
+		@Override
+		public Class<? extends Annotation> annotationType() {
+			return Skip.class;
+		}
+
+	};
+
+}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/spring_base_xml.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/spring_base_xml.ftl
@@ -34,6 +34,14 @@
 		<property name="sessionFactory" ref="liferaySessionFactory" />
 	</bean>
 	<bean id="serviceAdvice" class="com.liferay.portal.kernel.spring.util.SpringFactoryUtil" factory-method="newBean">
+		<constructor-arg value="com.liferay.portal.spring.aop.SkipAdvice" />
+		<constructor-arg>
+			<map>
+				<entry key="nextMethodInterceptor" value-ref="accessControlAdvice" />
+			</map>
+		</constructor-arg>
+	</bean>
+	<bean id="accessControlAdvice" class="com.liferay.portal.kernel.spring.util.SpringFactoryUtil" factory-method="newBean">
 		<constructor-arg value="com.liferay.portal.security.ac.AccessControlAdvice" />
 		<constructor-arg>
 			<map>


### PR DESCRIPTION
Brian, although this changes spring_base_xml.ftl, it does not affect backwards compatibility.

Because there no usage of @Skip in any exist plugin, even some customer plugin is using it, the worst case is the TransactionInterceptor is forced to run, only add some slowness to that plugin, nothing will break.
