### PR TITLE
LPS-37302 - Revert name change (see comment below)

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionImpl.java
@@ -202,7 +202,7 @@ public class LayoutRevisionImpl extends LayoutRevisionBaseImpl {
 	}
 
 	@Override
-	public boolean hasDefaultAssetPublisherPortletId() {
+	public boolean isContentDisplayPage() {
 		UnicodeProperties typeSettingsProperties = getTypeSettingsProperties();
 
 		String defaultAssetPublisherPortletId =

--- a/portal-service/src/com/liferay/portal/model/LayoutRevision.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutRevision.java
@@ -72,7 +72,7 @@ public interface LayoutRevision extends LayoutRevisionModel, PersistedModel {
 	public boolean hasChildren()
 		throws com.liferay.portal.kernel.exception.SystemException;
 
-	public boolean hasDefaultAssetPublisherPortletId();
+	public boolean isContentDisplayPage();
 
 	public boolean isInheritLookAndFeel();
 

--- a/portal-service/src/com/liferay/portal/model/LayoutRevisionWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutRevisionWrapper.java
@@ -1900,8 +1900,8 @@ public class LayoutRevisionWrapper implements LayoutRevision,
 	}
 
 	@Override
-	public boolean hasDefaultAssetPublisherPortletId() {
-		return _layoutRevision.hasDefaultAssetPublisherPortletId();
+	public boolean isContentDisplayPage() {
+		return _layoutRevision.isContentDisplayPage();
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/model/LayoutStagingHandler.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutStagingHandler.java
@@ -302,7 +302,7 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 		_layoutRevisionMethodNames.add("getWapColorSchemeId");
 		_layoutRevisionMethodNames.add("getWapTheme");
 		_layoutRevisionMethodNames.add("getWapThemeId");
-		_layoutRevisionMethodNames.add("hasDefaultAssetPublisherPortletId");
+		_layoutRevisionMethodNames.add("isContentDisplayPage");
 		_layoutRevisionMethodNames.add("isEscapedModel");
 		_layoutRevisionMethodNames.add("isIconImage");
 		_layoutRevisionMethodNames.add("isInheritLookAndFeel");


### PR DESCRIPTION
Hi Brian,

In case you're wondering why we need to revert this, it's because LayoutStagingHandler calls this method by reflection and the object it is calling it on can be a LayoutRevision, so we either have to change both names or use the one Layout has.

Cheers,
Zsolt
