### PR TITLE
LPS-39135 Retrieve the dispatcher in a thread safe way. Our portlet's di...

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ThreadLocalFacadeHttpServletRequestWrapper.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ThreadLocalFacadeHttpServletRequestWrapper.java
@@ -25,6 +25,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 
+import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletRequest;
@@ -87,6 +88,14 @@ public class ThreadLocalFacadeHttpServletRequestWrapper
 	@Override
 	public ServletRequest getRequest() {
 		return _nextHttpServletRequestThreadLocal.get();
+	}
+
+	@Override
+	public RequestDispatcher getRequestDispatcher(String uri) {
+		HttpServletRequest httpServletRequest =
+			_nextHttpServletRequestThreadLocal.get();
+
+		return httpServletRequest.getRequestDispatcher(uri);
 	}
 
 	@Override


### PR DESCRIPTION
...spatching mechanism works fine but rendering multiple Spring MVC portlets in parallel was using a wrong request to retrieve the dispatcher
