### PR TITLE
LPS-39662

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/CookieRemotePreference.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/CookieRemotePreference.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.model.impl;
+
+import com.liferay.portal.kernel.util.CookieKeys;
+import com.liferay.portal.model.UserRemotePreference;
+
+import javax.servlet.http.Cookie;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class CookieRemotePreference implements UserRemotePreference {
+
+	public CookieRemotePreference(Cookie cookie) {
+		_cookie = cookie;
+
+		String cookieName = cookie.getName();
+
+		_name = cookieName.substring(
+			CookieKeys.REMOTE_PREFERENCES_PREFIX.length());
+	}
+
+	public Cookie getCookie() {
+		return _cookie;
+	}
+
+	@Override
+	public String getName() {
+		return _name;
+	}
+
+	@Override
+	public String getValue() {
+		return _cookie.getValue();
+	}
+
+	private Cookie _cookie;
+	private String _name;
+
+}

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.model.Role;
 import com.liferay.portal.model.Team;
 import com.liferay.portal.model.UserConstants;
 import com.liferay.portal.model.UserGroup;
+import com.liferay.portal.model.UserRemotePreference;
 import com.liferay.portal.model.Website;
 import com.liferay.portal.security.auth.EmailAddressGenerator;
 import com.liferay.portal.security.auth.EmailAddressGeneratorFactory;
@@ -69,6 +70,8 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -89,8 +92,9 @@ public class UserImpl extends UserBaseImpl {
 	}
 
 	@Override
-	public void addRemotePreference(String name, String value) {
-		_remotePreferences.put(name, value);
+	public void addRemotePreference(UserRemotePreference userRemotePreference) {
+		_remotePreferences.put(
+			userRemotePreference.getName(), userRemotePreference);
 	}
 
 	@Override
@@ -551,13 +555,15 @@ public class UserImpl extends UserBaseImpl {
 	}
 
 	@Override
-	public String getRemotePreference(String name) {
+	public UserRemotePreference getRemotePreference(String name) {
 		return _remotePreferences.get(name);
 	}
 
 	@Override
-	public Map<String, String> getRemotePreferences() {
-		return _remotePreferences;
+	public Iterable<UserRemotePreference> getRemotePreferences() {
+		Collection<UserRemotePreference> values = _remotePreferences.values();
+
+		return Collections.unmodifiableCollection(values);
 	}
 
 	@Override
@@ -783,8 +789,8 @@ public class UserImpl extends UserBaseImpl {
 	private boolean _passwordModified;
 	private PasswordPolicy _passwordPolicy;
 	private String _passwordUnencrypted;
-	private Map<String, String> _remotePreferences =
-		new HashMap<String, String>();
+	private transient Map<String, UserRemotePreference> _remotePreferences =
+		new HashMap<String, UserRemotePreference>();
 	private TimeZone _timeZone;
 
 }

--- a/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserImpl.java
@@ -70,8 +70,10 @@ import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
@@ -84,6 +86,11 @@ import java.util.TreeSet;
 public class UserImpl extends UserBaseImpl {
 
 	public UserImpl() {
+	}
+
+	@Override
+	public void addRemotePreference(String name, String value) {
+		_remotePreferences.put(name, value);
 	}
 
 	@Override
@@ -544,6 +551,16 @@ public class UserImpl extends UserBaseImpl {
 	}
 
 	@Override
+	public String getRemotePreference(String name) {
+		return _remotePreferences.get(name);
+	}
+
+	@Override
+	public Map<String, String> getRemotePreferences() {
+		return _remotePreferences;
+	}
+
+	@Override
 	public long[] getRoleIds() throws SystemException {
 		List<Role> roles = getRoles();
 
@@ -766,6 +783,8 @@ public class UserImpl extends UserBaseImpl {
 	private boolean _passwordModified;
 	private PasswordPolicy _passwordPolicy;
 	private String _passwordUnencrypted;
+	private Map<String, String> _remotePreferences =
+		new HashMap<String, String>();
 	private TimeZone _timeZone;
 
 }

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -114,6 +114,7 @@ import com.liferay.portal.model.TicketConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.model.UserGroup;
 import com.liferay.portal.model.VirtualLayoutConstants;
+import com.liferay.portal.model.impl.CookieRemotePreference;
 import com.liferay.portal.model.impl.LayoutTypePortletImpl;
 import com.liferay.portal.model.impl.VirtualLayout;
 import com.liferay.portal.plugin.PluginPackageUtil;
@@ -5229,10 +5230,7 @@ public class PortalImpl implements Portal {
 			String cookieName = cookie.getName();
 
 			if (cookieName.startsWith(CookieKeys.REMOTE_PREFERENCES_PREFIX)) {
-				String name = cookieName.substring(
-					CookieKeys.REMOTE_PREFERENCES_PREFIX.length());
-
-				user.addRemotePreference(name, cookie.getValue());
+				user.addRemotePreference(new CookieRemotePreference(cookie));
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -250,6 +250,7 @@ import javax.portlet.WindowState;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
@@ -5222,6 +5223,17 @@ public class PortalImpl implements Portal {
 			user = UserLocalServiceUtil.getUserById(userId);
 
 			request.setAttribute(WebKeys.USER, user);
+		}
+
+		for (Cookie cookie : request.getCookies()) {
+			String cookieName = cookie.getName();
+
+			if (cookieName.startsWith(CookieKeys.REMOTE_PREFERENCES_PREFIX)) {
+				String name = cookieName.substring(
+					CookieKeys.REMOTE_PREFERENCES_PREFIX.length());
+
+				user.addRemotePreference(name, cookie.getValue());
+			}
 		}
 
 		return user;

--- a/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -50,6 +50,8 @@ public class CookieKeys {
 
 	public static final String REMEMBER_ME = "REMEMBER_ME";
 
+	public static final String REMOTE_PREFERENCES_PREFIX = "RP_";
+
 	public static final String SCREEN_NAME = "SCREEN_NAME";
 
 	public static final String USER_UUID = "USER_UUID";

--- a/portal-service/src/com/liferay/portal/model/User.java
+++ b/portal-service/src/com/liferay/portal/model/User.java
@@ -29,8 +29,7 @@ public interface User extends UserModel, PersistedModel {
 	 *
 	 * Never modify this interface directly. Add methods to {@link com.liferay.portal.model.impl.UserImpl} and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
-	public void addRemotePreference(java.lang.String name,
-		java.lang.String value);
+	public void addRemotePreference(UserRemotePreference userRemotePreference);
 
 	public java.util.List<com.liferay.portal.model.Address> getAddresses()
 		throws com.liferay.portal.kernel.exception.SystemException;
@@ -216,9 +215,9 @@ public interface User extends UserModel, PersistedModel {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
-	public java.util.Map<java.lang.String, java.lang.String> getRemotePreferences();
+	public UserRemotePreference getRemotePreference(java.lang.String name);
 
-	public java.lang.String getRemotePreference(java.lang.String name);
+	public Iterable<UserRemotePreference> getRemotePreferences();
 
 	public long[] getRoleIds()
 		throws com.liferay.portal.kernel.exception.SystemException;

--- a/portal-service/src/com/liferay/portal/model/User.java
+++ b/portal-service/src/com/liferay/portal/model/User.java
@@ -29,6 +29,9 @@ public interface User extends UserModel, PersistedModel {
 	 *
 	 * Never modify this interface directly. Add methods to {@link com.liferay.portal.model.impl.UserImpl} and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	public void addRemotePreference(java.lang.String name,
+		java.lang.String value);
+
 	public java.util.List<com.liferay.portal.model.Address> getAddresses()
 		throws com.liferay.portal.kernel.exception.SystemException;
 
@@ -212,6 +215,10 @@ public interface User extends UserModel, PersistedModel {
 	public java.util.Set<java.lang.String> getReminderQueryQuestions()
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
+
+	public java.util.Map<java.lang.String, java.lang.String> getRemotePreferences();
+
+	public java.lang.String getRemotePreference(java.lang.String name);
 
 	public long[] getRoleIds()
 		throws com.liferay.portal.kernel.exception.SystemException;

--- a/portal-service/src/com/liferay/portal/model/User.java
+++ b/portal-service/src/com/liferay/portal/model/User.java
@@ -29,7 +29,8 @@ public interface User extends UserModel, PersistedModel {
 	 *
 	 * Never modify this interface directly. Add methods to {@link com.liferay.portal.model.impl.UserImpl} and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
-	public void addRemotePreference(UserRemotePreference userRemotePreference);
+	public void addRemotePreference(
+		com.liferay.portal.model.UserRemotePreference userRemotePreference);
 
 	public java.util.List<com.liferay.portal.model.Address> getAddresses()
 		throws com.liferay.portal.kernel.exception.SystemException;
@@ -215,9 +216,10 @@ public interface User extends UserModel, PersistedModel {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
-	public UserRemotePreference getRemotePreference(java.lang.String name);
+	public com.liferay.portal.model.UserRemotePreference getRemotePreference(
+		java.lang.String name);
 
-	public Iterable<UserRemotePreference> getRemotePreferences();
+	public java.lang.Iterable<com.liferay.portal.model.UserRemotePreference> getRemotePreferences();
 
 	public long[] getRoleIds()
 		throws com.liferay.portal.kernel.exception.SystemException;

--- a/portal-service/src/com/liferay/portal/model/UserRemotePreference.java
+++ b/portal-service/src/com/liferay/portal/model/UserRemotePreference.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.model;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public interface UserRemotePreference {
+
+	public String getName();
+
+	public String getValue();
+
+}

--- a/portal-service/src/com/liferay/portal/model/UserWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserWrapper.java
@@ -1348,6 +1348,12 @@ public class UserWrapper implements User, ModelWrapper<User> {
 	}
 
 	@Override
+	public void addRemotePreference(java.lang.String name,
+		java.lang.String value) {
+		_user.addRemotePreference(name, value);
+	}
+
+	@Override
 	public java.util.List<com.liferay.portal.model.Address> getAddresses()
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return _user.getAddresses();
@@ -1654,6 +1660,16 @@ public class UserWrapper implements User, ModelWrapper<User> {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _user.getReminderQueryQuestions();
+	}
+
+	@Override
+	public java.util.Map<java.lang.String, java.lang.String> getRemotePreferences() {
+		return _user.getRemotePreferences();
+	}
+
+	@Override
+	public java.lang.String getRemotePreference(java.lang.String name) {
+		return _user.getRemotePreference(name);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/model/UserWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserWrapper.java
@@ -1348,9 +1348,9 @@ public class UserWrapper implements User, ModelWrapper<User> {
 	}
 
 	@Override
-	public void addRemotePreference(java.lang.String name,
-		java.lang.String value) {
-		_user.addRemotePreference(name, value);
+	public void addRemotePreference(
+		com.liferay.portal.model.UserRemotePreference userRemotePreference) {
+		_user.addRemotePreference(userRemotePreference);
 	}
 
 	@Override
@@ -1663,13 +1663,14 @@ public class UserWrapper implements User, ModelWrapper<User> {
 	}
 
 	@Override
-	public java.util.Map<java.lang.String, java.lang.String> getRemotePreferences() {
-		return _user.getRemotePreferences();
+	public com.liferay.portal.model.UserRemotePreference getRemotePreference(
+		java.lang.String name) {
+		return _user.getRemotePreference(name);
 	}
 
 	@Override
-	public java.lang.String getRemotePreference(java.lang.String name) {
-		return _user.getRemotePreference(name);
+	public java.lang.Iterable<com.liferay.portal.model.UserRemotePreference> getRemotePreferences() {
+		return _user.getRemotePreferences();
 	}
 
 	@Override


### PR DESCRIPTION
Hey Brian,

This pull is necessary to allow Content Targeting plugins to get access to some categorization/preference info from guest users. Thes "preferences" are intented to store things such as what the user "likes" or "dislikes" so content targeting, or other application, can benefit from this. These preferences need to be present even for unregistered users, so they very likely should/must be stored out of the portal. The main store are going to be cookies, but it may not be the only one, as we could think about having other sources of information such as social network information, among others.

There are two different implementations, one with only strings as key - value pairs and the second one using an interface and a wrapper around Cookie.

I prefer the class approach for the following:

Since this is API, we are not binding to a representation using string that could lead to users of the api to serialize data into strings or loose information (such as domain of the cookies that could be of use to some module)
Different plugins or core modules could add their own "preferences" representation without having to modify the API
