### PR TITLE
LPS-40225 Prevent double-escaping aui-input value.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/dependencies/ddm/documentlibrary.ftl
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/dependencies/ddm/documentlibrary.ftl
@@ -25,7 +25,7 @@
 </#if>
 
 <@aui["field-wrapper"] data=data>
-	<@aui.input inlineField=true label=escape(label) name="${namespacedFieldName}Title" readonly="readonly" type="text" value=escape(fileEntryTitle)>
+	<@aui.input inlineField=true label=escape(label) name="${namespacedFieldName}Title" readonly="readonly" type="text" value=fileEntryTitle>
 		<#if required>
 			<@aui.validator name="required" />
 		</#if>


### PR DESCRIPTION
Hey Brian,

Sorry, I thought this change was necessary too, but the aui-input is actually escaping the value attribute by itself. 

Thanks
