### PR TITLE
LPS-39747 - Set specific ignore rules for Finnish at LangBuilder

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/LangBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/LangBuilder.java
@@ -298,6 +298,10 @@ public class LangBuilder {
 					else if (languageId.equals("es") && key.equals("am")) {
 						translatedText = "";
 					}
+					else if (languageId.equals("fi") &&
+							 (key.equals("on") || key.equals("the"))) {
+						translatedText = "";
+					}
 					else if (languageId.equals("it") && key.equals("am")) {
 						translatedText = "";
 					}


### PR DESCRIPTION
Hi Brian,

At Finnish language we do not have prepositions like "the" or "on" and  those are also impossible to translate. So this change is ignoring those at LangBuilder.

This fix would be nice to get also to the 6.2 release.

Kind regards, Sampsa Sohlman
