### PR TITLE
LPS-39594 last publish date publishing fix - revisited - please read comments

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutExportBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutExportBackgroundTaskExecutor.java
@@ -64,6 +64,12 @@ public class LayoutExportBackgroundTaskExecutor
 		Date startDate = (Date)taskContextMap.get("startDate");
 		Date endDate = (Date)taskContextMap.get("endDate");
 
+		Date lastPublishDate = endDate;
+
+		if (lastPublishDate == null) {
+			lastPublishDate = new Date();
+		}
+
 		File larFile = LayoutLocalServiceUtil.exportLayoutsAsFile(
 			groupId, privateLayout, layoutIds, parameterMap, startDate,
 			endDate);
@@ -75,12 +81,6 @@ public class LayoutExportBackgroundTaskExecutor
 			parameterMap, PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE);
 
 		if (updateLastPublishDate) {
-			Date lastPublishDate = endDate;
-
-			if (lastPublishDate == null) {
-				lastPublishDate = new Date();
-			}
-
 			StagingUtil.updateLastPublishDate(
 				groupId, privateLayout, lastPublishDate);
 		}

--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -68,6 +68,12 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 		HttpPrincipal httpPrincipal = (HttpPrincipal)taskContextMap.get(
 			"httpPrincipal");
 
+		Date lastPublishDate = endDate;
+
+		if (lastPublishDate == null) {
+			lastPublishDate = new Date();
+		}
+
 		clearBackgroundTaskStatus(backgroundTask);
 
 		long stagingRequestId = 0;
@@ -126,12 +132,6 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 				parameterMap, PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE);
 
 			if (updateLastPublishDate) {
-				Date lastPublishDate = endDate;
-
-				if (lastPublishDate == null) {
-					lastPublishDate = new Date();
-				}
-
 				StagingUtil.updateLastPublishDate(
 					sourceGroupId, privateLayout, lastPublishDate);
 			}

--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutStagingBackgroundTaskExecutor.java
@@ -58,6 +58,12 @@ public class LayoutStagingBackgroundTaskExecutor
 		Date startDate = (Date)taskContextMap.get("startDate");
 		Date endDate = (Date)taskContextMap.get("endDate");
 
+		Date lastPublishDate = endDate;
+
+		if (lastPublishDate == null) {
+			lastPublishDate = new Date();
+		}
+
 		clearBackgroundTaskStatus(backgroundTask);
 
 		File file = null;
@@ -83,12 +89,6 @@ public class LayoutStagingBackgroundTaskExecutor
 				parameterMap, PortletDataHandlerKeys.UPDATE_LAST_PUBLISH_DATE);
 
 			if (updateLastPublishDate) {
-				Date lastPublishDate = endDate;
-
-				if (lastPublishDate == null) {
-					lastPublishDate = new Date();
-				}
-
 				StagingUtil.updateLastPublishDate(
 					sourceGroupId, privateLayout, lastPublishDate);
 			}


### PR DESCRIPTION
Hey Brian,

I've checked your changes and although I see your point with the optimize commit, we have to mark the time before the publication process because we might miss entities in the next publication window. Also original LayoutExport code piece marked the time before the process for the same reason. For the update we have to update if the process was successful so that's why the time is being marked in the beginning of the process and updated at the end.

Thanks,

Máté
