### PR TITLE
LPS-40753 Keep method overload as deprecated for backwards compatibility

### DIFF
--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/ColumnProcessor.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/ColumnProcessor.java
@@ -26,6 +26,11 @@ public interface ColumnProcessor {
 
 	public String processMax() throws Exception;
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #processMax()}
+	 */
+	public String processMax(String classNames) throws Exception;
+
 	public String processPortlet(String portletId) throws Exception;
 
 }

--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/CustomizationSettingsProcessor.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/CustomizationSettingsProcessor.java
@@ -108,6 +108,14 @@ public class CustomizationSettingsProcessor implements ColumnProcessor {
 		return StringPool.BLANK;
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #processMax()}
+	 */
+	@Override
+	public String processMax(String classNames) throws Exception {
+		return processMax();
+	}
+
 	@Override
 	public String processPortlet(String portletId) throws Exception {
 		_writer.append("<div class=\"portlet\">");

--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/velocity/TemplateProcessor.java
@@ -171,6 +171,14 @@ public class TemplateProcessor implements ColumnProcessor {
 		return bufferCacheServletResponse.getString();
 	}
 
+	/**
+	 * @deprecated As of 6.2.0, replaced by {@link #processMax()}
+	 */
+	@Override
+	public String processMax(String classNames) throws Exception {
+		return processMax();
+	}
+
 	@Override
 	public String processPortlet(String portletId) throws Exception {
 		_request.setAttribute(WebKeys.RENDER_PORTLET_RESOURCE, Boolean.TRUE);


### PR DESCRIPTION
Hi Brian,

@shuyangzhou removed the processMax(String className) overload because it was no longer used in the product. But any existing custom layout template using this method will fail. So I think we should keep it deprecated. 

Thanks!
