### PR TITLE
LPS-40502 Do not fail when ServiceContext is null

### DIFF
--- a/portal-service/src/com/liferay/portal/model/LayoutStagingHandler.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutStagingHandler.java
@@ -147,7 +147,7 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		if (!serviceContext.isSignedIn()) {
+		if ((serviceContext == null) || !serviceContext.isSignedIn()) {
 			LayoutRevision lastLayoutRevision = null;
 
 			lastLayoutRevision =


### PR DESCRIPTION
Avoid getting an NPE a newly created ServiceContext would have a false signedIn attribute anyway
