### PR TITLE
LPS-40704 ServiceContext has a default empty map for expando, do not set...

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -2099,8 +2099,10 @@ public class PortletDataContextImpl implements PortletDataContext {
 				Map<String, Serializable> expandoBridgeAttributes =
 					(Map<String, Serializable>)getZipEntryAsObject(expandoPath);
 
-				serviceContext.setExpandoBridgeAttributes(
-					expandoBridgeAttributes);
+				if (expandoBridgeAttributes != null) {
+					serviceContext.setExpandoBridgeAttributes(
+						expandoBridgeAttributes);
+				}
 			}
 			catch (Exception e) {
 				if (_log.isDebugEnabled()) {


### PR DESCRIPTION
... to null if not necessary, to avoid NPEs in subsequent calls
