### PR TITLE
[TECH SUPPORT] LPS-40651 Move validation after generating new articleId

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -740,18 +740,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			emailAddress = emailAddressGenerator.generate(companyId, userId);
 		}
 
-		validate(
-			companyId, userId, autoPassword, password1, password2,
-			autoScreenName, screenName, emailAddress, openId, firstName,
-			middleName, lastName, organizationIds);
-
-		if (!autoPassword) {
-			if (Validator.isNull(password1) || Validator.isNull(password2)) {
-				throw new UserPasswordException(
-					UserPasswordException.PASSWORD_INVALID);
-			}
-		}
-
 		if (autoScreenName) {
 			ScreenNameGenerator screenNameGenerator =
 				ScreenNameGeneratorFactory.getInstance();
@@ -764,6 +752,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				throw new SystemException(e);
 			}
 		}
+
+		validate(
+			companyId, userId, autoPassword, password1, password2,
+			autoScreenName, screenName, emailAddress, openId, firstName,
+			middleName, lastName, organizationIds);
 
 		User defaultUser = getDefaultUser(companyId);
 
@@ -4075,19 +4068,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				autoScreenName = true;
 			}
 
-			validate(
-				companyId, user.getUserId(), autoPassword, password1, password2,
-				autoScreenName, screenName, emailAddress, openId, firstName,
-				middleName, lastName, null);
-
-			if (!autoPassword) {
-				if (Validator.isNull(password1) ||
-					Validator.isNull(password2)) {
-						throw new UserPasswordException(
-							UserPasswordException.PASSWORD_INVALID);
-				}
-			}
-
 			if (autoScreenName) {
 				ScreenNameGenerator screenNameGenerator =
 					ScreenNameGeneratorFactory.getInstance();
@@ -4100,6 +4080,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 					throw new SystemException(e);
 				}
 			}
+
+			validate(
+				companyId, user.getUserId(), autoPassword, password1, password2,
+				autoScreenName, screenName, emailAddress, openId, firstName,
+				middleName, lastName, null);
 
 			FullNameGenerator fullNameGenerator =
 				FullNameGeneratorFactory.getInstance();
@@ -5858,6 +5843,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		if (!autoPassword) {
+			if (Validator.isNull(password1) || Validator.isNull(password2)) {
+				throw new UserPasswordException(
+					UserPasswordException.PASSWORD_INVALID);
+			}
+
 			PasswordPolicy passwordPolicy =
 				passwordPolicyLocalService.getDefaultPasswordPolicy(companyId);
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -315,15 +315,15 @@ public class JournalArticleLocalServiceImpl
 
 		Date now = new Date();
 
+		if (autoArticleId) {
+			articleId = String.valueOf(counterLocalService.increment());
+		}
+
 		validate(
 			user.getCompanyId(), groupId, classNameId, articleId, autoArticleId,
 			version, titleMap, content, type, ddmStructureKey, ddmTemplateKey,
 			expirationDate, smallImage, smallImageURL, smallImageFile,
 			smallImageBytes);
-
-		if (autoArticleId) {
-			articleId = String.valueOf(counterLocalService.increment());
-		}
 
 		long id = counterLocalService.increment();
 
@@ -6597,13 +6597,13 @@ public class JournalArticleLocalServiceImpl
 
 		if (!autoArticleId) {
 			validate(articleId);
-		}
 
-		JournalArticle article = journalArticlePersistence.fetchByG_A_V(
-			groupId, articleId, version);
+			JournalArticle article = journalArticlePersistence.fetchByG_A_V(
+				groupId, articleId, version);
 
-		if (article != null) {
-			throw new DuplicateArticleIdException();
+			if (article != null) {
+				throw new DuplicateArticleIdException();
+			}
 		}
 
 		validate(

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFeedLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFeedLocalServiceImpl.java
@@ -71,13 +71,13 @@ public class JournalFeedLocalServiceImpl
 		feedId = StringUtil.toUpperCase(feedId.trim());
 		Date now = new Date();
 
-		validate(
-			user.getCompanyId(), groupId, feedId, autoFeedId, name, structureId,
-			targetLayoutFriendlyUrl, contentField);
-
 		if (autoFeedId) {
 			feedId = String.valueOf(counterLocalService.increment());
 		}
+
+		validate(
+			user.getCompanyId(), groupId, feedId, autoFeedId, name, structureId,
+			targetLayoutFriendlyUrl, contentField);
 
 		long id = counterLocalService.increment();
 


### PR DESCRIPTION
Found this occurrences for the same pattern:
- JournalFeedLSI - applied
- UserLSI - applied, with minor additional restructuring
- JournalTemplateLSI - this is deprecated and add method does not use this pattern, copy uses the pattern we are using  elsewhere
- JournalStructureLSI - same as template
- ShoppingCouponLSI - already used this pattern
- CompanyLSI and DLFileEntryLSI - they has boolean auto\* vars but not used for this purpose.
