### PR TITLE
LPS-40537 Themes are not exported anymore but referenced to be validated if necessary during import

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -384,6 +384,12 @@ public class LayoutExporter {
 			}
 		}
 
+		Element missingReferencesElement = rootElement.addElement(
+			"missing-references");
+
+		portletDataContext.setMissingReferencesElement(
+			missingReferencesElement);
+
 		if (layoutSetBranch != null) {
 			_themeExporter.exportTheme(portletDataContext, layoutSetBranch);
 		}
@@ -440,12 +446,6 @@ public class LayoutExporter {
 					});
 			}
 		}
-
-		Element missingReferencesElement = rootElement.addElement(
-			"missing-references");
-
-		portletDataContext.setMissingReferencesElement(
-			missingReferencesElement);
 
 		portletDataContext.addDeletionSystemEventStagedModelTypes(
 			new StagedModelType(Layout.class));

--- a/portal-impl/src/com/liferay/portal/lar/ThemeExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/ThemeExporter.java
@@ -18,26 +18,11 @@ import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.servlet.ServletContextPool;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Element;
-import com.liferay.portal.kernel.zip.ZipWriter;
-import com.liferay.portal.kernel.zip.ZipWriterFactoryUtil;
-import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutSet;
 import com.liferay.portal.model.LayoutSetBranch;
-import com.liferay.portal.model.Theme;
-import com.liferay.portal.theme.ThemeLoader;
-import com.liferay.portal.theme.ThemeLoaderFactory;
-import com.liferay.util.ContentUtil;
-
-import java.io.File;
-
-import javax.servlet.ServletContext;
+import com.liferay.portlet.pluginsadmin.lar.ThemeStagingWrapper;
 
 /**
  * @author Mate Thurzo
@@ -45,44 +30,35 @@ import javax.servlet.ServletContext;
 public class ThemeExporter {
 
 	public void exportTheme(
-			PortletDataContext portletDataContext, Layout layout)
-		throws Exception {
-
-		boolean exportTheme = MapUtil.getBoolean(
-			portletDataContext.getParameterMap(), PortletDataHandlerKeys.THEME);
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Export theme " + exportTheme);
-		}
-
-		if (exportTheme && !portletDataContext.isPerformDirectBinaryImport() &&
-			!layout.isInheritLookAndFeel()) {
-
-			Theme theme = layout.getTheme();
-
-			StringBundler sb = new StringBundler(6);
-
-			ZipWriter zipWriter = portletDataContext.getZipWriter();
-
-			sb.append(zipWriter.getPath());
-			sb.append(StringPool.SLASH);
-			sb.append("theme");
-			sb.append(StringPool.DASH);
-			sb.append(String.valueOf(layout.getLayoutId()));
-			sb.append(".zip");
-
-			File themeZipFile = new File(sb.toString());
-
-			exportTheme(theme, themeZipFile);
-		}
-	}
-
-	public void exportTheme(
 			PortletDataContext portletDataContext, LayoutSet layoutSet)
 		throws Exception {
 
-		exportTheme(
-			portletDataContext, layoutSet.getTheme(),
+		boolean exportThemeSettings = MapUtil.getBoolean(
+			portletDataContext.getParameterMap(),
+			PortletDataHandlerKeys.THEME_REFERENCE);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Export theme settings " + exportThemeSettings);
+		}
+
+		if (!exportThemeSettings) {
+			return;
+		}
+
+		ThemeStagingWrapper themeStagingWrapper = new ThemeStagingWrapper(
+			layoutSet.getTheme());
+
+		if (!portletDataContext.isPerformDirectBinaryImport()) {
+			Element layoutSetElement = portletDataContext.getExportDataElement(
+				layoutSet);
+
+			portletDataContext.addReferenceElement(
+				layoutSet, layoutSetElement, themeStagingWrapper,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+		}
+
+		exportThemeSettings(
+			portletDataContext, themeStagingWrapper.getThemeId(),
 			layoutSet.getColorSchemeId(), layoutSet.getCss());
 	}
 
@@ -91,146 +67,50 @@ public class ThemeExporter {
 			LayoutSetBranch layoutSetBranch)
 		throws Exception {
 
-		exportTheme(
-			portletDataContext, layoutSetBranch.getTheme(),
-			layoutSetBranch.getColorSchemeId(), layoutSetBranch.getCss());
-	}
-
-	protected void exportTheme(
-			PortletDataContext portletDataContext, Theme theme,
-			String colorSchemeId, String css)
-		throws Exception {
-
-		boolean exportTheme = MapUtil.getBoolean(
-			portletDataContext.getParameterMap(), PortletDataHandlerKeys.THEME);
 		boolean exportThemeSettings = MapUtil.getBoolean(
 			portletDataContext.getParameterMap(),
 			PortletDataHandlerKeys.THEME_REFERENCE);
 
 		if (_log.isDebugEnabled()) {
-			_log.debug("Export theme " + exportTheme);
 			_log.debug("Export theme settings " + exportThemeSettings);
 		}
+
+		if (!exportThemeSettings) {
+			return;
+		}
+
+		ThemeStagingWrapper themeStagingWrapper = new ThemeStagingWrapper(
+			layoutSetBranch.getTheme());
+
+		if (!portletDataContext.isPerformDirectBinaryImport()) {
+			Element layoutSetBranchElement =
+				portletDataContext.getExportDataElement(layoutSetBranch);
+
+			portletDataContext.addReferenceElement(
+				layoutSetBranch, layoutSetBranchElement, themeStagingWrapper,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+		}
+
+		exportThemeSettings(
+			portletDataContext, themeStagingWrapper.getThemeId(),
+			layoutSetBranch.getColorSchemeId(), layoutSetBranch.getCss());
+	}
+
+	protected void exportThemeSettings(
+			PortletDataContext portletDataContext, String themeId,
+			String colorSchemeId, String css)
+		throws Exception {
 
 		Element exportDataRootElement =
 			portletDataContext.getExportDataRootElement();
 		Element headerElement = exportDataRootElement.element("header");
 
-		if (exportTheme || exportThemeSettings) {
-			headerElement.addAttribute("theme-id", theme.getThemeId());
-			headerElement.addAttribute("color-scheme-id", colorSchemeId);
-		}
-
-		if (exportTheme && !portletDataContext.isPerformDirectBinaryImport()) {
-			ZipWriter zipWriter = portletDataContext.getZipWriter();
-
-			File themeZipFile = new File(zipWriter.getPath() + "/theme.zip");
-
-			exportTheme(theme, themeZipFile);
-		}
+		headerElement.addAttribute("theme-id", themeId);
+		headerElement.addAttribute("color-scheme-id", colorSchemeId);
 
 		Element cssElement = headerElement.addElement("css");
 
 		cssElement.addCDATA(css);
-	}
-
-	protected void exportTheme(Theme theme, File themeZipFile)
-		throws Exception {
-
-		String lookAndFeelXML = ContentUtil.get(
-			"com/liferay/portal/dependencies/liferay-look-and-feel.xml.tmpl");
-
-		lookAndFeelXML = StringUtil.replace(
-			lookAndFeelXML,
-			new String[] {
-				"[$TEMPLATE_EXTENSION$]", "[$VIRTUAL_PATH$]"
-			},
-			new String[] {
-				theme.getTemplateExtension(), theme.getVirtualPath()
-			}
-		);
-
-		String servletContextName = theme.getServletContextName();
-
-		ServletContext servletContext = ServletContextPool.get(
-			servletContextName);
-
-		if (servletContext == null) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Servlet context not found for theme " +
-						theme.getThemeId());
-			}
-
-			return;
-		}
-
-		ZipWriter themeZipWriter = ZipWriterFactoryUtil.getZipWriter(
-			themeZipFile);
-
-		themeZipWriter.addEntry("liferay-look-and-feel.xml", lookAndFeelXML);
-
-		File cssPath = null;
-		File imagesPath = null;
-		File javaScriptPath = null;
-		File templatesPath = null;
-
-		if (!theme.isLoadFromServletContext()) {
-			ThemeLoader themeLoader = ThemeLoaderFactory.getThemeLoader(
-				servletContextName);
-
-			if (themeLoader == null) {
-				_log.error(
-					servletContextName + " does not map to a theme loader");
-			}
-			else {
-				File file = themeLoader.getFileStorage();
-
-				String realPath =
-					file.getPath() + StringPool.SLASH + theme.getName();
-
-				cssPath = new File(realPath + "/css");
-				imagesPath = new File(realPath + "/images");
-				javaScriptPath = new File(realPath + "/javascript");
-				templatesPath = new File(realPath + "/templates");
-			}
-		}
-		else {
-			cssPath = new File(servletContext.getRealPath(theme.getCssPath()));
-			imagesPath = new File(
-				servletContext.getRealPath(theme.getImagesPath()));
-			javaScriptPath = new File(
-				servletContext.getRealPath(theme.getJavaScriptPath()));
-			templatesPath = new File(
-				servletContext.getRealPath(theme.getTemplatesPath()));
-		}
-
-		exportThemeFiles("css", cssPath, themeZipWriter);
-		exportThemeFiles("images", imagesPath, themeZipWriter);
-		exportThemeFiles("javascript", javaScriptPath, themeZipWriter);
-		exportThemeFiles("templates", templatesPath, themeZipWriter);
-	}
-
-	protected void exportThemeFiles(String path, File dir, ZipWriter zipWriter)
-		throws Exception {
-
-		if ((dir == null) || !dir.exists()) {
-			return;
-		}
-
-		File[] files = dir.listFiles();
-
-		for (File file : files) {
-			if (file.isDirectory()) {
-				exportThemeFiles(
-					path + StringPool.SLASH + file.getName(), file, zipWriter);
-			}
-			else {
-				zipWriter.addEntry(
-					path + StringPool.SLASH + file.getName(),
-					FileUtil.getBytes(file));
-			}
-		}
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(ThemeExporter.class);

--- a/portal-impl/src/com/liferay/portal/lar/ThemeImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/ThemeImporter.java
@@ -14,43 +14,16 @@
 
 package com.liferay.portal.lar;
 
-import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
-import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.ColorSchemeFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.MethodHandler;
-import com.liferay.portal.kernel.util.MethodKey;
-import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Attribute;
 import com.liferay.portal.kernel.xml.Element;
-import com.liferay.portal.kernel.zip.ZipReader;
-import com.liferay.portal.kernel.zip.ZipReaderFactoryUtil;
-import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutSet;
-import com.liferay.portal.model.PortletConstants;
-import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutSetLocalServiceUtil;
-import com.liferay.portal.theme.ThemeLoader;
-import com.liferay.portal.theme.ThemeLoaderFactory;
-import com.liferay.portal.util.PortalUtil;
-import com.liferay.portal.util.PropsValues;
-
-import java.io.InputStream;
-
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang.time.StopWatch;
 
 /**
  * @author Mate Thurzo
@@ -58,73 +31,14 @@ import org.apache.commons.lang.time.StopWatch;
 public class ThemeImporter {
 
 	public void importTheme(
-			PortletDataContext portletDataContext, Layout layout)
-		throws Exception {
-
-		boolean importTheme = MapUtil.getBoolean(
-			portletDataContext.getParameterMap(), PortletDataHandlerKeys.THEME);
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Import theme " + importTheme);
-		}
-
-		if (!importTheme || layout.isInheritLookAndFeel()) {
-			return;
-		}
-
-		StringBundler sb = new StringBundler(4);
-
-		sb.append("theme");
-		sb.append(StringPool.DASH);
-		sb.append(layout.getLayoutId());
-		sb.append(".zip");
-
-		InputStream themeZipInputStream =
-			portletDataContext.getZipEntryAsInputStream(sb.toString());
-
-		if (themeZipInputStream != null) {
-			String themeId = layout.getThemeId();
-			String colorSchemeId = layout.getColorSchemeId();
-
-			long groupId = portletDataContext.getGroupId();
-			boolean privateLayout = portletDataContext.isPrivateLayout();
-
-			Map<Long, Layout> newLayoutsMap =
-				(Map<Long, Layout>)portletDataContext.getNewPrimaryKeysMap(
-					Layout.class + ".layout");
-
-			Layout importedLayout = newLayoutsMap.get(layout.getLayoutId());
-
-			long layoutId = importedLayout.getLayoutId();
-
-			String importThemeId = importTheme(
-				groupId, privateLayout, layoutId, themeZipInputStream);
-
-			if (importThemeId != null) {
-				themeId = importThemeId;
-
-				colorSchemeId =
-					ColorSchemeFactoryUtil.getDefaultRegularColorSchemeId();
-			}
-
-			LayoutLocalServiceUtil.updateLookAndFeel(
-				groupId, privateLayout, layoutId, themeId, colorSchemeId,
-				importedLayout.getCss(), false);
-		}
-	}
-
-	public void importTheme(
 			PortletDataContext portletDataContext, LayoutSet layoutSet)
 		throws Exception {
 
-		boolean importTheme = MapUtil.getBoolean(
-			portletDataContext.getParameterMap(), PortletDataHandlerKeys.THEME);
 		boolean importThemeSettings = MapUtil.getBoolean(
 			portletDataContext.getParameterMap(),
 			PortletDataHandlerKeys.THEME_REFERENCE);
 
 		if (_log.isDebugEnabled()) {
-			_log.debug("Import theme " + importTheme);
 			_log.debug("Import theme settings " + importThemeSettings);
 		}
 
@@ -150,38 +64,6 @@ public class ThemeImporter {
 			}
 		}
 
-		InputStream themeZipInputStream = null;
-
-		if (importTheme) {
-			themeZipInputStream = portletDataContext.getZipEntryAsInputStream(
-				"theme.zip");
-		}
-
-		if (themeZipInputStream != null) {
-			StopWatch stopWatch = null;
-
-			if (_log.isDebugEnabled()) {
-				stopWatch = new StopWatch();
-
-				stopWatch.start();
-			}
-
-			String importThemeId = importTheme(
-				layoutSet.getGroupId(), layoutSet.isPrivateLayout(), 0,
-				themeZipInputStream);
-
-			if (importThemeId != null) {
-				themeId = importThemeId;
-				colorSchemeId =
-					ColorSchemeFactoryUtil.getDefaultRegularColorSchemeId();
-			}
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Importing theme takes " + stopWatch.getTime() + " ms");
-			}
-		}
-
 		String css = GetterUtil.getString(headerElement.elementText("css"));
 
 		LayoutSetLocalServiceUtil.updateLookAndFeel(
@@ -189,105 +71,6 @@ public class ThemeImporter {
 			colorSchemeId, css, false);
 	}
 
-	protected String importTheme(
-			long groupId, boolean privateLayout, long layoutId,
-			InputStream themeZipInputStream)
-		throws Exception {
-
-		ThemeLoader themeLoader = ThemeLoaderFactory.getDefaultThemeLoader();
-
-		if (themeLoader == null) {
-			_log.error("No theme loaders are deployed");
-
-			return null;
-		}
-
-		ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(
-			themeZipInputStream);
-
-		String lookAndFeelXML = zipReader.getEntryAsString(
-			"liferay-look-and-feel.xml");
-
-		StringBundler sb = new StringBundler();
-
-		sb.append(String.valueOf(groupId));
-
-		if (privateLayout) {
-			sb.append("-private");
-		}
-		else {
-			sb.append("-public");
-		}
-
-		if (Validator.isNotNull(layoutId)) {
-			sb.append(StringPool.DASH);
-			sb.append(String.valueOf(layoutId));
-		}
-
-		if (PropsValues.THEME_LOADER_NEW_THEME_ID_ON_IMPORT) {
-			sb.append(StringPool.DASH);
-			sb.append(Time.getShortTimestamp());
-		}
-
-		String themeId = sb.toString();
-
-		lookAndFeelXML = StringUtil.replace(
-			lookAndFeelXML,
-			new String[] {
-				"[$GROUP_ID$]", "[$THEME_ID$]", "[$THEME_NAME$]"
-			},
-			new String[] {
-				String.valueOf(groupId), themeId, themeId
-			}
-		);
-
-		FileUtil.deltree(
-			themeLoader.getFileStorage() + StringPool.SLASH + themeId);
-
-		List<String> zipEntries = zipReader.getEntries();
-
-		for (String zipEntry : zipEntries) {
-			String key = zipEntry;
-
-			sb = new StringBundler(5);
-
-			sb.append(themeLoader.getFileStorage());
-			sb.append(StringPool.SLASH);
-			sb.append(themeId);
-			sb.append(StringPool.SLASH);
-			sb.append(key);
-
-			String fileName = sb.toString();
-
-			if (key.equals("liferay-look-and-feel.xml")) {
-				FileUtil.write(fileName, lookAndFeelXML.getBytes());
-			}
-			else {
-				InputStream is = zipReader.getEntryAsInputStream(zipEntry);
-
-				FileUtil.write(fileName, is);
-			}
-		}
-
-		themeLoader.loadThemes();
-
-		ClusterRequest clusterRequest = ClusterRequest.createMulticastRequest(
-			_loadThemesMethodHandler, true);
-
-		clusterRequest.setFireAndForget(true);
-
-		ClusterExecutorUtil.execute(clusterRequest);
-
-		themeId +=
-			PortletConstants.WAR_SEPARATOR +
-				themeLoader.getServletContextName();
-
-		return PortalUtil.getJsSafePortletId(themeId);
-	}
-
 	private static Log _log = LogFactoryUtil.getLog(ThemeImporter.class);
-
-	private static MethodHandler _loadThemesMethodHandler = new MethodHandler(
-		new MethodKey(ThemeLoaderFactory.class, "loadThemes"));
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -886,9 +886,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 			new String[] {PortletDataHandlerKeys.
 				PORTLETS_MERGE_MODE_ADD_TO_BOTTOM});
 		parameterMap.put(
-			PortletDataHandlerKeys.THEME,
-			new String[] {Boolean.FALSE.toString()});
-		parameterMap.put(
 			PortletDataHandlerKeys.THEME_REFERENCE,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -119,6 +119,7 @@ import com.liferay.portlet.documentlibrary.DuplicateFileException;
 import com.liferay.portlet.documentlibrary.FileExtensionException;
 import com.liferay.portlet.documentlibrary.FileNameException;
 import com.liferay.portlet.documentlibrary.FileSizeException;
+import com.liferay.portlet.pluginsadmin.lar.ThemeStagingWrapper;
 
 import java.io.Serializable;
 
@@ -641,9 +642,19 @@ public class StagingImpl implements Staging {
 			JSONObject errorMessageJSONObject =
 				JSONFactoryUtil.createJSONObject();
 
+			String className = missingReference.getClassName();
 			Map<String, String> referrers = missingReference.getReferrers();
 
-			if (referrers.size() == 1) {
+			if (className.equals(ThemeStagingWrapper.class.getName())) {
+				errorMessageJSONObject.put(
+					"info",
+					LanguageUtil.format(
+						locale,
+						"the-referenced-theme-x-is-not-deployed-in-the-" +
+							"current-environment",
+						missingReference.getClassPk()));
+			}
+			else if (referrers.size() == 1) {
 				Set<Map.Entry<String, String>> referrerDisplayNames =
 					referrers.entrySet();
 

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -1086,9 +1086,6 @@ public class StagingImpl implements Staging {
 			PortletDataHandlerKeys.PORTLET_SETUP_ALL,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
-			PortletDataHandlerKeys.THEME,
-			new String[] {Boolean.FALSE.toString()});
-		parameterMap.put(
 			PortletDataHandlerKeys.THEME_REFERENCE,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
@@ -1173,12 +1170,6 @@ public class StagingImpl implements Staging {
 
 			parameterMap.put(
 				PortletDataHandlerKeys.PORTLET_DATA_ALL,
-				new String[] {Boolean.FALSE.toString()});
-		}
-
-		if (!parameterMap.containsKey(PortletDataHandlerKeys.THEME)) {
-			parameterMap.put(
-				PortletDataHandlerKeys.THEME,
 				new String[] {Boolean.FALSE.toString()});
 		}
 

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -212,7 +212,7 @@ public class LayoutStagedModelDataHandler
 		}
 
 		if (layout.isTypeArticle()) {
-			exportJournalArticle(portletDataContext, layout, layoutElement);
+			exportJournalArticle(portletDataContext, layout);
 		}
 		else if (layout.isTypeLinkToLayout()) {
 			exportLinkedLayout(portletDataContext, layout, layoutElement);
@@ -485,7 +485,7 @@ public class LayoutStagedModelDataHandler
 			PortletDataHandlerKeys.PORTLETS_MERGE_MODE_REPLACE);
 
 		if (layout.isTypeArticle()) {
-			importJournalArticle(portletDataContext, layout, layoutElement);
+			importJournalArticle(portletDataContext, layout);
 
 			updateTypeSettings(importedLayout, layout);
 		}
@@ -569,8 +569,7 @@ public class LayoutStagedModelDataHandler
 	}
 
 	protected void exportJournalArticle(
-			PortletDataContext portletDataContext, Layout layout,
-			Element layoutElement)
+			PortletDataContext portletDataContext, Layout layout)
 		throws Exception {
 
 		UnicodeProperties typeSettingsProperties =
@@ -816,8 +815,7 @@ public class LayoutStagedModelDataHandler
 	}
 
 	protected void importJournalArticle(
-			PortletDataContext portletDataContext, Layout layout,
-			Element layoutElement)
+			PortletDataContext portletDataContext, Layout layout)
 		throws Exception {
 
 		UnicodeProperties typeSettingsProperties =
@@ -832,7 +830,7 @@ public class LayoutStagedModelDataHandler
 
 		List<Element> referenceDataElements =
 			portletDataContext.getReferenceDataElements(
-				layoutElement, JournalArticle.class);
+				layout, JournalArticle.class);
 
 		if (!referenceDataElements.isEmpty()) {
 			StagedModelDataHandlerUtil.importReferenceStagedModel(

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -43,8 +43,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.lar.LayoutExporter;
-import com.liferay.portal.lar.ThemeExporter;
-import com.liferay.portal.lar.ThemeImporter;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Image;
 import com.liferay.portal.model.Layout;
@@ -74,6 +72,7 @@ import com.liferay.portlet.journal.NoSuchArticleException;
 import com.liferay.portlet.journal.model.JournalArticle;
 import com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.portlet.journal.service.JournalContentSearchLocalServiceUtil;
+import com.liferay.portlet.pluginsadmin.lar.ThemeStagingWrapper;
 import com.liferay.portlet.sites.util.SitesUtil;
 
 import java.io.IOException;
@@ -526,17 +525,20 @@ public class LayoutStagedModelDataHandler
 			PortletDataHandlerKeys.THEME_REFERENCE);
 
 		if (importThemeSettings) {
-			importedLayout.setThemeId(layout.getThemeId());
 			importedLayout.setColorSchemeId(layout.getColorSchemeId());
+			importedLayout.setCss(layout.getCss());
+			importedLayout.setThemeId(layout.getThemeId());
+			importedLayout.setWapColorSchemeId(layout.getWapColorSchemeId());
+			importedLayout.setWapThemeId(layout.getWapThemeId());
 		}
 		else {
-			importedLayout.setThemeId(StringPool.BLANK);
 			importedLayout.setColorSchemeId(StringPool.BLANK);
+			importedLayout.setCss(StringPool.BLANK);
+			importedLayout.setThemeId(StringPool.BLANK);
+			importedLayout.setWapColorSchemeId(StringPool.BLANK);
+			importedLayout.setWapThemeId(StringPool.BLANK);
 		}
 
-		importedLayout.setWapThemeId(layout.getWapThemeId());
-		importedLayout.setWapColorSchemeId(layout.getWapColorSchemeId());
-		importedLayout.setCss(layout.getCss());
 		importedLayout.setPriority(layout.getPriority());
 		importedLayout.setLayoutPrototypeUuid(layout.getLayoutPrototypeUuid());
 		importedLayout.setLayoutPrototypeLinkEnabled(
@@ -562,8 +564,6 @@ public class LayoutStagedModelDataHandler
 		layoutPlids.put(layout.getPlid(), importedLayout.getPlid());
 
 		importLayoutFriendlyURLs(portletDataContext, layout);
-
-		importTheme(portletDataContext, layout);
 
 		portletDataContext.importClassedModel(layout, importedLayout);
 	}
@@ -672,9 +672,28 @@ public class LayoutStagedModelDataHandler
 			PortletDataContext portletDataContext, Layout layout)
 		throws Exception {
 
-		ThemeExporter themeExporter = new ThemeExporter();
+		boolean exportThemeSettings = MapUtil.getBoolean(
+			portletDataContext.getParameterMap(),
+			PortletDataHandlerKeys.THEME_REFERENCE);
 
-		themeExporter.exportTheme(portletDataContext, layout);
+		if (_log.isDebugEnabled()) {
+			_log.debug("Export theme settings " + exportThemeSettings);
+		}
+
+		if (exportThemeSettings &&
+			!portletDataContext.isPerformDirectBinaryImport() &&
+			!layout.isInheritLookAndFeel()) {
+
+			ThemeStagingWrapper themeStagingWrapper = new ThemeStagingWrapper(
+				layout.getTheme());
+
+			Element layoutElement = portletDataContext.getExportDataElement(
+				layout);
+
+			portletDataContext.addReferenceElement(
+				layout, layoutElement, themeStagingWrapper,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+		}
 	}
 
 	protected Object[] extractFriendlyURLInfo(Layout layout) {
@@ -940,15 +959,6 @@ public class LayoutStagedModelDataHandler
 		}
 
 		updateTypeSettings(importedLayout, layout);
-	}
-
-	protected void importTheme(
-			PortletDataContext portletDataContext, Layout layout)
-		throws Exception {
-
-		ThemeImporter themeImporter = new ThemeImporter();
-
-		themeImporter.importTheme(portletDataContext, layout);
 	}
 
 	protected void initNewLayoutPermissions(

--- a/portal-impl/src/com/liferay/portlet/pluginsadmin/lar/ThemeStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/pluginsadmin/lar/ThemeStagedModelDataHandler.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.pluginsadmin.lar;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.lar.BaseStagedModelDataHandler;
+import com.liferay.portal.kernel.lar.PortletDataContext;
+import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.model.Theme;
+import com.liferay.portal.service.ThemeLocalServiceUtil;
+
+import java.util.List;
+
+/**
+ * @author Mate Thurzo
+ */
+public class ThemeStagedModelDataHandler
+	extends BaseStagedModelDataHandler<ThemeStagingWrapper> {
+
+	public static final String[] CLASS_NAMES =
+		{ThemeStagingWrapper.class.getName()};
+
+	@Override
+	public void deleteStagedModel(
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException, SystemException {
+	}
+
+	@Override
+	public String[] getClassNames() {
+		return CLASS_NAMES;
+	}
+
+	@Override
+	public String getDisplayName(ThemeStagingWrapper themeStagingWrapper) {
+		return themeStagingWrapper.getThemeId();
+	}
+
+	@Override
+	public boolean validateReference(
+		PortletDataContext portletDataContext, Element rootElement,
+		Element referenceElement) {
+
+		boolean importThemeSettings = MapUtil.getBoolean(
+			portletDataContext.getParameterMap(),
+			PortletDataHandlerKeys.THEME_REFERENCE);
+
+		if (!importThemeSettings) {
+			return true;
+		}
+
+		String elementName = referenceElement.getName();
+
+		if (elementName.equals("missing-reference")) {
+			String classPK = referenceElement.attributeValue("class-pk");
+
+			List<Theme> themes = ThemeLocalServiceUtil.getThemes(
+				portletDataContext.getCompanyId());
+
+			for (Theme theme : themes) {
+				if (theme.getThemeId().equals(classPK)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	protected void doExportStagedModel(
+			PortletDataContext portletDataContext,
+			ThemeStagingWrapper themeStagingWrapper)
+		throws Exception {
+	}
+
+	@Override
+	protected void doImportStagedModel(
+			PortletDataContext portletDataContext,
+			ThemeStagingWrapper themeStagingWrapper)
+		throws Exception {
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/pluginsadmin/lar/ThemeStagingWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/pluginsadmin/lar/ThemeStagingWrapper.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.pluginsadmin.lar;
+
+import com.liferay.portal.kernel.lar.StagedModelType;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.StagedModel;
+import com.liferay.portal.model.Theme;
+import com.liferay.portal.model.impl.ThemeImpl;
+import com.liferay.portal.security.auth.CompanyThreadLocal;
+import com.liferay.portlet.expando.model.ExpandoBridge;
+
+import java.io.Serializable;
+
+import java.util.Date;
+
+/**
+ * @author Mate Thurzo
+ */
+public class ThemeStagingWrapper extends ThemeImpl implements StagedModel {
+
+	public ThemeStagingWrapper(Theme theme) {
+		super(theme.getThemeId());
+	}
+
+	@Override
+	public Object clone() {
+		ThemeImpl themeImpl = new ThemeImpl(getThemeId());
+
+		return new ThemeStagingWrapper(themeImpl);
+	}
+
+	@Override
+	public long getCompanyId() {
+		return CompanyThreadLocal.getCompanyId();
+	}
+
+	@Override
+	public Date getCreateDate() {
+		return new Date();
+	}
+
+	@Override
+	public ExpandoBridge getExpandoBridge() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Class<?> getModelClass() {
+		return ThemeStagingWrapper.class;
+	}
+
+	@Override
+	public String getModelClassName() {
+		return ThemeStagingWrapper.class.getName();
+	}
+
+	@Override
+	public Date getModifiedDate() {
+		return new Date();
+	}
+
+	@Override
+	public Serializable getPrimaryKeyObj() {
+		return getThemeId();
+	}
+
+	@Override
+	public StagedModelType getStagedModelType() {
+		return new StagedModelType(ThemeStagingWrapper.class);
+	}
+
+	@Override
+	public String getUuid() {
+		return StringPool.BLANK;
+	}
+
+	@Override
+	public void setCompanyId(long companyId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setCreateDate(Date date) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setModifiedDate(Date date) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setPrimaryKeyObj(Serializable primaryKeyObj) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setUuid(String uuid) {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -667,9 +667,6 @@ public class SitesImpl implements Sites {
 			PortletDataHandlerKeys.PORTLET_SETUP_ALL,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
-			PortletDataHandlerKeys.THEME,
-			new String[] {Boolean.FALSE.toString()});
-		parameterMap.put(
 			PortletDataHandlerKeys.THEME_REFERENCE,
 			new String[] {Boolean.TRUE.toString()});
 		parameterMap.put(
@@ -1735,9 +1732,6 @@ public class SitesImpl implements Sites {
 		parameterMap.put(
 			PortletDataHandlerKeys.PORTLET_SETUP_ALL,
 			new String[] {Boolean.TRUE.toString()});
-		parameterMap.put(
-			PortletDataHandlerKeys.THEME,
-			new String[] {Boolean.FALSE.toString()});
 		parameterMap.put(
 			PortletDataHandlerKeys.THEME_REFERENCE,
 			new String[] {Boolean.TRUE.toString()});

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -218,6 +218,8 @@ category.wsrp=WSRP
 ## Model resources
 ##
 
+model.resource.com.liferay.portlet.pluginsadmin.lar.ThemeStagingWrapper=Theme
+
 model.resource.com.liferay.portal.kernel.repository.model.FileEntry=Document
 model.resource.com.liferay.portal.kernel.repository.model.Folder=Folder
 model.resource.com.liferay.portal.model.Group=Site
@@ -440,6 +442,8 @@ action.VIEW_USER=View User
 ##
 ## Messages
 ##
+
+the-referenced-theme-x-is-not-deployed-in-the-current-environment=The referenced theme {0} is not deployed in the current environment.
 
 1-day=1 Day
 1-minute=1 Minute

--- a/portal-service/src/com/liferay/portal/kernel/lar/MissingReference.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/MissingReference.java
@@ -30,6 +30,7 @@ public class MissingReference implements Serializable {
 
 	public MissingReference(Element element) {
 		_className = element.attributeValue("class-name");
+		_classPk = element.attributeValue("class-pk");
 		_displayName = GetterUtil.getString(
 			element.attributeValue("display-name"));
 		_referrerClassName = element.attributeValue("referrer-class-name");
@@ -55,6 +56,10 @@ public class MissingReference implements Serializable {
 		return _className;
 	}
 
+	public String getClassPk() {
+		return _classPk;
+	}
+
 	public String getDisplayName() {
 		return _displayName;
 	}
@@ -76,6 +81,7 @@ public class MissingReference implements Serializable {
 	}
 
 	private String _className;
+	private String _classPk;
 	private String _displayName;
 	private String _referrerClassName;
 	private Map<String, String> _referrers = new HashMap<String, String>();

--- a/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandlerKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/PortletDataHandlerKeys.java
@@ -114,8 +114,6 @@ public class PortletDataHandlerKeys {
 
 	public static final String SELECTED_LAYOUTS = "SELECTED_LAYOUTS";
 
-	public static final String THEME = "THEME";
-
 	public static final String THEME_REFERENCE = "THEME_REFERENCE";
 
 	public static final String UPDATE_LAST_PUBLISH_DATE =

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1261,6 +1261,7 @@
 		<icon>/html/icons/plugins_admin.png</icon>
 		<struts-path>plugins_admin</struts-path>
 		<portlet-url-class>com.liferay.portal.struts.StrutsActionPortletURL</portlet-url-class>
+		<staged-model-data-handler-class>com.liferay.portlet.pluginsadmin.lar.ThemeStagedModelDataHandler</staged-model-data-handler-class>
 		<control-panel-entry-category>apps</control-panel-entry-category>
 		<control-panel-entry-weight>5.0</control-panel-entry-weight>
 		<preferences-owned-by-group>true</preferences-owned-by-group>

--- a/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
@@ -137,8 +137,6 @@ portletURL.setParameter("rootNodeName", rootNodeName);
 								</aui:fieldset>
 
 								<aui:fieldset cssClass="portlet-data-section" label="look-and-feel">
-									<aui:input helpMessage="export-import-theme-help" label="theme" name="<%= PortletDataHandlerKeys.THEME %>" type="checkbox" value="<%= false %>" />
-
 									<aui:input helpMessage="export-import-theme-settings-help" label="theme-settings" name="<%= PortletDataHandlerKeys.THEME_REFERENCE %>" type="checkbox" value="<%= true %>" />
 
 									<aui:input label="logo" name="<%= PortletDataHandlerKeys.LOGO %>" type="checkbox" value="<%= true %>" />
@@ -602,7 +600,6 @@ portletURL.setParameter("rootNodeName", rootNodeName);
 			rangeLastNode: '#rangeLast',
 			ratingsNode: '#<%= PortletDataHandlerKeys.RATINGS %>Checkbox',
 			setupNode: '#<%= PortletDataHandlerKeys.PORTLET_SETUP_ALL %>Checkbox',
-			themeNode: '#<%= PortletDataHandlerKeys.THEME %>Checkbox',
 			themeReferenceNode: '#<%= PortletDataHandlerKeys.THEME_REFERENCE %>Checkbox',
 			userPreferencesNode: '#<%= PortletDataHandlerKeys.PORTLET_USER_PREFERENCES_ALL %>Checkbox'
 		}

--- a/portal-web/docroot/html/portlet/layouts_admin/import_layouts_resources.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/import_layouts_resources.jsp
@@ -184,8 +184,6 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 
 							<aui:input label="site-pages-settings" name="<%= PortletDataHandlerKeys.LAYOUT_SET_SETTINGS %>" type="checkbox" value="<%= true %>" />
 
-							<aui:input helpMessage="export-import-theme-help" label="theme" name="<%= PortletDataHandlerKeys.THEME %>" type="checkbox" value="<%= true %>" />
-
 							<aui:input helpMessage="export-import-theme-settings-help" label="theme-settings" name="<%= PortletDataHandlerKeys.THEME_REFERENCE %>" type="checkbox" value="<%= true %>" />
 
 							<aui:input label="logo" name="<%= PortletDataHandlerKeys.LOGO %>" type="checkbox" value="<%= true %>" />
@@ -591,7 +589,6 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 			namespace: '<portlet:namespace />',
 			ratingsNode: '#<%= PortletDataHandlerKeys.RATINGS %>Checkbox',
 			setupNode: '#<%= PortletDataHandlerKeys.PORTLET_SETUP_ALL %>Checkbox',
-			themeNode: '#<%= PortletDataHandlerKeys.THEME %>Checkbox',
 			themeReferenceNode: '#<%= PortletDataHandlerKeys.THEME_REFERENCE %>Checkbox',
 			userPreferencesNode: '#<%= PortletDataHandlerKeys.PORTLET_USER_PREFERENCES_ALL %>Checkbox'
 		}

--- a/portal-web/docroot/html/portlet/layouts_admin/js/main.js
+++ b/portal-web/docroot/html/portlet/layouts_admin/js/main.js
@@ -46,7 +46,6 @@ AUI.add(
 					remoteGroupIdNode: defaultConfig,
 					secureConnectionNode: defaultConfig,
 					setupNode: defaultConfig,
-					themeNode: defaultConfig,
 					themeReferenceNode: defaultConfig,
 					userPreferencesNode: defaultConfig
 				},
@@ -1129,10 +1128,6 @@ AUI.add(
 
 						if (instance._isChecked('layoutSetSettingsNode')) {
 							selectedPages.push(Liferay.Language.get('site-pages-settings'));
-						}
-
-						if (instance._isChecked('themeNode')) {
-							selectedPages.push(Liferay.Language.get('theme'));
 						}
 
 						if (instance._isChecked('themeReferenceNode')) {

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
@@ -463,7 +463,6 @@ else {
 			remoteGroupIdNode: '#<portlet:namespace />remoteGroupId',
 			secureConnectionNode: '#secureConnectionCheckbox',
 			setupNode: '#<%= PortletDataHandlerKeys.PORTLET_SETUP_ALL %>Checkbox',
-			themeNode: '#<%= PortletDataHandlerKeys.THEME %>Checkbox',
 			themeReferenceNode: '#<%= PortletDataHandlerKeys.THEME_REFERENCE %>Checkbox',
 			userPreferencesNode: '#<%= PortletDataHandlerKeys.PORTLET_USER_PREFERENCES_ALL %>Checkbox'
 		}

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_select_pages.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_select_pages.jspf
@@ -76,10 +76,6 @@
 	</aui:fieldset>
 
 	<aui:fieldset cssClass="portlet-data-section" label="look-and-feel">
-		<c:if test="<%= !localPublishing %>">
-			<aui:input helpMessage="export-import-theme-help" label="theme" name="<%= PortletDataHandlerKeys.THEME %>" type="checkbox" value="<%= false %>" />
-		</c:if>
-
 		<aui:input helpMessage="export-import-theme-settings-help" label="theme-settings" name="<%= PortletDataHandlerKeys.THEME_REFERENCE %>" type="checkbox" value="<%= true %>" />
 
 		<aui:input inlineLabel="right" label="logo" name="<%= PortletDataHandlerKeys.LOGO %>" type="checkbox" value="<%= true %>" />


### PR DESCRIPTION
Hey Brian,

I've added a wrapper object for Theme to fit in the staging so it could act like a StagedModel. I haven't modified the Theme interface or the ThemeImpl itself I wanted to separate this special staging logic being added for validation from the original behavior. This could be a good pattern in the future maybe for similar entities are not Classed/StagedModels

Wasn't sure about the name ThemeStagingWrapper, if you think something else would be good for it, just let me know and I'll rename it accordingly (with the language keys and other stuff)

Thanks,

Máté

reviewed by @KocsisDaniel
