### PR TITLE
LPS-39079

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/ActionUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/ActionUtil.java
@@ -116,9 +116,7 @@ public class ActionUtil {
 
 		String cmd = ParamUtil.getString(request, Constants.CMD);
 
-		if ((fileEntry.isInTrash() || fileEntry.isInTrashContainer()) &&
-			!cmd.equals(Constants.MOVE_FROM_TRASH)) {
-
+		if (fileEntry.isInTrash() && !cmd.equals(Constants.MOVE_FROM_TRASH)) {
 			throw new NoSuchFileEntryException();
 		}
 	}
@@ -200,7 +198,7 @@ public class ActionUtil {
 			if (folder.getModel() instanceof DLFolder) {
 				DLFolder dlFolder = (DLFolder)folder.getModel();
 
-				if (dlFolder.isInTrash() || dlFolder.isInTrashContainer()) {
+				if (dlFolder.isInTrash()) {
 					throw new NoSuchFolderException();
 				}
 			}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
@@ -364,9 +364,7 @@ public class DLPortletDataHandler extends BasePortletDataHandler {
 
 				DLFileEntry dlFileEntry = (DLFileEntry)object;
 
-				if (dlFileEntry.isInTrash() ||
-					dlFileEntry.isInTrashContainer()) {
-
+				if (dlFileEntry.isInTrash()) {
 					return;
 				}
 
@@ -434,7 +432,7 @@ public class DLPortletDataHandler extends BasePortletDataHandler {
 
 				DLFolder dlFolder = (DLFolder)object;
 
-				if (dlFolder.isInTrash() || dlFolder.isInTrashContainer()) {
+				if (dlFolder.isInTrash()) {
 					return;
 				}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.model.Lock;
 import com.liferay.portal.model.Repository;
 import com.liferay.portal.service.LockLocalServiceUtil;
 import com.liferay.portal.service.RepositoryLocalServiceUtil;
-import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryMetadata;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryType;
@@ -276,26 +275,6 @@ public class DLFileEntryImpl extends DLFileEntryBaseImpl {
 		}
 	}
 
-	@Override
-	public DLFolder getTrashContainer()
-		throws PortalException, SystemException {
-
-		DLFolder dlFolder = null;
-
-		try {
-			dlFolder = getFolder();
-		}
-		catch (NoSuchFolderException nsfe) {
-			return null;
-		}
-
-		if (dlFolder.isInTrash()) {
-			return dlFolder;
-		}
-
-		return dlFolder.getTrashContainer();
-	}
-
 	/**
 	 * @deprecated As of 6.2.0, replaced by {@link DLFileVersion#getUserId()}
 	 */
@@ -404,19 +383,6 @@ public class DLFileEntryImpl extends DLFileEntryBaseImpl {
 		else {
 			return false;
 		}
-	}
-
-	@Override
-	public boolean isInTrashContainer() {
-		try {
-			if (getTrashContainer() != null) {
-				return true;
-			}
-		}
-		catch (Exception e) {
-		}
-
-		return false;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileShortcutImpl.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Repository;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portal.service.RepositoryLocalServiceUtil;
-import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
@@ -81,26 +80,6 @@ public class DLFileShortcutImpl extends DLFileShortcutBaseImpl {
 	}
 
 	@Override
-	public DLFolder getTrashContainer()
-		throws PortalException, SystemException {
-
-		DLFolder dlFolder = null;
-
-		try {
-			dlFolder = getDLFolder();
-		}
-		catch (NoSuchFolderException nsfe) {
-			return null;
-		}
-
-		if (dlFolder.isInTrash()) {
-			return dlFolder;
-		}
-
-		return dlFolder.getTrashContainer();
-	}
-
-	@Override
 	public boolean isInHiddenFolder() {
 		try {
 			long repositoryId = getRepositoryId();
@@ -113,19 +92,6 @@ public class DLFileShortcutImpl extends DLFileShortcutBaseImpl {
 			DLFolder dlFolder = DLFolderLocalServiceUtil.getFolder(dlFolderId);
 
 			return dlFolder.isHidden();
-		}
-		catch (Exception e) {
-		}
-
-		return false;
-	}
-
-	@Override
-	public boolean isInTrashContainer() {
-		try {
-			if (getTrashContainer() != null) {
-				return true;
-			}
 		}
 		catch (Exception e) {
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileVersionImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.security.auth.PrincipalThreadLocal;
-import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
@@ -114,38 +113,6 @@ public class DLFileVersionImpl extends DLFileVersionBaseImpl {
 	@Override
 	public String getIcon() {
 		return DLUtil.getFileIcon(getExtension());
-	}
-
-	@Override
-	public DLFolder getTrashContainer()
-		throws PortalException, SystemException {
-
-		DLFolder dlFolder = null;
-
-		try {
-			dlFolder = getFolder();
-		}
-		catch (NoSuchFolderException nsfe) {
-			return null;
-		}
-
-		if (dlFolder.isInTrash()) {
-			return dlFolder;
-		}
-
-		return dlFolder.getTrashContainer();
-	}
-
-	@Override
-	public boolean isInTrashContainer()
-		throws PortalException, SystemException {
-
-		if (getTrashContainer() != null) {
-			return true;
-		}
-		else {
-			return false;
-		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFolderImpl.java
@@ -144,33 +144,6 @@ public class DLFolderImpl extends DLFolderBaseImpl {
 	}
 
 	@Override
-	public DLFolder getTrashContainer() {
-		DLFolder dlFolder = null;
-
-		try {
-			dlFolder = getParentFolder();
-		}
-		catch (Exception e) {
-			return null;
-		}
-
-		while (dlFolder != null) {
-			if (dlFolder.isInTrash()) {
-				return dlFolder;
-			}
-
-			try {
-				dlFolder = dlFolder.getParentFolder();
-			}
-			catch (Exception e) {
-				return null;
-			}
-		}
-
-		return null;
-	}
-
-	@Override
 	public boolean hasInheritableLock() {
 		try {
 			return DLFolderServiceUtil.hasInheritableLock(getFolderId());
@@ -208,16 +181,6 @@ public class DLFolderImpl extends DLFolderBaseImpl {
 		}
 
 		return false;
-	}
-
-	@Override
-	public boolean isInTrashContainer() {
-		if (getTrashContainer() != null) {
-			return true;
-		}
-		else {
-			return false;
-		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -1385,7 +1385,7 @@ public class DLAppHelperLocalServiceImpl
 			}
 
 			if ((oldStatus != WorkflowConstants.STATUS_IN_TRASH) &&
-				!fileEntry.isInTrashContainer()) {
+				!fileEntry.isInTrash()) {
 
 				// Social
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -74,7 +74,6 @@ import com.liferay.portlet.trash.util.TrashUtil;
 import java.io.Serializable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -416,27 +415,68 @@ public class DLAppHelperLocalServiceImpl
 	}
 
 	@Override
-	public void moveDependentsToTrash(List<Object> dlFileEntriesAndDLFolders)
+	public void moveDependentsToTrash(
+			List<Object> dlFileEntriesAndDLFolders, long trashEntryId)
 		throws PortalException, SystemException {
 
 		for (Object object : dlFileEntriesAndDLFolders) {
 			if (object instanceof DLFileEntry) {
+
+				// File entry
+
 				DLFileEntry dlFileEntry = (DLFileEntry)object;
+
+				if (dlFileEntry.isInTrash()) {
+					continue;
+				}
+
+				// File shortcut
+
+				dlFileShortcutLocalService.disableFileShortcuts(
+					dlFileEntry.getFileEntryId());
+
+				// File Versions
 
 				List<DLFileVersion> dlFileVersions =
 					dlFileVersionLocalService.getFileVersions(
 						dlFileEntry.getFileEntryId(),
 						WorkflowConstants.STATUS_ANY);
 
-				dlFileVersions = ListUtil.copy(dlFileVersions);
+				for (DLFileVersion dlFileVersion : dlFileVersions) {
 
-				Collections.sort(
-					dlFileVersions, new FileVersionVersionComparator());
+					// File version
 
-				// File shortcut
+					int oldStatus = dlFileVersion.getStatus();
 
-				dlFileShortcutLocalService.disableFileShortcuts(
-					dlFileEntry.getFileEntryId());
+					dlFileVersion.setStatus(WorkflowConstants.STATUS_IN_TRASH);
+
+					dlFileVersionPersistence.update(dlFileVersion);
+
+					// Trash
+
+					int status = oldStatus;
+
+					if (oldStatus == WorkflowConstants.STATUS_PENDING) {
+						status = WorkflowConstants.STATUS_DRAFT;
+					}
+
+					if (oldStatus != WorkflowConstants.STATUS_APPROVED) {
+						trashVersionLocalService.addTrashVersion(
+							trashEntryId, DLFileVersion.class.getName(),
+							dlFileVersion.getFileVersionId(), status);
+					}
+
+					// Workflow
+
+					if (oldStatus == WorkflowConstants.STATUS_PENDING) {
+						workflowInstanceLinkLocalService.
+							deleteWorkflowInstanceLink(
+								dlFileVersion.getCompanyId(),
+								dlFileVersion.getGroupId(),
+								DLFileEntryConstants.getClassName(),
+								dlFileVersion.getFileVersionId());
+					}
+				}
 
 				// Asset
 
@@ -450,30 +490,29 @@ public class DLAppHelperLocalServiceImpl
 					DLFileEntry.class);
 
 				indexer.reindex(dlFileEntry);
-
-				// Workflow
-
-				for (DLFileVersion dlFileVersion : dlFileVersions) {
-					if (!dlFileVersion.isPending()) {
-						continue;
-					}
-
-					dlFileVersion.setStatus(WorkflowConstants.STATUS_DRAFT);
-
-					dlFileVersionPersistence.update(dlFileVersion);
-
-					workflowInstanceLinkLocalService.deleteWorkflowInstanceLink(
-						dlFileVersion.getCompanyId(),
-						dlFileVersion.getGroupId(),
-						DLFileEntryConstants.getClassName(),
-						dlFileVersion.getFileVersionId());
-				}
 			}
 			else if (object instanceof DLFolder) {
+
+				// Folder
+
 				DLFolder dlFolder = (DLFolder)object;
 
 				if (dlFolder.isInTrash()) {
 					continue;
+				}
+
+				int oldStatus = dlFolder.getStatus();
+
+				dlFolder.setStatus(WorkflowConstants.STATUS_IN_TRASH);
+
+				dlFolderPersistence.update(dlFolder);
+
+				// Trash
+
+				if (oldStatus != WorkflowConstants.STATUS_APPROVED) {
+					trashVersionLocalService.addTrashVersion(
+						trashEntryId, DLFolder.class.getName(),
+						dlFolder.getFolderId(), oldStatus);
 				}
 
 				// Folders, file entries, and file shortcuts
@@ -487,7 +526,8 @@ public class DLAppHelperLocalServiceImpl
 							dlFolder.getGroupId(), dlFolder.getFolderId(), null,
 							false, queryDefinition);
 
-				moveDependentsToTrash(foldersAndFileEntriesAndFileShortcuts);
+				moveDependentsToTrash(
+					foldersAndFileEntriesAndFileShortcuts, trashEntryId);
 
 				// Asset
 
@@ -733,29 +773,52 @@ public class DLAppHelperLocalServiceImpl
 
 	@Override
 	public void restoreDependentsFromTrash(
-			List<Object> dlFileEntriesAndDLFolders)
+			List<Object> dlFileEntriesAndDLFolders, long trashEntryId)
 		throws PortalException, SystemException {
 
 		for (Object object : dlFileEntriesAndDLFolders) {
 			if (object instanceof DLFileEntry) {
+
+				// File entry
+
 				DLFileEntry dlFileEntry = (DLFileEntry)object;
+
+				TrashEntry trashEntry = trashEntryLocalService.fetchEntry(
+					DLFileEntry.class.getName(), dlFileEntry.getFileEntryId());
+
+				if (trashEntry != null) {
+					continue;
+				}
+
+				// File versions
 
 				List<DLFileVersion> dlFileVersions =
 					dlFileVersionLocalService.getFileVersions(
 						dlFileEntry.getFileEntryId(),
-						WorkflowConstants.STATUS_ANY);
+						WorkflowConstants.STATUS_IN_TRASH);
 
-				dlFileVersions = ListUtil.copy(dlFileVersions);
+				for (DLFileVersion dlFileVersion : dlFileVersions) {
+					TrashVersion trashVersion =
+						trashVersionLocalService.fetchVersion(
+							trashEntryId, DLFileVersion.class.getName(),
+							dlFileVersion.getFileVersionId());
 
-				Collections.sort(
-					dlFileVersions, new FileVersionVersionComparator());
+					int oldStatus = WorkflowConstants.STATUS_APPROVED;
 
-				DLFileVersion latestDlFileVersion = dlFileVersions.get(0);
+					if (trashVersion != null) {
+						oldStatus = trashVersion.getStatus();
+					}
 
-				if (latestDlFileVersion.getStatus() ==
-						WorkflowConstants.STATUS_IN_TRASH) {
+					dlFileVersion.setStatus(oldStatus);
 
-					continue;
+					dlFileVersionPersistence.update(dlFileVersion);
+
+					// Trash
+
+					if (trashVersion != null) {
+						trashVersionLocalService.deleteTrashVersion(
+							trashVersion);
+					}
 				}
 
 				// File shortcut
@@ -764,6 +827,9 @@ public class DLAppHelperLocalServiceImpl
 					dlFileEntry.getFileEntryId());
 
 				// Asset
+
+				DLFileVersion latestDlFileVersion =
+					dlFileEntry.getLatestFileVersion(false);
 
 				if (latestDlFileVersion.isApproved()) {
 					assetEntryLocalService.updateVisible(
@@ -779,11 +845,32 @@ public class DLAppHelperLocalServiceImpl
 				indexer.reindex(dlFileEntry);
 			}
 			else if (object instanceof DLFolder) {
+
+				// Folder
+
 				DLFolder dlFolder = (DLFolder)object;
 
-				if (dlFolder.isInTrash()) {
+				TrashEntry trashEntry = trashEntryLocalService.fetchEntry(
+					DLFolder.class.getName(), dlFolder.getFolderId());
+
+				if (trashEntry != null) {
 					continue;
 				}
+
+				TrashVersion trashVersion =
+					trashVersionLocalService.fetchVersion(
+						trashEntryId, DLFolder.class.getName(),
+						dlFolder.getFolderId());
+
+				int oldStatus = WorkflowConstants.STATUS_APPROVED;
+
+				if (trashVersion != null) {
+					oldStatus = trashVersion.getStatus();
+				}
+
+				dlFolder.setStatus(oldStatus);
+
+				dlFolderPersistence.update(dlFolder);
 
 				// Folders, file entries, and file shortcuts
 
@@ -797,7 +884,13 @@ public class DLAppHelperLocalServiceImpl
 							false, queryDefinition);
 
 				restoreDependentsFromTrash(
-					foldersAndFileEntriesAndFileShortcuts);
+					foldersAndFileEntriesAndFileShortcuts, trashEntryId);
+
+				// Trash
+
+				if (trashVersion != null) {
+					trashVersionLocalService.deleteTrashVersion(trashVersion);
+				}
 
 				// Asset
 
@@ -934,8 +1027,11 @@ public class DLAppHelperLocalServiceImpl
 
 		dlFolderPersistence.update(dlFolder);
 
+		TrashEntry trashEntry = trashEntryLocalService.getEntry(
+			DLFolder.class.getName(), dlFolder.getFolderId());
+
 		dlFolderLocalService.updateStatus(
-			userId, folder.getFolderId(), WorkflowConstants.STATUS_APPROVED,
+			userId, folder.getFolderId(), trashEntry.getStatus(),
 			new HashMap<String, Serializable>(), new ServiceContext());
 
 		// File rank
@@ -945,7 +1041,7 @@ public class DLAppHelperLocalServiceImpl
 		// Folders, file entries, and file shortcuts
 
 		QueryDefinition queryDefinition = new QueryDefinition(
-			WorkflowConstants.STATUS_ANY);
+			WorkflowConstants.STATUS_IN_TRASH);
 
 		List<Object> foldersAndFileEntriesAndFileShortcuts =
 			dlFolderLocalService.getFoldersAndFileEntriesAndFileShortcuts(
@@ -953,7 +1049,7 @@ public class DLAppHelperLocalServiceImpl
 				queryDefinition);
 
 		dlAppHelperLocalService.restoreDependentsFromTrash(
-			foldersAndFileEntriesAndFileShortcuts);
+			foldersAndFileEntriesAndFileShortcuts, trashEntry.getEntryId());
 
 		// Sync
 
@@ -962,8 +1058,7 @@ public class DLAppHelperLocalServiceImpl
 
 		// Trash
 
-		trashEntryLocalService.deleteEntry(
-			DLFolderConstants.getClassName(), dlFolder.getFolderId());
+		trashEntryLocalService.deleteEntry(trashEntry.getEntryId());
 
 		// Social
 
@@ -1351,14 +1446,13 @@ public class DLAppHelperLocalServiceImpl
 
 		// File entry
 
-		List<DLFileVersion> dlFileVersions =
-			dlFileVersionLocalService.getFileVersions(
-				fileEntry.getFileEntryId(), WorkflowConstants.STATUS_ANY);
+		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
-		dlFileVersions = ListUtil.sort(
-			dlFileVersions, new FileVersionVersionComparator());
+		TrashEntry trashEntry = dlFileEntry.getTrashEntry();
 
-		if (fileEntry.isInTrash()) {
+		if (trashEntry.isTrashEntry(
+				DLFileEntry.class, dlFileEntry.getFileEntryId())) {
+
 			restoreFileEntryFromTrash(userId, fileEntry);
 
 			fileEntry = dlAppLocalService.moveFileEntry(
@@ -1373,11 +1467,55 @@ public class DLAppHelperLocalServiceImpl
 			return fileEntry;
 		}
 
+		List<DLFileVersion> dlFileVersions =
+			dlFileVersionLocalService.getFileVersions(
+				fileEntry.getFileEntryId(), WorkflowConstants.STATUS_IN_TRASH);
+
+		dlFileVersions = ListUtil.sort(
+			dlFileVersions, new FileVersionVersionComparator());
+
 		FileVersion fileVersion = new LiferayFileVersion(dlFileVersions.get(0));
 
+		TrashVersion trashVersion = trashVersionLocalService.fetchVersion(
+			trashEntry.getEntryId(), DLFileVersion.class.getName(),
+			fileVersion.getFileVersionId());
+
+		int oldStatus = WorkflowConstants.STATUS_APPROVED;
+
+		if (trashVersion != null) {
+			oldStatus = trashVersion.getStatus();
+		}
+
 		dlFileEntryLocalService.updateStatus(
-			userId, fileVersion.getFileVersionId(), fileVersion.getStatus(),
+			userId, fileVersion.getFileVersionId(), oldStatus,
 			new HashMap<String, Serializable>(), serviceContext);
+
+		// File versions
+
+		for (DLFileVersion dlFileVersion : dlFileVersions) {
+
+			// File version
+
+			trashVersion = trashVersionLocalService.fetchVersion(
+				trashEntry.getEntryId(), DLFileVersion.class.getName(),
+				dlFileVersion.getFileVersionId());
+
+			oldStatus = WorkflowConstants.STATUS_APPROVED;
+
+			if (trashVersion != null) {
+				oldStatus = trashVersion.getStatus();
+			}
+
+			dlFileVersion.setStatus(oldStatus);
+
+			dlFileVersionPersistence.update(dlFileVersion);
+
+			// Trash
+
+			if (trashVersion != null) {
+				trashVersionLocalService.deleteTrashVersion(trashVersion);
+			}
+		}
 
 		if (DLAppHelperThreadLocal.isEnabled()) {
 
@@ -1530,15 +1668,28 @@ public class DLAppHelperLocalServiceImpl
 
 		DLFolder dlFolder = (DLFolder)folder.getModel();
 
-		if (dlFolder.isInTrash()) {
+		TrashEntry trashEntry = dlFolder.getTrashEntry();
+
+		if (trashEntry.isTrashEntry(DLFolder.class, dlFolder.getFolderId())) {
 			restoreFolderFromTrash(userId, folder);
 		}
 		else {
 
 			// Folder
 
+			TrashVersion trashVersion =
+				trashVersionLocalService.fetchVersion(
+					trashEntry.getEntryId(), DLFolder.class.getName(),
+					dlFolder.getFolderId());
+
+			int status = WorkflowConstants.STATUS_APPROVED;
+
+			if (trashVersion != null) {
+				status = trashVersion.getStatus();
+			}
+
 			dlFolderLocalService.updateStatus(
-				userId, folder.getFolderId(), WorkflowConstants.STATUS_APPROVED,
+				userId, folder.getFolderId(), status,
 				new HashMap<String, Serializable>(), new ServiceContext());
 
 			// File rank
@@ -1546,10 +1697,16 @@ public class DLAppHelperLocalServiceImpl
 			dlFileRankLocalService.enableFileRanksByFolderId(
 				folder.getFolderId());
 
+			// Trash
+
+			if (trashVersion != null) {
+				trashVersionLocalService.deleteTrashVersion(trashVersion);
+			}
+
 			// Folders, file entries, and file shortcuts
 
 			QueryDefinition queryDefinition = new QueryDefinition(
-				WorkflowConstants.STATUS_ANY);
+				WorkflowConstants.STATUS_IN_TRASH);
 
 			List<Object> foldersAndFileEntriesAndFileShortcuts =
 				dlFolderLocalService.getFoldersAndFileEntriesAndFileShortcuts(
@@ -1557,7 +1714,7 @@ public class DLAppHelperLocalServiceImpl
 					queryDefinition);
 
 			dlAppHelperLocalService.restoreDependentsFromTrash(
-				foldersAndFileEntriesAndFileShortcuts);
+				foldersAndFileEntriesAndFileShortcuts, trashEntry.getEntryId());
 
 			// Sync
 
@@ -1620,7 +1777,7 @@ public class DLAppHelperLocalServiceImpl
 				queryDefinition);
 
 		dlAppHelperLocalService.moveDependentsToTrash(
-			foldersAndFileEntriesAndFileShortcuts);
+			foldersAndFileEntriesAndFileShortcuts, trashEntry.getEntryId());
 
 		// Sync
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackRegistryUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -1637,6 +1638,30 @@ public class DLAppHelperLocalServiceImpl
 			extraDataJSONObject.toString(), 0);
 
 		return new LiferayFolder(dlFolder);
+	}
+
+	protected List<ObjectValuePair<Long, Integer>> getDlFileVersionStatuses(
+		List<DLFileVersion> dlFileVersions) {
+
+		List<ObjectValuePair<Long, Integer>> dlFileVersionStatusOVPs =
+			new ArrayList<ObjectValuePair<Long, Integer>>(
+				dlFileVersions.size());
+
+		for (DLFileVersion dlFileVersion : dlFileVersions) {
+			int status = dlFileVersion.getStatus();
+
+			if (status == WorkflowConstants.STATUS_PENDING) {
+				status = WorkflowConstants.STATUS_DRAFT;
+			}
+
+			ObjectValuePair<Long, Integer> dlFileVersionStatusOVP =
+				new ObjectValuePair<Long, Integer>(
+					dlFileVersion.getFileVersionId(), status);
+
+			dlFileVersionStatusOVPs.add(dlFileVersionStatusOVP);
+		}
+
+		return dlFileVersionStatusOVPs;
 	}
 
 	protected long getFileEntryTypeId(FileEntry fileEntry) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.transaction.TransactionCommitCallbackRegistryUt
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
@@ -835,35 +836,47 @@ public class DLAppHelperLocalServiceImpl
 
 		// File version
 
-		Map<String, Serializable> workflowContext =
-			new HashMap<String, Serializable>();
+		dlFileEntryLocalService.updateStatus(
+			userId, fileVersion.getFileVersionId(), trashEntry.getStatus(),
+			new HashMap<String, Serializable>(), new ServiceContext());
+
+		if (DLAppHelperThreadLocal.isEnabled()) {
+
+			// File shortcut
+
+			dlFileShortcutLocalService.enableFileShortcuts(
+				fileEntry.getFileEntryId());
+
+			// File rank
+
+			dlFileRankLocalService.enableFileRanks(fileEntry.getFileEntryId());
+
+			// Sync
+
+			registerDLSyncEventCallback(
+				DLSyncConstants.EVENT_RESTORE_FROM_TRASH, fileEntry);
+		}
+
+		// Trash
 
 		List<TrashVersion> trashVersions = trashVersionLocalService.getVersions(
 			trashEntry.getEntryId());
 
-		workflowContext.put("trashVersions", (Serializable)trashVersions);
+		for (TrashVersion trashVersion : trashVersions) {
+			DLFileVersion trashDLFileVersion =
+				dlFileVersionPersistence.findByPrimaryKey(
+					trashVersion.getClassPK());
 
-		dlFileEntryLocalService.updateStatus(
-			userId, fileVersion.getFileVersionId(), trashEntry.getStatus(),
-			workflowContext, new ServiceContext());
+			trashDLFileVersion.setStatus(trashVersion.getStatus());
+
+			dlFileVersionPersistence.update(trashDLFileVersion);
+		}
+
+		trashEntryLocalService.deleteEntry(trashEntry.getEntryId());
 
 		if (!DLAppHelperThreadLocal.isEnabled()) {
 			return;
 		}
-
-		// File shortcut
-
-		dlFileShortcutLocalService.enableFileShortcuts(
-			fileEntry.getFileEntryId());
-
-		// File rank
-
-		dlFileRankLocalService.enableFileRanks(fileEntry.getFileEntryId());
-
-		// Sync
-
-		registerDLSyncEventCallback(
-			DLSyncConstants.EVENT_RESTORE_FROM_TRASH, fileEntry);
 
 		// Social
 
@@ -929,10 +942,28 @@ public class DLAppHelperLocalServiceImpl
 
 		dlFileRankLocalService.enableFileRanksByFolderId(folder.getFolderId());
 
+		// Folders, file entries, and file shortcuts
+
+		QueryDefinition queryDefinition = new QueryDefinition(
+			WorkflowConstants.STATUS_ANY);
+
+		List<Object> foldersAndFileEntriesAndFileShortcuts =
+			dlFolderLocalService.getFoldersAndFileEntriesAndFileShortcuts(
+				dlFolder.getGroupId(), dlFolder.getFolderId(), null, false,
+				queryDefinition);
+
+		dlAppHelperLocalService.restoreDependentsFromTrash(
+			foldersAndFileEntriesAndFileShortcuts);
+
 		// Sync
 
 		registerDLSyncEventCallback(
 			DLSyncConstants.EVENT_RESTORE_FROM_TRASH, folder);
+
+		// Trash
+
+		trashEntryLocalService.deleteEntry(
+			DLFolderConstants.getClassName(), dlFolder.getFolderId());
 
 		// Social
 
@@ -1399,24 +1430,63 @@ public class DLAppHelperLocalServiceImpl
 
 		FileVersion fileVersion = new LiferayFileVersion(dlFileVersions.get(0));
 
-		Map<String, Serializable> workflowContext =
-			new HashMap<String, Serializable>();
-
-		workflowContext.put("dlFileVersions", (Serializable)dlFileVersions);
-
 		int oldStatus = fileVersion.getStatus();
 
 		dlFileEntryLocalService.updateStatus(
 			userId, fileVersion.getFileVersionId(),
-			WorkflowConstants.STATUS_IN_TRASH, workflowContext,
-			new ServiceContext());
+			WorkflowConstants.STATUS_IN_TRASH,
+			new HashMap<String, Serializable>(), new ServiceContext());
 
-		// File entry
+		if (DLAppHelperThreadLocal.isEnabled()) {
+
+			// File shortcut
+
+			dlFileShortcutLocalService.disableFileShortcuts(
+				fileEntry.getFileEntryId());
+
+			// File rank
+
+			dlFileRankLocalService.disableFileRanks(fileEntry.getFileEntryId());
+
+			// Sync
+
+			registerDLSyncEventCallback(
+				DLSyncConstants.EVENT_MOVE_TO_TRASH, fileEntry);
+		}
+
+		// Trash
+
+		int oldDLFileVersionStatus = WorkflowConstants.STATUS_ANY;
+
+		List<ObjectValuePair<Long, Integer>> dlFileVersionStatusOVPs =
+			new ArrayList<ObjectValuePair<Long, Integer>>();
+
+		if ((dlFileVersions != null) && !dlFileVersions.isEmpty()) {
+			DLFileVersion oldDLFileVersion = dlFileVersions.get(0);
+
+			oldDLFileVersionStatus = oldDLFileVersion.getStatus();
+
+			dlFileVersionStatusOVPs = getDlFileVersionStatuses(dlFileVersions);
+		}
+
+		for (DLFileVersion curDLFileVersion : dlFileVersions) {
+			curDLFileVersion.setStatus(WorkflowConstants.STATUS_IN_TRASH);
+
+			dlFileVersionPersistence.update(curDLFileVersion);
+		}
 
 		DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
 
-		TrashEntry trashEntry = trashEntryLocalService.getEntry(
-			DLFileEntryConstants.getClassName(), dlFileEntry.getFileEntryId());
+		UnicodeProperties typeSettingsProperties = new UnicodeProperties();
+
+		typeSettingsProperties.put("title", dlFileEntry.getTitle());
+
+		TrashEntry trashEntry = trashEntryLocalService.addTrashEntry(
+			userId, dlFileEntry.getGroupId(),
+			DLFileEntryConstants.getClassName(), dlFileEntry.getFileEntryId(),
+			dlFileEntry.getUuid(), dlFileEntry.getClassName(),
+			oldDLFileVersionStatus, dlFileVersionStatusOVPs,
+			typeSettingsProperties);
 
 		String trashTitle = TrashUtil.getTrashTitle(trashEntry.getEntryId());
 
@@ -1427,20 +1497,6 @@ public class DLAppHelperLocalServiceImpl
 		if (!DLAppHelperThreadLocal.isEnabled()) {
 			return fileEntry;
 		}
-
-		// File shortcut
-
-		dlFileShortcutLocalService.disableFileShortcuts(
-			fileEntry.getFileEntryId());
-
-		// File rank
-
-		dlFileRankLocalService.disableFileRanks(fileEntry.getFileEntryId());
-
-		// Sync
-
-		registerDLSyncEventCallback(
-			DLSyncConstants.EVENT_MOVE_TO_TRASH, fileEntry);
 
 		// Social
 
@@ -1490,6 +1546,19 @@ public class DLAppHelperLocalServiceImpl
 			dlFileRankLocalService.enableFileRanksByFolderId(
 				folder.getFolderId());
 
+			// Folders, file entries, and file shortcuts
+
+			QueryDefinition queryDefinition = new QueryDefinition(
+				WorkflowConstants.STATUS_ANY);
+
+			List<Object> foldersAndFileEntriesAndFileShortcuts =
+				dlFolderLocalService.getFoldersAndFileEntriesAndFileShortcuts(
+					dlFolder.getGroupId(), dlFolder.getFolderId(), null, false,
+					queryDefinition);
+
+			dlAppHelperLocalService.restoreDependentsFromTrash(
+				foldersAndFileEntriesAndFileShortcuts);
+
 			// Sync
 
 			registerDLSyncEventCallback(
@@ -1521,18 +1590,37 @@ public class DLAppHelperLocalServiceImpl
 			userId, folder.getFolderId(), WorkflowConstants.STATUS_IN_TRASH,
 			new HashMap<String, Serializable>(), new ServiceContext());
 
-		TrashEntry trashEntry = trashEntryLocalService.getEntry(
-			DLFolderConstants.getClassName(), dlFolder.getFolderId());
-
-		String trashTitle = TrashUtil.getTrashTitle(trashEntry.getEntryId());
-
-		dlFolder.setName(trashTitle);
-
-		dlFolderPersistence.update(dlFolder);
-
 		// File rank
 
 		dlFileRankLocalService.disableFileRanksByFolderId(folder.getFolderId());
+
+		// Trash
+
+		UnicodeProperties typeSettingsProperties = new UnicodeProperties();
+
+		typeSettingsProperties.put("title", dlFolder.getName());
+
+		TrashEntry trashEntry = trashEntryLocalService.addTrashEntry(
+			userId, dlFolder.getGroupId(), DLFolderConstants.getClassName(),
+			dlFolder.getFolderId(), dlFolder.getUuid(), null,
+			WorkflowConstants.STATUS_APPROVED, null, typeSettingsProperties);
+
+		dlFolder.setName(TrashUtil.getTrashTitle(trashEntry.getEntryId()));
+
+		dlFolderPersistence.update(dlFolder);
+
+		// Folders, file entries, and file shortcuts
+
+		QueryDefinition queryDefinition = new QueryDefinition(
+			WorkflowConstants.STATUS_ANY);
+
+		List<Object> foldersAndFileEntriesAndFileShortcuts =
+			dlFolderLocalService.getFoldersAndFileEntriesAndFileShortcuts(
+				dlFolder.getGroupId(), dlFolder.getFolderId(), null, false,
+				queryDefinition);
+
+		dlAppHelperLocalService.moveDependentsToTrash(
+			foldersAndFileEntriesAndFileShortcuts);
 
 		// Sync
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1382,10 +1382,6 @@ public class DLFileEntryLocalServiceImpl
 			companyId, queryDefinition);
 
 		for (DLFileEntry dlFileEntry : dlFileEntries) {
-			if (dlFileEntry.isInTrashContainer()) {
-				continue;
-			}
-
 			dlFileEntry.setTreePath(dlFileEntry.buildTreePath());
 
 			dlFileEntryPersistence.update(dlFileEntry);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -1988,30 +1988,6 @@ public class DLFileEntryLocalServiceImpl
 		}
 	}
 
-	protected List<ObjectValuePair<Long, Integer>> getDlFileVersionStatuses(
-		List<DLFileVersion> dlFileVersions) {
-
-		List<ObjectValuePair<Long, Integer>> dlFileVersionStatusOVPs =
-			new ArrayList<ObjectValuePair<Long, Integer>>(
-				dlFileVersions.size());
-
-		for (DLFileVersion dlFileVersion : dlFileVersions) {
-			int status = dlFileVersion.getStatus();
-
-			if (status == WorkflowConstants.STATUS_PENDING) {
-				status = WorkflowConstants.STATUS_DRAFT;
-			}
-
-			ObjectValuePair<Long, Integer> dlFileVersionStatusOVP =
-				new ObjectValuePair<Long, Integer>(
-					dlFileVersion.getFileVersionId(), status);
-
-			dlFileVersionStatusOVPs.add(dlFileVersionStatusOVP);
-		}
-
-		return dlFileVersionStatusOVPs;
-	}
-
 	protected String getNextVersion(
 			DLFileEntry dlFileEntry, boolean majorVersion, int workflowAction)
 		throws PortalException, SystemException {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -105,7 +104,6 @@ import com.liferay.portlet.expando.model.ExpandoColumnConstants;
 import com.liferay.portlet.expando.model.ExpandoRow;
 import com.liferay.portlet.expando.model.ExpandoTable;
 import com.liferay.portlet.expando.util.ExpandoBridgeFactoryUtil;
-import com.liferay.portlet.trash.model.TrashVersion;
 
 import java.awt.image.RenderedImage;
 
@@ -1598,22 +1596,6 @@ public class DLFileEntryLocalServiceImpl
 
 		int oldStatus = dlFileVersion.getStatus();
 
-		int oldDLFileVersionStatus = WorkflowConstants.STATUS_ANY;
-
-		List<ObjectValuePair<Long, Integer>> dlFileVersionStatusOVPs =
-			new ArrayList<ObjectValuePair<Long, Integer>>();
-
-		List<DLFileVersion> dlFileVersions =
-			(List<DLFileVersion>)workflowContext.get("dlFileVersions");
-
-		if ((dlFileVersions != null) && !dlFileVersions.isEmpty()) {
-			DLFileVersion oldDLFileVersion = dlFileVersions.get(0);
-
-			oldDLFileVersionStatus = oldDLFileVersion.getStatus();
-
-			dlFileVersionStatusOVPs = getDlFileVersionStatuses(dlFileVersions);
-		}
-
 		dlFileVersion.setStatus(status);
 		dlFileVersion.setStatusByUserId(user.getUserId());
 		dlFileVersion.setStatusByUserName(user.getFullName());
@@ -1678,58 +1660,6 @@ public class DLFileEntryLocalServiceImpl
 
 				indexer.delete(dlFileEntry);
 			}
-		}
-
-		// File versions
-
-		if (oldStatus == WorkflowConstants.STATUS_IN_TRASH) {
-
-			// Trash
-
-			List<TrashVersion> trashVersions =
-				(List<TrashVersion>)workflowContext.get("trashVersions");
-
-			for (TrashVersion trashVersion : trashVersions) {
-				DLFileVersion trashDLFileVersion =
-					dlFileVersionPersistence.findByPrimaryKey(
-						trashVersion.getClassPK());
-
-				trashDLFileVersion.setStatus(trashVersion.getStatus());
-
-				dlFileVersionPersistence.update(trashDLFileVersion);
-			}
-
-			trashEntryLocalService.deleteEntry(
-				DLFileEntryConstants.getClassName(),
-				dlFileEntry.getFileEntryId());
-
-			// Indexer
-
-			Indexer indexer = IndexerRegistryUtil.nullSafeGetIndexer(
-				DLFileEntry.class);
-
-			indexer.delete(dlFileEntry);
-		}
-		else if (status == WorkflowConstants.STATUS_IN_TRASH) {
-
-			// Trash
-
-			for (DLFileVersion curDLFileVersion : dlFileVersions) {
-				curDLFileVersion.setStatus(WorkflowConstants.STATUS_IN_TRASH);
-
-				dlFileVersionPersistence.update(curDLFileVersion);
-			}
-
-			UnicodeProperties typeSettingsProperties = new UnicodeProperties();
-
-			typeSettingsProperties.put("title", dlFileEntry.getTitle());
-
-			trashEntryLocalService.addTrashEntry(
-				userId, dlFileEntry.getGroupId(),
-				DLFileEntryConstants.getClassName(),
-				dlFileEntry.getFileEntryId(), dlFileEntry.getUuid(),
-				dlFileEntry.getClassName(), oldDLFileVersionStatus,
-				dlFileVersionStatusOVPs, typeSettingsProperties);
 		}
 
 		// App helper

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryServiceImpl.java
@@ -491,15 +491,21 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 			int status, int start, int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
+		QueryDefinition queryDefinition = new QueryDefinition(
+			status, start, end, obc);
+
+		if (rootFolderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			return dlFileEntryFinder.findByG_U_F_M(
+				groupId, userId, new ArrayList<Long>(), mimeTypes,
+				queryDefinition);
+		}
+
 		List<Long> folderIds = dlFolderService.getFolderIds(
 			groupId, rootFolderId);
 
 		if (folderIds.size() == 0) {
 			return Collections.emptyList();
 		}
-
-		QueryDefinition queryDefinition = new QueryDefinition(
-			status, start, end, obc);
 
 		return dlFileEntryFinder.findByG_U_F_M(
 			groupId, userId, folderIds, mimeTypes, queryDefinition);
@@ -531,6 +537,12 @@ public class DLFileEntryServiceImpl extends DLFileEntryServiceBaseImpl {
 			long groupId, long userId, long rootFolderId, String[] mimeTypes,
 			int status)
 		throws PortalException, SystemException {
+
+		if (rootFolderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			return dlFileEntryFinder.countByG_U_F_M(
+				groupId, userId, new ArrayList<Long>(), mimeTypes,
+				new QueryDefinition(status));
+		}
 
 		List<Long> folderIds = dlFolderService.getFolderIds(
 			groupId, rootFolderId);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -294,10 +294,6 @@ public class DLFileShortcutLocalServiceImpl
 				companyId, WorkflowConstants.STATUS_IN_TRASH);
 
 		for (DLFileShortcut fileShortcut : fileShortcuts) {
-			if (fileShortcut.isInTrashContainer()) {
-				continue;
-			}
-
 			fileShortcut.setTreePath(fileShortcut.buildTreePath());
 
 			dlFileShortcutPersistence.update(fileShortcut);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileVersionLocalServiceImpl.java
@@ -137,10 +137,6 @@ public class DLFileVersionLocalServiceImpl
 				companyId, WorkflowConstants.STATUS_IN_TRASH);
 
 		for (DLFileVersion dlFileVersion : dlFileVersions) {
-			if (dlFileVersion.isInTrashContainer()) {
-				continue;
-			}
-
 			dlFileVersion.setTreePath(dlFileVersion.buildTreePath());
 
 			dlFileVersionPersistence.update(dlFileVersion);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Group;
@@ -1025,18 +1024,6 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 
 		dlFolderPersistence.update(dlFolder);
 
-		// Folders, file entries, and file shortcuts
-
-		QueryDefinition queryDefinition = new QueryDefinition(
-			WorkflowConstants.STATUS_ANY);
-
-		List<Object> foldersAndFileEntriesAndFileShortcuts =
-			getFoldersAndFileEntriesAndFileShortcuts(
-				dlFolder.getGroupId(), folderId, null, false, queryDefinition);
-
-		dlAppHelperLocalService.updateDependentStatus(
-			user, foldersAndFileEntriesAndFileShortcuts, status);
-
 		// Asset
 
 		if (status == WorkflowConstants.STATUS_APPROVED) {
@@ -1046,24 +1033,6 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 		else if (status == WorkflowConstants.STATUS_IN_TRASH) {
 			assetEntryLocalService.updateVisible(
 				DLFolder.class.getName(), dlFolder.getFolderId(), false);
-		}
-
-		// Trash
-
-		if (status == WorkflowConstants.STATUS_IN_TRASH) {
-			UnicodeProperties typeSettingsProperties = new UnicodeProperties();
-
-			typeSettingsProperties.put("title", dlFolder.getName());
-
-			trashEntryLocalService.addTrashEntry(
-				userId, dlFolder.getGroupId(), DLFolderConstants.getClassName(),
-				dlFolder.getFolderId(), dlFolder.getUuid(), null,
-				WorkflowConstants.STATUS_APPROVED, null,
-				typeSettingsProperties);
-		}
-		else {
-			trashEntryLocalService.deleteEntry(
-				DLFolderConstants.getClassName(), dlFolder.getFolderId());
 		}
 
 		// Indexer

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -772,10 +772,6 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 			companyId, WorkflowConstants.STATUS_IN_TRASH);
 
 		for (DLFolder dlFolder : dlFolders) {
-			if (dlFolder.isInTrashContainer()) {
-				continue;
-			}
-
 			dlFolder.setTreePath(dlFolder.buildTreePath());
 
 			dlFolderPersistence.update(dlFolder);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
@@ -369,7 +369,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			groupId, folderId, false, WorkflowConstants.STATUS_APPROVED);
 
 		for (DLFolder dlFolder : dlFolders) {
-			if (dlFolder.isInHiddenFolder() || dlFolder.isInTrashContainer()) {
+			if (dlFolder.isInHiddenFolder() || dlFolder.isInTrash()) {
 				continue;
 			}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandler.java
@@ -152,20 +152,6 @@ public class DLFileEntryTrashHandler extends DLBaseTrashHandler {
 	}
 
 	@Override
-	public ContainerModel getTrashContainer(long classPK)
-		throws PortalException, SystemException {
-
-		try {
-			DLFileEntry dlFileEntry = getDLFileEntry(classPK);
-
-			return dlFileEntry.getTrashContainer();
-		}
-		catch (InvalidRepositoryException ire) {
-			return null;
-		}
-	}
-
-	@Override
 	public TrashEntry getTrashEntry(long classPK)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandler.java
@@ -115,16 +115,6 @@ public class DLFileShortcutTrashHandler extends DLBaseTrashHandler {
 	}
 
 	@Override
-	public ContainerModel getTrashContainer(long classPK)
-		throws PortalException, SystemException {
-
-		DLFileShortcut dlFileShortcut =
-			DLFileShortcutLocalServiceUtil.getDLFileShortcut(classPK);
-
-		return dlFileShortcut.getTrashContainer();
-	}
-
-	@Override
 	public TrashEntry getTrashEntry(long classPK)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandler.java
@@ -140,20 +140,6 @@ public class DLFolderTrashHandler extends DLBaseTrashHandler {
 	}
 
 	@Override
-	public ContainerModel getTrashContainer(long classPK)
-		throws PortalException, SystemException {
-
-		try {
-			DLFolder dlFolder = getDLFolder(classPK);
-
-			return dlFolder.getTrashContainer();
-		}
-		catch (InvalidRepositoryException ire) {
-			return null;
-		}
-	}
-
-	@Override
 	public TrashEntry getTrashEntry(long classPK)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -45,7 +45,6 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Repository;
 import com.liferay.portal.security.permission.ActionKeys;
@@ -57,7 +56,6 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsValues;
-import com.liferay.portlet.documentlibrary.asset.DLFileEntryAssetRendererFactory;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryMetadata;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryType;
@@ -433,21 +431,6 @@ public class DLFileEntryIndexer extends BaseIndexer {
 				}
 				catch (Exception e) {
 				}
-			}
-
-			if (!dlFileEntry.isInTrash() && dlFileEntry.isInTrashContainer()) {
-				DLFolder dlFolder = dlFileEntry.getTrashContainer();
-
-				addTrashFields(
-					document, DLFolder.class.getName(), dlFolder.getFolderId(),
-					null, null, DLFileEntryAssetRendererFactory.TYPE);
-
-				document.addKeyword(
-					Field.ROOT_ENTRY_CLASS_NAME, DLFolder.class.getName());
-				document.addKeyword(
-					Field.ROOT_ENTRY_CLASS_PK, dlFolder.getFolderId());
-				document.addKeyword(
-					Field.STATUS, WorkflowConstants.STATUS_IN_TRASH);
 			}
 
 			if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFolderIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFolderIndexer.java
@@ -35,11 +35,9 @@ import com.liferay.portal.kernel.search.Summary;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.util.PortletKeys;
-import com.liferay.portlet.documentlibrary.asset.DLFileEntryAssetRendererFactory;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.permission.DLFolderPermission;
@@ -129,24 +127,6 @@ public class DLFolderIndexer extends BaseIndexer {
 		document.addKeyword(
 			Field.TREE_PATH,
 			StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH));
-
-		if (!dlFolder.isInTrash() && dlFolder.isInTrashContainer()) {
-			DLFolder trashedFolder = dlFolder.getTrashContainer();
-
-			if (trashedFolder != null) {
-				addTrashFields(
-					document, DLFolder.class.getName(),
-					trashedFolder.getFolderId(), null, null,
-					DLFileEntryAssetRendererFactory.TYPE);
-
-				document.addKeyword(
-					Field.ROOT_ENTRY_CLASS_NAME, DLFolder.class.getName());
-				document.addKeyword(
-					Field.ROOT_ENTRY_CLASS_PK, trashedFolder.getFolderId());
-				document.addKeyword(
-					Field.STATUS, WorkflowConstants.STATUS_IN_TRASH);
-			}
-		}
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Document " + dlFolder + " indexed successfully");

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntry.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntry.java
@@ -82,10 +82,6 @@ public interface DLFileEntry extends DLFileEntryModel, PersistedModel {
 
 	public java.lang.String getLuceneProperties();
 
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
 	/**
 	* @deprecated As of 6.2.0, replaced by {@link DLFileVersion#getUserId()}
 	*/

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryWrapper.java
@@ -1147,13 +1147,6 @@ public class DLFileEntryWrapper implements DLFileEntry,
 		return _dlFileEntry.getLuceneProperties();
 	}
 
-	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return _dlFileEntry.getTrashContainer();
-	}
-
 	/**
 	* @deprecated As of 6.2.0, replaced by {@link DLFileVersion#getUserId()}
 	*/

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcut.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcut.java
@@ -45,9 +45,5 @@ public interface DLFileShortcut extends DLFileShortcutModel, PersistedModel {
 
 	public java.lang.String getToTitle();
 
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
 	public boolean isInHiddenFolder();
 }

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcutWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcutWrapper.java
@@ -865,13 +865,6 @@ public class DLFileShortcutWrapper implements DLFileShortcut,
 	}
 
 	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return _dlFileShortcut.getTrashContainer();
-	}
-
-	@Override
 	public boolean isInHiddenFolder() {
 		return _dlFileShortcut.isInHiddenFolder();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersion.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersion.java
@@ -51,14 +51,6 @@ public interface DLFileVersion extends DLFileVersionModel, PersistedModel {
 
 	public java.lang.String getIcon();
 
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
-	public boolean isInTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
 	public void setExtraSettingsProperties(
 		com.liferay.portal.kernel.util.UnicodeProperties extraSettingsProperties);
 }

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersionWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersionWrapper.java
@@ -1056,20 +1056,6 @@ public class DLFileVersionWrapper implements DLFileVersion,
 	}
 
 	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return _dlFileVersion.getTrashContainer();
-	}
-
-	@Override
-	public boolean isInTrashContainer()
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return _dlFileVersion.isInTrashContainer();
-	}
-
-	@Override
 	public void setExtraSettingsProperties(
 		com.liferay.portal.kernel.util.UnicodeProperties extraSettingsProperties) {
 		_dlFileVersion.setExtraSettingsProperties(extraSettingsProperties);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolder.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolder.java
@@ -55,8 +55,6 @@ public interface DLFolder extends DLFolderModel, PersistedModel {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer();
-
 	public boolean hasInheritableLock();
 
 	public boolean hasLock();

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolderWrapper.java
@@ -1087,11 +1087,6 @@ public class DLFolderWrapper implements DLFolder, ModelWrapper<DLFolder> {
 	}
 
 	@Override
-	public com.liferay.portlet.documentlibrary.model.DLFolder getTrashContainer() {
-		return _dlFolder.getTrashContainer();
-	}
-
-	@Override
 	public boolean hasInheritableLock() {
 		return _dlFolder.hasInheritableLock();
 	}

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalService.java
@@ -130,6 +130,12 @@ public interface DLAppHelperLocalService extends BaseLocalService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portal.kernel.repository.model.FileEntry> getNoAssetFileEntries();
 
+	public void moveDependentsToTrash(
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders,
+		long trashEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	public void moveFileEntry(
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -215,6 +221,12 @@ public interface DLAppHelperLocalService extends BaseLocalService {
 		com.liferay.portal.kernel.repository.model.Folder folder)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
+	public void restoreDependentsFromTrash(
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders,
+		long trashEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	public void restoreFileEntryFromTrash(long userId,
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -249,11 +261,6 @@ public interface DLAppHelperLocalService extends BaseLocalService {
 		com.liferay.portal.kernel.repository.model.Folder folder,
 		long[] assetCategoryIds, java.lang.String[] assetTagNames,
 		long[] assetLinkEntryIds)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
-	public void updateDependentStatus(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceUtil.java
@@ -151,6 +151,15 @@ public class DLAppHelperLocalServiceUtil {
 		return getService().getNoAssetFileEntries();
 	}
 
+	public static void moveDependentsToTrash(
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders,
+		long trashEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		getService()
+			.moveDependentsToTrash(dlFileEntriesAndDLFolders, trashEntryId);
+	}
+
 	public static void moveFileEntry(
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -262,6 +271,15 @@ public class DLAppHelperLocalServiceUtil {
 		getService().registerDLSyncEventCallback(event, folder);
 	}
 
+	public static void restoreDependentsFromTrash(
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders,
+		long trashEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		getService()
+			.restoreDependentsFromTrash(dlFileEntriesAndDLFolders, trashEntryId);
+	}
+
 	public static void restoreFileEntryFromTrash(long userId,
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -316,15 +334,6 @@ public class DLAppHelperLocalServiceUtil {
 		return getService()
 				   .updateAsset(userId, folder, assetCategoryIds,
 			assetTagNames, assetLinkEntryIds);
-	}
-
-	public static void updateDependentStatus(
-		com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		getService()
-			.updateDependentStatus(user, dlFileEntriesAndDLFolders, status);
 	}
 
 	public static void updateFileEntry(long userId,

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppHelperLocalServiceWrapper.java
@@ -163,6 +163,16 @@ public class DLAppHelperLocalServiceWrapper implements DLAppHelperLocalService,
 	}
 
 	@Override
+	public void moveDependentsToTrash(
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders,
+		long trashEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		_dlAppHelperLocalService.moveDependentsToTrash(dlFileEntriesAndDLFolders,
+			trashEntryId);
+	}
+
+	@Override
 	public void moveFileEntry(
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -282,6 +292,16 @@ public class DLAppHelperLocalServiceWrapper implements DLAppHelperLocalService,
 	}
 
 	@Override
+	public void restoreDependentsFromTrash(
+		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders,
+		long trashEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		_dlAppHelperLocalService.restoreDependentsFromTrash(dlFileEntriesAndDLFolders,
+			trashEntryId);
+	}
+
+	@Override
 	public void restoreFileEntryFromTrash(long userId,
 		com.liferay.portal.kernel.repository.model.FileEntry fileEntry)
 		throws com.liferay.portal.kernel.exception.PortalException,
@@ -338,15 +358,6 @@ public class DLAppHelperLocalServiceWrapper implements DLAppHelperLocalService,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _dlAppHelperLocalService.updateAsset(userId, folder,
 			assetCategoryIds, assetTagNames, assetLinkEntryIds);
-	}
-
-	@Override
-	public void updateDependentStatus(com.liferay.portal.model.User user,
-		java.util.List<java.lang.Object> dlFileEntriesAndDLFolders, int status)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		_dlAppHelperLocalService.updateDependentStatus(user,
-			dlFileEntriesAndDLFolders, status);
 	}
 
 	@Override


### PR DESCRIPTION
Hey Brian,

We have the method name "moveFrom" because it's using a container. The same pattern is used in Bookmarks, Journal and Message Boards (basically in every entity that has a container and it can be restored and moved to a different container in case the container doesn't exist anymore or the container is in trash)

See BookmarksEntryLocalServiceImpl:326

``` java
    @Override
    public BookmarksEntry moveEntryFromTrash(
            long userId, long entryId, long parentFolderId)
        throws PortalException, SystemException {
```

or 

BookmarksFolderLocalServiceImpl:341

``` java
    @Override
    public BookmarksFolder moveFolderFromTrash(
            long userId, long folderId, long parentFolderId)
        throws PortalException, SystemException {
```

Let us know if you have any other question.

Thanks!
