### PR TITLE
LPS-40824

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -390,19 +390,19 @@ public class DLFileEntryLocalServiceImpl
 				user.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName(),
 				DLFileEntryConstants.PRIVATE_WORKING_COPY_VERSION, version);
-		}
 
-		// Folder
+			// Folder
 
-		if (dlFileEntry.getFolderId() !=
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			if (dlFileEntry.getFolderId() !=
+					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
-			DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(
-				dlFileEntry.getFolderId());
+				DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(
+					dlFileEntry.getFolderId());
 
-			dlFolder.setLastPostDate(dlFileEntry.getModifiedDate());
+				dlFolder.setLastPostDate(latestDLFileVersion.getModifiedDate());
 
-			dlFolderPersistence.update(dlFolder);
+				dlFolderPersistence.update(dlFolder);
+			}
 		}
 
 		// Workflow

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -284,17 +284,6 @@ public class DLFileEntryLocalServiceImpl
 
 		removeFileVersion(dlFileEntry, dlFileVersion);
 
-		if (dlFileEntry.getFolderId() !=
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-
-			DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(
-				dlFileEntry.getFolderId());
-
-			dlFolder.setLastPostDate(new Date());
-
-			dlFolderPersistence.update(dlFolder);
-		}
-
 		return dlFileVersion;
 	}
 
@@ -621,17 +610,6 @@ public class DLFileEntryLocalServiceImpl
 				dlFileEntry.getCompanyId(), dlFileVersion.getFileEntryTypeId(),
 				fileEntryId, dlFileVersionId, dlFileVersion.getFileVersionId(),
 				serviceContext);
-		}
-
-		if (dlFileEntry.getFolderId() !=
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-
-			DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(
-				dlFileEntry.getFolderId());
-
-			dlFolder.setLastPostDate(dlFileVersion.getModifiedDate());
-
-			dlFolderPersistence.update(dlFolder);
 		}
 
 		return dlFileEntry;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2404,8 +2404,9 @@ public class DLFileEntryLocalServiceImpl
 
 			// Folder
 
-			if (dlFileEntry.getFolderId() !=
-					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			if (!checkedOut &&
+				(dlFileEntry.getFolderId() !=
+					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
 
 				DLFolder dlFolder = dlFolderPersistence.findByPrimaryKey(
 					dlFileEntry.getFolderId());

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLCheckInCheckOutTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLCheckInCheckOutTest.java
@@ -44,6 +44,8 @@ import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 
 import java.io.InputStream;
 
+import java.util.Date;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -96,6 +98,10 @@ public class DLCheckInCheckOutTest {
 		DLAppServiceUtil.checkOutFileEntry(
 			_fileEntry.getFileEntryId(), _serviceContext);
 
+		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Date lastPostDate = folder.getLastPostDate();
+
 		FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
 			_fileEntry.getFileEntryId());
 
@@ -107,6 +113,10 @@ public class DLCheckInCheckOutTest {
 
 		DLAppServiceUtil.cancelCheckOut(_fileEntry.getFileEntryId());
 
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Assert.assertEquals(lastPostDate, folder.getLastPostDate());
+
 		fileEntry = DLAppServiceUtil.getFileEntry(_fileEntry.getFileEntryId());
 
 		Assert.assertEquals("1.0", fileEntry.getVersion());
@@ -117,6 +127,10 @@ public class DLCheckInCheckOutTest {
 		for (int i = 0; i < 2; i++) {
 			DLAppServiceUtil.checkOutFileEntry(
 				_fileEntry.getFileEntryId(), _serviceContext);
+
+			Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+			Date lastPostDate = folder.getLastPostDate();
 
 			FileVersion fileVersion = _fileEntry.getLatestFileVersion();
 
@@ -132,6 +146,16 @@ public class DLCheckInCheckOutTest {
 				_fileEntry.getFileEntryId(), false, StringPool.BLANK,
 				_serviceContext);
 
+			folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+			if (i == 1) {
+				Assert.assertTrue(
+					lastPostDate.before(folder.getLastPostDate()));
+			}
+			else {
+				Assert.assertEquals(lastPostDate, folder.getLastPostDate());
+			}
+
 			FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
 				_fileEntry.getFileEntryId());
 
@@ -145,8 +169,16 @@ public class DLCheckInCheckOutTest {
 
 	@Test
 	public void testCheckOut() throws Exception {
+		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Date lastPostDate = folder.getLastPostDate();
+
 		DLAppServiceUtil.checkOutFileEntry(
 			_fileEntry.getFileEntryId(), _serviceContext);
+
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Assert.assertEquals(lastPostDate, folder.getLastPostDate());
 
 		FileVersion fileVersion = _fileEntry.getLatestFileVersion();
 
@@ -157,7 +189,15 @@ public class DLCheckInCheckOutTest {
 
 	@Test
 	public void testUpdateFileEntry() throws Exception {
+		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Date lastPostDate = folder.getLastPostDate();
+
 		FileEntry fileEntry = updateFileEntry(_fileEntry.getFileEntryId());
+
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Assert.assertTrue(lastPostDate.before(folder.getLastPostDate()));
 
 		Assert.assertEquals("1.1", fileEntry.getVersion());
 
@@ -169,7 +209,15 @@ public class DLCheckInCheckOutTest {
 		DLAppServiceUtil.checkOutFileEntry(
 			_fileEntry.getFileEntryId(), _serviceContext);
 
+		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Date lastPostDate = folder.getLastPostDate();
+
 		FileEntry fileEntry = updateFileEntry(_fileEntry.getFileEntryId());
+
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Assert.assertEquals(lastPostDate, folder.getLastPostDate());
 
 		Assert.assertEquals("1.0" , fileEntry.getVersion());
 
@@ -180,6 +228,10 @@ public class DLCheckInCheckOutTest {
 		DLAppServiceUtil.checkInFileEntry(
 			_fileEntry.getFileEntryId(), false, StringPool.BLANK,
 			_serviceContext);
+
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Assert.assertTrue(lastPostDate.before(folder.getLastPostDate()));
 
 		fileEntry = DLAppServiceUtil.getFileEntry(_fileEntry.getFileEntryId());
 
@@ -219,9 +271,17 @@ public class DLCheckInCheckOutTest {
 		InputStream inputStream = new UnsyncByteArrayInputStream(
 			_TEST_CONTENT.getBytes());
 
+		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Date lastPostDate = folder.getLastPostDate();
+
 		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
 			repositoryId, folderId, fileName, ContentTypes.TEXT_PLAIN, fileName,
 			null, null, inputStream, _TEST_CONTENT.length(), _serviceContext);
+
+		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+		Assert.assertTrue(lastPostDate.before(folder.getLastPostDate()));
 
 		Assert.assertNotNull(fileEntry);
 
@@ -279,6 +339,10 @@ public class DLCheckInCheckOutTest {
 
 			long fileEntryId = fileEntry.getFileEntryId();
 
+			Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+			Date lastPostDate = folder.getLastPostDate();
+
 			DLAppServiceUtil.checkOutFileEntry(fileEntryId, _serviceContext);
 
 			ServiceTestUtil.setUser(overriderUser);
@@ -314,6 +378,11 @@ public class DLCheckInCheckOutTest {
 				if (!expectOverride) {
 					Assert.fail("Should not have succeeded check in");
 				}
+
+				folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+				Assert.assertTrue(
+					lastPostDate.before(folder.getLastPostDate()));
 
 				fileEntry = DLAppServiceUtil.getFileEntry(fileEntryId);
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLCheckInCheckOutTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLCheckInCheckOutTest.java
@@ -115,7 +115,8 @@ public class DLCheckInCheckOutTest {
 
 		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
 
-		Assert.assertEquals(lastPostDate, folder.getLastPostDate());
+		Assert.assertEquals(
+			lastPostDate.getTime(), folder.getLastPostDate().getTime());
 
 		fileEntry = DLAppServiceUtil.getFileEntry(_fileEntry.getFileEntryId());
 
@@ -153,7 +154,8 @@ public class DLCheckInCheckOutTest {
 					lastPostDate.before(folder.getLastPostDate()));
 			}
 			else {
-				Assert.assertEquals(lastPostDate, folder.getLastPostDate());
+				Assert.assertEquals(
+					lastPostDate.getTime(), folder.getLastPostDate().getTime());
 			}
 
 			FileEntry fileEntry = DLAppServiceUtil.getFileEntry(
@@ -178,7 +180,8 @@ public class DLCheckInCheckOutTest {
 
 		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
 
-		Assert.assertEquals(lastPostDate, folder.getLastPostDate());
+		Assert.assertEquals(
+			lastPostDate.getTime(), folder.getLastPostDate().getTime());
 
 		FileVersion fileVersion = _fileEntry.getLatestFileVersion();
 
@@ -214,10 +217,6 @@ public class DLCheckInCheckOutTest {
 		Date lastPostDate = folder.getLastPostDate();
 
 		FileEntry fileEntry = updateFileEntry(_fileEntry.getFileEntryId());
-
-		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
-
-		Assert.assertEquals(lastPostDate, folder.getLastPostDate());
 
 		Assert.assertEquals("1.0" , fileEntry.getVersion());
 
@@ -271,17 +270,9 @@ public class DLCheckInCheckOutTest {
 		InputStream inputStream = new UnsyncByteArrayInputStream(
 			_TEST_CONTENT.getBytes());
 
-		Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
-
-		Date lastPostDate = folder.getLastPostDate();
-
 		FileEntry fileEntry = DLAppServiceUtil.addFileEntry(
 			repositoryId, folderId, fileName, ContentTypes.TEXT_PLAIN, fileName,
 			null, null, inputStream, _TEST_CONTENT.length(), _serviceContext);
-
-		folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
-
-		Assert.assertTrue(lastPostDate.before(folder.getLastPostDate()));
 
 		Assert.assertNotNull(fileEntry);
 
@@ -333,15 +324,15 @@ public class DLCheckInCheckOutTest {
 		ServiceTestUtil.setUser(authorUser);
 
 		try {
+			Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
+
+			Date lastPostDate = folder.getLastPostDate();
+
 			String fileName = "OverrideCheckoutTest.txt";
 
 			FileEntry fileEntry = createFileEntry(fileName);
 
 			long fileEntryId = fileEntry.getFileEntryId();
-
-			Folder folder = DLAppServiceUtil.getFolder(_folder.getFolderId());
-
-			Date lastPostDate = folder.getLastPostDate();
 
 			DLAppServiceUtil.checkOutFileEntry(fileEntryId, _serviceContext);
 


### PR DESCRIPTION
@pure59 

Hey Brian,

I tried to clean it up a bit. The pattern throughout the test is:

getLastPostDate (Folder)
getFileVersion (FileEntry)

_Action_ (cancelCheckOut, checkInFileEntry, checkOutFileEntry, updateFileEntry, updateFileEntry + checkInFileEntry or checkOutFileEntry + cancelCheckOut + checkInFileEntry)

assert (lastPostDate)
assert (fileVersion)

We purposely only getLastPostDate() before checkOutFileEntry in testCheckOut() because that is the _Action_ that we are testing.
