### PR TITLE
LPS-32232

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
@@ -270,21 +270,28 @@ public class UserFinderImpl
 			for (long groupId : groupIds) {
 				Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 
-				if ((group != null) && group.isOrganization()) {
+				if (group == null) {
+					continue;
+				}
+
+				if (group.isOrganization()) {
 					organizationIds.add(group.getOrganizationId());
 				}
-
-				List<Organization> organizations = GroupUtil.getOrganizations(
-					groupId);
-
-				for (Organization organization : organizations) {
-					organizationIds.add(organization.getOrganizationId());
+				else if (group.isUserGroup()) {
+					userGroupIds.add(group.getClassPK());
 				}
+				else {
+					for (Organization organization :
+							GroupUtil.getOrganizations(groupId)) {
 
-				List<UserGroup> userGroups = GroupUtil.getUserGroups(groupId);
+						organizationIds.add(organization.getOrganizationId());
+					}
 
-				for (UserGroup userGroup : userGroups) {
-					userGroupIds.add(userGroup.getUserGroupId());
+					for (UserGroup userGroup :
+							GroupUtil.getUserGroups(groupId)) {
+
+						userGroupIds.add(userGroup.getUserGroupId());
+					}
 				}
 			}
 
@@ -326,6 +333,20 @@ public class UserFinderImpl
 					}
 					else {
 						roleGroupIds.add(group.getGroupId());
+
+						for (Organization organization :
+								GroupUtil.getOrganizations(
+									group.getGroupId())) {
+
+							organizationIds.add(
+								organization.getOrganizationId());
+						}
+
+						for (UserGroup userGroup :
+								GroupUtil.getUserGroups(group.getGroupId())) {
+
+							userGroupIds.add(userGroup.getUserGroupId());
+						}
 					}
 				}
 			}
@@ -592,21 +613,28 @@ public class UserFinderImpl
 			for (long groupId : groupIds) {
 				Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 
-				if ((group != null) && group.isOrganization()) {
+				if (group == null) {
+					continue;
+				}
+
+				if (group.isOrganization()) {
 					organizationIds.add(group.getOrganizationId());
 				}
-
-				List<Organization> organizations = GroupUtil.getOrganizations(
-					groupId);
-
-				for (Organization organization : organizations) {
-					organizationIds.add(organization.getOrganizationId());
+				else if (group.isUserGroup()) {
+					userGroupIds.add(group.getClassPK());
 				}
+				else {
+					for (Organization organization :
+							GroupUtil.getOrganizations(groupId)) {
 
-				List<UserGroup> userGroups = GroupUtil.getUserGroups(groupId);
+						organizationIds.add(organization.getOrganizationId());
+					}
 
-				for (UserGroup userGroup : userGroups) {
-					userGroupIds.add(userGroup.getUserGroupId());
+					for (UserGroup userGroup :
+							GroupUtil.getUserGroups(groupId)) {
+
+						userGroupIds.add(userGroup.getUserGroupId());
+					}
 				}
 			}
 
@@ -648,6 +676,20 @@ public class UserFinderImpl
 					}
 					else {
 						roleGroupIds.add(group.getGroupId());
+
+						for (Organization organization :
+								GroupUtil.getOrganizations(
+									group.getGroupId())) {
+
+							organizationIds.add(
+								organization.getOrganizationId());
+						}
+
+						for (UserGroup userGroup :
+								GroupUtil.getUserGroups(group.getGroupId())) {
+
+							userGroupIds.add(userGroup.getUserGroupId());
+						}
 					}
 				}
 			}

--- a/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
@@ -329,11 +329,11 @@ public class UserFinderImpl
 				List<Group> groups = RoleUtil.getGroups(roleId);
 
 				for (Group group : groups) {
-					if (group.isUserGroup()) {
-						userGroupIds.add(group.getClassPK());
-					}
-					else if (group.isOrganization()) {
+					if (group.isOrganization()) {
 						organizationIds.add(group.getOrganizationId());
+					}
+					else if (group.isUserGroup()) {
+						userGroupIds.add(group.getClassPK());
 					}
 					else {
 						roleGroupIds.add(group.getGroupId());
@@ -643,11 +643,11 @@ public class UserFinderImpl
 				List<Group> groups = RoleUtil.getGroups(roleId);
 
 				for (Group group : groups) {
-					if (group.isUserGroup()) {
-						userGroupIds.add(group.getClassPK());
-					}
-					else if (group.isOrganization()) {
+					if (group.isOrganization()) {
 						organizationIds.add(group.getOrganizationId());
+					}
+					else if (group.isUserGroup()) {
+						userGroupIds.add(group.getClassPK());
 					}
 					else {
 						roleGroupIds.add(group.getGroupId());

--- a/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
@@ -311,19 +311,34 @@ public class UserFinderImpl
 
 			params2.remove("usersRoles");
 
+			params3 = new LinkedHashMap<String, Object>(params1);
+
+			params3.remove("usersRoles");
+
+
 			List<Long> roleGroupIds = new ArrayList<Long>();
+			List<Long> userGroupIds = new ArrayList<Long>();
 
 			for (long roleId : roleIds) {
 				List<Group> groups = RoleUtil.getGroups(roleId);
 
 				for (Group group : groups) {
-					roleGroupIds.add(group.getGroupId());
+					if (group.isUserGroup()) {
+						userGroupIds.add(group.getClassPK());
+					}
+					else {
+						roleGroupIds.add(group.getGroupId());
+					}
 				}
 			}
 
 			params2.put(
 				"usersGroups",
 				roleGroupIds.toArray(new Long[roleGroupIds.size()]));
+
+			params3.put(
+				"usersUserGroups",
+				userGroupIds.toArray(new Long[userGroupIds.size()]));
 		}
 
 		Session session = null;
@@ -344,9 +359,7 @@ public class UserFinderImpl
 						session, companyId, firstNames, middleNames, lastNames,
 						screenNames, emailAddresses, status, params2,
 						andOperator));
-			}
 
-			if (doUnionOnGroup) {
 				userIds.addAll(
 					countByC_FN_MN_LN_SN_EA_S(
 						session, companyId, firstNames, middleNames, lastNames,
@@ -591,19 +604,33 @@ public class UserFinderImpl
 
 			params2.remove("usersRoles");
 
+			params3 = new LinkedHashMap<String, Object>(params1);
+
+			params3.remove("usersRoles");
+
 			List<Long> roleGroupIds = new ArrayList<Long>();
+			List<Long> userGroupIds = new ArrayList<Long>();
 
 			for (long roleId : roleIds) {
 				List<Group> groups = RoleUtil.getGroups(roleId);
 
 				for (Group group : groups) {
-					roleGroupIds.add(group.getGroupId());
+					if (group.isUserGroup()) {
+						userGroupIds.add(group.getClassPK());
+					}
+					else {
+						roleGroupIds.add(group.getGroupId());
+					}
 				}
 			}
 
 			params2.put(
 				"usersGroups",
 				roleGroupIds.toArray(new Long[roleGroupIds.size()]));
+
+			params3.put(
+				"usersUserGroups",
+				userGroupIds.toArray(new Long[userGroupIds.size()]));
 		}
 
 		Session session = null;
@@ -643,9 +670,7 @@ public class UserFinderImpl
 				sb.append(" UNION (");
 				sb.append(replaceJoinAndWhere(sql, params2));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
-			}
 
-			if (doUnionOnGroup) {
 				sb.append(" UNION (");
 				sb.append(replaceJoinAndWhere(sql, params3));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
@@ -694,9 +719,7 @@ public class UserFinderImpl
 				if (status != WorkflowConstants.STATUS_ANY) {
 					qPos.add(status);
 				}
-			}
 
-			if (doUnionOnGroup) {
 				setJoin(qPos, params3);
 
 				qPos.add(companyId);

--- a/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
@@ -51,6 +51,7 @@ import java.util.Set;
  * @author Jon Steer
  * @author Raymond Augé
  * @author Connor McKay
+ * @author Shuyang Zhou
  */
 public class UserFinderImpl
 	extends BasePersistenceImpl<User> implements UserFinder {
@@ -262,17 +263,7 @@ public class UserFinderImpl
 
 		boolean inherit = GetterUtil.getBoolean(params.get("inherit"));
 
-		boolean doUnionOnGroup = ArrayUtil.isNotEmpty(groupIds) && inherit;
-
-		if (doUnionOnGroup) {
-			params2 = new LinkedHashMap<String, Object>(params1);
-
-			params2.remove("usersGroups");
-
-			params3 = new LinkedHashMap<String, Object>(params1);
-
-			params3.remove("usersGroups");
-
+		if (ArrayUtil.isNotEmpty(groupIds) && inherit) {
 			List<Long> organizationIds = new ArrayList<Long>();
 			List<Long> userGroupIds = new ArrayList<Long>();
 
@@ -297,30 +288,28 @@ public class UserFinderImpl
 				}
 			}
 
-			params2.put(
-				"usersOrgs",
-				organizationIds.toArray(new Long[organizationIds.size()]));
+			if (!organizationIds.isEmpty()) {
+				params2 = new LinkedHashMap<String, Object>(params1);
 
-			params3.put(
-				"usersUserGroups",
-				userGroupIds.toArray(new Long[userGroupIds.size()]));
+				params2.remove("usersGroups");
+
+				params2.put(
+					"usersOrgs",
+					organizationIds.toArray(new Long[organizationIds.size()]));
+			}
+
+			if (!userGroupIds.isEmpty()) {
+				params3 = new LinkedHashMap<String, Object>(params1);
+
+				params3.remove("usersGroups");
+
+				params3.put(
+					"usersUserGroups",
+					userGroupIds.toArray(new Long[userGroupIds.size()]));
+			}
 		}
 
-		boolean doUnionOnRole = ArrayUtil.isNotEmpty(roleIds) && inherit;
-
-		if (doUnionOnRole) {
-			params2 = new LinkedHashMap<String, Object>(params1);
-
-			params2.remove("usersRoles");
-
-			params3 = new LinkedHashMap<String, Object>(params1);
-
-			params3.remove("usersRoles");
-
-			params4 = new LinkedHashMap<String, Object>(params1);
-
-			params4.remove("usersRoles");
-
+		if (ArrayUtil.isNotEmpty(roleIds) && inherit) {
 			List<Long> organizationIds = new ArrayList<Long>();
 			List<Long> roleGroupIds = new ArrayList<Long>();
 			List<Long> userGroupIds = new ArrayList<Long>();
@@ -341,17 +330,35 @@ public class UserFinderImpl
 				}
 			}
 
-			params2.put(
-				"usersGroups",
-				roleGroupIds.toArray(new Long[roleGroupIds.size()]));
+			if (!roleGroupIds.isEmpty()) {
+				params2 = new LinkedHashMap<String, Object>(params1);
 
-			params3.put(
-				"usersUserGroups",
-				userGroupIds.toArray(new Long[userGroupIds.size()]));
+				params2.remove("usersRoles");
 
-			params4.put(
-				"usersOrgs",
-				organizationIds.toArray(new Long[organizationIds.size()]));
+				params2.put(
+					"usersGroups",
+					roleGroupIds.toArray(new Long[roleGroupIds.size()]));
+			}
+
+			if (!userGroupIds.isEmpty()) {
+				params3 = new LinkedHashMap<String, Object>(params1);
+
+				params3.remove("usersRoles");
+
+				params3.put(
+					"usersUserGroups",
+					userGroupIds.toArray(new Long[userGroupIds.size()]));
+			}
+
+			if (!organizationIds.isEmpty()) {
+				params4 = new LinkedHashMap<String, Object>(params1);
+
+				params4.remove("usersRoles");
+
+				params4.put(
+					"usersOrgs",
+					organizationIds.toArray(new Long[organizationIds.size()]));
+			}
 		}
 
 		Session session = null;
@@ -366,13 +373,15 @@ public class UserFinderImpl
 					session, companyId, firstNames, middleNames, lastNames,
 					screenNames, emailAddresses, status, params1, andOperator));
 
-			if (doUnionOnGroup || doUnionOnRole) {
+			if (params2 != null) {
 				userIds.addAll(
 					countByC_FN_MN_LN_SN_EA_S(
 						session, companyId, firstNames, middleNames, lastNames,
 						screenNames, emailAddresses, status, params2,
 						andOperator));
+			}
 
+			if (params3 != null) {
 				userIds.addAll(
 					countByC_FN_MN_LN_SN_EA_S(
 						session, companyId, firstNames, middleNames, lastNames,
@@ -380,7 +389,7 @@ public class UserFinderImpl
 						andOperator));
 			}
 
-			if (doUnionOnRole) {
+			if (params4 != null) {
 				userIds.addAll(
 					countByC_FN_MN_LN_SN_EA_S(
 						session, companyId, firstNames, middleNames, lastNames,
@@ -576,17 +585,7 @@ public class UserFinderImpl
 
 		boolean inherit = GetterUtil.getBoolean(params.get("inherit"));
 
-		boolean doUnionOnGroup = ArrayUtil.isNotEmpty(groupIds) && inherit;
-
-		if (doUnionOnGroup) {
-			params2 = new LinkedHashMap<String, Object>(params1);
-
-			params2.remove("usersGroups");
-
-			params3 = new LinkedHashMap<String, Object>(params1);
-
-			params3.remove("usersGroups");
-
+		if (ArrayUtil.isNotEmpty(groupIds) && inherit) {
 			List<Long> organizationIds = new ArrayList<Long>();
 			List<Long> userGroupIds = new ArrayList<Long>();
 
@@ -611,30 +610,28 @@ public class UserFinderImpl
 				}
 			}
 
-			params2.put(
-				"usersOrgs",
-				organizationIds.toArray(new Long[organizationIds.size()]));
+			if (!organizationIds.isEmpty()) {
+				params2 = new LinkedHashMap<String, Object>(params1);
 
-			params3.put(
-				"usersUserGroups",
-				userGroupIds.toArray(new Long[userGroupIds.size()]));
+				params2.remove("usersGroups");
+
+				params2.put(
+					"usersOrgs",
+					organizationIds.toArray(new Long[organizationIds.size()]));
+			}
+
+			if (!userGroupIds.isEmpty()) {
+				params3 = new LinkedHashMap<String, Object>(params1);
+
+				params3.remove("usersGroups");
+
+				params3.put(
+					"usersUserGroups",
+					userGroupIds.toArray(new Long[userGroupIds.size()]));
+			}
 		}
 
-		boolean doUnionOnRole = ArrayUtil.isNotEmpty(roleIds) && inherit;
-
-		if (doUnionOnRole) {
-			params2 = new LinkedHashMap<String, Object>(params1);
-
-			params2.remove("usersRoles");
-
-			params3 = new LinkedHashMap<String, Object>(params1);
-
-			params3.remove("usersRoles");
-
-			params4 = new LinkedHashMap<String, Object>(params1);
-
-			params4.remove("usersRoles");
-
+		if (ArrayUtil.isNotEmpty(roleIds) && inherit) {
 			List<Long> organizationIds = new ArrayList<Long>();
 			List<Long> roleGroupIds = new ArrayList<Long>();
 			List<Long> userGroupIds = new ArrayList<Long>();
@@ -655,17 +652,35 @@ public class UserFinderImpl
 				}
 			}
 
-			params2.put(
-				"usersGroups",
-				roleGroupIds.toArray(new Long[roleGroupIds.size()]));
+			if (!roleGroupIds.isEmpty()) {
+				params2 = new LinkedHashMap<String, Object>(params1);
 
-			params3.put(
-				"usersUserGroups",
-				userGroupIds.toArray(new Long[userGroupIds.size()]));
+				params2.remove("usersRoles");
 
-			params4.put(
-				"usersOrgs",
-				organizationIds.toArray(new Long[organizationIds.size()]));
+				params2.put(
+					"usersGroups",
+					roleGroupIds.toArray(new Long[roleGroupIds.size()]));
+			}
+
+			if (!userGroupIds.isEmpty()) {
+				params3 = new LinkedHashMap<String, Object>(params1);
+
+				params3.remove("usersRoles");
+
+				params3.put(
+					"usersUserGroups",
+					userGroupIds.toArray(new Long[userGroupIds.size()]));
+			}
+
+			if (!organizationIds.isEmpty()) {
+				params4 = new LinkedHashMap<String, Object>(params1);
+
+				params4.remove("usersRoles");
+
+				params4.put(
+					"usersOrgs",
+					organizationIds.toArray(new Long[organizationIds.size()]));
+			}
 		}
 
 		Session session = null;
@@ -701,17 +716,19 @@ public class UserFinderImpl
 			sb.append(replaceJoinAndWhere(sql, params1));
 			sb.append(StringPool.CLOSE_PARENTHESIS);
 
-			if (doUnionOnGroup || doUnionOnRole) {
+			if (params2 != null) {
 				sb.append(" UNION (");
 				sb.append(replaceJoinAndWhere(sql, params2));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
+			}
 
+			if (params3 != null) {
 				sb.append(" UNION (");
 				sb.append(replaceJoinAndWhere(sql, params3));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 
-			if (doUnionOnRole) {
+			if (params4 != null) {
 				sb.append(" UNION (");
 				sb.append(replaceJoinAndWhere(sql, params4));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
@@ -746,7 +763,7 @@ public class UserFinderImpl
 				qPos.add(status);
 			}
 
-			if (doUnionOnGroup || doUnionOnRole) {
+			if (params2 != null) {
 				setJoin(qPos, params2);
 
 				qPos.add(companyId);
@@ -760,7 +777,9 @@ public class UserFinderImpl
 				if (status != WorkflowConstants.STATUS_ANY) {
 					qPos.add(status);
 				}
+			}
 
+			if (params3 != null) {
 				setJoin(qPos, params3);
 
 				qPos.add(companyId);
@@ -776,7 +795,7 @@ public class UserFinderImpl
 				}
 			}
 
-			if (doUnionOnRole) {
+			if (params4 != null) {
 				setJoin(qPos, params4);
 
 				qPos.add(companyId);
@@ -1007,27 +1026,21 @@ public class UserFinderImpl
 			else if (value instanceof Long[]) {
 				Long[] groupIds = (Long[])value;
 
-				if (groupIds.length == 0) {
-					join = "WHERE (Users_Groups.groupId = -1)";
-				}
-				else {
-					StringBundler sb = new StringBundler(
-						groupIds.length * 2 + 1);
+				StringBundler sb = new StringBundler(groupIds.length * 2 + 1);
 
-					sb.append("WHERE (");
+				sb.append("WHERE (");
 
-					for (int i = 0; i < groupIds.length; i++) {
-						sb.append("(Users_Groups.groupId = ?) ");
+				for (int i = 0; i < groupIds.length; i++) {
+					sb.append("(Users_Groups.groupId = ?) ");
 
-						if ((i + 1) < groupIds.length) {
-							sb.append("OR ");
-						}
+					if ((i + 1) < groupIds.length) {
+						sb.append("OR ");
 					}
-
-					sb.append(StringPool.CLOSE_PARENTHESIS);
-
-					join = sb.toString();
 				}
+
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+
+				join = sb.toString();
 			}
 		}
 		else if (key.equals("usersOrgs")) {
@@ -1037,27 +1050,22 @@ public class UserFinderImpl
 			else if (value instanceof Long[]) {
 				Long[] organizationIds = (Long[])value;
 
-				if (organizationIds.length == 0) {
-					join = "WHERE (Users_Orgs.organizationId = -1)";
-				}
-				else {
-					StringBundler sb = new StringBundler(
-						organizationIds.length * 2 + 1);
+				StringBundler sb = new StringBundler(
+					organizationIds.length * 2 + 1);
 
-					sb.append("WHERE (");
+				sb.append("WHERE (");
 
-					for (int i = 0; i < organizationIds.length; i++) {
-						sb.append("(Users_Orgs.organizationId = ?) ");
+				for (int i = 0; i < organizationIds.length; i++) {
+					sb.append("(Users_Orgs.organizationId = ?) ");
 
-						if ((i + 1) < organizationIds.length) {
-							sb.append("OR ");
-						}
+					if ((i + 1) < organizationIds.length) {
+						sb.append("OR ");
 					}
-
-					sb.append(StringPool.CLOSE_PARENTHESIS);
-
-					join = sb.toString();
 				}
+
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+
+				join = sb.toString();
 			}
 		}
 		else if (key.equals("usersOrgsTree")) {
@@ -1102,27 +1110,22 @@ public class UserFinderImpl
 			else if (value instanceof Long[]) {
 				Long[] userGroupIds = (Long[])value;
 
-				if (userGroupIds.length == 0) {
-					join = "WHERE (Users_UserGroups.userGroupId = -1)";
-				}
-				else {
-					StringBundler sb = new StringBundler(
-						userGroupIds.length * 2 + 1);
+				StringBundler sb = new StringBundler(
+					userGroupIds.length * 2 + 1);
 
-					sb.append("WHERE (");
+				sb.append("WHERE (");
 
-					for (int i = 0; i < userGroupIds.length; i++) {
-						sb.append("(Users_UserGroups.userGroupId = ?) ");
+				for (int i = 0; i < userGroupIds.length; i++) {
+					sb.append("(Users_UserGroups.userGroupId = ?) ");
 
-						if ((i + 1) < userGroupIds.length) {
-							sb.append("OR ");
-						}
+					if ((i + 1) < userGroupIds.length) {
+						sb.append("OR ");
 					}
-
-					sb.append(StringPool.CLOSE_PARENTHESIS);
-
-					join = sb.toString();
 				}
+
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+
+				join = sb.toString();
 			}
 		}
 		else if (key.equals("announcementsDeliveryEmailOrSms")) {

--- a/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/UserFinderImpl.java
@@ -232,6 +232,8 @@ public class UserFinderImpl
 
 		LinkedHashMap<String, Object> params3 = null;
 
+		LinkedHashMap<String, Object> params4 = null;
+
 		Long[] groupIds = null;
 
 		if (params.get("usersGroups") instanceof Long) {
@@ -315,7 +317,11 @@ public class UserFinderImpl
 
 			params3.remove("usersRoles");
 
+			params4 = new LinkedHashMap<String, Object>(params1);
 
+			params4.remove("usersRoles");
+
+			List<Long> organizationIds = new ArrayList<Long>();
 			List<Long> roleGroupIds = new ArrayList<Long>();
 			List<Long> userGroupIds = new ArrayList<Long>();
 
@@ -325,6 +331,9 @@ public class UserFinderImpl
 				for (Group group : groups) {
 					if (group.isUserGroup()) {
 						userGroupIds.add(group.getClassPK());
+					}
+					else if (group.isOrganization()) {
+						organizationIds.add(group.getOrganizationId());
 					}
 					else {
 						roleGroupIds.add(group.getGroupId());
@@ -339,6 +348,10 @@ public class UserFinderImpl
 			params3.put(
 				"usersUserGroups",
 				userGroupIds.toArray(new Long[userGroupIds.size()]));
+
+			params4.put(
+				"usersOrgs",
+				organizationIds.toArray(new Long[organizationIds.size()]));
 		}
 
 		Session session = null;
@@ -364,6 +377,14 @@ public class UserFinderImpl
 					countByC_FN_MN_LN_SN_EA_S(
 						session, companyId, firstNames, middleNames, lastNames,
 						screenNames, emailAddresses, status, params3,
+						andOperator));
+			}
+
+			if (doUnionOnRole) {
+				userIds.addAll(
+					countByC_FN_MN_LN_SN_EA_S(
+						session, companyId, firstNames, middleNames, lastNames,
+						screenNames, emailAddresses, status, params4,
 						andOperator));
 			}
 
@@ -525,6 +546,8 @@ public class UserFinderImpl
 
 		LinkedHashMap<String, Object> params3 = null;
 
+		LinkedHashMap<String, Object> params4 = null;
+
 		Long[] groupIds = null;
 
 		if (params.get("usersGroups") instanceof Long) {
@@ -608,6 +631,11 @@ public class UserFinderImpl
 
 			params3.remove("usersRoles");
 
+			params4 = new LinkedHashMap<String, Object>(params1);
+
+			params4.remove("usersRoles");
+
+			List<Long> organizationIds = new ArrayList<Long>();
 			List<Long> roleGroupIds = new ArrayList<Long>();
 			List<Long> userGroupIds = new ArrayList<Long>();
 
@@ -617,6 +645,9 @@ public class UserFinderImpl
 				for (Group group : groups) {
 					if (group.isUserGroup()) {
 						userGroupIds.add(group.getClassPK());
+					}
+					else if (group.isOrganization()) {
+						organizationIds.add(group.getOrganizationId());
 					}
 					else {
 						roleGroupIds.add(group.getGroupId());
@@ -631,6 +662,10 @@ public class UserFinderImpl
 			params3.put(
 				"usersUserGroups",
 				userGroupIds.toArray(new Long[userGroupIds.size()]));
+
+			params4.put(
+				"usersOrgs",
+				organizationIds.toArray(new Long[organizationIds.size()]));
 		}
 
 		Session session = null;
@@ -673,6 +708,12 @@ public class UserFinderImpl
 
 				sb.append(" UNION (");
 				sb.append(replaceJoinAndWhere(sql, params3));
+				sb.append(StringPool.CLOSE_PARENTHESIS);
+			}
+
+			if (doUnionOnRole) {
+				sb.append(" UNION (");
+				sb.append(replaceJoinAndWhere(sql, params4));
 				sb.append(StringPool.CLOSE_PARENTHESIS);
 			}
 
@@ -721,6 +762,22 @@ public class UserFinderImpl
 				}
 
 				setJoin(qPos, params3);
+
+				qPos.add(companyId);
+				qPos.add(false);
+				qPos.add(firstNames, 2);
+				qPos.add(middleNames, 2);
+				qPos.add(lastNames, 2);
+				qPos.add(screenNames, 2);
+				qPos.add(emailAddresses, 2);
+
+				if (status != WorkflowConstants.STATUS_ANY) {
+					qPos.add(status);
+				}
+			}
+
+			if (doUnionOnRole) {
+				setJoin(qPos, params4);
 
 				qPos.add(companyId);
 				qPos.add(false);

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.persistence;
+
+import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Organization;
+import com.liferay.portal.model.User;
+import com.liferay.portal.model.UserGroup;
+import com.liferay.portal.service.GroupLocalServiceUtil;
+import com.liferay.portal.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.service.RoleLocalServiceUtil;
+import com.liferay.portal.service.UserGroupLocalServiceUtil;
+import com.liferay.portal.service.UserLocalServiceUtil;
+import com.liferay.portal.test.EnvironmentExecutionTestListener;
+import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
+import com.liferay.portal.test.TransactionalExecutionTestListener;
+import com.liferay.portal.util.GroupTestUtil;
+import com.liferay.portal.util.OrganizationTestUtil;
+import com.liferay.portal.util.RoleTestUtil;
+import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portal.util.UserGroupTestUtil;
+import com.liferay.portal.util.UserTestUtil;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jozsef Illes
+ */
+@ExecutionTestListeners(
+	listeners = {
+		EnvironmentExecutionTestListener.class,
+		TransactionalExecutionTestListener.class
+	})
+@RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
+public class UserFinderTest {
+
+	@Before
+	public void setUp() throws Exception {
+		FinderCacheUtil.clearCache();
+
+		createGroupsWithUsers();
+	}
+
+	@Test
+	public void testCountByKeywordsWithGroupUnion()
+		throws PortalException, SystemException {
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put(
+			"usersGroups",
+			new Long[] {
+				_site.getGroupId(), _org.getGroupId(),
+				_userGroup.getGroup().getGroupId()
+			});
+		params.put("inherit", Boolean.TRUE);
+
+		int userCount = countByKeywords(params);
+
+		Assert.assertEquals(4, userCount);
+	}
+
+	@Test
+	public void testCountByKeywordsWithRoleUnion() throws Exception {
+		long roleId = RoleTestUtil.addRegularRole(_site.getGroupId());
+
+		RoleLocalServiceUtil.addGroupRole(_org.getGroupId(), roleId);
+
+		RoleLocalServiceUtil.addGroupRole(
+			_userGroup.getGroup().getGroupId(), roleId);
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersRoles", roleId);
+		params.put("inherit", Boolean.TRUE);
+
+		int userCount = countByKeywords(params);
+
+		Assert.assertEquals(4, userCount);
+	}
+
+	@Test
+	public void testCountByKeywordsWithRoleUnionThroughSite() throws Exception {
+		GroupLocalServiceUtil.addOrganizationGroup(
+			_org.getOrganizationId(), _site);
+
+		GroupLocalServiceUtil.addUserGroupGroup(
+			_userGroup.getUserGroupId(), _site);
+
+		long roleId = RoleTestUtil.addRegularRole(_site.getGroupId());
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersRoles", roleId);
+		params.put("inherit", Boolean.TRUE);
+
+		int userCount = countByKeywords(params);
+
+		Assert.assertEquals(4, userCount);
+	}
+
+	@Test
+	public void testFindByKeywordsWithGroupUnion()
+		throws PortalException, SystemException {
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put(
+			"usersGroups",
+			new Long[] {
+				_site.getGroupId(), _org.getGroupId(),
+				_userGroup.getGroup().getGroupId()
+			});
+		params.put("inherit", Boolean.TRUE);
+
+		List<User> usersFound =
+			UserFinderUtil.findByKeywords(
+				TestPropsValues.getCompanyId(), null,
+				WorkflowConstants.STATUS_APPROVED, params, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, (OrderByComparator)null);
+
+		Assert.assertTrue(usersFound.contains(_siteUser));
+
+		Assert.assertTrue(usersFound.contains(_orgUser));
+
+		Assert.assertTrue(usersFound.contains(_userGroupUser));
+
+		User testUser =
+			UserLocalServiceUtil.getUserByScreenName(
+				TestPropsValues.getCompanyId(), "test");
+
+		Assert.assertTrue(usersFound.contains(testUser));
+
+		Assert.assertEquals(4, usersFound.size());
+	}
+
+	@Test
+	public void testFindByKeywordsWithRoleUnion() throws Exception {
+		long roleId = RoleTestUtil.addRegularRole(_site.getGroupId());
+
+		RoleLocalServiceUtil.addGroupRole(_org.getGroupId(), roleId);
+
+		RoleLocalServiceUtil.addGroupRole(
+			_userGroup.getGroup().getGroupId(), roleId);
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersRoles", roleId);
+		params.put("inherit", Boolean.TRUE);
+
+		List<User> usersFound = findByKeywords(params);
+
+		Assert.assertTrue(
+			"Site user must inherit Role", usersFound.contains(_siteUser));
+
+		Assert.assertTrue(
+			"Organization user must inherit Role",
+			usersFound.contains(_orgUser));
+
+		Assert.assertTrue(
+			"User Group user must inherit Role",
+			usersFound.contains(_userGroupUser));
+
+		User testUser =
+			UserLocalServiceUtil.getUserByScreenName(
+				TestPropsValues.getCompanyId(), "test");
+
+		Assert.assertTrue(usersFound.contains(testUser));
+
+		Assert.assertEquals(4, usersFound.size());
+	}
+
+	@Test
+	public void testFindByKeywordsWithRoleUnionThroughSite() throws Exception {
+		GroupLocalServiceUtil.addOrganizationGroup(
+			_org.getOrganizationId(), _site);
+
+		GroupLocalServiceUtil.addUserGroupGroup(
+			_userGroup.getUserGroupId(), _site);
+
+		long roleId = RoleTestUtil.addRegularRole(_site.getGroupId());
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersRoles", roleId);
+		params.put("inherit", Boolean.TRUE);
+
+		List<User> usersFound = findByKeywords(params);
+
+		Assert.assertTrue(
+			"Site user must inherit Role", usersFound.contains(_siteUser));
+
+		Assert.assertTrue(
+			"Organization user must inherit Role",
+			usersFound.contains(_orgUser));
+
+		Assert.assertTrue(
+			"User Group user must inherit Role",
+			usersFound.contains(_userGroupUser));
+
+		User testUser =
+			UserLocalServiceUtil.getUserByScreenName(
+				TestPropsValues.getCompanyId(), "test");
+
+		Assert.assertTrue(usersFound.contains(testUser));
+
+		Assert.assertEquals(4, usersFound.size());
+	}
+
+	@Test
+	public void testFindGroupUsersByKeywords()
+		throws PortalException, SystemException {
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersGroups", _site.getGroupId());
+
+		List<User> usersFound = findByKeywords(params);
+
+		Assert.assertTrue(usersFound.contains(_siteUser));
+	}
+
+	@Test
+	public void testFindOrgUsersByKeywords()
+		throws PortalException, SystemException {
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersOrgs", _org.getOrganizationId());
+
+		List<User> usersFound = findByKeywords(params);
+
+		Assert.assertTrue(usersFound.contains(_orgUser));
+	}
+
+	@Test
+	public void testFindUserGroupUsersByKeywords()
+		throws PortalException, SystemException {
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersUserGroups", _userGroup.getUserGroupId());
+
+		List<User> usersFound = findByKeywords(params);
+
+		Assert.assertTrue(usersFound.contains(_userGroupUser));
+	}
+
+	protected int countByKeywords(LinkedHashMap<String, Object> params)
+		throws PortalException, SystemException {
+
+		return UserFinderUtil.countByKeywords(
+			TestPropsValues.getCompanyId(), null,
+			WorkflowConstants.STATUS_APPROVED, params);
+	}
+
+	protected User createApprovedUser(String screenName) throws Exception {
+		User user = UserTestUtil.addUser(
+			screenName, TestPropsValues.getGroupId());
+
+		user.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+		UserLocalServiceUtil.updateUser(user);
+
+		return user;
+	}
+
+	protected void createGroupsWithUsers() throws Exception {
+		_site = GroupTestUtil.addGroup();
+		_siteUser = createApprovedUser("siteMember");
+		GroupLocalServiceUtil.addUserGroup(_siteUser.getUserId(), _site);
+
+		_org = OrganizationTestUtil.addOrganization();
+		_orgUser = createApprovedUser("orgMember");
+		OrganizationLocalServiceUtil.addUserOrganization(
+			_orgUser.getUserId(), _org);
+
+		_userGroup = UserGroupTestUtil.addUserGroup();
+		_userGroupUser = createApprovedUser("userGroupMember");
+		UserGroupLocalServiceUtil.addUserUserGroup(
+			_userGroupUser.getUserId(), _userGroup);
+	}
+
+	protected List<User> findByKeywords(LinkedHashMap<String, Object> params)
+		throws PortalException, SystemException {
+
+		return UserFinderUtil.findByKeywords(
+			TestPropsValues.getCompanyId(), null,
+			WorkflowConstants.STATUS_APPROVED, params, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, (OrderByComparator)null);
+	}
+
+	private Organization _org;
+	private User _orgUser;
+	private Group _site;
+	private User _siteUser;
+	private UserGroup _userGroup;
+	private User _userGroupUser;
+
+}


### PR DESCRIPTION
@BeforeClass was intentional. It is needed because we need to create the user outside of the transactional context

Because of the workflow logic in ULSI, addUser changes the status of the user in a callback (UserLocalServiceImpl.startWorkflowInstance().. which we'll never receive.

By running it in @BeforeClass, it passes the callbackListList.isEmpty() check in TransactionCommitCallbackUtil and invokes it right away.

The alternative was to add a user, change the status, and update the user as jozsefilles does here: 1bc3dcd.

I ran this by Shuyang and this is what he advised me to do.
