### PR TITLE
LPS-41109 Drop off the initial caches synchronization, the current cache...

### DIFF
--- a/portal-impl/src/com/liferay/portal/cache/ehcache/EhcacheStreamBootstrapCacheLoader.java
+++ b/portal-impl/src/com/liferay/portal/cache/ehcache/EhcacheStreamBootstrapCacheLoader.java
@@ -46,13 +46,16 @@ public class EhcacheStreamBootstrapCacheLoader implements BootstrapCacheLoader {
 			_started = true;
 		}
 
+		if (_deferredEhcaches.isEmpty()) {
+			return;
+		}
+
 		if (_log.isDebugEnabled()) {
 			_log.debug("Loading deferred caches");
 		}
 
 		try {
 			EhcacheStreamBootstrapHelpUtil.loadCachesFromCluster(
-				true,
 				_deferredEhcaches.toArray(
 					new Ehcache[_deferredEhcaches.size()]));
 		}
@@ -94,8 +97,7 @@ public class EhcacheStreamBootstrapCacheLoader implements BootstrapCacheLoader {
 		}
 
 		try {
-			EhcacheStreamBootstrapHelpUtil.loadCachesFromCluster(
-				false, ehcache);
+			EhcacheStreamBootstrapHelpUtil.loadCachesFromCluster(ehcache);
 		}
 		catch (Exception e) {
 			throw new CacheException(e);


### PR DESCRIPTION
... infrastructure can not tell whether a cache is for portal or plugins, for plugins' caches it is possible that cache is loaded before plugin initialization which will cause classloading failure.
