### PR TITLE
LPS-35520

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -601,6 +601,8 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 				String path = ExportImportPathUtil.getModelPath(fileEntry);
 
 				sb.replace(beginPos, endPos, "[$dl-reference=" + path + "$]");
+
+				_deleteTimestampFromUrlParams(sb, beginPos);
 			}
 			catch (Exception e) {
 				if (_log.isDebugEnabled()) {
@@ -1767,6 +1769,31 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		}
 
 		return null;
+	}
+
+	private void _deleteTimestampFromUrlParams(StringBuilder sb, int beginPos) {
+		int closeBracketPos = sb.indexOf(StringPool.CLOSE_BRACKET, beginPos);
+
+		if ((closeBracketPos == -1) || (closeBracketPos == (sb.length() - 1)) ||
+			(sb.charAt(closeBracketPos + 1) != CharPool.QUESTION)) {
+
+			return;
+		}
+
+		int questionPos = closeBracketPos + 1;
+
+		int endPosParams = StringUtil.indexOfAny(
+			sb.toString(), _DL_REFERENCE_LEGACY_STOP_CHARS, questionPos + 1);
+
+		if (endPosParams == -1) {
+			return;
+		}
+
+		String urlParams = sb.substring(questionPos, endPosParams);
+
+		urlParams = HttpUtil.removeParameter(urlParams, "t");
+
+		sb.replace(questionPos, endPosParams, urlParams);
 	}
 
 	private static final char[] _DL_REFERENCE_LEGACY_STOP_CHARS = {

--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -602,7 +602,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 
 				sb.replace(beginPos, endPos, "[$dl-reference=" + path + "$]");
 
-				_deleteTimestampFromUrlParams(sb, beginPos);
+				deleteTimestampFromUrlParams(sb, beginPos);
 			}
 			catch (Exception e) {
 				if (_log.isDebugEnabled()) {
@@ -1511,6 +1511,31 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		}
 	}
 
+	protected void deleteTimestampFromUrlParams(
+		StringBuilder sb, int beginPos) {
+
+		beginPos = sb.indexOf(StringPool.CLOSE_BRACKET, beginPos);
+
+		if ((beginPos == -1) || (beginPos == (sb.length() - 1)) ||
+			(sb.charAt(beginPos + 1) != CharPool.QUESTION)) {
+
+			return;
+		}
+
+		int endPos = StringUtil.indexOfAny(
+			sb.toString(), _DL_REFERENCE_LEGACY_STOP_CHARS, beginPos + 2);
+
+		if (endPos == -1) {
+			return;
+		}
+
+		String urlParams = sb.substring(beginPos + 1, endPos);
+
+		urlParams = HttpUtil.removeParameter(urlParams, "t");
+
+		sb.replace(beginPos + 1, endPos, urlParams);
+	}
+
 	protected Map<String, String[]> getDLReferenceParameters(
 		PortletDataContext portletDataContext, String content, int beginPos,
 		int endPos) {
@@ -1769,31 +1794,6 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		}
 
 		return null;
-	}
-
-	private void _deleteTimestampFromUrlParams(StringBuilder sb, int beginPos) {
-		int closeBracketPos = sb.indexOf(StringPool.CLOSE_BRACKET, beginPos);
-
-		if ((closeBracketPos == -1) || (closeBracketPos == (sb.length() - 1)) ||
-			(sb.charAt(closeBracketPos + 1) != CharPool.QUESTION)) {
-
-			return;
-		}
-
-		int questionPos = closeBracketPos + 1;
-
-		int endPosParams = StringUtil.indexOfAny(
-			sb.toString(), _DL_REFERENCE_LEGACY_STOP_CHARS, questionPos + 1);
-
-		if (endPosParams == -1) {
-			return;
-		}
-
-		String urlParams = sb.substring(questionPos, endPosParams);
-
-		urlParams = HttpUtil.removeParameter(urlParams, "t");
-
-		sb.replace(questionPos, endPosParams, urlParams);
 	}
 
 	private static final char[] _DL_REFERENCE_LEGACY_STOP_CHARS = {

--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -573,8 +573,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 					portletDataContext, content,
 					beginPos + contextPath.length(), endPos);
 
-			FileEntry fileEntry = getFileEntry(
-				portletDataContext, dlReferenceParameters);
+			FileEntry fileEntry = getFileEntry(dlReferenceParameters);
 
 			if (fileEntry == null) {
 				endPos = beginPos - 1;
@@ -1608,9 +1607,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		return map;
 	}
 
-	protected FileEntry getFileEntry(
-		PortletDataContext portletDataContext, Map<String, String[]> map) {
-
+	protected FileEntry getFileEntry(Map<String, String[]> map) {
 		if (map == null) {
 			return null;
 		}

--- a/portal-impl/test/integration/com/liferay/portal/lar/ExportImportHelperUtilTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/ExportImportHelperUtilTest.java
@@ -503,7 +503,7 @@ public class ExportImportHelperUtilTest extends PowerMockito {
 
 	protected List<String> getURLs(String content) {
 		Pattern pattern = Pattern.compile(
-			"(?:href=|\\{|\\[)(.*?)(?:>|\\}|\\]|Link\\]\\])");
+			"(?:href=|\\{|\\[[^$])(.*?)(?:>|\\}|[^$]\\]|Link\\]\\])");
 
 		Matcher matcher = pattern.matcher(content);
 

--- a/portal-impl/test/integration/com/liferay/portal/lar/ExportImportHelperUtilTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/ExportImportHelperUtilTest.java
@@ -171,51 +171,30 @@ public class ExportImportHelperUtilTest extends PowerMockito {
 		String content = replaceParameters(
 			getContent("dl_references_timestamp.txt"), _fileEntry);
 
-		String[] urls = content.split("\n");
+		List<String> urls = replaceTimestampParameters(content);
 
-		List<String> urlsWithTimestamp = replaceTimestampParameters(urls);
-
-		Assert.assertEquals(
-			"Testmethod replaceTimestampParameters is bad", 3 * urls.length,
-			urlsWithTimestamp.size());
-
-		content = StringUtil.merge(urlsWithTimestamp,"\n");
+		content = StringUtil.merge(urls,"\n");
 
 		content = ExportImportHelperUtil.replaceExportContentReferences(
 			_portletDataContextExport, _referrerStagedModel,
 			rootElement.element("entry"), content, true);
 
-		String[] urlsExported = content.split("\n");
+		String[] exportedUrls = content.split("\n");
 
-		Assert.assertEquals(urlsExported.length, urlsWithTimestamp.size());
+		Assert.assertEquals(urls.size(), exportedUrls.length);
 
-		Pattern p = Pattern.compile("[?&]t=");
-		Matcher m = p.matcher("");
+		for (int i = 0; i < urls.size(); i++) {
+			String exportedUrl = exportedUrls[i];
+			String url = urls.get(i);
 
-		for (int i = 0; i < urlsWithTimestamp.size(); i++) {
-			String urlExported = urlsExported[i];
-			String urlWithTimestamp = urlsWithTimestamp.get(i);
+			Assert.assertFalse(exportedUrl.matches("[?&]t="));
 
-			Assert.assertFalse(
-				"timestamp not deleted:" + urlExported,
-				m.reset(urlExported).find());
-
-			if (urlWithTimestamp.contains("/documents/") &&
-				urlWithTimestamp.contains("?")) {
-
-				Assert.assertTrue(
-					"other parameters deleted:" + urlExported + ", " +
-						urlWithTimestamp,
-					urlExported.contains("width=100&height=100"));
+			if (url.contains("/documents/") && url.contains("?")) {
+				Assert.assertTrue(exportedUrl.contains("width=100&height=100"));
 			}
 
-			if (urlWithTimestamp.contains("/documents/") &&
-				urlWithTimestamp.contains("mustkeep")) {
-
-				Assert.assertTrue(
-					"other parameters deleted:" + urlExported + ", " +
-						urlWithTimestamp,
-					urlExported.contains("mustkeep"));
+			if (url.contains("/documents/") && url.contains("mustkeep")) {
+				Assert.assertTrue(exportedUrl.contains("mustkeep"));
 			}
 		}
 	}
@@ -539,35 +518,48 @@ public class ExportImportHelperUtilTest extends PowerMockito {
 			});
 	}
 
-	protected List<String> replaceTimestampParameters(String[] urls)
+	protected List<String> replaceTimestampParameters(String content)
 		throws Exception {
 
-		String time = "t=" + ServiceTestUtil.randomLong();
-		String width = "width=100";
-		String height = "height=100";
+		List<String> urls = new ArrayList<String>();
 
-		String[] params = {
-			time + "&" + width + "&" + height,
-			width + "&" + time + "&" + height, width + "&" + height + "&" + time
-		};
+		for (String line : content.split("\n")) {
+			if (line.contains("TIMESTAMP$]")) {
+				urls.add(line);
+			}
+		}
+
+		String timestampParameter = "t=" + ServiceTestUtil.randomLong();
+
+		String parameters1 = timestampParameter + "&width=100&height=100";
+		String parameters2 = "width=100&" + timestampParameter + "&height=100";
+		String parameters3 = "width=100&height=100&" + timestampParameter;
+		String parameters4 =
+			timestampParameter + "?" + timestampParameter +
+				"&width=100&height=100";
 
 		List<String> outUrls = new ArrayList<String>();
 
 		for (String url : urls) {
-			for (String param : params) {
-				String urlWithTimestamp = url.replace(
-					"[$TIMESTAMP$]", "&" + param);
+			outUrls.add(
+				StringUtil.replace(
+					url, new String[] {"[$TIMESTAMP$]", "[$ONLYTIMESTAMP$]"},
+					new String[] {"&" + parameters1, "?" + parameters1}));
 
-				String urlWithTimestampOnly = url.replace(
-					"[$ONLYTIMESTAMP$]", "?" + param);
+			outUrls.add(
+				StringUtil.replace(
+					url, new String[] {"[$TIMESTAMP$]", "[$ONLYTIMESTAMP$]"},
+					new String[] {"&" + parameters2, "?" + parameters2}));
 
-				if (!urlWithTimestamp.equals(url)) {
-					outUrls.add(urlWithTimestamp);
-				}
-				else {
-					outUrls.add(urlWithTimestampOnly);
-				}
-			}
+			outUrls.add(
+				StringUtil.replace(
+					url, new String[] {"[$TIMESTAMP$]", "[$ONLYTIMESTAMP$]"},
+					new String[] {"&" + parameters3, "?" + parameters3}));
+
+			outUrls.add(
+				StringUtil.replace(
+					url, new String[] {"[$TIMESTAMP$]", "[$ONLYTIMESTAMP$]"},
+					new String[] {"", "?" + parameters4}));
 		}
 
 		return outUrls;

--- a/portal-impl/test/integration/com/liferay/portal/lar/dependencies/dl_references.txt
+++ b/portal-impl/test/integration/com/liferay/portal/lar/dependencies/dl_references.txt
@@ -38,6 +38,16 @@ HTML reference with no quotes:
 <a href=/image/image_gallery?img_id=[$IMAGE_ID$]>Link</a>
 <a href=/image/image_gallery?i_id=[$IMAGE_ID$]>Link</a>
 
+HTML reference with no quotes but space:
+
+<a href=/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$] style=mustkeep>Link</a>
+<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]?t=1366811139876 style=mustkeep>Link</a>
+<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?image_id=[$IMAGE_ID$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?img_id=[$IMAGE_ID$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?i_id=[$IMAGE_ID$] style=mustkeep>Link</a>
+
 HTML reference with double quotes:
 
 <a href="/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$]">Link</a>

--- a/portal-impl/test/integration/com/liferay/portal/lar/dependencies/dl_references_timestamp.txt
+++ b/portal-impl/test/integration/com/liferay/portal/lar/dependencies/dl_references_timestamp.txt
@@ -1,0 +1,70 @@
+CREOLE image reference:
+
+{{/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]}}
+{{/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]}}
+{{/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]}}
+{{/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]}}
+{{/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]}}
+{{/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]}}
+{{/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]}}
+
+CREOLE link with text:
+
+[[/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]|Link]]
+[[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]|Link]]
+[[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]|Link]]
+[[/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]|Link]]
+[[/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]|Link]]
+[[/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]|Link]]
+[[/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]|Link]]
+
+CREOLE link without text:
+
+[[/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]]]
+[[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]]]
+[[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]]]
+[[/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]]]
+[[/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]]]
+[[/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]]]
+[[/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]]]
+
+HTML reference with no quotes:
+
+<a href=/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]>Link</a>
+<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]>Link</a>
+<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]>Link</a>
+<a href=/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]>Link</a>
+<a href=/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]>Link</a>
+<a href=/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]>Link</a>
+<a href=/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]>Link</a>
+
+HTML reference with no quotes but space:
+
+<a href=/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
+<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$] style=mustkeep>Link</a>
+<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
+<a href=/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
+
+
+HTML reference with double quotes:
+
+<a href="/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]">Link</a>
+<a href="/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]">Link</a>
+<a href="/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]">Link</a>
+<a href="/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]">Link</a>
+<a href="/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]">Link</a>
+<a href="/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]">Link</a>
+<a href="/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]">Link</a>
+
+HTML reference with single quotes:
+
+<a href='/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]'>Link</a>
+<a href='/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]'>Link</a>
+<a href='/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]'>Link</a>
+<a href='/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]'>Link</a>
+<a href='/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]'>Link</a>
+<a href='/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]'>Link</a>
+<a href='/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$]'>Link</a>

--- a/portal-impl/test/integration/com/liferay/portal/lar/dependencies/dl_references_timestamp.txt
+++ b/portal-impl/test/integration/com/liferay/portal/lar/dependencies/dl_references_timestamp.txt
@@ -2,7 +2,6 @@ CREOLE image reference:
 
 {{/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]}}
 {{/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]}}
-{{/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]}}
 {{/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]}}
 {{/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]}}
 {{/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]}}
@@ -12,7 +11,6 @@ CREOLE link with text:
 
 [[/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]|Link]]
 [[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]|Link]]
-[[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]|Link]]
 [[/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]|Link]]
 [[/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]|Link]]
 [[/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]|Link]]
@@ -22,7 +20,6 @@ CREOLE link without text:
 
 [[/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]]]
 [[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]]]
-[[/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]]]
 [[/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]]]
 [[/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]]]
 [[/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]]]
@@ -32,7 +29,6 @@ HTML reference with no quotes:
 
 <a href=/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]>Link</a>
 <a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]>Link</a>
-<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]>Link</a>
 <a href=/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]>Link</a>
 <a href=/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]>Link</a>
 <a href=/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]>Link</a>
@@ -42,18 +38,15 @@ HTML reference with no quotes but space:
 
 <a href=/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
 <a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$] style=mustkeep>Link</a>
-<a href=/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$] style=mustkeep>Link</a>
 <a href=/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
 <a href=/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
 <a href=/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
 <a href=/image/image_gallery?i_id=[$IMAGE_ID$][$TIMESTAMP$] style=mustkeep>Link</a>
 
-
 HTML reference with double quotes:
 
 <a href="/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]">Link</a>
 <a href="/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]">Link</a>
-<a href="/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]">Link</a>
 <a href="/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]">Link</a>
 <a href="/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]">Link</a>
 <a href="/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]">Link</a>
@@ -63,7 +56,6 @@ HTML reference with single quotes:
 
 <a href='/c/document_library/get_file?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]'>Link</a>
 <a href='/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$][$ONLYTIMESTAMP$]'>Link</a>
-<a href='/documents/[$GROUP_ID$]/0/[$TITLE$]/[$UUID$]'>Link</a>
 <a href='/image/image_gallery?uuid=[$UUID$]&groupId=[$GROUP_ID$][$TIMESTAMP$]'>Link</a>
 <a href='/image/image_gallery?image_id=[$IMAGE_ID$][$TIMESTAMP$]'>Link</a>
 <a href='/image/image_gallery?img_id=[$IMAGE_ID$][$TIMESTAMP$]'>Link</a>


### PR DESCRIPTION
Hi Brian,

I am re-sending this pull after we extended the test case with a new scenario where the URL has 2 time stamp parameters. Zsolt also answered your question in the LPS, but to summarize it we decided to fix it on the export site because we wanted to make sure the URL doesn't have any t parameters after the export (we remove all of these with HttpUtil.removeParameter()), so the importer can process the URL and append the new t attribute without any logic change.

thanks,
Daniel
