### PR TITLE
LPS-31279

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/http/GroupServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/GroupServiceHttp.java
@@ -786,51 +786,12 @@ public class GroupServiceHttp {
 	}
 
 	public static java.util.List<com.liferay.portal.model.Group> getUserPlaces(
-		HttpPrincipal httpPrincipal, long userId,
-		java.lang.String[] classNames, java.lang.String name, boolean active,
-		boolean includeControlPanel, int start, int end)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		try {
-			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserPlaces", _getUserPlacesParameterTypes20);
-
-			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
-					classNames, name, active, includeControlPanel, start, end);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception e) {
-				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
-					throw (com.liferay.portal.kernel.exception.PortalException)e;
-				}
-
-				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
-					throw (com.liferay.portal.kernel.exception.SystemException)e;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(e);
-			}
-
-			return (java.util.List<com.liferay.portal.model.Group>)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
-
-			throw se;
-		}
-	}
-
-	public static java.util.List<com.liferay.portal.model.Group> getUserPlaces(
 		HttpPrincipal httpPrincipal, java.lang.String[] classNames, int max)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserPlaces", _getUserPlacesParameterTypes21);
+					"getUserPlaces", _getUserPlacesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					classNames, max);
@@ -866,7 +827,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserPlacesCount", _getUserPlacesCountParameterTypes22);
+					"getUserPlacesCount", _getUserPlacesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
 
@@ -902,7 +863,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserSites", _getUserSitesParameterTypes23);
+					"getUserSites", _getUserSitesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
 
@@ -938,9 +899,47 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserSitesGroups", _getUserSitesGroupsParameterTypes24);
+					"getUserSitesGroups", _getUserSitesGroupsParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portal.model.Group>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
+		HttpPrincipal httpPrincipal, long userId,
+		java.lang.String[] classNames, int max)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
+					"getUserSitesGroups", _getUserSitesGroupsParameterTypes24);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
+					classNames, max);
 
 			Object returnObj = null;
 
@@ -1007,89 +1006,12 @@ public class GroupServiceHttp {
 	}
 
 	public static java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		HttpPrincipal httpPrincipal, long userId,
-		java.lang.String[] classNames, int max)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		try {
-			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserSitesGroups", _getUserSitesGroupsParameterTypes26);
-
-			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
-					classNames, max);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception e) {
-				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
-					throw (com.liferay.portal.kernel.exception.PortalException)e;
-				}
-
-				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
-					throw (com.liferay.portal.kernel.exception.SystemException)e;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(e);
-			}
-
-			return (java.util.List<com.liferay.portal.model.Group>)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
-
-			throw se;
-		}
-	}
-
-	public static java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		HttpPrincipal httpPrincipal, long userId,
-		java.lang.String[] classNames, java.lang.String name, boolean active,
-		boolean includeControlPanel, int start, int end)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		try {
-			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserSitesGroups", _getUserSitesGroupsParameterTypes27);
-
-			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
-					classNames, name, active, includeControlPanel, start, end);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception e) {
-				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
-					throw (com.liferay.portal.kernel.exception.PortalException)e;
-				}
-
-				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
-					throw (com.liferay.portal.kernel.exception.SystemException)e;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(e);
-			}
-
-			return (java.util.List<com.liferay.portal.model.Group>)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
-
-			throw se;
-		}
-	}
-
-	public static java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
 		HttpPrincipal httpPrincipal, java.lang.String[] classNames, int max)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"getUserSitesGroups", _getUserSitesGroupsParameterTypes28);
+					"getUserSitesGroups", _getUserSitesGroupsParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					classNames, max);
@@ -1126,7 +1048,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
 					"getUserSitesGroupsCount",
-					_getUserSitesGroupsCountParameterTypes29);
+					_getUserSitesGroupsCountParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
 
@@ -1162,7 +1084,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"hasUserGroup", _hasUserGroupParameterTypes30);
+					"hasUserGroup", _hasUserGroupParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
 					groupId);
@@ -1201,7 +1123,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"search", _searchParameterTypes31);
+					"search", _searchParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, name, description, params, start, end);
@@ -1238,7 +1160,7 @@ public class GroupServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"searchCount", _searchCountParameterTypes32);
+					"searchCount", _searchCountParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, name, description, params);
@@ -1271,7 +1193,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"setRoleGroups", _setRoleGroupsParameterTypes33);
+					"setRoleGroups", _setRoleGroupsParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, roleId,
 					groupIds);
@@ -1304,7 +1226,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"unsetRoleGroups", _unsetRoleGroupsParameterTypes34);
+					"unsetRoleGroups", _unsetRoleGroupsParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, roleId,
 					groupIds);
@@ -1337,7 +1259,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"updateFriendlyURL", _updateFriendlyURLParameterTypes35);
+					"updateFriendlyURL", _updateFriendlyURLParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					friendlyURL);
@@ -1378,7 +1300,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"updateGroup", _updateGroupParameterTypes36);
+					"updateGroup", _updateGroupParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentGroupId, name, description, type, manualMembership,
@@ -1416,7 +1338,7 @@ public class GroupServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
-					"updateGroup", _updateGroupParameterTypes37);
+					"updateGroup", _updateGroupParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					typeSettings);
@@ -1455,7 +1377,7 @@ public class GroupServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(GroupServiceUtil.class,
 					"updateStagedPortlets",
-					_updateStagedPortletsParameterTypes38);
+					_updateStagedPortletsParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					stagedPortletIds);
@@ -1551,65 +1473,57 @@ public class GroupServiceHttp {
 			long.class, java.lang.String[].class, int.class
 		};
 	private static final Class<?>[] _getUserPlacesParameterTypes20 = new Class[] {
-			long.class, java.lang.String[].class, java.lang.String.class,
-			boolean.class, boolean.class, int.class, int.class
-		};
-	private static final Class<?>[] _getUserPlacesParameterTypes21 = new Class[] {
 			java.lang.String[].class, int.class
 		};
-	private static final Class<?>[] _getUserPlacesCountParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getUserPlacesCountParameterTypes21 = new Class[] {
 			
 		};
-	private static final Class<?>[] _getUserSitesParameterTypes23 = new Class[] {  };
-	private static final Class<?>[] _getUserSitesGroupsParameterTypes24 = new Class[] {
+	private static final Class<?>[] _getUserSitesParameterTypes22 = new Class[] {  };
+	private static final Class<?>[] _getUserSitesGroupsParameterTypes23 = new Class[] {
 			
+		};
+	private static final Class<?>[] _getUserSitesGroupsParameterTypes24 = new Class[] {
+			long.class, java.lang.String[].class, int.class
 		};
 	private static final Class<?>[] _getUserSitesGroupsParameterTypes25 = new Class[] {
 			long.class, java.lang.String[].class, boolean.class, int.class
 		};
 	private static final Class<?>[] _getUserSitesGroupsParameterTypes26 = new Class[] {
-			long.class, java.lang.String[].class, int.class
-		};
-	private static final Class<?>[] _getUserSitesGroupsParameterTypes27 = new Class[] {
-			long.class, java.lang.String[].class, java.lang.String.class,
-			boolean.class, boolean.class, int.class, int.class
-		};
-	private static final Class<?>[] _getUserSitesGroupsParameterTypes28 = new Class[] {
 			java.lang.String[].class, int.class
 		};
-	private static final Class<?>[] _getUserSitesGroupsCountParameterTypes29 = new Class[] {
+	private static final Class<?>[] _getUserSitesGroupsCountParameterTypes27 = new Class[] {
 			
 		};
-	private static final Class<?>[] _hasUserGroupParameterTypes30 = new Class[] {
+	private static final Class<?>[] _hasUserGroupParameterTypes28 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _searchParameterTypes31 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes29 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String[].class, int.class, int.class
 		};
-	private static final Class<?>[] _searchCountParameterTypes32 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes30 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String[].class
 		};
-	private static final Class<?>[] _setRoleGroupsParameterTypes33 = new Class[] {
+	private static final Class<?>[] _setRoleGroupsParameterTypes31 = new Class[] {
 			long.class, long[].class
 		};
-	private static final Class<?>[] _unsetRoleGroupsParameterTypes34 = new Class[] {
+	private static final Class<?>[] _unsetRoleGroupsParameterTypes32 = new Class[] {
 			long.class, long[].class
 		};
-	private static final Class<?>[] _updateFriendlyURLParameterTypes35 = new Class[] {
+	private static final Class<?>[] _updateFriendlyURLParameterTypes33 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _updateGroupParameterTypes36 = new Class[] {
+	private static final Class<?>[] _updateGroupParameterTypes34 = new Class[] {
 			long.class, long.class, java.lang.String.class,
 			java.lang.String.class, int.class, boolean.class, int.class,
 			java.lang.String.class, boolean.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateGroupParameterTypes37 = new Class[] {
+	private static final Class<?>[] _updateGroupParameterTypes35 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _updateStagedPortletsParameterTypes38 = new Class[] {
+	private static final Class<?>[] _updateStagedPortletsParameterTypes36 = new Class[] {
 			long.class, java.util.Map.class
 		};
 }

--- a/portal-impl/src/com/liferay/portal/service/http/GroupServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/GroupServiceSoap.java
@@ -611,27 +611,6 @@ public class GroupServiceSoap {
 	}
 
 	/**
-	* @deprecated As of 6.2.0, replaced by {@link #getUserSitesGroups(long,
-	String[], String, boolean, boolean, int, int)}
-	*/
-	public static com.liferay.portal.model.GroupSoap[] getUserPlaces(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
-		throws RemoteException {
-		try {
-			java.util.List<com.liferay.portal.model.Group> returnValue = GroupServiceUtil.getUserPlaces(userId,
-					classNames, name, active, includeControlPanel, start, end);
-
-			return com.liferay.portal.model.GroupSoap.toSoapModels(returnValue);
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-
-			throw new RemoteException(e.getMessage());
-		}
-	}
-
-	/**
 	* Returns the guest or current user's groups &quot;sites&quot; associated
 	* with the group entity class names, including the Control Panel group if
 	* the user is permitted to view the Control Panel.
@@ -743,22 +722,6 @@ public class GroupServiceSoap {
 		}
 	}
 
-	public static com.liferay.portal.model.GroupSoap[] getUserSitesGroups(
-		long userId, java.lang.String[] classNames,
-		boolean includeControlPanel, int max) throws RemoteException {
-		try {
-			java.util.List<com.liferay.portal.model.Group> returnValue = GroupServiceUtil.getUserSitesGroups(userId,
-					classNames, includeControlPanel, max);
-
-			return com.liferay.portal.model.GroupSoap.toSoapModels(returnValue);
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-
-			throw new RemoteException(e.getMessage());
-		}
-	}
-
 	/**
 	* Returns the user's groups &quot;sites&quot; associated with the group
 	* entity class names, including the Control Panel group if the user is
@@ -810,12 +773,11 @@ public class GroupServiceSoap {
 	}
 
 	public static com.liferay.portal.model.GroupSoap[] getUserSitesGroups(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
-		throws RemoteException {
+		long userId, java.lang.String[] classNames,
+		boolean includeControlPanel, int max) throws RemoteException {
 		try {
 			java.util.List<com.liferay.portal.model.Group> returnValue = GroupServiceUtil.getUserSitesGroups(userId,
-					classNames, name, active, includeControlPanel, start, end);
+					classNames, includeControlPanel, max);
 
 			return com.liferay.portal.model.GroupSoap.toSoapModels(returnValue);
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
@@ -577,20 +577,6 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of 6.2.0, replaced by {@link #getUserSitesGroups(long,
-	 *             String[], String, boolean, boolean, int, int)}
-	 */
-	@Override
-	public List<Group> getUserPlaces(
-			long userId, String[] classNames, String name, boolean active,
-			boolean includeControlPanel, int start, int end)
-		throws PortalException, SystemException {
-
-		return getUserSitesGroups(
-			userId, classNames, name, active, includeControlPanel, start, end);
-	}
-
-	/**
 	 * Returns the guest or current user's groups &quot;sites&quot; associated
 	 * with the group entity class names, including the Control Panel group if
 	 * the user is permitted to view the Control Panel.

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupServiceImpl.java
@@ -662,59 +662,6 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 			int max)
 		throws PortalException, SystemException {
 
-		return getUserSitesGroups(
-			userId, classNames, null, true, includeControlPanel,
-			QueryUtil.ALL_POS, max);
-	}
-
-	/**
-	 * Returns the user's groups &quot;sites&quot; associated with the group
-	 * entity class names, including the Control Panel group if the user is
-	 * permitted to view the Control Panel.
-	 *
-	 * <ul>
-	 * <li>
-	 * Class name &quot;User&quot; includes the user's layout set
-	 * group.
-	 * </li>
-	 * <li>
-	 * Class name &quot;Organization&quot; includes the user's
-	 * immediate organization groups and inherited organization groups.
-	 * </li>
-	 * <li>
-	 * Class name &quot;Group&quot; includes the user's immediate
-	 * organization groups and site groups.
-	 * </li>
-	 * <li>
-	 * A <code>classNames</code>
-	 * value of <code>null</code> includes the user's layout set group,
-	 * organization groups, inherited organization groups, and site groups.
-	 * </li>
-	 * </ul>
-	 *
-	 * @param  userId the primary key of the user
-	 * @param  classNames the group entity class names (optionally
-	 *         <code>null</code>). For more information see {@link
-	 *         #getUserSitesGroups(long, String[], boolean, int)}
-	 * @param  max the maximum number of groups to return
-	 * @return the user's groups &quot;sites&quot;
-	 * @throws PortalException if a portal exception occurred
-	 * @throws SystemException if a system exception occurred
-	 */
-	@Override
-	public List<Group> getUserSitesGroups(
-			long userId, String[] classNames, int max)
-		throws PortalException, SystemException {
-
-		return getUserSitesGroups(userId, classNames, false, max);
-	}
-
-	@Override
-	public List<Group> getUserSitesGroups(
-			long userId, String[] classNames, String name, boolean active,
-			boolean includeControlPanel, int start, int end)
-		throws PortalException, SystemException {
-
 		User user = userPersistence.fetchByPrimaryKey(userId);
 
 		if (user.isDefaultUser()) {
@@ -723,18 +670,26 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 
 		List<Group> userSiteGroups = new UniqueList<Group>();
 
+		int start = QueryUtil.ALL_POS;
+		int end = QueryUtil.ALL_POS;
+
+		if (max != QueryUtil.ALL_POS) {
+			start = 0;
+			end = max;
+		}
+
 		if ((classNames == null) ||
 			ArrayUtil.contains(classNames, Group.class.getName())) {
 
 			LinkedHashMap<String, Object> groupParams =
 				new LinkedHashMap<String, Object>();
 
-			groupParams.put("active", active);
-			groupParams.put("usersGroups", new Long(userId));
+			groupParams.put("active", true);
+			groupParams.put("usersGroups", userId);
 
 			userSiteGroups.addAll(
 				groupLocalService.search(
-					user.getCompanyId(), name, groupParams, start, end));
+					user.getCompanyId(), groupParams, start, end));
 		}
 
 		if ((classNames == null) ||
@@ -805,6 +760,48 @@ public class GroupServiceImpl extends GroupServiceBaseImpl {
 
 		return Collections.unmodifiableList(
 			ListUtil.subList(userSiteGroups, start, end));
+	}
+
+	/**
+	 * Returns the user's groups &quot;sites&quot; associated with the group
+	 * entity class names, including the Control Panel group if the user is
+	 * permitted to view the Control Panel.
+	 *
+	 * <ul>
+	 * <li>
+	 * Class name &quot;User&quot; includes the user's layout set
+	 * group.
+	 * </li>
+	 * <li>
+	 * Class name &quot;Organization&quot; includes the user's
+	 * immediate organization groups and inherited organization groups.
+	 * </li>
+	 * <li>
+	 * Class name &quot;Group&quot; includes the user's immediate
+	 * organization groups and site groups.
+	 * </li>
+	 * <li>
+	 * A <code>classNames</code>
+	 * value of <code>null</code> includes the user's layout set group,
+	 * organization groups, inherited organization groups, and site groups.
+	 * </li>
+	 * </ul>
+	 *
+	 * @param  userId the primary key of the user
+	 * @param  classNames the group entity class names (optionally
+	 *         <code>null</code>). For more information see {@link
+	 *         #getUserSitesGroups(long, String[], boolean, int)}
+	 * @param  max the maximum number of groups to return
+	 * @return the user's groups &quot;sites&quot;
+	 * @throws PortalException if a portal exception occurred
+	 * @throws SystemException if a system exception occurred
+	 */
+	@Override
+	public List<Group> getUserSitesGroups(
+			long userId, String[] classNames, int max)
+		throws PortalException, SystemException {
+
+		return getUserSitesGroups(userId, classNames, false, max);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/GroupService.java
+++ b/portal-service/src/com/liferay/portal/service/GroupService.java
@@ -420,17 +420,6 @@ public interface GroupService extends BaseService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	/**
-	* @deprecated As of 6.2.0, replaced by {@link #getUserSitesGroups(long,
-	String[], String, boolean, boolean, int, int)}
-	*/
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public java.util.List<com.liferay.portal.model.Group> getUserPlaces(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
-	/**
 	* Returns the guest or current user's groups &quot;sites&quot; associated
 	* with the group entity class names, including the Control Panel group if
 	* the user is permitted to view the Control Panel.
@@ -507,13 +496,6 @@ public interface GroupService extends BaseService {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		long userId, java.lang.String[] classNames,
-		boolean includeControlPanel, int max)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException;
-
 	/**
 	* Returns the user's groups &quot;sites&quot; associated with the group
 	* entity class names, including the Control Panel group if the user is
@@ -556,8 +538,8 @@ public interface GroupService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
+		long userId, java.lang.String[] classNames,
+		boolean includeControlPanel, int max)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portal/service/GroupServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/GroupServiceUtil.java
@@ -454,20 +454,6 @@ public class GroupServiceUtil {
 	}
 
 	/**
-	* @deprecated As of 6.2.0, replaced by {@link #getUserSitesGroups(long,
-	String[], String, boolean, boolean, int, int)}
-	*/
-	public static java.util.List<com.liferay.portal.model.Group> getUserPlaces(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return getService()
-				   .getUserPlaces(userId, classNames, name, active,
-			includeControlPanel, start, end);
-	}
-
-	/**
 	* Returns the guest or current user's groups &quot;sites&quot; associated
 	* with the group entity class names, including the Control Panel group if
 	* the user is permitted to view the Control Panel.
@@ -548,16 +534,6 @@ public class GroupServiceUtil {
 		return getService().getUserSitesGroups();
 	}
 
-	public static java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		long userId, java.lang.String[] classNames,
-		boolean includeControlPanel, int max)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return getService()
-				   .getUserSitesGroups(userId, classNames, includeControlPanel,
-			max);
-	}
-
 	/**
 	* Returns the user's groups &quot;sites&quot; associated with the group
 	* entity class names, including the Control Panel group if the user is
@@ -600,13 +576,13 @@ public class GroupServiceUtil {
 	}
 
 	public static java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
+		long userId, java.lang.String[] classNames,
+		boolean includeControlPanel, int max)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService()
-				   .getUserSitesGroups(userId, classNames, name, active,
-			includeControlPanel, start, end);
+				   .getUserSitesGroups(userId, classNames, includeControlPanel,
+			max);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/GroupServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/GroupServiceWrapper.java
@@ -462,20 +462,6 @@ public class GroupServiceWrapper implements GroupService,
 	}
 
 	/**
-	* @deprecated As of 6.2.0, replaced by {@link #getUserSitesGroups(long,
-	String[], String, boolean, boolean, int, int)}
-	*/
-	@Override
-	public java.util.List<com.liferay.portal.model.Group> getUserPlaces(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return _groupService.getUserPlaces(userId, classNames, name, active,
-			includeControlPanel, start, end);
-	}
-
-	/**
 	* Returns the guest or current user's groups &quot;sites&quot; associated
 	* with the group entity class names, including the Control Panel group if
 	* the user is permitted to view the Control Panel.
@@ -560,16 +546,6 @@ public class GroupServiceWrapper implements GroupService,
 		return _groupService.getUserSitesGroups();
 	}
 
-	@Override
-	public java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		long userId, java.lang.String[] classNames,
-		boolean includeControlPanel, int max)
-		throws com.liferay.portal.kernel.exception.PortalException,
-			com.liferay.portal.kernel.exception.SystemException {
-		return _groupService.getUserSitesGroups(userId, classNames,
-			includeControlPanel, max);
-	}
-
 	/**
 	* Returns the user's groups &quot;sites&quot; associated with the group
 	* entity class names, including the Control Panel group if the user is
@@ -614,12 +590,12 @@ public class GroupServiceWrapper implements GroupService,
 
 	@Override
 	public java.util.List<com.liferay.portal.model.Group> getUserSitesGroups(
-		long userId, java.lang.String[] classNames, java.lang.String name,
-		boolean active, boolean includeControlPanel, int start, int end)
+		long userId, java.lang.String[] classNames,
+		boolean includeControlPanel, int max)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
-		return _groupService.getUserSitesGroups(userId, classNames, name,
-			active, includeControlPanel, start, end);
+		return _groupService.getUserSitesGroups(userId, classNames,
+			includeControlPanel, max);
 	}
 
 	/**


### PR DESCRIPTION
This is a roll back of 84c2825 + all the fixes done to it. Since it was so long ago, I copied and pasted the old method and manually applied all the source formatting done to it on the way.

---

Some background on this ticket.. Eduardo added this piece for Marc Lundgren who is working on a new feature so the My Sites Dropdown could be paginated/searched.

There are a few issues with this:
1. Currently, anything after page one will return the 1 result since we are sublisting twice on the same range (this can be easily fixed).
2. The values start and end apply to BOTH organization and groups search.. that means if there are the same amount of organizations and groups, groups will be never be returned. For example, for each page on a 10 delta (start 0 end 10) we grab 10 organizations and 10 groups and sublist it to grab the first 10 of the combined list.. always leaving the groups out.
3. All of this is assuming that we don't includeControlPanel and user public/private layouts. Because if we do, they will be at the top of every result set.
4. Even if we fix all of the above (probably by adding more parameters), the results returned are off in certain scenarios because of the removal logic in there. We can't easily predict what was already returned in the previous call so there may be duplicate or missing results.

Marc said that his story won't likely get in 6.2 so I think rolling this back is the best option rather than locking us into a non-straightfoward API. We will work on a different solution for 7.0.
