### PR TITLE
LPS-41323 Fix, keys with [message-board] to get correct translation

### DIFF
--- a/portal-web/docroot/html/portlet/message_boards/category_columns.jspf
+++ b/portal-web/docroot/html/portlet/message_boards/category_columns.jspf
@@ -16,7 +16,7 @@
 
 <liferay-ui:search-container-column-text
 	buffer="buffer"
-	name="category"
+	name="category[message-board]"
 >
 
 	<%
@@ -78,7 +78,7 @@
 
 <liferay-ui:search-container-column-text
 	href="<%= rowURL %>"
-	name="categories"
+	name="categories[message-board]"
 	value="<%= String.valueOf(categoryDisplay.getSubcategoriesCount(curCategory)) %>"
 />
 

--- a/portal-web/docroot/html/portlet/message_boards/select_category.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/select_category.jsp
@@ -75,7 +75,7 @@ else {
 			<liferay-ui:search-container-column-text
 				buffer="buffer"
 				href="<%= rowURL %>"
-				name="category"
+				name="category[message-board]"
 			>
 
 				<%


### PR DESCRIPTION
Hi Brian,

This is fixing missing parts of Finnish translation on Message Board headers. No new keys added only the [message-board] added. This does not effect other languages, since these keys are already defined at language.properties
