### PR TITLE
LPS-41277 Restrict variables in DDL and ADT templates

### DIFF
--- a/portal-impl/src/com/liferay/portal/freemarker/FreeMarkerTemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/freemarker/FreeMarkerTemplateContextHelper.java
@@ -43,7 +43,7 @@ public class FreeMarkerTemplateContextHelper extends TemplateContextHelper {
 	@Override
 	public Set<String> getRestrictedVariables() {
 		return SetUtil.fromArray(
-			PropsValues.JOURNAL_TEMPLATE_FREEMARKER_RESTRICTED_VARIABLES);
+			PropsValues.FREEMARKER_ENGINE_RESTRICTED_VARIABLES);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -748,6 +748,8 @@ public class PropsValues {
 
 	public static final String[] FREEMARKER_ENGINE_RESTRICTED_PACKAGES = PropsUtil.getArray(PropsKeys.FREEMARKER_ENGINE_RESTRICTED_PACKAGES);
 
+	public static final String[] FREEMARKER_ENGINE_RESTRICTED_VARIABLES = PropsUtil.getArray(PropsKeys.FREEMARKER_ENGINE_RESTRICTED_VARIABLES);
+
 	public static final String FREEMARKER_ENGINE_TEMPLATE_EXCEPTION_HANDLER = PropsUtil.get(PropsKeys.FREEMARKER_ENGINE_TEMPLATE_EXCEPTION_HANDLER);
 
 	public static final String[] FREEMARKER_ENGINE_TEMPLATE_PARSERS = PropsUtil.getArray(PropsKeys.FREEMARKER_ENGINE_TEMPLATE_PARSERS);
@@ -913,10 +915,6 @@ public class PropsValues {
 	public static final boolean JOURNAL_PUBLISH_TO_LIVE_BY_DEFAULT = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.JOURNAL_PUBLISH_TO_LIVE_BY_DEFAULT));
 
 	public static final boolean JOURNAL_PUBLISH_VERSION_HISTORY_BY_DEFAULT = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.JOURNAL_PUBLISH_VERSION_HISTORY_BY_DEFAULT));
-
-	public static final String[] JOURNAL_TEMPLATE_FREEMARKER_RESTRICTED_VARIABLES = PropsUtil.getArray(PropsKeys.JOURNAL_TEMPLATE_FREEMARKER_RESTRICTED_VARIABLES);
-
-	public static final String[] JOURNAL_TEMPLATE_VELOCITY_RESTRICTED_VARIABLES = PropsUtil.getArray(PropsKeys.JOURNAL_TEMPLATE_VELOCITY_RESTRICTED_VARIABLES);
 
 	public static final String[] JPA_CONFIGS = PropsUtil.getArray(PropsKeys.JPA_CONFIGS);
 
@@ -1941,6 +1939,8 @@ public class PropsValues {
 	public static final String[] VELOCITY_ENGINE_RESTRICTED_CLASSES = PropsUtil.getArray(PropsKeys.VELOCITY_ENGINE_RESTRICTED_CLASSES);
 
 	public static final String[] VELOCITY_ENGINE_RESTRICTED_PACKAGES = PropsUtil.getArray(PropsKeys.VELOCITY_ENGINE_RESTRICTED_PACKAGES);
+
+	public static final String[] VELOCITY_ENGINE_RESTRICTED_VARIABLES = PropsUtil.getArray(PropsKeys.VELOCITY_ENGINE_RESTRICTED_VARIABLES);
 
 	public static final boolean VERIFY_DATABASE_TRANSACTIONS_DISABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.VERIFY_DATABASE_TRANSACTIONS_DISABLED));
 

--- a/portal-impl/src/com/liferay/portal/velocity/VelocityTemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/velocity/VelocityTemplateContextHelper.java
@@ -51,7 +51,7 @@ public class VelocityTemplateContextHelper extends TemplateContextHelper {
 	@Override
 	public Set<String> getRestrictedVariables() {
 		return SetUtil.fromArray(
-			PropsValues.JOURNAL_TEMPLATE_VELOCITY_RESTRICTED_VARIABLES);
+			PropsValues.VELOCITY_ENGINE_RESTRICTED_VARIABLES);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/assetcategoriesnavigation/dependencies/portlet_display_template_multi_column_layout.ftl
+++ b/portal-impl/src/com/liferay/portlet/assetcategoriesnavigation/dependencies/portlet_display_template_multi_column_layout.ftl
@@ -32,11 +32,13 @@
 
 					<a href="${categoryURL}">${category.getName()}</a>
 
-					<#assign assetCategoryService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetCategoryService")>
+					<#if serviceLocator??>
+						<#assign assetCategoryService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetCategoryService")>
 
-					<#assign childCategories = assetCategoryService.getChildCategories(category.getCategoryId())>
+						<#assign childCategories = assetCategoryService.getChildCategories(category.getCategoryId())>
 
-					<@displayCategories categories=childCategories />
+						<@displayCategories categories=childCategories />
+					</#if>
 				</li>
 			</#list>
 		</ul>

--- a/portal-impl/src/com/liferay/portlet/assetcategoriesnavigation/template/AssetCategoriesNavigationPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/assetcategoriesnavigation/template/AssetCategoriesNavigationPortletDisplayTemplateHandler.java
@@ -75,8 +75,10 @@ public class AssetCategoriesNavigationPortletDisplayTemplateHandler
 			"vocabularies", List.class, PortletDisplayTemplateConstants.ENTRIES,
 			"vocabulary", AssetVocabulary.class, "curVocabulary", "name");
 
+		String[] restrictedVariables = getRestrictedVariables(language);
+
 		TemplateVariableGroup categoriesServicesTemplateVariableGroup =
-			new TemplateVariableGroup("category-services");
+			new TemplateVariableGroup("category-services", restrictedVariables);
 
 		categoriesServicesTemplateVariableGroup.setAutocompleteEnabled(false);
 

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/template/AssetPublisherPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/template/AssetPublisherPortletDisplayTemplateHandler.java
@@ -71,8 +71,11 @@ public class AssetPublisherPortletDisplayTemplateHandler
 		Map<String, TemplateVariableGroup> templateVariableGroups =
 			super.getTemplateVariableGroups(classPK, language, locale);
 
+		String[] restrictedVariables = getRestrictedVariables(language);
+
 		TemplateVariableGroup assetPublisherUtilTemplateVariableGroup =
-			new TemplateVariableGroup("asset-publisher-util");
+			new TemplateVariableGroup(
+				"asset-publisher-util", restrictedVariables);
 
 		assetPublisherUtilTemplateVariableGroup.addVariable(
 			"asset-publisher-helper", AssetPublisherHelper.class,
@@ -95,7 +98,7 @@ public class AssetPublisherPortletDisplayTemplateHandler
 			PortletDisplayTemplateConstants.ENTRY, "getTitle(locale)");
 
 		TemplateVariableGroup assetServicesTemplateVariableGroup =
-			new TemplateVariableGroup("asset-services");
+			new TemplateVariableGroup("asset-services", restrictedVariables);
 
 		assetServicesTemplateVariableGroup.setAutocompleteEnabled(false);
 

--- a/portal-impl/src/com/liferay/portlet/assettagsnavigation/dependencies/portlet_display_template_color_by_popularity.ftl
+++ b/portal-impl/src/com/liferay/portlet/assettagsnavigation/dependencies/portlet_display_template_color_by_popularity.ftl
@@ -1,7 +1,5 @@
 <#if entries?has_content>
 	<ul class="tag-items tag-list">
-		<#assign assetTagService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetTagService")>
-
 		<#assign scopeGroupId = getterUtil.getLong(scopeGroupId, themeDisplay.getScopeGroupId()) />
 		<#assign classNameId = getterUtil.getLong(classNameId, 0) />
 
@@ -9,14 +7,8 @@
 		<#assign minCount = 1 />
 
 		<#list entries as entry>
-			<#if (classNameId > 0)>
-				<#assign count = assetTagService.getTagsCount(scopeGroupId, classNameId, entry.getName()) />
-			<#else>
-				<#assign count = assetTagService.getTagsCount(scopeGroupId, entry.getName()) />
-			</#if>
-
-			<#assign maxCount = liferay.max(maxCount, count) />
-			<#assign minCount = liferay.min(minCount, count) />
+			<#assign maxCount = liferay.max(maxCount, entry.getAssetCount()) />
+			<#assign minCount = liferay.min(minCount, entry.getAssetCount()) />
 		</#list>
 
 		<#assign multiplier = 1 />
@@ -27,15 +19,7 @@
 
 		<#list entries as entry>
 			<li class="taglib-asset-tags-summary">
-				<#assign count = 0 />
-
-				<#if (classNameId > 0)>
-					<#assign count = assetTagService.getTagsCount(scopeGroupId, classNameId, entry.getName()) />
-				<#else>
-					<#assign count = assetTagService.getTagsCount(scopeGroupId, entry.getName()) />
-				</#if>
-
-				<#assign popularity = (maxCount - (maxCount - (count - minCount))) * multiplier />
+				<#assign popularity = (maxCount - (maxCount - (entry.getAssetCount() - minCount))) * multiplier />
 
 				<#if popularity < 1>
 					<#assign color = "green" />

--- a/portal-impl/src/com/liferay/portlet/assettagsnavigation/template/AssetTagsNavigationPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/assettagsnavigation/template/AssetTagsNavigationPortletDisplayTemplateHandler.java
@@ -73,8 +73,10 @@ public class AssetTagsNavigationPortletDisplayTemplateHandler
 			"tags", List.class, PortletDisplayTemplateConstants.ENTRIES, "tag",
 			AssetTag.class, "curTag", "name");
 
+		String[] restrictedVariables = getRestrictedVariables(language);
+
 		TemplateVariableGroup assetServicesTemplateVariableGroup =
-			new TemplateVariableGroup("tag-services");
+			new TemplateVariableGroup("tag-services", restrictedVariables);
 
 		assetServicesTemplateVariableGroup.setAutocompleteEnabled(false);
 

--- a/portal-impl/src/com/liferay/portlet/blogs/template/BlogsPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/template/BlogsPortletDisplayTemplateHandler.java
@@ -72,8 +72,10 @@ public class BlogsPortletDisplayTemplateHandler
 			"blog-entries", List.class, PortletDisplayTemplateConstants.ENTRIES,
 			"blog-entry", BlogsEntry.class, "curBlogEntry", "title");
 
+		String[] restrictedVariables = getRestrictedVariables(language);
+
 		TemplateVariableGroup blogServicesTemplateVariableGroup =
-			new TemplateVariableGroup("blog-services");
+			new TemplateVariableGroup("blog-services", restrictedVariables);
 
 		blogServicesTemplateVariableGroup.setAutocompleteEnabled(false);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/template/DocumentLibraryPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/template/DocumentLibraryPortletDisplayTemplateHandler.java
@@ -74,8 +74,10 @@ public class DocumentLibraryPortletDisplayTemplateHandler
 			"documents", List.class, PortletDisplayTemplateConstants.ENTRIES,
 			"document", FileEntry.class, "curFileEntry", "title");
 
+		String[] restrictedVariables = getRestrictedVariables(language);
+
 		TemplateVariableGroup documentServicesTemplateVariableGroup =
-			new TemplateVariableGroup("document-services");
+			new TemplateVariableGroup("document-services", restrictedVariables);
 
 		documentServicesTemplateVariableGroup.setAutocompleteEnabled(false);
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/template/DDLTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/template/DDLTemplateHandler.java
@@ -90,8 +90,11 @@ public class DDLTemplateHandler extends BaseDDMTemplateHandler {
 		addTemplateVariableGroup(
 			templateVariableGroups, getUtilTemplateVariableGroup());
 
+		String[] restrictedVariables = getRestrictedVariables(language);
+
 		TemplateVariableGroup ddlServicesTemplateVariableGroup =
-			new TemplateVariableGroup("data-list-services");
+			new TemplateVariableGroup(
+				"data-list-services", restrictedVariables);
 
 		ddlServicesTemplateVariableGroup.setAutocompleteEnabled(false);
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/util/DDLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/util/DDLImpl.java
@@ -455,6 +455,6 @@ public class DDLImpl implements DDL {
 	private static Log _log = LogFactoryUtil.getLog(DDLImpl.class);
 
 	private Transformer _transformer = new Transformer(
-		PropsKeys.DYNAMIC_DATA_LISTS_ERROR_TEMPLATE, false);
+		PropsKeys.DYNAMIC_DATA_LISTS_ERROR_TEMPLATE, true);
 
 }

--- a/portal-impl/src/com/liferay/portlet/journal/template/JournalTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/template/JournalTemplateHandler.java
@@ -15,13 +15,11 @@
 package com.liferay.portlet.journal.template;
 
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateVariableCodeHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalService;
 import com.liferay.portlet.dynamicdatamapping.service.DDMStructureService;
 import com.liferay.portlet.dynamicdatamapping.service.DDMTemplateLocalService;
@@ -57,25 +55,6 @@ public class JournalTemplateHandler extends BaseDDMTemplateHandler {
 	@Override
 	public String getResourceName() {
 		return "com.liferay.portlet.journal.template";
-	}
-
-	@Override
-	public String[] getRestrictedVariables(String language) {
-		String[] restrictedVariables;
-
-		if (language.equals(TemplateConstants.LANG_TYPE_FTL)) {
-			restrictedVariables =
-				PropsValues.JOURNAL_TEMPLATE_FREEMARKER_RESTRICTED_VARIABLES;
-		}
-		else if (language.equals(TemplateConstants.LANG_TYPE_VM)) {
-			restrictedVariables =
-				PropsValues.JOURNAL_TEMPLATE_VELOCITY_RESTRICTED_VARIABLES;
-		}
-		else {
-			restrictedVariables = new String[0];
-		}
-
-		return restrictedVariables;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/portletdisplaytemplate/util/PortletDisplayTemplateImpl.java
+++ b/portal-impl/src/com/liferay/portlet/portletdisplaytemplate/util/PortletDisplayTemplateImpl.java
@@ -426,6 +426,6 @@ public class PortletDisplayTemplateImpl implements PortletDisplayTemplate {
 		PortletDisplayTemplateImpl.class);
 
 	private Transformer _transformer = new Transformer(
-		PropsKeys.DYNAMIC_DATA_LISTS_ERROR_TEMPLATE, false);
+		PropsKeys.DYNAMIC_DATA_LISTS_ERROR_TEMPLATE, true);
 
 }

--- a/portal-impl/src/com/liferay/portlet/wiki/dependencies/portlet_display_template_social.ftl
+++ b/portal-impl/src/com/liferay/portlet/wiki/dependencies/portlet_display_template_social.ftl
@@ -1,10 +1,6 @@
 <#assign liferay_ui = taglibLiferayHash["/WEB-INF/tld/liferay-ui.tld"] />
 
-<#assign assetEntryLocalService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetEntryLocalService") />
-
 <#assign wikiPageClassName = "com.liferay.portlet.wiki.model.WikiPage" />
-
-<#assign assetEntry = assetEntryLocalService.getEntry(wikiPageClassName, entry.getResourcePrimKey()) />
 
 <#assign assetRenderer = assetEntry.getAssetRenderer() />
 
@@ -100,9 +96,6 @@
 				<th>
 					<@liferay.language key="ratings" />
 				</th>
-				<th>
-					<@liferay.language key="views" />
-				</th>
 			</tr>
 
 			<#list childPages as childPage>
@@ -124,9 +117,6 @@
 					</td>
 					<td>
 						<@getRatings cssClass="child-ratings" entry=childPage />
-					</td>
-					<td>
-						<span class="stats">${assetEntryLocalService.getEntry(wikiPageClassName, childPage.getResourcePrimKey()).getViewCount()}</span>
 					</td>
 				</tr>
 			</#list>

--- a/portal-impl/src/com/liferay/portlet/wiki/template/WikiPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/template/WikiPortletDisplayTemplateHandler.java
@@ -74,8 +74,10 @@ public class WikiPortletDisplayTemplateHandler
 		fieldsTemplateVariableGroup.addVariable(
 			"wiki-page-content", String.class, "formattedContent");
 
+		String[] restrictedVariables = getRestrictedVariables(language);
+
 		TemplateVariableGroup wikiServicesTemplateVariableGroup =
-			new TemplateVariableGroup("wiki-services");
+			new TemplateVariableGroup("wiki-services", restrictedVariables);
 
 		wikiServicesTemplateVariableGroup.setAutocompleteEnabled(false);
 

--- a/portal-impl/src/com/liferay/portlet/wiki/template/WikiPortletDisplayTemplateHandler.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/template/WikiPortletDisplayTemplateHandler.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.portletdisplaytemplate.util.PortletDisplayTemplateConstants;
 import com.liferay.portlet.wiki.model.WikiPage;
 import com.liferay.portlet.wiki.service.WikiNodeLocalService;
@@ -69,6 +70,8 @@ public class WikiPortletDisplayTemplateHandler
 
 		fieldsTemplateVariableGroup.empty();
 
+		fieldsTemplateVariableGroup.addVariable(
+			"asset-entry", AssetEntry.class, "assetEntry");
 		fieldsTemplateVariableGroup.addVariable(
 			"wiki-page", WikiPage.class, PortletDisplayTemplateConstants.ENTRY);
 		fieldsTemplateVariableGroup.addVariable(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6360,6 +6360,13 @@
     freemarker.engine.restricted.packages=
 
     #
+    # Set a comma delimited list of variables the Freemarker engine cannot
+    # have access to. This will affect Journal templates, Dynamic Data List
+    # templates and Portlet Display templates.
+    #
+    freemarker.engine.restricted.variables=serviceLocator
+
+    #
     # The exception handler can have its value set to the name of a class
     # implementing FreeMarker's TemplateExceptionHandler, or to rethrow, debug,
     # debug_html, or ignore.
@@ -8074,6 +8081,13 @@
     # have access to.
     #
     velocity.engine.restricted.packages=
+
+    #
+    # Set a comma delimited list of variables the Velocity engine cannot
+    # have access to. This will affect Journal templates, Dynamic Data List
+    # templates and Portlet Display templates.
+    #
+    velocity.engine.restricted.variables=serviceLocator
 
     #
     # Input a list of comma delimited macros that will be loaded. These files
@@ -9834,18 +9848,6 @@
     journal.template.language.content[ftl]=com/liferay/portlet/journal/dependencies/template.ftl
     journal.template.language.content[vm]=com/liferay/portlet/journal/dependencies/template.vm
     journal.template.language.content[xsl]=com/liferay/portlet/journal/dependencies/template.xsl
-
-    #
-    # Input a comma delimited list of variables which are restricted from the
-    # context in FreeMarker based Journal templates.
-    #
-    journal.template.freemarker.restricted.variables=serviceLocator
-
-    #
-    # Input a comma delimited list of variables which are restricted from the
-    # context in Velocity based Journal templates.
-    #
-    journal.template.velocity.restricted.variables=serviceLocator
 
     #
     # Set the maximum file size and valid file extensions for images. A value of

--- a/portal-service/src/com/liferay/portal/kernel/template/BaseTemplateHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/template/BaseTemplateHandler.java
@@ -53,7 +53,21 @@ public abstract class BaseTemplateHandler implements TemplateHandler {
 
 	@Override
 	public String[] getRestrictedVariables(String language) {
-		return new String[0];
+		String[] restrictedVariables;
+
+		if (language.equals(TemplateConstants.LANG_TYPE_FTL)) {
+			restrictedVariables = PropsUtil.getArray(
+				PropsKeys.JOURNAL_TEMPLATE_FREEMARKER_RESTRICTED_VARIABLES);
+		}
+		else if (language.equals(TemplateConstants.LANG_TYPE_VM)) {
+			restrictedVariables = PropsUtil.getArray(
+				PropsKeys.JOURNAL_TEMPLATE_VELOCITY_RESTRICTED_VARIABLES);
+		}
+		else {
+			restrictedVariables = new String[0];
+		}
+
+		return restrictedVariables;
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/template/BaseTemplateHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/template/BaseTemplateHandler.java
@@ -57,11 +57,11 @@ public abstract class BaseTemplateHandler implements TemplateHandler {
 
 		if (language.equals(TemplateConstants.LANG_TYPE_FTL)) {
 			restrictedVariables = PropsUtil.getArray(
-				PropsKeys.JOURNAL_TEMPLATE_FREEMARKER_RESTRICTED_VARIABLES);
+				PropsKeys.FREEMARKER_ENGINE_RESTRICTED_VARIABLES);
 		}
 		else if (language.equals(TemplateConstants.LANG_TYPE_VM)) {
 			restrictedVariables = PropsUtil.getArray(
-				PropsKeys.JOURNAL_TEMPLATE_VELOCITY_RESTRICTED_VARIABLES);
+				PropsKeys.VELOCITY_ENGINE_RESTRICTED_VARIABLES);
 		}
 		else {
 			restrictedVariables = new String[0];

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -889,6 +889,8 @@ public interface PropsKeys {
 
 	public static final String FREEMARKER_ENGINE_RESTRICTED_PACKAGES = "freemarker.engine.restricted.packages";
 
+	public static final String FREEMARKER_ENGINE_RESTRICTED_VARIABLES = "freemarker.engine.restricted.variables";
+
 	public static final String FREEMARKER_ENGINE_TEMPLATE_EXCEPTION_HANDLER = "freemarker.engine.template.exception.handler";
 
 	public static final String FREEMARKER_ENGINE_TEMPLATE_PARSERS = "freemarker.engine.template.parsers";
@@ -1199,11 +1201,7 @@ public interface PropsKeys {
 
 	public static final String JOURNAL_SYNC_CONTENT_SEARCH_ON_STARTUP = "journal.sync.content.search.on.startup";
 
-	public static final String JOURNAL_TEMPLATE_FREEMARKER_RESTRICTED_VARIABLES = "journal.template.freemarker.restricted.variables";
-
 	public static final String JOURNAL_TEMPLATE_LANGUAGE_CONTENT = "journal.template.language.content";
-
-	public static final String JOURNAL_TEMPLATE_VELOCITY_RESTRICTED_VARIABLES = "journal.template.velocity.restricted.variables";
 
 	public static final String JOURNAL_TRANSFORMER_LISTENER = "journal.transformer.listener";
 
@@ -2568,6 +2566,8 @@ public interface PropsKeys {
 	public static final String VELOCITY_ENGINE_RESTRICTED_CLASSES = "velocity.engine.restricted.classes";
 
 	public static final String VELOCITY_ENGINE_RESTRICTED_PACKAGES = "velocity.engine.restricted.packages";
+
+	public static final String VELOCITY_ENGINE_RESTRICTED_VARIABLES = "velocity.engine.restricted.variables";
 
 	public static final String VELOCITY_ENGINE_VELOCIMACRO_LIBRARY = "velocity.engine.velocimacro.library";
 

--- a/portal-web/docroot/html/portlet/wiki/view.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view.jsp
@@ -116,8 +116,10 @@ if (Validator.isNotNull(ParamUtil.getString(request, "title"))) {
 	AssetUtil.addLayoutTags(request, AssetTagLocalServiceUtil.getTags(WikiPage.class.getName(), wikiPage.getResourcePrimKey()));
 }
 
+AssetEntry layoutAssetEntry = null;
+
 if (wikiPage != null) {
-	AssetEntry layoutAssetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
+	layoutAssetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
 
 	request.setAttribute(WebKeys.LAYOUT_ASSET_ENTRY, layoutAssetEntry);
 }
@@ -171,6 +173,7 @@ long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayT
 
 		Map<String, Object> contextObjects = new HashMap<String, Object>();
 
+		contextObjects.put("assetEntry", layoutAssetEntry);
 		contextObjects.put("formattedContent", formattedContent);
 		%>
 

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_color_by_popularity.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_color_by_popularity.ftl
@@ -1,7 +1,5 @@
 <#if entries?has_content>
 	<ul class="tag-items tag-list">
-		<#assign assetTagService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetTagService")>
-
 		<#assign scopeGroupId = getterUtil.getLong(scopeGroupId, themeDisplay.getScopeGroupId()) />
 		<#assign classNameId = getterUtil.getLong(classNameId, 0) />
 
@@ -9,14 +7,8 @@
 		<#assign minCount = 1 />
 
 		<#list entries as entry>
-			<#if (classNameId > 0)>
-				<#assign count = assetTagService.getTagsCount(scopeGroupId, classNameId, entry.getName()) />
-			<#else>
-				<#assign count = assetTagService.getTagsCount(scopeGroupId, entry.getName()) />
-			</#if>
-
-			<#assign maxCount = liferay.max(maxCount, count) />
-			<#assign minCount = liferay.min(minCount, count) />
+			<#assign maxCount = liferay.max(maxCount, entry.getAssetCount()) />
+			<#assign minCount = liferay.min(minCount, entry.getAssetCount()) />
 		</#list>
 
 		<#assign multiplier = 1 />
@@ -27,15 +19,7 @@
 
 		<#list entries as entry>
 			<li class="taglib-asset-tags-summary">
-				<#assign count = 0 />
-
-				<#if (classNameId > 0)>
-					<#assign count = assetTagService.getTagsCount(scopeGroupId, classNameId, entry.getName()) />
-				<#else>
-					<#assign count = assetTagService.getTagsCount(scopeGroupId, entry.getName()) />
-				</#if>
-
-				<#assign popularity = (maxCount - (maxCount - (count - minCount))) * multiplier />
+				<#assign popularity = (maxCount - (maxCount - (entry.getAssetCount() - minCount))) * multiplier />
 
 				<#if popularity < 1>
 					<#assign color = "green" />

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_multi_column_layout.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_multi_column_layout.ftl
@@ -32,11 +32,13 @@
 
 					<a href="${categoryURL}">${category.getName()}</a>
 
-					<#assign assetCategoryService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetCategoryService")>
+					<#if serviceLocator??>
+						<#assign assetCategoryService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetCategoryService")>
 
-					<#assign childCategories = assetCategoryService.getChildCategories(category.getCategoryId())>
+						<#assign childCategories = assetCategoryService.getChildCategories(category.getCategoryId())>
 
-					<@displayCategories categories=childCategories />
+						<@displayCategories categories=childCategories />
+					</#if>
 				</li>
 			</#list>
 		</ul>

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_social.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_social.ftl
@@ -1,10 +1,6 @@
 <#assign liferay_ui = taglibLiferayHash["/WEB-INF/tld/liferay-ui.tld"] />
 
-<#assign assetEntryLocalService = serviceLocator.findService("com.liferay.portlet.asset.service.AssetEntryLocalService") />
-
 <#assign wikiPageClassName = "com.liferay.portlet.wiki.model.WikiPage" />
-
-<#assign assetEntry = assetEntryLocalService.getEntry(wikiPageClassName, entry.getResourcePrimKey()) />
 
 <#assign assetRenderer = assetEntry.getAssetRenderer() />
 
@@ -100,9 +96,6 @@
 				<th>
 					<@liferay.language key="ratings" />
 				</th>
-				<th>
-					<@liferay.language key="views" />
-				</th>
 			</tr>
 
 			<#list childPages as childPage>
@@ -124,9 +117,6 @@
 					</td>
 					<td>
 						<@getRatings cssClass="child-ratings" entry=childPage />
-					</td>
-					<td>
-						<span class="stats">${assetEntryLocalService.getEntry(wikiPageClassName, childPage.getResourcePrimKey()).getViewCount()}</span>
 					</td>
 				</tr>
 			</#list>


### PR DESCRIPTION
Hey Brian,

In the last commit I renamed the journal.template.*.restricted.variables to more generic names, so that they can be also used for DDL and ADT templates. 

@JorgeFerrer told me to include this change in the upgrade instructions wiki, in case you finally accept it.

Thanks
