### PR TITLE
LPS-41309 Refactor to render error page on spi failure rather than triggering error processing logic

### DIFF
--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -280,7 +280,11 @@
 	</bean>
 	<bean id="com.liferay.portal.kernel.resiliency.spi.SPIRegistryUtil" class="com.liferay.portal.kernel.resiliency.spi.SPIRegistryUtil">
 		<property name="sPIRegistry">
-			<bean class="com.liferay.portal.resiliency.spi.SPIRegistryImpl" />
+			<bean class="com.liferay.portal.resiliency.spi.SPIRegistryImpl">
+				<property name="errorSPI">
+					<bean class="com.liferay.portal.resiliency.spi.ErrorSPI" />
+				</property>
+			</bean>
 		</property>
 	</bean>
 	<bean id="com.liferay.portal.kernel.resiliency.spi.agent.SPIAgentFactoryUtil" class="com.liferay.portal.kernel.resiliency.spi.agent.SPIAgentFactoryUtil">

--- a/portal-impl/src/com/liferay/portal/resiliency/spi/ErrorSPI.java
+++ b/portal-impl/src/com/liferay/portal/resiliency/spi/ErrorSPI.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.resiliency.spi;
+
+import com.liferay.portal.kernel.nio.intraband.RegistrationReference;
+import com.liferay.portal.kernel.resiliency.mpi.MPI;
+import com.liferay.portal.kernel.resiliency.spi.SPI;
+import com.liferay.portal.kernel.resiliency.spi.SPIConfiguration;
+import com.liferay.portal.kernel.resiliency.spi.agent.SPIAgent;
+import com.liferay.portal.resiliency.spi.agent.ErrorSPIAgent;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ErrorSPI implements SPI {
+
+	@Override
+	public void addServlet(
+		String contextPath, String docBasePath, String mappingPattern,
+		String servletClassName) {
+	}
+
+	@Override
+	public void addWebapp(String contextPath, String docBasePath) {
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public MPI getMPI() {
+		return null;
+	}
+
+	@Override
+	public RegistrationReference getRegistrationReference() {
+		return null;
+	}
+
+	@Override
+	public SPIAgent getSPIAgent() {
+		return _SPI_AGENT;
+	}
+
+	@Override
+	public SPIConfiguration getSPIConfiguration() {
+		return null;
+	}
+
+	@Override
+	public String getSPIProviderName() {
+		return null;
+	}
+
+	@Override
+	public void init() {
+	}
+
+	@Override
+	public boolean isAlive() {
+		return true;
+	}
+
+	@Override
+	public void start() {
+	}
+
+	@Override
+	public void stop() {
+	}
+
+	private static final SPIAgent _SPI_AGENT = new ErrorSPIAgent();
+
+}

--- a/portal-impl/src/com/liferay/portal/resiliency/spi/agent/ErrorSPIAgent.java
+++ b/portal-impl/src/com/liferay/portal/resiliency/spi/agent/ErrorSPIAgent.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.resiliency.spi.agent;
+
+import com.liferay.portal.kernel.portlet.ActionResult;
+import com.liferay.portal.kernel.resiliency.PortalResiliencyException;
+import com.liferay.portal.kernel.resiliency.spi.SPI;
+import com.liferay.portal.kernel.resiliency.spi.agent.SPIAgent;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.Collections;
+
+import javax.portlet.Event;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ErrorSPIAgent implements SPIAgent {
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void init(SPI spi) {
+	}
+
+	@Override
+	public HttpServletRequest prepareRequest(HttpServletRequest request) {
+		return request;
+	}
+
+	@Override
+	public HttpServletResponse prepareResponse(
+		HttpServletRequest request, HttpServletResponse response) {
+
+		return response;
+	}
+
+	@Override
+	public void service(
+			HttpServletRequest request, HttpServletResponse response)
+		throws PortalResiliencyException {
+
+		SPIAgent.Lifecycle lifecycle = (SPIAgent.Lifecycle)request.getAttribute(
+			WebKeys.SPI_AGENT_LIFECYCLE);
+
+		switch (lifecycle) {
+			case ACTION :
+				request.setAttribute(
+					WebKeys.SPI_AGENT_ACTION_RESULT,
+					new ActionResult(
+						Collections.<Event>emptyList(), StringPool.SLASH));
+
+				return;
+			case EVENT :
+				request.setAttribute(
+					WebKeys.SPI_AGENT_EVENT_RESULT, Collections.emptyList());
+
+				return;
+			case RENDER :
+				try {
+					PrintWriter printWriter = response.getWriter();
+
+					printWriter.write("<div class=\"alert alert-error\">");
+					printWriter.write("SPI is temporarily unavailable.");
+					printWriter.write("</div>");
+				}
+				catch (IOException ioe) {
+					throw new PortalResiliencyException(ioe);
+				}
+
+				return;
+			case RESOURCE :
+		}
+	}
+
+	@Override
+	public void transferResponse(
+		HttpServletRequest request, HttpServletResponse response, Exception e) {
+	}
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/resiliency/spi/MockSPIRegistryValidator.java
+++ b/portal-impl/test/unit/com/liferay/portal/resiliency/spi/MockSPIRegistryValidator.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.resiliency.spi;
 
 import com.liferay.portal.kernel.resiliency.spi.SPI;
+import com.liferay.portal.kernel.resiliency.spi.SPIRegistryUtil;
 import com.liferay.portal.kernel.resiliency.spi.SPIRegistryValidator;
 
 /**
@@ -23,11 +24,21 @@ import com.liferay.portal.kernel.resiliency.spi.SPIRegistryValidator;
 public class MockSPIRegistryValidator implements SPIRegistryValidator {
 
 	@Override
-	public void validatePortletSPI(String portletId, SPI spi) {
+	public SPI validatePortletSPI(String portletId, SPI spi) {
+		if (spi != null) {
+			spi = SPIRegistryUtil.getErrorSPI();
+		}
+
+		return spi;
 	}
 
 	@Override
-	public void validateServletContextSPI(String servletContextName, SPI spi) {
+	public SPI validateServletContextSPI(String servletContextName, SPI spi) {
+		if (spi != null) {
+			spi = SPIRegistryUtil.getErrorSPI();
+		}
+
+		return spi;
 	}
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/resiliency/spi/SPIRegistryImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/resiliency/spi/SPIRegistryImplTest.java
@@ -14,10 +14,10 @@
 
 package com.liferay.portal.resiliency.spi;
 
-import com.liferay.portal.kernel.resiliency.PortalResiliencyException;
 import com.liferay.portal.kernel.resiliency.spi.MockSPI;
 import com.liferay.portal.kernel.resiliency.spi.SPI;
 import com.liferay.portal.kernel.resiliency.spi.SPIConfiguration;
+import com.liferay.portal.kernel.resiliency.spi.SPIRegistryUtil;
 import com.liferay.portal.kernel.test.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -63,13 +63,19 @@ public class SPIRegistryImplTest {
 	public void setUp() throws Exception {
 		_spiRegistryImpl = new SPIRegistryImpl();
 
+		_spiRegistryImpl.setErrorSPI(new ErrorSPI());
+
+		SPIRegistryUtil spiRegistryUtil = new SPIRegistryUtil();
+
+		spiRegistryUtil.setSPIRegistry(_spiRegistryImpl);
+
 		_excludedPortletIds = _getExcludedPortletIds(_spiRegistryImpl);
 		_portletIds = _getPortletIds(_spiRegistryImpl);
 		_portletSPIs = _getPortletSPIs(_spiRegistryImpl);
 	}
 
 	@Test
-	public void testExcludedPortletIds() throws PortalResiliencyException {
+	public void testExcludedPortletIds() {
 		Assert.assertSame(
 			_excludedPortletIds, _spiRegistryImpl.getExcludedPortletIds());
 
@@ -93,7 +99,9 @@ public class SPIRegistryImplTest {
 			new MockSPIRegistryValidator());
 
 		Assert.assertNull(_spiRegistryImpl.getPortletSPI(portlet1));
-		Assert.assertSame(spi, _spiRegistryImpl.getPortletSPI(portlet2));
+		Assert.assertSame(
+			_spiRegistryImpl.getErrorSPI(),
+			_spiRegistryImpl.getPortletSPI(portlet2));
 
 		_spiRegistryImpl.setSPIRegistryValidator(null);
 
@@ -151,9 +159,11 @@ public class SPIRegistryImplTest {
 			new MockSPIRegistryValidator());
 
 		Assert.assertSame(
-			mockSPI, _spiRegistryImpl.getServletContextSPI("portletApp1"));
+			_spiRegistryImpl.getErrorSPI(),
+			_spiRegistryImpl.getServletContextSPI("portletApp1"));
 		Assert.assertSame(
-			mockSPI, _spiRegistryImpl.getServletContextSPI("portletApp2"));
+			_spiRegistryImpl.getErrorSPI(),
+			_spiRegistryImpl.getServletContextSPI("portletApp2"));
 		Assert.assertNull(_spiRegistryImpl.getServletContextSPI("portletApp3"));
 
 		_spiRegistryImpl.setSPIRegistryValidator(null);

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIRegistry.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIRegistry.java
@@ -27,6 +27,8 @@ public interface SPIRegistry {
 
 	public void addExcludedPortletId(String portletId);
 
+	public SPI getErrorSPI();
+
 	public Set<String> getExcludedPortletIds();
 
 	public SPI getPortletSPI(String portletId) throws PortalResiliencyException;

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIRegistryUtil.java
@@ -30,6 +30,10 @@ public class SPIRegistryUtil {
 		getSPIRegistry().addExcludedPortletId(portletId);
 	}
 
+	public static SPI getErrorSPI() {
+		return getSPIRegistry().getErrorSPI();
+	}
+
 	public static Set<String> getExcludedPortletIds() {
 		return getSPIRegistry().getExcludedPortletIds();
 	}

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIRegistryValidator.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/spi/SPIRegistryValidator.java
@@ -14,17 +14,13 @@
 
 package com.liferay.portal.kernel.resiliency.spi;
 
-import com.liferay.portal.kernel.resiliency.PortalResiliencyException;
-
 /**
  * @author Shuyang Zhou
  */
 public interface SPIRegistryValidator {
 
-	public void validatePortletSPI(String portletId, SPI spi)
-		throws PortalResiliencyException;
+	public SPI validatePortletSPI(String portletId, SPI spi);
 
-	public void validateServletContextSPI(String servletContextName, SPI spi)
-		throws PortalResiliencyException;
+	public SPI validateServletContextSPI(String servletContextName, SPI spi);
 
 }


### PR DESCRIPTION
cc @mhan810

1) Create a class that impls SPIRegistryValidator from the console plugin
2) Register it into portal by calling SPIRegistryUtil.setSPIRegistryValidator(SPIRegistryValidator)
3) In the SPIRegistryValidator impl, when it sees the targeting spi is down, returns SPIRegistryUtil.getErrorSPI(), which does NOP on ACTION/EVENT/RESOURCE phases. On render phase, it simply outputs a message to say the spi is not unavailable, if necessary we may want to refine the message. See ErrorSPIAgent.service() render phase.
