### PR TITLE
master-qa-5989

### DIFF
--- a/build-test-plugins.xml
+++ b/build-test-plugins.xml
@@ -46,10 +46,27 @@ plugins.includes=${plugins.includes}</echo>
 			</then>
 		</if>
 
-		<ant dir="${lp.plugins.dir}/${plugin.types}" inheritAll="false">
-			<target name="clean" />
-			<target name="deploy" />
-		</ant>
+		<if>
+			<equals arg1="${release.plugin}" arg2="true" />
+			<then>
+				<for list="${plugins.includes}" param="plugin.includes">
+					<sequential>
+						<copy todir="${liferay.home}/deploy">
+							<fileset
+								dir="${release.dir}/${release.plugins.dir}"
+								includes="@{plugin.includes}*.war"
+							/>
+						</copy>
+					</sequential>
+				</for>
+			</then>
+			<else>
+				<ant dir="${lp.plugins.dir}/${plugin.types}" inheritAll="false">
+					<target name="clean" />
+					<target name="deploy" />
+				</ant>
+			</else>
+		</if>
 
 		<delete dir="${lp.plugins.dir}/dist" />
 		<mkdir dir="${lp.plugins.dir}/dist" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-5989

Hey Brian,

Here's the ant code for deploying release plugins. Feel free to change the property names to whatever you think is best.

I've made it so that if you set the property "release.plugin" to be "true", it will iterate through the list of plugins and copy them over from the directory set by "${release.dir}/${release.plugins.dir}". Since the release plugins file names have the Liferay version and time stamp appended to the end, I used ${plugin.includes}*.war. As long as what's being passed in is follows the same format that we've always used to pass in plugins (e.g. contacts-portlet,ddl-form-portlet,kaleo-web) it will be specific enough.

If the property release.plugin is not set, the script will execute the default plugin deployment.

Let me know if there is anything I need to change.
