### PR TITLE
LPS-41820 fix visibility and remove old trashversions --> Please read comment

### DIFF
--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -928,6 +928,22 @@ public class JournalArticleLocalServiceImpl
 
 		expandoRowLocalService.deleteRows(article.getId());
 
+		// Trash
+
+		if (article.isInTrash()) {
+			TrashEntry trashEntry = article.getTrashEntry();
+
+			if ((trashEntry != null) &&
+				!trashEntry.isTrashEntry(
+					JournalArticle.class.getName(),
+					article.getResourcePrimKey())) {
+
+				trashVersionLocalService.deleteTrashVersion(
+					trashEntry.getEntryId(), JournalArticle.class.getName(),
+					article.getId());
+			}
+		}
+
 		// Workflow
 
 		if (!article.isDraft()) {

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -933,11 +933,7 @@ public class JournalArticleLocalServiceImpl
 		if (article.isInTrash()) {
 			TrashEntry trashEntry = article.getTrashEntry();
 
-			if ((trashEntry != null) &&
-				!trashEntry.isTrashEntry(
-					JournalArticle.class.getName(),
-					article.getResourcePrimKey())) {
-
+			if ((trashEntry != null)) {
 				trashVersionLocalService.deleteTrashVersion(
 					trashEntry.getEntryId(), JournalArticle.class.getName(),
 					article.getId());

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -777,9 +777,7 @@ public class JournalFolderLocalServiceImpl
 
 				JournalArticle article = (JournalArticle)object;
 
-				int oldStatus = article.getStatus();
-
-				if (oldStatus == WorkflowConstants.STATUS_IN_TRASH) {
+				if (article.getStatus() == WorkflowConstants.STATUS_IN_TRASH) {
 					continue;
 				}
 
@@ -833,11 +831,9 @@ public class JournalFolderLocalServiceImpl
 
 				// Asset
 
-				if (oldStatus == WorkflowConstants.STATUS_APPROVED) {
-					assetEntryLocalService.updateVisible(
-						JournalArticle.class.getName(),
-						article.getResourcePrimKey(), false);
-				}
+				assetEntryLocalService.updateVisible(
+					JournalArticle.class.getName(),
+					article.getResourcePrimKey(), false);
 
 				// Indexer
 

--- a/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashVersionLocalServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.trash.service.impl;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
@@ -50,6 +51,20 @@ public class TrashVersionLocalServiceImpl
 		trashVersion.setStatus(status);
 
 		trashVersionPersistence.update(trashVersion);
+	}
+
+	@Override
+	public TrashVersion deleteTrashVersion(
+			long entryId, String className, long classPK)
+		throws PortalException, SystemException {
+
+		TrashVersion trashVersion = fetchVersion(entryId, className, classPK);
+
+		if (trashVersion != null) {
+			return deleteTrashVersion(trashVersion);
+		}
+
+		return null;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashVersionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashVersionLocalServiceImpl.java
@@ -74,10 +74,8 @@ public class TrashVersionLocalServiceImpl
 
 		long classNameId = PortalUtil.getClassNameId(className);
 
-		TrashVersion version = trashVersionPersistence.fetchByE_C_C(
+		return trashVersionPersistence.fetchByE_C_C(
 			entryId, classNameId, classPK);
-
-		return version;
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/trash/BlogsEntryTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/trash/BlogsEntryTrashHandlerTest.java
@@ -51,6 +51,12 @@ public class BlogsEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashDuplicate() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/bookmarks/trash/BookmarksEntryTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/bookmarks/trash/BookmarksEntryTrashHandlerTest.java
@@ -55,6 +55,12 @@ public class BookmarksEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/bookmarks/trash/BookmarksFolderTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/bookmarks/trash/BookmarksFolderTrashHandlerTest.java
@@ -52,6 +52,12 @@ public class BookmarksFolderTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/trash/DLFileEntryTrashHandlerTest.java
@@ -71,6 +71,12 @@ import org.junit.runner.RunWith;
 @Sync
 public class DLFileEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 
+	@Ignore()
+	@Override
+	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
 	@Test
 	@Transactional
 	public void testTrashDLFileRank() throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashHandlerTest.java
@@ -60,6 +60,12 @@ public class DLFileShortcutTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/trash/DLFolderTrashHandlerTest.java
@@ -54,6 +54,12 @@ public class DLFolderTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/journal/trash/JournalArticleTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/trash/JournalArticleTrashHandlerTest.java
@@ -15,9 +15,11 @@
 package com.liferay.portlet.journal.trash;
 
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.ClassedModel;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.model.WorkflowedModel;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
@@ -36,6 +38,8 @@ import com.liferay.portlet.journal.service.JournalFolderServiceUtil;
 import com.liferay.portlet.journal.util.JournalTestUtil;
 import com.liferay.portlet.trash.BaseTrashHandlerTestCase;
 import com.liferay.portlet.trash.util.TrashUtil;
+
+import java.util.List;
 
 import org.junit.runner.RunWith;
 
@@ -86,6 +90,18 @@ public class JournalArticleTrashHandlerTest extends BaseTrashHandlerTestCase {
 	}
 
 	@Override
+	protected BaseModel<?> expireBaseModel(
+			BaseModel<?> baseModel, ServiceContext serviceContext)
+		throws Exception {
+
+		JournalArticle article = (JournalArticle)baseModel;
+
+		return JournalArticleLocalServiceUtil.expireArticle(
+			article.getUserId(), article.getGroupId(), article.getArticleId(),
+			article.getVersion(), StringPool.BLANK, serviceContext);
+	}
+
+	@Override
 	protected Long getAssetClassPK(ClassedModel classedModel) {
 		JournalArticle article = (JournalArticle)classedModel;
 
@@ -116,6 +132,17 @@ public class JournalArticleTrashHandlerTest extends BaseTrashHandlerTestCase {
 		JournalArticle article = (JournalArticle)classedModel;
 
 		return article.getArticleId();
+	}
+
+	@Override
+	protected List<? extends WorkflowedModel> getChildrenWorkflowedModels(
+			BaseModel<?> parentBaseModel)
+		throws Exception {
+
+		JournalFolder folder = (JournalFolder)parentBaseModel;
+
+		return JournalArticleLocalServiceUtil.getArticles(
+			folder.getGroupId(), folder.getFolderId());
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/journal/trash/JournalFolderTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/trash/JournalFolderTrashHandlerTest.java
@@ -51,6 +51,12 @@ public class JournalFolderTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/journal/util/JournalTestUtil.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/util/JournalTestUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -52,6 +53,8 @@ import com.liferay.portlet.journal.service.JournalFeedLocalServiceUtil;
 import com.liferay.portlet.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.util.RSSUtil;
 
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -641,14 +644,43 @@ public class JournalTestUtil {
 			titleMap.put(locale, title);
 		}
 
+		Date displayDate = article.getDisplayDate();
+
+		int displayDateMonth = 0;
+		int displayDateDay = 0;
+		int displayDateYear = 0;
+		int displayDateHour = 0;
+		int displayDateMinute = 0;
+
+		if (displayDate != null) {
+			Calendar displayCal = CalendarFactoryUtil.getCalendar(
+				TestPropsValues.getUser().getTimeZone());
+
+			displayCal.setTime(displayDate);
+
+			displayDateMonth = displayCal.get(Calendar.MONTH);
+			displayDateDay = displayCal.get(Calendar.DATE);
+			displayDateYear = displayCal.get(Calendar.YEAR);
+			displayDateHour = displayCal.get(Calendar.HOUR);
+			displayDateMinute = displayCal.get(Calendar.MINUTE);
+
+			if (displayCal.get(Calendar.AM_PM) == Calendar.PM) {
+				displayDateHour += 12;
+			}
+		}
+
 		serviceContext.setCommand(Constants.UPDATE);
 
 		return JournalArticleLocalServiceUtil.updateArticle(
 			article.getUserId(), article.getGroupId(), article.getFolderId(),
 			article.getArticleId(), article.getVersion(), titleMap,
-			article.getDescriptionMap(),
-			createLocalizedContent(content, LocaleUtil.getSiteDefault()),
-			article.getLayoutUuid(), serviceContext);
+			article.getDescriptionMap(), content, article.getType(),
+			article.getStructureId(), article.getTemplateId(),
+			article.getLayoutUuid(), displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute, 0, 0, 0, 0, 0,
+			true, 0, 0, 0, 0, 0, true, article.getIndexable(),
+			article.isSmallImage(), article.getSmallImageURL(), null, null,
+			null, serviceContext);
 	}
 
 	private static String _getFeedFriendlyURL(long groupId, long plid)

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/trash/MBCategoryTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/trash/MBCategoryTrashHandlerTest.java
@@ -50,6 +50,12 @@ public class MBCategoryTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/trash/MBThreadTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/trash/MBThreadTrashHandlerTest.java
@@ -98,6 +98,12 @@ public class MBThreadTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/trash/BaseTrashHandlerTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/BaseTrashHandlerTestCase.java
@@ -50,6 +50,7 @@ import com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil;
 import com.liferay.portlet.trash.model.TrashEntry;
 import com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil;
 import com.liferay.portlet.trash.service.TrashEntryServiceUtil;
+import com.liferay.portlet.trash.service.TrashVersionLocalServiceUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,6 +78,37 @@ public abstract class BaseTrashHandlerTestCase {
 	@After
 	public void tearDown() throws Exception {
 		GroupLocalServiceUtil.deleteGroup(group);
+	}
+
+	@Test
+	@Transactional
+	public void testDeleteTrashVersions() throws Exception {
+		ServiceContext serviceContext = ServiceTestUtil.getServiceContext(
+			group.getGroupId());
+
+		BaseModel<?> parentBaseModel = getParentBaseModel(
+			group, serviceContext);
+
+		int initialTrashVersionsCount =
+			TrashVersionLocalServiceUtil.getTrashVersionsCount();
+
+		baseModel = addBaseModel(parentBaseModel, true, serviceContext);
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		baseModel = updateBaseModel(
+			(Long)baseModel.getPrimaryKeyObj(), serviceContext);
+
+		moveParentBaseModelToTrash((Long)parentBaseModel.getPrimaryKeyObj());
+
+		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
+			getBaseModelClassName());
+
+		trashHandler.deleteTrashEntry(getTrashEntryClassPK(baseModel));
+
+		Assert.assertEquals(
+			initialTrashVersionsCount,
+			TrashVersionLocalServiceUtil.getTrashVersionsCount());
 	}
 
 	@Test

--- a/portal-impl/test/integration/com/liferay/portlet/wiki/trash/WikiNodeTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/wiki/trash/WikiNodeTrashHandlerTest.java
@@ -49,6 +49,12 @@ public class WikiNodeTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/wiki/trash/WikiPageTrashHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/wiki/trash/WikiPageTrashHandlerTest.java
@@ -58,6 +58,12 @@ public class WikiPageTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Ignore()
 	@Override
 	@Test
+	public void testDeleteTrashVersions() throws Exception {
+	}
+
+	@Ignore()
+	@Override
+	@Test
 	public void testTrashAndDeleteDraft() throws Exception {
 	}
 

--- a/portal-service/src/com/liferay/portlet/trash/service/TrashVersionLocalService.java
+++ b/portal-service/src/com/liferay/portlet/trash/service/TrashVersionLocalService.java
@@ -248,6 +248,11 @@ public interface TrashVersionLocalService extends BaseLocalService,
 		com.liferay.portal.kernel.util.UnicodeProperties typeSettingsProperties)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
+	public com.liferay.portlet.trash.model.TrashVersion deleteTrashVersion(
+		long entryId, java.lang.String className, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portlet.trash.model.TrashVersion fetchVersion(
 		long entryId, java.lang.String className, long classPK)

--- a/portal-service/src/com/liferay/portlet/trash/service/TrashVersionLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/trash/service/TrashVersionLocalServiceUtil.java
@@ -277,6 +277,13 @@ public class TrashVersionLocalServiceUtil {
 			typeSettingsProperties);
 	}
 
+	public static com.liferay.portlet.trash.model.TrashVersion deleteTrashVersion(
+		long entryId, java.lang.String className, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService().deleteTrashVersion(entryId, className, classPK);
+	}
+
 	public static com.liferay.portlet.trash.model.TrashVersion fetchVersion(
 		long entryId, java.lang.String className, long classPK)
 		throws com.liferay.portal.kernel.exception.SystemException {

--- a/portal-service/src/com/liferay/portlet/trash/service/TrashVersionLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/trash/service/TrashVersionLocalServiceWrapper.java
@@ -289,6 +289,15 @@ public class TrashVersionLocalServiceWrapper implements TrashVersionLocalService
 	}
 
 	@Override
+	public com.liferay.portlet.trash.model.TrashVersion deleteTrashVersion(
+		long entryId, java.lang.String className, long classPK)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _trashVersionLocalService.deleteTrashVersion(entryId, className,
+			classPK);
+	}
+
+	@Override
 	public com.liferay.portlet.trash.model.TrashVersion fetchVersion(
 		long entryId, java.lang.String className, long classPK)
 		throws com.liferay.portal.kernel.exception.SystemException {


### PR DESCRIPTION
Hi Brian,

could we backport this? It is mostly tests. Maybe we can just backport the commit which says: "set asset visibility to false", that will fix the issue and it is very simple.
