### PR TITLE
LPS-41935 It is better to launch startup checking via PortalLifecycle, just in case user is slowly responsing setup wizard, we won't repeatly overwriting the undeployed wars.

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/GlobalStartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/GlobalStartupAction.java
@@ -30,9 +30,12 @@ import com.liferay.portal.kernel.javadoc.JavadocManagerUtil;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceActionsManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.BasePortalLifecycle;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.InstanceFactory;
+import com.liferay.portal.kernel.util.PortalLifecycle;
+import com.liferay.portal.kernel.util.PortalLifecycleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringPool;
@@ -312,7 +315,18 @@ public class GlobalStartupAction extends SimpleAction {
 
 		// Plugins
 
-		RequiredPluginsUtil.startCheckingRequiredPlugins();
+		PortalLifecycleUtil.register(new BasePortalLifecycle() {
+
+			@Override
+			protected void doPortalDestroy() {
+			}
+
+			@Override
+			protected void doPortalInit() {
+				RequiredPluginsUtil.startCheckingRequiredPlugins();
+			}
+
+		}, PortalLifecycle.METHOD_INIT);
 
 		// POP server
 


### PR DESCRIPTION
Brian, I have to do this after all.

Without it, if you don't finish setup wizard within 1 min, we will overwrite the undeployed war file, nothing will break, but the console output will be very annoying.
