### PR TITLE
LPS-40690 Avoid calling local methods by aop reference in ***LocalServiceImpl.

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -116,7 +116,7 @@ public class LayoutBranchLocalServiceImpl
 			layoutBranch.getLayoutSetBranchId(), layoutBranchId,
 			layoutBranch.getPlid());
 
-		return layoutBranchLocalService.deleteLayoutBranch(layoutBranch);
+		return deleteLayoutBranch(layoutBranch);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -2586,7 +2586,7 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 		Layout layout = layoutPersistence.findByG_P_L(
 			groupId, privateLayout, layoutId);
 
-		return layoutLocalService.updateName(layout, name, languageId);
+		return updateName(layout, name, languageId);
 	}
 
 	/**
@@ -2607,7 +2607,7 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		Layout layout = layoutPersistence.findByPrimaryKey(plid);
 
-		return layoutLocalService.updateName(layout, name, languageId);
+		return updateName(layout, name, languageId);
 	}
 
 	/**


### PR DESCRIPTION
Brian, the change to LayoutBranchLocalServiceImpl is safe.

Because both deleteLayoutBranch(long) and deleteLayoutBranch(LayoutBranch) have the @Indexable(type = IndexableType.DELETE), as before this change, we were actually deleting the index data twice.
