### PR TITLE
LPS-41781

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/Validator.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Validator.java
@@ -1369,7 +1369,7 @@ public class Validator {
 
 	private static Pattern _emailAddressPattern = Pattern.compile(
 		"[\\w!#$%&'*+/=?^_`{|}~-]+(?:\\.[\\w!#$%&'*+/=?^_`{|}~-]+)*@" +
-		"(?:[\\w](?:[\\w-]*[\\w])?\\.)+[\\w](?:[\\w-]*[\\w])?");
+		"(?:[a-zA-Z0-9](?:-*[a-zA-Z0-9])?\\.*)+");
 	private static Pattern _ipv4AddressPattern = Pattern.compile(
 		"^" +
 		"(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/ValidatorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/ValidatorTest.java
@@ -92,7 +92,7 @@ public class ValidatorTest extends PowerMockito {
 			"test", "liferay.com", "@liferay.com", "test(@liferay.com",
 			"test)@liferay.com", "test,@liferay.com", ".test@liferay.com",
 			"test.@liferay.com", "te..st@liferay.com", "test user@liferay.com",
-			"test@-liferay.com", "test@liferay.com-", "test@_liferay.com"
+			"test@-liferay.com", "test@_liferay.com"
 		};
 
 		testValidEmailAddreses(invalidEmailAddresses, false);

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/ValidatorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/ValidatorTest.java
@@ -92,7 +92,7 @@ public class ValidatorTest extends PowerMockito {
 			"test", "liferay.com", "@liferay.com", "test(@liferay.com",
 			"test)@liferay.com", "test,@liferay.com", ".test@liferay.com",
 			"test.@liferay.com", "te..st@liferay.com", "test user@liferay.com",
-			"test@-liferay.com", "test@liferay"
+			"test@-liferay.com", "test@liferay.com-", "test@_liferay.com"
 		};
 
 		testValidEmailAddreses(invalidEmailAddresses, false);
@@ -384,7 +384,8 @@ public class ValidatorTest extends PowerMockito {
 			"test-@liferay.com", "test/@liferay.com", "test=@liferay.com",
 			"test?@liferay.com", "test^@liferay.com", "test_@liferay.com",
 			"test`@liferay.com", "test{@liferay.com", "test|@liferay.com",
-			"test{@liferay.com", "test~@liferay.com"
+			"test{@liferay.com", "test~@liferay.com", "test@liferay.com.",
+			"test@liferay"
 		};
 
 		testValidEmailAddreses(validEmailAddresses, true);


### PR DESCRIPTION
- Change from `\w` to `a-zA-Z0-9` because `_` is not allowed in the domain part of an email address
- It's okay to end the domain part of an email address with a period
- A period is not required in the domain part
