### PR TITLE
LPS-40742 jrebel file keeps being deleted when doing ant all

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -66,6 +66,12 @@
     #jdbc.drivers.optional.dir=
 
 ##
+## JRebel
+##
+
+    jrebel.auto.setup=off
+
+##
 ## JUnit
 ##
 

--- a/build.xml
+++ b/build.xml
@@ -7,6 +7,12 @@
 		<antcall target="clean" />
 		<antcall target="start" />
 		<antcall target="deploy" />
+		<if>
+			<equals arg1="${jrebel.auto.setup}" arg2="on" />
+			<then>
+				<antcall target="setup-jrebel" />
+			</then>
+		</if>
 	</target>
 
 	<target name="clean">


### PR DESCRIPTION
Hey Brian, you suggested to not remove this file, and we have tried but we haven't been able to do it. The Root folder is deleted completely and we can not leave just one file there. We think it makes more sense to regenerated when doing ant all for those who want it.
