### PR TITLE
LPS-42555 fix regression bug - themedeployer/basedeployer generates invalid liferay-look-and-feel.xml

### DIFF
--- a/portal-impl/src/com/liferay/portal/templateparser/Transformer.java
+++ b/portal-impl/src/com/liferay/portal/templateparser/Transformer.java
@@ -525,7 +525,7 @@ public class Transformer {
 				"type", StringPool.BLANK);
 
 			TemplateNode templateNode = new TemplateNode(
-				themeDisplay, name, stripCDATA(data), type);
+				themeDisplay, name, StringUtil.stripCDATA(data), type);
 
 			if (dynamicElementElement.element("dynamic-element") != null) {
 				templateNode.appendChildren(
@@ -539,7 +539,7 @@ public class Transformer {
 
 				for (Element optionElement : optionElements) {
 					templateNode.appendOption(
-						stripCDATA(optionElement.getText()));
+						StringUtil.stripCDATA(optionElement.getText()));
 				}
 			}
 
@@ -645,18 +645,6 @@ public class Transformer {
 		}
 
 		template.prepare(themeDisplay.getRequest());
-	}
-
-	protected String stripCDATA(String s) {
-		if (s.startsWith(StringPool.CDATA_OPEN) &&
-			s.endsWith(StringPool.CDATA_CLOSE)) {
-
-			s = s.substring(
-				StringPool.CDATA_OPEN.length(),
-				s.length() - StringPool.CDATA_CLOSE.length());
-		}
-
-		return s;
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(Transformer.class);

--- a/portal-impl/src/com/liferay/portal/tools/deploy/ThemeDeployer.java
+++ b/portal-impl/src/com/liferay/portal/tools/deploy/ThemeDeployer.java
@@ -121,7 +121,7 @@ public class ThemeDeployer extends BaseDeployer {
 
 		String themeName = filterMap.get("plugin_name");
 
-		filterMap.put("theme_name", themeName);
+		filterMap.put("theme_name", StringUtil.stripCDATA(themeName));
 
 		String liferayVersions = filterMap.get("liferay_versions");
 

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -3649,6 +3649,10 @@ public class StringUtil {
 	}
 
 	public static String stripCDATA(String s) {
+		if (s == null) {
+			return s;
+		}
+
 		if (s.startsWith(StringPool.CDATA_OPEN) &&
 			s.endsWith(StringPool.CDATA_CLOSE)) {
 

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -3648,6 +3648,18 @@ public class StringUtil {
 		return sb.toString();
 	}
 
+	public static String stripCDATA(String s) {
+		if (s.startsWith(StringPool.CDATA_OPEN) &&
+			s.endsWith(StringPool.CDATA_CLOSE)) {
+
+			s = s.substring(
+				StringPool.CDATA_OPEN.length(),
+				s.length() - StringPool.CDATA_CLOSE.length());
+		}
+
+		return s;
+	}
+
 	/**
 	 * Returns a string representing the Unicode character codes of the
 	 * characters comprising the string <code>s</code>.


### PR DESCRIPTION
Hi Brian please review code. As you requested I detected stripCDATA and moved it to StringUtil. This issue affects ee-6.2.x and ee-6.1.x (where initial changes were backported) but please note that in 6.1 stripCDATA is present in VelocityTemplateParser, not in Transformer class. Thank you.
