### PR TITLE
master-qa-6335

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -58,6 +58,7 @@
 	<path id="test.classpath">
 		<pathelement path="test-classes/${test.type}" />
 		<pathelement path="${classpath}" />
+		<pathelement path="${imported.classpath}" />
 		<fileset dir="${project.dir}/lib/development" includes="*.jar" excludes="jalopy.jar,jetty*.jar,tomcat*.jar" />
 		<fileset dir="${project.dir}/lib/global" includes="*.jar" />
 		<fileset dir="${project.dir}/lib/portal" includes="*.jar" excludes="ant.jar" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -942,12 +942,17 @@ tck.url=true</echo>
 		</if>
 
 		<if>
-			<isset property="test.basedir.name" />
+			<isset property="test.basedir" />
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
-					test.basedir.name=${test.basedir.name}
+					test.basedir=${test.basedir}
 				</echo>
 			</then>
+			<else>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					test.basedir=${basedir.unix}/portal-web
+				</echo>
+			</else>
 		</if>
 
 		<if>

--- a/portal-web/test/functional/com/liferay/portalweb/portal/util/TestPropsValues.java
+++ b/portal-web/test/functional/com/liferay/portalweb/portal/util/TestPropsValues.java
@@ -77,8 +77,7 @@ public class TestPropsValues extends com.liferay.portal.util.TestPropsValues {
 		GetterUtil.getBoolean(
 			TestPropsUtil.get("test.assert.javascript.errors"));
 
-	public static final String TEST_BASEDIR_NAME = TestPropsUtil.get(
-		"test.basedir.name");
+	public static final String TEST_BASEDIR = TestPropsUtil.get("test.basedir");
 
 	public static final boolean TEST_DATABASE_MINIMAL = GetterUtil.getBoolean(
 		TestPropsUtil.get("test.database.minimal"));

--- a/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/Logger.java
+++ b/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/Logger.java
@@ -249,23 +249,21 @@ public class Logger {
 			_liferaySelenium.getPrimaryTestSuiteName();
 
 		String htmlFileName =
-			_TEST_BASEDIR_NAME + "/test/functional-generated/" +
+			_TEST_BASEDIR + "/test/functional-generated/" +
 				StringUtil.replace(primaryTestSuiteName, ".", "/") + ".html";
 
 		if (_loggerStarted) {
 			return;
 		}
 
-		if (FileUtil.exists(_liferaySelenium.getProjectDir() + htmlFileName)) {
-			_webDriver.get(
-				"file:///" + _liferaySelenium.getProjectDir() + htmlFileName);
+		if (FileUtil.exists(htmlFileName)) {
+			_webDriver.get("file:///" + htmlFileName);
 		}
 		else {
 			_webDriver.get(
-				"file:///" + _liferaySelenium.getProjectDir() +
-					_TEST_BASEDIR_NAME + "/test/functional/com/liferay/" +
-						"portalweb/portal/util/liferayselenium/dependencies/" +
-						"Logger.html");
+				"file:///" + _TEST_BASEDIR + "/test/functional/com/liferay/" +
+					"portalweb/portal/util/liferayselenium/dependencies/" +
+					"Logger.html");
 		}
 
 		_loggerStarted = true;
@@ -281,8 +279,7 @@ public class Logger {
 					"outerHTML;");
 
 			String fileName =
-				_liferaySelenium.getProjectDir() +
-					_TEST_BASEDIR_NAME + "/test-results/functional/report.html";
+				_TEST_BASEDIR + "/test-results/functional/report.html";
 
 			File file = new File(fileName);
 
@@ -433,8 +430,7 @@ public class Logger {
 		_javascriptExecutor.executeScript(sb.toString());
 	}
 
-	private static final String _TEST_BASEDIR_NAME =
-		TestPropsValues.TEST_BASEDIR_NAME;
+	private static final String _TEST_BASEDIR = TestPropsValues.TEST_BASEDIR;
 
 	private int _errorCount;
 	private JavascriptExecutor _javascriptExecutor;

--- a/portal-web/test/test-portal-web.properties
+++ b/portal-web/test/test-portal-web.properties
@@ -34,7 +34,7 @@ selenium.logger.enabled=true
 selenium.port=14444
 
 test.assert.javascript.errors=true
-test.basedir.name=portal-web
+#test.basedir=
 test.skip.tear.down=false
 
 testing.class.method=false


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-6335

There were two main changes I made. This is so that we can run tests in the liferay-qa-portal-legacy-ee repository.
1. I added <pathelement path="${imported.classpath}" /> to build-common.xml. I wanted to reuse the "test-cmd" target in build-common, but to do that, I needed to give build-common.xml access to the test classes that are in liferay-qa-portal-legacy-ee. Hashi and I thought that ${imported.classpath} is a good generic name. We're not sure what else to call it, but if you want to rename it that is perfectly fine.
2. I changed "test.basedir.name" to "test.basedir". This is to make test.basedir an absolute path rather than just a directory name so it'd be easy to pass in the base directory for the tests.
