### PR TITLE
Lps 42599

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SQLQueryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SQLQueryImpl.java
@@ -66,6 +66,27 @@ public class SQLQueryImpl implements SQLQuery {
 		return this;
 	}
 
+	@Override
+	public SQLQuery addSynchronizedEntityClass(Class<?> entityClass) {
+		_sqlQuery.addSynchronizedEntityClass(entityClass);
+
+		return this;
+	}
+
+	@Override
+	public SQLQuery addSynchronizedEntityName(String entityName) {
+		_sqlQuery.addSynchronizedEntityName(entityName);
+
+		return this;
+	}
+
+	@Override
+	public SQLQuery addSynchronizedQuerySpace(String querySpace) {
+		_sqlQuery.addSynchronizedQuerySpace(querySpace);
+
+		return this;
+	}
+
 	@NotPrivileged
 	@Override
 	public int executeUpdate() throws ORMException {

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/AssetTagFinderImpl.java
@@ -32,7 +32,9 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.asset.NoSuchTagException;
 import com.liferay.portlet.asset.model.AssetTag;
 import com.liferay.portlet.asset.model.AssetTagConstants;
+import com.liferay.portlet.asset.model.impl.AssetEntryModelImpl;
 import com.liferay.portlet.asset.model.impl.AssetTagImpl;
+import com.liferay.portlet.asset.model.impl.AssetTagModelImpl;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.ArrayList;
@@ -272,6 +274,11 @@ public class AssetTagFinderImpl
 			SQLQuery q = session.createSQLQuery(sql);
 
 			q.addScalar(COUNT_COLUMN_NAME, Type.LONG);
+
+			q.addSynchronizedQuerySpace(AssetEntryModelImpl.TABLE_NAME);
+			q.addSynchronizedQuerySpace(
+				AssetEntryModelImpl.MAPPING_TABLE_ASSETENTRIES_ASSETTAGS_NAME);
+			q.addSynchronizedQuerySpace(AssetTagModelImpl.TABLE_NAME);
 
 			QueryPos qPos = QueryPos.getInstance(q);
 

--- a/portal-service/src/com/liferay/portal/kernel/dao/orm/SQLQuery.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/orm/SQLQuery.java
@@ -23,4 +23,10 @@ public interface SQLQuery extends Query {
 
 	public SQLQuery addScalar(String columnAlias, Type type);
 
+	public SQLQuery addSynchronizedEntityClass(Class<?> entityClass);
+
+	public SQLQuery addSynchronizedEntityName(String entityName);
+
+	public SQLQuery addSynchronizedQuerySpace(String querySpace);
+
 }


### PR DESCRIPTION
Brian, this is a very critical bug, which pretty much affects all XXXFinderImpl.java

The root problem is, hibernate's SQLQuery is not like its Query, Query is based on QueryPlan which can easily figure out what tables this select is against, then before the select, flush out any previous change that may affect the current select. SQLQuery is just a thin wrapper on top of JDBC, it does not understand the content of the given sql query, which means we need to tell it what tables this query involves in order to help it to do a proper auto flush. This behavior is clearly documented on org.hibernate.SQLQuery javadoc since 3.6 version.

So all of our XXXFinderImpl is technically affected by this, in order to fix it, we have to manually add the synchronized info to the SQLQuery, see my demo fix to AssetTagFinderImpl.doCountByG_C_N()

@matthewkong found this bug through this method.

Although this is technically critical, but luckily, in most cases, it won't really be noticed. Because we rarely do a custom sql query right after a session based update, if we do any Query select before SQLQuery select, the session cache will be flushed anyway, then it won't cause any problem.

But anyway, we need to globally fix our XXFinderImpl SQLQuery usage, there are too many of them, they are very easy to fix, just too much manual work, please have someone else to apply this globally.
