### PR TITLE
LPS-42103 Adds missing redirect param

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/assetpublisher/util/AssetPublisherServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/assetpublisher/util/AssetPublisherServiceTest.java
@@ -38,6 +38,8 @@ import com.liferay.portlet.journal.util.JournalTestUtil;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.portlet.PortletPreferences;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,10 +70,15 @@ public class AssetPublisherServiceTest {
 	@Test
 	@Transactional
 	public void testGetAssetEntries() throws Exception {
+		PortletPreferences mockPortletPreferences =
+			new MockPortletPreferences();
+
+		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
-			new MockPortletRequest(), new MockPortletPreferences(),
+			new MockPortletRequest(), mockPortletPreferences,
 			_permissionChecker, new long[] {TestPropsValues.getGroupId()},
-			_assetEntryXmls, false, false);
+			false, false);
 
 		Assert.assertEquals(_assetEntries, assetEntries);
 	}
@@ -89,10 +96,15 @@ public class AssetPublisherServiceTest {
 		List<AssetEntry> expectedAssetEntries = addAssetEntries(
 			allAssetCategoryIds, _NO_ASSET_TAG_NAMES, 2, true);
 
+		PortletPreferences mockPortletPreferences =
+			new MockPortletPreferences();
+
+		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
-			new MockPortletRequest(), new MockPortletPreferences(),
+			new MockPortletRequest(), mockPortletPreferences,
 			_permissionChecker, new long[] {TestPropsValues.getGroupId()},
-			_assetEntryXmls, false, false);
+			false, false);
 
 		Assert.assertEquals(
 			_assetEntries.size() + expectedAssetEntries.size(),
@@ -100,10 +112,9 @@ public class AssetPublisherServiceTest {
 
 		List<AssetEntry> filteredAsssetEntries =
 			AssetPublisherUtil.getAssetEntries(
-				new MockPortletRequest(), new MockPortletPreferences(),
+				new MockPortletRequest(), mockPortletPreferences,
 				_permissionChecker, new long[] {TestPropsValues.getGroupId()},
-				allAssetCategoryIds, _assetEntryXmls, _NO_ASSET_TAG_NAMES,
-				false, false);
+				allAssetCategoryIds, _NO_ASSET_TAG_NAMES, false, false);
 
 		Assert.assertEquals(expectedAssetEntries, filteredAsssetEntries);
 	}
@@ -124,10 +135,15 @@ public class AssetPublisherServiceTest {
 		List<AssetEntry> expectedAssetEntries = addAssetEntries(
 			allCategoyIds, allAssetTagNames, 2, true);
 
+		PortletPreferences mockPortletPreferences =
+			new MockPortletPreferences();
+
+		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
-			new MockPortletRequest(), new MockPortletPreferences(),
+			new MockPortletRequest(), mockPortletPreferences,
 			_permissionChecker, new long[] {TestPropsValues.getGroupId()},
-			_assetEntryXmls, false, false);
+			false, false);
 
 		Assert.assertEquals(
 			_assetEntries.size() + expectedAssetEntries.size(),
@@ -135,9 +151,9 @@ public class AssetPublisherServiceTest {
 
 		List<AssetEntry> filteredAssetEntries =
 			AssetPublisherUtil.getAssetEntries(
-				new MockPortletRequest(), new MockPortletPreferences(),
+				new MockPortletRequest(), mockPortletPreferences,
 				_permissionChecker, new long[] {TestPropsValues.getGroupId()},
-				allCategoyIds, _assetEntryXmls, allAssetTagNames, false, false);
+				allCategoyIds, allAssetTagNames, false, false);
 
 		Assert.assertEquals(expectedAssetEntries, filteredAssetEntries);
 	}
@@ -150,10 +166,15 @@ public class AssetPublisherServiceTest {
 		List<AssetEntry> expectedAssetEntries = addAssetEntries(
 			_NO_ASSET_CATEGORY_IDS, allAssetTagNames, 2, true);
 
+		PortletPreferences mockPortletPreferences =
+			new MockPortletPreferences();
+
+		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
-			new MockPortletRequest(), new MockPortletPreferences(),
+			new MockPortletRequest(), mockPortletPreferences,
 			_permissionChecker, new long[] {TestPropsValues.getGroupId()},
-			_assetEntryXmls, false, false);
+			false, false);
 
 		Assert.assertEquals(
 			_assetEntries.size() + expectedAssetEntries.size(),
@@ -161,10 +182,9 @@ public class AssetPublisherServiceTest {
 
 		List<AssetEntry> filteredAssetEntries =
 			AssetPublisherUtil.getAssetEntries(
-				new MockPortletRequest(), new MockPortletPreferences(),
+				new MockPortletRequest(), mockPortletPreferences,
 				_permissionChecker, new long[] {TestPropsValues.getGroupId()},
-				_NO_ASSET_CATEGORY_IDS, _assetEntryXmls, allAssetTagNames,
-				false, false);
+				_NO_ASSET_CATEGORY_IDS, allAssetTagNames, false, false);
 
 		Assert.assertEquals(expectedAssetEntries, filteredAssetEntries);
 	}

--- a/portal-impl/test/integration/com/liferay/portlet/assetpublisher/util/AssetPublisherServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/assetpublisher/util/AssetPublisherServiceTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.portlet.PortletPreferences;
+import javax.portlet.ReadOnlyException;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -71,9 +72,7 @@ public class AssetPublisherServiceTest {
 	@Transactional
 	public void testGetAssetEntries() throws Exception {
 		PortletPreferences mockPortletPreferences =
-			new MockPortletPreferences();
-
-		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+			getAssetPublisherPortletPreferences();
 
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
 			new MockPortletRequest(), mockPortletPreferences,
@@ -97,9 +96,7 @@ public class AssetPublisherServiceTest {
 			allAssetCategoryIds, _NO_ASSET_TAG_NAMES, 2, true);
 
 		PortletPreferences mockPortletPreferences =
-			new MockPortletPreferences();
-
-		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+			getAssetPublisherPortletPreferences();
 
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
 			new MockPortletRequest(), mockPortletPreferences,
@@ -136,9 +133,7 @@ public class AssetPublisherServiceTest {
 			allCategoyIds, allAssetTagNames, 2, true);
 
 		PortletPreferences mockPortletPreferences =
-			new MockPortletPreferences();
-
-		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+			getAssetPublisherPortletPreferences();
 
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
 			new MockPortletRequest(), mockPortletPreferences,
@@ -167,9 +162,7 @@ public class AssetPublisherServiceTest {
 			_NO_ASSET_CATEGORY_IDS, allAssetTagNames, 2, true);
 
 		PortletPreferences mockPortletPreferences =
-			new MockPortletPreferences();
-
-		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+			getAssetPublisherPortletPreferences();
 
 		List<AssetEntry> assetEntries = AssetPublisherUtil.getAssetEntries(
 			new MockPortletRequest(), mockPortletPreferences,
@@ -254,6 +247,17 @@ public class AssetPublisherServiceTest {
 					TestPropsValues.getGroupId()));
 
 		addAssetCategories(assetVocabulary.getVocabularyId());
+	}
+
+	protected PortletPreferences getAssetPublisherPortletPreferences()
+		throws ReadOnlyException {
+
+		PortletPreferences mockPortletPreferences =
+			new MockPortletPreferences();
+
+		mockPortletPreferences.setValues("assetEntryXml", _assetEntryXmls);
+
+		return mockPortletPreferences;
 	}
 
 	private static final String[] _ASSET_CATEGORY_NAMES =

--- a/portal-web/docroot/html/taglib/ui/asset_links/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_links/page.jsp
@@ -63,6 +63,7 @@ if (assetEntryId > 0) {
 					LiferayPortletURL assetPublisherURL = new PortletURLImpl(request, PortletKeys.ASSET_PUBLISHER, plid, PortletRequest.RENDER_PHASE);
 
 					assetPublisherURL.setParameter("struts_action", "/asset_publisher/view_content");
+					assetPublisherURL.setParameter("redirect", currentURL);
 					assetPublisherURL.setParameter("assetEntryId", String.valueOf(assetLinkEntry.getEntryId()));
 					assetPublisherURL.setParameter("type", assetRendererFactory.getType());
 


### PR DESCRIPTION
Both params (with and without namespace are needed). One is ready by asset publisher, the other by the FindAction.
