### PR TITLE
master-qa-6629

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb2/enduser/administration/users/cpusergroups/block/CPUsergroups.path
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduser/administration/users/cpusergroups/block/CPUsergroups.path
@@ -71,7 +71,7 @@
 </tr>
 <tr>
 	<td>BASIC_SEARCH_ADVANCED</td>
-	<td>//span[@id='toggle_id_users_groups_admin_group_searchtoggleAdvanced']</td>
+	<td>//button[@id='toggle_id_users_groups_admin_group_searchtoggleAdvanced'] | //span[@id='toggle_id_users_groups_admin_group_searchtoggleAdvanced']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb2/enduser/administration/users/cpusersandorganizations/block/action/CPUsersandorganizationsVieworganizations.path
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduser/administration/users/cpusersandorganizations/block/action/CPUsersandorganizationsVieworganizations.path
@@ -51,7 +51,7 @@
 </tr>
 <tr>
 	<td>BASIC_SEARCH_ADVANCED</td>
-	<td>//span[@id='toggle_id_users_admin_organization_searchtoggleAdvanced']</td>
+	<td>//button[@id='toggle_id_users_admin_organization_searchtoggleAdvanced'] | //span[@id='toggle_id_users_admin_organization_searchtoggleAdvanced']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb2/util/block/action/Home.path
+++ b/portal-web/test/functional/com/liferay/portalweb2/util/block/action/Home.path
@@ -133,7 +133,7 @@
 <!--PAGE-->
 <tr>
 	<td>PAGE</td>
-	<td>//li[contains(@class,'lfr-nav-item')]/a[contains(.,'${key_pageName}')]</td>
+	<td>//li[contains(@class,'add-page')]/a[contains(.,'${key_pageName}')] | //li[contains(@class,'lfr-nav-item')]/a[contains(.,'${key_pageName}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-6629

This commit syncs the ee-6.2.10 and ee-6.2.x tests. I copied the portalweb2 folder from ee-6.2.x into ee-6.2.10 and added the "|" operator when there were discrepancies in the html identifiers. I included a pull request for master because we're keeping the master and ee-6.2.x tests synced up for now.

Moving forward, the tests be the same and will work in both ee-6.2.x and ee-6.2.10.
