### PR TITLE
master-qa-6335

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -849,7 +849,10 @@ message.boards.subscribe.by.default=false</echo>
 			</elseif>
 			<elseif>
 				<or>
+					<equals arg1="${portal.version}" arg2="6.1.2" />
+					<equals arg1="${portal.version}" arg2="6.1.10" />
 					<equals arg1="${portal.version}" arg2="6.1.20" />
+					<equals arg1="${portal.version}" arg2="6.1.30" />
 				</or>
 				<then>
 					<echo file="portal-impl/src/portal-ext.properties" append="true">

--- a/test.properties
+++ b/test.properties
@@ -200,6 +200,12 @@
     os.type=winxp
 
 ##
+## Portal Legacy
+##
+
+    #portal.legacy.dir=
+
+##
 ## SQL
 ##
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-6335
1. (master, ee-6.2.x, and ee-6.2.10 only) - The if block for 6.1 legacy properties only had 6.1.20, so I added in 6.1.10, 6.1.30, and 6.1.2.

I ordered the conditionals like this. I was following the convention that was used for 5.2 (line 733) and 6.0 (line 807). Let me know if this isn't the proper way to order it.
equals arg1="${portal.version}" arg2="6.1.2"
equals arg1="${portal.version}" arg2="6.1.10"
equals arg1="${portal.version}" arg2="6.1.20"
equals arg1="${portal.version}" arg2="6.1.30"
1. I Added the "portal.legacy.dir" property to test.properties. Hashi said it'd be good to put it in and have it commented out.
