### PR TITLE
LPS-42537 Apply RTL to non-theme CSS

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSUtil.java
@@ -116,6 +116,10 @@ public class DynamicCSSUtil {
 					_log.warn("No theme found for " + currentURL);
 				}
 
+				if (PortalUtil.isRightToLeft(request)) {
+					content = RTLCSSUtil.getRtlCss(resourcePath, content);
+				}
+
 				return content;
 			}
 		}


### PR DESCRIPTION
Hey Brian,

You were right about the sorting of main_rtl.css. It should follow the sorting pattern for SASS, and not for plain CSS. I've sent a PR to Nate. I've also noticed that we need to apply RTL when serving CSS resources that do not belong to themes (for example, those in AUI widgets). This is the required change.

Thanks!
