### PR TITLE
LPS-42336 - Clicking back icon does not bring user back to original page in Users and Organizations admin

### DIFF
--- a/portal-web/docroot/html/portlet/directory/tabs1.jsp
+++ b/portal-web/docroot/html/portlet/directory/tabs1.jsp
@@ -25,8 +25,9 @@ String tabs1Names = ParamUtil.getString(request, "tabs1Names", "users,organizati
 
 String tabs1Values = tabs1Names;
 
-String redirect = ParamUtil.getString(request, "redirect", viewUsersRedirect);
 String viewUsersRedirect = ParamUtil.getString(request, "viewUsersRedirect");
+
+String redirect = ParamUtil.getString(request, "redirect", viewUsersRedirect);
 String backURL = ParamUtil.getString(request, "backURL", redirect);
 %>
 

--- a/portal-web/docroot/html/portlet/users_admin/view_flat_organizations.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/view_flat_organizations.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/html/portlet/users_admin/init.jsp" %>
 
 <%
+String toolbarItem = "view-all-organizations";
+
 String usersListView = (String)request.getAttribute("view.jsp-usersListView");
 
 PortletURL portletURL = (PortletURL)request.getAttribute("view.jsp-portletURL");
@@ -60,7 +62,7 @@ if (filterManageableOrganizations) {
 
 					<portlet:renderURL var="viewOrganizationsFlatURL">
 						<portlet:param name="struts_action" value="/users_admin/view" />
-						<portlet:param name="toolbarItem" value="view-all-organizations" />
+						<portlet:param name="toolbarItem" value="<%= toolbarItem %>" />
 						<portlet:param name="usersListView" value="<%= UserConstants.LIST_VIEW_FLAT_ORGANIZATIONS %>" />
 						<portlet:param name="saveUsersListView" value="<%= Boolean.TRUE.toString() %>" />
 					</portlet:renderURL>


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-42336.  These compile errors were caused by changes in Giit SHA ID b8ccf0479ac50e31c9d7e8c4f4dd8c633575a24d and fb24489d458ee8e90e0d0bd1ac2be9f70f7e6321.

Please let me know if you have any questions.  Thanks!
