### PR TITLE
master-qa-6335

### DIFF
--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -1479,14 +1479,23 @@ public class Creole10Parser]]></replacevalue>
 	</target>
 
 	<target name="format-source">
-		<copy todir="classes" overwrite="true" preservelastmodified="true">
-			<fileset dir="src" includes="com/liferay/portal/tools/dependencies/*.properties" />
+		<if>
+			<not>
+				<isset property="dir" />
+			</not>
+			<then>
+				<property name="dir" value="${project.dir}" />
+			</then>
+		</if>
+
+		<copy todir="${project.dir}/portal-impl/classes" overwrite="true" preservelastmodified="true">
+			<fileset dir="${project.dir}/portal-impl/src" includes="com/liferay/portal/tools/dependencies/*.properties" />
 		</copy>
 
 		<java
 			classname="com.liferay.portal.tools.sourceformatter.SourceFormatter"
 			classpathref="project.classpath"
-			dir="${project.dir}"
+			dir="${dir}"
 			fork="true"
 			newenvironment="true"
 		>


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-6335

Because format-source will now format the automation tests, we should add format-source to the portal-legacy repo as well. 

In this, I changed format-source so that it could be used outside of portal-impl.
1. I added a property called "dir" that represents the directory the source formatter is run in. Before, it used to be ${project.dir}. I wasn't able to come up with a more specific name, but I echoed ${dir} and it wasn't being used. 
2. I made the dir attribute in the copy an absolute path instead of a relative one because the portal legacy repo doesn't have a "src" folder.

Let me know if anything needs to be changed or if this isn't the way to do this.

The parallel pull request for portal-legacy repo is here:
https://github.com/brianchandotcom/liferay-qa-portal-legacy-ee/pull/12
