### PR TITLE
LPS-43351 web.server.display.node should include port info

### DIFF
--- a/portal-web/docroot/html/portal/layout/view/common.jspf
+++ b/portal-web/docroot/html/portal/layout/view/common.jspf
@@ -32,7 +32,7 @@
 
 <c:if test="<%= PropsValues.WEB_SERVER_DISPLAY_NODE %>">
 	<div class="alert alert-info">
-		<liferay-ui:message key="node" />: <%= StringUtil.toLowerCase(PortalUtil.getComputerName()) %>
+		<liferay-ui:message key="node" />: <%= StringUtil.toLowerCase(PortalUtil.getComputerName()) + StringPool.COLON + PortalUtil.getPortalPort(false)%>
 	</div>
 </c:if>
 


### PR DESCRIPTION
Please backport this to 6.2.x, qa needs this to automate cluster testing on the same host.
