### PR TITLE
LPS-42712 Do not translate arguments when it's not needed

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetBranchLocalServiceImpl.java
@@ -448,7 +448,8 @@ public class LayoutSetBranchLocalServiceImpl
 			sb.append(
 				LanguageUtil.format(
 					locale, "merged-from-x-x",
-					new String[] {mergeLayoutSetBranch.getName(), nowString}));
+					new String[] {mergeLayoutSetBranch.getName(), nowString},
+					false));
 
 			LayoutBranch layoutBranch =
 				layoutBranchLocalService.addLayoutBranch(

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -597,7 +597,7 @@ public class StagingImpl implements Staging {
 						locale,
 						"the-referenced-theme-x-is-not-deployed-in-the-" +
 							"current-environment",
-						missingReference.getClassPK()));
+						missingReference.getClassPK(), false));
 			}
 			else if (referrers.size() == 1) {
 				Set<Map.Entry<String, String>> referrerDisplayNames =
@@ -624,14 +624,14 @@ public class StagingImpl implements Staging {
 							ResourceActionsUtil.getModelResource(
 								locale, referrerClassName),
 							referrerDisplayName
-						}
-					));
+						}, false));
 			}
 			else {
 				errorMessageJSONObject.put(
 					"info",
 					LanguageUtil.format(
-						locale, "referenced-by-x-elements", referrers.size()));
+						locale, "referenced-by-x-elements", referrers.size(),
+						true));
 			}
 
 			errorMessageJSONObject.put("name", missingReferenceDisplayName);
@@ -667,7 +667,7 @@ public class StagingImpl implements Staging {
 			errorMessage = LanguageUtil.format(
 				locale,
 				"document-names-must-end-with-one-of-the-following-extensions",
-				".lar");
+				".lar", false);
 			errorType = ServletResponseConstants.SC_FILE_EXTENSION_EXCEPTION;
 		}
 		else if (e instanceof FileNameException) {
@@ -695,7 +695,7 @@ public class StagingImpl implements Staging {
 			errorMessage = LanguageUtil.format(
 				locale,
 				"please-enter-a-file-with-a-valid-file-size-no-larger-than-x",
-				fileMaxSize/1024);
+				fileMaxSize/1024, false);
 			errorType = ServletResponseConstants.SC_FILE_SIZE_EXCEPTION;
 		}
 		else if (e instanceof LARTypeException) {
@@ -704,7 +704,7 @@ public class StagingImpl implements Staging {
 			errorMessage = LanguageUtil.format(
 				locale,
 				"please-import-a-lar-file-of-the-correct-type-x-is-not-valid",
-				lte.getMessage());
+				lte.getMessage(), false);
 			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
 		}
 		else if (e instanceof LARFileException) {
@@ -770,7 +770,8 @@ public class StagingImpl implements Staging {
 					StringUtil.merge(
 						le.getTargetAvailableLocales(),
 						StringPool.COMMA_AND_SPACE)
-				});
+				}, false);
+
 			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
 		}
 		else if (e instanceof MissingReferenceException) {
@@ -833,8 +834,7 @@ public class StagingImpl implements Staging {
 						ResourceActionsUtil.getModelResource(
 							locale, referrerClassName),
 						referrerDisplayName
-					}
-				);
+					}, false);
 			}
 			else if (pde.getType() == PortletDataException.MISSING_DEPENDENCY) {
 				errorMessage = LanguageUtil.format(
@@ -845,8 +845,7 @@ public class StagingImpl implements Staging {
 						ResourceActionsUtil.getModelResource(
 							locale, referrerClassName),
 						referrerDisplayName
-					}
-				);
+					}, false);
 			}
 			else if (pde.getType() == PortletDataException.STATUS_IN_TRASH) {
 				errorMessage = LanguageUtil.format(
@@ -857,8 +856,7 @@ public class StagingImpl implements Staging {
 						ResourceActionsUtil.getModelResource(
 							locale, referrerClassName),
 						referrerDisplayName
-					}
-				);
+					}, false);
 			}
 			else if (pde.getType() == PortletDataException.STATUS_UNAVAILABLE) {
 				errorMessage = LanguageUtil.format(
@@ -869,8 +867,7 @@ public class StagingImpl implements Staging {
 						ResourceActionsUtil.getModelResource(
 							locale, referrerClassName),
 						referrerDisplayName
-					}
-				);
+					}, false);
 			}
 			else {
 				errorMessage = e.getLocalizedMessage();
@@ -1240,7 +1237,8 @@ public class StagingImpl implements Staging {
 						"the-original-x-does-not-exist-in-the-current-" +
 							"environment",
 						ResourceActionsUtil.getModelResource(
-							locale, missingReference.getClassName())));
+							locale, missingReference.getClassName()
+						), false));
 			}
 
 			errorMessageJSONObject.put("size", referrers.size());
@@ -1999,7 +1997,7 @@ public class StagingImpl implements Staging {
 
 		String description = LanguageUtil.format(
 			PortalUtil.getSiteDefaultLocale(groupId), masterBranchDescription,
-			groupName);
+			groupName, false);
 
 		try {
 			serviceContext.setWorkflowAction(WorkflowConstants.STATUS_APPROVED);

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -704,7 +704,7 @@ public class StagingImpl implements Staging {
 			errorMessage = LanguageUtil.format(
 				locale,
 				"please-import-a-lar-file-of-the-correct-type-x-is-not-valid",
-				lte.getMessage(), false);
+				lte.getMessage());
 			errorType = ServletResponseConstants.SC_FILE_CUSTOM_EXCEPTION;
 		}
 		else if (e instanceof LARFileException) {

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/dependencies/portlet_display_template_rich_summary.ftl
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/dependencies/portlet_display_template_rich_summary.ftl
@@ -83,7 +83,7 @@
 		<#assign editPortletURL = assetRenderer.getURLEdit(renderRequest, renderResponse, windowStateFactory.getWindowState("pop_up"), redirectURL)!"" />
 
 		<#if validator.isNotNull(editPortletURL)>
-			<#assign title = languageUtil.format(locale, "edit-x", entryTitle) />
+			<#assign title = languageUtil.format(locale, "edit-x", entryTitle, false) />
 
 			<@liferay_ui["icon"]
 				image="edit"
@@ -170,7 +170,7 @@
 		<@liferay_ui["icon"]
 			image="print"
 			message="print"
-			url="javascript:Liferay.Util.openWindow({id:'" + renderResponse.getNamespace() + "printAsset', title: '" + languageUtil.format(locale, "print-x-x", ["hide-accessible", entryTitle]) + "', uri: '" + htmlUtil.escapeURL(printURL.toString()) + "'});"
+			url="javascript:Liferay.Util.openWindow({id:'" + renderResponse.getNamespace() + "printAsset', title: '" + languageUtil.format(locale, "print-x-x", ["hide-accessible", entryTitle], false) + "', uri: '" + htmlUtil.escapeURL(printURL.toString()) + "'});"
 		/>
 	</#if>
 </#macro>

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/trash/DLFileShortcutTrashRenderer.java
@@ -77,7 +77,7 @@ public class DLFileShortcutTrashRenderer extends BaseTrashRenderer {
 	@Override
 	public String getTitle(Locale locale) {
 		return LanguageUtil.format(
-			locale, "shortcut-to-x", _fileShortcut.getToTitle());
+			locale, "shortcut-to-x", _fileShortcut.getToTitle(), false);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/asset/DDLRecordAssetRenderer.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/asset/DDLRecordAssetRenderer.java
@@ -91,7 +91,7 @@ public class DDLRecordAssetRenderer extends BaseAssetRenderer {
 
 		return LanguageUtil.format(
 			locale, "new-x-for-list-x",
-			new Object[] {ddmStructureName, recordSetName});
+			new Object[] {ddmStructureName, recordSetName}, false);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/dependencies/template/document-library.ftl
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/dependencies/template/document-library.ftl
@@ -1,6 +1,6 @@
 <#include "init-display.ftl">
 
-<#assign labelName = "languageUtil.format(" + localeVariable + ", \"download-x\", \"" + label + "\")">
+<#assign labelName = "languageUtil.format(" + localeVariable + ", \"download-x\", \"" + label + "\", false)">
 
 <a href="${getVariableReferenceCode(displayFieldValue)}">
 	${getVariableReferenceCode(labelName)}

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordLocalServiceImpl.java
@@ -446,7 +446,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 		String title = LanguageUtil.format(
 			locale, "new-x-for-list-x",
-			new Object[] {ddmStructureName, recordSetName});
+			new Object[] {ddmStructureName, recordSetName}, false);
 
 		if (addDraftAssetEntry) {
 			assetEntryLocalService.updateEntry(

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/util/DDLIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/util/DDLIndexer.java
@@ -244,7 +244,7 @@ public class DDLIndexer extends BaseIndexer {
 
 			return LanguageUtil.format(
 				locale, "new-x-for-list-x",
-				new Object[] {ddmStructureName, recordSetName});
+				new Object[] {ddmStructureName, recordSetName}, false);
 		}
 		catch (Exception e) {
 			_log.error(e, e);

--- a/portal-impl/src/com/liferay/portlet/journal/dependencies/template/document-library.ftl
+++ b/portal-impl/src/com/liferay/portlet/journal/dependencies/template/document-library.ftl
@@ -6,7 +6,7 @@
 	<#assign localeVariable = "$" + localeVariable>
 </#if>
 
-<#assign labelName = "languageUtil.format(" + localeVariable + ", \"download-x\", \"" + label + "\")">
+<#assign labelName = "languageUtil.format(" + localeVariable + ", \"download-x\", \"" + label + "\", false)">
 
 <a href="${getVariableReferenceCode(variableName)}">
 	${getVariableReferenceCode(labelName)}

--- a/portal-impl/src/com/liferay/portlet/wiki/dependencies/portlet_display_template_social.ftl
+++ b/portal-impl/src/com/liferay/portlet/wiki/dependencies/portlet_display_template_social.ftl
@@ -216,7 +216,7 @@
 	${printURL.setParameter("viewMode", "print")}
 	${printURL.setWindowState("pop_up")}
 
-	<#assign title = languageUtil.format(locale, "print-x-x", ["hide-accessible", htmlUtil.escape(assetRenderer.getTitle(locale))]) />
+	<#assign title = languageUtil.format(locale, "print-x-x", ["hide-accessible", htmlUtil.escape(assetRenderer.getTitle(locale))], false) />
 	<#assign taglibPrintURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id:'" + renderResponse.getNamespace() + "printAsset', title: '" + title + "', uri: '" + htmlUtil.escapeURL(printURL.toString()) + "'});" />
 
 	<@liferay_ui["icon"]

--- a/portal-service/src/com/liferay/portal/kernel/dao/search/DateSearchEntry.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/DateSearchEntry.java
@@ -60,8 +60,8 @@ public class DateSearchEntry extends TextSearchEntry {
 						pageContext, "x-ago",
 						LanguageUtil.getTimeDescription(
 							pageContext,
-							System.currentTimeMillis() - _date.getTime(),
-							true)));
+							System.currentTimeMillis() - _date.getTime(), true
+						), false));
 			}
 			else {
 				sb.append(
@@ -69,8 +69,8 @@ public class DateSearchEntry extends TextSearchEntry {
 						pageContext, "within-x",
 						LanguageUtil.getTimeDescription(
 							pageContext,
-							_date.getTime() - System.currentTimeMillis(),
-							true)));
+							_date.getTime() - System.currentTimeMillis(), true
+						), false));
 			}
 
 			sb.append("</span>");

--- a/portal-service/src/com/liferay/portal/kernel/dao/search/DateSearchEntry.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/DateSearchEntry.java
@@ -60,8 +60,8 @@ public class DateSearchEntry extends TextSearchEntry {
 						pageContext, "x-ago",
 						LanguageUtil.getTimeDescription(
 							pageContext,
-							System.currentTimeMillis() - _date.getTime(), true
-						), false));
+							System.currentTimeMillis() - _date.getTime(), true),
+						false));
 			}
 			else {
 				sb.append(
@@ -69,8 +69,8 @@ public class DateSearchEntry extends TextSearchEntry {
 						pageContext, "within-x",
 						LanguageUtil.getTimeDescription(
 							pageContext,
-							_date.getTime() - System.currentTimeMillis(), true
-						), false));
+							_date.getTime() - System.currentTimeMillis(), true),
+						false));
 			}
 
 			sb.append("</span>");

--- a/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -363,21 +363,7 @@ public class LiferayPortlet extends GenericPortlet {
 	}
 
 	protected String translate(
-		PortletRequest portletRequest, String key, Object argument) {
-
-		PortletConfig portletConfig =
-			(PortletConfig)portletRequest.getAttribute(
-				JavaConstants.JAVAX_PORTLET_CONFIG);
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		return LanguageUtil.format(
-			portletConfig, themeDisplay.getLocale(), key, argument);
-	}
-
-	protected String translate(
-		PortletRequest portletRequest, String key, Object[] arguments) {
+		PortletRequest portletRequest, String key, Object... arguments) {
 
 		PortletConfig portletConfig =
 			(PortletConfig)portletRequest.getAttribute(

--- a/portal-service/src/com/liferay/portal/kernel/util/Time.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Time.java
@@ -189,18 +189,19 @@ public class Time {
 		}
 		else if (millisAgo < Time.HOUR) {
 			return LanguageUtil.format(
-				locale, "x-minutes-ago", (millisAgo / Time.MINUTE));
+				locale, "x-minutes-ago", (millisAgo / Time.MINUTE), false);
 		}
 		else if ((millisAgo / Time.HOUR) == 1) {
 			return LanguageUtil.get(locale, "about-an-hour-ago");
 		}
 		else if ((millisAgo < Time.DAY) || (daysBetween == 0)) {
 			return LanguageUtil.format(
-				locale, "x-hours-ago", (millisAgo / Time.HOUR));
+				locale, "x-hours-ago", (millisAgo / Time.HOUR), false);
 		}
 		else if (daysBetween == 1) {
 			return LanguageUtil.format(
-				locale, "yesterday-at-x", timeFormat.format(milliseconds));
+				locale, "yesterday-at-x", timeFormat.format(milliseconds),
+				false);
 		}
 
 		Format dateFormat = FastDateFormatFactoryUtil.getSimpleDateFormat(

--- a/portal-service/src/com/liferay/portal/theme/ThemeDisplay.java
+++ b/portal-service/src/com/liferay/portal/theme/ThemeDisplay.java
@@ -1471,11 +1471,7 @@ public class ThemeDisplay
 		return LanguageUtil.get(getLocale(), key);
 	}
 
-	public String translate(String pattern, Object argument) {
-		return LanguageUtil.format(getLocale(), pattern, argument);
-	}
-
-	public String translate(String pattern, Object[] arguments) {
+	public String translate(String pattern, Object... arguments) {
 		return LanguageUtil.format(getLocale(), pattern, arguments);
 	}
 

--- a/portal-web/docroot/html/common/themes/layout_friendly_url_redirect.jsp
+++ b/portal-web/docroot/html/common/themes/layout_friendly_url_redirect.jsp
@@ -30,7 +30,7 @@ String alternativeLayoutFriendlyURL = (String)SessionMessages.get(request, "alte
 	</liferay-util:buffer>
 
 	<p class="redirected-to-message">
-		<liferay-ui:message arguments="<%= redirectedLink %>" key="you-were-redirected-to-x" />
+		<liferay-ui:message arguments="<%= redirectedLink %>" key="you-were-redirected-to-x" translateArguments="<%= false %>" />
 	</p>
 
 	<liferay-util:buffer var="originalLink">
@@ -40,6 +40,6 @@ String alternativeLayoutFriendlyURL = (String)SessionMessages.get(request, "alte
 	</liferay-util:buffer>
 
 	<p class="original-url">
-		<liferay-ui:message arguments="<%= originalLink %>" key="click-the-following-link-if-you-want-to-dismiss-this-redirect-and-access-the-original-url-x" />
+		<liferay-ui:message arguments="<%= originalLink %>" key="click-the-following-link-if-you-want-to-dismiss-this-redirect-and-access-the-original-url-x" translateArguments="<%= false %>" />
 	</p>
 </c:if>

--- a/portal-web/docroot/html/common/themes/portlet_messages.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_messages.jspf
@@ -80,7 +80,7 @@ else if (group.isStagingGroup()) {
 			String taglibMessage = "class=\"lfr-hide-dialog\" href=\"javascript:;\"";
 			%>
 
-			<liferay-ui:message arguments="<%= taglibMessage %>" key="the-page-will-be-refreshed-when-you-close-this-dialog.alternatively-you-can-hide-this-dialog-x" />
+			<liferay-ui:message arguments="<%= taglibMessage %>" key="the-page-will-be-refreshed-when-you-close-this-dialog.alternatively-you-can-hide-this-dialog-x" translateArguments="<%= false %>" />
 		</c:if>
 	</div>
 </c:if>

--- a/portal-web/docroot/html/common/themes/user_locale_options.jsp
+++ b/portal-web/docroot/html/common/themes/user_locale_options.jsp
@@ -27,7 +27,7 @@ Locale[] availableLocales = LanguageUtil.getAvailableLocales(themeDisplay.getSit
 <c:if test="<%= !locale.equals(user.getLocale()) %>">
 	<button class="close" id="ignoreUserLocaleOptions" type="button">&times;</button>
 
-	<%= LanguageUtil.format(userLocale, "this-page-is-displayed-in-x", locale.getDisplayName(userLocale)) %>
+	<%= LanguageUtil.format(userLocale, "this-page-is-displayed-in-x", locale.getDisplayName(userLocale), false) %>
 
 	<c:if test="<%= ArrayUtil.contains(availableLocales, userLocale) %>">
 
@@ -46,7 +46,7 @@ Locale[] availableLocales = LanguageUtil.getAvailableLocales(themeDisplay.getSit
 		displayPreferredLanguageURLString = HttpUtil.addParameter(displayPreferredLanguageURLString, "showUserLocaleOptionsMessage", false);
 		%>
 
-		<aui:a href="<%= displayPreferredLanguageURLString %>"><%= LanguageUtil.format(userLocale, "display-the-page-in-x", userLocale.getDisplayName(userLocale)) %></aui:a>
+		<aui:a href="<%= displayPreferredLanguageURLString %>"><%= LanguageUtil.format(userLocale, "display-the-page-in-x", userLocale.getDisplayName(userLocale), false) %></aui:a>
 	</c:if>
 
 	<%
@@ -63,7 +63,7 @@ Locale[] availableLocales = LanguageUtil.getAvailableLocales(themeDisplay.getSit
 	changePreferredLanguageURLString = HttpUtil.addParameter(changePreferredLanguageURLString, "showUserLocaleOptionsMessage", false);
 	%>
 
-	<aui:a href="<%= changePreferredLanguageURLString %>"><%= LanguageUtil.format(userLocale, "set-x-as-your-preferred-language", locale.getDisplayName(userLocale)) %></aui:a>
+	<aui:a href="<%= changePreferredLanguageURLString %>"><%= LanguageUtil.format(userLocale, "set-x-as-your-preferred-language", locale.getDisplayName(userLocale), false) %></aui:a>
 
 	<aui:script use="aui-base,liferay-store">
 		var ignoreUserLocaleOptionsNode = A.one('#ignoreUserLocaleOptions');

--- a/portal-web/docroot/html/portal/layout/edit/portlet.jsp
+++ b/portal-web/docroot/html/portal/layout/edit/portlet.jsp
@@ -24,7 +24,7 @@ Boolean showLayoutTemplates = ParamUtil.getBoolean(request, "showLayoutTemplates
 <div class="<%= showCopyPortlets ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />copyPortletsFromPage">
 	<p>
 		<c:if test="<%= selLayout != null %>">
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(selLayout.getName(locale)) %>" key="the-applications-in-page-x-will-be-replaced-with-the-ones-in-the-page-you-select-below" />
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(selLayout.getName(locale)) %>" key="the-applications-in-page-x-will-be-replaced-with-the-ones-in-the-page-you-select-below" translateArguments="<%= false %>" />
 		</c:if>
 	</p>
 

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -390,7 +390,7 @@
 									String taglibArguments = "<span class=\"lfr-inline-code\">" + PropsValues.LIFERAY_HOME + StringPool.SLASH + SetupWizardUtil.PROPERTIES_FILE_NAME + "</span>";
 									%>
 
-									<liferay-ui:message arguments="<%= taglibArguments %>" key="the-configuration-was-saved-in" />
+									<liferay-ui:message arguments="<%= taglibArguments %>" key="the-configuration-was-saved-in" translateArguments="<%= false %>" />
 								</p>
 
 								<%
@@ -399,7 +399,7 @@
 
 								<c:if test="<%= !passwordUpdated %>">
 									<p class="lfr-setup-notice">
-										<liferay-ui:message arguments="<%= PropsValues.DEFAULT_ADMIN_PASSWORD %>" key="your-password-is-x.-you-will-be-required-to-change-your-password-the-next-time-you-log-into-the-portal" />
+										<liferay-ui:message arguments="<%= PropsValues.DEFAULT_ADMIN_PASSWORD %>" key="your-password-is-x.-you-will-be-required-to-change-your-password-the-next-time-you-log-into-the-portal" translateArguments="<%= false %>" />
 									</p>
 								</c:if>
 
@@ -414,7 +414,7 @@
 									String taglibArguments = "<span class=\"lfr-inline-code\">" + PropsValues.LIFERAY_HOME + "</span>";
 									%>
 
-									<liferay-ui:message arguments="<%= taglibArguments %>" key="sorry,-we-were-not-able-to-save-the-configuration-file-in-x" />
+									<liferay-ui:message arguments="<%= taglibArguments %>" key="sorry,-we-were-not-able-to-save-the-configuration-file-in-x" translateArguments="<%= false %>" />
 								</div>
 							</p>
 

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -69,7 +69,7 @@
 
 						<div class="row-fluid">
 							<aui:fieldset cssClass="span6" label="portal">
-								<aui:input helpTextCssClass="help-inline" label="portal-name" name="companyName" suffix='<%= LanguageUtil.format(pageContext, "for-example-x", "Liferay") %>' value="<%= PropsValues.COMPANY_DEFAULT_NAME %>" />
+								<aui:input helpTextCssClass="help-inline" label="portal-name" name="companyName" suffix='<%= LanguageUtil.format(pageContext, "for-example-x", "Liferay", false) %>' value="<%= PropsValues.COMPANY_DEFAULT_NAME %>" />
 
 								<aui:select inlineField="<%= true %>" label="default-language" name="companyLocale">
 

--- a/portal-web/docroot/html/portlet/activities/view.jsp
+++ b/portal-web/docroot/html/portlet/activities/view.jsp
@@ -36,11 +36,11 @@ ResourceURL rssURL = liferayPortletResponse.createResourceURL();
 rssURL.setCacheability(ResourceURL.FULL);
 rssURL.setParameter("struts_action", "/activities/rss");
 
-String feedTitle = LanguageUtil.format(pageContext, "x's-activities", HtmlUtil.escape(group.getDescriptiveName(locale)));
+String feedTitle = LanguageUtil.format(pageContext, "x's-activities", HtmlUtil.escape(group.getDescriptiveName(locale)), false);
 
 rssURL.setParameter("feedTitle", feedTitle);
 
-String taglibFeedTitle = LanguageUtil.format(pageContext, "subscribe-to-x's-activities", HtmlUtil.escape(group.getDescriptiveName(locale)));
+String taglibFeedTitle = LanguageUtil.format(pageContext, "subscribe-to-x's-activities", HtmlUtil.escape(group.getDescriptiveName(locale)), false);
 %>
 
 <liferay-ui:social-activities

--- a/portal-web/docroot/html/portlet/admin/edit_document_library_extra_settings.jsp
+++ b/portal-web/docroot/html/portlet/admin/edit_document_library_extra_settings.jsp
@@ -64,7 +64,7 @@ if (!dlFileEntries.isEmpty()) {
 	<c:otherwise>
 		<c:if test="<%= (expandoBridgeAttributeNames != null) && !expandoBridgeAttributeNames.isEmpty() %>">
 			<div class="alert alert-error">
-				<%= LanguageUtil.format(pageContext, "custom-fields-already-exist-for-these-extra-settings-x", StringUtil.merge(expandoBridgeAttributeNames)) %>
+				<%= LanguageUtil.format(pageContext, "custom-fields-already-exist-for-these-extra-settings-x", StringUtil.merge(expandoBridgeAttributeNames), false) %>
 			</div>
 		</c:if>
 
@@ -82,7 +82,7 @@ if (!dlFileEntries.isEmpty()) {
 			%>
 
 				<aui:fieldset>
-					<%= LanguageUtil.format(pageContext, "convert-extra-settings-key-from-x-to", key) %>
+					<%= LanguageUtil.format(pageContext, "convert-extra-settings-key-from-x-to", key, false) %>
 
 					<br />
 

--- a/portal-web/docroot/html/portlet/admin/server.jspf
+++ b/portal-web/docroot/html/portlet/admin/server.jspf
@@ -378,7 +378,7 @@ serverURL.setParameter("tabs3", tabs3);
 				<liferay-ui:error key="reCaptchaPublicKey" message="the-recaptcha-public-key-is-not-valid" />
 
 				<aui:fieldset>
-					<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "recaptcha-help", "https://www.google.com/recaptcha/admin/create") %>' label="enable-recaptcha" name="reCaptchaEnabled" type="checkbox" value="<%= PrefsPropsUtil.getString(PropsKeys.CAPTCHA_ENGINE_IMPL, PropsValues.CAPTCHA_ENGINE_IMPL).equals(ReCaptchaImpl.class.getName()) %>" />
+					<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "recaptcha-help", "https://www.google.com/recaptcha/admin/create", false) %>' label="enable-recaptcha" name="reCaptchaEnabled" type="checkbox" value="<%= PrefsPropsUtil.getString(PropsKeys.CAPTCHA_ENGINE_IMPL, PropsValues.CAPTCHA_ENGINE_IMPL).equals(ReCaptchaImpl.class.getName()) %>" />
 
 					<aui:input cssClass="lfr-input-text-container" label="recaptcha-public-key" name="reCaptchaPublicKey" type="text" value="<%= PrefsPropsUtil.getString(PropsKeys.CAPTCHA_ENGINE_RECAPTCHA_KEY_PUBLIC, PropsValues.CAPTCHA_ENGINE_RECAPTCHA_KEY_PUBLIC) %>" />
 
@@ -648,7 +648,7 @@ serverURL.setParameter("tabs3", tabs3);
 								<c:otherwise>
 
 									<%
-									String xugglerHelp = LanguageUtil.format(pageContext, "xuggler-help", "http://www.xuggle.com/xuggler/downloads");
+									String xugglerHelp = LanguageUtil.format(pageContext, "xuggler-help", "http://www.xuggle.com/xuggler/downloads", false);
 
 									String[] xugglerOptions = PropsUtil.getArray(PropsKeys.XUGGLER_JAR_OPTIONS);
 

--- a/portal-web/docroot/html/portlet/asset_browser/toolbar.jsp
+++ b/portal-web/docroot/html/portlet/asset_browser/toolbar.jsp
@@ -49,7 +49,7 @@ Map<Long, String> classTypes = assetRendererFactory.getClassTypes(new long[] {th
 			addPortletURLString = HttpUtil.addParameter(addPortletURLString, "refererPlid", plid);
 			%>
 
-			<aui:nav-item href="<%= addPortletURLString %>" label='<%= LanguageUtil.format(pageContext, "add-x", assetRendererFactory.getTypeName(locale, false)) %>' />
+			<aui:nav-item href="<%= addPortletURLString %>" label='<%= LanguageUtil.format(pageContext, "add-x", assetRendererFactory.getTypeName(locale, false), false) %>' />
 		</c:if>
 	</c:when>
 	<c:otherwise>

--- a/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/add_asset.jspf
@@ -33,14 +33,14 @@
 					<aui:nav-item
 						href="<%= _getURL(groupId, plid, entry.getValue(), message, defaultAssetPublisher, layout, pageContext, liferayPortletResponse) %>"
 						iconCssClass="icon-file"
-						label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message)) %>'
+						label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(message), false) %>'
 					/>
 				</c:when>
 				<c:otherwise>
 					<aui:nav-item
 						dropdown="<%= true %>"
 						iconCssClass="icon-plus"
-						label='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "add-new" : "add-new-in-x", new Object[] {HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale))}) %>'
+						label='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "add-new" : "add-new-in-x", new Object[] {HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale))}, false) %>'
 					>
 
 						<%
@@ -99,6 +99,6 @@ private String _getURL(long groupId, long plid, PortletURL addPortletURL, String
 		addPortletURLString = HttpUtil.addParameter(addPortletURLString, "layoutUuid", layout.getUuid());
 	}
 
-	return "javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, id: '" + liferayPortletResponse.getNamespace() + "editAsset', title: '" + HtmlUtil.escapeJS(LanguageUtil.format(pageContext, "new-x", HtmlUtil.escape(message))) + "', uri: '" + HtmlUtil.escapeJS(addPortletURLString) + "'});";
+	return "javascript:Liferay.Util.openWindow({dialog: {destroyOnHide: true}, id: '" + liferayPortletResponse.getNamespace() + "editAsset', title: '" + HtmlUtil.escapeJS(LanguageUtil.format(pageContext, "new-x", HtmlUtil.escape(message), false)) + "', uri: '" + HtmlUtil.escapeJS(addPortletURLString) + "'});";
 }
 %>

--- a/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
@@ -49,13 +49,13 @@ if (showEditURL && assetRenderer.hasEditPermission(permissionChecker)) {
 	<div class="lfr-meta-actions asset-actions">
 
 		<%
-		String taglibEditURL = "javascript:Liferay.Util.openWindow({id: '" + renderResponse.getNamespace() + "editAsset', title: '" + LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale))) + "', uri:'" + HtmlUtil.escapeURL(editPortletURL.toString()) + "'});";
+		String taglibEditURL = "javascript:Liferay.Util.openWindow({id: '" + renderResponse.getNamespace() + "editAsset', title: '" + LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale)), false) + "', uri:'" + HtmlUtil.escapeURL(editPortletURL.toString()) + "'});";
 		%>
 
 		<liferay-ui:icon
 			image="edit"
 			label="<%= showIconLabel %>"
-			message='<%= showIconLabel ? LanguageUtil.format(pageContext, "edit-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}) : LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale))) %>'
+			message='<%= showIconLabel ? LanguageUtil.format(pageContext, "edit-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}, false) : LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale)), false) %>'
 			url="<%= taglibEditURL %>"
 		/>
 	</div>

--- a/portal-web/docroot/html/portlet/asset_publisher/asset_export.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/asset_export.jspf
@@ -30,7 +30,7 @@ exportAssetURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 		<liferay-ui:icon
 			image='<%= "../file_system/small/" + extension %>'
 			label="<%= true %>"
-			message='<%= LanguageUtil.format(pageContext, "x-convert-x-to-x", new Object[] {"hide-accessible", assetRenderer.getTitle(locale), StringUtil.toUpperCase(extension)}) %>'
+			message='<%= LanguageUtil.format(pageContext, "x-convert-x-to-x", new Object[] {"hide-accessible", assetRenderer.getTitle(locale), StringUtil.toUpperCase(extension)}, false) %>'
 			method="get"
 			url="<%= exportAssetURL.toString() %>"
 		/>

--- a/portal-web/docroot/html/portlet/asset_publisher/asset_print.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/asset_print.jspf
@@ -38,7 +38,7 @@ printAssetURL.setWindowState(LiferayWindowState.POP_UP);
 		<liferay-ui:icon
 			image="print"
 			label="<%= true %>"
-			message='<%= LanguageUtil.format(pageContext, "print-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}) %>'
+			message='<%= LanguageUtil.format(pageContext, "print-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}, false) %>'
 			url="javascript:print();"
 		/>
 
@@ -50,7 +50,7 @@ printAssetURL.setWindowState(LiferayWindowState.POP_UP);
 		<liferay-ui:icon
 			image="print"
 			label="<%= true %>"
-			message='<%= LanguageUtil.format(pageContext, "print-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}) %>'
+			message='<%= LanguageUtil.format(pageContext, "print-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))}, false) %>'
 			url='<%= "javascript:" + renderResponse.getNamespace() + "printPage_" + assetEntryIndex + "();" %>'
 		/>
 

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
@@ -144,7 +144,7 @@ String selectStyle = (String)request.getAttribute("configuration.jsp-selectStyle
 					%>
 
 						<div class='asset-subtype <%= (assetSelectedClassTypeIds.length < 1) ? StringPool.BLANK : "hide" %>' id="<portlet:namespace /><%= className %>Options">
-							<aui:select label='<%= LanguageUtil.format(pageContext, "x-subtype", ResourceActionsUtil.getModelResource(locale, assetRendererFactory.getClassName())) %>' name='<%= "preferences--anyClassType" + className + "--" %>'>
+							<aui:select label='<%= LanguageUtil.format(pageContext, "x-subtype", ResourceActionsUtil.getModelResource(locale, assetRendererFactory.getClassName()), false) %>' name='<%= "preferences--anyClassType" + className + "--" %>'>
 								<aui:option label="any" selected="<%= anyAssetSubtype %>" value="<%= true %>" />
 								<aui:option label='<%= LanguageUtil.get(pageContext, "select-more-than-one") + StringPool.TRIPLE_PERIOD %>' selected="<%= !anyAssetSubtype && (assetSelectedClassTypeIds.length > 1) %>" value="<%= false %>" />
 

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration_manual.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration_manual.jsp
@@ -104,7 +104,7 @@ String eventName = "_" + HtmlUtil.escapeJS(portletResource) + "_selectAsset";
 
 				<div class="select-asset-selector">
 					<div class="lfr-meta-actions edit-controls">
-						<liferay-ui:icon-menu cssClass="select-existing-selector" direction="right" icon='<%= themeDisplay.getPathThemeImages() + "/common/add.png" %>' message='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "select" : "select-in-x", new Object[] {HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale))}) %>' showWhenSingleIcon="<%= true %>">
+						<liferay-ui:icon-menu cssClass="select-existing-selector" direction="right" icon='<%= themeDisplay.getPathThemeImages() + "/common/add.png" %>' message='<%= LanguageUtil.format(pageContext, (groupIds.length == 1) ? "select" : "select-in-x", new Object[] {HtmlUtil.escape((GroupLocalServiceUtil.getGroup(groupId)).getDescriptiveName(locale))}, false) %>' showWhenSingleIcon="<%= true %>">
 
 							<%
 							PortletURL assetBrowserURL = PortletURLFactoryUtil.create(request, PortletKeys.ASSET_BROWSER, PortalUtil.getControlPanelPlid(company.getCompanyId()), PortletRequest.RENDER_PHASE);
@@ -127,7 +127,7 @@ String eventName = "_" + HtmlUtil.escapeJS(portletResource) + "_selectAsset";
 
 								data.put("groupid", String.valueOf(groupId));
 								data.put("href", assetBrowserURL.toString());
-								data.put("title", LanguageUtil.format(pageContext, "select-x", curRendererFactory.getTypeName(locale, false)));
+								data.put("title", LanguageUtil.format(pageContext, "select-x", curRendererFactory.getTypeName(locale, false), false));
 
 								String type = curRendererFactory.getTypeName(locale, false);
 

--- a/portal-web/docroot/html/portlet/asset_publisher/display/abstracts.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/display/abstracts.jsp
@@ -110,7 +110,7 @@ viewURL = AssetUtil.checkViewURL(assetEntry, viewInContext, viewURL, currentURL,
 
 			<c:if test="<%= Validator.isNotNull(viewURL) %>">
 				<div class="asset-more">
-					<a href="<%= viewURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))} %>' key="<%= viewURLMessage %>" /> &raquo; </a>
+					<a href="<%= viewURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(assetRenderer.getTitle(locale))} %>' key="<%= viewURLMessage %>" translateArguments="<%= false %>" /> &raquo; </a>
 				</div>
 			</c:if>
 		</div>

--- a/portal-web/docroot/html/portlet/asset_publisher/display_settings.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/display_settings.jspf
@@ -81,11 +81,11 @@
 	</c:if>
 
 	<%
-	String helpMessage1 = "<em>" + LanguageUtil.format(pageContext, "content-related-to-x", StringPool.DOUBLE_PERIOD) + "</em>";
-	String helpMessage2 = "<em>" + LanguageUtil.format(pageContext, "content-with-tag-x", StringPool.DOUBLE_PERIOD) + "</em>";
+	String helpMessage1 = "<em>" + LanguageUtil.format(pageContext, "content-related-to-x", StringPool.DOUBLE_PERIOD, false) + "</em>";
+	String helpMessage2 = "<em>" + LanguageUtil.format(pageContext, "content-with-tag-x", StringPool.DOUBLE_PERIOD, false) + "</em>";
 	%>
 
-	<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "such-as-x-or-x", new Object[] {helpMessage1, helpMessage2}) %>' name="preferences--showMetadataDescriptions--" type="checkbox" value="<%= assetPublisherDisplayContext.isShowMetadataDescriptions() %>" />
+	<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "such-as-x-or-x", new Object[] {helpMessage1, helpMessage2}, false) %>' name="preferences--showMetadataDescriptions--" type="checkbox" value="<%= assetPublisherDisplayContext.isShowMetadataDescriptions() %>" />
 
 	<aui:input name="preferences--showAvailableLocales--" type="checkbox" value="<%= assetPublisherDisplayContext.isShowAvailableLocales() %>" />
 

--- a/portal-web/docroot/html/portlet/blogs/edit_entry.jsp
+++ b/portal-web/docroot/html/portlet/blogs/edit_entry.jsp
@@ -251,7 +251,7 @@ boolean showHeader = ParamUtil.getBoolean(request, "showHeader", true);
 
 			<c:if test="<%= (entry != null) && entry.isApproved() && WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(entry.getCompanyId(), entry.getGroupId(), BlogsEntry.class.getName()) %>">
 				<div class="alert alert-info">
-					<%= LanguageUtil.format(pageContext, "this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again", ResourceActionsUtil.getModelResource(locale, BlogsEntry.class.getName())) %>
+					<%= LanguageUtil.format(pageContext, "this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again", ResourceActionsUtil.getModelResource(locale, BlogsEntry.class.getName()), false) %>
 				</div>
 			</c:if>
 

--- a/portal-web/docroot/html/portlet/blogs/edit_entry.jsp
+++ b/portal-web/docroot/html/portlet/blogs/edit_entry.jsp
@@ -164,7 +164,7 @@ boolean showHeader = ParamUtil.getBoolean(request, "showHeader", true);
 				long imageMaxSize = PrefsPropsUtil.getLong(PropsKeys.BLOGS_IMAGE_SMALL_MAX_SIZE) / 1024;
 				%>
 
-				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-small-image-with-a-valid-file-size-no-larger-than-x" />
+				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-small-image-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 			</liferay-ui:error>
 
 			<aui:fieldset>

--- a/portal-web/docroot/html/portlet/blogs/search.jsp
+++ b/portal-web/docroot/html/portlet/blogs/search.jsp
@@ -48,7 +48,7 @@ String keywords = ParamUtil.getString(request, "keywords");
 	%>
 
 	<liferay-ui:search-container
-		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>") %>'
+		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false) %>'
 		iteratorURL="<%= portletURL %>"
 	>
 

--- a/portal-web/docroot/html/portlet/blogs/view_entry_content.jsp
+++ b/portal-web/docroot/html/portlet/blogs/view_entry_content.jsp
@@ -160,7 +160,7 @@ AssetEntry assetEntry = (AssetEntry)request.getAttribute("view_entry_content.jsp
 
 						<br />
 
-						<aui:a href="<%= viewEntryURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" /> &raquo;</aui:a>
+						<aui:a href="<%= viewEntryURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" translateArguments="<%= false %>" /> &raquo;</aui:a>
 					</c:when>
 					<c:when test='<%= displayStyle.equals(BlogsUtil.DISPLAY_STYLE_FULL_CONTENT) || strutsAction.equals("/blogs/view_entry") %>'>
 
@@ -199,7 +199,7 @@ AssetEntry assetEntry = (AssetEntry)request.getAttribute("view_entry_content.jsp
 						</c:if>
 					</c:when>
 					<c:when test='<%= displayStyle.equals(BlogsUtil.DISPLAY_STYLE_TITLE) && !strutsAction.equals("/blogs/view_entry") %>'>
-						<aui:a href="<%= viewEntryURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" /> &raquo;</aui:a>
+						<aui:a href="<%= viewEntryURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" translateArguments="<%= false %>" /> &raquo;</aui:a>
 					</c:when>
 				</c:choose>
 			</div>

--- a/portal-web/docroot/html/portlet/blogs_aggregator/view_entry_content.jspf
+++ b/portal-web/docroot/html/portlet/blogs_aggregator/view_entry_content.jspf
@@ -100,7 +100,7 @@
 						<a href="<%= viewAllEntriesURL %>">
 							&quot;<%= StringUtil.shorten(StringUtil.trim(HtmlUtil.stripHtml(entry.getContent())), 100, StringPool.BLANK) + StringPool.TRIPLE_PERIOD %> &quot;
 
-							<span class="nobreak"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" /> &raquo;</span>
+							<span class="nobreak"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" translateArguments="<%= false %>" /> &raquo;</span>
 						</a>
 					</span>
 				</c:when>
@@ -113,7 +113,7 @@
 		<div class="comments">
 			<c:choose>
 				<c:when test='<%= displayStyle.startsWith("abstract") %>'>
-					<a href="<%= viewEntryURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" /> &raquo;</a>
+					<a href="<%= viewEntryURL %>"><liferay-ui:message arguments='<%= new Object[] {"hide-accessible", HtmlUtil.escape(entry.getTitle())} %>' key="read-more-x-about-x" translateArguments="<%= false %>" /> &raquo;</a>
 				</c:when>
 				<c:when test='<%= !displayStyle.startsWith("quote") %>'>
 

--- a/portal-web/docroot/html/portlet/bookmarks/asset/folder_full_content.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/asset/folder_full_content.jsp
@@ -43,7 +43,7 @@ BookmarksFolder folder = (BookmarksFolder)request.getAttribute(WebKeys.BOOKMARKS
 
 			<div class="lfr-asset-metadata">
 				<div class="lfr-asset-icon lfr-asset-date">
-					<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate())) %>
+					<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate()), false) %>
 				</div>
 
 				<div class="lfr-asset-icon lfr-asset-subfolders">

--- a/portal-web/docroot/html/portlet/bookmarks/edit_entry.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/edit_entry.jsp
@@ -66,7 +66,7 @@ boolean showHeader = ParamUtil.getBoolean(request, "showHeader", true);
 		<liferay-ui:header
 			backURL="<%= backURL %>"
 			localizeTitle="<%= (entry == null) %>"
-			title='<%= (entry == null) ? "add-bookmark" : LanguageUtil.format(pageContext, "edit-x", entry.getName()) %>'
+			title='<%= (entry == null) ? "add-bookmark" : LanguageUtil.format(pageContext, "edit-x", entry.getName(), false) %>'
 		/>
 	</c:if>
 

--- a/portal-web/docroot/html/portlet/bookmarks/edit_folder.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/edit_folder.jsp
@@ -65,7 +65,7 @@ else {
 	<liferay-ui:header
 		backURL="<%= redirect %>"
 		localizeTitle="<%= (folder == null) %>"
-		title='<%= (folder == null) ? ((parentFolderId > 0) ? "add-subfolder" : "add-folder") : LanguageUtil.format(pageContext, "edit-x", folder.getName()) %>'
+		title='<%= (folder == null) ? ((parentFolderId > 0) ? "add-subfolder" : "add-folder") : LanguageUtil.format(pageContext, "edit-x", folder.getName(), false) %>'
 	/>
 
 	<liferay-ui:error exception="<%= FolderNameException.class %>" message="please-enter-a-valid-name" />

--- a/portal-web/docroot/html/portlet/bookmarks/search.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/search.jsp
@@ -76,7 +76,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(pageContext, "sea
 	%>
 
 	<liferay-ui:search-container
-		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>") %>'
+		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false) %>'
 		iteratorURL="<%= portletURL %>"
 	>
 

--- a/portal-web/docroot/html/portlet/bookmarks/view.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/view.jsp
@@ -99,7 +99,7 @@ if (folder != null) {
 
 						<div class="lfr-asset-metadata">
 							<div class="lfr-asset-icon lfr-asset-date">
-								<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate())) %>
+								<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate()), false) %>
 							</div>
 
 							<div class="lfr-asset-icon lfr-asset-subfolders">

--- a/portal-web/docroot/html/portlet/bookmarks/view_entry.jsp
+++ b/portal-web/docroot/html/portlet/bookmarks/view_entry.jsp
@@ -99,7 +99,7 @@ BookmarksUtil.addPortletBreadcrumbEntries(entry, request, renderResponse);
 
 		<div class="lfr-asset-metadata">
 			<div class="lfr-asset-icon lfr-asset-author">
-				<%= LanguageUtil.format(pageContext, "created-by-x", HtmlUtil.escape(PortalUtil.getUserName(entry.getUserId(), themeDisplay.getScopeGroupName()))) %>
+				<%= LanguageUtil.format(pageContext, "created-by-x", HtmlUtil.escape(PortalUtil.getUserName(entry.getUserId(), themeDisplay.getScopeGroupName())), false) %>
 			</div>
 
 			<div class="lfr-asset-icon lfr-asset-date">

--- a/portal-web/docroot/html/portlet/control_panel_home/view_actions.jsp
+++ b/portal-web/docroot/html/portlet/control_panel_home/view_actions.jsp
@@ -79,7 +79,7 @@
 
 								String siteName = HtmlUtil.escape(StringUtil.shorten(refererGroup.getDescriptiveName(locale), 35));
 
-								String buttonLabel = LanguageUtil.format(pageContext, "manage-x", siteName);
+								String buttonLabel = LanguageUtil.format(pageContext, "manage-x", siteName, false);
 
 								PortletURL siteAdministrationURL = PortalUtil.getSiteAdministrationURL(renderResponse, siteThemeDisplay);
 						%>

--- a/portal-web/docroot/html/portlet/directory/view_users.jsp
+++ b/portal-web/docroot/html/portlet/directory/view_users.jsp
@@ -66,13 +66,13 @@ if (Validator.isNotNull(viewUsersRedirect)) {
 	<c:if test="<%= organization != null %>">
 		<aui:input name="<%= UserDisplayTerms.ORGANIZATION_ID %>" type="hidden" value="<%= organization.getOrganizationId() %>" />
 
-		<h3><%= HtmlUtil.escape(LanguageUtil.format(pageContext, "users-of-x", organization.getName())) %></h3>
+		<h3><%= HtmlUtil.escape(LanguageUtil.format(pageContext, "users-of-x", organization.getName(), false)) %></h3>
 	</c:if>
 
 	<c:if test="<%= userGroup != null %>">
 		<aui:input name="<%= UserDisplayTerms.USER_GROUP_ID %>" type="hidden" value="<%= userGroup.getUserGroupId() %>" />
 
-		<h3><%= LanguageUtil.format(pageContext, "users-of-x", HtmlUtil.escape(userGroup.getName())) %></h3>
+		<h3><%= LanguageUtil.format(pageContext, "users-of-x", HtmlUtil.escape(userGroup.getName()), false) %></h3>
 	</c:if>
 
 	<aui:nav-bar>

--- a/portal-web/docroot/html/portlet/dockbar/view_user_account.jspf
+++ b/portal-web/docroot/html/portlet/dockbar/view_user_account.jspf
@@ -46,7 +46,7 @@
 				String impersonatingUserLabel = "you-are-impersonating-the-guest-user";
 
 				if (themeDisplay.isSignedIn()) {
-					impersonatingUserLabel = LanguageUtil.format(pageContext, "you-are-impersonating-x", new Object[] {HtmlUtil.escape(user.getFullName())});
+					impersonatingUserLabel = LanguageUtil.format(pageContext, "you-are-impersonating-x", new Object[] {HtmlUtil.escape(user.getFullName())}, false);
 				}
 				%>
 
@@ -71,11 +71,11 @@
 
 					if (locale.getLanguage().equals(realUserLocale.getLanguage()) && locale.getCountry().equals(realUserLocale.getCountry())) {
 						doAsUserLanguageId = userLocale.getLanguage() + "_" + userLocale.getCountry();
-						changeLanguageMessage = LanguageUtil.format(realUserLocale, "use-x's-preferred-language-(x)", new String[] {HtmlUtil.escape(user.getFullName()), userLocale.getDisplayLanguage(realUserLocale)});
+						changeLanguageMessage = LanguageUtil.format(realUserLocale, "use-x's-preferred-language-(x)", new String[] {HtmlUtil.escape(user.getFullName()), userLocale.getDisplayLanguage(realUserLocale)}, false);
 					}
 					else {
 						doAsUserLanguageId = realUserLocale.getLanguage() + "_" + realUserLocale.getCountry();
-						changeLanguageMessage = LanguageUtil.format(realUserLocale, "use-your-preferred-language-(x)", realUserLocale.getDisplayLanguage(realUserLocale));
+						changeLanguageMessage = LanguageUtil.format(realUserLocale, "use-your-preferred-language-(x)", realUserLocale.getDisplayLanguage(realUserLocale), false);
 					}
 					%>
 

--- a/portal-web/docroot/html/portlet/document_library/asset/file_entry_abstract.jsp
+++ b/portal-web/docroot/html/portlet/document_library/asset/file_entry_abstract.jsp
@@ -62,7 +62,7 @@ if (fileEntry.getVersion().equals(fileVersion.getVersion())) {
 				<liferay-ui:icon
 					image="download"
 					label="<%= true %>"
-					message='<%= LanguageUtil.format(pageContext, "download-x", taglibFileEntryTitle) + " (" + TextFormatter.formatStorageSize(fileVersion.getSize(), locale) + ")" %>'
+					message='<%= LanguageUtil.format(pageContext, "download-x", taglibFileEntryTitle, false) + " (" + TextFormatter.formatStorageSize(fileVersion.getSize(), locale) + ")" %>'
 					url="<%= assetRenderer.getURLDownload(themeDisplay) %>"
 				/>
 			</c:otherwise>

--- a/portal-web/docroot/html/portlet/document_library/asset/folder_full_content.jsp
+++ b/portal-web/docroot/html/portlet/document_library/asset/folder_full_content.jsp
@@ -43,7 +43,7 @@ Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 			<div class="lfr-asset-metadata">
 				<div class="lfr-asset-icon lfr-asset-date">
-					<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDateTime.format(folder.getModifiedDate())) %>
+					<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDateTime.format(folder.getModifiedDate()), false) %>
 				</div>
 
 				<div class="lfr-asset-icon lfr-asset-subfolders">

--- a/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
@@ -212,7 +212,7 @@ if ((checkedOut || pending) && !PropsValues.DL_FILE_ENTRY_DRAFTS_ENABLED) {
 	%>
 
 	<liferay-ui:error exception="<%= FileSizeException.class %>">
-		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 	</liferay-ui:error>
 
 	<liferay-ui:asset-categories-error />

--- a/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_file_entry.jsp
@@ -157,7 +157,7 @@ if ((checkedOut || pending) && !PropsValues.DL_FILE_ENTRY_DRAFTS_ENABLED) {
 		localizeTitle= false;
 	}
 	else if (dlFileEntryType != null) {
-		headerTitle = LanguageUtil.format(pageContext, "new-x", new Object[] {dlFileEntryType.getName(locale)});
+		headerTitle = LanguageUtil.format(pageContext, "new-x", new Object[] {dlFileEntryType.getName(locale)}, false);
 	}
 	%>
 

--- a/portal-web/docroot/html/portlet/document_library/edit_file_shortcut.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_file_shortcut.jsp
@@ -84,7 +84,7 @@ portletURL.setParameter("fileShortcutId", String.valueOf(fileShortcutId));
 
 	<liferay-ui:header
 		backURL="<%= redirect %>"
-		title='<%= (fileShortcut != null)? LanguageUtil.format(pageContext, "shortcut-to-x", fileShortcut.getToTitle()) : "new-file-shortcut" %>'
+		title='<%= (fileShortcut != null)? LanguageUtil.format(pageContext, "shortcut-to-x", fileShortcut.getToTitle(), false) : "new-file-shortcut" %>'
 	/>
 
 	<liferay-ui:error exception="<%= FileShortcutPermissionException.class %>" message="you-do-not-have-permission-to-create-a-shortcut-to-the-selected-document" />

--- a/portal-web/docroot/html/portlet/document_library/edit_folder.jsp
+++ b/portal-web/docroot/html/portlet/document_library/edit_folder.jsp
@@ -168,7 +168,7 @@ if (workflowEnabled) {
 									}
 								%>
 
-									<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion()) + ")" %>' selected="<%= selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
+									<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion(), false) + ")" %>' selected="<%= selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
 
 								<%
 								}
@@ -221,7 +221,7 @@ if (workflowEnabled) {
 												}
 											%>
 
-												<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion()) + ")" %>' selected="<%= selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
+												<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion(), false) + ")" %>' selected="<%= selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
 
 											<%
 											}
@@ -291,7 +291,7 @@ if (workflowEnabled) {
 			for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
 			%>
 
-				<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion()) + ")" %>' selected="<% selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
+				<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion(), false) + ")" %>' selected="<% selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
 
 			<%
 			}

--- a/portal-web/docroot/html/portlet/document_library/folder_action.jsp
+++ b/portal-web/docroot/html/portlet/document_library/folder_action.jsp
@@ -433,10 +433,10 @@ String iconMenuId = null;
 		String webDavHelpMessage = null;
 
 		if (BrowserSnifferUtil.isWindows(request)) {
-			webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-windows-help", new Object[] {"http://www.microsoft.com/downloads/details.aspx?FamilyId=17C36612-632E-4C04-9382-987622ED1D64", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV"});
+			webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-windows-help", new Object[] {"http://www.microsoft.com/downloads/details.aspx?FamilyId=17C36612-632E-4C04-9382-987622ED1D64", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV"}, false);
 		}
 		else {
-			webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-help", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV");
+			webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-help", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV", false);
 		}
 		%>
 

--- a/portal-web/docroot/html/portlet/document_library/move_entries.jsp
+++ b/portal-web/docroot/html/portlet/document_library/move_entries.jsp
@@ -109,7 +109,7 @@ for (DLFileShortcut curFileShortcut : fileShortcuts) {
 
 	<c:if test="<%= !validMoveFolders.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-folders-ready-to-be-moved", validMoveFolders.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-folders-ready-to-be-moved", validMoveFolders.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -135,7 +135,7 @@ for (DLFileShortcut curFileShortcut : fileShortcuts) {
 
 	<c:if test="<%= !invalidMoveFolders.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-folders-cannot-be-moved", invalidMoveFolders.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-folders-cannot-be-moved", invalidMoveFolders.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -174,7 +174,7 @@ for (DLFileShortcut curFileShortcut : fileShortcuts) {
 
 	<c:if test="<%= !validMoveFileEntries.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-files-ready-to-be-moved", validMoveFileEntries.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-files-ready-to-be-moved", validMoveFileEntries.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -200,7 +200,7 @@ for (DLFileShortcut curFileShortcut : fileShortcuts) {
 
 	<c:if test="<%= !invalidMoveFileEntries.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-files-cannot-be-moved", invalidMoveFileEntries.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-files-cannot-be-moved", invalidMoveFileEntries.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -240,7 +240,7 @@ for (DLFileShortcut curFileShortcut : fileShortcuts) {
 
 	<c:if test="<%= !validShortcutEntries.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-shortcuts-ready-to-be-moved", validShortcutEntries.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-shortcuts-ready-to-be-moved", validShortcutEntries.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -266,7 +266,7 @@ for (DLFileShortcut curFileShortcut : fileShortcuts) {
 
 	<c:if test="<%= !invalidShortcutEntries.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-shortcuts-cannot-be-moved", invalidShortcutEntries.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-shortcuts-cannot-be-moved", invalidShortcutEntries.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">

--- a/portal-web/docroot/html/portlet/document_library/move_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/move_file_entry.jsp
@@ -76,7 +76,7 @@ portletURL.setParameter("fileEntryId", String.valueOf(fileEntryId));
 
 <c:if test="<%= cmd.equals(Constants.MOVE_FROM_TRASH) %>">
 	<div class="alert alert-block">
-		<liferay-ui:message arguments="<%= fileEntry.getTitle() %>" key="the-original-folder-does-not-exist-anymore" />
+		<liferay-ui:message arguments="<%= fileEntry.getTitle() %>" key="the-original-folder-does-not-exist-anymore" translateArguments="<%= false %>" />
 	</div>
 </c:if>
 

--- a/portal-web/docroot/html/portlet/document_library/move_file_shortcut.jsp
+++ b/portal-web/docroot/html/portlet/document_library/move_file_shortcut.jsp
@@ -36,7 +36,7 @@ long folderId = BeanParamUtil.getLong(fileShortcut, request, "folderId");
 
 <c:if test="<%= cmd.equals(Constants.MOVE_FROM_TRASH) %>">
 	<div class="alert alert-block">
-		<liferay-ui:message arguments='<%= fileShortcut.getToTitle() + " (" + LanguageUtil.get(pageContext, "shortcut") + ")" %>' key="the-original-folder-does-not-exist-anymore" />
+		<liferay-ui:message arguments='<%= fileShortcut.getToTitle() + " (" + LanguageUtil.get(pageContext, "shortcut") + ")" %>' key="the-original-folder-does-not-exist-anymore" translateArguments="<%= false %>" />
 	</div>
 </c:if>
 

--- a/portal-web/docroot/html/portlet/document_library/move_folder.jsp
+++ b/portal-web/docroot/html/portlet/document_library/move_folder.jsp
@@ -33,7 +33,7 @@ long parentFolderId = BeanParamUtil.getLong(folder, request, "parentFolderId", D
 
 <c:if test="<%= cmd.equals(Constants.MOVE_FROM_TRASH) %>">
 	<div class="alert alert-block">
-		<liferay-ui:message arguments="<%= folder.getName() %>" key="the-original-folder-does-not-exist-anymore" />
+		<liferay-ui:message arguments="<%= folder.getName() %>" key="the-original-folder-does-not-exist-anymore" translateArguments="<%= false %>" />
 	</div>
 </c:if>
 

--- a/portal-web/docroot/html/portlet/document_library/search_resources.jsp
+++ b/portal-web/docroot/html/portlet/document_library/search_resources.jsp
@@ -112,7 +112,7 @@ else if ((searchType == DLSearchConstants.SINGLE) && !ajax) {
 	<liferay-util:buffer var="searchInfo">
 		<div class="search-info">
 			<span class="keywords">
-				<%= (folder != null) ? LanguageUtil.format(pageContext, "searched-for-x-in-x", new Object[] {HtmlUtil.escape(keywords), folder.getName()}) : LanguageUtil.format(pageContext, "searched-for-x-everywhere", HtmlUtil.escape(keywords)) %>
+				<%= (folder != null) ? LanguageUtil.format(pageContext, "searched-for-x-in-x", new Object[] {HtmlUtil.escape(keywords), folder.getName()}, false) : LanguageUtil.format(pageContext, "searched-for-x-everywhere", HtmlUtil.escape(keywords), false) %>
 			</span>
 
 			<c:if test="<%= folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID %>">
@@ -320,7 +320,7 @@ else if ((searchType == DLSearchConstants.SINGLE) && !ajax) {
 
 				<c:if test="<%= searchResultsList.isEmpty() %>">
 					<div class="alert alert-info">
-						<%= LanguageUtil.format(pageContext, "no-documents-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>") %>
+						<%= LanguageUtil.format(pageContext, "no-documents-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false) %>
 					</div>
 				</c:if>
 

--- a/portal-web/docroot/html/portlet/document_library/view_entries.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_entries.jsp
@@ -334,7 +334,7 @@ request.setAttribute("view_entries.jsp-entryEnd", String.valueOf(searchContainer
 	<div class="entries-empty alert alert-info">
 		<c:choose>
 			<c:when test="<%= (fileEntryTypeId >= 0) %>">
-				<liferay-ui:message arguments="<%= HtmlUtil.escape(dlFileEntryTypeName) %>" key="there-are-no-documents-or-media-files-of-type-x" />
+				<liferay-ui:message arguments="<%= HtmlUtil.escape(dlFileEntryTypeName) %>" key="there-are-no-documents-or-media-files-of-type-x" translateArguments="<%= false %>" />
 			</c:when>
 			<c:otherwise>
 				<liferay-ui:message key="there-are-no-documents-or-media-files-in-this-folder" />

--- a/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
@@ -442,7 +442,7 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 						</h3>
 
 						<div class="lfr-asset-icon lfr-asset-author">
-							<liferay-ui:message arguments="<%= HtmlUtil.escape(fileVersion.getStatusByUserName()) %>" key="last-updated-by-x" />
+							<liferay-ui:message arguments="<%= HtmlUtil.escape(fileVersion.getStatusByUserName()) %>" key="last-updated-by-x" translateArguments="<%= false %>" />
 						</div>
 
 						<div class="lfr-asset-icon lfr-asset-date">

--- a/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
@@ -206,7 +206,7 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 							}
 							%>
 
-							<liferay-ui:icon image="../document_library/add_document" label="<%= true %>" message='<%= LanguageUtil.format(pageContext, "uploaded-by-x-x", new Object[] {displayURL, HtmlUtil.escape(fileEntry.getUserName()), dateFormatDateTime.format(fileEntry.getCreateDate())}) %>' />
+							<liferay-ui:icon image="../document_library/add_document" label="<%= true %>" message='<%= LanguageUtil.format(pageContext, "uploaded-by-x-x", new Object[] {displayURL, HtmlUtil.escape(fileEntry.getUserName()), dateFormatDateTime.format(fileEntry.getCreateDate())}, false) %>' />
 						</span>
 
 						<c:if test="<%= enableRatings && fileEntry.isSupportsSocial() %>">
@@ -520,10 +520,10 @@ request.setAttribute("view_file_entry.jsp-fileEntry", fileEntry);
 								String webDavHelpMessage = null;
 
 								if (BrowserSnifferUtil.isWindows(request)) {
-									webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-windows-help", new Object[] {"http://www.microsoft.com/downloads/details.aspx?FamilyId=17C36612-632E-4C04-9382-987622ED1D64", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV"});
+									webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-windows-help", new Object[] {"http://www.microsoft.com/downloads/details.aspx?FamilyId=17C36612-632E-4C04-9382-987622ED1D64", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV"}, false);
 								}
 								else {
-									webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-help", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV");
+									webDavHelpMessage = LanguageUtil.format(pageContext, "webdav-help", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV", false);
 								}
 								%>
 

--- a/portal-web/docroot/html/portlet/document_library_display/search.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/search.jsp
@@ -123,7 +123,7 @@ int mountFoldersCount = DLAppServiceUtil.getMountFoldersCount(scopeGroupId, DLFo
 	%>
 
 	<liferay-ui:search-container
-		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-documents-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>") %>'
+		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-documents-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false) %>'
 		iteratorURL="<%= portletURL %>"
 	>
 

--- a/portal-web/docroot/html/portlet/document_library_display/search.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/search.jsp
@@ -105,7 +105,7 @@ int mountFoldersCount = DLAppServiceUtil.getMountFoldersCount(scopeGroupId, DLFo
 		%>
 
 		<span class="alert alert-info">
-			<liferay-ui:message arguments="<%= sb.toString() %>" key="results-from-the-local-repository-search-in-x" />
+			<liferay-ui:message arguments="<%= sb.toString() %>" key="results-from-the-local-repository-search-in-x" translateArguments="<%= false %>" />
 		</span>
 	</c:if>
 

--- a/portal-web/docroot/html/portlet/document_library_display/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/view.jsp
@@ -116,7 +116,7 @@ request.setAttribute("view.jsp-useAssetEntryQuery", String.valueOf(useAssetEntry
 
 						<div class="lfr-asset-metadata">
 							<div class="lfr-asset-icon lfr-asset-date">
-								<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDateTime.format(folder.getModifiedDate())) %>
+								<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDateTime.format(folder.getModifiedDate()), false) %>
 							</div>
 
 							<div class="lfr-asset-icon lfr-asset-subfolders">

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record.jsp
@@ -94,7 +94,7 @@ if (translating) {
 	<aui:input name="workflowAction" type="hidden" value="<%= WorkflowConstants.ACTION_PUBLISH %>" />
 
 	<liferay-ui:error exception="<%= FileSizeException.class %>">
-		<liferay-ui:message arguments="<%= PrefsPropsUtil.getLong(PropsKeys.DL_FILE_MAX_SIZE) / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+		<liferay-ui:message arguments="<%= PrefsPropsUtil.getLong(PropsKeys.DL_FILE_MAX_SIZE) / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 	</liferay-ui:error>
 
 	<liferay-ui:error exception="<%= StorageFieldRequiredException.class %>" message="please-fill-out-all-required-fields" />

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record.jsp
@@ -77,7 +77,7 @@ if (translating) {
 <liferay-ui:header
 	backURL="<%= redirect %>"
 	showBackURL="<%= !translating %>"
-	title='<%= (record != null) ? LanguageUtil.format(pageContext, "edit-x", ddmStructure.getName(locale)) : LanguageUtil.format(pageContext, "new-x", ddmStructure.getName(locale)) %>'
+	title='<%= (record != null) ? LanguageUtil.format(pageContext, "edit-x", ddmStructure.getName(locale), false) : LanguageUtil.format(pageContext, "new-x", ddmStructure.getName(locale), false) %>'
 />
 
 <portlet:actionURL var="editRecordURL">
@@ -283,9 +283,9 @@ portletURL.setParameter("recordSetId", String.valueOf(recordSetId));
 PortalUtil.addPortletBreadcrumbEntry(request, recordSet.getName(locale), portletURL.toString());
 
 if (record != null) {
-	PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(pageContext, "edit-x", ddmStructure.getName(locale)), currentURL);
+	PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(pageContext, "edit-x", ddmStructure.getName(locale), false), currentURL);
 }
 else {
-	PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(pageContext, "add-x", ddmStructure.getName(locale)), currentURL);
+	PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(pageContext, "add-x", ddmStructure.getName(locale), false), currentURL);
 }
 %>

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record_set.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/edit_record_set.jsp
@@ -117,7 +117,7 @@ if (ddmStructureId > 0) {
 					}
 				%>
 
-					<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion()) + ")" %>' selected="<%= selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
+					<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion(), false) + ")" %>' selected="<%= selected %>" value="<%= workflowDefinition.getName() + StringPool.AT + workflowDefinition.getVersion() %>" />
 
 				<%
 				}

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/view_record.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/view_record.jsp
@@ -40,7 +40,7 @@ DDLRecordVersion latestRecordVersion = record.getLatestRecordVersion();
 
 <liferay-ui:header
 	backURL="<%= redirect %>"
-	title='<%= LanguageUtil.format(pageContext, "view-x", ddmStructure.getName(locale)) %>'
+	title='<%= LanguageUtil.format(pageContext, "view-x", ddmStructure.getName(locale), false) %>'
 />
 
 <c:if test="<%= recordVersion != null %>">
@@ -99,5 +99,5 @@ portletURL.setParameter("struts_action", "/dynamic_data_lists/view_record_set");
 portletURL.setParameter("recordSetId", String.valueOf(recordSetId));
 
 PortalUtil.addPortletBreadcrumbEntry(request, recordSet.getName(locale), portletURL.toString());
-PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(pageContext, "view-x", ddmStructure.getName(locale)), currentURL);
+PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.format(pageContext, "view-x", ddmStructure.getName(locale), false), currentURL);
 %>

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/view_record_history.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/view_record_history.jsp
@@ -36,7 +36,7 @@ portletURL.setParameter("recordId", String.valueOf(record.getRecordId()));
 
 <liferay-ui:header
 	backURL="<%= redirect %>"
-	title='<%= LanguageUtil.format(pageContext, "x-history", ddmStructure.getName(locale)) %>'
+	title='<%= LanguageUtil.format(pageContext, "x-history", ddmStructure.getName(locale), false) %>'
 />
 
 <aui:form action="<%= portletURL.toString() %>" method="post" name="fm">

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/view_records.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/view_records.jsp
@@ -68,7 +68,7 @@ portletURL.setParameter("recordSetId", String.valueOf(recordSet.getRecordSetId()
 	%>
 
 	<liferay-ui:search-container
-		searchContainer='<%= new SearchContainer(renderRequest, new DisplayTerms(request), null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, LanguageUtil.format(pageContext, "no-x-records-were-found", HtmlUtil.escape(ddmStructure.getName(locale)))) %>'
+		searchContainer='<%= new SearchContainer(renderRequest, new DisplayTerms(request), null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, LanguageUtil.format(pageContext, "no-x-records-were-found", HtmlUtil.escape(ddmStructure.getName(locale)), false)) %>'
 	>
 
 		<aui:nav-bar>
@@ -81,7 +81,7 @@ portletURL.setParameter("recordSetId", String.valueOf(recordSet.getRecordSetId()
 						<portlet:param name="formDDMTemplateId" value="<%= String.valueOf(formDDMTemplateId) %>" />
 					</portlet:renderURL>
 
-					<aui:nav-item href="<%= addRecordURL %>" iconCssClass="icon-plus" label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' />
+					<aui:nav-item href="<%= addRecordURL %>" iconCssClass="icon-plus" label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(ddmStructure.getName(locale)), false) %>' />
 				</c:if>
 			</aui:nav>
 

--- a/portal-web/docroot/html/portlet/dynamic_data_lists/view_template_records.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_lists/view_template_records.jsp
@@ -43,7 +43,7 @@ if (DDLUtil.isEditable(request, portletDisplay.getId(), themeDisplay.getScopeGro
 					<portlet:param name="formDDMTemplateId" value="<%= String.valueOf(formDDMTemplateId) %>" />
 				</portlet:renderURL>
 
-				<aui:nav-item href="<%= addRecordURL %>" iconCssClass="icon-plus" label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' />
+				<aui:nav-item href="<%= addRecordURL %>" iconCssClass="icon-plus" label='<%= LanguageUtil.format(pageContext, "add-x", HtmlUtil.escape(ddmStructure.getName(locale)), false) %>' />
 			</aui:nav>
 		</aui:nav-bar>
 	</c:if>

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/edit_structure.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/edit_structure.jsp
@@ -100,7 +100,7 @@ if (Validator.isNotNull(script)) {
 		title = structure.getName(locale);
 	}
 	else {
-		title = LanguageUtil.format(pageContext, "new-x", ddmDisplay.getStructureName(locale));
+		title = LanguageUtil.format(pageContext, "new-x", ddmDisplay.getStructureName(locale), false);
 	}
 	%>
 
@@ -176,7 +176,7 @@ if (Validator.isNotNull(script)) {
 
 				<aui:input name="description" />
 
-				<aui:field-wrapper label='<%= LanguageUtil.format(pageContext, "parent-x", ddmDisplay.getStructureName(locale)) %>'>
+				<aui:field-wrapper label='<%= LanguageUtil.format(pageContext, "parent-x", ddmDisplay.getStructureName(locale), false) %>'>
 					<aui:input name="parentStructureId" type="hidden" value="<%= parentStructureId %>" />
 
 					<div class="input-append">

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/edit_template.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/edit_template.jsp
@@ -108,7 +108,7 @@ if (Validator.isNotNull(structureAvailableFields)) {
 		long imageMaxSize = PrefsPropsUtil.getLong(PropsKeys.DYNAMIC_DATA_MAPPING_IMAGE_SMALL_MAX_SIZE) / 1024;
 		%>
 
-		<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-small-image-with-a-valid-file-size-no-larger-than-x" />
+		<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-small-image-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 	</liferay-ui:error>
 
 	<%

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/view.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/view.jsp
@@ -176,7 +176,7 @@ portletURL.setParameter("tabs1", tabs1);
 			{
 				id: '<portlet:namespace />copyStructure',
 				refreshWindow: window,
-				title: '<%= UnicodeLanguageUtil.format(pageContext, "copy-x", ddmDisplay.getStructureName(locale)) %>',
+				title: '<%= UnicodeLanguageUtil.format(pageContext, "copy-x", ddmDisplay.getStructureName(locale), false) %>',
 				uri: uri
 			}
 		);

--- a/portal-web/docroot/html/portlet/expando/view_attributes.jsp
+++ b/portal-web/docroot/html/portlet/expando/view_attributes.jsp
@@ -42,7 +42,7 @@ List<String> attributeNames = Collections.list(expandoBridge.getAttributeNames()
 %>
 
 <liferay-ui:search-container
-	emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-custom-fields-are-defined-for-x", modelResourceName) %>'
+	emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-custom-fields-are-defined-for-x", modelResourceName, false) %>'
 	iteratorURL="<%= portletURL %>"
 >
 	<liferay-ui:search-container-results

--- a/portal-web/docroot/html/portlet/flags/edit_entry.jsp
+++ b/portal-web/docroot/html/portlet/flags/edit_entry.jsp
@@ -35,7 +35,7 @@ long reportedUserId = ParamUtil.getLong(request, "reportedUserId");
 <div class="portlet-flags" id="<portlet:namespace />flagsPopup">
 	<aui:form method="post" name="flagsForm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "flag();" %>'>
 		<p>
-			<%= LanguageUtil.format(pageContext, "you-are-about-to-report-a-violation-of-our-x-terms-of-use.-all-reports-are-strictly-confidential", themeDisplay.getPathMain() + "/portal/terms_of_use") %>
+			<%= LanguageUtil.format(pageContext, "you-are-about-to-report-a-violation-of-our-x-terms-of-use.-all-reports-are-strictly-confidential", themeDisplay.getPathMain() + "/portal/terms_of_use", false) %>
 		</p>
 
 		<aui:fieldset>
@@ -73,7 +73,7 @@ long reportedUserId = ParamUtil.getLong(request, "reportedUserId");
 <div class="hide" id="<portlet:namespace />confirmation">
 	<p><strong><liferay-ui:message key="thank-you-for-your-report" /></strong></p>
 
-	<p><%= LanguageUtil.format(pageContext, "although-we-cannot-disclose-our-final-decision,-we-do-review-every-report-and-appreciate-your-effort-to-make-sure-x-is-a-safe-environment-for-everyone", HtmlUtil.escape(company.getName())) %></p>
+	<p><%= LanguageUtil.format(pageContext, "although-we-cannot-disclose-our-final-decision,-we-do-review-every-report-and-appreciate-your-effort-to-make-sure-x-is-a-safe-environment-for-everyone", HtmlUtil.escape(company.getName()), false) %></p>
 </div>
 
 <div class="hide" id="<portlet:namespace />error">

--- a/portal-web/docroot/html/portlet/group_statistics/view.jsp
+++ b/portal-web/docroot/html/portlet/group_statistics/view.jsp
@@ -45,7 +45,7 @@ for (int displayActivityCounterNameIndex : displayActivityCounterNameIndexes) {
 			assetTags = AssetTagLocalServiceUtil.getSocialActivityCounterOffsetTags(scopeGroupId, displayActivityCounterName, -12, 0);
 		}
 
-		title = title + LanguageUtil.format(pageContext, "tag-cloud-for-x", new Object[] {LanguageUtil.get(pageContext, "group.statistics.title." + displayActivityCounterName)});
+		title = title + LanguageUtil.format(pageContext, "tag-cloud-for-x", new Object[] {LanguageUtil.get(pageContext, "group.statistics.title." + displayActivityCounterName)}, false);
 
 		dataSize = assetTags.size();
 	}

--- a/portal-web/docroot/html/portlet/iframe/view.jsp
+++ b/portal-web/docroot/html/portlet/iframe/view.jsp
@@ -56,7 +56,7 @@ if (windowState.equals(WindowState.MAXIMIZED)) {
 	<c:otherwise>
 		<div>
 			<iframe alt="<%= HtmlUtil.escapeAttribute(alt) %>" border="<%= HtmlUtil.escapeAttribute(border) %>" bordercolor="<%= HtmlUtil.escapeAttribute(bordercolor) %>" frameborder="<%= HtmlUtil.escapeAttribute(frameborder) %>" height="<%= HtmlUtil.escapeAttribute(iframeHeight) %>" hspace="<%= HtmlUtil.escapeAttribute(hspace) %>" id="<portlet:namespace />iframe" longdesc="<%= HtmlUtil.escapeAttribute(longdesc) %>" name="<portlet:namespace />iframe" onload="<portlet:namespace />monitorIframe();" scrolling="<%= HtmlUtil.escapeAttribute(scrolling) %>" src="<%= HtmlUtil.escapeHREF(iframeSrc) %>" title="<%= HtmlUtil.escapeAttribute(title) %>" vspace="<%= HtmlUtil.escapeAttribute(vspace) %>" width="<%= HtmlUtil.escapeAttribute(width) %>">
-				<%= LanguageUtil.format(pageContext, "your-browser-does-not-support-inline-frames-or-is-currently-configured-not-to-display-inline-frames.-content-can-be-viewed-at-actual-source-page-x", HtmlUtil.escape(iframeSrc)) %>
+				<%= LanguageUtil.format(pageContext, "your-browser-does-not-support-inline-frames-or-is-currently-configured-not-to-display-inline-frames.-content-can-be-viewed-at-actual-source-page-x", HtmlUtil.escape(iframeSrc), false) %>
 			</iframe>
 		</div>
 	</c:otherwise>

--- a/portal-web/docroot/html/portlet/image_gallery_display/search.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/search.jsp
@@ -73,7 +73,7 @@ String[] mediaGalleryMimeTypes = DLUtil.getMediaGalleryMimeTypes(portletPreferen
 	portletURL.setParameter("searchFolderIds", String.valueOf(searchFolderIds));
 	portletURL.setParameter("keywords", keywords);
 
-	SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, null, LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>"));
+	SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, null, LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false));
 
 	try {
 		SearchContext searchContext = SearchContextFactory.getInstance(request);

--- a/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/view.jsp
@@ -170,7 +170,7 @@ long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayT
 
 								<div class="lfr-asset-metadata">
 									<div class="lfr-asset-icon lfr-asset-date">
-										<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate())) %>
+										<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDate.format(folder.getModifiedDate()), false) %>
 									</div>
 
 									<div class="lfr-asset-icon lfr-asset-subfolders">

--- a/portal-web/docroot/html/portlet/image_gallery_display/view_images.jsp
+++ b/portal-web/docroot/html/portlet/image_gallery_display/view_images.jsp
@@ -298,7 +298,7 @@ embeddedPlayerURL.setWindowState(LiferayWindowState.POP_UP);
 				</c:if>
 			},
 			delay: 5000,
-			infoTemplate: '<%= LanguageUtil.format(pageContext, "image-x-of-x", new String[] {"{current}", "{total}"}) %>',
+			infoTemplate: '<%= LanguageUtil.format(pageContext, "image-x-of-x", new String[] {"{current}", "{total}"}, false) %>',
 			links: '#<portlet:namespace />imageGalleryAssetInfo .image-link.preview',
 			maxHeight: maxHeight,
 			maxWidth: maxWidth,

--- a/portal-web/docroot/html/portlet/image_uploader/view.jsp
+++ b/portal-web/docroot/html/portlet/image_uploader/view.jsp
@@ -59,7 +59,7 @@ String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 			<liferay-ui:error exception="<%= UploadException.class %>" message="an-unexpected-error-occurred-while-uploading-your-file" />
 
 			<liferay-ui:error exception="<%= FileSizeException.class %>">
-				<liferay-ui:message arguments="<%= maxFileSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+				<liferay-ui:message arguments="<%= maxFileSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 			</liferay-ui:error>
 
 			<aui:fieldset cssClass="lfr-portrait-editor">

--- a/portal-web/docroot/html/portlet/invitation/view.jsp
+++ b/portal-web/docroot/html/portlet/invitation/view.jsp
@@ -37,7 +37,7 @@
 			<aui:input name="redirect" type="hidden" value="<%= redirectURL %>" />
 
 			<div class="alert alert-info">
-				<liferay-ui:message arguments="<%= InvitationUtil.getEmailMessageMaxRecipients() %>" key="enter-up-to-x-email-addresses-of-friends-you-would-like-to-invite" />
+				<liferay-ui:message arguments="<%= InvitationUtil.getEmailMessageMaxRecipients() %>" key="enter-up-to-x-email-addresses-of-friends-you-would-like-to-invite" translateArguments="<%= false %>" />
 			</div>
 
 			<%

--- a/portal-web/docroot/html/portlet/journal/article/abstract.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/abstract.jsp
@@ -46,7 +46,7 @@ String toLanguageId = (String)request.getAttribute("edit_article.jsp-toLanguageI
 	long imageMaxSize = PrefsPropsUtil.getLong(PropsKeys.JOURNAL_IMAGE_SMALL_MAX_SIZE) / 1024;
 	%>
 
-	<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-small-image-with-a-valid-file-size-no-larger-than-x" />
+	<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-small-image-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
 <aui:fieldset>

--- a/portal-web/docroot/html/portlet/journal/article/content.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/content.jsp
@@ -373,7 +373,7 @@ if (Validator.isNotNull(content)) {
 									<img alt="" src='<%= HtmlUtil.escapeAttribute(themeDisplay.getPathThemeImages() + "/language/" + toLanguageId + ".png") %>' />
 								</liferay-util:buffer>
 
-								<%= LanguageUtil.format(pageContext, "translating-web-content-to-x", languageLabel) %>
+								<%= LanguageUtil.format(pageContext, "translating-web-content-to-x", languageLabel, false) %>
 
 								<aui:input name="toLanguageId" type="hidden" value="<%= toLanguageId %>" />
 							</c:when>

--- a/portal-web/docroot/html/portlet/journal/article/display_page.jsp
+++ b/portal-web/docroot/html/portlet/journal/article/display_page.jsp
@@ -580,7 +580,7 @@ Group parentGroup = themeDisplay.getSiteGroup();
 	%>
 
 	<c:if test="<%= Validator.isNotNull(urlViewInContext) %>">
-		<a href="<%= urlViewInContext %>" target="blank"><%= LanguageUtil.format(pageContext, "view-content-in-x", defaultDisplayLayout.getName(locale)) %></a>
+		<a href="<%= urlViewInContext %>" target="blank"><%= LanguageUtil.format(pageContext, "view-content-in-x", defaultDisplayLayout.getName(locale), false) %></a>
 	</c:if>
 </c:if>
 

--- a/portal-web/docroot/html/portlet/journal/asset/folder_full_content.jsp
+++ b/portal-web/docroot/html/portlet/journal/asset/folder_full_content.jsp
@@ -43,7 +43,7 @@ JournalFolder folder = (JournalFolder)request.getAttribute(WebKeys.JOURNAL_FOLDE
 
 			<div class="lfr-asset-metadata">
 				<div class="lfr-asset-icon lfr-asset-date">
-					<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDateTime.format(folder.getModifiedDate())) %>
+					<%= LanguageUtil.format(pageContext, "last-updated-x", dateFormatDateTime.format(folder.getModifiedDate()), false) %>
 				</div>
 
 				<div class="lfr-asset-icon lfr-asset-subfolders">

--- a/portal-web/docroot/html/portlet/journal/edit_feed.jsp
+++ b/portal-web/docroot/html/portlet/journal/edit_feed.jsp
@@ -251,7 +251,7 @@ if (feed != null) {
 							for (DDMTemplate curTemplate : ddmTemplates) {
 							%>
 
-								<aui:option data-contentField="<%= JournalFeedConstants.RENDERED_WEB_CONTENT %>" label='<%= LanguageUtil.format(pageContext, "use-template-x", HtmlUtil.escape(curTemplate.getName(locale))) %>' selected="<%= rendererTemplateId.equals(curTemplate.getTemplateKey()) %>" value="<%= curTemplate.getTemplateKey() %>" />
+								<aui:option data-contentField="<%= JournalFeedConstants.RENDERED_WEB_CONTENT %>" label='<%= LanguageUtil.format(pageContext, "use-template-x", HtmlUtil.escape(curTemplate.getName(locale)), false) %>' selected="<%= rendererTemplateId.equals(curTemplate.getTemplateKey()) %>" value="<%= curTemplate.getTemplateKey() %>" />
 
 							<%
 							}

--- a/portal-web/docroot/html/portlet/journal/move_entries.jsp
+++ b/portal-web/docroot/html/portlet/journal/move_entries.jsp
@@ -84,7 +84,7 @@ for (JournalArticle curArticle : articles) {
 
 	<c:if test="<%= !validMoveFolders.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-folders-ready-to-be-moved", validMoveFolders.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-folders-ready-to-be-moved", validMoveFolders.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -110,7 +110,7 @@ for (JournalArticle curArticle : articles) {
 
 	<c:if test="<%= !invalidMoveFolders.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-folders-cannot-be-moved", invalidMoveFolders.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-folders-cannot-be-moved", invalidMoveFolders.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -142,7 +142,7 @@ for (JournalArticle curArticle : articles) {
 
 	<c:if test="<%= !validMoveArticles.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-web-content-instances-are-ready-to-be-moved", validMoveArticles.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-web-content-instances-are-ready-to-be-moved", validMoveArticles.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">
@@ -168,7 +168,7 @@ for (JournalArticle curArticle : articles) {
 
 	<c:if test="<%= !invalidMoveArticles.isEmpty() %>">
 		<div class="move-list-info">
-			<h4><%= LanguageUtil.format(pageContext, "x-web-content-instances-cannot-be-moved", invalidMoveArticles.size()) %></h4>
+			<h4><%= LanguageUtil.format(pageContext, "x-web-content-instances-cannot-be-moved", invalidMoveArticles.size(), false) %></h4>
 		</div>
 
 		<div class="move-list">

--- a/portal-web/docroot/html/portlet/journal/search_resources.jsp
+++ b/portal-web/docroot/html/portlet/journal/search_resources.jsp
@@ -96,7 +96,7 @@ ArticleSearch searchContainer = new ArticleSearch(liferayPortletRequest, entryEn
 
 				if (advancedSearch) {
 					if (folder != null) {
-						message = LanguageUtil.format(pageContext, "advanced-search-in-x", new Object[] {folder.getName()});
+						message = LanguageUtil.format(pageContext, "advanced-search-in-x", new Object[] {folder.getName()}, false);
 					}
 					else {
 						message = LanguageUtil.get(pageContext, "advanced-search-everywhere");
@@ -104,10 +104,10 @@ ArticleSearch searchContainer = new ArticleSearch(liferayPortletRequest, entryEn
 				}
 				else {
 					if (folder != null) {
-						message = LanguageUtil.format(pageContext, "searched-for-x-in-x", new Object[] {HtmlUtil.escape(keywords), folder.getName()});
+						message = LanguageUtil.format(pageContext, "searched-for-x-in-x", new Object[] {HtmlUtil.escape(keywords), folder.getName()}, false);
 					}
 					else {
-						message = LanguageUtil.format(pageContext, "searched-for-x-everywhere", HtmlUtil.escape(keywords));
+						message = LanguageUtil.format(pageContext, "searched-for-x-everywhere", HtmlUtil.escape(keywords), false);
 					}
 				}
 				%>
@@ -427,7 +427,7 @@ ArticleSearch searchContainer = new ArticleSearch(liferayPortletRequest, entryEn
 						String message = LanguageUtil.get(pageContext, "no-web-content-was-found-that-matched-the-specified-filters");
 
 						if (!advancedSearch) {
-							message = LanguageUtil.format(pageContext, "no-web-content-was-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>");
+							message = LanguageUtil.format(pageContext, "no-web-content-was-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false);
 						}
 						%>
 

--- a/portal-web/docroot/html/portlet/journal/view_entries.jsp
+++ b/portal-web/docroot/html/portlet/journal/view_entries.jsp
@@ -215,7 +215,7 @@ request.setAttribute("view_entries.jsp-entryEnd", String.valueOf(searchContainer
 		<c:choose>
 			<c:when test="<%= Validator.isNotNull(displayTerms.getStructureId()) %>">
 				<c:if test="<%= total == 0 %>">
-					<liferay-ui:message arguments="<%= HtmlUtil.escape(ddmStructureName) %>" key="there-is-no-web-content-with-structure-x" />
+					<liferay-ui:message arguments="<%= HtmlUtil.escape(ddmStructureName) %>" key="there-is-no-web-content-with-structure-x" translateArguments="<%= false %>" />
 				</c:if>
 			</c:when>
 			<c:otherwise>

--- a/portal-web/docroot/html/portlet/journal_content/view.jsp
+++ b/portal-web/docroot/html/portlet/journal_content/view.jsp
@@ -125,7 +125,7 @@ boolean expired = true;
 												<liferay-ui:icon
 													image="print"
 													label="<%= true %>"
-													message='<%= LanguageUtil.format(pageContext, "print-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(articleDisplay.getTitle())}) %>'
+													message='<%= LanguageUtil.format(pageContext, "print-x-x", new Object[] {"hide-accessible", HtmlUtil.escape(articleDisplay.getTitle())}, false) %>'
 													url='<%= "javascript:" + renderResponse.getNamespace() + "printPage();" %>'
 												/>
 											</div>

--- a/portal-web/docroot/html/portlet/journal_content_search/search.jsp
+++ b/portal-web/docroot/html/portlet/journal_content_search/search.jsp
@@ -53,7 +53,7 @@
 			headerNames.add("name");
 			headerNames.add("content");
 
-			SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, LanguageUtil.format(pageContext, "no-pages-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>"));
+			SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, LanguageUtil.format(pageContext, "no-pages-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false));
 
 			try {
 				Indexer indexer = IndexerRegistryUtil.getIndexer(JournalArticle.class);

--- a/portal-web/docroot/html/portlet/layout_prototypes/merge_alert.jsp
+++ b/portal-web/docroot/html/portlet/layout_prototypes/merge_alert.jsp
@@ -50,7 +50,7 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutPrototype);
 	%>
 
 	<span class="alert alert-block">
-		<liferay-ui:message arguments='<%= new Object[] {mergeFailCount, "page-template"} %>' key="the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors" />
+		<liferay-ui:message arguments='<%= new Object[] {mergeFailCount, LanguageUtil.get(pageContext, "page-template")} %>' key="the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors" translateArguments="<%= false %>" />
 
 		<liferay-ui:message arguments="page-template" key='<%= merge ? "click-reset-and-propagate-to-reset-the-failure-count-and-propagate-changes-from-the-x" : "click-reset-to-reset-the-failure-count-and-reenable-propagation" %>' />
 

--- a/portal-web/docroot/html/portlet/layout_prototypes/view.jsp
+++ b/portal-web/docroot/html/portlet/layout_prototypes/view.jsp
@@ -70,7 +70,7 @@ portletURL.setParameter("struts_action", "/layout_prototypes/view");
 				<c:if test="<%= mergeFailCount > PropsValues.LAYOUT_PROTOTYPE_MERGE_FAIL_THRESHOLD %>">
 					<liferay-ui:icon
 						image="../messages/alert"
-						message='<%= LanguageUtil.format(pageContext, "the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors", new Object[] {mergeFailCount, "page-template"}) %>'
+						message='<%= LanguageUtil.format(pageContext, "the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors", new Object[] {mergeFailCount, LanguageUtil.get(pageContext, "page-template")}, false) %>'
 					/>
 				</c:if>
 			</liferay-ui:search-container-column-text>

--- a/portal-web/docroot/html/portlet/layout_set_prototypes/merge_alert.jsp
+++ b/portal-web/docroot/html/portlet/layout_set_prototypes/merge_alert.jsp
@@ -52,7 +52,7 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutSetPrototype);
 	%>
 
 	<div class="alert alert-block">
-		<liferay-ui:message arguments='<%= new Object[] {mergeFailCount, "site-template"} %>' key="the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors" />
+		<liferay-ui:message arguments='<%= new Object[] {mergeFailCount, LanguageUtil.get(pageContext, "site-template")} %>' key="the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors" translateArguments="<%= false %>" />
 
 		<liferay-ui:message arguments="site-template" key='<%= merge ? "click-reset-and-propagate-to-reset-the-failure-count-and-propagate-changes-from-the-x" : "click-reset-to-reset-the-failure-count-and-reenable-propagation" %>' />
 

--- a/portal-web/docroot/html/portlet/layout_set_prototypes/view.jsp
+++ b/portal-web/docroot/html/portlet/layout_set_prototypes/view.jsp
@@ -78,7 +78,7 @@ portletURL.setParameter("struts_action", "/layout_set_prototypes/view");
 				<c:if test="<%= mergeFailCount > PropsValues.LAYOUT_SET_PROTOTYPE_MERGE_FAIL_THRESHOLD %>">
 					<liferay-ui:icon
 						image="../messages/alert"
-						message='<%= LanguageUtil.format(pageContext, "the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors", new Object[] {mergeFailCount, "site-template"}) %>'
+						message='<%= LanguageUtil.format(pageContext, "the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors", new Object[] {mergeFailCount, LanguageUtil.get(pageContext, "site-template")}, false) %>'
 					/>
 				</c:if>
 			</liferay-ui:search-container-column-text>

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -154,7 +154,7 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 
 	<c:choose>
 		<c:when test="<%= incomplete %>">
-			<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(selLayout.getName(locale)), HtmlUtil.escape(layoutSetBranchName)} %>" key="the-page-x-is-not-enabled-in-x,-but-is-available-in-other-pages-variations" />
+			<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(selLayout.getName(locale)), HtmlUtil.escape(layoutSetBranchName)} %>" key="the-page-x-is-not-enabled-in-x,-but-is-available-in-other-pages-variations" translateArguments="<%= false %>" />
 
 			<aui:input name="incompleteLayoutRevisionId" type="hidden" value="<%= layoutRevision.getLayoutRevisionId() %>" />
 
@@ -220,7 +220,7 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 					%>
 
 					<div class="alert alert-block">
-						<liferay-ui:message arguments="<%= HtmlUtil.escape(userGroup.getName()) %>" key="this-page-cannot-be-modified-because-it-belongs-to-the-user-group-x" />
+						<liferay-ui:message arguments="<%= HtmlUtil.escape(userGroup.getName()) %>" key="this-page-cannot-be-modified-because-it-belongs-to-the-user-group-x" translateArguments="<%= false %>" />
 					</div>
 				</c:if>
 

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -165,7 +165,7 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 			%>
 
 			<aui:button-row>
-				<aui:button name="enableLayout" onClick="<%= taglibEnableOnClick %>" value='<%= LanguageUtil.format(pageContext, "enable-in-x", HtmlUtil.escape(layoutSetBranchName)) %>' />
+				<aui:button name="enableLayout" onClick="<%= taglibEnableOnClick %>" value='<%= LanguageUtil.format(pageContext, "enable-in-x", HtmlUtil.escape(layoutSetBranchName), false) %>' />
 
 				<aui:button name="deleteLayout" onClick="<%= taglibDeleteOnClick %>" value="delete-in-all-pages-variations" />
 			</aui:button-row>

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
@@ -191,13 +191,13 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 			var ok = false;
 
 			if (currentValue == 0) {
-				ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-deactivate-staging-for-x", liveGroup.getDescriptiveName(locale)) %>');
+				ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-deactivate-staging-for-x", liveGroup.getDescriptiveName(locale), false) %>');
 			}
 			else if (currentValue == 1) {
-				ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-local-staging-for-x", liveGroup.getDescriptiveName(locale)) %>');
+				ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-local-staging-for-x", liveGroup.getDescriptiveName(locale), false) %>');
 			}
 			else if (currentValue == 2) {
-				ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-remote-staging-for-x", liveGroup.getDescriptiveName(locale)) %>');
+				ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-remote-staging-for-x", liveGroup.getDescriptiveName(locale), false) %>');
 			}
 
 			if (ok) {

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_pages_children.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_pages_children.jsp
@@ -255,14 +255,14 @@ if (!StringUtil.contains(tabs4Names, tabs4)) {
 		boolean mergeGuestPublicPages = PropertiesParamUtil.getBoolean(groupTypeSettings, request, "mergeGuestPublicPages");
 		%>
 
-		<liferay-ui:message arguments="<%= HtmlUtil.escape(company.getGroup().getDescriptiveName(locale)) %>" key="you-can-configure-the-top-level-pages-of-this-public-site-to-merge-with-the-top-level-pages-of-the-public-x-site" />
+		<liferay-ui:message arguments="<%= HtmlUtil.escape(company.getGroup().getDescriptiveName(locale)) %>" key="you-can-configure-the-top-level-pages-of-this-public-site-to-merge-with-the-top-level-pages-of-the-public-x-site" translateArguments="<%= false %>" />
 
 		<br /><br />
 
 		<table class="lfr-table">
 		<tr>
 			<td class="lfr-label">
-				<liferay-ui:message arguments="<%= HtmlUtil.escape(company.getGroup().getDescriptiveName(locale)) %>" key="merge-x-public-pages" />
+				<liferay-ui:message arguments="<%= HtmlUtil.escape(company.getGroup().getDescriptiveName(locale)) %>" key="merge-x-public-pages" translateArguments="<%= false %>" />
 			</td>
 			<td>
 				<liferay-ui:input-checkbox defaultValue="<%= mergeGuestPublicPages %>" param="mergeGuestPublicPages" />

--- a/portal-web/docroot/html/portlet/layouts_admin/error_auth_exception.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/error_auth_exception.jspf
@@ -26,7 +26,7 @@
 		RemoteAuthException rae = (RemoteAuthException)errorException;
 		%>
 
-		<liferay-ui:message arguments='<%= "<em>" + rae.getURL() + "</em>" %>' key="an-unexpected-error-occurred-in-the-remote-server-at-x" />
+		<liferay-ui:message arguments='<%= "<em>" + rae.getURL() + "</em>" %>' key="an-unexpected-error-occurred-in-the-remote-server-at-x" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= ae.getType() == AuthException.INTERNAL_SERVER_ERROR %>">

--- a/portal-web/docroot/html/portlet/layouts_admin/error_friendly_url_exception.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/error_friendly_url_exception.jspf
@@ -40,7 +40,7 @@
 		Layout duplicateLayout = LayoutLocalServiceUtil.getLayout(duplicateClassPK);
 		%>
 
-		<liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getModelResource(locale, duplicateClassName), duplicateLayout.getName(locale)} %>" key="please-enter-a-unique-friendly-url" />
+		<liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getModelResource(locale, duplicateClassName), duplicateLayout.getName(locale)} %>" key="please-enter-a-unique-friendly-url" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= lfurle.getType() == LayoutFriendlyURLException.ENDS_WITH_SLASH %>">

--- a/portal-web/docroot/html/portlet/layouts_admin/error_friendly_url_exception.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/error_friendly_url_exception.jspf
@@ -52,7 +52,7 @@
 	</c:if>
 
 	<c:if test="<%= lfurle.getType() == LayoutFriendlyURLException.KEYWORD_CONFLICT %>">
-		<%= LanguageUtil.format(pageContext, "please-enter-a-friendly-url-that-does-not-conflict-with-the-keyword-x", lfurle.getKeywordConflict()) %>
+		<%= LanguageUtil.format(pageContext, "please-enter-a-friendly-url-that-does-not-conflict-with-the-keyword-x", lfurle.getKeywordConflict(), false) %>
 	</c:if>
 
 	<c:if test="<%= lfurle.getType() == LayoutFriendlyURLException.POSSIBLE_DUPLICATE %>">

--- a/portal-web/docroot/html/portlet/layouts_admin/error_remote_export_exception.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/error_remote_export_exception.jspf
@@ -21,14 +21,14 @@
 	%>
 
 	<c:if test="<%= ree.getType() == RemoteExportException.BAD_CONNECTION %>">
-		<liferay-ui:message arguments='<%= "<em>" + ree.getURL() + "</em>" %>' key="could-not-connect-to-address-x.-please-verify-that-the-specified-port-is-correct-and-that-the-remote-server-is-configured-to-accept-requests-from-this-server" />
+		<liferay-ui:message arguments='<%= "<em>" + ree.getURL() + "</em>" %>' key="could-not-connect-to-address-x.-please-verify-that-the-specified-port-is-correct-and-that-the-remote-server-is-configured-to-accept-requests-from-this-server" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= ree.getType() == RemoteExportException.NO_GROUP %>">
-		<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="no-site-exists-on-the-remote-server-with-site-id-x" />
+		<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="no-site-exists-on-the-remote-server-with-site-id-x" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= ree.getType() == RemoteExportException.NO_PERMISSIONS %>">
-		<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="you-do-not-have-permissions-to-edit-the-site-with-id-x-on-the-remote-server" />
+		<liferay-ui:message arguments="<%= ree.getGroupId() %>" key="you-do-not-have-permissions-to-edit-the-site-with-id-x-on-the-remote-server" translateArguments="<%= false %>" />
 	</c:if>
 </liferay-ui:error>

--- a/portal-web/docroot/html/portlet/layouts_admin/error_remote_options_exception.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/error_remote_options_exception.jspf
@@ -21,18 +21,18 @@
 	%>
 
 	<c:if test="<%= roe.getType() == RemoteOptionsException.REMOTE_ADDRESS %>">
-		<liferay-ui:message arguments="<%= roe.getRemoteAddress() %>" key="the-remote-address-x-is-not-valid" />
+		<liferay-ui:message arguments="<%= roe.getRemoteAddress() %>" key="the-remote-address-x-is-not-valid" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= roe.getType() == RemoteOptionsException.REMOTE_GROUP_ID %>">
-		<liferay-ui:message arguments="<%= roe.getRemoteGroupId() %>" key="the-remote-site-id-x-is-not-valid" />
+		<liferay-ui:message arguments="<%= roe.getRemoteGroupId() %>" key="the-remote-site-id-x-is-not-valid" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= roe.getType() == RemoteOptionsException.REMOTE_PATH_CONTEXT %>">
-		<liferay-ui:message arguments="<%= roe.getRemotePathContext() %>" key="the-remote-path-context-x-is-not-valid" />
+		<liferay-ui:message arguments="<%= roe.getRemotePathContext() %>" key="the-remote-path-context-x-is-not-valid" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= roe.getType() == RemoteOptionsException.REMOTE_PORT %>">
-		<liferay-ui:message arguments="<%= roe.getRemotePort() %>" key="the-remote-port-x-is-not-valid" />
+		<liferay-ui:message arguments="<%= roe.getRemotePort() %>" key="the-remote-port-x-is-not-valid" translateArguments="<%= false %>" />
 	</c:if>
 </liferay-ui:error>

--- a/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_layouts.jsp
@@ -351,10 +351,10 @@ portletURL.setParameter("rootNodeName", rootNodeName);
 															<ul class="hide unstyled" id="<portlet:namespace />rangeLastInputs">
 																<li>
 																	<aui:select cssClass="relative-range" label="" name="last">
-																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12") %>' value="12" />
-																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24") %>' value="24" />
-																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48") %>' value="48" />
-																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7") %>' value="168" />
+																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12", false) %>' value="12" />
+																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24", false) %>' value="24" />
+																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48", false) %>' value="48" />
+																		<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7", false) %>' value="168" />
 																	</aui:select>
 																</li>
 															</ul>

--- a/portal-web/docroot/html/portlet/layouts_admin/import_layouts_resources.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/import_layouts_resources.jsp
@@ -44,10 +44,10 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 <liferay-ui:error exception="<%= LARTypeException.class %>">
 
 	<%
-	LARTypeException lpe = (LARTypeException)errorException;
+	LARTypeException lte = (LARTypeException)errorException;
 	%>
 
-	<liferay-ui:message arguments="<%= lpe.getMessage() %>" key="please-import-a-lar-file-of-the-correct-type-x-is-not-valid" />
+	<liferay-ui:message arguments="<%= lte.getMessage() %>" key="please-import-a-lar-file-of-the-correct-type-x-is-not-valid" />
 </liferay-ui:error>
 
 <liferay-ui:error exception="<%= LayoutImportException.class %>" message="an-unexpected-error-occurred-while-importing-your-file" />

--- a/portal-web/docroot/html/portlet/layouts_admin/import_layouts_resources.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/import_layouts_resources.jsp
@@ -38,7 +38,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 <liferay-ui:error exception="<%= LARFileException.class %>" message="please-specify-a-lar-file-to-import" />
 
 <liferay-ui:error exception="<%= LARFileSizeException.class %>">
-	<liferay-ui:message arguments="<%= PrefsPropsUtil.getLong(PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE) / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+	<liferay-ui:message arguments="<%= PrefsPropsUtil.getLong(PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE) / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
 <liferay-ui:error exception="<%= LARTypeException.class %>">
@@ -89,7 +89,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 	%>
 
 	<c:if test="<%= le.getType() == LocaleException.TYPE_EXPORT_IMPORT %>">
-		<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x" />
+		<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x" translateArguments="<%= false %>" />
 	</c:if>
 </liferay-ui:error>
 
@@ -99,7 +99,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 	RecordSetDuplicateRecordSetKeyException rsdrske = (RecordSetDuplicateRecordSetKeyException)errorException;
 	%>
 
-	<liferay-ui:message arguments="<%= rsdrske.getRecordSetKey() %>" key="dynamic-data-list-record-set-with-record-set-key-x-already-exists" />
+	<liferay-ui:message arguments="<%= rsdrske.getRecordSetKey() %>" key="dynamic-data-list-record-set-with-record-set-key-x-already-exists" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
 <liferay-ui:error exception="<%= StructureDuplicateStructureKeyException.class %>">
@@ -108,7 +108,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 	StructureDuplicateStructureKeyException sdske = (StructureDuplicateStructureKeyException)errorException;
 	%>
 
-	<liferay-ui:message arguments="<%= sdske.getStructureKey() %>" key="dynamic-data-mapping-structure-with-structure-key-x-already-exists" />
+	<liferay-ui:message arguments="<%= sdske.getStructureKey() %>" key="dynamic-data-mapping-structure-with-structure-key-x-already-exists" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
 <portlet:actionURL var="importPagesURL">
@@ -148,7 +148,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 						%>
 
 						<span onmouseover="Liferay.Portal.ToolTip.show(this, '<%= dateFormatDateTime.format(exportDate) %>')">
-							<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(pageContext, System.currentTimeMillis() - exportDate.getTime(), true) %>" key="x-ago" />
+							<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(pageContext, System.currentTimeMillis() - exportDate.getTime(), true) %>" key="x-ago" translateArguments="<%= false %>" />
 						</span>
 					</dd>
 					<dt>

--- a/portal-web/docroot/html/portlet/layouts_admin/incomplete_processes_message.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/incomplete_processes_message.jsp
@@ -26,7 +26,7 @@ int incompleteBackgroundTaskCount = ParamUtil.getInteger(request, "incompleteBac
 			<liferay-ui:message key="there-is-currently-1-process-in-progress" />
 		</c:when>
 		<c:when test="<%= incompleteBackgroundTaskCount > 1 %>">
-			<liferay-ui:message arguments="<%= incompleteBackgroundTaskCount - 1 %>" key="there-is-currently-1-process-in-progress-and-x-pending" />
+			<liferay-ui:message arguments="<%= incompleteBackgroundTaskCount - 1 %>" key="there-is-currently-1-process-in-progress-and-x-pending" translateArguments="<%= false %>" />
 		</c:when>
 		<c:otherwise>
 			<liferay-ui:message key="there-are-no-processes-in-progress-anymore" />

--- a/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout/details.jsp
@@ -96,7 +96,7 @@ StringBuilder friendlyURLBase = new StringBuilder();
 
 			<c:choose>
 				<c:when test="<%= PortalUtil.isLayoutFriendliable(selLayout) %>">
-					<aui:field-wrapper cssClass="input-append input-flex-add-on input-prepend" helpMessage='<%= LanguageUtil.format(pageContext, "for-example-x", "<em>/news</em>") %>' label="friendly-url" name="friendlyURL">
+					<aui:field-wrapper cssClass="input-append input-flex-add-on input-prepend" helpMessage='<%= LanguageUtil.format(pageContext, "for-example-x", "<em>/news</em>", false) %>' label="friendly-url" name="friendlyURL">
 						<span class="add-on" id="<portlet:namespace />urlBase"><liferay-ui:message key="<%= StringUtil.shorten(friendlyURLBase.toString(), 40) %>" /></span>
 
 						<liferay-ui:input-localized availableLocales="<%= LanguageUtil.getAvailableLocales(themeDisplay.getSiteGroupId()) %>" cssClass="input-medium" defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" name="friendlyURL" xml="<%= selLayout.getFriendlyURLsXML() %>" />
@@ -133,7 +133,7 @@ StringBuilder friendlyURLBase = new StringBuilder();
 
 		<aui:input name="layoutPrototypeUuid" type="hidden" value="<%= selLayout.getLayoutPrototypeUuid() %>" />
 
-		<aui:input label='<%= LanguageUtil.format(pageContext, "automatically-apply-changes-done-to-the-page-template-x", HtmlUtil.escape(layoutPrototype.getName(user.getLocale()))) %>' name="layoutPrototypeLinkEnabled" type="checkbox" value="<%= selLayout.isLayoutPrototypeLinkEnabled() %>" />
+		<aui:input label='<%= LanguageUtil.format(pageContext, "automatically-apply-changes-done-to-the-page-template-x", HtmlUtil.escape(layoutPrototype.getName(user.getLocale())), false) %>' name="layoutPrototypeLinkEnabled" type="checkbox" value="<%= selLayout.isLayoutPrototypeLinkEnabled() %>" />
 
 		<div class='<%= selLayout.isLayoutPrototypeLinkEnabled() ? "" : "hide" %>' id="<portlet:namespace/>layoutPrototypeMergeAlert">
 

--- a/portal-web/docroot/html/portlet/layouts_admin/layout/look_and_feel.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout/look_and_feel.jsp
@@ -87,7 +87,7 @@ else {
 		taglibLabel = LanguageUtil.get(pageContext, "use-the-same-look-and-feel-of-the-pages-in-which-this-template-is-used");
 	}
 	else {
-		taglibLabel = LanguageUtil.format(pageContext, "use-the-same-look-and-feel-of-the-x", rootNodeNameLink);
+		taglibLabel = LanguageUtil.format(pageContext, "use-the-same-look-and-feel-of-the-x", rootNodeNameLink, false);
 	}
 	%>
 

--- a/portal-web/docroot/html/portlet/layouts_admin/layout/mobile_device_rules.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout/mobile_device_rules.jsp
@@ -45,7 +45,7 @@ int mdrRuleGroupInstancesCount = MDRRuleGroupInstanceServiceUtil.getRuleGroupIns
 	</c:choose>
 </liferay-util:buffer>
 
-<aui:input checked="<%= mdrRuleGroupInstancesCount == 0 %>" disabled="<%= mdrRuleGroupInstancesCount > 0 %>" id="inheritRuleGroupInstances" label='<%= LanguageUtil.format(pageContext, "use-the-same-mobile-device-rules-of-the-x", rootNodeNameLink) %>' name="inheritRuleGroupInstances" type="radio" value="<%= true %>" />
+<aui:input checked="<%= mdrRuleGroupInstancesCount == 0 %>" disabled="<%= mdrRuleGroupInstancesCount > 0 %>" id="inheritRuleGroupInstances" label='<%= LanguageUtil.format(pageContext, "use-the-same-mobile-device-rules-of-the-x", rootNodeNameLink, false) %>' name="inheritRuleGroupInstances" type="radio" value="<%= true %>" />
 
 <aui:input checked="<%= mdrRuleGroupInstancesCount > 0 %>" id="uniqueRuleGroupInstances" label="define-specific-mobile-device-rules-for-this-page" name="inheritRuleGroupInstances" type="radio" value="<%= false %>" />
 

--- a/portal-web/docroot/html/portlet/layouts_admin/layout/mobile_device_rules.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout/mobile_device_rules.jsp
@@ -51,7 +51,7 @@ int mdrRuleGroupInstancesCount = MDRRuleGroupInstanceServiceUtil.getRuleGroupIns
 
 <div class="<%= (mdrRuleGroupInstancesCount == 0) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />inheritRuleGroupInstancesContainer">
 	<div class="alert alert-info">
-		<liferay-ui:message arguments="<%= rootNodeNameLink %>" key="mobile-device-rules-will-be-inhertited-from-x" />
+		<liferay-ui:message arguments="<%= rootNodeNameLink %>" key="mobile-device-rules-will-be-inhertited-from-x" translateArguments="<%= false %>" />
 	</div>
 </div>
 

--- a/portal-web/docroot/html/portlet/layouts_admin/layout_set/advanced.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout_set/advanced.jsp
@@ -35,8 +35,8 @@ boolean mergeGuestPublicPages = PropertiesParamUtil.getBoolean(groupTypeSettings
 		<c:when test="<%= !privateLayout && (liveGroup.getGroupId() != guestGroup.getGroupId()) %>">
 
 			<%
-			String taglibLabel = LanguageUtil.format(pageContext, "merge-x-public-pages", HtmlUtil.escape(guestGroup.getDescriptiveName(locale)));
-			String taglibHelpMessage = LanguageUtil.format(pageContext, "you-can-configure-the-top-level-pages-of-this-public-site-to-merge-with-the-top-level-pages-of-the-public-x-site", HtmlUtil.escape(guestGroup.getDescriptiveName(locale)));
+			String taglibLabel = LanguageUtil.format(pageContext, "merge-x-public-pages", HtmlUtil.escape(guestGroup.getDescriptiveName(locale)), false);
+			String taglibHelpMessage = LanguageUtil.format(pageContext, "you-can-configure-the-top-level-pages-of-this-public-site-to-merge-with-the-top-level-pages-of-the-public-x-site", HtmlUtil.escape(guestGroup.getDescriptiveName(locale)), false);
 			%>
 
 			<aui:input helpMessage="<%= taglibHelpMessage %>" label="<%= taglibLabel %>" name="mergeGuestPublicPages" type="checkbox" value="<%= mergeGuestPublicPages %>" />

--- a/portal-web/docroot/html/portlet/layouts_admin/layout_set/logo.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/layout_set/logo.jsp
@@ -40,7 +40,7 @@ LayoutSet selLayoutSet = ((LayoutSet)request.getAttribute("edit_pages.jsp-selLay
 		fileMaxSize /= 1024;
 		%>
 
-		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 	</liferay-ui:error>
 
 	<p><%= LanguageUtil.get(pageContext, "upload-a-logo-for-the-" + (privateLayout ? "private" : "public") + "-pages-that-will-be-used-instead-of-the-default-enterprise-logo") %></p>

--- a/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
@@ -198,7 +198,7 @@ Map<String, ThemeSetting> configurableSettings = selTheme.getConfigurableSetting
 		<div class="float-container lfr-available-themes" id="<%= device %>availableThemes">
 			<legend>
 				<span class="header-title">
-					<%= LanguageUtil.format(pageContext, "available-themes-x", (themes.size() - 1)) %>
+					<%= LanguageUtil.format(pageContext, "available-themes-x", (themes.size() - 1), false) %>
 				</span>
 
 				<c:if test="<%= permissionChecker.isOmniadmin() && PortletLocalServiceUtil.hasPortlet(themeDisplay.getCompanyId(), PortletKeys.MARKETPLACE_STORE) && PrefsPropsUtil.getBoolean(PropsKeys.AUTO_DEPLOY_ENABLED, PropsValues.AUTO_DEPLOY_ENABLED) %>">

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_portlets_data.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_portlets_data.jspf
@@ -165,10 +165,10 @@ ManifestSummary manifestSummary = portletDataContext.getManifestSummary();
 								<ul class="hide unstyled" id="<portlet:namespace />rangeLastInputs">
 									<li>
 										<aui:select cssClass="relative-range" label="" name="last">
-											<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12") %>' value="12" />
-											<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24") %>' value="24" />
-											<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48") %>' value="48" />
-											<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7") %>' value="168" />
+											<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12", false) %>' value="12" />
+											<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24", false) %>' value="24" />
+											<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48", false) %>' value="48" />
+											<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7", false) %>' value="168" />
 										</aui:select>
 									</li>
 								</ul>

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_process_message_task_details.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_process_message_task_details.jsp
@@ -33,7 +33,7 @@ catch (Exception e) {
 <c:choose>
 	<c:when test="<%= jsonObject == null %>">
 		<div class="alert <%= backgroundTask.getStatus() == BackgroundTaskConstants.STATUS_FAILED ? "alert-error" : StringPool.BLANK %> publish-error">
-			<liferay-ui:message arguments="<%= backgroundTask.getStatusMessage() %>" key="unable-to-execute-process-x" />
+			<liferay-ui:message arguments="<%= backgroundTask.getStatusMessage() %>" key="unable-to-execute-process-x" translateArguments="<%= false %>" />
 		</div>
 	</c:when>
 	<c:otherwise>

--- a/portal-web/docroot/html/portlet/login/forgot_password.jsp
+++ b/portal-web/docroot/html/portlet/login/forgot_password.jsp
@@ -114,7 +114,7 @@ if (reminderAttempts == null) {
 					%>
 
 					<div class="alert alert-info">
-						<%= LanguageUtil.format(pageContext, "a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question", login) %>
+						<%= LanguageUtil.format(pageContext, "a-new-password-will-be-sent-to-x-if-you-can-correctly-answer-the-following-question", login, false) %>
 					</div>
 
 					<aui:input autoFocus="<%= true %>" label="<%= HtmlUtil.escape(user2.getReminderQueryQuestion()) %>" name="answer" type="text" />

--- a/portal-web/docroot/html/portlet/login/login.jsp
+++ b/portal-web/docroot/html/portlet/login/login.jsp
@@ -75,7 +75,7 @@
 								<%= LanguageUtil.get(pageContext, "thank-you-for-creating-an-account") %>
 
 								<c:if test="<%= company.isStrangersVerify() %>">
-									<%= LanguageUtil.format(pageContext, "your-email-verification-code-has-been-sent-to-x", userEmailAddress) %>
+									<%= LanguageUtil.format(pageContext, "your-email-verification-code-has-been-sent-to-x", userEmailAddress, false) %>
 								</c:if>
 							</c:when>
 							<c:otherwise>
@@ -84,7 +84,7 @@
 						</c:choose>
 
 						<c:if test="<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.ADMIN_EMAIL_USER_ADDED_ENABLED) %>">
-							<%= LanguageUtil.format(pageContext, "your-password-has-been-sent-to-x", userEmailAddress) %>
+							<%= LanguageUtil.format(pageContext, "your-password-has-been-sent-to-x", userEmailAddress, false) %>
 						</c:if>
 					</div>
 				</c:when>
@@ -95,7 +95,7 @@
 					%>
 
 					<div class="alert alert-success">
-						<%= LanguageUtil.format(pageContext, "thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your-account-has-been-approved", userEmailAddress) %>
+						<%= LanguageUtil.format(pageContext, "thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your-account-has-been-approved", userEmailAddress, false) %>
 					</div>
 				</c:when>
 			</c:choose>

--- a/portal-web/docroot/html/portlet/login/login_redirect.jsp
+++ b/portal-web/docroot/html/portlet/login/login_redirect.jsp
@@ -81,10 +81,10 @@ boolean anonymousAccount = ParamUtil.getBoolean(request, "anonymousUser");
 								var userStatus = response.userStatus;
 
 								if (userStatus == 'user_added') {
-									message = '<%= UnicodeLanguageUtil.format(pageContext, "thank-you-for-creating-an-account-your-password-has-been-sent-to-x", new Object[] {emailAddress}) %>';
+									message = '<%= UnicodeLanguageUtil.format(pageContext, "thank-you-for-creating-an-account-your-password-has-been-sent-to-x", new Object[] {emailAddress}, false) %>';
 								}
 								else if (userStatus == 'user_pending') {
-									message = '<%= UnicodeLanguageUtil.format(pageContext, "thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your-account-has-been-approved", new Object[] {emailAddress}) %>';
+									message = '<%= UnicodeLanguageUtil.format(pageContext, "thank-you-for-creating-an-account.-you-will-be-notified-via-email-at-x-when-your-account-has-been-approved", new Object[] {emailAddress}, false) %>';
 								}
 
 								<portlet:namespace />showStatusMessage('success', message);

--- a/portal-web/docroot/html/portlet/login/update_account.jsp
+++ b/portal-web/docroot/html/portlet/login/update_account.jsp
@@ -92,7 +92,7 @@ String jobTitle = BeanParamUtil.getString(selUser, request, "jobTitle");
 	</aui:form>
 
 	<div class="alert alert-block">
-		<liferay-ui:message arguments="<%= emailAddress %>" key="an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account" />
+		<liferay-ui:message arguments="<%= emailAddress %>" key="an-account-with-x-as-the-email-address-already-exists-in-the-portal.-do-you-want-to-associate-this-activity-with-that-account" translateArguments="<%= false %>" />
 	</div>
 
 	<aui:button name="updateUser" onClick='<%= renderResponse.getNamespace() + "updateUser();" %>' value="associate-account" />

--- a/portal-web/docroot/html/portlet/message_boards/asset/discussion_full_content.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/asset/discussion_full_content.jsp
@@ -58,7 +58,7 @@ MBMessage parentMessage = MBMessageLocalServiceUtil.getMessage(message.getParent
 
 		<div>
 			<c:if test="<%= message.getParentMessageId() == rootMessage.getMessageId() %>">
-				<%= LanguageUtil.format(pageContext, "posted-on-x", dateFormatDateTime.format(message.getModifiedDate())) %>
+				<%= LanguageUtil.format(pageContext, "posted-on-x", dateFormatDateTime.format(message.getModifiedDate()), false) %>
 			</c:if>
 		</div>
 	</td>

--- a/portal-web/docroot/html/portlet/message_boards/configuration.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/configuration.jsp
@@ -120,10 +120,10 @@ String emailSignature = PrefsParamUtil.getString(portletPreferences, request, em
 				<aui:input name="preferences--threadAsQuestionByDefault--" type="checkbox" value="<%= threadAsQuestionByDefault %>" />
 
 				<aui:select label="show-recent-posts-from-last" name="preferences--recentPostsDateOffset--">
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", 24) %>' selected='<%= recentPostsDateOffset.equals("1") %>' value="1" />
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 7) %>' selected='<%= recentPostsDateOffset.equals("7") %>' value="7" />
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 30) %>' selected='<%= recentPostsDateOffset.equals("30") %>' value="30" />
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 365) %>' selected='<%= recentPostsDateOffset.equals("365") %>' value="365" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", 24, false) %>' selected='<%= recentPostsDateOffset.equals("1") %>' value="1" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 7, false) %>' selected='<%= recentPostsDateOffset.equals("7") %>' value="7" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 30, false) %>' selected='<%= recentPostsDateOffset.equals("30") %>' value="30" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 365, false) %>' selected='<%= recentPostsDateOffset.equals("365") %>' value="365" />
 				</aui:select>
 			</aui:fieldset>
 		</c:when>

--- a/portal-web/docroot/html/portlet/message_boards/configuration.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/configuration.jsp
@@ -120,10 +120,10 @@ String emailSignature = PrefsParamUtil.getString(portletPreferences, request, em
 				<aui:input name="preferences--threadAsQuestionByDefault--" type="checkbox" value="<%= threadAsQuestionByDefault %>" />
 
 				<aui:select label="show-recent-posts-from-last" name="preferences--recentPostsDateOffset--">
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", 24, false) %>' selected='<%= recentPostsDateOffset.equals("1") %>' value="1" />
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 7, false) %>' selected='<%= recentPostsDateOffset.equals("7") %>' value="7" />
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 30, false) %>' selected='<%= recentPostsDateOffset.equals("30") %>' value="30" />
-					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", 365, false) %>' selected='<%= recentPostsDateOffset.equals("365") %>' value="365" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24", false) %>' selected='<%= recentPostsDateOffset.equals("1") %>' value="1" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7", false) %>' selected='<%= recentPostsDateOffset.equals("7") %>' value="7" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "30", false) %>' selected='<%= recentPostsDateOffset.equals("30") %>' value="30" />
+					<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "365", false) %>' selected='<%= recentPostsDateOffset.equals("365") %>' value="365" />
 				</aui:select>
 			</aui:fieldset>
 		</c:when>

--- a/portal-web/docroot/html/portlet/message_boards/edit_category.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/edit_category.jsp
@@ -78,7 +78,7 @@ else {
 <liferay-ui:header
 	backURL="<%= redirect %>"
 	localizeTitle="<%= (category == null) %>"
-	title='<%= (category == null) ? "add-category[message-board]" : LanguageUtil.format(pageContext, "edit-x", category.getName()) %>'
+	title='<%= (category == null) ? "add-category[message-board]" : LanguageUtil.format(pageContext, "edit-x", category.getName(), false) %>'
 />
 
 <portlet:actionURL var="editCategoryURL">

--- a/portal-web/docroot/html/portlet/message_boards/edit_discussion.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/edit_discussion.jsp
@@ -101,7 +101,7 @@ if (message != null) {
 
 		<c:if test="<%= (message != null) && message.isApproved() && WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(message.getCompanyId(), message.getGroupId(), MBMessage.class.getName()) %>">
 			<div class="alert alert-info">
-				<%= LanguageUtil.format(pageContext, "this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again", ResourceActionsUtil.getModelResource(locale, MBMessage.class.getName())) %>
+				<%= LanguageUtil.format(pageContext, "this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again", ResourceActionsUtil.getModelResource(locale, MBMessage.class.getName()), false) %>
 			</div>
 		</c:if>
 

--- a/portal-web/docroot/html/portlet/message_boards/edit_message.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/edit_message.jsp
@@ -108,7 +108,7 @@ else {
 <liferay-ui:header
 	backURL="<%= redirect %>"
 	localizeTitle="<%= (message == null) %>"
-	title='<%= (curParentMessage != null) ? LanguageUtil.format(pageContext, "reply-to-x", curParentMessage.getSubject()) : (message == null) ? "add-message" : LanguageUtil.format(pageContext, "edit-x", message.getSubject()) %>'
+	title='<%= (curParentMessage != null) ? LanguageUtil.format(pageContext, "reply-to-x", curParentMessage.getSubject(), false) : (message == null) ? "add-message" : LanguageUtil.format(pageContext, "edit-x", message.getSubject(), false) %>'
 />
 
 <c:if test="<%= preview %>">
@@ -453,7 +453,7 @@ else {
 
 		<c:if test="<%= (message != null) && message.isApproved() && WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(message.getCompanyId(), message.getGroupId(), MBMessage.class.getName()) %>">
 			<div class="alert alert-info">
-				<%= LanguageUtil.format(pageContext, "this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again", ResourceActionsUtil.getModelResource(locale, MBMessage.class.getName())) %>
+				<%= LanguageUtil.format(pageContext, "this-x-is-approved.-publishing-these-changes-will-cause-it-to-be-unpublished-and-go-through-the-approval-process-again", ResourceActionsUtil.getModelResource(locale, MBMessage.class.getName()), false) %>
 			</div>
 		</c:if>
 

--- a/portal-web/docroot/html/portlet/message_boards/edit_message.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/edit_message.jsp
@@ -194,7 +194,7 @@ else {
 		fileMaxSize /= 1024;
 		%>
 
-		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 	</liferay-ui:error>
 
 	<liferay-ui:error exception="<%= LockedThreadException.class %>" message="thread-is-locked" />

--- a/portal-web/docroot/html/portlet/message_boards/last_post_question.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/last_post_question.jsp
@@ -48,7 +48,7 @@ User userDisplay = UserLocalServiceUtil.getUserById(thread.getLastPostByUserId()
 		<liferay-ui:icon
 			image="../aui/time"
 			label="<%= true %>"
-			message='<%= LanguageUtil.format(pageContext, "x-ago", LanguageUtil.getTimeDescription(pageContext, lastPostAgo, true)) %>'
+			message='<%= LanguageUtil.format(pageContext, "x-ago", LanguageUtil.getTimeDescription(pageContext, lastPostAgo, true), false) %>'
 		/>
 	</div>
 </div>

--- a/portal-web/docroot/html/portlet/message_boards/move_category.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/move_category.jsp
@@ -29,7 +29,7 @@ long parentCategoryId = BeanParamUtil.getLong(category, request, "parentCategory
 <liferay-ui:header
 	backURL="<%= redirect %>"
 	localizeTitle="<%= (category == null) %>"
-	title='<%= LanguageUtil.format(pageContext, "move-x", category.getName()) %>'
+	title='<%= LanguageUtil.format(pageContext, "move-x", category.getName(), false) %>'
 />
 
 <portlet:actionURL var="moveCategoryURL">

--- a/portal-web/docroot/html/portlet/message_boards/search.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/search.jsp
@@ -72,7 +72,7 @@ String keywords = ParamUtil.getString(request, "keywords");
 	%>
 
 	<liferay-ui:search-container
-		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-messages-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>") %>'
+		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-messages-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false) %>'
 		iteratorURL="<%= portletURL %>"
 	>
 

--- a/portal-web/docroot/html/portlet/message_boards/view_thread_message.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/view_thread_message.jsp
@@ -192,7 +192,7 @@ MBThread thread = (MBThread)request.getAttribute("edit_message.jsp-thread");
 						String author = parentMessage.isAnonymous() ? LanguageUtil.get(pageContext, "anonymous") : HtmlUtil.escape(PortalUtil.getUserName(parentMessage.getUserId(), parentMessage.getUserName()));
 						%>
 
-						<%= LanguageUtil.format(pageContext, "posted-as-a-reply-to", author) %>
+						<%= LanguageUtil.format(pageContext, "posted-as-a-reply-to", author, false) %>
 					</c:if>
 				</div>
 
@@ -370,7 +370,7 @@ MBThread thread = (MBThread)request.getAttribute("edit_message.jsp-thread");
 										<liferay-ui:icon
 											image="delete_attachment"
 											label="<%= true %>"
-											message='<%= LanguageUtil.format(pageContext, (deletedAttachmentsFileEntriesCount == 1) ? "x-recently-removed-attachment" : "x-recently-removed-attachments", deletedAttachmentsFileEntriesCount) %>'
+											message='<%= LanguageUtil.format(pageContext, (deletedAttachmentsFileEntriesCount == 1) ? "x-recently-removed-attachment" : "x-recently-removed-attachments", deletedAttachmentsFileEntriesCount, false) %>'
 											url="<%= viewTrashAttachmentsURL %>"
 										/>
 									</li>

--- a/portal-web/docroot/html/portlet/mobile_device_rules/action/theme.jsp
+++ b/portal-web/docroot/html/portlet/mobile_device_rules/action/theme.jsp
@@ -90,7 +90,7 @@ ColorScheme selColorScheme = ThemeLocalServiceUtil.getColorScheme(company.getCom
 		<c:if test="<%= !colorSchemes.isEmpty() %>">
 			<liferay-ui:panel-container extended="<%= true %>" id="mobileDeviceRulesColorSchemesPanelContainer" persistState="<%= true %>">
 				<c:if test="<%= !colorSchemes.isEmpty() %>">
-					<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" id="mobileDeviceRulesColorSchemesPanel" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, "color-schemes-x", colorSchemes.size()) %>'>
+					<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" id="mobileDeviceRulesColorSchemesPanel" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, "color-schemes-x", colorSchemes.size(), false) %>'>
 						<aui:fieldset cssClass="color-schemes">
 							<div class="lfr-theme-list unstyled">
 
@@ -131,7 +131,7 @@ ColorScheme selColorScheme = ThemeLocalServiceUtil.getColorScheme(company.getCom
 				List<Theme> themes = ThemeLocalServiceUtil.getPageThemes(company.getCompanyId(), groupId, user.getUserId(), false);
 				%>
 
-				<%= LanguageUtil.format(pageContext, "available-themes-x", (themes.size() - 1)) %>
+				<%= LanguageUtil.format(pageContext, "available-themes-x", (themes.size() - 1), false) %>
 			</span>
 		</h3>
 

--- a/portal-web/docroot/html/portlet/monitoring/view.jsp
+++ b/portal-web/docroot/html/portlet/monitoring/view.jsp
@@ -108,9 +108,9 @@ portletURL.setParameter("struts_action", "/monitoring/view");
 		</liferay-ui:search-container>
 	</c:when>
 	<c:when test="<%= !PropsValues.LIVE_USERS_ENABLED %>">
-		<%= LanguageUtil.format(pageContext, "display-of-live-session-data-is-disabled", PropsKeys.LIVE_USERS_ENABLED) %>
+		<%= LanguageUtil.format(pageContext, "display-of-live-session-data-is-disabled", PropsKeys.LIVE_USERS_ENABLED, false) %>
 	</c:when>
 	<c:otherwise>
-		<%= LanguageUtil.format(pageContext, "display-of-live-session-data-is-disabled", PropsKeys.SESSION_TRACKER_MEMORY_ENABLED) %>
+		<%= LanguageUtil.format(pageContext, "display-of-live-session-data-is-disabled", PropsKeys.SESSION_TRACKER_MEMORY_ENABLED, false) %>
 	</c:otherwise>
 </c:choose>

--- a/portal-web/docroot/html/portlet/password_policies_admin/edit_password_policy.jsp
+++ b/portal-web/docroot/html/portlet/password_policies_admin/edit_password_policy.jsp
@@ -113,7 +113,7 @@ boolean defaultPolicy = BeanParamUtil.getBoolean(passwordPolicy, request, "defau
 					<aui:input helpMessage="minimum-upper-case-help" label="minimum-upper-case" name="minUpperCase" />
 
 					<%
-					String taglinbHelpMessage = LanguageUtil.format(pageContext, "regular-expression-help", new Object[] {"<a href=\"http://docs.oracle.com/javase/tutorial/essential/regex\" target=\"_blank\">", "</a>"});
+					String taglinbHelpMessage = LanguageUtil.format(pageContext, "regular-expression-help", new Object[] {"<a href=\"http://docs.oracle.com/javase/tutorial/essential/regex\" target=\"_blank\">", "</a>"}, false);
 					%>
 
 					<aui:input helpMessage="<%= taglinbHelpMessage %>" label="regular-expression" name="regex" />

--- a/portal-web/docroot/html/portlet/password_policies_admin/edit_password_policy_assignments.jsp
+++ b/portal-web/docroot/html/portlet/password_policies_admin/edit_password_policy_assignments.jsp
@@ -135,7 +135,7 @@ portletURL.setParameter("tabs3", tabs3);
 								<portlet:param name="passwordPolicyId" value="<%= String.valueOf(curPasswordPolicy.getPasswordPolicyId()) %>" />
 							</portlet:renderURL>
 
-							<liferay-ui:icon-help message='<%= LanguageUtil.format(pageContext, "this-user-is-already-assigned-to-password-policy-x", new Object[] {assignMembersURL, curPasswordPolicy.getName()}) %>' />
+							<liferay-ui:icon-help message='<%= LanguageUtil.format(pageContext, "this-user-is-already-assigned-to-password-policy-x", new Object[] {assignMembersURL, curPasswordPolicy.getName()}, false) %>' />
 						</c:if>
 					</liferay-ui:search-container-column-text>
 
@@ -229,7 +229,7 @@ portletURL.setParameter("tabs3", tabs3);
 								<portlet:param name="passwordPolicyId" value="<%= String.valueOf(curPasswordPolicy.getPasswordPolicyId()) %>" />
 							</portlet:renderURL>
 
-							<liferay-ui:icon-help message='<%= LanguageUtil.format(pageContext, "this-organization-is-already-assigned-to-password-policy-x", new Object[] {assignMembersURL, curPasswordPolicy.getName()}) %>' />
+							<liferay-ui:icon-help message='<%= LanguageUtil.format(pageContext, "this-organization-is-already-assigned-to-password-policy-x", new Object[] {assignMembersURL, curPasswordPolicy.getName()}, false) %>' />
 						</c:if>
 					</liferay-ui:search-container-column-text>
 

--- a/portal-web/docroot/html/portlet/plugins_admin/edit_plugin.jsp
+++ b/portal-web/docroot/html/portlet/plugins_admin/edit_plugin.jsp
@@ -99,7 +99,7 @@ if (pluginType.equals(Plugin.TYPE_PORTLET)) {
 
 					<c:if test="<%= rolesCount > maxNumberOfRolesChecked %>">
 						<div class="alert alert-block">
-							<%= LanguageUtil.format(pageContext, "the-portal-has-more-roles-than-the-maximum-that-can-be-checked-x", maxNumberOfRolesChecked) %>
+							<%= LanguageUtil.format(pageContext, "the-portal-has-more-roles-than-the-maximum-that-can-be-checked-x", maxNumberOfRolesChecked, false) %>
 						</div>
 					</c:if>
 

--- a/portal-web/docroot/html/portlet/polls/view_question_results.jspf
+++ b/portal-web/docroot/html/portlet/polls/view_question_results.jspf
@@ -197,7 +197,7 @@ for (int i = 0; i < choices.size(); i++) {
 	<br />
 
 	<div style="font-size: xx-small;">
-		<%= LanguageUtil.format(pageContext, "voting-is-disabled-because-this-poll-expired-on-x", dateFormatDateTime.format(question.getExpirationDate())) %>
+		<%= LanguageUtil.format(pageContext, "voting-is-disabled-because-this-poll-expired-on-x", dateFormatDateTime.format(question.getExpirationDate()), false) %>
 	</div>
 </c:if>
 

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_permissions.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_permissions.jsp
@@ -416,7 +416,7 @@ definePermissionsURL.setRefererPlid(plid);
 
 						if (Validator.isNotNull(preselectedMsg)) {
 							buffer.append("onclick=\"return false;\" onmouseover=\"Liferay.Portal.ToolTip.show(this, '");
-							buffer.append(UnicodeLanguageUtil.format(pageContext, preselectedMsg, new Object[] {role.getTitle(locale), ResourceActionsUtil.getAction(pageContext, action), Validator.isNull(modelResource) ? selResourceDescription : ResourceActionsUtil.getModelResource(locale, resource.getName()), HtmlUtil.escape(group.getDescriptiveName(locale))}));
+							buffer.append(UnicodeLanguageUtil.format(pageContext, preselectedMsg, new Object[] {role.getTitle(locale), ResourceActionsUtil.getAction(pageContext, action), Validator.isNull(modelResource) ? selResourceDescription : ResourceActionsUtil.getModelResource(locale, resource.getName()), HtmlUtil.escape(group.getDescriptiveName(locale))}, false));
 							buffer.append("'); return false;\" ");
 						}
 

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_public_render_parameters.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_public_render_parameters.jsp
@@ -42,7 +42,7 @@ editPublicRenderParameterURL.setParameter("portletResource", portletResource);
 </portlet:actionURL>
 
 <div class="alert alert-info">
-	<liferay-ui:message arguments='<%= "http://www.liferay.com/community/wiki/-/wiki/Main/Portlet+Communication+Configuration" %>' key="set-up-the-communication-among-the-portlets-that-use-public-render-parameters" />
+	<liferay-ui:message arguments='<%= "http://www.liferay.com/community/wiki/-/wiki/Main/Portlet+Communication+Configuration" %>' key="set-up-the-communication-among-the-portlets-that-use-public-render-parameters" translateArguments="<%= false %>" />
 </div>
 
 <aui:form action="<%= editPRPURL %>" method="post" name="fm">

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_sharing.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_sharing.jsp
@@ -77,7 +77,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 					<textarea class="lfr-textarea-container" onClick="Liferay.Util.selectAndCopy(this);"><%= HtmlUtil.escape(textAreaContent) %></textarea>
 				</aui:field-wrapper>
 
-				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-any-website", portletDisplay.getTitle()) %>' name="widgetShowAddAppLink" type="checkbox" value="<%= widgetShowAddAppLink %>" />
+				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-any-website", portletDisplay.getTitle(), false) %>' name="widgetShowAddAppLink" type="checkbox" value="<%= widgetShowAddAppLink %>" />
 			</c:when>
 			<c:when test='<%= tabs2.equals("facebook") %>'>
 
@@ -121,7 +121,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 
 					<liferay-ui:input-resource url="<%= callbackURL %>" />
 
-					<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-facebook", portletDisplay.getTitle()) %>' name="facebookShowAddAppLink" type="checkbox" value="<%= facebookShowAddAppLink %>" />
+					<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-facebook", portletDisplay.getTitle(), false) %>' name="facebookShowAddAppLink" type="checkbox" value="<%= facebookShowAddAppLink %>" />
 				</c:if>
 			</c:when>
 			<c:when test='<%= tabs2.equals("opensocial-gadget") %>'>
@@ -138,7 +138,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 
 				<liferay-ui:input-resource url="<%= PortalUtil.getGoogleGadgetURL(portlet, themeDisplay) %>" />
 
-				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-igoogle", portletDisplay.getTitle()) %>' name="iGoogleShowAddAppLink" type="checkbox" value="<%= iGoogleShowAddAppLink %>" />
+				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-igoogle", portletDisplay.getTitle(), false) %>' name="iGoogleShowAddAppLink" type="checkbox" value="<%= iGoogleShowAddAppLink %>" />
 			</c:when>
 			<c:when test='<%= tabs2.equals("netvibes") %>'>
 
@@ -154,7 +154,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 
 				<liferay-ui:input-resource url="<%= PortalUtil.getNetvibesURL(portlet, themeDisplay) %>" />
 
-				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-netvibes-pages", portletDisplay.getTitle()) %>' name="netvibesShowAddAppLink" type="checkbox" value="<%= netvibesShowAddAppLink %>" />
+				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-add-x-to-netvibes-pages", portletDisplay.getTitle(), false) %>' name="netvibesShowAddAppLink" type="checkbox" value="<%= netvibesShowAddAppLink %>" />
 			</c:when>
 			<c:when test='<%= tabs2.equals("friends") %>'>
 
@@ -162,7 +162,7 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 				boolean appShowShareWithFriendsLink = GetterUtil.getBoolean(portletPreferences.getValue("lfrAppShowShareWithFriendsLink", null));
 				%>
 
-				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-share-x-with-friends", portletDisplay.getTitle()) %>' name="appShowShareWithFriendsLink" type="checkbox" value="<%= appShowShareWithFriendsLink %>" />
+				<aui:input label='<%= LanguageUtil.format(pageContext, "allow-users-to-share-x-with-friends", portletDisplay.getTitle(), false) %>' name="appShowShareWithFriendsLink" type="checkbox" value="<%= appShowShareWithFriendsLink %>" />
 			</c:when>
 		</c:choose>
 	</aui:fieldset>

--- a/portal-web/docroot/html/portlet/portlet_configuration/error.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/error.jsp
@@ -22,7 +22,7 @@
 />
 
 <liferay-ui:error exception="<%= LARFileSizeException.class %>">
-	<liferay-ui:message arguments="<%= PrefsPropsUtil.getLong(PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE) / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+	<liferay-ui:message arguments="<%= PrefsPropsUtil.getLong(PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE) / 1024 %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
 <liferay-ui:error exception="<%= PrincipalException.class %>" message="you-do-not-have-the-required-permissions" />

--- a/portal-web/docroot/html/portlet/portlet_configuration/export_import.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/export_import.jsp
@@ -71,7 +71,7 @@ else if (scopeGroup.isLayout()) {
 	%>
 
 	<c:if test="<%= le.getType() == LocaleException.TYPE_EXPORT_IMPORT %>">
-		<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x" />
+		<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-available-languages-in-the-lar-file-x-do-not-match-the-site's-available-languages-x" translateArguments="<%= false %>" />
 	</c:if>
 </liferay-ui:error>
 
@@ -103,7 +103,7 @@ else if (scopeGroup.isLayout()) {
 	RecordSetDuplicateRecordSetKeyException rsdrske = (RecordSetDuplicateRecordSetKeyException)errorException;
 	%>
 
-	<liferay-ui:message arguments="<%= rsdrske.getRecordSetKey() %>" key="dynamic-data-list-record-set-with-record-set-key-x-already-exists" />
+	<liferay-ui:message arguments="<%= rsdrske.getRecordSetKey() %>" key="dynamic-data-list-record-set-with-record-set-key-x-already-exists" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
 <liferay-ui:error exception="<%= StructureDuplicateStructureKeyException.class %>">
@@ -112,7 +112,7 @@ else if (scopeGroup.isLayout()) {
 	StructureDuplicateStructureKeyException sdske = (StructureDuplicateStructureKeyException)errorException;
 	%>
 
-	<liferay-ui:message arguments="<%= sdske.getStructureKey() %>" key="dynamic-data-mapping-structure-with-structure-key-x-already-exists" />
+	<liferay-ui:message arguments="<%= sdske.getStructureKey() %>" key="dynamic-data-mapping-structure-with-structure-key-x-already-exists" translateArguments="<%= false %>" />
 </liferay-ui:error>
 
 <c:choose>

--- a/portal-web/docroot/html/portlet/portlet_configuration/export_import.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/export_import.jsp
@@ -56,10 +56,10 @@ else if (scopeGroup.isLayout()) {
 <liferay-ui:error exception="<%= LARTypeException.class %>">
 
 	<%
-	LARTypeException lpe = (LARTypeException)errorException;
+	LARTypeException lte = (LARTypeException)errorException;
 	%>
 
-	<liferay-ui:message arguments="<%= lpe.getMessage() %>" key="please-import-a-lar-file-of-the-correct-type-x-is-not-valid" />
+	<liferay-ui:message arguments="<%= lte.getMessage() %>" key="please-import-a-lar-file-of-the-correct-type-x-is-not-valid" />
 </liferay-ui:error>
 
 <liferay-ui:error exception="<%= ExportImportAction.class %>" message="an-unexpected-error-occurred-while-importing-your-file" />

--- a/portal-web/docroot/html/portlet/portlet_configuration/export_portlet.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/export_portlet.jsp
@@ -232,10 +232,10 @@ portletURL.setParameter("tabs3", "current-and-previous");
 											<ul class="hide unstyled" id="<portlet:namespace />rangeLastInputs">
 												<li>
 													<aui:select cssClass="relative-range" label="" name="last">
-														<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12") %>' value="12" />
-														<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24") %>' value="24" />
-														<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48") %>' value="48" />
-														<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7") %>' value="168" />
+														<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12", false) %>' value="12" />
+														<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24", false) %>' value="24" />
+														<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48", false) %>' value="48" />
+														<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7", false) %>' value="168" />
 													</aui:select>
 												</li>
 											</ul>

--- a/portal-web/docroot/html/portlet/portlet_configuration/import_portlet_resources.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/import_portlet_resources.jsp
@@ -69,7 +69,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(them
 						%>
 
 						<span onmouseover="Liferay.Portal.ToolTip.show(this, '<%= dateFormatDateTime.format(exportDate) %>')">
-							<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(pageContext, System.currentTimeMillis() - exportDate.getTime(), true) %>" key="x-ago" />
+							<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(pageContext, System.currentTimeMillis() - exportDate.getTime(), true) %>" key="x-ago" translateArguments="<%= false %>" />
 						</span>
 					</dd>
 					<dt>

--- a/portal-web/docroot/html/portlet/portlet_configuration/publish_portlet.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/publish_portlet.jsp
@@ -288,10 +288,10 @@ portletURL.setParameter("tabs3", "current-and-previous");
 													<ul class="hide unstyled" id="<portlet:namespace />rangeLastInputs">
 														<li>
 															<aui:select cssClass="relative-range" label="" name="last">
-																<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12") %>' value="12" />
-																<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24") %>' value="24" />
-																<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48") %>' value="48" />
-																<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7") %>' value="168" />
+																<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "12", false) %>' value="12" />
+																<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "24", false) %>' value="24" />
+																<aui:option label='<%= LanguageUtil.format(pageContext, "x-hours", "48", false) %>' value="48" />
+																<aui:option label='<%= LanguageUtil.format(pageContext, "x-days", "7", false) %>' value="168" />
 															</aui:select>
 														</li>
 													</ul>

--- a/portal-web/docroot/html/portlet/search/facets/calendar.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/calendar.jsp
@@ -67,7 +67,7 @@ int firstDayOfWeek = localeCal.getFirstDayOfWeek() - 1;
 		Liferay.Search.tokenList.add(
 			{
 				clearFields: '<%= renderResponse.getNamespace() + facet.getFieldId() %>',
-				html: '<%= UnicodeLanguageUtil.format(pageContext, "from-x-to-x", new Object[] {"<strong>" + HtmlUtil.escape(fieldParamFrom) + "</strong>", "<strong>" + HtmlUtil.escape(fieldParamTo) + "</strong>"}) %>'
+				html: '<%= UnicodeLanguageUtil.format(pageContext, "from-x-to-x", new Object[] {"<strong>" + HtmlUtil.escape(fieldParamFrom) + "</strong>", "<strong>" + HtmlUtil.escape(fieldParamTo) + "</strong>"}, false) %>'
 			}
 		);
 	</aui:script>

--- a/portal-web/docroot/html/portlet/search/facets/modified.jsp
+++ b/portal-web/docroot/html/portlet/search/facets/modified.jsp
@@ -136,7 +136,7 @@ int firstDayOfWeek = localeCal.getFirstDayOfWeek() - 1;
 			String fromDateLabel = HtmlUtil.escape(fieldParamFrom);
 			String toDateLabel = HtmlUtil.escape(fieldParamTo);
 
-			tokenLabel = UnicodeLanguageUtil.format(pageContext, "from-x-to-x", new Object[] {"<strong>" + fromDateLabel + "</strong>", "<strong>" + toDateLabel + "</strong>"});
+			tokenLabel = UnicodeLanguageUtil.format(pageContext, "from-x-to-x", new Object[] {"<strong>" + fromDateLabel + "</strong>", "<strong>" + toDateLabel + "</strong>"}, false);
 		}
 		%>
 

--- a/portal-web/docroot/html/portlet/search/main_search.jspf
+++ b/portal-web/docroot/html/portlet/search/main_search.jspf
@@ -19,7 +19,7 @@ SearchContainer mainSearchSearchContainer = new SearchContainer(renderRequest, n
 
 SearchContext searchContext = SearchContextFactory.getInstance(request);
 
-mainSearchSearchContainer.setEmptyResultsMessage(LanguageUtil.format(pageContext, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(searchContext.getKeywords()) + "</strong>"));
+mainSearchSearchContainer.setEmptyResultsMessage(LanguageUtil.format(pageContext, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(searchContext.getKeywords()) + "</strong>", false));
 
 searchContext.setAttribute("paginationType", "more");
 searchContext.setEnd(mainSearchSearchContainer.getEnd());

--- a/portal-web/docroot/html/portlet/search/main_search_result_form.jsp
+++ b/portal-web/docroot/html/portlet/search/main_search_result_form.jsp
@@ -136,7 +136,7 @@ PortletURL portletURL = (PortletURL)request.getAttribute("search.jsp-portletURL"
 		</a>
 
 		<c:if test="<%= Validator.isNotNull(downloadURL) %>">
-			<liferay-ui:icon image="../arrows/01_down" label="<%= false %>" message='<%= LanguageUtil.format(pageContext, "download-x", HtmlUtil.escape(entryTitle)) %>' url="<%= downloadURL %>" />
+			<liferay-ui:icon image="../arrows/01_down" label="<%= false %>" message='<%= LanguageUtil.format(pageContext, "download-x", HtmlUtil.escape(entryTitle), false) %>' url="<%= downloadURL %>" />
 		</c:if>
 	</span>
 

--- a/portal-web/docroot/html/portlet/search/open_search.jspf
+++ b/portal-web/docroot/html/portlet/search/open_search.jspf
@@ -107,7 +107,7 @@ for (int i = 0; i < portlets.size(); i++) {
 	//headerNames.add("tags");
 	//headerNames.add("score");
 
-	SearchContainer openSearchSearchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM + i, 5, portletURL, null, LanguageUtil.format(pageContext, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>"));
+	SearchContainer openSearchSearchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM + i, 5, portletURL, null, LanguageUtil.format(pageContext, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false));
 
 	if (Validator.isNotNull(primarySearch) && primarySearch.equals(portlet.getOpenSearchClass())) {
 		int delta = ParamUtil.getInteger(request, SearchContainer.DEFAULT_DELTA_PARAM + i);
@@ -357,7 +357,7 @@ for (int i = 0; i < portlets.size(); i++) {
 						<portlet:param name="format" value="<%= format %>" />
 					</portlet:renderURL>
 
-					<aui:a href="<%= moreResultsURL %>"><%= LanguageUtil.format(pageContext, "more-x-results", portletTitle) %> &raquo;</aui:a>
+					<aui:a href="<%= moreResultsURL %>"><%= LanguageUtil.format(pageContext, "more-x-results", portletTitle, false) %> &raquo;</aui:a>
 				</div>
 			</c:otherwise>
 		</c:choose>
@@ -369,6 +369,6 @@ for (int i = 0; i < portlets.size(); i++) {
 
 <c:if test="<%= totalResults == 0 %>">
 	<div class="no-results">
-		<%= LanguageUtil.format(pageContext, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>") %>
+		<%= LanguageUtil.format(pageContext, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false) %>
 	</div>
 </c:if>

--- a/portal-web/docroot/html/portlet/shopping/edit_item.jsp
+++ b/portal-web/docroot/html/portlet/shopping/edit_item.jsp
@@ -444,7 +444,7 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 				long imageMaxSize = PrefsPropsUtil.getLong(PropsKeys.SHOPPING_IMAGE_LARGE_MAX_SIZE) / 1024;
 				%>
 
-				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 			</liferay-ui:error>
 
 			<liferay-ui:error exception="<%= ItemMediumImageNameException.class %>">
@@ -462,7 +462,7 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 				long imageMaxSize = PrefsPropsUtil.getLong(PropsKeys.SHOPPING_IMAGE_MEDIUM_MAX_SIZE) / 1024;
 				%>
 
-				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 			</liferay-ui:error>
 
 			<liferay-ui:error exception="<%= ItemSmallImageNameException.class %>">
@@ -480,7 +480,7 @@ int priceId = ParamUtil.getInteger(request, "priceId", -1);
 				long imageMaxSize = PrefsPropsUtil.getLong(PropsKeys.SHOPPING_IMAGE_SMALL_MAX_SIZE) / 1024;
 				%>
 
-				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+				<liferay-ui:message arguments="<%= imageMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 			</liferay-ui:error>
 
 			<aui:fieldset>

--- a/portal-web/docroot/html/portlet/shopping/search.jsp
+++ b/portal-web/docroot/html/portlet/shopping/search.jsp
@@ -76,7 +76,7 @@ String keywords = ParamUtil.getString(request, "keywords");
 	headerNames.add("price");
 	headerNames.add(StringPool.BLANK);
 
-	SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>"));
+	SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false));
 
 	int total = ShoppingItemLocalServiceUtil.searchCount(scopeGroupId, categoryIdsArray, keywords);
 

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site.jsp
@@ -239,13 +239,13 @@ String[][] categorySections = {mainSections, seoSections, advancedSections, misc
 				ok = false;
 
 				if (0 == currentValue) {
-					ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-deactivate-staging-for-x", liveGroup.getDescriptiveName(locale)) %>');
+					ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-deactivate-staging-for-x", liveGroup.getDescriptiveName(locale), false) %>');
 				}
 				else if (1 == currentValue) {
-					ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-local-staging-for-x", liveGroup.getDescriptiveName(locale)) %>');
+					ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-local-staging-for-x", liveGroup.getDescriptiveName(locale), false) %>');
 				}
 				else if (2 == currentValue) {
-					ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-remote-staging-for-x", liveGroup.getDescriptiveName(locale)) %>');
+					ok = confirm('<%= UnicodeLanguageUtil.format(pageContext, "are-you-sure-you-want-to-activate-remote-staging-for-x", liveGroup.getDescriptiveName(locale), false) %>');
 				}
 			}
 		</c:if>

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments.jsp
@@ -130,7 +130,7 @@ request.setAttribute("edit_site_assignments.jsp-portletURL", portletURL);
 						<liferay-ui:icon
 							image="manage_task"
 							label="<%= true %>"
-							message='<%= LanguageUtil.format(pageContext, "there-are-x-membership-requests-pending", String.valueOf(pendingRequests)) %>'
+							message='<%= LanguageUtil.format(pageContext, "there-are-x-membership-requests-pending", String.valueOf(pendingRequests), false) %>'
 							url="<%= viewMembershipRequestsURL %>"
 						/>
 					</c:if>

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_organizations.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_organizations.jsp
@@ -99,7 +99,7 @@ searchContainer.setEmptyResultsMessage(emptyResultsMessage);
 			<%= organization.getName() %>
 
 			<c:if test="<%= group.getOrganizationId() == organization.getOrganizationId() %>">
-				<liferay-ui:icon-help message='<%= LanguageUtil.format(pageContext, "this-site-belongs-to-x-which-is-an-organization-of-type-x", new String[] {organization.getName(), LanguageUtil.get(pageContext, organization.getType())}) + StringPool.SPACE + LanguageUtil.format(pageContext, "all-users-of-x-are-automatically-members-of-the-site", organization.getName()) %>' />
+				<liferay-ui:icon-help message='<%= LanguageUtil.format(pageContext, "this-site-belongs-to-x-which-is-an-organization-of-type-x", new String[] {organization.getName(), LanguageUtil.get(pageContext, organization.getType())}, false) + StringPool.SPACE + LanguageUtil.format(pageContext, "all-users-of-x-are-automatically-members-of-the-site", organization.getName(), false) %>' />
 			</c:if>
 		</liferay-ui:search-container-column-text>
 
@@ -183,7 +183,7 @@ searchContainer.setEmptyResultsMessage(emptyResultsMessage);
 
 	<c:choose>
 		<c:when test='<%= tabs1.equals("summary") && (total > 0) %>'>
-			<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, (total > 1) ? "x-organizations" : "x-organization", total) %>'>
+			<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, (total > 1) ? "x-organizations" : "x-organization", total, false) %>'>
 				<span class="form-search">
 					<liferay-ui:input-search name='<%= DisplayTerms.KEYWORDS + "_organizations" %>' />
 				</span>

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_user_groups.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_user_groups.jsp
@@ -172,7 +172,7 @@ userGroupSearch.setEmptyResultsMessage(emptyResultsMessage);
 
 	<c:choose>
 		<c:when test='<%= tabs1.equals("summary") && (total > 0) %>'>
-			<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, (total > 1) ? "x-user-groups" : "x-user-group", total) %>'>
+			<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, (total > 1) ? "x-user-groups" : "x-user-group", total, false) %>'>
 				<span class="form-search">
 					<liferay-ui:input-search name='<%= DisplayTerms.KEYWORDS + "_user_groups" %>' />
 				</span>

--- a/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_users.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_site_assignments_users.jsp
@@ -138,10 +138,10 @@ searchContainer.setEmptyResultsMessage(emptyResultsMessage);
 
 			if (organizationUser || userGroupUser) {
 				if (names.size() == 1) {
-					message = LanguageUtil.format(pageContext, "this-user-is-a-member-of-x-because-he-belongs-to-x", new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), names.get(0)});
+					message = LanguageUtil.format(pageContext, "this-user-is-a-member-of-x-because-he-belongs-to-x", new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), names.get(0)}, false);
 				}
 				else {
-					message = LanguageUtil.format(pageContext, "this-user-is-a-member-of-x-because-he-belongs-to-x-and-x", new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), StringUtil.merge(names.subList(0, names.size() - 1).toArray(new String[names.size() - 1]), ", "), names.get(names.size() - 1)});
+					message = LanguageUtil.format(pageContext, "this-user-is-a-member-of-x-because-he-belongs-to-x-and-x", new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), StringUtil.merge(names.subList(0, names.size() - 1).toArray(new String[names.size() - 1]), ", "), names.get(names.size() - 1)}, false);
 				}
 			%>
 
@@ -247,7 +247,7 @@ searchContainer.setEmptyResultsMessage(emptyResultsMessage);
 
 	<c:choose>
 		<c:when test='<%= tabs1.equals("summary") && (total > 0) %>'>
-			<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, (total > 1) ? "x-users" : "x-user", total) %>'>
+			<liferay-ui:panel collapsible="<%= true %>" extended="<%= false %>" persistState="<%= true %>" title='<%= LanguageUtil.format(pageContext, (total > 1) ? "x-users" : "x-user", total, false) %>'>
 				<span class="form-search">
 					<liferay-ui:input-search name='<%= DisplayTerms.KEYWORDS + "_users" %>' />
 				</span>

--- a/portal-web/docroot/html/portlet/sites_admin/edit_user_group_roles_role.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_user_group_roles_role.jsp
@@ -26,7 +26,7 @@ PortletURL portletURL = (PortletURL)request.getAttribute("edit_user_group_roles.
 %>
 
 <div>
-	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"1", "2"}) %>
+	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"1", "2"}, false) %>
 
 	<liferay-ui:message key="choose-a-role" />
 </div>

--- a/portal-web/docroot/html/portlet/sites_admin/edit_user_group_roles_users.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_user_group_roles_users.jsp
@@ -34,9 +34,9 @@ PortletURL portletURL = (PortletURL)request.getAttribute("edit_user_group_roles.
 <aui:input name="removeUserGroupIds" type="hidden" />
 
 <div>
-	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"2", "2"}) %>
+	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"2", "2"}, false) %>
 
-	<%= LanguageUtil.format(pageContext, "current-signifies-current-user-groups-associated-with-the-x-role.-available-signifies-all-user-groups-associated-with-the-x-x", new String[] {HtmlUtil.escape(role.getTitle(locale)), HtmlUtil.escape(groupDescriptiveName), LanguageUtil.get(pageContext, (group.isOrganization() ? "organization" : "site"))}) %>
+	<%= LanguageUtil.format(pageContext, "current-signifies-current-user-groups-associated-with-the-x-role.-available-signifies-all-user-groups-associated-with-the-x-x", new String[] {HtmlUtil.escape(role.getTitle(locale)), HtmlUtil.escape(groupDescriptiveName), LanguageUtil.get(pageContext, (group.isOrganization() ? LanguageUtil.get(pageContext, "organization") : LanguageUtil.get(pageContext, "site")))}, false) %>
 </div>
 
 <br />

--- a/portal-web/docroot/html/portlet/sites_admin/edit_user_roles_role.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_user_roles_role.jsp
@@ -26,7 +26,7 @@ PortletURL portletURL = (PortletURL)request.getAttribute("edit_user_roles.jsp-po
 %>
 
 <div>
-	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"1", "2"}) %>
+	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"1", "2"}, false) %>
 
 	<liferay-ui:message key="choose-a-role" />
 </div>

--- a/portal-web/docroot/html/portlet/sites_admin/edit_user_roles_users.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_user_roles_users.jsp
@@ -34,9 +34,9 @@ PortletURL portletURL = (PortletURL)request.getAttribute("edit_user_roles.jsp-po
 <aui:input name="removeUserIds" type="hidden" />
 
 <div>
-	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"2", "2"}) %>
+	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"2", "2"}, false) %>
 
-	<%= LanguageUtil.format(pageContext, "current-signifies-current-users-associated-with-the-x-role.-available-signifies-all-users-associated-with-the-x-x", new String[] {HtmlUtil.escape(role.getTitle(locale)), HtmlUtil.escape(groupDescriptiveName), LanguageUtil.get(pageContext, (group.isOrganization() ? "organization" : "site"))}) %>
+	<%= LanguageUtil.format(pageContext, "current-signifies-current-users-associated-with-the-x-role.-available-signifies-all-users-associated-with-the-x-x", new String[] {HtmlUtil.escape(role.getTitle(locale)), HtmlUtil.escape(groupDescriptiveName), LanguageUtil.get(pageContext, (group.isOrganization() ? LanguageUtil.get(pageContext, "organization") : LanguageUtil.get(pageContext, "site")))}) %>
 </div>
 
 <br />

--- a/portal-web/docroot/html/portlet/sites_admin/edit_user_roles_users.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/edit_user_roles_users.jsp
@@ -36,7 +36,7 @@ PortletURL portletURL = (PortletURL)request.getAttribute("edit_user_roles.jsp-po
 <div>
 	<%= LanguageUtil.format(pageContext, "step-x-of-x", new String[] {"2", "2"}, false) %>
 
-	<%= LanguageUtil.format(pageContext, "current-signifies-current-users-associated-with-the-x-role.-available-signifies-all-users-associated-with-the-x-x", new String[] {HtmlUtil.escape(role.getTitle(locale)), HtmlUtil.escape(groupDescriptiveName), LanguageUtil.get(pageContext, (group.isOrganization() ? LanguageUtil.get(pageContext, "organization") : LanguageUtil.get(pageContext, "site")))}) %>
+	<%= LanguageUtil.format(pageContext, "current-signifies-current-users-associated-with-the-x-role.-available-signifies-all-users-associated-with-the-x-x", new String[] {HtmlUtil.escape(role.getTitle(locale)), HtmlUtil.escape(groupDescriptiveName), LanguageUtil.get(pageContext, (group.isOrganization() ? "organization" : "site"))}) %>
 </div>
 
 <br />

--- a/portal-web/docroot/html/portlet/sites_admin/post_membership_request.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/post_membership_request.jsp
@@ -42,7 +42,7 @@ MembershipRequest membershipRequest = (MembershipRequest)request.getAttribute(We
 			backURL="<%= redirect %>"
 			escapeXml="<%= false %>"
 			localizeTitle="<%= false %>"
-			title='<%= LanguageUtil.format(pageContext, "request-membership-for-x", HtmlUtil.escape(group.getDescriptiveName(locale))) %>'
+			title='<%= LanguageUtil.format(pageContext, "request-membership-for-x", HtmlUtil.escape(group.getDescriptiveName(locale)), false) %>'
 		/>
 	</c:if>
 

--- a/portal-web/docroot/html/portlet/sites_admin/reply_membership_request.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/reply_membership_request.jsp
@@ -47,7 +47,7 @@ MembershipRequest membershipRequest = (MembershipRequest)request.getAttribute(We
 			backURL="<%= redirect %>"
 			escapeXml="<%= false %>"
 			localizeTitle="<%= false %>"
-			title='<%= LanguageUtil.format(pageContext, "reply-membership-request-for-x", HtmlUtil.escape(group.getDescriptiveName(locale))) %>'
+			title='<%= LanguageUtil.format(pageContext, "reply-membership-request-for-x", HtmlUtil.escape(group.getDescriptiveName(locale)), false) %>'
 		/>
 	</c:if>
 

--- a/portal-web/docroot/html/portlet/sites_admin/site/analytics.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/analytics.jsp
@@ -56,7 +56,7 @@ for (String analyticsType : analyticsTypes) {
 			String analyticsScript = PropertiesParamUtil.getString(groupTypeSettings, request, Sites.ANALYTICS_PREFIX + analyticsType);
 			%>
 
-			<aui:input cols="60" helpMessage='<%= LanguageUtil.format(pageContext, "set-the-script-for-x-that-will-be-used-for-this-set-of-pages", analyticsName) %>' label="<%= analyticsName %>" name="<%= Sites.ANALYTICS_PREFIX + analyticsType %>" rows="15" type="textarea" value="<%= analyticsScript %>" wrap="soft" />
+			<aui:input cols="60" helpMessage='<%= LanguageUtil.format(pageContext, "set-the-script-for-x-that-will-be-used-for-this-set-of-pages", analyticsName, false) %>' label="<%= analyticsName %>" name="<%= Sites.ANALYTICS_PREFIX + analyticsType %>" rows="15" type="textarea" value="<%= analyticsScript %>" wrap="soft" />
 		</c:otherwise>
 	</c:choose>
 

--- a/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
@@ -265,7 +265,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 													</div>
 												</c:if>
 
-												<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
+												<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 
 												<div class='<%= publicLayoutSetPrototypeLinkEnabled ? "" : "hide" %>' id="<portlet:namespace/>publicLayoutSetPrototypeMergeAlert">
 
@@ -367,7 +367,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 													</div>
 												</c:if>
 
-												<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
+												<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 
 												<div class='<%= privateLayoutSetPrototypeLinkEnabled ? "" : "hide" %>' id="<portlet:namespace/>privateLayoutSetPrototypeMergeAlert">
 
@@ -409,7 +409,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 						}
 						%>
 
-						<aui:select helpMessage='<%= LanguageUtil.format(pageContext, "application-adapter-help", "http://www.liferay.com/community/wiki/-/wiki/Main/Application+Adapters") %>' label="application-adapter" name="customJspServletContextName">
+						<aui:select helpMessage='<%= LanguageUtil.format(pageContext, "application-adapter-help", "http://www.liferay.com/community/wiki/-/wiki/Main/Application+Adapters", false) %>' label="application-adapter" name="customJspServletContextName">
 							<aui:option label="none" value="" />
 
 							<%
@@ -431,8 +431,8 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 					<aui:input name="layoutSetPrototypeId" type="hidden" value="<%= layoutSetPrototype.getLayoutSetPrototypeId() %>" />
 
 					<aui:field-wrapper label="copy-as">
-						<aui:input checked="<%= true %>" helpMessage='<%= LanguageUtil.format(pageContext, "select-this-to-copy-the-pages-of-the-site-template-x-as-public-pages-for-this-site", HtmlUtil.escape(layoutSetPrototype.getName(user.getLanguageId()))) %>' label="public-pages" name="layoutSetVisibility" type="radio" value="0" />
-						<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "select-this-to-copy-the-pages-of-the-site-template-x-as-private-pages-for-this-site", HtmlUtil.escape(layoutSetPrototype.getName(user.getLanguageId()))) %>' label="private-pages" name="layoutSetVisibility" type="radio" value="1" />
+						<aui:input checked="<%= true %>" helpMessage='<%= LanguageUtil.format(pageContext, "select-this-to-copy-the-pages-of-the-site-template-x-as-public-pages-for-this-site", HtmlUtil.escape(layoutSetPrototype.getName(user.getLanguageId())), false) %>' label="public-pages" name="layoutSetVisibility" type="radio" value="0" />
+						<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "select-this-to-copy-the-pages-of-the-site-template-x-as-private-pages-for-this-site", HtmlUtil.escape(layoutSetPrototype.getName(user.getLanguageId())), false) %>' label="private-pages" name="layoutSetVisibility" type="radio" value="1" />
 					</aui:field-wrapper>
 
 					<c:choose>

--- a/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
@@ -280,7 +280,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 												</div>
 											</c:when>
 											<c:when test="<%= publicLayoutSetPrototype != null %>">
-												<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+												<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 												<aui:input name="publicLayoutSetPrototypeLinkEnabled" type="hidden" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 											</c:when>
@@ -382,7 +382,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 												</div>
 											</c:when>
 											<c:when test="<%= privateLayoutSetPrototype != null %>">
-												<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+												<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 												<aui:input name="privateLayoutSetPrototypeLinkEnabled" type="hidden" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 											</c:when>

--- a/portal-web/docroot/html/portlet/sites_admin/site/display_settings.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/display_settings.jsp
@@ -88,10 +88,10 @@ if (publicLayoutSet.isLayoutSetPrototypeLinkEnabled() || privateLayoutSet.isLayo
 
 		<c:choose>
 			<c:when test="<%= le.getType() == LocaleException.TYPE_DEFAULT %>">
-				<liferay-ui:message arguments="<%= StringUtil.merge(LocaleUtil.toDisplayNames(le.getTargetAvailableLocales(), locale), StringPool.COMMA_AND_SPACE) %>" key="please-select-a-default-language-among-the-available-languages-of-the-site-x" />
+				<liferay-ui:message arguments="<%= StringUtil.merge(LocaleUtil.toDisplayNames(le.getTargetAvailableLocales(), locale), StringPool.COMMA_AND_SPACE) %>" key="please-select-a-default-language-among-the-available-languages-of-the-site-x" translateArguments="<%= false %>" />
 			</c:when>
 			<c:when test="<%= le.getType() == LocaleException.TYPE_DISPLAY_SETTINGS %>">
-				<liferay-ui:message arguments="<%= StringUtil.merge(LocaleUtil.toDisplayNames(le.getSourceAvailableLocales(), locale), StringPool.COMMA_AND_SPACE) %>" key="please-select-the-available-languages-of-the-site-among-the-available-languages-of-the-portal-x" />
+				<liferay-ui:message arguments="<%= StringUtil.merge(LocaleUtil.toDisplayNames(le.getSourceAvailableLocales(), locale), StringPool.COMMA_AND_SPACE) %>" key="please-select-the-available-languages-of-the-site-among-the-available-languages-of-the-portal-x" translateArguments="<%= false %>" />
 			</c:when>
 		</c:choose>
 	</liferay-ui:error>

--- a/portal-web/docroot/html/portlet/sites_admin/site/site_template.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/site_template.jsp
@@ -63,7 +63,7 @@ if (Validator.isNotNull(publicLayoutSet.getLayoutSetPrototypeUuid())) {
 					boolean layoutsUpdateable = GetterUtil.getBoolean(publicLayoutSetPrototype.getSettingsProperty("layoutsUpdateable"), true);
 					%>
 
-					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 					<aui:field-wrapper label="site-template-settings">
 						<aui:input disabled="<%= true %>" name="active" type="checkbox" value="<%= publicLayoutSetPrototype.isActive() %>" />
@@ -71,7 +71,7 @@ if (Validator.isNotNull(publicLayoutSet.getLayoutSetPrototypeUuid())) {
 					</aui:field-wrapper>
 				</c:when>
 				<c:otherwise>
-					<liferay-ui:message arguments="<%= new Object[] {publicLayoutSetPrototype.getName(locale)} %>" key="this-site-was-cloned-from-site-template-x" />
+					<liferay-ui:message arguments="<%= new Object[] {publicLayoutSetPrototype.getName(locale)} %>" key="this-site-was-cloned-from-site-template-x" translateArguments="<%= false %>" />
 				</c:otherwise>
 			</c:choose>
 		</aui:fieldset>
@@ -86,7 +86,7 @@ if (Validator.isNotNull(publicLayoutSet.getLayoutSetPrototypeUuid())) {
 					boolean layoutsUpdateable = GetterUtil.getBoolean(privateLayoutSetPrototype.getSettingsProperty("layoutsUpdateable"), true);
 					%>
 
-					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 					<aui:field-wrapper label="site-template-settings">
 						<aui:input disabled="<%= true %>" name="active" type="checkbox" value="<%= privateLayoutSetPrototype.isActive() %>" />
@@ -94,7 +94,7 @@ if (Validator.isNotNull(publicLayoutSet.getLayoutSetPrototypeUuid())) {
 					</aui:field-wrapper>
 				</c:when>
 				<c:otherwise>
-					<liferay-ui:message arguments="<%= new Object[] {privateLayoutSetPrototype.getName(locale)} %>" key="this-site-was-cloned-from-site-template-x" />
+					<liferay-ui:message arguments="<%= new Object[] {privateLayoutSetPrototype.getName(locale)} %>" key="this-site-was-cloned-from-site-template-x" translateArguments="<%= false %>" />
 				</c:otherwise>
 			</c:choose>
 		</aui:fieldset>

--- a/portal-web/docroot/html/portlet/sites_admin/site/site_url.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/site_url.jsp
@@ -70,7 +70,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 		}
 		%>
 
-		<liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getModelResource(locale, duplicateClassName), name} %>" key="please-enter-a-unique-friendly-url" />
+		<liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getModelResource(locale, duplicateClassName), name} %>" key="please-enter-a-unique-friendly-url" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= gfurle.getType() == GroupFriendlyURLException.ENDS_WITH_SLASH %>">
@@ -107,7 +107,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 <aui:fieldset label="friendly-url">
 	<liferay-ui:message key="enter-the-friendly-url-that-will-be-used-by-both-public-and-private-pages" />
 
-	<liferay-ui:message arguments="<%= new Object[] {themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPublic(), themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPrivateGroup()} %>" key="the-friendly-url-is-appended-to-x-for-public-pages-and-x-for-private-pages" />
+	<liferay-ui:message arguments="<%= new Object[] {themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPublic(), themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPrivateGroup()} %>" key="the-friendly-url-is-appended-to-x-for-public-pages-and-x-for-private-pages" translateArguments="<%= false %>" />
 
 	<%
 	String taglibLabel = "site-friendly-url";
@@ -127,7 +127,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 <aui:fieldset label="virtual-hosts">
 	<liferay-ui:message key="enter-the-public-and-private-virtual-host-that-will-map-to-the-public-and-private-friendly-url" />
 
-	<liferay-ui:message arguments="<%= new Object[] {HttpUtil.getProtocol(request), themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPublic()} %>" key="for-example,-if-the-public-virtual-host-is-www.helloworld.com-and-the-friendly-url-is-/helloworld" />
+	<liferay-ui:message arguments="<%= new Object[] {HttpUtil.getProtocol(request), themeDisplay.getPortalURL() + themeDisplay.getPathFriendlyURLPublic()} %>" key="for-example,-if-the-public-virtual-host-is-www.helloworld.com-and-the-friendly-url-is-/helloworld" translateArguments="<%= false %>" />
 
 	<aui:input label="public-pages" name="publicVirtualHost" type="text" value="<%= publicVirtualHost %>" />
 

--- a/portal-web/docroot/html/portlet/sites_admin/site/site_url.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/site_url.jsp
@@ -82,7 +82,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 	</c:if>
 
 	<c:if test="<%= gfurle.getType() == GroupFriendlyURLException.KEYWORD_CONFLICT %>">
-		<%= LanguageUtil.format(pageContext, "please-enter-a-friendly-url-that-does-not-conflict-with-the-keyword-x", gfurle.getKeywordConflict()) %>
+		<%= LanguageUtil.format(pageContext, "please-enter-a-friendly-url-that-does-not-conflict-with-the-keyword-x", gfurle.getKeywordConflict(), false) %>
 	</c:if>
 
 	<c:if test="<%= gfurle.getType() == GroupFriendlyURLException.POSSIBLE_DUPLICATE %>">
@@ -181,7 +181,7 @@ String privateVirtualHost = ParamUtil.getString(request, "privateVirtualHost", B
 		boolean directoryIndexingEnabled = PropertiesParamUtil.getBoolean(typeSettingsProperties, request, "directoryIndexingEnabled");
 		%>
 
-		<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "directory-indexing-help", new Object[] {HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale())), themeDisplay.getPortalURL() + "/documents" + group.getFriendlyURL()}) %>' label="directory-indexing-enabled" name="TypeSettingsProperties--directoryIndexingEnabled--" type="checkbox" value="<%= directoryIndexingEnabled %>" />
+		<aui:input helpMessage='<%= LanguageUtil.format(pageContext, "directory-indexing-help", new Object[] {HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale())), themeDisplay.getPortalURL() + "/documents" + group.getFriendlyURL()}, false) %>' label="directory-indexing-enabled" name="TypeSettingsProperties--directoryIndexingEnabled--" type="checkbox" value="<%= directoryIndexingEnabled %>" />
 	</c:if>
 </aui:fieldset>
 

--- a/portal-web/docroot/html/portlet/sites_admin/site/sitemap.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/sitemap.jsp
@@ -49,7 +49,7 @@ if (!host.equals(privateLayoutSet.getVirtualHostname())) {
 	<aui:a href="http://www.sitemaps.org" target="_blank">http://www.sitemaps.org</aui:a>
 </liferay-util:buffer>
 
-<liferay-ui:message key="the-sitemap-protocol-notifies-search-engines-of-the-structure-of-the-website" /> <liferay-ui:message arguments="<%= linkContent %>" key="see-x-for-more-information" />
+<liferay-ui:message key="the-sitemap-protocol-notifies-search-engines-of-the-structure-of-the-website" /> <liferay-ui:message arguments="<%= linkContent %>" key="see-x-for-more-information" translateArguments="<%= false %>" />
 
 <br /><br />
 

--- a/portal-web/docroot/html/portlet/sites_admin/site/sitemap.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/sitemap.jsp
@@ -54,7 +54,7 @@ if (!host.equals(privateLayoutSet.getVirtualHostname())) {
 <br /><br />
 
 <aui:fieldset label="public-pages">
-	<%= LanguageUtil.format(pageContext, "send-sitemap-information-to-preview", new Object[] {"<a target=\"_blank\" href=\"" + publicSitemapUrl + "\">", "</a>"}) %>
+	<%= LanguageUtil.format(pageContext, "send-sitemap-information-to-preview", new Object[] {"<a target=\"_blank\" href=\"" + publicSitemapUrl + "\">", "</a>"}, false) %>
 
 	<ul>
 		<li>
@@ -67,7 +67,7 @@ if (!host.equals(privateLayoutSet.getVirtualHostname())) {
 </aui:fieldset>
 
 <aui:fieldset label="private-pages">
-	<%= LanguageUtil.format(pageContext, "send-sitemap-information-to-preview", new Object[] {"<a target=\"_blank\" href=\"" + privateSitemapUrl + "\">", "</a>"}) %>
+	<%= LanguageUtil.format(pageContext, "send-sitemap-information-to-preview", new Object[] {"<a target=\"_blank\" href=\"" + privateSitemapUrl + "\">", "</a>"}, false) %>
 
 	<ul>
 		<li>

--- a/portal-web/docroot/html/portlet/sites_admin/site/staging.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/staging.jsp
@@ -123,7 +123,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskLoc
 			%>
 
 			<c:if test="<%= le.getType() == LocaleException.TYPE_EXPORT_IMPORT %>">
-				<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-default-language-x-does-not-match-the-portal's-available-languages-x" />
+				<liferay-ui:message arguments="<%= new String[] {StringUtil.merge(le.getSourceAvailableLocales(), StringPool.COMMA_AND_SPACE), StringUtil.merge(le.getTargetAvailableLocales(), StringPool.COMMA_AND_SPACE)} %>" key="the-default-language-x-does-not-match-the-portal's-available-languages-x" translateArguments="<%= false %>" />
 			</c:if>
 		</liferay-ui:error>
 

--- a/portal-web/docroot/html/portlet/sites_admin/site_columns.jspf
+++ b/portal-web/docroot/html/portlet/sites_admin/site_columns.jspf
@@ -55,10 +55,10 @@
 
 	if (organizationUser || userGroupUser) {
 		if (names.size() == 1) {
-			message = LanguageUtil.format(pageContext, "you-are-a-member-of-x-because-you-belong-to-x", new Object[] {HtmlUtil.escape(curGroup.getDescriptiveName(locale)), names.get(0)});
+			message = LanguageUtil.format(pageContext, "you-are-a-member-of-x-because-you-belong-to-x", new Object[] {HtmlUtil.escape(curGroup.getDescriptiveName(locale)), names.get(0)}, false);
 		}
 		else {
-			message = LanguageUtil.format(pageContext, "you-are-a-member-of-x-because-you-belong-to-x-and-x", new Object[] {HtmlUtil.escape(curGroup.getDescriptiveName(locale)), StringUtil.merge(names.subList(0, names.size() - 1).toArray(new String[names.size() - 1]), ", "), names.get(names.size() - 1)});
+			message = LanguageUtil.format(pageContext, "you-are-a-member-of-x-because-you-belong-to-x-and-x", new Object[] {HtmlUtil.escape(curGroup.getDescriptiveName(locale)), StringUtil.merge(names.subList(0, names.size() - 1).toArray(new String[names.size() - 1]), ", "), names.get(names.size() - 1)}, false);
 		}
 	%>
 
@@ -87,7 +87,7 @@
 			buffer.append("<div class=\"subsites-count\"><a href=\"");
 			buffer.append(viewSubsitesURL.toString());
 			buffer.append("\">");
-			buffer.append(LanguageUtil.format(pageContext, childSites.size() == 1 ? "this-site-has-x-child-site" : "this-site-has-x-child-sites", String.valueOf(childSites.size())));
+			buffer.append(LanguageUtil.format(pageContext, childSites.size() == 1 ? "this-site-has-x-child-site" : "this-site-has-x-child-sites", String.valueOf(childSites.size()), false));
 			buffer.append("</a></div>");
 		}
 	}
@@ -116,7 +116,7 @@
 
 	if (usersCount > 0) {
 		buffer.append("<div class=\"user-count\">");
-		buffer.append(LanguageUtil.format(pageContext, usersCount > 1 ? "x-users" : "x-user", usersCount));
+		buffer.append(LanguageUtil.format(pageContext, usersCount > 1 ? "x-users" : "x-user", usersCount, false));
 		buffer.append("</div>");
 	}
 
@@ -129,7 +129,7 @@
 
 	if (organizationsCount > 0) {
 		buffer.append("<div class=\"organization-count\">");
-		buffer.append(LanguageUtil.format(pageContext, organizationsCount > 1 ? "x-organizations" : "x-organization", organizationsCount));
+		buffer.append(LanguageUtil.format(pageContext, organizationsCount > 1 ? "x-organizations" : "x-organization", organizationsCount, false));
 		buffer.append("</div>");
 	}
 
@@ -141,7 +141,7 @@
 
 	if (userGroupsCount > 0) {
 		buffer.append("<div class=\"user-group-count\">");
-		buffer.append(LanguageUtil.format(pageContext, userGroupsCount > 1 ? "x-user-groups" : "x-user-group", userGroupsCount));
+		buffer.append(LanguageUtil.format(pageContext, userGroupsCount > 1 ? "x-user-groups" : "x-user-group", userGroupsCount, false));
 		buffer.append("</div>");
 	}
 

--- a/portal-web/docroot/html/portlet/sites_admin/site_columns.jspf
+++ b/portal-web/docroot/html/portlet/sites_admin/site_columns.jspf
@@ -26,11 +26,11 @@
 		Organization organization = OrganizationLocalServiceUtil.getOrganization(curGroup.getOrganizationId());
 
 		buffer.append("<img align=\"left\" alt=\"");
-		buffer.append(LanguageUtil.format(pageContext, "belongs-to-an-organization-of-type-x", LanguageUtil.get(pageContext, organization.getType())));
+		buffer.append(LanguageUtil.format(pageContext, "belongs-to-an-organization-of-type-x", organization.getType()));
 		buffer.append("\" border=\"0\" style=\"margin: 0px 5px 0px 0px;\" src=\"");
 		buffer.append(curGroup.getIconURL(themeDisplay));
 		buffer.append("\" title=\"");
-		buffer.append(LanguageUtil.format(pageContext, "belongs-to-an-organization-of-type-x", LanguageUtil.get(pageContext, organization.getType())));
+		buffer.append(LanguageUtil.format(pageContext, "belongs-to-an-organization-of-type-x", organization.getType()));
 		buffer.append("\">");
 	}
 	else {

--- a/portal-web/docroot/html/portlet/sites_admin/view.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/view.jsp
@@ -59,7 +59,7 @@ String searchURLString = searchURL.toString();
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
 		%>
 
-		<liferay-ui:message arguments="<%= HtmlUtil.escape(group.getDescriptiveName(locale)) %>" key="site-x-does-not-have-any-private-pages" />
+		<liferay-ui:message arguments="<%= HtmlUtil.escape(group.getDescriptiveName(locale)) %>" key="site-x-does-not-have-any-private-pages" translateArguments="<%= false %>" />
 	</liferay-ui:error>
 
 	<liferay-ui:error exception="<%= RequiredGroupException.class %>">

--- a/portal-web/docroot/html/portlet/sites_admin/view_site_info.jspf
+++ b/portal-web/docroot/html/portlet/sites_admin/view_site_info.jspf
@@ -72,7 +72,7 @@ if (group.getType() == GroupConstants.TYPE_SITE_RESTRICTED) {
 				<liferay-ui:icon
 					image="user_icon"
 					label="<%= true %>"
-					message='<%= LanguageUtil.format(pageContext, (usersCount == 1) ? "x-user" : "x-users", usersCount) %>'
+					message='<%= LanguageUtil.format(pageContext, (usersCount == 1) ? "x-user" : "x-users", usersCount, false) %>'
 					url='<%= HttpUtil.addParameter(assignMembersURL.toString(), "tabs1", "users") %>'
 				/>
 			</c:if>
@@ -81,7 +81,7 @@ if (group.getType() == GroupConstants.TYPE_SITE_RESTRICTED) {
 				<liferay-ui:icon
 					image="organization_icon"
 					label="<%= true %>"
-					message='<%= LanguageUtil.format(pageContext, (organizationsCount == 1) ? "x-organization" : "x-organizations", organizationsCount) %>'
+					message='<%= LanguageUtil.format(pageContext, (organizationsCount == 1) ? "x-organization" : "x-organizations", organizationsCount, false) %>'
 					url='<%= HttpUtil.addParameter(assignMembersURL.toString(), "tabs1", "organizations") %>'
 				/>
 			</c:if>
@@ -90,7 +90,7 @@ if (group.getType() == GroupConstants.TYPE_SITE_RESTRICTED) {
 				<liferay-ui:icon
 					image="group"
 					label="<%= true %>"
-					message='<%= LanguageUtil.format(pageContext, (userGroupsCount == 1) ? "x-user-groups" : "x-user-groups", userGroupsCount) %>'
+					message='<%= LanguageUtil.format(pageContext, (userGroupsCount == 1) ? "x-user-groups" : "x-user-groups", userGroupsCount, false) %>'
 					url='<%= HttpUtil.addParameter(assignMembersURL.toString(), "tabs1", "user-groups") %>'
 				/>
 			</c:if>
@@ -111,7 +111,7 @@ if (group.getType() == GroupConstants.TYPE_SITE_RESTRICTED) {
 				<liferay-ui:icon
 					image="manage_task"
 					label="<%= true %>"
-					message='<%= LanguageUtil.format(pageContext, (pendingRequests == 1) ? "x-request-pending" : "x-requests-pending", pendingRequests) %>'
+					message='<%= LanguageUtil.format(pageContext, (pendingRequests == 1) ? "x-request-pending" : "x-requests-pending", pendingRequests, false) %>'
 					url="<%= viewMembershipRequestsURL %>"
 				/>
 			</dd>

--- a/portal-web/docroot/html/portlet/sites_admin/view_site_info.jspf
+++ b/portal-web/docroot/html/portlet/sites_admin/view_site_info.jspf
@@ -53,7 +53,7 @@ if (group.getType() == GroupConstants.TYPE_SITE_RESTRICTED) {
 	%>
 
 	<div class="organizations-msg-info portlet-msg">
-		<liferay-ui:message arguments="<%= new String[] {groupOrganization.getName(), LanguageUtil.get(pageContext, groupOrganization.getType())} %>" key="this-site-belongs-to-x-which-is-an-organization-of-type-x" />
+		<liferay-ui:message arguments="<%= new String[] {groupOrganization.getName(), LanguageUtil.get(pageContext, groupOrganization.getType())} %>" key="this-site-belongs-to-x-which-is-an-organization-of-type-x" translateArguments="<%= false %>" />
 	</div>
 </c:if>
 

--- a/portal-web/docroot/html/portlet/staging_bar/last_publication_date_message.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/last_publication_date_message.jsp
@@ -89,7 +89,7 @@ if (Validator.isNull(publisherName)) {
 	<c:when test="<%= lastImportDate > 0 %>">
 		<c:if test="<%= Validator.isNotNull(lastImportLayoutSetBranchName) && Validator.isNotNull(publisherName) %>">
 			<span class="last-publication-branch">
-				<liferay-ui:message arguments='<%= new String[] {"<strong>" + HtmlUtil.escape(layout.getName(locale)) + "</strong>", "<em>" + LanguageUtil.get(pageContext, HtmlUtil.escape(lastImportLayoutSetBranchName)) + "</em>"} %>' key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "page-x-was-last-published-to-live" : "page-x-was-last-published-from-x" %>' />
+				<liferay-ui:message arguments='<%= new String[] {"<strong>" + HtmlUtil.escape(layout.getName(locale)) + "</strong>", "<em>" + LanguageUtil.get(pageContext, HtmlUtil.escape(lastImportLayoutSetBranchName)) + "</em>"} %>' key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "page-x-was-last-published-to-live" : "page-x-was-last-published-from-x" %>' translateArguments="<%= false %>" />
 
 				<c:if test="<%= (Validator.isNotNull(lastImportLayoutBranchName) && (layoutRevisions.size() > 1)) || Validator.isNotNull(lastImportLayoutRevisionId) %>">
 					<span class="last-publication-variation-details">(
@@ -109,17 +109,17 @@ if (Validator.isNull(publisherName)) {
 			</span>
 
 			<span class="last-publication-user">
-				<liferay-ui:message arguments="<%= new String[] {LanguageUtil.getTimeDescription(pageContext, (System.currentTimeMillis() - lastImportDate), true), HtmlUtil.escape(publisherName)} %>" key="x-ago-by-x" />
+				<liferay-ui:message arguments="<%= new String[] {LanguageUtil.getTimeDescription(pageContext, (System.currentTimeMillis() - lastImportDate), true), HtmlUtil.escape(publisherName)} %>" key="x-ago-by-x" translateArguments="<%= false %>" />
 			</span>
 		</c:if>
 	</c:when>
 	<c:otherwise>
 		<span class="staging-live-group-name">
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key="x-is-staged" />
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key="x-is-staged" translateArguments="<%= false %>" />
 		</span>
 
 		<span class="staging-live-help">
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "staging-staging-help-x" : "staging-live-help-x" %>' />
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(liveGroup.getDescriptiveName(locale)) %>" key='<%= (group.isStagingGroup() || group.isStagedRemotely()) ? "staging-staging-help-x" : "staging-live-help-x" %>' translateArguments="<%= false %>" />
 		</span>
 	</c:otherwise>
 </c:choose>

--- a/portal-web/docroot/html/portlet/staging_bar/merge_layout_set_branch.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/merge_layout_set_branch.jsp
@@ -72,7 +72,7 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 					buffer.append("' data-layoutSetBranchName='");
 					buffer.append(HtmlUtil.escapeAttribute(curLayoutSetBranch.getName()));
 					buffer.append("' data-layoutSetBranchMessage='");
-					buffer.append(HtmlUtil.escapeAttribute(LanguageUtil.format(pageContext, "are-you-sure-you-want-to-merge-changes-from-x", curLayoutSetBranch.getName())));
+					buffer.append(HtmlUtil.escapeAttribute(LanguageUtil.format(pageContext, "are-you-sure-you-want-to-merge-changes-from-x", curLayoutSetBranch.getName(), false)));
 					buffer.append("' href='#'>");
 					buffer.append(LanguageUtil.get(pageContext, "select"));
 					buffer.append("</a>");

--- a/portal-web/docroot/html/portlet/staging_bar/view.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view.jsp
@@ -126,7 +126,7 @@ if (layout != null) {
 											<c:choose>
 												<c:when test="<%= liveLayout == null %>">
 													<span class="last-publication-branch">
-														<liferay-ui:message arguments='<%= "<strong>" + HtmlUtil.escape(layout.getName(locale)) + "</strong>" %>' key="page-x-has-not-been-published-to-live-yet" />
+														<liferay-ui:message arguments='<%= "<strong>" + HtmlUtil.escape(layout.getName(locale)) + "</strong>" %>' key="page-x-has-not-been-published-to-live-yet" translateArguments="<%= false %>" />
 													</span>
 												</c:when>
 												<c:otherwise>

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_branches.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_branches.jsp
@@ -54,11 +54,11 @@ request.setAttribute("view_layout_branches.jsp-currenttLayoutBranchId", String.v
 	</c:if>
 
 	<c:if test="<%= lbne.getType() == LayoutBranchNameException.TOO_LONG %>">
-		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" />
+		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= lbne.getType() == LayoutBranchNameException.TOO_SHORT %>">
-		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" />
+		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" translateArguments="<%= false %>" />
 	</c:if>
 </liferay-ui:error>
 

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_revision_details.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_revision_details.jsp
@@ -40,7 +40,7 @@ if (workflowEnabled) {
 String taglibHelpMessage = null;
 
 if (layoutRevision.isHead()) {
-	taglibHelpMessage = LanguageUtil.format(pageContext, "this-version-will-be-published-when-x-is-published-to-live", HtmlUtil.escape(layoutSetBranch.getName()));
+	taglibHelpMessage = LanguageUtil.format(pageContext, "this-version-will-be-published-when-x-is-published-to-live", HtmlUtil.escape(layoutSetBranch.getName()), false);
 }
 else if (hasWorkflowTask) {
 	taglibHelpMessage = "you-are-currently-reviewing-this-page.-you-can-make-changes-and-send-them-to-the-next-step-in-the-workflow-when-ready";
@@ -179,7 +179,7 @@ else {
 			String label = null;
 
 			if (layoutRevision.isIncomplete()) {
-				label = LanguageUtil.format(pageContext, "enable-in-x", layoutSetBranch.getName());
+				label = LanguageUtil.format(pageContext, "enable-in-x", layoutSetBranch.getName(), false);
 			}
 			else {
 				if (workflowEnabled) {

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_revision_details.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_revision_details.jsp
@@ -171,7 +171,7 @@ else {
 		<c:if test="<%= !layoutRevision.isHead() && LayoutPermissionUtil.contains(permissionChecker, layoutRevision.getPlid(), ActionKeys.UPDATE) %>">
 			<c:if test="<%= layoutRevision.isIncomplete() %>">
 				<p>
-					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(layoutRevision.getName(locale)), HtmlUtil.escape(layoutSetBranch.getName())} %>" key="the-page-x-is-not-enabled-in-x,-but-is-available-in-other-pages-variations" />
+					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(layoutRevision.getName(locale)), HtmlUtil.escape(layoutSetBranch.getName())} %>" key="the-page-x-is-not-enabled-in-x,-but-is-available-in-other-pages-variations" translateArguments="<%= false %>" />
 				</p>
 			</c:if>
 

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_revisions.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_revisions.jsp
@@ -104,7 +104,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 						}
 
 						buffer.append("<span class=\"approximate-date\">");
-						buffer.append(LanguageUtil.format(pageContext, "x-ago", LanguageUtil.getTimeDescription(pageContext, timeAgo, true)));
+						buffer.append(LanguageUtil.format(pageContext, "x-ago", LanguageUtil.getTimeDescription(pageContext, timeAgo, true), false));
 						buffer.append("</span><span class=\"real-date\">");
 						buffer.append(dateFormatDateTime.format(curLayoutRevision.getCreateDate()));
 						buffer.append("</span>");

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_set_branch_details.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_set_branch_details.jsp
@@ -29,7 +29,7 @@ String stagingFriendlyURL = (String)request.getAttribute("view.jsp-stagingFriend
 			<liferay-util:buffer var="taglibMessage">
 				<liferay-ui:message key="<%= HtmlUtil.escape(layoutSetBranch.getName()) %>" />
 
-				<small>(<liferay-ui:message arguments="<%= layouts.size() %>" key='<%= (layouts.size() == 1) ? "1-page" : "x-pages" %>' />)</small>
+				<small>(<liferay-ui:message arguments="<%= layouts.size() %>" key='<%= (layouts.size() == 1) ? "1-page" : "x-pages" %>' translateArguments="<%= false %>" />)</small>
 			</liferay-util:buffer>
 
 			<c:choose>

--- a/portal-web/docroot/html/portlet/staging_bar/view_layout_set_branches.jsp
+++ b/portal-web/docroot/html/portlet/staging_bar/view_layout_set_branches.jsp
@@ -44,11 +44,11 @@ request.setAttribute("view_layout_set_branches.jsp-currentLayoutSetBranchId", St
 	</c:if>
 
 	<c:if test="<%= lsbne.getType() == LayoutSetBranchNameException.TOO_LONG %>">
-		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" />
+		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" translateArguments="<%= false %>" />
 	</c:if>
 
 	<c:if test="<%= lsbne.getType() == LayoutSetBranchNameException.TOO_SHORT %>">
-		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" />
+		<liferay-ui:message arguments="<%= new Object[] {4, 100} %>" key="please-enter-a-value-between-x-and-x-characters-long" translateArguments="<%= false %>" />
 	</c:if>
 </liferay-ui:error>
 

--- a/portal-web/docroot/html/portlet/trash/restore_entry.jsp
+++ b/portal-web/docroot/html/portlet/trash/restore_entry.jsp
@@ -48,7 +48,7 @@ String renameMessage = ParamUtil.getString(request, "renameMessage");
 %>
 
 <div class="alert alert-block" id="<portlet:namespace />messageContainer">
-	<liferay-ui:message arguments="<%= new String[] {oldName} %>" key="an-entry-with-name-x-already-exists" />
+	<liferay-ui:message arguments="<%= new String[] {oldName} %>" key="an-entry-with-name-x-already-exists" translateArguments="<%= false %>" />
 </div>
 
 <portlet:actionURL var="restoreActionURL">

--- a/portal-web/docroot/html/portlet/trash/restore_path.jsp
+++ b/portal-web/docroot/html/portlet/trash/restore_path.jsp
@@ -51,7 +51,7 @@
 						<em class="restore-entry-title"><aui:a href="<%= restoreLinks.get(i) %>" label="<%= HtmlUtil.escape(restoreMessages.get(i)) %>" /></em>
 					</liferay-util:buffer>
 
-					<liferay-ui:message arguments="<%= new Object[] {type, entityLink.trim(), link.trim()} %>" key="the-x-x-was-restored-to-x" />
+					<liferay-ui:message arguments="<%= new Object[] {type, entityLink.trim(), link.trim()} %>" key="the-x-x-was-restored-to-x" translateArguments="<%= false %>" />
 
 				<%
 				}

--- a/portal-web/docroot/html/portlet/trash/view.jsp
+++ b/portal-web/docroot/html/portlet/trash/view.jsp
@@ -127,7 +127,7 @@ if (Validator.isNotNull(keywords)) {
 		searchContainer.setResults(results);
 
 		if ((searchContainer.getTotal() == 0) && Validator.isNotNull(searchTerms.getKeywords())) {
-			searchContainer.setEmptyResultsMessage(LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(searchTerms.getKeywords()) + "</strong>"));
+			searchContainer.setEmptyResultsMessage(LanguageUtil.format(pageContext, "no-entries-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(searchTerms.getKeywords()) + "</strong>", false));
 		}
 		%>
 

--- a/portal-web/docroot/html/portlet/trash/view.jsp
+++ b/portal-web/docroot/html/portlet/trash/view.jsp
@@ -215,7 +215,7 @@ if (Validator.isNotNull(keywords)) {
 					/>
 				</liferay-util:buffer>
 
-				<span class="trash-root-entry">(<liferay-ui:message arguments="<%= rootEntryIcon %>" key="<%= rootTrashHandler.getDeleteMessage() %>" />)</span>
+				<span class="trash-root-entry">(<liferay-ui:message arguments="<%= rootEntryIcon %>" key="<%= rootTrashHandler.getDeleteMessage() %>" translateArguments="<%= false %>" />)</span>
 			</c:if>
 		</liferay-ui:search-container-column-text>
 

--- a/portal-web/docroot/html/portlet/trash/view_container_model.jsp
+++ b/portal-web/docroot/html/portlet/trash/view_container_model.jsp
@@ -45,7 +45,7 @@ TrashUtil.addContainerModelBreadcrumbEntries(request, trashHandler.getContainerM
 %>
 
 <div class="alert alert-block">
-	<liferay-ui:message arguments="<%= new Object[] {trashHandler.getContainerModelName(), trashRenderer.getTitle(locale)} %>" key="the-original-x-does-not-exist-anymore" />
+	<liferay-ui:message arguments="<%= new Object[] {trashHandler.getContainerModelName(), trashRenderer.getTitle(locale)} %>" key="the-original-x-does-not-exist-anymore" translateArguments="<%= false %>" />
 </div>
 
 <aui:form method="post" name="selectFolderFm">

--- a/portal-web/docroot/html/portlet/trash/view_container_model.jsp
+++ b/portal-web/docroot/html/portlet/trash/view_container_model.jsp
@@ -51,7 +51,7 @@ TrashUtil.addContainerModelBreadcrumbEntries(request, trashHandler.getContainerM
 <aui:form method="post" name="selectFolderFm">
 	<liferay-ui:header
 		showBackURL="<%= containerModel != null %>"
-		title='<%= LanguageUtil.format(pageContext, "select-x", trashHandler.getContainerModelName(), true) %>'
+		title='<%= LanguageUtil.format(pageContext, "select-x", trashHandler.getContainerModelName()) %>'
 	/>
 
 	<liferay-ui:breadcrumb showGuestGroup="<%= false %>" showLayout="<%= false %>" showParentGroups="<%= false %>" />
@@ -66,7 +66,7 @@ TrashUtil.addContainerModelBreadcrumbEntries(request, trashHandler.getContainerM
 		data.put("containermodelid", containerModelId);
 		%>
 
-		<aui:button cssClass="selector-button" data="<%= data %>" value='<%= LanguageUtil.format(pageContext, "choose-this-x", trashHandler.getContainerModelName(), true) %>' />
+		<aui:button cssClass="selector-button" data="<%= data %>" value='<%= LanguageUtil.format(pageContext, "choose-this-x", trashHandler.getContainerModelName()) %>' />
 	</aui:button-row>
 
 	<br />
@@ -119,7 +119,7 @@ TrashUtil.addContainerModelBreadcrumbEntries(request, trashHandler.getContainerM
 			</liferay-ui:search-container-column-text>
 
 			<liferay-ui:search-container-column-text
-				name='<%= LanguageUtil.format(pageContext, "num-of-x", trashHandler.getContainerModelName(), true) %>'
+				name='<%= LanguageUtil.format(pageContext, "num-of-x", trashHandler.getContainerModelName()) %>'
 				value="<%= String.valueOf(trashHandler.getContainerModelsCount(classPK, curContainerModel.getContainerModelId())) %>"
 			/>
 

--- a/portal-web/docroot/html/portlet/trash/view_content.jsp
+++ b/portal-web/docroot/html/portlet/trash/view_content.jsp
@@ -212,7 +212,7 @@
 
 				<c:if test="<%= (containerModelsCount + baseModelsCount) == 0 %>">
 					<div class="alert alert-info">
-						<liferay-ui:message arguments="<%= new String[] {ResourceActionsUtil.getModelResource(locale, className)} %>" key="this-x-does-not-contain-an-entry" />
+						<liferay-ui:message arguments="<%= new String[] {ResourceActionsUtil.getModelResource(locale, className)} %>" key="this-x-does-not-contain-an-entry" translateArguments="<%= false %>" />
 					</div>
 				</c:if>
 			</liferay-ui:panel-container>

--- a/portal-web/docroot/html/portlet/trash/view_content.jsp
+++ b/portal-web/docroot/html/portlet/trash/view_content.jsp
@@ -141,12 +141,12 @@
 								</liferay-ui:search-container-column-text>
 
 								<liferay-ui:search-container-column-text
-									name='<%= LanguageUtil.format(pageContext, "num-of-x", curTrashHandler.getTrashContainedModelName(), true) %>'
+									name='<%= LanguageUtil.format(pageContext, "num-of-x", curTrashHandler.getTrashContainedModelName()) %>'
 									value="<%= String.valueOf(curBaseModelsCount) %>"
 								/>
 
 								<liferay-ui:search-container-column-text
-									name='<%= LanguageUtil.format(pageContext, "num-of-x", curTrashHandler.getTrashContainerModelName(), true) %>'
+									name='<%= LanguageUtil.format(pageContext, "num-of-x", curTrashHandler.getTrashContainerModelName()) %>'
 									value="<%= String.valueOf(curContainerModelsCount) %>"
 								/>
 

--- a/portal-web/docroot/html/portlet/user_groups_admin/edit_user_group.jsp
+++ b/portal-web/docroot/html/portlet/user_groups_admin/edit_user_group.jsp
@@ -174,7 +174,7 @@ long userGroupId = BeanParamUtil.getLong(userGroup, request, "userGroupId");
 
 								<c:choose>
 									<c:when test="<%= (publicLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
-										<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
+										<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 									</c:when>
 									<c:when test="<%= publicLayoutSetPrototype != null %>">
 										<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
@@ -244,7 +244,7 @@ long userGroupId = BeanParamUtil.getLong(userGroup, request, "userGroupId");
 
 								<c:choose>
 									<c:when test="<%= (privateLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
-										<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
+										<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 									</c:when>
 									<c:when test="<%= privateLayoutSetPrototype != null %>">
 										<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />

--- a/portal-web/docroot/html/portlet/user_groups_admin/edit_user_group.jsp
+++ b/portal-web/docroot/html/portlet/user_groups_admin/edit_user_group.jsp
@@ -177,7 +177,7 @@ long userGroupId = BeanParamUtil.getLong(userGroup, request, "userGroupId");
 										<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 									</c:when>
 									<c:when test="<%= publicLayoutSetPrototype != null %>">
-										<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+										<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 										<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 									</c:when>
@@ -247,7 +247,7 @@ long userGroupId = BeanParamUtil.getLong(userGroup, request, "userGroupId");
 										<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 									</c:when>
 									<c:when test="<%= privateLayoutSetPrototype != null %>">
-										<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+										<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 										<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 									</c:when>

--- a/portal-web/docroot/html/portlet/user_groups_admin/user_group_action.jsp
+++ b/portal-web/docroot/html/portlet/user_groups_admin/user_group_action.jsp
@@ -64,7 +64,7 @@ UserGroup userGroup = (UserGroup)row.getObject();
 	<c:if test="<%= hasPermissionsPermission %>">
 		<liferay-security:permissionsURL
 			modelResource="<%= Group.class.getName() %>"
-			modelResourceDescription='<%= LanguageUtil.format(pageContext, "site-for-user-group-x", userGroup.getName()) %>'
+			modelResourceDescription='<%= LanguageUtil.format(pageContext, "site-for-user-group-x", userGroup.getName(), false) %>'
 			resourcePrimKey="<%= String.valueOf(userGroup.getGroup().getGroupId()) %>"
 			var="permissionsURL"
 		/>

--- a/portal-web/docroot/html/portlet/user_statistics/view.jsp
+++ b/portal-web/docroot/html/portlet/user_statistics/view.jsp
@@ -81,7 +81,7 @@ if (!rankingNamesList.isEmpty()) {
 	<c:if test="<%= showHeaderText %>">
 		<div class="top-users">
 			<c:if test="<%= total > 0 %>">
-				<liferay-ui:message arguments="<%= total %>" key="top-users-out-of-x" /> <%= LanguageUtil.format(pageContext, "ranking-is-based-on-x", rankingNamesMessage, false) %><br />
+				<liferay-ui:message arguments="<%= total %>" key="top-users-out-of-x" translateArguments="<%= false %>" /> <%= LanguageUtil.format(pageContext, "ranking-is-based-on-x", rankingNamesMessage, false) %><br />
 			</c:if>
 		</div>
 	</c:if>

--- a/portal-web/docroot/html/portlet/user_statistics/view.jsp
+++ b/portal-web/docroot/html/portlet/user_statistics/view.jsp
@@ -22,11 +22,11 @@ PortletURL portletURL = renderResponse.createRenderURL();
 List<String> rankingNamesList = new ArrayList<String>();
 
 if (rankByParticipation) {
-	rankingNamesList.add(LanguageUtil.get(pageContext, SocialActivityCounterConstants.NAME_PARTICIPATION));
+	rankingNamesList.add(SocialActivityCounterConstants.NAME_PARTICIPATION);
 }
 
 if (rankByContribution) {
-	rankingNamesList.add(LanguageUtil.get(pageContext, SocialActivityCounterConstants.NAME_CONTRIBUTION));
+	rankingNamesList.add(SocialActivityCounterConstants.NAME_CONTRIBUTION);
 }
 
 String[] rankingNames = rankingNamesList.toArray(new String[rankingNamesList.size()]);
@@ -74,7 +74,7 @@ if (!rankingNamesList.isEmpty()) {
 	String rankingNamesMessage = LanguageUtil.format(pageContext, rankingNames[0], StringPool.BLANK, false);
 
 	for (int i = 1; i < rankingNames.length; i++) {
-		rankingNamesMessage = LanguageUtil.format(pageContext, "x-and-y", new Object[] {rankingNamesMessage, rankingNames[i]}, false);
+		rankingNamesMessage = LanguageUtil.format(pageContext, "x-and-y", new Object[] {rankingNamesMessage, rankingNames[i]});
 	}
 	%>
 

--- a/portal-web/docroot/html/portlet/user_statistics/view.jsp
+++ b/portal-web/docroot/html/portlet/user_statistics/view.jsp
@@ -22,11 +22,11 @@ PortletURL portletURL = renderResponse.createRenderURL();
 List<String> rankingNamesList = new ArrayList<String>();
 
 if (rankByParticipation) {
-	rankingNamesList.add(SocialActivityCounterConstants.NAME_PARTICIPATION);
+	rankingNamesList.add(LanguageUtil.get(pageContext, SocialActivityCounterConstants.NAME_PARTICIPATION));
 }
 
 if (rankByContribution) {
-	rankingNamesList.add(SocialActivityCounterConstants.NAME_CONTRIBUTION);
+	rankingNamesList.add(LanguageUtil.get(pageContext, SocialActivityCounterConstants.NAME_CONTRIBUTION));
 }
 
 String[] rankingNames = rankingNamesList.toArray(new String[rankingNamesList.size()]);
@@ -71,17 +71,17 @@ if (!rankingNamesList.isEmpty()) {
 		resultRows.add(row);
 	}
 
-	String rankingNamesMessage = LanguageUtil.format(pageContext, rankingNames[0], StringPool.BLANK);
+	String rankingNamesMessage = LanguageUtil.format(pageContext, rankingNames[0], StringPool.BLANK, false);
 
 	for (int i = 1; i < rankingNames.length; i++) {
-		rankingNamesMessage = LanguageUtil.format(pageContext, "x-and-y", new Object[] {rankingNamesMessage, rankingNames[i]});
+		rankingNamesMessage = LanguageUtil.format(pageContext, "x-and-y", new Object[] {rankingNamesMessage, rankingNames[i]}, false);
 	}
 	%>
 
 	<c:if test="<%= showHeaderText %>">
 		<div class="top-users">
 			<c:if test="<%= total > 0 %>">
-				<liferay-ui:message arguments="<%= total %>" key="top-users-out-of-x" /> <%= LanguageUtil.format(pageContext, "ranking-is-based-on-x", rankingNamesMessage) %><br />
+				<liferay-ui:message arguments="<%= total %>" key="top-users-out-of-x" /> <%= LanguageUtil.format(pageContext, "ranking-is-based-on-x", rankingNamesMessage, false) %><br />
 			</c:if>
 		</div>
 	</c:if>

--- a/portal-web/docroot/html/portlet/users_admin/edit_organization.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/edit_organization.jsp
@@ -63,10 +63,10 @@ else if (parentOrganizationId > 0) {
 String headerTitle = null;
 
 if (organization != null) {
-	headerTitle = LanguageUtil.format(pageContext, "edit-x", organization.getName());
+	headerTitle = LanguageUtil.format(pageContext, "edit-x", organization.getName(), false);
 }
 else if (Validator.isNotNull(type)) {
-	headerTitle = LanguageUtil.format(pageContext, "add-x", type);
+	headerTitle = LanguageUtil.format(pageContext, "add-x", type, false);
 }
 else {
 	headerTitle = LanguageUtil.get(pageContext, "add-organization");

--- a/portal-web/docroot/html/portlet/users_admin/edit_user.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/edit_user.jsp
@@ -205,7 +205,7 @@ if (selUser != null) {
 		backURL="<%= backURL %>"
 		escapeXml="<%= false %>"
 		localizeTitle="<%= (selUser == null) %>"
-		title='<%= (selUser == null) ? "add-user" : LanguageUtil.format(pageContext, "edit-user-x", HtmlUtil.escape(selUser.getFullName())) %>'
+		title='<%= (selUser == null) ? "add-user" : LanguageUtil.format(pageContext, "edit-user-x", HtmlUtil.escape(selUser.getFullName()), false) %>'
 	/>
 </c:if>
 

--- a/portal-web/docroot/html/portlet/users_admin/organization/organization_columns.jspf
+++ b/portal-web/docroot/html/portlet/users_admin/organization/organization_columns.jspf
@@ -50,7 +50,7 @@
 		buffer.append("<br /><em class=\"organization-details\">");
 
 		if (suborganizationsCount > 0) {
-			buffer.append((suborganizationsCount == 1) ? LanguageUtil.format(pageContext, "x-suborganization", String.valueOf(suborganizationsCount)) : LanguageUtil.format(pageContext, "x-suborganizations", String.valueOf(suborganizationsCount)));
+			buffer.append((suborganizationsCount == 1) ? LanguageUtil.format(pageContext, "x-suborganization", String.valueOf(suborganizationsCount), false) : LanguageUtil.format(pageContext, "x-suborganizations", String.valueOf(suborganizationsCount), false));
 		}
 
 		if ((suborganizationsCount > 0) && (organizationUserCount > 0)) {
@@ -58,7 +58,7 @@
 		}
 
 		if (organizationUserCount > 0) {
-			buffer.append((organizationUserCount == 1) ? LanguageUtil.format(pageContext, "x-user", String.valueOf(organizationUserCount)) : LanguageUtil.format(pageContext, "x-users", String.valueOf(organizationUserCount)));
+			buffer.append((organizationUserCount == 1) ? LanguageUtil.format(pageContext, "x-user", String.valueOf(organizationUserCount), false) : LanguageUtil.format(pageContext, "x-users", String.valueOf(organizationUserCount), false));
 		}
 
 		buffer.append("</em>");

--- a/portal-web/docroot/html/portlet/users_admin/organization/organization_site.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/organization/organization_site.jsp
@@ -158,7 +158,7 @@ if (organization != null) {
 											<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 										</c:when>
 										<c:when test="<%= publicLayoutSetPrototype != null %>">
-											<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+											<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 											<aui:input name="publicLayoutSetPrototypeLinkEnabled" type="hidden" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 										</c:when>
@@ -234,7 +234,7 @@ if (organization != null) {
 											<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 										</c:when>
 										<c:when test="<%= privateLayoutSetPrototype != null %>">
-											<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+											<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 											<aui:input name="privateLayoutSetPrototypeLinkEnabled" type="hidden" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 										</c:when>

--- a/portal-web/docroot/html/portlet/users_admin/organization/organization_site.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/organization/organization_site.jsp
@@ -155,7 +155,7 @@ if (organization != null) {
 
 									<c:choose>
 										<c:when test="<%= (publicLayoutSetPrototype != null) && !organizationGroup.isStaged() && hasUnlinkLayoutSetPrototypePermission %>">
-											<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
+											<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 										</c:when>
 										<c:when test="<%= publicLayoutSetPrototype != null %>">
 											<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
@@ -231,7 +231,7 @@ if (organization != null) {
 
 									<c:choose>
 										<c:when test="<%= (privateLayoutSetPrototype != null) && !organizationGroup.isStaged() && hasUnlinkLayoutSetPrototypePermission %>">
-											<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
+											<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 										</c:when>
 										<c:when test="<%= privateLayoutSetPrototype != null %>">
 											<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />

--- a/portal-web/docroot/html/portlet/users_admin/organization_action.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/organization_action.jsp
@@ -163,7 +163,7 @@ if (row == null) {
 
 				<liferay-ui:icon
 					image="add_location"
-					message='<%= LanguageUtil.format(pageContext, "add-x", new String [] {LanguageUtil.get(pageContext, childrenType)}) %>'
+					message='<%= LanguageUtil.format(pageContext, "add-x", new String [] {childrenType}) %>'
 					url="<%= addSuborganizationURL %>"
 				/>
 			</c:if>

--- a/portal-web/docroot/html/portlet/users_admin/user/announcements_checkbox.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/announcements_checkbox.jsp
@@ -51,7 +51,7 @@ else if (index == 3) {
 	disabled="<%= disabled %>"
 	label=""
 	name="<%= param %>"
-	title="<%= LanguageUtil.format(pageContext, messageKey, delivery.getType(), true) %>"
+	title="<%= LanguageUtil.format(pageContext, messageKey, delivery.getType()) %>"
 	type="checkbox"
 	value="<%= defaultValue %>"
 />

--- a/portal-web/docroot/html/portlet/users_admin/user/details.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/details.jsp
@@ -76,7 +76,7 @@ if (selContact != null) {
 			}
 			%>
 
-			<liferay-ui:message arguments="<%= sb.toString() %>" key="your-portal-administrator-has-disabled-the-ability-to-modify-the-following-fields" />
+			<liferay-ui:message arguments="<%= sb.toString() %>" key="your-portal-administrator-has-disabled-the-ability-to-modify-the-following-fields" translateArguments="<%= false %>" />
 		</liferay-ui:error>
 
 		<liferay-ui:error exception="<%= UserScreenNameException.class %>" focusField="screenName" message="please-enter-a-valid-screen-name" />

--- a/portal-web/docroot/html/portlet/users_admin/user/personal_site.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/personal_site.jsp
@@ -136,7 +136,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:when test="<%= publicLayoutSetPrototype != null %>">
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:when>
@@ -208,7 +208,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:when test="<%= privateLayoutSetPrototype != null %>">
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
+									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:when>

--- a/portal-web/docroot/html/portlet/users_admin/user/personal_site.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/personal_site.jsp
@@ -133,7 +133,7 @@ if (selUser != null) {
 						<c:if test="<%= PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED %>">
 							<c:choose>
 								<c:when test="<%= (publicLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
-									<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
+									<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:when test="<%= publicLayoutSetPrototype != null %>">
 									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />
@@ -205,7 +205,7 @@ if (selUser != null) {
 						<c:if test="<%= PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED %>">
 							<c:choose>
 								<c:when test="<%= (privateLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
-									<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId()))) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
+									<aui:input label='<%= LanguageUtil.format(pageContext, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(user.getLanguageId())), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:when test="<%= privateLayoutSetPrototype != null %>">
 									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" />

--- a/portal-web/docroot/html/portlet/users_admin/view_tree.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/view_tree.jsp
@@ -255,10 +255,10 @@ if (organization != null) {
 								organizationsTitle = LanguageUtil.get(pageContext, filterManageableOrganizations ? "my-organizations" : "top-level-organizations");
 							}
 							else if (organizationsCount == 1) {
-								organizationsTitle = LanguageUtil.format(pageContext, "x-suborganization", String.valueOf(organizationsCount));
+								organizationsTitle = LanguageUtil.format(pageContext, "x-suborganization", String.valueOf(organizationsCount), false);
 							}
 							else {
-								organizationsTitle = LanguageUtil.format(pageContext, "x-suborganizations", String.valueOf(organizationsCount));
+								organizationsTitle = LanguageUtil.format(pageContext, "x-suborganizations", String.valueOf(organizationsCount), false);
 							}
 							%>
 
@@ -401,10 +401,10 @@ if (organization != null) {
 							}
 							else {
 								if ((active && (usersCount == 1)) || (!active && (inactiveUsersCount == 1))) {
-									usersTitle = LanguageUtil.format(pageContext, (active ? "x-user" : "x-inactive-user"), String.valueOf((active ? usersCount : inactiveUsersCount)));
+									usersTitle = LanguageUtil.format(pageContext, (active ? "x-user" : "x-inactive-user"), String.valueOf((active ? usersCount : inactiveUsersCount)), false);
 								}
 								else {
-									usersTitle = LanguageUtil.format(pageContext, (active ? "x-users" : "x-inactive-users"), String.valueOf((active ? usersCount : inactiveUsersCount)));
+									usersTitle = LanguageUtil.format(pageContext, (active ? "x-users" : "x-inactive-users"), String.valueOf((active ? usersCount : inactiveUsersCount)), false);
 								}
 							}
 							%>

--- a/portal-web/docroot/html/portlet/wiki/edit_page.jsp
+++ b/portal-web/docroot/html/portlet/wiki/edit_page.jsp
@@ -464,7 +464,7 @@ if (Validator.isNull(redirect)) {
 					Format dateFormatDate = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 					%>
 
-					<%= LanguageUtil.format(pageContext, "this-page-cannot-be-edited-because-user-x-is-modifying-it-and-the-results-have-not-been-published-yet", new Object[] {wikiPage.getUserName(), dateFormatDate.format(wikiPage.getModifiedDate())}) %>
+					<%= LanguageUtil.format(pageContext, "this-page-cannot-be-edited-because-user-x-is-modifying-it-and-the-results-have-not-been-published-yet", new Object[] {wikiPage.getUserName(), dateFormatDate.format(wikiPage.getModifiedDate())}, false) %>
 				</div>
 			</c:if>
 		</c:otherwise>

--- a/portal-web/docroot/html/portlet/wiki/edit_page_attachment.jsp
+++ b/portal-web/docroot/html/portlet/wiki/edit_page_attachment.jsp
@@ -60,7 +60,7 @@ WikiPage wikiPage = (WikiPage)request.getAttribute(WebKeys.WIKI_PAGE);
 		fileMaxSize /= 1024;
 		%>
 
-		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" />
+		<liferay-ui:message arguments="<%= fileMaxSize %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 	</liferay-ui:error>
 
 	<div class="lfr-dynamic-uploader">

--- a/portal-web/docroot/html/portlet/wiki/error.jsp
+++ b/portal-web/docroot/html/portlet/wiki/error.jsp
@@ -105,13 +105,13 @@
 				String taglibSearch = "location.href = '" + searchURL.toString() + "';";
 				%>
 
-				<aui:button onClick="<%= taglibSearch %>" value='<%= LanguageUtil.format(pageContext, "search-for-x", HtmlUtil.escapeAttribute(title)) %>' />
+				<aui:button onClick="<%= taglibSearch %>" value='<%= LanguageUtil.format(pageContext, "search-for-x", HtmlUtil.escapeAttribute(title), false) %>' />
 
 				<%
 				String taglibEditPage = "location.href = '" + editPageURL.toString() + "';";
 				%>
 
-				<aui:button onClick="<%= taglibEditPage %>" value='<%= LanguageUtil.format(pageContext, "create-page-x", HtmlUtil.escapeAttribute(title)) %>' />
+				<aui:button onClick="<%= taglibEditPage %>" value='<%= LanguageUtil.format(pageContext, "create-page-x", HtmlUtil.escapeAttribute(title), false) %>' />
 			</div>
 		</c:otherwise>
 	</c:choose>

--- a/portal-web/docroot/html/portlet/wiki/history_navigation.jsp
+++ b/portal-web/docroot/html/portlet/wiki/history_navigation.jsp
@@ -103,7 +103,7 @@ if (type.equals("html")) {
 			cssClass="central-title"
 			image="pages"
 			label="<%= true %>"
-			message='<%= LanguageUtil.format(pageContext, "comparing-versions-x-and-x", new Object[] {sourceVersionString, targetVersionString}) %>'
+			message='<%= LanguageUtil.format(pageContext, "comparing-versions-x-and-x", new Object[] {sourceVersionString, targetVersionString}, false) %>'
 		/>
 
 		<c:choose>

--- a/portal-web/docroot/html/portlet/wiki/search.jsp
+++ b/portal-web/docroot/html/portlet/wiki/search.jsp
@@ -60,7 +60,7 @@ portletURL.setParameter("keywords", keywords);
 	</div>
 
 	<liferay-ui:search-container
-		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-pages-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>") %>'
+		emptyResultsMessage='<%= LanguageUtil.format(pageContext, "no-pages-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(keywords) + "</strong>", false) %>'
 		iteratorURL="<%= portletURL %>"
 	>
 

--- a/portal-web/docroot/html/portlet/wiki/view.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view.jsp
@@ -235,7 +235,7 @@ long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayT
 			%>
 
 			<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
-				(<%= LanguageUtil.format(pageContext, "redirected-from-x", originalPage.getTitle()) %>)
+				(<%= LanguageUtil.format(pageContext, "redirected-from-x", originalPage.getTitle(), false) %>)
 			</div>
 		</c:if>
 

--- a/portal-web/docroot/html/portlet/wiki/view_page_activities.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view_page_activities.jsp
@@ -111,21 +111,21 @@ iteratorURL.setParameter("title", wikiPage.getTitle());
 								<liferay-ui:icon
 									image="clip"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "x-added-the-attachment-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), attachmentTitle}) %>'
+									message='<%= LanguageUtil.format(pageContext, "x-added-the-attachment-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), attachmentTitle}, false) %>'
 								/>
 							</c:when>
 							<c:when test="<%= socialActivity.getType() == SocialActivityConstants.TYPE_MOVE_ATTACHMENT_TO_TRASH %>">
 								<liferay-ui:icon
 									image="delete_attachment"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "x-removed-the-attachment-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), attachmentTitle}) %>'
+									message='<%= LanguageUtil.format(pageContext, "x-removed-the-attachment-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), attachmentTitle}, false) %>'
 								/>
 							</c:when>
 							<c:when test="<%= socialActivity.getType() == SocialActivityConstants.TYPE_RESTORE_ATTACHMENT_FROM_TRASH %>">
 								<liferay-ui:icon
 									image="undo"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "x-restored-the-attachment-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), attachmentTitle}) %>'
+									message='<%= LanguageUtil.format(pageContext, "x-restored-the-attachment-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), attachmentTitle}, false) %>'
 								/>
 							</c:when>
 						</c:choose>
@@ -145,7 +145,7 @@ iteratorURL.setParameter("title", wikiPage.getTitle());
 
 						<liferay-ui:icon
 							label="<%= true %>"
-							message='<%= LanguageUtil.format(pageContext, "x-added-a-comment", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), viewPageURL + "#wikiCommentsPanel"}) %>'
+							message='<%= LanguageUtil.format(pageContext, "x-added-a-comment", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), viewPageURL + "#wikiCommentsPanel"}, false) %>'
 						/>
 					</c:when>
 
@@ -169,7 +169,7 @@ iteratorURL.setParameter("title", wikiPage.getTitle());
 								<liferay-ui:icon
 									image="trash"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "activity-wiki-page-move-to-trash", new Object[] {StringPool.BLANK, HtmlUtil.escape(socialActivityUser.getFullName()), socialActivityWikiPage.getTitle()}) %>'
+									message='<%= LanguageUtil.format(pageContext, "activity-wiki-page-move-to-trash", new Object[] {StringPool.BLANK, HtmlUtil.escape(socialActivityUser.getFullName()), socialActivityWikiPage.getTitle()}, false) %>'
 								/>
 							</c:when>
 							<c:when test="<%= socialActivity.getType() == SocialActivityConstants.TYPE_RESTORE_FROM_TRASH %>">
@@ -180,7 +180,7 @@ iteratorURL.setParameter("title", wikiPage.getTitle());
 								<liferay-ui:icon
 									image="undo"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "activity-wiki-page-restore-from-trash", new Object[] {StringPool.BLANK, HtmlUtil.escape(socialActivityUser.getFullName()), pageTitleLink}) %>'
+									message='<%= LanguageUtil.format(pageContext, "activity-wiki-page-restore-from-trash", new Object[] {StringPool.BLANK, HtmlUtil.escape(socialActivityUser.getFullName()), pageTitleLink}, false) %>'
 								/>
 							</c:when>
 							<c:when test="<%= socialActivity.getType() == WikiActivityKeys.ADD_PAGE %>">
@@ -191,7 +191,7 @@ iteratorURL.setParameter("title", wikiPage.getTitle());
 								<liferay-ui:icon
 									image="add_article"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "x-added-the-page-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), pageTitleLink}) %>'
+									message='<%= LanguageUtil.format(pageContext, "x-added-the-page-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), pageTitleLink}, false) %>'
 								/>
 							</c:when>
 							<c:when test="<%= socialActivity.getType() == WikiActivityKeys.UPDATE_PAGE %>">
@@ -208,7 +208,7 @@ iteratorURL.setParameter("title", wikiPage.getTitle());
 								<liferay-ui:icon
 									image="edit"
 									label="<%= true %>"
-									message='<%= LanguageUtil.format(pageContext, "x-updated-the-page-to-version-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), pageTitleLink}) %>'
+									message='<%= LanguageUtil.format(pageContext, "x-updated-the-page-to-version-x", new Object[] {HtmlUtil.escape(socialActivityUser.getFullName()), pageTitleLink}, false) %>'
 								/>
 
 								<c:if test="<%= socialActivityWikiPage.getStatus() != WorkflowConstants.STATUS_APPROVED %>">

--- a/portal-web/docroot/html/portlet/wiki/view_page_attachments.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view_page_attachments.jsp
@@ -101,7 +101,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(pageContext, "att
 					cssClass="trash-attachments"
 					image="delete_attachment"
 					label="<%= true %>"
-					message='<%= LanguageUtil.format(pageContext, (deletedAttachmentsCount == 1) ? "x-recently-removed-attachment" : "x-recently-removed-attachments", deletedAttachmentsCount) %>'
+					message='<%= LanguageUtil.format(pageContext, (deletedAttachmentsCount == 1) ? "x-recently-removed-attachment" : "x-recently-removed-attachments", deletedAttachmentsCount, false) %>'
 					url="<%= viewTrashAttachmentsURL %>"
 				/>
 			</c:if>

--- a/portal-web/docroot/html/portlet/wiki/view_page_content.jspf
+++ b/portal-web/docroot/html/portlet/wiki/view_page_content.jspf
@@ -25,7 +25,7 @@ try {
 		<c:choose>
 			<c:when test="<%= !followRedirect && (redirectPage != null) %>">
 				<div class="alert alert-info">
-					<%= LanguageUtil.format(pageContext, "this-page-is-currently-redirected-to-x", redirectPage.getTitle()) %>
+					<%= LanguageUtil.format(pageContext, "this-page-is-currently-redirected-to-x", redirectPage.getTitle(), false) %>
 				</div>
 
 				<c:if test="<%= WikiPagePermission.contains(permissionChecker, wikiPage, ActionKeys.UPDATE) %>">

--- a/portal-web/docroot/html/portlet/workflow_definition_links/view_resources.jspf
+++ b/portal-web/docroot/html/portlet/workflow_definition_links/view_resources.jspf
@@ -137,7 +137,7 @@ portletURL.setParameter("tabs1", "default-configuration");
 						}
 					%>
 
-						<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion()) + ")" %>' selected="<%= selected %>" value="<%= HtmlUtil.escapeAttribute(workflowDefinition.getName()) + StringPool.AT + workflowDefinition.getVersion() %>" />
+						<aui:option label='<%= workflowDefinition.getName() + " (" + LanguageUtil.format(locale, "version-x", workflowDefinition.getVersion(), false) + ")" %>' selected="<%= selected %>" value="<%= HtmlUtil.escapeAttribute(workflowDefinition.getName()) + StringPool.AT + workflowDefinition.getVersion() %>" />
 
 					<%
 					}

--- a/portal-web/docroot/html/portlet/workflow_instances/edit_workflow_instance.jsp
+++ b/portal-web/docroot/html/portlet/workflow_instances/edit_workflow_instance.jsp
@@ -93,7 +93,7 @@ request.setAttribute(WebKeys.WORKFLOW_ASSET_PREVIEW, Boolean.TRUE);
 		<liferay-ui:panel-container cssClass="task-panel-container" extended="<%= true %>" id="preview">
 
 			<c:if test="<%= assetRenderer != null %>">
-				<liferay-ui:panel defaultState="open" title='<%= LanguageUtil.format(pageContext, "preview-of-x", ResourceActionsUtil.getModelResource(locale, className)) %>'>
+				<liferay-ui:panel defaultState="open" title='<%= LanguageUtil.format(pageContext, "preview-of-x", ResourceActionsUtil.getModelResource(locale, className), false) %>'>
 					<div class="task-content-actions">
 						<liferay-ui:icon-list>
 							<c:if test="<%= assetRenderer.hasViewPermission(permissionChecker) %>">

--- a/portal-web/docroot/html/portlet/workflow_instances/workflow_logs.jspf
+++ b/portal-web/docroot/html/portlet/workflow_instances/workflow_logs.jspf
@@ -38,7 +38,7 @@ for (WorkflowLog workflowLog : workflowLogs) {
 		<c:choose>
 			<c:when test="<%= workflowLog.getType() == WorkflowLog.TASK_COMPLETION %>">
 				<div>
-					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(actorName), workflowLog.getState()} %>" key="x-completed-the-task-x" />
+					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(actorName), workflowLog.getState()} %>" key="x-completed-the-task-x" translateArguments="<%= false %>" />
 				</div>
 			</c:when>
 			<c:when test="<%= workflowLog.getType() == WorkflowLog.TASK_UPDATE %>">
@@ -48,14 +48,14 @@ for (WorkflowLog workflowLog : workflowLogs) {
 			</c:when>
 			<c:when test="<%= workflowLog.getType() == WorkflowLog.TRANSITION %>">
 				<div>
-					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(actorName), workflowLog.getPreviousState(), workflowLog.getState()} %>" key="x-changed-the-state-from-x-to-x" />
+					<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(actorName), workflowLog.getPreviousState(), workflowLog.getState()} %>" key="x-changed-the-state-from-x-to-x" translateArguments="<%= false %>" />
 				</div>
 			</c:when>
 			<c:otherwise>
 				<c:choose>
 					<c:when test="<%= (curUser != null) && (workflowLog.getAuditUserId() == curUser.getUserId()) %>">
 						<div>
-							<liferay-ui:message arguments="<%= HtmlUtil.escape(curUser.getFullName()) %>" key='<%= curUser.isMale() ? "x-assigned-the-task-to-himself" : "x-assigned-the-task-to-herself" %>' />
+							<liferay-ui:message arguments="<%= HtmlUtil.escape(curUser.getFullName()) %>" key='<%= curUser.isMale() ? "x-assigned-the-task-to-himself" : "x-assigned-the-task-to-herself" %>' translateArguments="<%= false %>" />
 						</div>
 					</c:when>
 					<c:otherwise>
@@ -66,10 +66,10 @@ for (WorkflowLog workflowLog : workflowLogs) {
 						%>
 
 							<div>
-								<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(assignerName), HtmlUtil.escape(actorName)} %>" key="x-assigned-the-task-to-x" />
+								<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(assignerName), HtmlUtil.escape(actorName)} %>" key="x-assigned-the-task-to-x" translateArguments="<%= false %>" />
 
 								<c:if test="<%= workflowLog.getPreviousUserId() != 0 %>">
-									<liferay-ui:message arguments="<%= PortalUtil.getUserName(workflowLog.getPreviousUserId(), StringPool.BLANK) %>" key="previous-assignee-was-x" />
+									<liferay-ui:message arguments="<%= PortalUtil.getUserName(workflowLog.getPreviousUserId(), StringPool.BLANK) %>" key="previous-assignee-was-x" translateArguments="<%= false %>" />
 								</c:if>
 							</div>
 
@@ -79,7 +79,7 @@ for (WorkflowLog workflowLog : workflowLogs) {
 						%>
 
 							<div>
-								<liferay-ui:message arguments="<%= HtmlUtil.escape(actorName) %>" key="task-initially-assigned-to-the-x-role" />
+								<liferay-ui:message arguments="<%= HtmlUtil.escape(actorName) %>" key="task-initially-assigned-to-the-x-role" translateArguments="<%= false %>" />
 							</div>
 
 						<%

--- a/portal-web/docroot/html/portlet/workflow_tasks/edit_workflow_task.jsp
+++ b/portal-web/docroot/html/portlet/workflow_tasks/edit_workflow_task.jsp
@@ -189,7 +189,7 @@ request.setAttribute(WebKeys.WORKFLOW_ASSET_PREVIEW, Boolean.TRUE);
 
 		<liferay-ui:panel-container cssClass="task-panel-container" extended="<%= true %>">
 			<c:if test="<%= assetRenderer != null %>">
-				<liferay-ui:panel defaultState="open" title='<%= LanguageUtil.format(pageContext, "preview-of-x", ResourceActionsUtil.getModelResource(locale, className)) %>'>
+				<liferay-ui:panel defaultState="open" title='<%= LanguageUtil.format(pageContext, "preview-of-x", ResourceActionsUtil.getModelResource(locale, className), false) %>'>
 					<div class="task-content-actions">
 						<liferay-ui:icon-list>
 							<c:if test="<%= assetRenderer.hasViewPermission(permissionChecker) %>">
@@ -212,7 +212,7 @@ request.setAttribute(WebKeys.WORKFLOW_ASSET_PREVIEW, Boolean.TRUE);
 									<c:when test="<%= assetRenderer.hasEditPermission(permissionChecker) && showEditURL %>">
 
 										<%
-										String taglibEditURL = "javascript:Liferay.Util.openWindow({id: '" + renderResponse.getNamespace() + "editAsset', title: '" + LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale))) + "', uri:'" + HtmlUtil.escapeURL(editPortletURLString) + "'});";
+										String taglibEditURL = "javascript:Liferay.Util.openWindow({id: '" + renderResponse.getNamespace() + "editAsset', title: '" + LanguageUtil.format(pageContext, "edit-x", HtmlUtil.escape(assetRenderer.getTitle(locale)), false) + "', uri:'" + HtmlUtil.escapeURL(editPortletURLString) + "'});";
 										%>
 
 										<liferay-ui:icon image="edit" url="<%= taglibEditURL %>" />

--- a/portal-web/docroot/html/taglib/ui/app_view_entry/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/app_view_entry/page.jsp
@@ -229,7 +229,7 @@ if (showLinkTitle) {
 							</c:choose>
 
 							<dd class="entry-author">
-								<liferay-ui:message arguments="<%= new String[] {LanguageUtil.getTimeDescription(locale, System.currentTimeMillis() - modifiedDate.getTime(), true), author} %>" key="x-ago-by-x" />
+								<liferay-ui:message arguments="<%= new String[] {LanguageUtil.getTimeDescription(locale, System.currentTimeMillis() - modifiedDate.getTime(), true), author} %>" key="x-ago-by-x" translateArguments="<%= false %>" />
 							</dd>
 						</c:if>
 

--- a/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
@@ -127,7 +127,7 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 							<liferay-ui:icon
 								image='<%= "../file_system/small/" + DLUtil.getFileIcon(fileEntry.getExtension()) %>'
 								label="<%= true %>"
-								message='<%= LanguageUtil.format(locale, "attachment-added-by-x", HtmlUtil.escape(fileEntry.getUserName())) %>'
+								message='<%= LanguageUtil.format(locale, "attachment-added-by-x", HtmlUtil.escape(fileEntry.getUserName()), false) %>'
 							/>
 						</span>
 
@@ -160,7 +160,7 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 						<liferay-ui:icon
 							image="message"
 							label="<%= true %>"
-							message='<%= LanguageUtil.format(locale, "comment-by-x", HtmlUtil.escape(userDisplay.getFullName())) %>'
+							message='<%= LanguageUtil.format(locale, "comment-by-x", HtmlUtil.escape(userDisplay.getFullName()), false) %>'
 						/>
 					</span>
 

--- a/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_categories_selector/page.jsp
@@ -112,7 +112,7 @@ if (Validator.isNotNull(className)) {
 					moreResultsLabel: '<%= UnicodeLanguageUtil.get(pageContext, "load-more-results") %>',
 					portalModelResource: <%= Validator.isNotNull(className) && (ResourceActionsUtil.isPortalModelResource(className) || className.equals(Group.class.getName())) %>,
 					singleSelect: <%= !vocabulary.isMultiValued() %>,
-					title: '<%= UnicodeLanguageUtil.format(pageContext, "select-x", vocabulary.getTitle(locale)) %>',
+					title: '<%= UnicodeLanguageUtil.format(pageContext, "select-x", vocabulary.getTitle(locale), false) %>',
 					vocabularyGroupIds: '<%= vocabulary.getGroupId() %>',
 					vocabularyIds: '<%= String.valueOf(vocabulary.getVocabularyId()) %>'
 				}

--- a/portal-web/docroot/html/taglib/ui/categorization_filter/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/categorization_filter/page.jsp
@@ -92,7 +92,7 @@ if (assetCategoryId != 0) {
 		%>
 
 		<h2 class="taglib-categorization-filter entry-title">
-			<liferay-ui:message arguments="<%= new String[] {assetVocabularyTitle, removeCategory, removeTag} %>" key='<%= assetType.concat("-with-x-x-and-tag-x") %>' />
+			<liferay-ui:message arguments="<%= new String[] {assetVocabularyTitle, removeCategory, removeTag} %>" key='<%= assetType.concat("-with-x-x-and-tag-x") %>' translateArguments="<%= false %>" />
 		</h2>
 	</c:when>
 	<c:when test="<%= assetCategoryId != 0 %>">
@@ -104,7 +104,7 @@ if (assetCategoryId != 0) {
 		%>
 
 		<h2 class="taglib-categorization-filter entry-title">
-			<liferay-ui:message arguments="<%= new String[] {assetVocabularyTitle, removeCategory} %>" key='<%= assetType.concat("-with-x-x") %>' />
+			<liferay-ui:message arguments="<%= new String[] {assetVocabularyTitle, removeCategory} %>" key='<%= assetType.concat("-with-x-x") %>' translateArguments="<%= false %>" />
 		</h2>
 	</c:when>
 	<c:when test="<%= Validator.isNotNull(assetTagName) %>">
@@ -116,7 +116,7 @@ if (assetCategoryId != 0) {
 		%>
 
 		<h2 class="taglib-categorization-filter entry-title">
-			<liferay-ui:message arguments="<%= removeTag %>" key='<%= assetType.concat("-with-tag-x") %>' />
+			<liferay-ui:message arguments="<%= removeTag %>" key='<%= assetType.concat("-with-tag-x") %>' translateArguments="<%= false %>" />
 		</h2>
 	</c:when>
 </c:choose>

--- a/portal-web/docroot/html/taglib/ui/custom_attribute_list/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/custom_attribute_list/page.jsp
@@ -51,7 +51,7 @@ List<String> attributeNames = ListUtil.remove(Collections.list(expandoBridge.get
 	<c:if test="<%= attributeNames.isEmpty() %>">
 		<span class="field">
 			<span class="field-content">
-				<label><%= LanguageUtil.format(pageContext, "no-custom-fields-are-defined-for-x", modelResourceName) %></label>
+				<label><%= LanguageUtil.format(pageContext, "no-custom-fields-are-defined-for-x", modelResourceName, false) %></label>
 			</span>
 		</span>
 	</c:if>

--- a/portal-web/docroot/html/taglib/ui/diff/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/diff/page.jsp
@@ -96,7 +96,7 @@ List<DiffResult> targetResults = diffResults[1];
 		</table>
 	</c:when>
 	<c:otherwise>
-		<%= LanguageUtil.format(pageContext, "there-are-no-differences-between-x-and-x", new Object[] {sourceName, targetName}) %>
+		<%= LanguageUtil.format(pageContext, "there-are-no-differences-between-x-and-x", new Object[] {sourceName, targetName}, false) %>
 	</c:otherwise>
 </c:choose>
 

--- a/portal-web/docroot/html/taglib/ui/discussion/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/discussion/page.jsp
@@ -463,7 +463,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 							<div class="lfr-discussion-posted-on">
 								<c:choose>
 									<c:when test="<%= message.getParentMessageId() == rootMessage.getMessageId() %>">
-										<%= LanguageUtil.format(pageContext, "posted-on-x", dateFormatDateTime.format(message.getModifiedDate())) %>
+										<%= LanguageUtil.format(pageContext, "posted-on-x", dateFormatDateTime.format(message.getModifiedDate()), false) %>
 									</c:when>
 									<c:otherwise>
 
@@ -508,7 +508,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 										sb.append("</a>");
 										%>
 
-										<%= LanguageUtil.format(pageContext, "posted-on-x-in-reply-to-x", new Object[] {dateFormatDateTime.format(message.getModifiedDate()), sb.toString()}) %>
+										<%= LanguageUtil.format(pageContext, "posted-on-x-in-reply-to-x", new Object[] {dateFormatDateTime.format(message.getModifiedDate()), sb.toString()}, false) %>
 									</c:otherwise>
 								</c:choose>
 							</div>

--- a/portal-web/docroot/html/taglib/ui/input_asset_links/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_asset_links/page.jsp
@@ -118,7 +118,7 @@ assetBrowserURL.setWindowState(LiferayWindowState.POP_UP);
 			Map<String, Object> data = new HashMap<String, Object>();
 
 			data.put("href", assetBrowserURL.toString());
-			data.put("title", LanguageUtil.format(pageContext, "select-x", assetRendererFactory.getTypeName(locale, false)));
+			data.put("title", LanguageUtil.format(pageContext, "select-x", assetRendererFactory.getTypeName(locale, false), false));
 
 			String type = assetRendererFactory.getTypeName(locale, false);
 

--- a/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_move_boxes/page.jsp
@@ -82,12 +82,12 @@ List rightList = (List)request.getAttribute("liferay-ui:input-move-boxes:rightLi
 		{
 			contentBox: '#<%= randomNamespace + "input-move-boxes" %>',
 			strings: {
-				LEFT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-down", new Object[] {leftTitle}) %>',
-				LEFT_MOVE_UP: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-up", new Object[] {leftTitle}) %>',
-				MOVE_LEFT: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-items-from-x-to-x", new Object[] {leftTitle, rightTitle}) %>',
-				MOVE_RIGHT: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-items-from-x-to-x", new Object[] {rightTitle, leftTitle}) %>',
-				RIGHT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-down", new Object[] {rightTitle}) %>',
-				RIGHT_MOVE_UP: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-up", new Object[] {rightTitle}) %>'
+				LEFT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-down", new Object[] {leftTitle}, false) %>',
+				LEFT_MOVE_UP: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-up", new Object[] {leftTitle}, false) %>',
+				MOVE_LEFT: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-items-from-x-to-x", new Object[] {leftTitle, rightTitle}, false) %>',
+				MOVE_RIGHT: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-items-from-x-to-x", new Object[] {rightTitle, leftTitle}, false) %>',
+				RIGHT_MOVE_DOWN: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-down", new Object[] {rightTitle}, false) %>',
+				RIGHT_MOVE_UP: '<%= UnicodeLanguageUtil.format(pageContext, "move-selected-item-in-x-one-position-up", new Object[] {rightTitle}, false) %>'
 			}
 		}
 	).render();

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -202,7 +202,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 				%>
 
 					<td style="text-align: center;" <%= (action.equals(ActionKeys.VIEW)) ? "class=\"hide-accessible\"" : "" %>>
-						<label class="hidden-label" for="<%= checkboxFieldId %>"><liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getAction(pageContext, action), role.getTitle(themeDisplay.getLocale())} %>" key="give-x-permission-to-users-with-role-x" /></label>
+						<label class="hidden-label" for="<%= checkboxFieldId %>"><liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getAction(pageContext, action), role.getTitle(themeDisplay.getLocale())} %>" key="give-x-permission-to-users-with-role-x" translateArguments="<%= false %>" /></label>
 
 						<input <%= checked ? "checked" : "" %> <%= disabled ? "disabled" : "" %> id="<%= checkboxFieldId %>" name="<%= checkboxFieldName %>" title='<%= LanguageUtil.format(pageContext, "give-x-permission-to-users-with-role-x", new Object[] {ResourceActionsUtil.getAction(pageContext, action), role.getTitle(themeDisplay.getLocale())}, false) %>' type="checkbox" value="<%= action %>" />
 					</td>

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -88,7 +88,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 			<select id="<%= uniqueNamespace %>inputPermissionsViewRole" name="<%= namespace %>inputPermissionsViewRole" onChange="<%= uniqueNamespace + "updatePermissionsView();" %>">
 
 				<%
-				String guestRoleLabel = LanguageUtil.format(pageContext, "x-role", guestRole.getTitle(themeDisplay.getLocale()));
+				String guestRoleLabel = LanguageUtil.format(pageContext, "x-role", guestRole.getTitle(themeDisplay.getLocale()), false);
 
 				if (PropsValues.PERMISSIONS_CHECK_GUEST_ENABLED) {
 					guestRoleLabel = LanguageUtil.get(pageContext, "anyone") + StringPool.SPACE + StringPool.OPEN_PARENTHESIS + guestRoleLabel + StringPool.CLOSE_PARENTHESIS;
@@ -204,7 +204,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 					<td style="text-align: center;" <%= (action.equals(ActionKeys.VIEW)) ? "class=\"hide-accessible\"" : "" %>>
 						<label class="hidden-label" for="<%= checkboxFieldId %>"><liferay-ui:message arguments="<%= new Object[] {ResourceActionsUtil.getAction(pageContext, action), role.getTitle(themeDisplay.getLocale())} %>" key="give-x-permission-to-users-with-role-x" /></label>
 
-						<input <%= checked ? "checked" : "" %> <%= disabled ? "disabled" : "" %> id="<%= checkboxFieldId %>" name="<%= checkboxFieldName %>" title='<%= LanguageUtil.format(pageContext, "give-x-permission-to-users-with-role-x", new Object[] {ResourceActionsUtil.getAction(pageContext, action), role.getTitle(themeDisplay.getLocale())}) %>' type="checkbox" value="<%= action %>" />
+						<input <%= checked ? "checked" : "" %> <%= disabled ? "disabled" : "" %> id="<%= checkboxFieldId %>" name="<%= checkboxFieldName %>" title='<%= LanguageUtil.format(pageContext, "give-x-permission-to-users-with-role-x", new Object[] {ResourceActionsUtil.getAction(pageContext, action), role.getTitle(themeDisplay.getLocale())}, false) %>' type="checkbox" value="<%= action %>" />
 					</td>
 
 				<%

--- a/portal-web/docroot/html/taglib/ui/membership_policy_error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/membership_policy_error/page.jsp
@@ -26,28 +26,28 @@
 
 	<c:choose>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.ORGANIZATION_MEMBERSHIP_NOT_ALLOWED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getOrganizations(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-join-x" : "the-following-users-are-not-allowed-to-join-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getOrganizations(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-join-x" : "the-following-users-are-not-allowed-to-join-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.ORGANIZATION_MEMBERSHIP_REQUIRED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getOrganizations(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-leave-x" : "the-following-users-are-not-allowed-to-leave-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getOrganizations(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-leave-x" : "the-following-users-are-not-allowed-to-leave-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.ROLE_MEMBERSHIP_NOT_ALLOWED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getRoles(), "title", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-cannot-be-assigned-to-x" : "the-following-users-cannot-be-assigned-to-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getRoles(), "title", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-cannot-be-assigned-to-x" : "the-following-users-cannot-be-assigned-to-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.ROLE_MEMBERSHIP_REQUIRED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getRoles(), "title", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-cannot-be-unassigned-from-x" : "the-following-users-cannot-be-unassigned-from-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getRoles(), "title", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-cannot-be-unassigned-from-x" : "the-following-users-cannot-be-unassigned-from-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.SITE_MEMBERSHIP_NOT_ALLOWED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getGroups(), "descriptiveName", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-join-x" : "the-following-users-are-not-allowed-to-join-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getGroups(), "descriptiveName", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-join-x" : "the-following-users-are-not-allowed-to-join-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.SITE_MEMBERSHIP_REQUIRED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getGroups(), "descriptiveName", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-leave-x" : "the-following-users-are-not-allowed-to-leave-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getGroups(), "descriptiveName", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-is-not-allowed-to-leave-x" : "the-following-users-are-not-allowed-to-leave-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.USER_GROUP_MEMBERSHIP_NOT_ALLOWED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getUserGroups(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-are-not-allowed-to-join-x" : "the-following-users-are-not-allowed-to-join-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getUserGroups(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-are-not-allowed-to-join-x" : "the-following-users-are-not-allowed-to-join-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 		<c:when test="<%= mpe.getType() == MembershipPolicyException.USER_GROUP_MEMBERSHIP_REQUIRED %>">
-			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getUserGroups(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-are-not-allowed-to-leave-x" : "the-following-users-are-not-allowed-to-leave-x-x" %>' />
+			<liferay-ui:message arguments='<%= new Object[] {ListUtil.toString(users, "fullName", StringPool.COMMA_AND_SPACE), ListUtil.toString(mpe.getUserGroups(), "name", StringPool.COMMA_AND_SPACE)} %>' key='<%= users.size() == 1 ? "x-are-not-allowed-to-leave-x" : "the-following-users-are-not-allowed-to-leave-x-x" %>' translateArguments="<%= false %>" />
 		</c:when>
 	</c:choose>
 </liferay-ui:error>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/showing_x_results.jspf
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/showing_x_results.jspf
@@ -17,21 +17,21 @@
 <small class="search-results">
 	<c:choose>
 		<c:when test='<%= type.equals("approximate") %>'>
-			<%= LanguageUtil.format(pageContext, "page-x-of-approximately-x-results", new Object[] {numberFormat.format(cur), numberFormat.format(total)}) %>
+			<%= LanguageUtil.format(pageContext, "page-x-of-approximately-x-results", new Object[] {numberFormat.format(cur), numberFormat.format(total)}, false) %>
 		</c:when>
 		<c:when test='<%= type.equals("more") %>'>
-			<%= LanguageUtil.format(pageContext, "showing-x-x", new Object[] {numberFormat.format(start + 1), numberFormat.format(end)}) %>
+			<%= LanguageUtil.format(pageContext, "showing-x-x", new Object[] {numberFormat.format(start + 1), numberFormat.format(end)}, false) %>
 		</c:when>
 		<c:when test="<%= total > resultRowsSize %>">
-			<%= LanguageUtil.format(pageContext, "showing-x-x-of-x-results", new Object[] {numberFormat.format(start + 1), numberFormat.format(end), numberFormat.format(total)}) %>
+			<%= LanguageUtil.format(pageContext, "showing-x-x-of-x-results", new Object[] {numberFormat.format(start + 1), numberFormat.format(end), numberFormat.format(total)}, false) %>
 		</c:when>
 		<c:otherwise>
 			<c:choose>
 				<c:when test="<%= total != 1 %>">
-					<%= LanguageUtil.format(pageContext, "showing-x-results", numberFormat.format(total)) %>
+					<%= LanguageUtil.format(pageContext, "showing-x-results", numberFormat.format(total), false) %>
 				</c:when>
 				<c:otherwise>
-					<%= LanguageUtil.format(pageContext, "showing-x-result", numberFormat.format(total)) %>
+					<%= LanguageUtil.format(pageContext, "showing-x-result", numberFormat.format(total), false) %>
 				</c:otherwise>
 			</c:choose>
 		</c:otherwise>

--- a/portal-web/docroot/html/taglib/ui/ratings/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/ratings/page.jsp
@@ -96,7 +96,7 @@ if (ratingsEntry != null) {
 						for (int i = 1; i <= numberOfStars; i++) {
 						%>
 
-							<a class="rating-element <%= (i <= yourScore) ? "icon-star" : "icon-star-empty" %>" href="javascript:;" title="<%= TrashUtil.isInTrash(className, classPK) ? LanguageUtil.get(pageContext, "ratings-are-disabled-because-this-entry-is-in-the-recycle-bin") : ((i == 1) ? LanguageUtil.format(pageContext, "the-average-rating-is-x-stars-out-of-x", new Object[] {ratingsStats.getAverageScore(), numberOfStars}) : StringPool.BLANK) %>"></a>
+							<a class="rating-element <%= (i <= yourScore) ? "icon-star" : "icon-star-empty" %>" href="javascript:;" title="<%= TrashUtil.isInTrash(className, classPK) ? LanguageUtil.get(pageContext, "ratings-are-disabled-because-this-entry-is-in-the-recycle-bin") : ((i == 1) ? LanguageUtil.format(pageContext, "the-average-rating-is-x-stars-out-of-x", new Object[] {ratingsStats.getAverageScore(), numberOfStars}, false) : StringPool.BLANK) %>"></a>
 
 						<%
 						}

--- a/portal-web/docroot/html/taglib/ui/ratings/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/ratings/page.jsp
@@ -70,7 +70,7 @@ if (ratingsEntry != null) {
 									<a class="rating-element <%= (i <= yourScore) ? "icon-star" : "icon-star-empty" %>" href="javascript:;"></a>
 
 									<div class="rating-input-container">
-										<label for="<%= ratingId %>"><liferay-ui:message arguments="<%= new Object[] {i, numberOfStars} %>" key='<%= (yourScore == i) ? "you-have-rated-this-x-stars-out-of-x" : "rate-this-x-stars-out-of-x" %>' /></label>
+										<label for="<%= ratingId %>"><liferay-ui:message arguments="<%= new Object[] {i, numberOfStars} %>" key='<%= (yourScore == i) ? "you-have-rated-this-x-stars-out-of-x" : "rate-this-x-stars-out-of-x" %>' translateArguments="<%= false %>" /></label>
 
 										<input checked="<%= i == yourScore %>" class="rating-input" id="<%= ratingId %>" name="<portlet:namespace />rating" type="radio" value="<%= i %>">
 									</div>

--- a/portal-web/docroot/html/taglib/ui/search_container/status.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_container/status.jsp
@@ -35,7 +35,7 @@ User statusByUser = UserLocalServiceUtil.fetchUser(statusByUserId);
 					<aui:a href="<%= statusByUser.getDisplayURL(themeDisplay) %>"><%= StringUtil.shorten(statusByUser.getFullName(), 20) %></aui:a>
 				</div>
 				<div class="user-status-date">
-					<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(pageContext, System.currentTimeMillis() - statusDate.getTime(), true) %>" key="x-ago" />
+					<liferay-ui:message arguments="<%= LanguageUtil.getTimeDescription(pageContext, System.currentTimeMillis() - statusDate.getTime(), true) %>" key="x-ago" translateArguments="<%= false %>" />
 				</div>
 			</span>
 		</div>

--- a/portal-web/docroot/html/taglib/ui/search_toggle/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_toggle/start.jsp
@@ -45,4 +45,4 @@
 					</aui:select>
 				</liferay-util:buffer>
 
-				<liferay-ui:message arguments="<%= andOperator %>" key="match-x-of-the-following-fields" />
+				<liferay-ui:message arguments="<%= andOperator %>" key="match-x-of-the-following-fields" translateArguments="<%= false %>" />

--- a/portal-web/docroot/html/taglib/ui/sites_directory/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/sites_directory/page.jsp
@@ -60,7 +60,7 @@
 						<c:choose>
 							<c:when test="<%= Validator.isNull(portletDisplay.getId()) %>">
 								<div class="alert alert-info">
-									<liferay-ui:message arguments="<%= displayStyle %>" key="the-display-style-x-cannot-be-used-in-this-context" />
+									<liferay-ui:message arguments="<%= displayStyle %>" key="the-display-style-x-cannot-be-used-in-this-context" translateArguments="<%= false %>" />
 								</div>
 							</c:when>
 							<c:otherwise>

--- a/portal-web/docroot/html/taglib/ui/sites_directory/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/sites_directory/page.jsp
@@ -60,7 +60,7 @@
 						<c:choose>
 							<c:when test="<%= Validator.isNull(portletDisplay.getId()) %>">
 								<div class="alert alert-info">
-									<liferay-ui:message arguments="<%= displayStyle %>" key="the-display-style-x-cannot-be-used-in-this-context" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= displayStyle %>" key="the-display-style-x-cannot-be-used-in-this-context" />
 								</div>
 							</c:when>
 							<c:otherwise>

--- a/portal-web/docroot/html/taglib/ui/staging/staging_actions.jspf
+++ b/portal-web/docroot/html/taglib/ui/staging/staging_actions.jspf
@@ -67,7 +67,7 @@
 					publishRenderURL.setParameter("layoutSetBranchId", String.valueOf(layoutSetBranchId));
 					publishRenderURL.setParameter("layoutSetBranchName", layoutSetBranch.getName());
 
-					publishMessage = LanguageUtil.format(pageContext, publishDialogTitle, HtmlUtil.escape(layoutSetBranch.getName()));
+					publishMessage = LanguageUtil.format(pageContext, publishDialogTitle, HtmlUtil.escape(layoutSetBranch.getName()), false);
 					%>
 
 				</c:when>

--- a/portal-web/docroot/html/taglib/ui/trash_empty/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/trash_empty/page.jsp
@@ -32,7 +32,7 @@ int totalEntries = GetterUtil.getInteger(request.getAttribute("liferay-ui:trash-
 			String trashEntriesMaxAgeTimeDescription = LanguageUtil.getTimeDescription(locale, TrashUtil.getMaxAge(themeDisplay.getScopeGroup()) * Time.MINUTE, true);
 			%>
 
-			<liferay-ui:message arguments="<%= StringUtil.toLowerCase(trashEntriesMaxAgeTimeDescription) %>" key="<%= infoMessage %>" />
+			<liferay-ui:message arguments="<%= StringUtil.toLowerCase(trashEntriesMaxAgeTimeDescription) %>" key="<%= infoMessage %>" translateArguments="<%= false %>" />
 
 			<a class="trash-empty-link" href="javascript:;" id="<%= namespace %>empty"><liferay-ui:message key="<%= emptyMessage %>" /></a>
 

--- a/portal-web/docroot/html/taglib/ui/trash_undo/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/trash_undo/page.jsp
@@ -91,10 +91,10 @@ if (SessionMessages.contains(portletRequest, portletDisplay.getId() + SessionMes
 					<c:when test="<%= trashedEntriesCount > 1 %>">
 						<c:choose>
 							<c:when test="<%= Validator.equals(cmd, Constants.REMOVE) %>">
-								<liferay-ui:message arguments="<%= new Object[] {trashedEntriesCount} %>" key="x-items-were-removed" />
+								<liferay-ui:message arguments="<%= new Object[] {trashedEntriesCount} %>" key="x-items-were-removed" translateArguments="<%= false %>" />
 							</c:when>
 							<c:otherwise>
-								<liferay-ui:message arguments="<%= new Object[] {trashedEntriesCount, trashLink.trim()} %>" key="x-items-were-moved-to-x" />
+								<liferay-ui:message arguments="<%= new Object[] {trashedEntriesCount, trashLink.trim()} %>" key="x-items-were-moved-to-x" translateArguments="<%= false %>" />
 							</c:otherwise>
 						</c:choose>
 					</c:when>
@@ -149,10 +149,10 @@ if (SessionMessages.contains(portletRequest, portletDisplay.getId() + SessionMes
 
 						<c:choose>
 							<c:when test="<%= Validator.equals(cmd, Constants.REMOVE) %>">
-								<liferay-ui:message arguments="<%= new Object[] {type, trashEntityLink} %>" key="the-x-x-was-removed" />
+								<liferay-ui:message arguments="<%= new Object[] {LanguageUtil.get(pageContext, type), trashEntityLink} %>" key="the-x-x-was-removed" translateArguments="<%= false %>" />
 							</c:when>
 							<c:otherwise>
-								<liferay-ui:message arguments="<%= new Object[] {type, trashEntityLink, trashLink.trim()} %>" key="the-x-x-was-moved-to-x" />
+								<liferay-ui:message arguments="<%= new Object[] {LanguageUtil.get(pageContext, type), trashEntityLink, trashLink.trim()} %>" key="the-x-x-was-moved-to-x" translateArguments="<%= false %>" />
 							</c:otherwise>
 						</c:choose>
 					</c:otherwise>

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_rich_summary.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_rich_summary.ftl
@@ -83,7 +83,7 @@
 		<#assign editPortletURL = assetRenderer.getURLEdit(renderRequest, renderResponse, windowStateFactory.getWindowState("pop_up"), redirectURL)!"" />
 
 		<#if validator.isNotNull(editPortletURL)>
-			<#assign title = languageUtil.format(locale, "edit-x", entryTitle) />
+			<#assign title = languageUtil.format(locale, "edit-x", entryTitle, false) />
 
 			<@liferay_ui["icon"]
 				image="edit"
@@ -170,7 +170,7 @@
 		<@liferay_ui["icon"]
 			image="print"
 			message="print"
-			url="javascript:Liferay.Util.openWindow({id:'" + renderResponse.getNamespace() + "printAsset', title: '" + languageUtil.format(locale, "print-x-x", ["hide-accessible", entryTitle]) + "', uri: '" + htmlUtil.escapeURL(printURL.toString()) + "'});"
+			url="javascript:Liferay.Util.openWindow({id:'" + renderResponse.getNamespace() + "printAsset', title: '" + languageUtil.format(locale, "print-x-x", ["hide-accessible", entryTitle], false) + "', uri: '" + htmlUtil.escapeURL(printURL.toString()) + "'});"
 		/>
 	</#if>
 </#macro>

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_social.ftl
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/portlet_display_template_social.ftl
@@ -216,7 +216,7 @@
 	${printURL.setParameter("viewMode", "print")}
 	${printURL.setWindowState("pop_up")}
 
-	<#assign title = languageUtil.format(locale, "print-x-x", ["hide-accessible", htmlUtil.escape(assetRenderer.getTitle(locale))]) />
+	<#assign title = languageUtil.format(locale, "print-x-x", ["hide-accessible", htmlUtil.escape(assetRenderer.getTitle(locale))], false) />
 	<#assign taglibPrintURL = "javascript:Liferay.Util.openWindow({dialog: {width: 960}, id:'" + renderResponse.getNamespace() + "printAsset', title: '" + title + "', uri: '" + htmlUtil.escapeURL(printURL.toString()) + "'});" />
 
 	<@liferay_ui["icon"]


### PR DESCRIPTION
Hey Brian

We could also apply the same as in this commit https://github.com/sergiogonzalez/liferay-portal/commit/d978d3664c8add6d0a21e26c6d376499480406e9 to remove the LanguageUtil.get\* methods and we would leave only LanguageUtil.format\* methods.

Would you like us to deprecate the LanguageUtil.get\* methods and leave only LanguageUtil.format for both cases (when we have arguments and when we don't)?

Thanks!
