### PR TITLE
LPS-43602 On seeing a Finder/EntityCache mismatch, translate it to Finde...

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/orm/common/FinderCacheImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/common/FinderCacheImpl.java
@@ -260,6 +260,10 @@ public class FinderCacheImpl
 				Serializable result = _primaryKeyToResult(
 					finderPath, sessionFactory, curPrimaryKey);
 
+				if (result == null) {
+					return null;
+				}
+
 				list.add(result);
 			}
 


### PR DESCRIPTION
...rCache miss to trigger database refetch to correct the cache results.
