### PR TITLE
LPS-43543 Fix SF

### DIFF
--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -500,8 +500,9 @@ public class Creole10Parser]]></replacevalue>
 			<format property="tstamp.value" pattern="yyyyMMddkkmmssSSS" />
 		</tstamp>
 
-		<property name="r2.dir" value="${tstamp.value}/R2-${r2.version}" />
+		<property name="css-dependencies.dir" value="${project.dir}/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/dependencies" />
 		<property name="r2.version" value="liferay-0.1" />
+		<property name="r2.dir" value="${tstamp.value}/R2-${r2.version}" />
 
 		<unzip
 			dest="${tstamp.value}"
@@ -513,14 +514,14 @@ public class Creole10Parser]]></replacevalue>
 		</exec>
 
 		<copy
-			file="${tstamp.value}/r2_liferay.js"
+			file="${css-dependencies.dir}/r2_liferay.js"
 			tofile="${r2.dir}/r2_liferay.js"
 		/>
 
 		<exec dir="${r2.dir}" executable="browserify">
 			<arg value="r2_liferay.js" />
 			<arg value="-o" />
-			<arg value="${tstamp.value}/r2.js" />
+			<arg value="${css-dependencies.dir}/r2.js" />
 		</exec>
 
 		<delete dir="${tstamp.value}" />

--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/dependencies/r2_liferay.js
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/dependencies/r2_liferay.js
@@ -1,0 +1,15 @@
+function getGlobal() {
+	return (function() {
+		return this;
+	}).call(null);
+}
+
+var console = {
+	log: function(data) {
+		java.lang.System.out.println(data);
+	}
+};
+
+var global = getGlobal();
+
+global.r2 = require('./r2.js').swap;


### PR DESCRIPTION
Hey Brian, I found a couple of issues on the task after yesterday's review.
- I guess Nate intended to move the `r2_liferay.js` file, but deleted it instead. This is a dependency for portal, and does not come packaged in the zip file. One of the requisites to move away from our fork at some point.
- The output of the `browserify` execution needs to be placed onto the `portal-impl/.../dynamiccss/dependencies` folder, since that's where `RTLCSSUtil.java` is looking for it.

Let me know if you think we could simplify it somehow.

Thanks!
