### PR TITLE
LPS-43705 3 bug fixes for adding/editing pages

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.CookieKeys;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -391,6 +392,19 @@ public class LayoutImpl extends LayoutBaseImpl {
 		}
 
 		return _layoutType;
+	}
+
+	@Override
+	public Layout getLinkedToLayout() throws SystemException {
+		long linkToLayoutId = GetterUtil.getLong(
+			getTypeSettingsProperty("linkToLayoutId"));
+
+		if (linkToLayoutId <= 0) {
+			return null;
+		}
+
+		return LayoutLocalServiceUtil.fetchLayout(
+			getGroupId(), isPrivateLayout(), linkToLayoutId);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -281,6 +281,12 @@ public class EditLayoutsAction extends PortletAction {
 					 e instanceof UploadException) {
 
 				SessionErrors.add(actionRequest, e.getClass(), e);
+
+				if (cmd.equals(Constants.ADD)) {
+					SessionMessages.add(actionRequest,
+						PortalUtil.getPortletId(actionRequest) + "addError",
+						e);
+				}
 			}
 			else if (e instanceof SystemException) {
 				SessionErrors.add(actionRequest, e.getClass(), e);

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -283,9 +283,9 @@ public class EditLayoutsAction extends PortletAction {
 				SessionErrors.add(actionRequest, e.getClass(), e);
 
 				if (cmd.equals(Constants.ADD)) {
-					SessionMessages.add(actionRequest,
-						PortalUtil.getPortletId(actionRequest) + "addError",
-						e);
+					SessionMessages.add(
+						actionRequest,
+						PortalUtil.getPortletId(actionRequest) + "addError", e);
 				}
 			}
 			else if (e instanceof SystemException) {

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -167,15 +167,18 @@ public class EditLayoutsAction extends PortletAction {
 				layout = (Layout)returnValue[0];
 				oldFriendlyURL = (String)returnValue[1];
 
-				redirect = updateCloseRedirect(
-					themeDisplay, redirect, null, layout, oldFriendlyURL);
-				closeRedirect = updateCloseRedirect(
-					themeDisplay, closeRedirect, null, layout, oldFriendlyURL);
-
-				SessionMessages.add(
-					actionRequest,
-					PortalUtil.getPortletId(actionRequest) + "pageAdded",
-					layout);
+				if (cmd.equals(Constants.ADD)) {
+					SessionMessages.add(
+						actionRequest,
+						PortalUtil.getPortletId(actionRequest) + "pageAdded",
+						layout);
+				}
+				else if (cmd.equals(Constants.UPDATE)) {
+					redirect = updateCloseRedirect(
+						themeDisplay, redirect, null, layout, oldFriendlyURL);
+					closeRedirect = updateCloseRedirect(
+						themeDisplay, closeRedirect, null, layout, oldFriendlyURL);
+				}
 			}
 			else if (cmd.equals(Constants.DELETE)) {
 				long plid = ParamUtil.getLong(actionRequest, "plid");

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -174,10 +174,11 @@ public class EditLayoutsAction extends PortletAction {
 						layout);
 				}
 				else if (cmd.equals(Constants.UPDATE)) {
-					redirect = updateCloseRedirect(
+					redirect = updateRedirect(
 						themeDisplay, redirect, null, layout, oldFriendlyURL);
 					closeRedirect = updateCloseRedirect(
-						themeDisplay, closeRedirect, null, layout, oldFriendlyURL);
+						themeDisplay, closeRedirect, null, layout,
+						oldFriendlyURL);
 				}
 			}
 			else if (cmd.equals(Constants.DELETE)) {
@@ -1016,7 +1017,8 @@ public class EditLayoutsAction extends PortletAction {
 
 			layoutTypeSettingsProperties = layout.getTypeSettingsProperties();
 
-			if (oldFriendlyURL.equals(
+			if (!layout.isTypeURL() && !layout.isTypeLinkToLayout() &&
+				oldFriendlyURL.equals(
 					layout.getFriendlyURL(themeDisplay.getLocale()))) {
 
 				oldFriendlyURL = StringPool.BLANK;
@@ -1224,6 +1226,46 @@ public class EditLayoutsAction extends PortletAction {
 				groupId, privateLayout, layoutId, deviceThemeId,
 				deviceColorSchemeId, deviceCss, deviceWapTheme);
 		}
+	}
+
+	protected String updateRedirect(
+		ThemeDisplay themeDisplay, String redirect, Group group, Layout layout,
+		String oldLayoutFriendlyURL) {
+
+		if (Validator.isNull(redirect) ||
+			Validator.isNull(oldLayoutFriendlyURL)) {
+
+			return redirect;
+		}
+
+		if (layout != null) {
+			String oldPath = oldLayoutFriendlyURL;
+
+			if (layout.isTypeLinkToLayout() || layout.isTypeURL()) {
+				try {
+					layout = LayoutLocalServiceUtil.fetchFirstLayout(
+						layout.getGroupId(), layout.getPrivateLayout(),
+						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+				}
+				catch (Exception e) {
+					if (_log.isDebugEnabled()) {
+						_log.debug("First layout can not be found");
+					}
+				}
+			}
+
+			String newPath = layout.getFriendlyURL(themeDisplay.getLocale());
+
+			return PortalUtil.updateRedirect(redirect, oldPath, newPath);
+		}
+		else if (group != null) {
+			String oldPath = group.getFriendlyURL() + oldLayoutFriendlyURL;
+			String newPath = group.getFriendlyURL();
+
+			return PortalUtil.updateRedirect(redirect, oldPath, newPath);
+		}
+
+		return redirect;
 	}
 
 	protected UnicodeProperties updateThemeSettingsProperties(

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditLayoutsAction.java
@@ -259,6 +259,11 @@ public class EditLayoutsAction extends PortletAction {
 				updateLayoutRevision(actionRequest, themeDisplay);
 			}
 
+			HttpServletRequest request = PortalUtil.getHttpServletRequest(
+				actionRequest);
+
+			SessionMessages.add(request, "requestProcessed");
+
 			sendRedirect(
 				portletConfig, actionRequest, actionResponse, redirect,
 				closeRedirect);

--- a/portal-service/src/com/liferay/portal/model/Layout.java
+++ b/portal-service/src/com/liferay/portal/model/Layout.java
@@ -99,6 +99,9 @@ public interface Layout extends LayoutModel, PersistedModel {
 
 	public com.liferay.portal.model.LayoutType getLayoutType();
 
+	public com.liferay.portal.model.Layout getLinkedToLayout()
+		throws com.liferay.portal.kernel.exception.SystemException;
+
 	public long getParentPlid()
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;

--- a/portal-service/src/com/liferay/portal/model/LayoutWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutWrapper.java
@@ -1819,6 +1819,12 @@ public class LayoutWrapper implements Layout, ModelWrapper<Layout> {
 	}
 
 	@Override
+	public com.liferay.portal.model.Layout getLinkedToLayout()
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return _layout.getLinkedToLayout();
+	}
+
+	@Override
 	public long getParentPlid()
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {

--- a/portal-web/docroot/WEB-INF/struts-config.xml
+++ b/portal-web/docroot/WEB-INF/struts-config.xml
@@ -448,6 +448,11 @@
 
 		<action path="/dockbar/add_content_redirect" forward="portlet.dockbar.add_content_redirect" />
 
+		<action path="/dockbar/add_layout" type="com.liferay.portlet.grouppages.action.EditLayoutsAction">
+			<forward name="portlet.layouts_admin.edit_layouts" path="portlet.layouts_admin.add_layout" />
+			<forward name="portlet.layouts_admin.error" path="portlet.layouts_admin.add_layout" />
+		</action>
+
 		<action path="/dockbar/add_panel" type="com.liferay.portlet.layoutsadmin.action.EditLayoutsAction" >
 			<forward name="portlet.layouts_admin.edit_layouts" path="portlet.dockbar.add_panel" />
 			<forward name="portlet.layouts_admin.error" path="portlet.dockbar.add_panel" />

--- a/portal-web/docroot/WEB-INF/tiles-defs.xml
+++ b/portal-web/docroot/WEB-INF/tiles-defs.xml
@@ -418,10 +418,6 @@
 		<put name="portlet_content" value="/portlet/dockbar/add_content_redirect.jsp" />
 	</definition>
 
-	<definition name="portlet.dockbar.add_layout" extends="portlet.dockbar">
-		<put name="portlet_content" value="/portlet/layouts_admin/add_layout.jsp" />
-	</definition>
-
 	<definition name="portlet.dockbar.add_panel" extends="portlet.dockbar">
 		<put name="portlet_content" value="/portlet/dockbar/add_panel.jsp" />
 	</definition>
@@ -863,6 +859,10 @@
 	<!-- Layouts Admin -->
 
 	<definition name="portlet.layouts_admin" extends="portlet" />
+
+	<definition name="portlet.layouts_admin.add_layout" extends="portlet.layouts_admin">
+		<put name="portlet_content" value="/portlet/layouts_admin/add_layout.jsp" />
+	</definition>
 
 	<definition name="portlet.layouts_admin.edit_layouts" extends="portlet.layouts_admin">
 		<put name="portlet_content" value="/portlet/layouts_admin/view.jsp" />

--- a/portal-web/docroot/html/portlet/dockbar/edit_layout_panel.jsp
+++ b/portal-web/docroot/html/portlet/dockbar/edit_layout_panel.jsp
@@ -20,7 +20,7 @@
 
 <div id="<portlet:namespace />editLayoutContainer">
 	<c:choose>
-		<c:when test='<%= SessionMessages.contains(renderRequest, "requestProcessed") || ((selPlid == 0) && Validator.isNotNull(closeRedirect)) %>'>
+		<c:when test='<%= SessionMessages.contains(renderRequest, "requestProcessed") || SessionMessages.contains(request, "requestProcessed") || ((selPlid == 0) && Validator.isNotNull(closeRedirect)) %>'>
 
 			<%
 			String refreshURL = null;
@@ -30,6 +30,10 @@
 			}
 			else {
 				refreshURL = (String)SessionMessages.get(renderRequest, portletDisplay.getId() + SessionMessages.KEY_SUFFIX_CLOSE_REDIRECT);
+
+				if (Validator.isNull(refreshURL)) {
+					refreshURL = (String)SessionMessages.get(request, portletDisplay.getId() + SessionMessages.KEY_SUFFIX_CLOSE_REDIRECT);
+				}
 			}
 
 			if (Validator.isNull(refreshURL)) {

--- a/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
@@ -157,6 +157,8 @@ else {
 						<%
 						liferayPortletRequest.setAttribute(WebKeys.LAYOUT_LISTER_LIST, layoutView.getList());
 
+						int layoutsCount = LayoutLocalServiceUtil.getLayoutsCount(group, privateLayout);
+
 						for (int i = 0; i < PropsValues.LAYOUT_TYPES.length; i++) {
 							if (PropsValues.LAYOUT_TYPES[i].equals("portlet")) {
 								continue;
@@ -165,7 +167,7 @@ else {
 
 							<aui:nav-item cssClass="lfr-page-template" data-search='<%= LanguageUtil.get(pageContext, "layout.types." + PropsValues.LAYOUT_TYPES[i]) %>'>
 								<div class="lfr-page-template-title toggler-header toggler-header-collapsed" data-type="<%= PropsValues.LAYOUT_TYPES[i] %>">
-									<aui:input id='<%= "addLayoutSelectedPageTemplate" + PropsValues.LAYOUT_TYPES[i] %>' label='<%= "layout.types." + PropsValues.LAYOUT_TYPES[i] %>' name="selectedPageTemplate" type="radio" />
+									<aui:input disabled="<%= (layoutsCount == 0) && !PortalUtil.isLayoutFirstPageable(PropsValues.LAYOUT_TYPES[i]) %>" id='<%= "addLayoutSelectedPageTemplate" + PropsValues.LAYOUT_TYPES[i] %>' label='<%= "layout.types." + PropsValues.LAYOUT_TYPES[i] %>' name="selectedPageTemplate" type="radio" />
 
 									<div class="lfr-page-template-description">
 										<small><%= LanguageUtil.get(pageContext, "layout.types." + PropsValues.LAYOUT_TYPES[i] + ".description" ) %></small>

--- a/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
@@ -43,17 +43,17 @@ else {
 }
 %>
 
-<portlet:actionURL var="editLayoutActionURL" windowState="<%= themeDisplay.isStateExclusive() ? LiferayWindowState.EXCLUSIVE.toString() : WindowState.NORMAL.toString()  %>">
-	<portlet:param name="struts_action" value="/layouts_admin/edit_layouts" />
+<portlet:actionURL var="editLayoutActionURL" windowState="<%= themeDisplay.isStateExclusive() ? LiferayWindowState.EXCLUSIVE.toString() : WindowState.NORMAL.toString() %>">
+	<portlet:param name="struts_action" value='<%= portletName.equals(PortletKeys.DOCKBAR) ? "/layouts_admin/add_layout" : "/layouts_admin/edit_layouts" %>' />
 </portlet:actionURL>
 
 <portlet:renderURL var="editLayoutRenderURL" windowState="<%= themeDisplay.isStateExclusive() ? LiferayWindowState.EXCLUSIVE.toString() : WindowState.NORMAL.toString() %>">
-	<portlet:param name="struts_action" value="/layouts_admin/edit_layouts" />
+	<portlet:param name="struts_action" value='<%= portletName.equals(PortletKeys.DOCKBAR) ? "/layouts_admin/add_layout" : "/layouts_admin/edit_layouts" %>' />
 </portlet:renderURL>
 
 <aui:form action="<%= editLayoutActionURL %>" enctype="multipart/form-data" method="post" name="addPageFm" onSubmit="event.preventDefault()">
 	<aui:input id="addLayoutCMD" name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.ADD %>" />
-	<aui:input id="addLayoutRedirect" name="redirect" type="hidden" value="<%= layout.isTypeControlPanel() ? currentURL : editLayoutRenderURL.toString() %>" />
+	<aui:input id="addLayoutRedirect" name="redirect" type="hidden" value="<%= portletName.equals(PortletKeys.DOCKBAR) ? editLayoutRenderURL : currentURL %>" />
 	<aui:input id="addLayoutGroupId" name="groupId" type="hidden" value="<%= groupId %>" />
 	<aui:input id="addLayoutPrivateLayout" name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input id="addLayoutParentPlid" name="parentPlid" type="hidden" value="<%= parentPlid %>" />

--- a/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
@@ -43,11 +43,11 @@ else {
 }
 %>
 
-<portlet:actionURL var="editLayoutActionURL" windowState="<%= layout.isTypeControlPanel() ? LiferayWindowState.NORMAL.toString() : LiferayWindowState.EXCLUSIVE.toString() %>">
+<portlet:actionURL var="editLayoutActionURL" windowState="<%= themeDisplay.isStateExclusive() ? LiferayWindowState.EXCLUSIVE.toString() : WindowState.NORMAL.toString()  %>">
 	<portlet:param name="struts_action" value="/layouts_admin/edit_layouts" />
 </portlet:actionURL>
 
-<portlet:renderURL var="editLayoutRenderURL" windowState="<%= layout.isTypeControlPanel() ? LiferayWindowState.NORMAL.toString() : LiferayWindowState.EXCLUSIVE.toString() %>">
+<portlet:renderURL var="editLayoutRenderURL" windowState="<%= themeDisplay.isStateExclusive() ? LiferayWindowState.EXCLUSIVE.toString() : WindowState.NORMAL.toString() %>">
 	<portlet:param name="struts_action" value="/layouts_admin/edit_layouts" />
 </portlet:renderURL>
 

--- a/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/add_layout.jsp
@@ -43,11 +43,11 @@ else {
 }
 %>
 
-<portlet:actionURL var="editLayoutActionURL" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>">
+<portlet:actionURL var="editLayoutActionURL" windowState="<%= layout.isTypeControlPanel() ? LiferayWindowState.NORMAL.toString() : LiferayWindowState.EXCLUSIVE.toString() %>">
 	<portlet:param name="struts_action" value="/layouts_admin/edit_layouts" />
 </portlet:actionURL>
 
-<portlet:renderURL var="editLayoutRenderURL" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>">
+<portlet:renderURL var="editLayoutRenderURL" windowState="<%= layout.isTypeControlPanel() ? LiferayWindowState.NORMAL.toString() : LiferayWindowState.EXCLUSIVE.toString() %>">
 	<portlet:param name="struts_action" value="/layouts_admin/edit_layouts" />
 </portlet:renderURL>
 

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -326,7 +326,7 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 
 					A.one('#<portlet:namespace />layoutsNav').delegate('click', clickHandler, 'li a');
 
-					<c:if test='<%= layout.isTypeControlPanel() && Validator.isNotNull(SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError")) %>'>
+					<c:if test='<%= layout.isTypeControlPanel() && (SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError") != null) %>'>
 						executeAction('add-page');
 					</c:if>
 				</aui:script>

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -233,10 +233,10 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 
 						var dataValue = target.ancestor('li').attr('data-value') || target.attr('data-value');
 
-						executeAction(dataValue);
-					}
+						processDataValue(dataValue);
+					};
 
-					var executeAction = function(dataValue) {
+					var processDataValue = function(dataValue) {
 						if (dataValue === 'add-child-page') {
 							content = A.one('#<portlet:namespace />addLayout');
 
@@ -327,7 +327,7 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 					A.one('#<portlet:namespace />layoutsNav').delegate('click', clickHandler, 'li a');
 
 					<c:if test='<%= layout.isTypeControlPanel() && (SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError") != null) %>'>
-						executeAction('add-page');
+						processDataValue('add-page');
 					</c:if>
 				</aui:script>
 			</c:if>

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout.jsp
@@ -233,6 +233,10 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 
 						var dataValue = target.ancestor('li').attr('data-value') || target.attr('data-value');
 
+						executeAction(dataValue);
+					}
+
+					var executeAction = function(dataValue) {
 						if (dataValue === 'add-child-page') {
 							content = A.one('#<portlet:namespace />addLayout');
 
@@ -321,6 +325,10 @@ boolean showAddAction = ParamUtil.getBoolean(request, "showAddAction", true);
 					};
 
 					A.one('#<portlet:namespace />layoutsNav').delegate('click', clickHandler, 'li a');
+
+					<c:if test='<%= layout.isTypeControlPanel() && Validator.isNotNull(SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError")) %>'>
+						executeAction('add-page');
+					</c:if>
 				</aui:script>
 			</c:if>
 

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
@@ -216,10 +216,10 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 	var clickHandler = function(event) {
 		var dataValue = event.target.ancestor('li').attr('data-value');
 
-		executeAction(dataValue);
-	}
+		processDataValue(dataValue);
+	};
 
-	var executeAction = function(dataValue) {
+	var processDataValue = function(dataValue) {
 		if (dataValue === 'add-page' || dataValue === 'add-child-page') {
 			var content = A.one('#<portlet:namespace />addLayout');
 
@@ -300,7 +300,7 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 	A.one('#<portlet:namespace />layoutsNav').delegate('click', clickHandler, 'li a');
 
 	<c:if test='<%= layout.isTypeControlPanel() && (SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError") != null) %>'>
-		executeAction('add-page');
+		processDataValue('add-page');
 	</c:if>
 </aui:script>
 

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
@@ -216,6 +216,10 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 	var clickHandler = function(event) {
 		var dataValue = event.target.ancestor('li').attr('data-value');
 
+		executeAction(dataValue);
+	}
+
+	var executeAction = function(dataValue) {
 		if (dataValue === 'add-page' || dataValue === 'add-child-page') {
 			var content = A.one('#<portlet:namespace />addLayout');
 
@@ -294,6 +298,10 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 	};
 
 	A.one('#<portlet:namespace />layoutsNav').delegate('click', clickHandler, 'li a');
+
+	<c:if test='<%= layout.isTypeControlPanel() && Validator.isNotNull(SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError")) %>'>
+		executeAction('add-page');
+	</c:if>
 </aui:script>
 
 <%!

--- a/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/edit_layout_set.jsp
@@ -299,7 +299,7 @@ boolean hasViewPagesPermission = (pagesCount > 0) && (liveGroup.isStaged() || se
 
 	A.one('#<portlet:namespace />layoutsNav').delegate('click', clickHandler, 'li a');
 
-	<c:if test='<%= layout.isTypeControlPanel() && Validator.isNotNull(SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError")) %>'>
+	<c:if test='<%= layout.isTypeControlPanel() && (SessionMessages.get(liferayPortletRequest, portletDisplay.getId() + "addError") != null) %>'>
 		executeAction('add-page');
 	</c:if>
 </aui:script>


### PR DESCRIPTION
Question: 

How come you have to check for both? Shouldn't they both be the same?

```
SessionMessages.contains(renderRequest, "requestProcessed") || SessionMessages.contains(request, "requestProcessed")
```

Answer:
Hi Brian, I had added the explanation to the commit, but you probably missed it. Maybe there is a better way to achieve this, I will try to explain better the problem.

In this situation, we are executing an action from a portlet in page A (dockbar in page /link-to-welcome) and then we redirect to the same portlet in page B (dockbar in page /welcome). If we add the SessionMessage to the actionRequest and then use SessionMessages.contains(renderRequest, "requestProcessed"), the SessionMessage won't be found from the portlet in page B because the message is stored in the portletSession, which is finally stored in a map that used the plid as part of the key. The portletSession is different for the same portlet (even if it is not instanciable) in different pages and therefore the SessionMessages not shared.

For this reason, I had to add the SessionMessage to the HttpServletRequest (then it is stored in the session) and it can be found in the other page using SessionMessages.contains(request, "requestProcessed"). I checked that using the renderRequest doesn't find the SessionMessage.

All the changes related to this are in a separate commit explaining the change so that we can change it easily for a different mechanism if we have another way of achieving this.

Thank you very much Brian! :)
