### PR TITLE
LPS-43890: Under certain server settings, Liferay may not clean up temp files when deploying portlets

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
+++ b/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
@@ -804,7 +804,12 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 					WarTask.war(srcFile, deployDir, excludes, webXml);
 				}
 
-				DeleteTask.deleteDirectory(tempDir);
+				if (tempDir.isDirectory()) {
+					DeleteTask.deleteDirectory(tempDir);
+				}
+				else {
+					tempDir.delete();
+				}
 			}
 		}
 		else {


### PR DESCRIPTION
tested and verified that this fixes the delete issue.
