### PR TITLE
LPS-43884 - Organization Address section does not display correctly

### DIFF
--- a/portal-web/docroot/html/portlet/directory/user/addresses.jsp
+++ b/portal-web/docroot/html/portlet/directory/user/addresses.jsp
@@ -76,6 +76,8 @@ for (int i = 0; i < organizations.size(); i++) {
 			%>
 
 				<li class="<%= address.isPrimary() ? "primary" : "" %>">
+					<%@ include file="/html/portlet/directory/common/addresses_address_init.jspf" %>
+
 					<%@ include file="/html/portlet/directory/common/addresses_address.jspf" %>
 				</li>
 


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-43884.

This was caused by the Source Formatting at Git SHA ID: 7b8b5f39a57fff2d075fed92f683511605133489

Please let me know if you have any questions.  Thanks!
