### PR TITLE
master-bc-1062

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2453,20 +2453,6 @@ custom.sql.function.isnotnull=CONVERT(VARCHAR,?) IS NOT NULL</echo>
 			</then>
 		</if>
 
-		<if>
-			<or>
-				<isset property="hook.plugins.includes" />
-				<isset property="portlet.plugins.includes" />
-				<isset property="web.plugins.includes" />
-			</or>
-			<then>
-				<ant antfile="build-test-plugins.xml" target="deploy-simple-server-plugins">
-					<property name="plugin.types" value="hooks" />
-					<property name="plugins.includes" value="portal-compat-hook" />
-				</ant>
-			</then>
-		</if>
-
 		<antcall target="prepare-selenium" />
 
 		<if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-7509

This removes the deploying of the portal-compat-hook when there are plugins.

The reason we are doing this is because the portal-compat-hook has a bug (https://issues.liferay.com/browse/LPS-44286) that is causing every test in ee-6.2.x that deploys a plugin to fail (which is more than 100 of our tests).

We talked with Jeffrey, and he mentioned that the only plugin that needs the portal-compat-hook is social office. Since the social office team has already set a property in their own test files that ensures that the portal-compat-hook is deployed, we wanted to just remove it from build-test.xml.
