### PR TITLE
LPS-44390 No need to set _group variable to null, as it is always initialized on setUp

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
@@ -64,6 +64,7 @@ import org.junit.runner.RunWith;
 		TransactionalExecutionTestListener.class
 	})
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
+@Transactional
 public class MBAttachmentsTest {
 
 	@Before
@@ -81,7 +82,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testDeleteAttachmentsWhenDeletingMessage() throws Exception {
 		int initialFileEntriesCount =
 			DLFileEntryLocalServiceUtil.getFileEntriesCount();
@@ -106,7 +106,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testDeleteAttachmentsWhenDeletingRootMessage()
 		throws Exception {
 
@@ -127,7 +126,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenAddingAttachmentsToSameMessage()
 		throws Exception {
 
@@ -147,7 +145,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenAddingMessage() throws Exception {
 		int initialFoldersCount = DLFolderLocalServiceUtil.getDLFoldersCount();
 
@@ -162,7 +159,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenAddingMessageAttachment() throws Exception {
 		int initialFoldersCount = DLFolderLocalServiceUtil.getDLFoldersCount();
 
@@ -174,7 +170,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenAddingMessageAttachments()
 		throws Exception {
 
@@ -217,7 +212,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenAddingRootMessage() throws Exception {
 		int initialFoldersCount = DLFolderLocalServiceUtil.getDLFoldersCount();
 
@@ -228,7 +222,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenDeletingMessageWithAttachments()
 		throws Exception {
 
@@ -254,7 +247,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenDeletingMessageWithoutAttachments()
 		throws Exception {
 
@@ -276,7 +268,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenDeletingRootMessageWithAttachments()
 		throws Exception {
 
@@ -296,7 +287,6 @@ public class MBAttachmentsTest {
 	}
 
 	@Test
-	@Transactional
 	public void testFoldersCountWhenDeletingRootMessageWithoutAttachments()
 		throws Exception {
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
@@ -308,8 +308,6 @@ public class MBAttachmentsTest {
 		addMessageAttachment();
 
 		_trashMBAttachments(false);
-
-		GroupLocalServiceUtil.deleteGroup(_group);
 	}
 
 	@Test
@@ -317,8 +315,6 @@ public class MBAttachmentsTest {
 		addMessageAttachment();
 
 		_trashMBAttachments(true);
-
-		GroupLocalServiceUtil.deleteGroup(_group);
 	}
 
 	protected void addCategory() throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 import com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil;
-import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.ServiceTestUtil;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/attachments/MBAttachmentsTest.java
@@ -77,7 +77,6 @@ public class MBAttachmentsTest {
 	@After
 	public void tearDown() throws Exception {
 		_category = null;
-		_group = null;
 		_message = null;
 	}
 


### PR DESCRIPTION
This fix applies to LAX Jenkins, where this test fails
