### PR TITLE
[TECHNICAL-SUPPORT] LPS-44122 Search: escape & highlight don't work well together

### DIFF
--- a/portal-impl/src/com/liferay/portal/search/lucene/IndexAccessor.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/IndexAccessor.java
@@ -33,11 +33,11 @@ public interface IndexAccessor {
 
 	public static final long DEFAULT_LAST_GENERATION = -1;
 
+	public IndexSearcher acquireIndexSearcher() throws IOException;
+
 	public void addDocument(Document document) throws IOException;
 
 	public void addDocuments(Collection<Document> documents) throws IOException;
-
-	public IndexSearcher acquireIndexSearcher() throws IOException;
 
 	public void close();
 

--- a/portal-impl/src/com/liferay/portal/search/lucene/IndexAccessorImpl.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/IndexAccessorImpl.java
@@ -81,6 +81,11 @@ public class IndexAccessorImpl implements IndexAccessor {
 	}
 
 	@Override
+	public IndexSearcher acquireIndexSearcher() throws IOException {
+		return _indexSearcherManager.acquire();
+	}
+
+	@Override
 	public void addDocument(Document document) throws IOException {
 		if (SearchEngineUtil.isIndexReadOnly()) {
 			return;
@@ -103,11 +108,6 @@ public class IndexAccessorImpl implements IndexAccessor {
 		finally {
 			_commit();
 		}
-	}
-
-	@Override
-	public IndexSearcher acquireIndexSearcher() throws IOException {
-		return _indexSearcherManager.acquire();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelper.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelper.java
@@ -103,6 +103,8 @@ public interface LuceneHelper {
 
 	public IndexAccessor getIndexAccessor(long companyId);
 
+	public IndexSearcher getIndexSearcher(long companyId) throws IOException;
+
 	public long getLastGeneration(long companyId);
 
 	public InputStream getLoadIndexesInputStreamFromCluster(
@@ -110,8 +112,6 @@ public interface LuceneHelper {
 		throws SystemException;
 
 	public Set<String> getQueryTerms(Query query);
-
-	public IndexSearcher getIndexSearcher(long companyId) throws IOException;
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #getIndexSearcher(long)}
@@ -134,7 +134,8 @@ public interface LuceneHelper {
 
 	public void loadIndexesFromCluster(long companyId) throws SystemException;
 
-	public void releaseIndexSearcher(long companyId, IndexSearcher indexSearcher)
+	public void releaseIndexSearcher(
+			long companyId, IndexSearcher indexSearcher)
 		throws IOException;
 
 	public void shutdown();

--- a/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperImpl.java
@@ -430,6 +430,13 @@ public class LuceneHelperImpl implements LuceneHelper {
 	}
 
 	@Override
+	public IndexSearcher getIndexSearcher(long companyId) throws IOException {
+		IndexAccessor indexAccessor = getIndexAccessor(companyId);
+
+		return indexAccessor.acquireIndexSearcher();
+	}
+
+	@Override
 	public long getLastGeneration(long companyId) {
 		if (!isLoadIndexFromClusterEnabled()) {
 			return IndexAccessor.DEFAULT_LAST_GENERATION;
@@ -523,13 +530,6 @@ public class LuceneHelperImpl implements LuceneHelper {
 		}
 
 		return queryTerms;
-	}
-
-	@Override
-	public IndexSearcher getIndexSearcher(long companyId) throws IOException {
-		IndexAccessor indexAccessor = getIndexAccessor(companyId);
-
-		return indexAccessor.acquireIndexSearcher();
 	}
 
 	/**
@@ -664,7 +664,8 @@ public class LuceneHelperImpl implements LuceneHelper {
 	}
 
 	@Override
-	public void releaseIndexSearcher(long companyId, IndexSearcher indexSearcher)
+	public void releaseIndexSearcher(
+			long companyId, IndexSearcher indexSearcher)
 		throws IOException {
 
 		IndexAccessor indexAccessor = getIndexAccessor(companyId);

--- a/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/LuceneHelperUtil.java
@@ -320,6 +320,12 @@ public class LuceneHelperUtil {
 		return getLuceneHelper().getIndexAccessor(companyId);
 	}
 
+	public static IndexSearcher getIndexSearcher(long companyId)
+		throws IOException {
+
+		return getLuceneHelper().getIndexSearcher(companyId);
+	}
+
 	public static long getLastGeneration(long companyId) {
 		return getLuceneHelper().getLastGeneration(companyId);
 	}
@@ -338,12 +344,6 @@ public class LuceneHelperUtil {
 
 	public static Set<String> getQueryTerms(Query query) {
 		return getLuceneHelper().getQueryTerms(query);
-	}
-
-	public static IndexSearcher getIndexSearcher(long companyId)
-		throws IOException {
-
-		return getLuceneHelper().getIndexSearcher(companyId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/search/lucene/SynchronizedIndexAccessorImpl.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/SynchronizedIndexAccessorImpl.java
@@ -43,6 +43,18 @@ public class SynchronizedIndexAccessorImpl implements IndexAccessor {
 	}
 
 	@Override
+	public IndexSearcher acquireIndexSearcher() throws IOException {
+		_readLock.lock();
+
+		try {
+			return _indexAccessor.acquireIndexSearcher();
+		}
+		finally {
+			_readLock.unlock();
+		}
+	}
+
+	@Override
 	public void addDocument(Document document) throws IOException {
 		_readLock.lock();
 
@@ -62,18 +74,6 @@ public class SynchronizedIndexAccessorImpl implements IndexAccessor {
 
 		try {
 			_indexAccessor.addDocuments(documents);
-		}
-		finally {
-			_readLock.unlock();
-		}
-	}
-
-	@Override
-	public IndexSearcher acquireIndexSearcher() throws IOException {
-		_readLock.lock();
-
-		try {
-			return _indexAccessor.acquireIndexSearcher();
 		}
 		finally {
 			_readLock.unlock();

--- a/portal-service/src/com/liferay/portal/kernel/search/Summary.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Summary.java
@@ -50,10 +50,30 @@ public class Summary {
 		return _content;
 	}
 
+	/**
+	 * Returns the content that is optionally escaped and/or highlighted.
+	 * If both <code>escape</code> and <code>highlight</code> are set to
+	 * <code>true</code>, ensures that the operations are executed in the
+	 * correct order.
+	 *
+	 * @param escape whether to escape the content
+	 * @param highlight whether to highlight the content
+	 * @return the content
+	 */
 	public String getHighlightedContent() {
 		return _escapeAndHighlight(_content);
 	}
 
+	/**
+	 * Returns the title that is optionally escaped and/or highlighted.
+	 * If both <code>escape</code> and <code>highlight</code> are set to
+	 * <code>true</code>, ensures that the operations are executed in the
+	 * correct order
+	 *
+	 * @param escape whether to escape the title
+	 * @param highlight whether to highlight the title
+	 * @return the title
+	 */
 	public String getHighlightedTitle() {
 		return _escapeAndHighlight(_title);
 	}

--- a/portal-service/src/com/liferay/portal/kernel/search/Summary.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Summary.java
@@ -51,13 +51,9 @@ public class Summary {
 	}
 
 	/**
-	 * Returns the content that is optionally escaped and/or highlighted.
-	 * If both <code>escape</code> and <code>highlight</code> are set to
-	 * <code>true</code>, ensures that the operations are executed in the
-	 * correct order.
+	 * Returns the content escaped and highlighted and ensures that the
+	 * operations are executed in the correct order.
 	 *
-	 * @param escape whether to escape the content
-	 * @param highlight whether to highlight the content
 	 * @return the content
 	 */
 	public String getHighlightedContent() {
@@ -65,13 +61,9 @@ public class Summary {
 	}
 
 	/**
-	 * Returns the title that is optionally escaped and/or highlighted.
-	 * If both <code>escape</code> and <code>highlight</code> are set to
-	 * <code>true</code>, ensures that the operations are executed in the
-	 * correct order
+	 * Returns the title escaped and highlighted and ensures that the
+	 * operations are executed in the correct order.
 	 *
-	 * @param escape whether to escape the title
-	 * @param highlight whether to highlight the title
 	 * @return the title
 	 */
 	public String getHighlightedTitle() {

--- a/portal-service/src/com/liferay/portal/kernel/search/Summary.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Summary.java
@@ -50,8 +50,12 @@ public class Summary {
 		return _content;
 	}
 
-	public String getContent(boolean escape, boolean highlight) {
-		return _escapeAndHighlight(_content, escape, highlight);
+	public String getHighlightedContent() {
+		return _escapeAndHighlight(_content);
+	}
+
+	public String getHighlightedTitle() {
+		return _escapeAndHighlight(_title);
 	}
 
 	public Locale getLocale() {
@@ -72,10 +76,6 @@ public class Summary {
 
 	public String getTitle() {
 		return _title;
-	}
-
-	public String getTitle(boolean escape, boolean highlight) {
-		return _escapeAndHighlight(_title, escape, highlight);
 	}
 
 	public boolean isHighlight() {
@@ -122,35 +122,28 @@ public class Summary {
 		_title = title;
 	}
 
-	private String _escapeAndHighlight(
-		String s, boolean escape, boolean highlight) {
-
-		if (Validator.isNull(s) || ArrayUtil.isEmpty(_queryTerms)) {
-			return s;
+	private String _escapeAndHighlight(String text) {
+		if (Validator.isNull(text) || ArrayUtil.isEmpty(_queryTerms)) {
+			return text;
 		}
 
-		String result = s;
-
-		if (highlight) {
-			result = SearchUtil.highlight(
-				result, _queryTerms, ESCAPE_SAFE_HIGHLIGHT_1,
+		if (_highlight) {
+			text = SearchUtil.highlight(
+				text, _queryTerms, ESCAPE_SAFE_HIGHLIGHT_1,
 				ESCAPE_SAFE_HIGHLIGHT_2);
-		}
 
-		if (escape) {
-			result = HtmlUtil.escape(result);
-		}
+			text = HtmlUtil.escape(text);
 
-		if (highlight) {
-			result = StringUtil.replace(
-				result, new String[] {
-					ESCAPE_SAFE_HIGHLIGHT_1, ESCAPE_SAFE_HIGHLIGHT_2},
+			text = StringUtil.replace(
+				text,
+				new String[] {ESCAPE_SAFE_HIGHLIGHT_1, ESCAPE_SAFE_HIGHLIGHT_2},
 				new String[] {
 					SearchUtil.DEFAULT_HIGHLIGHT_1,
-					SearchUtil.DEFAULT_HIGHLIGHT_2});
+					SearchUtil.DEFAULT_HIGHLIGHT_2
+				});
 		}
 
-		return result;
+		return text;
 	}
 
 	private static final String ESCAPE_SAFE_HIGHLIGHT_1 = "[@HIGHLIGHT1@]";

--- a/portal-service/src/com/liferay/portal/kernel/search/util/SearchUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/util/SearchUtil.java
@@ -28,6 +28,11 @@ import java.util.regex.Pattern;
  */
 public class SearchUtil {
 
+	public static final String DEFAULT_HIGHLIGHT_1 =
+		"<span class=\"highlight\">";
+
+	public static final String DEFAULT_HIGHLIGHT_2 = "</span>";
+
 	/**
 	 * Returns the string <code>s</code> with any of the query terms found
 	 * within it highlighted with HTML.
@@ -40,7 +45,7 @@ public class SearchUtil {
 	 */
 	public static String highlight(String s, String[] queryTerms) {
 		return highlight(
-			s, queryTerms, "<span class=\"highlight\">", "</span>");
+			s, queryTerms, DEFAULT_HIGHLIGHT_1, DEFAULT_HIGHLIGHT_2);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/kernel/search/util/SearchUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/util/SearchUtil.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.search.util;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Tibor Lipusz
+ */
+public class SearchUtil {
+
+	/**
+	 * Returns the string <code>s</code> with any of the query terms found
+	 * within it highlighted with HTML.
+	 *
+	 * @param  s the string to search (optionally <code>null</code>)
+	 * @param  queryTerms the terms to search for in the string (optionally
+	 *         <code>null</code>)
+	 * @return the string <code>s</code> with any of the query terms found
+	 *         within it highlighted with HTML
+	 */
+	public static String highlight(String s, String[] queryTerms) {
+		return highlight(
+			s, queryTerms, "<span class=\"highlight\">", "</span>");
+	}
+
+	/**
+	 * Returns the string <code>s</code> with any of the query terms found
+	 * within it highlighted with the syntax highlighting tags.
+	 *
+	 * @param  s the string to search (optionally <code>null</code>)
+	 * @param  queryTerms the terms to search for in the string (optionally
+	 *         <code>null</code>)
+	 * @param  highlight1 the beginning highlight tag
+	 * @param  highlight2 the ending highlight tag
+	 * @return the string <code>s</code> with any of the query terms found
+	 *         within it highlighted with the syntax highlighting tags
+	 */
+	public static String highlight(
+		String s, String[] queryTerms, String highlight1, String highlight2) {
+
+		if (Validator.isNull(s) || ArrayUtil.isEmpty(queryTerms)) {
+			return s;
+		}
+
+		if (queryTerms.length == 0) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler sb = new StringBundler(2 * queryTerms.length - 1);
+
+		for (int i = 0; i < queryTerms.length; i++) {
+			sb.append(Pattern.quote(queryTerms[i].trim()));
+
+			if ((i + 1) < queryTerms.length) {
+				sb.append(StringPool.PIPE);
+			}
+		}
+
+		int flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
+
+		Pattern pattern = Pattern.compile(sb.toString(), flags);
+
+		return _highlight(s, pattern, highlight1, highlight2);
+	}
+
+	private static String _highlight(
+		String s, Pattern pattern, String highlight1, String highlight2) {
+
+		StringTokenizer st = new StringTokenizer(s);
+
+		if (st.countTokens() == 0) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler sb = new StringBundler(2 * st.countTokens() - 1);
+
+		while (st.hasMoreTokens()) {
+			String token = st.nextToken();
+
+			Matcher matcher = pattern.matcher(token);
+
+			if (matcher.find()) {
+				StringBuffer hightlighted = new StringBuffer();
+
+				do {
+					matcher.appendReplacement(
+						hightlighted,
+						highlight1 + matcher.group() + highlight2);
+				}
+				while (matcher.find());
+
+				matcher.appendTail(hightlighted);
+
+				sb.append(hightlighted);
+			}
+			else {
+				sb.append(token);
+			}
+
+			if (st.hasMoreTokens()) {
+				sb.append(StringPool.SPACE);
+			}
+		}
+
+		return sb.toString();
+	}
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.util.SearchUtil;
 import com.liferay.portal.kernel.security.RandomUtil;
 
 import java.io.IOException;
@@ -33,8 +34,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-import java.util.StringTokenizer;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -656,58 +655,26 @@ public class StringUtil {
 	}
 
 	/**
-	 * Returns the string <code>s</code> with any of the query terms found
-	 * within it highlighted with HTML.
-	 *
-	 * @param  s the string to search (optionally <code>null</code>)
-	 * @param  queryTerms the terms to search for in the string (optionally
-	 *         <code>null</code>)
-	 * @return the string <code>s</code> with any of the query terms found
-	 *         within it highlighted with HTML
+	 * @deprecated As of 7.0.0, moved to {@link
+	 *             com.liferay.portal.kernel.search.util.SearchUtil
+	 *             #highlight(String, String[])}}
 	 */
+	@Deprecated
 	public static String highlight(String s, String[] queryTerms) {
-		return highlight(
+		return SearchUtil.highlight(
 			s, queryTerms, "<span class=\"highlight\">", "</span>");
 	}
 
 	/**
-	 * Returns the string <code>s</code> with any of the query terms found
-	 * within it highlighted with the syntax highlighting tags.
-	 *
-	 * @param  s the string to search (optionally <code>null</code>)
-	 * @param  queryTerms the terms to search for in the string (optionally
-	 *         <code>null</code>)
-	 * @param  highlight1 the beginning highlight tag
-	 * @param  highlight2 the ending highlight tag
-	 * @return the string <code>s</code> with any of the query terms found
-	 *         within it highlighted with the syntax highlighting tags
+	 * @deprecated As of 7.0.0, moved to {@link
+	 *             com.liferay.portal.kernel.search.util.SearchUtil
+	 *             #highlight(String, String[], String, String)}}
 	 */
+	@Deprecated
 	public static String highlight(
 		String s, String[] queryTerms, String highlight1, String highlight2) {
 
-		if (Validator.isNull(s) || ArrayUtil.isEmpty(queryTerms)) {
-			return s;
-		}
-
-		if (queryTerms.length == 0) {
-			return StringPool.BLANK;
-		}
-
-		StringBundler sb = new StringBundler(2 * queryTerms.length - 1);
-
-		for (int i = 0; i < queryTerms.length; i++) {
-			sb.append(Pattern.quote(queryTerms[i].trim()));
-
-			if ((i + 1) < queryTerms.length) {
-				sb.append(StringPool.PIPE);
-			}
-		}
-
-		int flags = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE;
-
-		Pattern pattern = Pattern.compile(sb.toString(), flags);
-
-		return _highlight(s, pattern, highlight1, highlight2);
+		return SearchUtil.highlight(s, queryTerms, highlight1, highlight2);
 	}
 
 	/**
@@ -4490,48 +4457,6 @@ public class StringUtil {
 
 			return text;
 		}
-	}
-
-	private static String _highlight(
-		String s, Pattern pattern, String highlight1, String highlight2) {
-
-		StringTokenizer st = new StringTokenizer(s);
-
-		if (st.countTokens() == 0) {
-			return StringPool.BLANK;
-		}
-
-		StringBundler sb = new StringBundler(2 * st.countTokens() - 1);
-
-		while (st.hasMoreTokens()) {
-			String token = st.nextToken();
-
-			Matcher matcher = pattern.matcher(token);
-
-			if (matcher.find()) {
-				StringBuffer hightlighted = new StringBuffer();
-
-				do {
-					matcher.appendReplacement(
-						hightlighted,
-						highlight1 + matcher.group() + highlight2);
-				}
-				while (matcher.find());
-
-				matcher.appendTail(hightlighted);
-
-				sb.append(hightlighted);
-			}
-			else {
-				sb.append(token);
-			}
-
-			if (st.hasMoreTokens()) {
-				sb.append(StringPool.SPACE);
-			}
-		}
-
-		return sb.toString();
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -656,31 +656,6 @@ public class StringUtil {
 	}
 
 	/**
-	 * @deprecated As of 6.1.0
-	 */
-	@Deprecated
-	public static String highlight(String s, String keywords) {
-		return highlight(s, keywords, "<span class=\"highlight\">", "</span>");
-	}
-
-	/**
-	 * @deprecated As of 6.1.0
-	 */
-	@Deprecated
-	public static String highlight(
-		String s, String keywords, String highlight1, String highlight2) {
-
-		if (Validator.isNull(s) || Validator.isNull(keywords)) {
-			return s;
-		}
-
-		Pattern pattern = Pattern.compile(
-			Pattern.quote(keywords), Pattern.CASE_INSENSITIVE);
-
-		return _highlight(s, pattern, highlight1, highlight2);
-	}
-
-	/**
 	 * Returns the string <code>s</code> with any of the query terms found
 	 * within it highlighted with HTML.
 	 *

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -662,7 +662,8 @@ public class StringUtil {
 	@Deprecated
 	public static String highlight(String s, String[] queryTerms) {
 		return SearchUtil.highlight(
-			s, queryTerms, "<span class=\"highlight\">", "</span>");
+			s, queryTerms, SearchUtil.DEFAULT_HIGHLIGHT_1,
+			SearchUtil.DEFAULT_HIGHLIGHT_2);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil_IW.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil_IW.java
@@ -109,11 +109,19 @@ public class StringUtil_IW {
 		return StringUtil.extractLeadingDigits(s);
 	}
 
+	/**
+	 * @deprecated
+	 */
+	@Deprecated
 	public java.lang.String highlight(java.lang.String s,
 		java.lang.String[] queryTerms) {
 		return StringUtil.highlight(s, queryTerms);
 	}
 
+	/**
+	 * @deprecated
+	 */
+	@Deprecated
 	public java.lang.String highlight(java.lang.String s,
 		java.lang.String[] queryTerms, java.lang.String highlight1,
 		java.lang.String highlight2) {

--- a/portal-service/src/com/liferay/portal/kernel/util/StringUtil_IW.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringUtil_IW.java
@@ -109,25 +109,6 @@ public class StringUtil_IW {
 		return StringUtil.extractLeadingDigits(s);
 	}
 
-	/**
-	 * @deprecated
-	 */
-	@Deprecated
-	public java.lang.String highlight(java.lang.String s,
-		java.lang.String keywords) {
-		return StringUtil.highlight(s, keywords);
-	}
-
-	/**
-	 * @deprecated
-	 */
-	@Deprecated
-	public java.lang.String highlight(java.lang.String s,
-		java.lang.String keywords, java.lang.String highlight1,
-		java.lang.String highlight2) {
-		return StringUtil.highlight(s, keywords, highlight1, highlight2);
-	}
-
 	public java.lang.String highlight(java.lang.String s,
 		java.lang.String[] queryTerms) {
 		return StringUtil.highlight(s, queryTerms);

--- a/portal-service/test/unit/com/liferay/portal/kernel/search/util/SearchUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/search/util/SearchUtilTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.search.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Tibor Lipusz
+ *
+ */
+public class SearchUtilTest {
+
+	@Test
+	public void testHighlight() throws Exception {
+		Assert.assertEquals(
+			SearchUtil.DEFAULT_HIGHLIGHT_1 + "Hello" +
+			SearchUtil.DEFAULT_HIGHLIGHT_2 + " World " +
+			SearchUtil.DEFAULT_HIGHLIGHT_1 + "Liferay" +
+			SearchUtil.DEFAULT_HIGHLIGHT_2,
+			SearchUtil.highlight(
+				"Hello World Liferay", new String[] {"Hello","Liferay"}));
+	}
+
+}

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/StringUtilTest.java
@@ -51,15 +51,6 @@ public class StringUtilTest {
 	}
 
 	@Test
-	public void testHighlight() throws Exception {
-		Assert.assertEquals(
-			"<span class=\"highlight\">Hello</span> World <span " +
-				"class=\"highlight\">Liferay</span>",
-			StringUtil.highlight(
-				"Hello World Liferay", new String[] {"Hello","Liferay"}));
-	}
-
-	@Test
 	public void testIndexOfAny() throws Exception {
 		char[] chars = {CharPool.COLON, CharPool.COMMA};
 

--- a/portal-web/docroot/html/portlet/blogs/search.jsp
+++ b/portal-web/docroot/html/portlet/blogs/search.jsp
@@ -102,11 +102,11 @@ String keywords = ParamUtil.getString(request, "keywords");
 
 			<liferay-ui:app-view-search-entry
 				cssClass='<%= MathUtil.isEven(index) ? "search" : "search alt" %>'
-				description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : entry.getDescription() %>"
+				description="<%= (summary != null) ? summary.getContent() : entry.getDescription() %>"
 				mbMessages="<%= searchResult.getMBMessages() %>"
 				queryTerms="<%= hits.getQueryTerms() %>"
 				thumbnailSrc="<%= Validator.isNotNull(entry.getEntryImageURL(themeDisplay)) ? entry.getEntryImageURL(themeDisplay) : StringPool.BLANK %>"
-				title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : entry.getTitle() %>"
+				title="<%= (summary != null) ? summary.getTitle() : entry.getTitle() %>"
 				url="<%= rowURL %>"
 			/>
 		</liferay-ui:search-container-row>

--- a/portal-web/docroot/html/portlet/document_library/search_resources.jsp
+++ b/portal-web/docroot/html/portlet/document_library/search_resources.jsp
@@ -251,7 +251,7 @@ else if ((searchType == DLSearchConstants.SINGLE) && !ajax) {
 								actionJsp="/html/portlet/document_library/file_entry_action.jsp"
 								containerName="<%= DLUtil.getAbsolutePath(liferayPortletRequest, fileEntry.getFolderId()) %>"
 								cssClass='<%= MathUtil.isEven(i) ? "alt" : StringPool.BLANK %>'
-								description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : fileEntry.getDescription() %>"
+								description="<%= (summary != null) ? summary.getContent() : fileEntry.getDescription() %>"
 								locked="<%= fileEntry.isCheckedOut() %>"
 								mbMessages="<%= searchResult.getMBMessages() %>"
 								queryTerms="<%= hits.getQueryTerms() %>"
@@ -260,7 +260,7 @@ else if ((searchType == DLSearchConstants.SINGLE) && !ajax) {
 								showCheckbox="<%= DLFileEntryPermission.contains(permissionChecker, fileEntry, ActionKeys.DELETE) || DLFileEntryPermission.contains(permissionChecker, fileEntry, ActionKeys.UPDATE) %>"
 								status="<%= latestFileVersion.getStatus() %>"
 								thumbnailSrc="<%= DLUtil.getThumbnailSrc(fileEntry, null, themeDisplay) %>"
-								title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : fileEntry.getTitle() %>"
+								title="<%= (summary != null) ? summary.getTitle() : fileEntry.getTitle() %>"
 								url="<%= tempRowURL.toString() %>"
 							/>
 						</c:when>
@@ -295,13 +295,13 @@ else if ((searchType == DLSearchConstants.SINGLE) && !ajax) {
 								actionJsp="/html/portlet/document_library/folder_action.jsp"
 								containerName="<%= DLUtil.getAbsolutePath(liferayPortletRequest, curFolder.getParentFolderId()) %>"
 								cssClass='<%= MathUtil.isEven(i) ? "alt" : StringPool.BLANK %>'
-								description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : curFolder.getDescription() %>"
+								description="<%= (summary != null) ? summary.getContent() : curFolder.getDescription() %>"
 								queryTerms="<%= hits.getQueryTerms() %>"
 								rowCheckerId="<%= String.valueOf(curFolder.getFolderId()) %>"
 								rowCheckerName="<%= Folder.class.getSimpleName() %>"
 								showCheckbox="<%= DLFolderPermission.contains(permissionChecker, curFolder, ActionKeys.DELETE) || DLFolderPermission.contains(permissionChecker, curFolder, ActionKeys.UPDATE) %>"
 								thumbnailSrc='<%= themeDisplay.getPathThemeImages() + "/file_system/large/" + folderImage + ".png" %>'
-								title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : curFolder.getName() %>"
+								title="<%= (summary != null) ? summary.getTitle() : curFolder.getName() %>"
 								url="<%= tempRowURL.toString() %>"
 							/>
 						</c:when>

--- a/portal-web/docroot/html/portlet/document_library_display/search.jsp
+++ b/portal-web/docroot/html/portlet/document_library_display/search.jsp
@@ -188,11 +188,11 @@ int mountFoldersCount = DLAppServiceUtil.getMountFoldersCount(scopeGroupId, DLFo
 						actionJsp='<%= (showActions) ? "/html/portlet/document_library/file_entry_action.jsp" : StringPool.BLANK %>'
 						containerName="<%= DLUtil.getAbsolutePath(renderRequest, fileEntry.getFolderId()) %>"
 						cssClass='<%= MathUtil.isEven(index) ? "search" : "search alt" %>'
-						description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : fileEntry.getDescription() %>"
+						description="<%= (summary != null) ? summary.getContent() : fileEntry.getDescription() %>"
 						mbMessages="<%= searchResult.getMBMessages() %>"
 						queryTerms="<%= hits.getQueryTerms() %>"
 						thumbnailSrc="<%= DLUtil.getThumbnailSrc(fileEntry, null, themeDisplay) %>"
-						title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : fileEntry.getTitle() %>"
+						title="<%= (summary != null) ? summary.getTitle() : fileEntry.getTitle() %>"
 						url="<%= rowURL %>"
 					/>
 				</c:when>
@@ -220,10 +220,10 @@ int mountFoldersCount = DLAppServiceUtil.getMountFoldersCount(scopeGroupId, DLFo
 						actionJsp='<%= (showActions) ? "/html/portlet/document_library/folder_action.jsp" : StringPool.BLANK %>'
 						containerName="<%= DLUtil.getAbsolutePath(renderRequest, folder.getParentFolderId()) %>"
 						cssClass='<%= MathUtil.isEven(index) ? "search" : "search alt" %>'
-						description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : folder.getDescription() %>"
+						description="<%= (summary != null) ? summary.getContent() : folder.getDescription() %>"
 						queryTerms="<%= hits.getQueryTerms() %>"
 						thumbnailSrc='<%= themeDisplay.getPathThemeImages() + "/file_system/large/" + folderImage + ".png" %>'
-						title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : folder.getName() %>"
+						title="<%= (summary != null) ? summary.getTitle() : folder.getName() %>"
 						url="<%= rowURL %>"
 					/>
 				</c:when>

--- a/portal-web/docroot/html/portlet/journal/search_resources.jsp
+++ b/portal-web/docroot/html/portlet/journal/search_resources.jsp
@@ -287,7 +287,7 @@ ArticleSearch searchContainer = new ArticleSearch(liferayPortletRequest, entryEn
 										actionJsp="/html/portlet/journal/article_action.jsp"
 										containerName="<%= JournalUtil.getAbsolutePath(liferayPortletRequest, article.getFolderId()) %>"
 										cssClass='<%= MathUtil.isEven(i) ? "alt" : StringPool.BLANK %>'
-										description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : article.getDescription(locale) %>"
+										description="<%= (summary != null) ? summary.getContent() : article.getDescription(locale) %>"
 										mbMessages="<%= searchResult.getMBMessages() %>"
 										queryTerms="<%= hits.getQueryTerms() %>"
 										rowCheckerId="<%= String.valueOf(article.getArticleId()) %>"
@@ -295,7 +295,7 @@ ArticleSearch searchContainer = new ArticleSearch(liferayPortletRequest, entryEn
 										showCheckbox="<%= JournalArticlePermission.contains(permissionChecker, article, ActionKeys.DELETE) || JournalArticlePermission.contains(permissionChecker, article, ActionKeys.UPDATE) %>"
 										status="<%= article.getStatus() %>"
 										thumbnailSrc='<%= Validator.isNotNull(article.getArticleImageURL(themeDisplay)) ? article.getArticleImageURL(themeDisplay) : themeDisplay.getPathThemeImages() + "/file_system/large/article.png" %>'
-										title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : article.getTitle(locale) %>"
+										title="<%= (summary != null) ? summary.getTitle() : article.getTitle(locale) %>"
 										url="<%= rowURL.toString() %>"
 										versions="<%= versions %>"
 									/>
@@ -324,13 +324,13 @@ ArticleSearch searchContainer = new ArticleSearch(liferayPortletRequest, entryEn
 										actionJsp="/html/portlet/journal/folder_action.jsp"
 										containerName="<%= JournalUtil.getAbsolutePath(liferayPortletRequest, curFolder.getParentFolderId()) %>"
 										cssClass='<%= MathUtil.isEven(i) ? "alt" : StringPool.BLANK %>'
-										description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : curFolder.getDescription() %>"
+										description="<%= (summary != null) ? summary.getContent() : curFolder.getDescription() %>"
 										queryTerms="<%= hits.getQueryTerms() %>"
 										rowCheckerId="<%= String.valueOf(curFolder.getFolderId()) %>"
 										rowCheckerName="<%= JournalFolder.class.getSimpleName() %>"
 										showCheckbox="<%= JournalFolderPermission.contains(permissionChecker, curFolder, ActionKeys.DELETE) || JournalFolderPermission.contains(permissionChecker, curFolder, ActionKeys.UPDATE) %>"
 										thumbnailSrc='<%= themeDisplay.getPathThemeImages() + "/file_system/large/" + folderImage + ".png" %>'
-										title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : curFolder.getName() %>"
+										title="<%= (summary != null) ? summary.getTitle() : curFolder.getName() %>"
 										url="<%= rowURL.toString() %>"
 									/>
 								</c:when>

--- a/portal-web/docroot/html/portlet/journal_content_search/article_content.jsp
+++ b/portal-web/docroot/html/portlet/journal_content_search/article_content.jsp
@@ -21,11 +21,10 @@ ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_
 
 Object[] objArray = (Object[])row.getObject();
 
-String[] queryTerms = (String[])objArray[0];
-Document doc = (Document)objArray[1];
-Summary summary = (Summary)objArray[2];
+Document doc = (Document)objArray[0];
+Summary summary = (Summary)objArray[1];
 
-String content = HtmlUtil.escape(summary.getHighlightedContent(queryTerms));
+String content = summary.getContent(true, PropsValues.INDEX_SEARCH_HIGHLIGHT_ENABLED);
 
 long articleGroupId = GetterUtil.getLong(doc.get(Field.GROUP_ID));
 String articleId = doc.get("articleId");

--- a/portal-web/docroot/html/portlet/journal_content_search/article_content.jsp
+++ b/portal-web/docroot/html/portlet/journal_content_search/article_content.jsp
@@ -24,15 +24,13 @@ Object[] objArray = (Object[])row.getObject();
 Document doc = (Document)objArray[0];
 Summary summary = (Summary)objArray[1];
 
-String content = summary.getContent(true, PropsValues.INDEX_SEARCH_HIGHLIGHT_ENABLED);
-
 long articleGroupId = GetterUtil.getLong(doc.get(Field.GROUP_ID));
 String articleId = doc.get("articleId");
 
 List hitLayoutIds = JournalContentSearchLocalServiceUtil.getLayoutIds(layout.getGroupId(), layout.isPrivateLayout(), articleId);
 %>
 
-<%= content %><br />
+<%= summary.getHighlightedContent() %><br />
 
 <c:choose>
 	<c:when test="<%= !hitLayoutIds.isEmpty() %>">

--- a/portal-web/docroot/html/portlet/journal_content_search/article_language.jsp
+++ b/portal-web/docroot/html/portlet/journal_content_search/article_language.jsp
@@ -21,7 +21,7 @@ ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_
 
 Object[] objArray = (Object[])row.getObject();
 
-Locale snippetLocale = ((Summary)objArray[2]).getLocale();
+Locale snippetLocale = ((Summary)objArray[1]).getLocale();
 
 String languageId = LocaleUtil.toLanguageId(snippetLocale);
 %>

--- a/portal-web/docroot/html/portlet/journal_content_search/search.jsp
+++ b/portal-web/docroot/html/portlet/journal_content_search/search.jsp
@@ -89,9 +89,9 @@
 
 					Summary summary = indexer.getSummary(doc, locale, StringPool.BLANK, summaryURL);
 
-					summary.setHighlight(PropsValues.INDEX_SEARCH_HIGHLIGHT_ENABLED);
+					summary.setQueryTerms(queryTerms);
 
-					ResultRow row = new ResultRow(new Object[] {queryTerms, doc, summary}, i, i);
+					ResultRow row = new ResultRow(new Object[] {doc, summary}, i, i);
 
 					// Position
 
@@ -101,7 +101,7 @@
 
 					// Title
 
-					String title = HtmlUtil.escape(summary.getHighlightedTitle(queryTerms));
+					String title = summary.getTitle(true, PropsValues.INDEX_SEARCH_HIGHLIGHT_ENABLED);
 
 					row.addText(title);
 

--- a/portal-web/docroot/html/portlet/journal_content_search/search.jsp
+++ b/portal-web/docroot/html/portlet/journal_content_search/search.jsp
@@ -89,6 +89,7 @@
 
 					Summary summary = indexer.getSummary(doc, locale, StringPool.BLANK, summaryURL);
 
+					summary.setHighlight(PropsValues.INDEX_SEARCH_HIGHLIGHT_ENABLED);
 					summary.setQueryTerms(queryTerms);
 
 					ResultRow row = new ResultRow(new Object[] {doc, summary}, i, i);
@@ -101,7 +102,7 @@
 
 					// Title
 
-					String title = summary.getTitle(true, PropsValues.INDEX_SEARCH_HIGHLIGHT_ENABLED);
+					String title = summary.getHighlightedTitle();
 
 					row.addText(title);
 

--- a/portal-web/docroot/html/portlet/message_boards/search.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/search.jsp
@@ -129,10 +129,10 @@ String keywords = ParamUtil.getString(request, "keywords");
 				containerName="<%= MBUtil.getAbsolutePath(renderRequest, message.getCategoryId()) %>"
 				containerType='<%= LanguageUtil.get(locale, "category[message-board]") %>'
 				cssClass='<%= MathUtil.isEven(index) ? "search" : "search alt" %>'
-				description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : StringPool.BLANK %>"
+				description="<%= (summary != null) ? summary.getContent() : StringPool.BLANK %>"
 				fileEntryTuples="<%= searchResult.getFileEntryTuples() %>"
 				queryTerms="<%= hits.getQueryTerms() %>"
-				title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : HtmlUtil.escape(message.getSubject()) %>"
+				title="<%= (summary != null) ? summary.getTitle() : message.getSubject() %>"
 				url="<%= rowURL %>"
 			/>
 		</liferay-ui:search-container-row>

--- a/portal-web/docroot/html/portlet/search/init.jsp
+++ b/portal-web/docroot/html/portlet/search/init.jsp
@@ -32,6 +32,7 @@ page import="com.liferay.portal.kernel.search.facet.config.FacetConfiguration" %
 page import="com.liferay.portal.kernel.search.facet.config.FacetConfigurationUtil" %><%@
 page import="com.liferay.portal.kernel.search.facet.util.FacetFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.search.facet.util.RangeParserUtil" %><%@
+page import="com.liferay.portal.kernel.search.util.SearchUtil" %><%@
 page import="com.liferay.portal.kernel.util.DateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.xml.Element" %><%@
 page import="com.liferay.portal.kernel.xml.SAXReaderUtil" %><%@

--- a/portal-web/docroot/html/portlet/search/main_search_result_form.jsp
+++ b/portal-web/docroot/html/portlet/search/main_search_result_form.jsp
@@ -116,6 +116,7 @@ if (summary != null) {
 	boolean highlightEnabled = (Boolean)request.getAttribute("search.jsp-highlightEnabled");
 	String[] queryTerms = (String[])request.getAttribute("search.jsp-queryTerms");
 
+	summary.setHighlight(highlightEnabled);
 	summary.setQueryTerms(queryTerms);
 
 	PortletURL portletURL = (PortletURL)request.getAttribute("search.jsp-portletURL");
@@ -132,11 +133,11 @@ if (summary != null) {
 					<img alt="" src="<%= assetRenderer.getIconPath(renderRequest) %>" />
 				</c:if>
 
-				<%= summary.getTitle(true, highlightEnabled) %>
+				<%= summary.getHighlightedTitle() %>
 			</a>
 
 			<c:if test="<%= Validator.isNotNull(downloadURL) %>">
-				<liferay-ui:icon image="../arrows/01_down" label="<%= false %>" message='<%= LanguageUtil.format(pageContext, "download-x", summary.getTitle(true, false), false) %>' url="<%= downloadURL %>" />
+				<liferay-ui:icon image="../arrows/01_down" label="<%= false %>" message='<%= LanguageUtil.format(pageContext, "download-x", HtmlUtil.escape(summary.getTitle()), false) %>' url="<%= downloadURL %>" />
 			</c:if>
 		</span>
 
@@ -149,7 +150,7 @@ if (summary != null) {
 			<div class="asset-entry-content">
 				<c:if test="<%= Validator.isNotNull(summary.getContent()) %>">
 					<span class="asset-entry-summary">
-						<%= summary.getContent(true, highlightEnabled) %>
+						<%= summary.getHighlightedContent() %>
 					</span>
 				</c:if>
 

--- a/portal-web/docroot/html/portlet/search/open_search.jspf
+++ b/portal-web/docroot/html/portlet/search/open_search.jspf
@@ -219,12 +219,12 @@ for (int i = 0; i < portlets.size(); i++) {
 				rowSB.append("<a class=\"entry-title\" href=\"");
 				rowSB.append(entryHref);
 				rowSB.append("\">");
-				rowSB.append(StringUtil.highlight(HtmlUtil.escape(entryTitle), queryTerms));
+				rowSB.append(SearchUtil.highlight(HtmlUtil.escape(entryTitle), queryTerms));
 				rowSB.append("</a>");
 
 				if (Validator.isNotNull(summary)) {
 					rowSB.append("<br />");
-					rowSB.append(StringUtil.highlight(HtmlUtil.escape(summary), queryTerms));
+					rowSB.append(SearchUtil.highlight(HtmlUtil.escape(summary), queryTerms));
 				}
 
 				rowSB.append("<br />");
@@ -265,7 +265,7 @@ for (int i = 0; i < portlets.size(); i++) {
 					rowSB.append("<a class=\"tag\" href=\"");
 					rowSB.append(tagURL.toString());
 					rowSB.append("\">");
-					rowSB.append(StringUtil.highlight(tag, tagsQueryTerms));
+					rowSB.append(SearchUtil.highlight(tag, tagsQueryTerms));
 					rowSB.append("</a>");
 
 					if ((k + 1) == tags.length) {

--- a/portal-web/docroot/html/portlet/wiki/search.jsp
+++ b/portal-web/docroot/html/portlet/wiki/search.jsp
@@ -121,11 +121,11 @@ portletURL.setParameter("keywords", keywords);
 				containerName="<%= curNode.getName() %>"
 				containerType='<%= LanguageUtil.get(locale, "wiki-node") %>'
 				cssClass='<%= MathUtil.isEven(index) ? "search" : "search alt" %>'
-				description="<%= (summary != null) ? HtmlUtil.escape(summary.getContent()) : HtmlUtil.escape(wikiPage.getSummary()) %>"
+				description="<%= (summary != null) ? summary.getContent() : wikiPage.getSummary() %>"
 				fileEntryTuples="<%= searchResult.getFileEntryTuples() %>"
 				mbMessages="<%= searchResult.getMBMessages() %>"
 				queryTerms="<%= hits.getQueryTerms() %>"
-				title="<%= (summary != null) ? HtmlUtil.escape(summary.getTitle()) : wikiPage.getTitle() %>"
+				title="<%= (summary != null) ? summary.getTitle() : wikiPage.getTitle() %>"
 				url="<%= rowURL %>"
 			/>
 		</liferay-ui:search-container-row>

--- a/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
@@ -40,6 +40,7 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 
 Summary summary = new Summary(title, description, null);
 
+summary.setHighlight(highlightEnabled);
 summary.setQueryTerms(queryTerms);
 %>
 
@@ -57,7 +58,7 @@ summary.setQueryTerms(queryTerms);
 
 		<div class="entry-metadata">
 			<span class="entry-title">
-				<%= summary.getTitle(escape, highlightEnabled) %>
+				<%= summary.getHighlightedContent() %>
 
 				<c:if test="<%= (status != WorkflowConstants.STATUS_ANY) && (status != WorkflowConstants.STATUS_APPROVED) %>">
 					<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= status %>" />
@@ -109,7 +110,7 @@ summary.setQueryTerms(queryTerms);
 			</c:if>
 
 			<span class="entry-description">
-				<%= summary.getContent(escape, highlightEnabled) %>
+				<%= summary.getHighlightedContent() %>
 			</span>
 		</div>
 	</a>
@@ -141,7 +142,7 @@ summary.setQueryTerms(queryTerms);
 						</span>
 
 						<span class="body">
-							<%= summary.getContent(escape, highlightEnabled) %>
+							<%= summary.getHighlightedContent() %>
 						</span>
 				</aui:a>
 			</div>
@@ -176,7 +177,7 @@ summary.setQueryTerms(queryTerms);
 					</span>
 
 					<span class="body">
-						<%= summary.getContent(escape, highlightEnabled) %>
+						<%= summary.getHighlightedContent() %>
 					</span>
 				</aui:a>
 			</div>

--- a/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
@@ -37,6 +37,10 @@ String thumbnailSrc = (String)request.getAttribute("liferay-ui:app-view-search-e
 String title = (String)request.getAttribute("liferay-ui:app-view-search-entry:title");
 String url = (String)request.getAttribute("liferay-ui:app-view-search-entry:url");
 List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-search-entry:versions");
+
+Summary summary = new Summary(title, description, null);
+
+summary.setQueryTerms(queryTerms);
 %>
 
 <div class="app-view-entry app-view-search-entry-taglib entry-display-style <%= showCheckbox ? "selectable" : StringPool.BLANK %> <%= cssClass %>" data-title="<%= HtmlUtil.escapeAttribute(StringUtil.shorten(title, 60)) %>">
@@ -53,14 +57,7 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 
 		<div class="entry-metadata">
 			<span class="entry-title">
-				<c:choose>
-					<c:when test="<%= highlightEnabled %>">
-						<%= StringUtil.highlight(HtmlUtil.escape(title), queryTerms) %>
-					</c:when>
-					<c:otherwise>
-						<%= HtmlUtil.escape(title) %>
-					</c:otherwise>
-				</c:choose>
+				<%= summary.getTitle(escape, highlightEnabled) %>
 
 				<c:if test="<%= (status != WorkflowConstants.STATUS_ANY) && (status != WorkflowConstants.STATUS_APPROVED) %>">
 					<aui:workflow-status showIcon="<%= false %>" showLabel="<%= false %>" status="<%= status %>" />
@@ -112,14 +109,7 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 			</c:if>
 
 			<span class="entry-description">
-				<c:choose>
-					<c:when test="<%= highlightEnabled %>">
-						<%= StringUtil.highlight(HtmlUtil.escape(description), queryTerms) %>
-					</c:when>
-					<c:otherwise>
-						<%= HtmlUtil.escape(description) %>
-					</c:otherwise>
-				</c:choose>
+				<%= summary.getContent(escape, highlightEnabled) %>
 			</span>
 		</div>
 	</a>
@@ -129,7 +119,11 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 		<%
 		for (Tuple fileEntryTuple : fileEntryTuples) {
 			FileEntry fileEntry = (FileEntry)fileEntryTuple.getObject(0);
-			Summary summary = (Summary)fileEntryTuple.getObject(1);
+			summary = (Summary)fileEntryTuple.getObject(1);
+
+			if (Validator.isNull(summary.getContent())) {
+				summary.setContent(fileEntry.getTitle());
+			}
 		%>
 
 			<div class="entry-attachment">
@@ -147,19 +141,7 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 						</span>
 
 						<span class="body">
-
-							<%
-							String body = (Validator.isNotNull(summary.getContent()) ? summary.getContent() : fileEntry.getTitle());
-							%>
-
-							<c:choose>
-								<c:when test="<%= highlightEnabled %>">
-									<%= StringUtil.highlight(body, queryTerms) %>
-								</c:when>
-								<c:otherwise>
-									<%= body %>
-								</c:otherwise>
-							</c:choose>
+							<%= summary.getContent(escape, highlightEnabled) %>
 						</span>
 				</aui:a>
 			</div>
@@ -175,6 +157,8 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 		<%
 		for (MBMessage mbMessage : mbMessages) {
 			User userDisplay = UserLocalServiceUtil.getUser(mbMessage.getUserId());
+
+			summary = new Summary(null, mbMessage.getSubject(), null);
 		%>
 
 			<div class="entry-discussion">
@@ -192,12 +176,7 @@ List<String> versions = (List<String>)request.getAttribute("liferay-ui:app-view-
 					</span>
 
 					<span class="body">
-						<c:when test="<%= highlightEnabled %>">
-							<%= StringUtil.highlight(mbMessage.getSubject(), queryTerms) %>
-						</c:when>
-						<c:otherwise>
-							<%= mbMessage.getSubject() %>
-						</c:otherwise>
+						<%= summary.getContent(escape, highlightEnabled) %>
 					</span>
 				</aui:a>
 			</div>


### PR DESCRIPTION
Description from https://github.com/ealonso/liferay-portal/pull/135:

\cc @lipusz 

Methods StringUtil#highlight & HtmlImpl#escape work well individually
It is possible to search for a term that actually also occurs in an espace sequence, for example: (term) 34 --> (quote) '"' --> & # 34;
To deal with it, we should split the existing logic into a 3-steps method:
1. Highlight the given text using escape-safe tags
2. Escape the result text from 1.
3. Replace the temporary tags with the correct highlight tags

Note: we cannot use "$" sign in the escapeSafeHighlight variables, as "$" is a reserved group symbol in regex, because it would result

"java.lang.IllegalArgumentException: Illegal group reference"
