### PR TITLE
LPS-44255 Revert LPS-44255 since it cases major regressions in portal performance

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/PortletResponseUtil.java
@@ -155,8 +155,8 @@ public class PortletResponseUtil {
 		throws IOException {
 
 		sendFile(
-			portletRequest, mimeResponse, fileName, inputStream, contentLength,
-			contentType, null);
+			portletRequest, mimeResponse, fileName, inputStream, 0, contentType,
+			null);
 	}
 
 	public static void sendFile(

--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -180,8 +180,7 @@ public class ServletResponseUtil {
 		throws IOException {
 
 		sendFile(
-			request, response, fileName, inputStream, contentLength,
-			contentType, null);
+			request, response, fileName, inputStream, 0, contentType, null);
 	}
 
 	public static void sendFile(


### PR DESCRIPTION
Hi @dejuknow @mikemanyoung, 

@csierra has identified that this LPS is causing a major regression in the load time of pages in the portal today. You can verify it when loading any page in any browser, you will see the loading icon takes around 1 minute to finish and it seems to be related with the sprites image.
