### PR TITLE
master-qa-7646

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
+++ b/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
@@ -480,7 +480,7 @@ public class LiferaySeleniumHelper {
 		throws Exception {
 
 		for (int second = 0;; second++) {
-			if (second < TestPropsValues.TIMEOUT_EXPLICIT_WAIT) {
+			if (second >= TestPropsValues.TIMEOUT_EXPLICIT_WAIT) {
 				return liferaySelenium.isElementPresent(locator);
 			}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-7646

In isElementPresentAfterWait, it should return if "second" is greater than or equal to "TestPropsValues.TIMEOUT_EXPLICIT_WAIT" and not if it is less than.
