### PR TITLE
LPS-44671 Introduce a new pattern for documenting any changes that break backwards compatibility for the next release

### DIFF
--- a/upgrade/7.0/BREAKING_CHANGES.markdown
+++ b/upgrade/7.0/BREAKING_CHANGES.markdown
@@ -1,0 +1,37 @@
+# Breaking Changes for Liferay 7.0
+
+## Introduction
+
+This document present a chronological list of changes that break existing functionality, APIs or any contract with third party liferay developers or users. We try our best to minimize these disruptions, but sometimes they are unavoidable.
+
+The following type of changes are documented here:
+
+* Functionality removed or replaced
+* Incompatible API changes: Any changes done to public Java or JavaScript APIs
+* Changes in context variables made available for templates
+* Changes in CSS classes available to Liferay themes and portlets
+* Configuration changes: Changes in portal.properties and other configuration files
+* Execution requirements: Java version, J2EE Version, Browser versions, ...
+* Warnings deprecations or end of support: For example, that a certain relevant feature or API will be dropped in an upcoming version.
+* Recommendations: For example when a new API is introduced to replace an old API that is also kept for backwards compatibility.
+
+## Changes
+
+Each change is described in a section that starts with a brief title describing the change. Each section must contain the following information:
+
+1. Date: Format must be 2014-02-25
+2. What changed: Identify the component that was affected and the type of change that was made
+3. Who is affected: Is it an end user? A developer? If the only affected people are those using a certain feature or API, say so.
+4. How do I update my code: Explain the changes necessary to update client code (when appropriate).
+5. Why did this change happen: Explain the reasoning that justified a breaking change vs folowing a deprecation process.
+
+### [Title]
+Date:
+
+#### What changed?
+
+#### Who is affected?
+
+#### How do I update my code?
+
+#### Why did this change happen?


### PR DESCRIPTION
/cc @rotty3000 @juliocamarero @natecavanaugh @eduardolundgren 

As agreed in our call yesterday I have created a new pattern for documenting any breaking change going forward. Here are some decisions I made:
1. Create a directory structure instead of just adding the file at the top. I did this because it opens up the opportunity for adding more files related to the upgrade or even some tooling to facilitate it.
2. Make the file chronologically ordered. I did this so that it's much easier for developers to update it (just by adding at then end) vs trying to maintain a logical structure. After all, the biggest value of this file is to ensure that every breaking change is documented and justified. This document can later be used as the master source for release notes, upgrades instructions, etc.

If you guys have any breaking change that we have already done for 7.0, please let me know so that we add it.
