### PR TITLE
LPS-44649 Fix broken test. Parent folder parameter should not be always the default folder id

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
@@ -68,7 +68,7 @@ public class DLSubscriptionTest extends BaseSubscriptionTestCase {
 	@Override
 	protected long addContainerModel(long containerModelId) throws Exception {
 		Folder folder = DLAppTestUtil.addFolder(
-			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			group.getGroupId(), containerModelId,
 			ServiceTestUtil.randomString());
 
 		return folder.getFolderId();


### PR DESCRIPTION
This pull fixes one of the current failing tests cc/ @robertoDiaz
