### PR TITLE
master-bc-1239

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2478,7 +2478,7 @@ custom.sql.function.isnotnull=CONVERT(VARCHAR,?) IS NOT NULL</echo>
 				<delete includeemptydirs="true" failonerror="false">
 					<fileset
 						dir="${app.server.deploy.dir}"
-						excludes=",*.dodeploy,*.rar,*.sar/**,*.xml,.autodeploystatus/**,liferay-portal/**,liferay-portal.war/**,security/**,root/**,ROOT/**,ROOT.war/**,tunnel-web/**,tunnel-web.war/**"
+						excludes=",*.dodeploy,*.rar,*.sar/**,*.xml,.autodeploystatus/**,liferay-portal/**,liferay-portal.war/**,marketplace-portlet/**,security/**,root/**,ROOT/**,ROOT.war/**,tunnel-web/**,tunnel-web.war/**"
 					/>
 				</delete>
 			</then>


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-7830

This is to exclude marketplace from when the deploy directory initially gets cleaned. This won't affect the liferay-portal-frontend tests since there are no predeployed plugins, but this does affect the liferay-portal-bundle tests. There was an issue with 6.2.10 EE GA1 (that has since been fixed) where if marketplace isn't deployed, it will try to deploy the CE version of marketplace and throw errors, which causes our tests to break. If we don't clear out the predeployed marketplace to begin with, this won't be an issue.
