### PR TITLE
master-qa-7862

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
+++ b/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
@@ -570,6 +570,10 @@ public class LiferaySeleniumHelper {
 			return true;
 		}
 
+		if (line.contains("Table 'lportal.Lock_' doesn't exist")) {
+			return true;
+		}
+
 		// LPS-22821
 
 		if (line.contains(


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-7862

Currently the EvaluateLog test ignores the error message "Table lportal.lock_ doesn't exist" that shows up when the database is bare. I'm adding the uppercase version because the database tables are all uppercase in linux. 

I wasn't sure which one comes first (lowercase or uppercase). It felt better to have the lowercase one first, so I put the uppercase one below it. Let me know if it should be the other way around.
