### PR TITLE
master-qa-7870

### DIFF
--- a/portal-web/test/test-portal-web.properties
+++ b/portal-web/test/test-portal-web.properties
@@ -42,7 +42,7 @@ testing.class.method=false
 
 theme.ids=classic,controlpanel
 
-timeout.explicit.wait=30
+timeout.explicit.wait=60
 timeout.implicit.wait=3
 
 vm.host=vm-1


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-7870

This changes the explicit timeout wait from 30 seconds to 60 seconds to give things in the portal more time to load.
