### PR TITLE
LPS-44901 When multiple process are executing within the testing infrastructure they are creating a few module framework runtimes. We need to explicitly close the framework under these situations because we could easily fall into deadlock situations

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -222,6 +222,10 @@ public class InitUtil {
 		initWithSpring(false, extraConfigLocations);
 	}
 
+	public synchronized static void stopModuleFramework() throws Exception {
+		ModuleFrameworkUtilAdapter.stopFramework();
+	}
+
 	private static final boolean _PRINT_TIME = false;
 
 	private static boolean _initialized;

--- a/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.process.ProcessCallable;
 import com.liferay.portal.kernel.process.ProcessException;
 import com.liferay.portal.kernel.process.ProcessExecutor;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelperUtil;
-import com.liferay.portal.kernel.scheduler.SchedulerException;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.EnvironmentExecutionTestListener;
@@ -143,9 +142,11 @@ public class CounterLocalServiceTest {
 			finally {
 				try {
 					SchedulerEngineHelperUtil.shutdown();
+
+					InitUtil.stopModuleFramework();
 				}
-				catch (SchedulerException se) {
-					throw new ProcessException(se);
+				catch (Exception e) {
+					throw new ProcessException(e);
 				}
 			}
 


### PR DESCRIPTION
Pushed to upstream
