### PR TITLE
LPS-44977 - CLONE - Previous and next arrows in Blogs comments are not correctly displayed for RTL languages

### DIFF
--- a/portal-web/docroot/html/portlet/blogs/css/main_rtl.css
+++ b/portal-web/docroot/html/portlet/blogs/css/main_rtl.css
@@ -1,7 +1,11 @@
 .portlet-blogs {
 	.entry-navigation {
-		span.previous, .previous {
+		.previous {
 			background-image: url(@theme_image_path@/arrows/paging_next.png);
+			background-position: 100% 0%;
+		}
+
+		span.previous {
 			background-position: 100% 100%;
 		}
 


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-44977.

Please let me know if you have any questions.  Thanks!
