### PR TITLE
LPS-34578 - <hgroup> dropped from HTML5 specification

### DIFF
--- a/portal-web/docroot/html/portal/api/jsonws/index.jsp
+++ b/portal-web/docroot/html/portal/api/jsonws/index.jsp
@@ -22,7 +22,7 @@
 
 <div id="wrapper">
 	<header id="banner" role="banner">
-		<hgroup id="heading">
+		<div id="heading">
 			<h1 class="site-title">
 				<a class="logo" href="<%= HtmlUtil.escapeAttribute(jsonWSContextPath) %>" title="JSONWS API">
 					<img alt="JSONWS API" height="<%= themeDisplay.getCompanyLogoHeight() %>" src="<%= HtmlUtil.escape(themeDisplay.getCompanyLogo()) %>" width="<%= themeDisplay.getCompanyLogoWidth() %>" />
@@ -32,7 +32,7 @@
 					JSONWS API
 				</span>
 			</h1>
-		</hgroup>
+		</div>
 	</header>
 
 	<div id="content">


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-34578.

Please let me know if you have any questions.  Thanks!
