### PR TITLE
LPS-35877 Validation of OpenSSO URL's fails on OpenSSO LogoutURL

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/sso/opensso/OpenSSOUtil.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/sso/opensso/OpenSSOUtil.java
@@ -358,12 +358,23 @@ public class OpenSSOUtil {
 
 			int responseCode = httpURLConnection.getResponseCode();
 
-			if (responseCode != HttpURLConnection.HTTP_OK) {
-				if (_log.isDebugEnabled()) {
-					_log.debug("Attributes response code " + responseCode);
-				}
-
+			if (!(responseCode == HttpURLConnection.HTTP_OK
+					|| (responseCode >= HttpURLConnection.HTTP_MULT_CHOICE 
+						&& responseCode <= HttpURLConnection.HTTP_NOT_MODIFIED))) {
+					
+				_log.error("OpenSSO URL not valid. " 
+					+ "Response code " + responseCode + " "
+					+ "Url=" + url.toString()
+				);
+				
 				return false;
+			}
+			
+			if (_log.isDebugEnabled()) {
+				_log.debug("OpenSSO URL validated. " 
+					+ "Response code " + responseCode + " "
+					+ "Url=" + url.toString() 
+				);				
 			}
 		}
 		catch (IOException ioe) {

--- a/portal-service/src/com/liferay/portal/kernel/util/MapUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/MapUtil.java
@@ -65,7 +65,7 @@ public class MapUtil {
 			map.put(key, value);
 		}
 
-		return null;
+		return map;
 	}
 
 	public static boolean getBoolean(Map<String, ?> map, String key) {

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/MapUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/MapUtilTest.java
@@ -26,6 +26,62 @@ import org.junit.Test;
 public class MapUtilTest {
 
 	@Test
+	public void testFromArray() {
+		String[] array = new String[] {
+			PropsKeys.MESSAGE_BOARDS_EMAIL_FROM_ADDRESS,
+			PropsKeys.ADMIN_EMAIL_FROM_ADDRESS,
+			PropsKeys.MESSAGE_BOARDS_EMAIL_FROM_NAME,
+			PropsKeys.ADMIN_EMAIL_FROM_NAME, "allowAnonymousPosting",
+			PropsKeys.MESSAGE_BOARDS_ANONYMOUS_POSTING_ENABLED,
+			"emailFromAddress", PropsKeys.MESSAGE_BOARDS_EMAIL_FROM_ADDRESS,
+			"emailFromName", PropsKeys.MESSAGE_BOARDS_EMAIL_FROM_NAME,
+			"emailHtmlFormat", PropsKeys.MESSAGE_BOARDS_EMAIL_HTML_FORMAT,
+			"emailMessageAddedEnabled",
+			PropsKeys.MESSAGE_BOARDS_EMAIL_MESSAGE_ADDED_ENABLED,
+			"emailMessageUpdatedEnabled",
+			PropsKeys.MESSAGE_BOARDS_EMAIL_MESSAGE_UPDATED_ENABLED,
+			"enableFlags", PropsKeys.MESSAGE_BOARDS_FLAGS_ENABLED,
+			"enableRatings", PropsKeys.MESSAGE_BOARDS_RATINGS_ENABLED,
+			"enableRss", PropsKeys.MESSAGE_BOARDS_RSS_ENABLED, "messageFormat",
+			PropsKeys.MESSAGE_BOARDS_MESSAGE_FORMATS_DEFAULT, "priorities",
+			PropsKeys.MESSAGE_BOARDS_THREAD_PRIORITIES, "ranks",
+			PropsKeys.MESSAGE_BOARDS_USER_RANKS, "recentPostsDateOffset",
+			PropsKeys.MESSAGE_BOARDS_RECENT_POSTS_DATE_OFFSET, "rssDelta",
+			PropsKeys.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA, "rssDisplayStyle",
+			PropsKeys.RSS_FEED_DISPLAY_STYLE_DEFAULT, "rssFeedType",
+			PropsKeys.RSS_FEED_TYPE_DEFAULT, "subscribeByDefault",
+			PropsKeys.MESSAGE_BOARDS_SUBSCRIBE_BY_DEFAULT};
+
+		Map<String, String> map = MapUtil.fromArray(array);
+
+		Assert.assertNotNull(map);
+
+		for (int i = 0; i < array.length; i += 2) {
+			Assert.assertEquals(array[i + 1], map.get(array[i]));
+		}
+	}
+
+	@Test
+	public void testFromArrayWithOddLength() {
+		try {
+			MapUtil.fromArray(new String[] {"one", "two", "three"});
+
+			Assert.fail("An IllegalArgument exception should have been thrown");
+		}
+		catch (IllegalArgumentException iae) {
+			Assert.assertEquals(
+				"Array length is not an even number", iae.getMessage());
+		}
+	}
+
+	@Test
+	public void testFromArrayWithZeroLength() {
+		Map<String, String> map = MapUtil.fromArray(new String[] {});
+
+		Assert.assertTrue(map.isEmpty());
+	}
+
+	@Test
 	public void testPredicateFilter() throws Exception {
 		Map<String, String> inputMap = new HashMap<String, String>();
 


### PR DESCRIPTION
I have encountered the issue LPS-35877 (Validation of OpenSSO URL's fails on OpenSSO LogoutURL). Actually this patch has been produced and tested on Liferay 6.1.1 and OpenAM 11.0
