### PR TITLE
LPS-33427 - Related quote: There are only two hard things in Computer Science: cache invalidation and naming things (by Phil Karlton)

### DIFF
--- a/portal-impl/src/com/liferay/portlet/wiki/WikiSettings.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/WikiSettings.java
@@ -22,7 +22,6 @@ import com.liferay.portal.settings.Settings;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.util.ContentUtil;
-import com.liferay.util.RSSUtil;
 
 import java.util.Map;
 

--- a/portal-impl/test/integration/com/liferay/portal/util/BaseSubscriptionTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/BaseSubscriptionTestCase.java
@@ -195,7 +195,7 @@ public abstract class BaseSubscriptionTestCase {
 		return;
 	}
 
-	protected void addSubscriptionClassType(long baseModelId) throws Exception {
+	protected void addSubscriptionClassType(long classTypeId) throws Exception {
 		return;
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/util/BaseSubscriptionTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/BaseSubscriptionTestCase.java
@@ -68,6 +68,18 @@ public abstract class BaseSubscriptionTestCase {
 	}
 
 	@Test
+	public void testSubscriptionClassType() throws Exception {
+		long classTypeId = addClassType();
+
+		addSubscriptionClassType(classTypeId);
+
+		addBaseModelWithClassType(
+			_PARENT_CONTAINER_MODEL_ID_DEFAULT, classTypeId);
+
+		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
+	}
+
+	@Test
 	public void testSubscriptionContainerModelWhenInContainerModel()
 		throws Exception {
 
@@ -112,20 +124,8 @@ public abstract class BaseSubscriptionTestCase {
 	}
 
 	@Test
-	public void testSubscriptionModelType() throws Exception {
-		long modelTypeId = addModelType();
-
-		addSubscriptionModelType(modelTypeId);
-
-		addBaseModelWithModelType(
-			_PARENT_CONTAINER_MODEL_ID_DEFAULT, modelTypeId);
-
-		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
-	}
-
-	@Test
-	public void testSubscriptionDefaultModelType() throws Exception {
-		addSubscriptionModelType(_MODEL_TYPE_ID_DEFAULT);
+	public void testSubscriptionDefaultClassType() throws Exception {
+		addSubscriptionClassType(_CLASS_TYPE_ID_DEFAULT);
 
 		addBaseModel(_PARENT_CONTAINER_MODEL_ID_DEFAULT);
 
@@ -176,9 +176,14 @@ public abstract class BaseSubscriptionTestCase {
 	protected abstract long addBaseModel(long containerModelId)
 		throws Exception;
 
-	protected long addBaseModelWithModelType(
-		long containerModelId, long modelTypeId)
+	protected long addBaseModelWithClassType(
+			long containerModelId, long classTypeId)
 		throws Exception {
+
+		return 0;
+	}
+
+	protected long addClassType() throws Exception {
 		return 0;
 	}
 
@@ -186,21 +191,16 @@ public abstract class BaseSubscriptionTestCase {
 		return 0;
 	};
 
-	protected long addModelType() throws Exception {
-		return 0;
+	protected void addSubscriptionBaseModel(long baseModelId) throws Exception {
+		return;
 	}
 
-	protected void addSubscriptionBaseModel(long baseModelId) throws Exception {
+	protected void addSubscriptionClassType(long baseModelId) throws Exception {
 		return;
 	}
 
 	protected abstract void addSubscriptionContainerModel(long containerModelId)
 		throws Exception;
-
-	protected void addSubscriptionModelType(long baseModelId)
-		throws Exception {
-		return;
-	}
 
 	protected long updateEntry(long baseModelId) throws Exception {
 		return 0;
@@ -208,7 +208,7 @@ public abstract class BaseSubscriptionTestCase {
 
 	protected Group group;
 
-	private static final long _MODEL_TYPE_ID_DEFAULT = 0;
+	private static final long _CLASS_TYPE_ID_DEFAULT = 0;
 
 	private static final long _PARENT_CONTAINER_MODEL_ID_DEFAULT = 0;
 

--- a/portal-impl/test/integration/com/liferay/portal/util/BaseSubscriptionTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/util/BaseSubscriptionTestCase.java
@@ -112,6 +112,27 @@ public abstract class BaseSubscriptionTestCase {
 	}
 
 	@Test
+	public void testSubscriptionModelType() throws Exception {
+		long modelTypeId = addModelType();
+
+		addSubscriptionModelType(modelTypeId);
+
+		addBaseModelWithModelType(
+			_PARENT_CONTAINER_MODEL_ID_DEFAULT, modelTypeId);
+
+		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
+	}
+
+	@Test
+	public void testSubscriptionDefaultModelType() throws Exception {
+		addSubscriptionModelType(_MODEL_TYPE_ID_DEFAULT);
+
+		addBaseModel(_PARENT_CONTAINER_MODEL_ID_DEFAULT);
+
+		Assert.assertEquals(1, MailServiceTestUtil.getInboxSize());
+	}
+
+	@Test
 	public void testSubscriptionRootContainerModelWhenInContainerModel()
 		throws Exception {
 
@@ -155,9 +176,19 @@ public abstract class BaseSubscriptionTestCase {
 	protected abstract long addBaseModel(long containerModelId)
 		throws Exception;
 
+	protected long addBaseModelWithModelType(
+		long containerModelId, long modelTypeId)
+		throws Exception {
+		return 0;
+	}
+
 	protected long addContainerModel(long containerModelId) throws Exception {
 		return 0;
 	};
+
+	protected long addModelType() throws Exception {
+		return 0;
+	}
 
 	protected void addSubscriptionBaseModel(long baseModelId) throws Exception {
 		return;
@@ -166,11 +197,18 @@ public abstract class BaseSubscriptionTestCase {
 	protected abstract void addSubscriptionContainerModel(long containerModelId)
 		throws Exception;
 
+	protected void addSubscriptionModelType(long baseModelId)
+		throws Exception {
+		return;
+	}
+
 	protected long updateEntry(long baseModelId) throws Exception {
 		return 0;
 	};
 
 	protected Group group;
+
+	private static final long _MODEL_TYPE_ID_DEFAULT = 0;
 
 	private static final long _PARENT_CONTAINER_MODEL_ID_DEFAULT = 0;
 

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/service/BlogsSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/service/BlogsSubscriptionTest.java
@@ -74,6 +74,18 @@ public class BlogsSubscriptionTest extends BaseSubscriptionTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSubscriptionModelType() {
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testSubscriptionDefaultModelType() {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSubscriptionRootContainerModelWhenInContainerModel() {
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/service/BlogsSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/service/BlogsSubscriptionTest.java
@@ -56,6 +56,12 @@ public class BlogsSubscriptionTest extends BaseSubscriptionTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSubscriptionClassType() {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSubscriptionContainerModelWhenInContainerModel() {
 	}
 
@@ -74,13 +80,7 @@ public class BlogsSubscriptionTest extends BaseSubscriptionTestCase {
 	@Ignore
 	@Override
 	@Test
-	public void testSubscriptionModelType() {
-	}
-
-	@Ignore
-	@Override
-	@Test
-	public void testSubscriptionDefaultModelType() {
+	public void testSubscriptionDefaultClassType() {
 	}
 
 	@Ignore

--- a/portal-impl/test/integration/com/liferay/portlet/bookmarks/service/BookmarksSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/bookmarks/service/BookmarksSubscriptionTest.java
@@ -47,13 +47,13 @@ public class BookmarksSubscriptionTest extends BaseSubscriptionTestCase {
 	@Ignore
 	@Override
 	@Test
-	public void testSubscriptionModelType() {
+	public void testSubscriptionClassType() {
 	}
 
 	@Ignore
 	@Override
 	@Test
-	public void testSubscriptionDefaultModelType() {
+	public void testSubscriptionDefaultClassType() {
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/bookmarks/service/BookmarksSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/bookmarks/service/BookmarksSubscriptionTest.java
@@ -27,6 +27,8 @@ import com.liferay.portlet.bookmarks.model.BookmarksEntry;
 import com.liferay.portlet.bookmarks.model.BookmarksFolder;
 import com.liferay.portlet.bookmarks.util.BookmarksTestUtil;
 
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -41,6 +43,18 @@ import org.junit.runner.RunWith;
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
 @Sync
 public class BookmarksSubscriptionTest extends BaseSubscriptionTestCase {
+
+	@Ignore
+	@Override
+	@Test
+	public void testSubscriptionModelType() {
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testSubscriptionDefaultModelType() {
+	}
 
 	@Override
 	protected long addBaseModel(long containerModelId) throws Exception {

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
@@ -101,8 +101,9 @@ public class DLSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
-	protected void addSubscriptionClassType(long typeId) throws Exception {
-		DLAppServiceUtil.subscribeFileEntryType(group.getGroupId(), typeId);
+	protected void addSubscriptionClassType(long classTypeId) throws Exception {
+		DLAppServiceUtil.subscribeFileEntryType(
+			group.getGroupId(), classTypeId);
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
@@ -24,7 +24,11 @@ import com.liferay.portal.test.Sync;
 import com.liferay.portal.test.SynchronousMailExecutionTestListener;
 import com.liferay.portal.util.BaseSubscriptionTestCase;
 import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.model.DLFileEntryType;
 import com.liferay.portlet.documentlibrary.util.DLAppTestUtil;
+import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
+import com.liferay.portlet.dynamicdatamapping.util.DDMStructureTestUtil;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -65,6 +69,18 @@ public class DLSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
+	protected long addBaseModelWithModelType(
+		long containerModelId, long modelTypeId)
+		throws Exception {
+
+		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			group.getGroupId(), containerModelId,
+			ServiceTestUtil.randomString(), modelTypeId);
+
+		return fileEntry.getFileEntryId();
+	}
+
+	@Override
 	protected long addContainerModel(long containerModelId) throws Exception {
 		Folder folder = DLAppTestUtil.addFolder(
 			group.getGroupId(), containerModelId,
@@ -74,11 +90,27 @@ public class DLSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
+	protected long addModelType() throws Exception {
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			DLFileEntry.class.getName());
+
+		DLFileEntryType fileEntryType = DLAppTestUtil.addDLFileEntryType(
+			group.getGroupId(), ddmStructure.getStructureId());
+
+		return fileEntryType.getFileEntryTypeId();
+	}
+
+	@Override
 	protected void addSubscriptionContainerModel(long containerModelId)
 		throws Exception {
 
 		DLAppLocalServiceUtil.subscribeFolder(
 			TestPropsValues.getUserId(), group.getGroupId(), containerModelId);
+	}
+
+	@Override
+	protected void addSubscriptionModelType(long typeId) throws Exception {
+		DLAppServiceUtil.subscribeFileEntryType(group.getGroupId(), typeId);
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLSubscriptionTest.java
@@ -69,15 +69,26 @@ public class DLSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
-	protected long addBaseModelWithModelType(
-		long containerModelId, long modelTypeId)
+	protected long addBaseModelWithClassType(
+			long containerModelId, long classTypeId)
 		throws Exception {
 
 		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
 			group.getGroupId(), containerModelId,
-			ServiceTestUtil.randomString(), modelTypeId);
+			ServiceTestUtil.randomString(), classTypeId);
 
 		return fileEntry.getFileEntryId();
+	}
+
+	@Override
+	protected long addClassType() throws Exception {
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			DLFileEntry.class.getName());
+
+		DLFileEntryType fileEntryType = DLAppTestUtil.addDLFileEntryType(
+			group.getGroupId(), ddmStructure.getStructureId());
+
+		return fileEntryType.getFileEntryTypeId();
 	}
 
 	@Override
@@ -90,14 +101,8 @@ public class DLSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
-	protected long addModelType() throws Exception {
-		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
-			DLFileEntry.class.getName());
-
-		DLFileEntryType fileEntryType = DLAppTestUtil.addDLFileEntryType(
-			group.getGroupId(), ddmStructure.getStructureId());
-
-		return fileEntryType.getFileEntryTypeId();
+	protected void addSubscriptionClassType(long typeId) throws Exception {
+		DLAppServiceUtil.subscribeFileEntryType(group.getGroupId(), typeId);
 	}
 
 	@Override
@@ -106,11 +111,6 @@ public class DLSubscriptionTest extends BaseSubscriptionTestCase {
 
 		DLAppLocalServiceUtil.subscribeFolder(
 			TestPropsValues.getUserId(), group.getGroupId(), containerModelId);
-	}
-
-	@Override
-	protected void addSubscriptionModelType(long typeId) throws Exception {
-		DLAppServiceUtil.subscribeFileEntryType(group.getGroupId(), typeId);
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/util/DLAppTestUtil.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/util/DLAppTestUtil.java
@@ -174,6 +174,7 @@ public abstract class DLAppTestUtil {
 			groupId);
 
 		serviceContext.setAttribute("fileEntryTypeId", fileEntryTypeId);
+		serviceContext.setLayoutFullURL("http://localhost");
 
 		return addFileEntry(
 			userId, groupId, folderId, sourceFileName, mimeType, title, bytes,

--- a/portal-impl/test/integration/com/liferay/portlet/journal/service/JournalSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/service/JournalSubscriptionTest.java
@@ -23,7 +23,12 @@ import com.liferay.portal.test.Sync;
 import com.liferay.portal.test.SynchronousMailExecutionTestListener;
 import com.liferay.portal.util.BaseSubscriptionTestCase;
 import com.liferay.portal.util.TestPropsValues;
+import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
+import com.liferay.portlet.dynamicdatamapping.model.DDMTemplate;
+import com.liferay.portlet.dynamicdatamapping.util.DDMStructureTestUtil;
+import com.liferay.portlet.dynamicdatamapping.util.DDMTemplateTestUtil;
 import com.liferay.portlet.journal.model.JournalArticle;
+import com.liferay.portlet.journal.model.JournalArticleConstants;
 import com.liferay.portlet.journal.model.JournalFolder;
 import com.liferay.portlet.journal.util.JournalTestUtil;
 
@@ -65,6 +70,20 @@ public class JournalSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
+	protected long addBaseModelWithModelType(
+		long containerId, long modelTypeId)
+		throws Exception {
+
+		JournalArticle article = JournalTestUtil.addArticleWithXMLContent(
+			group.getGroupId(), containerId,
+			JournalArticleConstants.CLASSNAME_ID_DEFAULT,
+			"<title>Test Article</title>", _ddmStructure.getStructureKey(),
+			_ddmTemplate.getTemplateKey());
+
+		return article.getResourcePrimKey();
+	}
+
+	@Override
 	protected long addContainerModel(long containerModelId) throws Exception {
 		JournalFolder folder = JournalTestUtil.addFolder(
 			group.getGroupId(), containerModelId,
@@ -74,11 +93,28 @@ public class JournalSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
+	protected long addModelType() throws Exception {
+		_ddmStructure = DDMStructureTestUtil.addStructure(
+			group.getGroupId(), JournalArticle.class.getName());
+
+		_ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			group.getGroupId(), _ddmStructure.getStructureId());
+
+		return _ddmStructure.getStructureId();
+	}
+
+	@Override
 	protected void addSubscriptionContainerModel(long containerModelId)
 		throws Exception {
 
 		JournalFolderLocalServiceUtil.subscribe(
 			TestPropsValues.getUserId(), group.getGroupId(), containerModelId);
+	}
+
+	@Override
+	protected void addSubscriptionModelType(long typeId) throws Exception {
+		JournalArticleLocalServiceUtil.subscribeStructure(
+			group.getGroupId(), TestPropsValues.getUserId(), typeId);
 	}
 
 	@Override
@@ -92,5 +128,8 @@ public class JournalSubscriptionTest extends BaseSubscriptionTestCase {
 
 		return article.getResourcePrimKey();
 	}
+
+	protected DDMStructure _ddmStructure;
+	protected DDMTemplate _ddmTemplate;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/journal/service/JournalSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/service/JournalSubscriptionTest.java
@@ -103,9 +103,9 @@ public class JournalSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
-	protected void addSubscriptionClassType(long typeId) throws Exception {
+	protected void addSubscriptionClassType(long classTypeId) throws Exception {
 		JournalArticleLocalServiceUtil.subscribeStructure(
-			group.getGroupId(), TestPropsValues.getUserId(), typeId);
+			group.getGroupId(), TestPropsValues.getUserId(), classTypeId);
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/journal/service/JournalSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/service/JournalSubscriptionTest.java
@@ -70,8 +70,7 @@ public class JournalSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
-	protected long addBaseModelWithModelType(
-		long containerId, long modelTypeId)
+	protected long addBaseModelWithClassType(long containerId, long classTypeId)
 		throws Exception {
 
 		JournalArticle article = JournalTestUtil.addArticleWithXMLContent(
@@ -84,16 +83,7 @@ public class JournalSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
-	protected long addContainerModel(long containerModelId) throws Exception {
-		JournalFolder folder = JournalTestUtil.addFolder(
-			group.getGroupId(), containerModelId,
-			ServiceTestUtil.randomString());
-
-		return folder.getFolderId();
-	}
-
-	@Override
-	protected long addModelType() throws Exception {
+	protected long addClassType() throws Exception {
 		_ddmStructure = DDMStructureTestUtil.addStructure(
 			group.getGroupId(), JournalArticle.class.getName());
 
@@ -104,17 +94,26 @@ public class JournalSubscriptionTest extends BaseSubscriptionTestCase {
 	}
 
 	@Override
+	protected long addContainerModel(long containerModelId) throws Exception {
+		JournalFolder folder = JournalTestUtil.addFolder(
+			group.getGroupId(), containerModelId,
+			ServiceTestUtil.randomString());
+
+		return folder.getFolderId();
+	}
+
+	@Override
+	protected void addSubscriptionClassType(long typeId) throws Exception {
+		JournalArticleLocalServiceUtil.subscribeStructure(
+			group.getGroupId(), TestPropsValues.getUserId(), typeId);
+	}
+
+	@Override
 	protected void addSubscriptionContainerModel(long containerModelId)
 		throws Exception {
 
 		JournalFolderLocalServiceUtil.subscribe(
 			TestPropsValues.getUserId(), group.getGroupId(), containerModelId);
-	}
-
-	@Override
-	protected void addSubscriptionModelType(long typeId) throws Exception {
-		JournalArticleLocalServiceUtil.subscribeStructure(
-			group.getGroupId(), TestPropsValues.getUserId(), typeId);
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/wiki/service/WikiSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/wiki/service/WikiSubscriptionTest.java
@@ -54,6 +54,12 @@ public class WikiSubscriptionTest extends BaseSubscriptionTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSubscriptionClassType() {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSubscriptionContainerModelWhenInRootContainerModel() {
 	}
 
@@ -66,13 +72,7 @@ public class WikiSubscriptionTest extends BaseSubscriptionTestCase {
 	@Ignore
 	@Override
 	@Test
-	public void testSubscriptionModelType() {
-	}
-
-	@Ignore
-	@Override
-	@Test
-	public void testSubscriptionDefaultModelType() {
+	public void testSubscriptionDefaultClassType() {
 	}
 
 	@Ignore

--- a/portal-impl/test/integration/com/liferay/portlet/wiki/service/WikiSubscriptionTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/wiki/service/WikiSubscriptionTest.java
@@ -66,6 +66,18 @@ public class WikiSubscriptionTest extends BaseSubscriptionTestCase {
 	@Ignore
 	@Override
 	@Test
+	public void testSubscriptionModelType() {
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testSubscriptionDefaultModelType() {
+	}
+
+	@Ignore
+	@Override
+	@Test
 	public void testSubscriptionRootContainerModelWhenInContainerModel() {
 	}
 


### PR DESCRIPTION
Brian, this is the rationale of choosing "classType" as the most suitable name: we're trying to find a common term to describe the type you can apply to articles (implemented through DDMStructures) and to file entries (implemented through DLFileEntryType). So we need an abstract enough name to refer both of them.

For me AssetRendererFactory is pretty similar and "classType" is used there with the same meaning.

So, you ok with "classType" for the sake of consistency?
If not, any idea to name such an abstract thing? (:

Thanks!

cc @ealonso @juliocamarero
