### PR TITLE
master-qa-8163

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
+++ b/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
@@ -658,6 +658,8 @@ public class LiferaySeleniumHelper {
 		}
 
 		if (Validator.equals(
+				TestPropsValues.LIFERAY_PORTAL_BRANCH, "ee-6.2.10") ||
+			Validator.equals(
 				TestPropsValues.LIFERAY_PORTAL_BUNDLE, "6.2.10.1") ||
 			Validator.equals(
 				TestPropsValues.LIFERAY_PORTAL_BUNDLE, "6.2.10.2") ||


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-8163

This is to ignore (in ee-6.2.10) the shutdown errors that we already ignore for the 6.2.10 bundle jobs, since we have a liferay-portal-ee-6.2.10 job in jenkins now.
