### PR TITLE
master-qa-8181

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisherWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisherWebcontent.testcase
@@ -47,7 +47,7 @@
 		</execute>
 	</command>
 
-	<command name="SaveAsDraftWebContentPGViaAP" known-issues="LIFERAYQA-6795" priority="5">
+	<command name="SaveAsDraftWebContentPGViaAP" priority="5">
 		<var name="saveAsDraft" value="true" />
 		<var name="webContentContent" value="WC WebContent Content" />
 		<var name="webContentTitle" value="WC Webcontent Title" />

--- a/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgassetpublisher/block/action/PGAssetpublisherAddnewblogsentry.action
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgassetpublisher/block/action/PGAssetpublisherAddnewblogsentry.action
@@ -1,11 +1,11 @@
 <definition>
 	<command name="assertClick">
 		<case locator-key1="PUBLISH_BUTTON">
-			<execute function="AssertClick#assertTextClickAtCKEditor" />
+			<execute function="AssertClick#assertTextClickAtCKEditor" ignore-javascript-error="b is null" />
 		</case>
 
 		<case locator-key1="SUBMIT_FOR_PUBLICATION_BUTTON">
-			<execute function="AssertClick#assertTextClickAtCKEditor" />
+			<execute function="AssertClick#assertTextClickAtCKEditor" ignore-javascript-error="b is null" />
 		</case>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgassetpublisher/block/action/PGAssetpublisherAddnewwebcontent.action
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgassetpublisher/block/action/PGAssetpublisherAddnewwebcontent.action
@@ -1,11 +1,15 @@
 <definition>
 	<command name="assertClick">
 		<case locator-key1="PUBLISH_BUTTON">
-			<execute function="AssertClick#assertTextClickAtCKEditor" />
+			<execute function="AssertClick#assertTextClickAtCKEditor" ignore-javascript-error="b is null" />
+		</case>
+
+		<case locator-key1="SAVE_AS_DRAFT_BUTTON">
+			<execute function="AssertClick#assertTextClickAtCKEditor" ignore-javascript-error="b is null" />
 		</case>
 
 		<case locator-key1="SUBMIT_FOR_PUBLICATION_BUTTON">
-			<execute function="AssertClick#assertTextClickAtCKEditor" />
+			<execute function="AssertClick#assertTextClickAtCKEditor" ignore-javascript-error="b is null" />
 		</case>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgwebcontentdisplay/PGWebcontentdisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgwebcontentdisplay/PGWebcontentdisplay.testcase
@@ -26,7 +26,7 @@
 		<execute macro="Page#tearDownPG" />
 	</tear-down>
 
-	<command name="AddNewWebContentViaAddContentPanel" known-issues="LIFERAYQA-6795" priority="5">
+	<command name="AddNewWebContentViaAddContentPanel" priority="5">
 		<var name="assetType" value="Web Content Article" />
 		<var name="pageName" value="Web Content Page" />
 		<var name="webContentContent" value="WC WebContent Content" />

--- a/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgwebcontentdisplay/block/action/PGWebcontentdisplayAddwebcontent.action
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduser/wcm/webcontentpublication/pgwebcontentdisplay/block/action/PGWebcontentdisplayAddwebcontent.action
@@ -1,11 +1,11 @@
 <definition>
 	<command name="assertClick">
 		<case locator-key1="PUBLISH_BUTTON">
-			<execute function="AssertClick#assertTextClickAtCKEditor" />
+			<execute function="AssertClick#assertTextClickAtCKEditor" ignore-javascript-error="b is null" />
 		</case>
 
 		<case locator-key1="SUBMIT_FOR_PUBLICATION_BUTTON">
-			<execute function="AssertClick#assertTextClickAtCKEditor" />
+			<execute function="AssertClick#assertTextClickAtCKEditor" ignore-javascript-error="b is null" />
 		</case>
 	</command>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-8181

Turn back on the tests that are affected by "b is null" because we're now able to ignore it without ignoring the entire test.
