### PR TITLE
LPS-45461 Resend of Split DefaultConfigurationAction into two versions: one for PortletPreferences and another for Settings

### DIFF
--- a/portal-impl/src/com/liferay/portlet/assetpublisher/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/action/ConfigurationActionImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.assetpublisher.action;
 
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
@@ -86,10 +87,10 @@ import javax.servlet.http.HttpServletRequest;
 public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 	@Override
-	public void postProcessPortletPreferences(
+	public void postProcess(
 			long companyId, PortletRequest portletRequest,
 			PortletPreferences portletPreferences)
-		throws Exception {
+		throws SystemException {
 
 		removeDefaultValue(
 			portletRequest, portletPreferences, "emailFromAddress",

--- a/portal-impl/src/com/liferay/portlet/blogs/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/action/ConfigurationActionImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.blogs.action;
 
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -36,10 +37,10 @@ import javax.portlet.PortletRequest;
 public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 	@Override
-	public void postProcessPortletPreferences(
+	public void postProcess(
 			long companyId, PortletRequest portletRequest,
 			PortletPreferences portletPreferences)
-		throws Exception {
+		throws SystemException {
 
 		String emailFromAddress = PortalUtil.getEmailFromAddress(
 			portletPreferences, companyId,

--- a/portal-impl/src/com/liferay/portlet/bookmarks/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/action/ConfigurationActionImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.bookmarks.action;
 
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -37,10 +38,10 @@ import javax.portlet.PortletRequest;
 public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 	@Override
-	public void postProcessPortletPreferences(
+	public void postProcess(
 			long companyId, PortletRequest portletRequest,
 			PortletPreferences portletPreferences)
-		throws Exception {
+		throws SystemException {
 
 		removeDefaultValue(
 			portletRequest, portletPreferences, "emailFromAddress",

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/ConfigurationActionImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.documentlibrary.action;
 
 import com.liferay.portal.NoSuchRepositoryEntryException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Constants;
@@ -42,10 +43,10 @@ import javax.portlet.PortletRequest;
 public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 	@Override
-	public void postProcessPortletPreferences(
+	public void postProcess(
 			long companyId, PortletRequest portletRequest,
 			PortletPreferences portletPreferences)
-		throws Exception {
+		throws SystemException {
 
 		removeDefaultValue(
 			portletRequest, portletPreferences, "emailFromAddress",

--- a/portal-impl/src/com/liferay/portlet/invitation/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/invitation/action/ConfigurationActionImpl.java
@@ -31,10 +31,9 @@ import javax.portlet.PortletRequest;
 public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 	@Override
-	public void postProcessPortletPreferences(
-			long companyId, PortletRequest portletRequest,
-			PortletPreferences portletPreferences)
-		throws Exception {
+	public void postProcess(
+		long companyId, PortletRequest portletRequest,
+		PortletPreferences portletPreferences) {
 
 		String languageId = LocaleUtil.toLanguageId(
 			LocaleUtil.getSiteDefault());

--- a/portal-impl/src/com/liferay/portlet/journal/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/action/ConfigurationActionImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.journal.action;
 
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.util.PropsValues;
@@ -32,10 +33,10 @@ import javax.portlet.PortletRequest;
 public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 	@Override
-	public void postProcessPortletPreferences(
+	public void postProcess(
 			long companyId, PortletRequest portletRequest,
 			PortletPreferences portletPreferences)
-		throws Exception {
+		throws SystemException {
 
 		removeDefaultValue(
 			portletRequest, portletPreferences, "emailFromAddress",

--- a/portal-impl/src/com/liferay/portlet/login/action/ConfigurationActionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/login/action/ConfigurationActionImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.login.action;
 
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.util.PropsValues;
@@ -33,10 +34,10 @@ import javax.portlet.PortletRequest;
 public class ConfigurationActionImpl extends DefaultConfigurationAction {
 
 	@Override
-	public void postProcessPortletPreferences(
+	public void postProcess(
 			long companyId, PortletRequest portletRequest,
 			PortletPreferences portletPreferences)
-		throws Exception {
+		throws SystemException {
 
 		removeDefaultValue(
 			portletRequest, portletPreferences, "emailFromAddress",

--- a/portal-service/src/com/liferay/portal/kernel/portlet/BaseDefaultConfigurationAction.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/BaseDefaultConfigurationAction.java
@@ -1,0 +1,335 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.portlet;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PropertiesParamUtil;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.Portlet;
+import com.liferay.portal.security.permission.ActionKeys;
+import com.liferay.portal.service.PortletLocalServiceUtil;
+import com.liferay.portal.service.permission.PortletPermissionUtil;
+import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portlet.PortletConfigFactoryUtil;
+
+import java.io.IOException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
+import javax.portlet.PortletRequest;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+import javax.portlet.ValidatorException;
+
+import javax.servlet.ServletContext;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Julio Camarero
+ * @author Raymond Augé
+ * @author Iván Zaera
+ */
+public abstract class BaseDefaultConfigurationAction<T>
+	extends LiferayPortlet
+	implements ConfigurationAction, ResourceServingConfigurationAction {
+
+	public BaseDefaultConfigurationAction(
+		String configurationParametersPrefix) {
+
+		_configurationParametersPrefix = configurationParametersPrefix;
+	}
+
+	public String getLocalizedParameter(
+		PortletRequest portletRequest, String name) {
+
+		String languageId = ParamUtil.getString(portletRequest, "languageId");
+
+		return getLocalizedParameter(portletRequest, name, languageId);
+	}
+
+	public String getLocalizedParameter(
+		PortletRequest portletRequest, String name, String languageId) {
+
+		return getParameter(
+			portletRequest,
+			LocalizationUtil.getLocalizedName(name, languageId));
+	}
+
+	public String getParameter(PortletRequest portletRequest, String name) {
+		name = _configurationParametersPrefix + name + StringPool.DOUBLE_DASH;
+
+		return ParamUtil.getString(portletRequest, name);
+	}
+
+	@Override
+	public void processAction(
+			PortletConfig portletConfig, ActionRequest actionRequest,
+			ActionResponse actionResponse)
+		throws Exception {
+
+		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
+
+		if (!cmd.equals(Constants.UPDATE)) {
+			return;
+		}
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Layout layout = PortletConfigurationLayoutUtil.getLayout(themeDisplay);
+
+		String portletResource = ParamUtil.getString(
+			actionRequest, "portletResource");
+
+		PortletPermissionUtil.check(
+			themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroupId(),
+			layout, portletResource, ActionKeys.CONFIGURATION);
+
+		UnicodeProperties properties = PropertiesParamUtil.getProperties(
+			actionRequest, _configurationParametersPrefix);
+
+		T configuration = getConfiguration(actionRequest);
+
+		for (Map.Entry<String, String> entry : properties.entrySet()) {
+			String name = entry.getKey();
+			String value = entry.getValue();
+
+			setValue(configuration, name, value);
+		}
+
+		Map<String, String[]> portletPreferencesMap =
+			(Map<String, String[]>)actionRequest.getAttribute(
+				WebKeys.PORTLET_PREFERENCES_MAP);
+
+		if (portletPreferencesMap != null) {
+			for (Map.Entry<String, String[]> entry :
+					portletPreferencesMap.entrySet()) {
+
+				String name = entry.getKey();
+				String[] values = entry.getValue();
+
+				setValues(configuration, name, values);
+			}
+		}
+
+		postProcess(themeDisplay.getCompanyId(), actionRequest, configuration);
+
+		if (SessionErrors.isEmpty(actionRequest)) {
+			try {
+				store(configuration);
+			}
+			catch (ValidatorException ve) {
+				SessionErrors.add(
+					actionRequest, ValidatorException.class.getName(), ve);
+
+				return;
+			}
+
+			SessionMessages.add(
+				actionRequest,
+				PortalUtil.getPortletId(actionRequest) +
+					SessionMessages.KEY_SUFFIX_REFRESH_PORTLET,
+				portletResource);
+
+			SessionMessages.add(
+				actionRequest,
+				PortalUtil.getPortletId(actionRequest) +
+					SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION);
+
+			String redirect = PortalUtil.escapeRedirect(
+				ParamUtil.getString(actionRequest, "redirect"));
+
+			if (Validator.isNotNull(redirect)) {
+				actionResponse.sendRedirect(redirect);
+			}
+		}
+	}
+
+	@Override
+	public String render(
+			PortletConfig portletConfig, RenderRequest renderRequest,
+			RenderResponse renderResponse)
+		throws Exception {
+
+		PortletConfig selPortletConfig = getSelPortletConfig(renderRequest);
+
+		String configTemplate = selPortletConfig.getInitParameter(
+			"config-template");
+
+		if (Validator.isNotNull(configTemplate)) {
+			return configTemplate;
+		}
+
+		String configJSP = selPortletConfig.getInitParameter("config-jsp");
+
+		if (Validator.isNotNull(configJSP)) {
+			return configJSP;
+		}
+
+		return "/configuration.jsp";
+	}
+
+	@Override
+	public void serveResource(
+			PortletConfig portletConfig, ResourceRequest resourceRequest,
+			ResourceResponse resourceResponse)
+		throws Exception {
+	}
+
+	public void setPreference(
+		PortletRequest portletRequest, String name, String value) {
+
+		setPreference(portletRequest, name, new String[] {value});
+	}
+
+	public void setPreference(
+		PortletRequest portletRequest, String name, String[] values) {
+
+		Map<String, String[]> portletPreferencesMap =
+			(Map<String, String[]>)portletRequest.getAttribute(
+				WebKeys.PORTLET_PREFERENCES_MAP);
+
+		if (portletPreferencesMap == null) {
+			portletPreferencesMap = new HashMap<String, String[]>();
+
+			portletRequest.setAttribute(
+				WebKeys.PORTLET_PREFERENCES_MAP, portletPreferencesMap);
+		}
+
+		portletPreferencesMap.put(name, values);
+	}
+
+	protected abstract T getConfiguration(ActionRequest actionRequest)
+		throws PortalException, SystemException;
+
+	protected PortletConfig getSelPortletConfig(PortletRequest portletRequest)
+		throws SystemException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String portletResource = ParamUtil.getString(
+			portletRequest, "portletResource");
+
+		Portlet selPortlet = PortletLocalServiceUtil.getPortletById(
+			themeDisplay.getCompanyId(), portletResource);
+
+		ServletContext servletContext =
+			(ServletContext)portletRequest.getAttribute(WebKeys.CTX);
+
+		PortletConfig selPortletConfig = PortletConfigFactoryUtil.create(
+			selPortlet, servletContext);
+
+		return selPortletConfig;
+	}
+
+	protected abstract void postProcess(
+			long companyId, PortletRequest portletRequest, T configuration)
+		throws PortalException, SystemException;
+
+	protected void removeDefaultValue(
+		PortletRequest portletRequest, T configuration, String key,
+		String defaultValue) {
+
+		String value = getParameter(portletRequest, key);
+
+		if (defaultValue.equals(value) ||
+			StringUtil.equalsIgnoreBreakLine(defaultValue, value)) {
+
+			reset(configuration, key);
+		}
+	}
+
+	protected abstract void reset(T configuration, String key);
+
+	protected abstract void setValue(
+		T configuration, String name, String value);
+
+	protected abstract void setValues(
+		T configuration, String name, String[] values);
+
+	protected abstract void store(T configuration)
+		throws IOException, ValidatorException;
+
+	protected void validateEmail(
+		ActionRequest actionRequest, String emailParam, boolean localized) {
+
+		boolean emailEnabled = GetterUtil.getBoolean(
+			getParameter(actionRequest, emailParam + "Enabled"));
+		String emailSubject = null;
+		String emailBody = null;
+
+		if (localized) {
+			String languageId = LocaleUtil.toLanguageId(
+				LocaleUtil.getSiteDefault());
+
+			emailSubject = getLocalizedParameter(
+				actionRequest, emailParam + "Subject", languageId);
+			emailBody = getLocalizedParameter(
+				actionRequest, emailParam + "Body", languageId);
+		}
+		else {
+			emailSubject = getParameter(actionRequest, emailParam + "Subject");
+			emailBody = getParameter(actionRequest, emailParam + "Body");
+		}
+
+		if (emailEnabled) {
+			if (Validator.isNull(emailSubject)) {
+				SessionErrors.add(actionRequest, emailParam + "Subject");
+			}
+			else if (Validator.isNull(emailBody)) {
+				SessionErrors.add(actionRequest, emailParam + "Body");
+			}
+		}
+	}
+
+	protected void validateEmailFrom(ActionRequest actionRequest) {
+		String emailFromName = getParameter(actionRequest, "emailFromName");
+		String emailFromAddress = getParameter(
+			actionRequest, "emailFromAddress");
+
+		if (Validator.isNull(emailFromName)) {
+			SessionErrors.add(actionRequest, "emailFromName");
+		}
+		else if (!Validator.isEmailAddress(emailFromAddress) &&
+				 !Validator.isVariableTerm(emailFromAddress)) {
+
+			SessionErrors.add(actionRequest, "emailFromAddress");
+		}
+	}
+
+	private String _configurationParametersPrefix;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultConfigurationAction.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultConfigurationAction.java
@@ -14,361 +14,81 @@
 
 package com.liferay.portal.kernel.portlet;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.servlet.SessionMessages;
-import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.LocalizationUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.PropertiesParamUtil;
-import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.model.Layout;
-import com.liferay.portal.model.Portlet;
-import com.liferay.portal.security.permission.ActionKeys;
-import com.liferay.portal.service.PortletLocalServiceUtil;
-import com.liferay.portal.service.permission.PortletPermissionUtil;
-import com.liferay.portal.settings.Settings;
-import com.liferay.portal.settings.SettingsFactoryUtil;
-import com.liferay.portal.theme.ThemeDisplay;
-import com.liferay.portal.util.PortalUtil;
-import com.liferay.portlet.PortletConfigFactoryUtil;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 
 import javax.portlet.ActionRequest;
-import javax.portlet.ActionResponse;
-import javax.portlet.PortletConfig;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
-import javax.portlet.RenderRequest;
-import javax.portlet.RenderResponse;
-import javax.portlet.ResourceRequest;
-import javax.portlet.ResourceResponse;
+import javax.portlet.ReadOnlyException;
 import javax.portlet.ValidatorException;
 
-import javax.servlet.ServletContext;
-
 /**
- * @author Brian Wing Shun Chan
- * @author Julio Camarero
- * @author Raymond Augé
+ * @author Iván Zaera
  */
 public class DefaultConfigurationAction
-	extends LiferayPortlet
+	extends BaseDefaultConfigurationAction<PortletPreferences>
 	implements ConfigurationAction, ResourceServingConfigurationAction {
 
 	public static final String PREFERENCES_PREFIX = "preferences--";
 
-	public String getLocalizedParameter(
-		PortletRequest portletRequest, String name) {
-
-		String languageId = ParamUtil.getString(portletRequest, "languageId");
-
-		return getLocalizedParameter(portletRequest, name, languageId);
+	public DefaultConfigurationAction() {
+		super(PREFERENCES_PREFIX);
 	}
 
-	public String getLocalizedParameter(
-		PortletRequest portletRequest, String name, String languageId) {
-
-		return getParameter(
-			portletRequest,
-			LocalizationUtil.getLocalizedName(name, languageId));
+	@Override
+	protected PortletPreferences getConfiguration(ActionRequest actionRequest) {
+		return actionRequest.getPreferences();
 	}
 
-	public String getParameter(PortletRequest portletRequest, String name) {
-		name = PREFERENCES_PREFIX.concat(name).concat(StringPool.DOUBLE_DASH);
-
-		return ParamUtil.getString(portletRequest, name);
-	}
-
-	public void postProcessPortletPreferences(
+	@Override
+	protected void postProcess(
 			long companyId, PortletRequest portletRequest,
 			PortletPreferences portletPreferences)
-		throws Exception {
+		throws PortalException, SystemException {
 	}
 
 	@Override
-	public void processAction(
-			PortletConfig portletConfig, ActionRequest actionRequest,
-			ActionResponse actionResponse)
-		throws Exception {
-
-		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
-
-		if (!cmd.equals(Constants.UPDATE)) {
-			return;
-		}
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		Layout layout = PortletConfigurationLayoutUtil.getLayout(themeDisplay);
-
-		String portletResource = ParamUtil.getString(
-			actionRequest, "portletResource");
-
-		PortletPermissionUtil.check(
-			themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroupId(),
-			layout, portletResource, ActionKeys.CONFIGURATION);
-
-		PortletPreferences portletPreferences = null;
-		Settings settings = null;
-
-		String settingsScope = ParamUtil.getString(
-			actionRequest, "settingsScope");
-
-		UnicodeProperties properties = PropertiesParamUtil.getProperties(
-			actionRequest, PREFERENCES_PREFIX);
-
-		if (Validator.isNull(settingsScope)) {
-			portletPreferences = actionRequest.getPreferences();
-
-			for (Map.Entry<String, String> entry : properties.entrySet()) {
-				String name = entry.getKey();
-				String value = entry.getValue();
-
-				portletPreferences.setValue(name, value);
-			}
-
-			Map<String, String[]> portletPreferencesMap =
-				(Map<String, String[]>)actionRequest.getAttribute(
-					WebKeys.PORTLET_PREFERENCES_MAP);
-
-			if (portletPreferencesMap != null) {
-				for (Map.Entry<String, String[]> entry :
-						portletPreferencesMap.entrySet()) {
-
-					String name = entry.getKey();
-					String[] values = entry.getValue();
-
-					portletPreferences.setValues(name, values);
-				}
-			}
-
-			postProcessPortletPreferences(
-				themeDisplay.getCompanyId(), actionRequest, portletPreferences);
-		}
-		else {
-			String serviceName = ParamUtil.getString(
-				actionRequest, "serviceName");
-
-			if (settingsScope.equals("company")) {
-				settings = SettingsFactoryUtil.getCompanyServiceSettings(
-					themeDisplay.getCompanyId(), serviceName);
-			}
-			else if (settingsScope.equals("group")) {
-				settings = SettingsFactoryUtil.getGroupServiceSettings(
-					themeDisplay.getSiteGroupId(), serviceName);
-			}
-			else if (settingsScope.equals("portletInstance")) {
-				settings = SettingsFactoryUtil.getPortletInstanceSettings(
-					themeDisplay.getLayout(), portletResource);
-			}
-
-			if (settings != null) {
-				for (Map.Entry<String, String> entry : properties.entrySet()) {
-					String name = entry.getKey();
-					String value = entry.getValue();
-
-					settings.setValue(name, value);
-				}
-
-				Map<String, String[]> portletPreferencesMap =
-					(Map<String, String[]>)actionRequest.getAttribute(
-						WebKeys.PORTLET_PREFERENCES_MAP);
-
-				if (portletPreferencesMap != null) {
-					for (Map.Entry<String, String[]> entry :
-							portletPreferencesMap.entrySet()) {
-
-						String name = entry.getKey();
-						String[] values = entry.getValue();
-
-						settings.setValues(name, values);
-					}
-				}
-			}
-		}
-
-		if (SessionErrors.isEmpty(actionRequest)) {
-			try {
-				if (portletPreferences != null) {
-					portletPreferences.store();
-				}
-
-				if (settings != null) {
-					settings.store();
-				}
-			}
-			catch (ValidatorException ve) {
-				SessionErrors.add(
-					actionRequest, ValidatorException.class.getName(), ve);
-
-				return;
-			}
-
-			SessionMessages.add(
-				actionRequest,
-				PortalUtil.getPortletId(actionRequest) +
-					SessionMessages.KEY_SUFFIX_REFRESH_PORTLET,
-				portletResource);
-
-			SessionMessages.add(
-				actionRequest,
-				PortalUtil.getPortletId(actionRequest) +
-					SessionMessages.KEY_SUFFIX_UPDATED_CONFIGURATION);
-
-			String redirect = PortalUtil.escapeRedirect(
-				ParamUtil.getString(actionRequest, "redirect"));
-
-			if (Validator.isNotNull(redirect)) {
-				actionResponse.sendRedirect(redirect);
-			}
-		}
-	}
-
-	@Override
-	public String render(
-			PortletConfig portletConfig, RenderRequest renderRequest,
-			RenderResponse renderResponse)
-		throws Exception {
-
-		PortletConfig selPortletConfig = getSelPortletConfig(renderRequest);
-
-		String configTemplate = selPortletConfig.getInitParameter(
-			"config-template");
-
-		if (Validator.isNotNull(configTemplate)) {
-			return configTemplate;
-		}
-
-		String configJSP = selPortletConfig.getInitParameter("config-jsp");
-
-		if (Validator.isNotNull(configJSP)) {
-			return configJSP;
-		}
-
-		return "/configuration.jsp";
-	}
-
-	@Override
-	public void serveResource(
-			PortletConfig portletConfig, ResourceRequest resourceRequest,
-			ResourceResponse resourceResponse)
-		throws Exception {
-	}
-
-	public void setPreference(
-		PortletRequest portletRequest, String name, String value) {
-
-		setPreference(portletRequest, name, new String[] {value});
-	}
-
-	public void setPreference(
-		PortletRequest portletRequest, String name, String[] values) {
-
-		Map<String, String[]> portletPreferencesMap =
-			(Map<String, String[]>)portletRequest.getAttribute(
-				WebKeys.PORTLET_PREFERENCES_MAP);
-
-		if (portletPreferencesMap == null) {
-			portletPreferencesMap = new HashMap<String, String[]>();
-
-			portletRequest.setAttribute(
-				WebKeys.PORTLET_PREFERENCES_MAP, portletPreferencesMap);
-		}
-
-		portletPreferencesMap.put(name, values);
-	}
-
-	protected PortletConfig getSelPortletConfig(PortletRequest portletRequest)
-		throws SystemException {
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		String portletResource = ParamUtil.getString(
-			portletRequest, "portletResource");
-
-		Portlet selPortlet = PortletLocalServiceUtil.getPortletById(
-			themeDisplay.getCompanyId(), portletResource);
-
-		ServletContext servletContext =
-			(ServletContext)portletRequest.getAttribute(WebKeys.CTX);
-
-		PortletConfig selPortletConfig = PortletConfigFactoryUtil.create(
-			selPortlet, servletContext);
-
-		return selPortletConfig;
-	}
-
-	protected void removeDefaultValue(
-			PortletRequest portletRequest,
-			PortletPreferences portletPreferences, String key,
-			String defaultValue)
-		throws Exception {
-
-		String value = getParameter(portletRequest, key);
-
-		if (defaultValue.equals(value) ||
-			StringUtil.equalsIgnoreBreakLine(defaultValue, value)) {
-
+	protected void reset(PortletPreferences portletPreferences, String key) {
+		try {
 			portletPreferences.reset(key);
 		}
-	}
-
-	protected void validateEmail(
-		ActionRequest actionRequest, String emailParam, boolean localized) {
-
-		boolean emailEnabled = GetterUtil.getBoolean(
-			getParameter(actionRequest, emailParam + "Enabled"));
-		String emailSubject = null;
-		String emailBody = null;
-
-		if (localized) {
-			String languageId = LocaleUtil.toLanguageId(
-				LocaleUtil.getSiteDefault());
-
-			emailSubject = getLocalizedParameter(
-				actionRequest, emailParam + "Subject", languageId);
-			emailBody = getLocalizedParameter(
-				actionRequest, emailParam + "Body", languageId);
-		}
-		else {
-			emailSubject = getParameter(actionRequest, emailParam + "Subject");
-			emailBody = getParameter(actionRequest, emailParam + "Body");
-		}
-
-		if (emailEnabled) {
-			if (Validator.isNull(emailSubject)) {
-				SessionErrors.add(actionRequest, emailParam + "Subject");
-			}
-			else if (Validator.isNull(emailBody)) {
-				SessionErrors.add(actionRequest, emailParam + "Body");
-			}
+		catch (ReadOnlyException roe) {
+			throw new RuntimeException(roe);
 		}
 	}
 
-	protected void validateEmailFrom(ActionRequest actionRequest) {
-		String emailFromName = getParameter(actionRequest, "emailFromName");
-		String emailFromAddress = getParameter(
-			actionRequest, "emailFromAddress");
+	@Override
+	protected void setValue(
+		PortletPreferences portletPreferences, String name, String value) {
 
-		if (Validator.isNull(emailFromName)) {
-			SessionErrors.add(actionRequest, "emailFromName");
+		try {
+			portletPreferences.setValue(name, value);
 		}
-		else if (!Validator.isEmailAddress(emailFromAddress) &&
-				 !Validator.isVariableTerm(emailFromAddress)) {
+		catch (ReadOnlyException roe) {
+			throw new RuntimeException(roe);
+		}
+	}
 
-			SessionErrors.add(actionRequest, "emailFromAddress");
+	@Override
+	protected void setValues(
+		PortletPreferences portletPreferences, String name, String[] values) {
+
+		try {
+			portletPreferences.setValues(name, values);
 		}
+		catch (ReadOnlyException roe) {
+			throw new RuntimeException(roe);
+		}
+	}
+
+	@Override
+	protected void store(PortletPreferences portletPreferences)
+		throws IOException, ValidatorException {
+
+		portletPreferences.store();
 	}
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/portlet/SettingsDefaultConfigurationAction.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/SettingsDefaultConfigurationAction.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.portlet;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.settings.Settings;
+import com.liferay.portal.settings.SettingsFactoryUtil;
+import com.liferay.portal.theme.ThemeDisplay;
+
+import java.io.IOException;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.PortletRequest;
+import javax.portlet.ValidatorException;
+
+/**
+ * @author Iván Zaera
+ */
+public class SettingsDefaultConfigurationAction
+	extends BaseDefaultConfigurationAction<Settings>
+	implements ConfigurationAction, ResourceServingConfigurationAction {
+
+	public static final String SETTINGS_PREFIX = "preferences--";
+
+	public SettingsDefaultConfigurationAction() {
+		super(SETTINGS_PREFIX);
+	}
+
+	@Override
+	protected Settings getConfiguration(ActionRequest actionRequest)
+		throws PortalException, SystemException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String serviceName = ParamUtil.getString(actionRequest, "serviceName");
+
+		String settingsScope = ParamUtil.getString(
+			actionRequest, "settingsScope");
+
+		if (settingsScope.equals("company")) {
+			return SettingsFactoryUtil.getCompanyServiceSettings(
+				themeDisplay.getCompanyId(), serviceName);
+		}
+		else if (settingsScope.equals("group")) {
+			return SettingsFactoryUtil.getGroupServiceSettings(
+				themeDisplay.getSiteGroupId(), serviceName);
+		}
+		else if (settingsScope.equals("portletInstance")) {
+			String portletResource = ParamUtil.getString(
+				actionRequest, "portletResource");
+
+			return SettingsFactoryUtil.getPortletInstanceSettings(
+				themeDisplay.getLayout(), portletResource);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid settings scope " + settingsScope);
+	}
+
+	@Override
+	@SuppressWarnings("unused")
+	protected void postProcess(
+			long companyId, PortletRequest portletRequest, Settings settings)
+		throws PortalException, SystemException {
+	}
+
+	@Override
+	protected void reset(Settings settings, String key) {
+		settings.reset(key);
+	}
+
+	@Override
+	protected void setValue(Settings settings, String name, String value) {
+		settings.setValue(name, value);
+	}
+
+	@Override
+	protected void setValues(Settings settings, String name, String[] values) {
+		settings.setValues(name, values);
+	}
+
+	@Override
+	protected void store(Settings settings)
+		throws IOException, ValidatorException {
+
+		settings.store();
+	}
+
+}


### PR DESCRIPTION
Hi Brian:

I have decided to remove the @Deprecated from DefaultConfigurationAction. This is because we need to migrate all portal from PortletPreferences to Settings to mark it as deprecated and that's a huge task.

The rest of the pull mainly remains the same as the one sent yesterday. I will send a further pull to migrate Blogs from DefaultConfigurationAction to SettingsDefaultConfigurationAction to see how it will look in the end.

If we like the result, then we'll keep migrating the rest of ConfigurationActionImpls.

Cheers,
Ivan
