### PR TITLE
LPS-44724 Create the root folder resource with the default value when it's necessary to avoid error due it doesn't exist

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLPermission.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/permission/DLPermission.java
@@ -16,8 +16,11 @@ package com.liferay.portlet.documentlibrary.service.permission;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.staging.permission.StagingPermissionUtil;
+import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.permission.PermissionChecker;
+import com.liferay.portal.service.ResourceLocalServiceUtil;
+import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.util.PortletKeys;
 
 /**
@@ -48,8 +51,23 @@ public class DLPermission {
 			return hasPermission.booleanValue();
 		}
 
-		return permissionChecker.hasPermission(
-			groupId, RESOURCE_NAME, groupId, actionId);
+		try {
+			int count =
+				ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
+					permissionChecker.getCompanyId(), RESOURCE_NAME,
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(groupId));
+
+			if (count > 0) {
+				ResourceLocalServiceUtil.addResources(
+					permissionChecker.getCompanyId(), groupId, 0, RESOURCE_NAME,
+					groupId, false, true, true);
+			}
+		}
+		finally {
+			return permissionChecker.hasPermission(
+				groupId, RESOURCE_NAME, groupId, actionId);
+		}
 	}
 
 }


### PR DESCRIPTION
This is done because the portlets are not being added to the page, therefore the root resources are never created.
