### PR TITLE
LPS-45890

### DIFF
--- a/portal-impl/src/META-INF/messaging-misc-spring.xml
+++ b/portal-impl/src/META-INF/messaging-misc-spring.xml
@@ -59,6 +59,9 @@
 	<bean id="destination.message_boards_mailing_list" class="com.liferay.portal.kernel.messaging.ParallelDestination">
 		<property name="name" value="liferay/message_boards_mailing_list" />
 	</bean>
+	<bean id="destination.push_notification" class="com.liferay.portal.kernel.messaging.SerialDestination">
+		<property name="name" value="liferay/push_notification" />
+	</bean>
 	<bean id="destination.subscription_clean_up" class="com.liferay.portal.kernel.messaging.ParallelDestination">
 		<property name="name" value="liferay/subscription_clean_up" />
 	</bean>

--- a/portal-impl/src/META-INF/portal-hbm.xml
+++ b/portal-impl/src/META-INF/portal-hbm.xml
@@ -1186,6 +1186,7 @@
 		<property name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="type" type="com.liferay.portal.dao.orm.hibernate.StringType" column="type_" />
 		<property name="timestamp" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property name="deliveryType" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property name="deliverBy" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property name="delivered" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property name="payload" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1097,6 +1097,7 @@
 		<field name="userId" type="long" />
 		<field name="type" type="String" />
 		<field name="timestamp" type="long" />
+		<field name="deliveryType" type="int" />
 		<field name="deliverBy" type="long" />
 		<field name="delivered" type="boolean" />
 		<field name="payload" type="String">

--- a/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventCacheModel.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventCacheModel.java
@@ -46,7 +46,7 @@ public class UserNotificationEventCacheModel implements CacheModel<UserNotificat
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(23);
+		StringBundler sb = new StringBundler(25);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -62,6 +62,8 @@ public class UserNotificationEventCacheModel implements CacheModel<UserNotificat
 		sb.append(type);
 		sb.append(", timestamp=");
 		sb.append(timestamp);
+		sb.append(", deliveryType=");
+		sb.append(deliveryType);
 		sb.append(", deliverBy=");
 		sb.append(deliverBy);
 		sb.append(", delivered=");
@@ -100,6 +102,7 @@ public class UserNotificationEventCacheModel implements CacheModel<UserNotificat
 		}
 
 		userNotificationEventImpl.setTimestamp(timestamp);
+		userNotificationEventImpl.setDeliveryType(deliveryType);
 		userNotificationEventImpl.setDeliverBy(deliverBy);
 		userNotificationEventImpl.setDelivered(delivered);
 
@@ -126,6 +129,7 @@ public class UserNotificationEventCacheModel implements CacheModel<UserNotificat
 		userId = objectInput.readLong();
 		type = objectInput.readUTF();
 		timestamp = objectInput.readLong();
+		deliveryType = objectInput.readInt();
 		deliverBy = objectInput.readLong();
 		delivered = objectInput.readBoolean();
 		payload = objectInput.readUTF();
@@ -156,6 +160,7 @@ public class UserNotificationEventCacheModel implements CacheModel<UserNotificat
 		}
 
 		objectOutput.writeLong(timestamp);
+		objectOutput.writeInt(deliveryType);
 		objectOutput.writeLong(deliverBy);
 		objectOutput.writeBoolean(delivered);
 
@@ -176,6 +181,7 @@ public class UserNotificationEventCacheModel implements CacheModel<UserNotificat
 	public long userId;
 	public String type;
 	public long timestamp;
+	public int deliveryType;
 	public long deliverBy;
 	public boolean delivered;
 	public String payload;

--- a/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
@@ -67,12 +67,13 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 			{ "userId", Types.BIGINT },
 			{ "type_", Types.VARCHAR },
 			{ "timestamp", Types.BIGINT },
+			{ "deliveryType", Types.INTEGER },
 			{ "deliverBy", Types.BIGINT },
 			{ "delivered", Types.BOOLEAN },
 			{ "payload", Types.CLOB },
 			{ "archived", Types.BOOLEAN }
 		};
-	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(75) null,timestamp LONG,deliverBy LONG,delivered BOOLEAN,payload TEXT null,archived BOOLEAN)";
+	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(75) null,timestamp LONG,deliveryType INTEGER,deliverBy LONG,delivered BOOLEAN,payload TEXT null,archived BOOLEAN)";
 	public static final String TABLE_SQL_DROP = "drop table UserNotificationEvent";
 	public static final String ORDER_BY_JPQL = " ORDER BY userNotificationEvent.timestamp DESC";
 	public static final String ORDER_BY_SQL = " ORDER BY UserNotificationEvent.timestamp DESC";
@@ -141,6 +142,7 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 		attributes.put("userId", getUserId());
 		attributes.put("type", getType());
 		attributes.put("timestamp", getTimestamp());
+		attributes.put("deliveryType", getDeliveryType());
 		attributes.put("deliverBy", getDeliverBy());
 		attributes.put("delivered", getDelivered());
 		attributes.put("payload", getPayload());
@@ -195,6 +197,12 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 
 		if (timestamp != null) {
 			setTimestamp(timestamp);
+		}
+
+		Integer deliveryType = (Integer)attributes.get("deliveryType");
+
+		if (deliveryType != null) {
+			setDeliveryType(deliveryType);
 		}
 
 		Long deliverBy = (Long)attributes.get("deliverBy");
@@ -353,6 +361,16 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 	}
 
 	@Override
+	public int getDeliveryType() {
+		return _deliveryType;
+	}
+
+	@Override
+	public void setDeliveryType(int deliveryType) {
+		_deliveryType = deliveryType;
+	}
+
+	@Override
 	public long getDeliverBy() {
 		return _deliverBy;
 	}
@@ -469,6 +487,7 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 		userNotificationEventImpl.setUserId(getUserId());
 		userNotificationEventImpl.setType(getType());
 		userNotificationEventImpl.setTimestamp(getTimestamp());
+		userNotificationEventImpl.setDeliveryType(getDeliveryType());
 		userNotificationEventImpl.setDeliverBy(getDeliverBy());
 		userNotificationEventImpl.setDelivered(getDelivered());
 		userNotificationEventImpl.setPayload(getPayload());
@@ -594,6 +613,8 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 
 		userNotificationEventCacheModel.timestamp = getTimestamp();
 
+		userNotificationEventCacheModel.deliveryType = getDeliveryType();
+
 		userNotificationEventCacheModel.deliverBy = getDeliverBy();
 
 		userNotificationEventCacheModel.delivered = getDelivered();
@@ -613,7 +634,7 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(23);
+		StringBundler sb = new StringBundler(25);
 
 		sb.append("{mvccVersion=");
 		sb.append(getMvccVersion());
@@ -629,6 +650,8 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 		sb.append(getType());
 		sb.append(", timestamp=");
 		sb.append(getTimestamp());
+		sb.append(", deliveryType=");
+		sb.append(getDeliveryType());
 		sb.append(", deliverBy=");
 		sb.append(getDeliverBy());
 		sb.append(", delivered=");
@@ -644,7 +667,7 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 
 	@Override
 	public String toXmlString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(40);
 
 		sb.append("<model><model-name>");
 		sb.append("com.liferay.portal.model.UserNotificationEvent");
@@ -677,6 +700,10 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 		sb.append(
 			"<column><column-name>timestamp</column-name><column-value><![CDATA[");
 		sb.append(getTimestamp());
+		sb.append("]]></column-value></column>");
+		sb.append(
+			"<column><column-name>deliveryType</column-name><column-value><![CDATA[");
+		sb.append(getDeliveryType());
 		sb.append("]]></column-value></column>");
 		sb.append(
 			"<column><column-name>deliverBy</column-name><column-value><![CDATA[");
@@ -716,6 +743,7 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 	private boolean _setOriginalUserId;
 	private String _type;
 	private long _timestamp;
+	private int _deliveryType;
 	private long _deliverBy;
 	private boolean _delivered;
 	private boolean _originalDelivered;

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -2982,6 +2982,7 @@
 
 		<column name="type" type="String" />
 		<column name="timestamp" type="long" />
+		<column name="deliveryType" type="int" />
 		<column name="deliverBy" type="long" />
 		<column name="delivered" type="boolean" />
 		<column name="payload" type="String" />

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -257,6 +257,7 @@ public class UserNotificationEventLocalServiceImpl
 		return getArchivedUserNotificationEventsCount(userId, archived);
 	}
 
+	@Override
 	public List<UserNotificationEvent> sendUserNotificationEvents(
 			long userId, String portletId, int notificationType,
 			JSONObject notificationEventJSONObject)

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -306,6 +306,12 @@ public class UserNotificationEventLocalServiceImpl
 					addUserNotificationEvent(userId, notificationEvent);
 
 				userNotificationEvents.add(userNotificationEvent);
+
+				if (userNotificationDeliveryType.getType() ==
+						UserNotificationDeliveryConstants.TYPE_PUSH) {
+
+					sendPushNotitication(userNotificationEvent);
+				}
 			}
 		}
 
@@ -348,6 +354,29 @@ public class UserNotificationEventLocalServiceImpl
 		}
 
 		return userNotificationEvents;
+	}
+
+	protected void sendPushNotitication(
+		final UserNotificationEvent userNotificationEvent) {
+
+		TransactionCommitCallbackRegistryUtil.registerCallback(
+			new Callable<Void>() {
+
+				@Override
+				public Void call() throws Exception {
+					Message message = new Message();
+
+					message.put("userId", userNotificationEvent.getUserId());
+					message.put("data", userNotificationEvent.getPayload());
+
+					MessageBusUtil.sendMessage(
+						DestinationNames.PUSH_NOTIFICATION, message);
+
+					return null;
+				}
+
+			}
+		);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserNotificationEventPersistenceImpl.java
@@ -3127,6 +3127,7 @@ public class UserNotificationEventPersistenceImpl extends BasePersistenceImpl<Us
 		userNotificationEventImpl.setUserId(userNotificationEvent.getUserId());
 		userNotificationEventImpl.setType(userNotificationEvent.getType());
 		userNotificationEventImpl.setTimestamp(userNotificationEvent.getTimestamp());
+		userNotificationEventImpl.setDeliveryType(userNotificationEvent.getDeliveryType());
 		userNotificationEventImpl.setDeliverBy(userNotificationEvent.getDeliverBy());
 		userNotificationEventImpl.setDelivered(userNotificationEvent.isDelivered());
 		userNotificationEventImpl.setPayload(userNotificationEvent.getPayload());

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/UserNotificationEventPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/UserNotificationEventPersistenceTest.java
@@ -123,6 +123,8 @@ public class UserNotificationEventPersistenceTest {
 
 		newUserNotificationEvent.setTimestamp(ServiceTestUtil.nextLong());
 
+		newUserNotificationEvent.setDeliveryType(ServiceTestUtil.nextInt());
+
 		newUserNotificationEvent.setDeliverBy(ServiceTestUtil.nextLong());
 
 		newUserNotificationEvent.setDelivered(ServiceTestUtil.randomBoolean());
@@ -149,6 +151,8 @@ public class UserNotificationEventPersistenceTest {
 			newUserNotificationEvent.getType());
 		Assert.assertEquals(existingUserNotificationEvent.getTimestamp(),
 			newUserNotificationEvent.getTimestamp());
+		Assert.assertEquals(existingUserNotificationEvent.getDeliveryType(),
+			newUserNotificationEvent.getDeliveryType());
 		Assert.assertEquals(existingUserNotificationEvent.getDeliverBy(),
 			newUserNotificationEvent.getDeliverBy());
 		Assert.assertEquals(existingUserNotificationEvent.getDelivered(),
@@ -265,8 +269,8 @@ public class UserNotificationEventPersistenceTest {
 		return OrderByComparatorFactoryUtil.create("UserNotificationEvent",
 			"mvccVersion", true, "uuid", true, "userNotificationEventId", true,
 			"companyId", true, "userId", true, "type", true, "timestamp", true,
-			"deliverBy", true, "delivered", true, "payload", true, "archived",
-			true);
+			"deliveryType", true, "deliverBy", true, "delivered", true,
+			"payload", true, "archived", true);
 	}
 
 	@Test
@@ -401,6 +405,8 @@ public class UserNotificationEventPersistenceTest {
 		userNotificationEvent.setType(ServiceTestUtil.randomString());
 
 		userNotificationEvent.setTimestamp(ServiceTestUtil.nextLong());
+
+		userNotificationEvent.setDeliveryType(ServiceTestUtil.nextInt());
 
 		userNotificationEvent.setDeliverBy(ServiceTestUtil.nextLong());
 

--- a/portal-service/src/com/liferay/portal/kernel/messaging/DestinationNames.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/DestinationNames.java
@@ -119,6 +119,8 @@ public interface DestinationNames {
 
 	public static final String POLLER_RESPONSE = "liferay/poller_response";
 
+	public static final String PUSH_NOTIFICATION = "liferay/push_notification";
+
 	public static final String REPORT_COMPILER = "liferay/report_compiler";
 
 	public static final String REPORT_REQUEST = "liferay/report_request";

--- a/portal-service/src/com/liferay/portal/kernel/notifications/NotificationEvent.java
+++ b/portal-service/src/com/liferay/portal/kernel/notifications/NotificationEvent.java
@@ -57,6 +57,10 @@ public class NotificationEvent implements Serializable {
 		return _deliverBy;
 	}
 
+	public int getDeliveryType() {
+		return _deliveryType;
+	}
+
 	public JSONObject getPayload() {
 		return _payloadJSONObject;
 	}
@@ -119,6 +123,10 @@ public class NotificationEvent implements Serializable {
 		_deliveryRequired = true;
 	}
 
+	public void setDeliveryType(int deliveryType) {
+		_deliverBy = deliveryType;
+	}
+
 	public void setTimestamp(long timestamp) {
 		_timestamp = timestamp;
 	}
@@ -130,7 +138,10 @@ public class NotificationEvent implements Serializable {
 	public JSONObject toJSONObject() {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
+		jsonObject.put(_KEY_ARCHIVED, _archived);
+		jsonObject.put(_KEY_DELIVERY_BY, _deliverBy);
 		jsonObject.put(_KEY_DELIVERY_REQUIRED, _deliveryRequired);
+		jsonObject.put(_KEY_DELIVERY_TYPE, _deliveryType);
 		jsonObject.put(_KEY_PAYLOAD, _payloadJSONObject);
 		jsonObject.put(_KEY_TIMESTAMP, _timestamp);
 		jsonObject.put(_KEY_TYPE, _type);
@@ -139,7 +150,13 @@ public class NotificationEvent implements Serializable {
 		return jsonObject;
 	}
 
+	private static final String _KEY_ARCHIVED = "archived";
+
+	private static final String _KEY_DELIVERY_BY = "deliveryBy";
+
 	private static final String _KEY_DELIVERY_REQUIRED = "deliveryRequired";
+
+	private static final String _KEY_DELIVERY_TYPE = "deliveryType";
 
 	private static final String _KEY_PAYLOAD = "payload";
 
@@ -152,6 +169,7 @@ public class NotificationEvent implements Serializable {
 	private boolean _archived;
 	private long _deliverBy;
 	private boolean _deliveryRequired;
+	private int _deliveryType;
 	private JSONObject _payloadJSONObject;
 	private long _timestamp;
 	private String _type;

--- a/portal-service/src/com/liferay/portal/model/UserNotificationDeliveryConstants.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationDeliveryConstants.java
@@ -25,6 +25,8 @@ public class UserNotificationDeliveryConstants {
 
 	public static final int TYPE_PRIVATE_MESSAGE = 10004;
 
+	public static final int TYPE_PUSH = 10005;
+
 	public static final int TYPE_SMS = 10001;
 
 	public static final int TYPE_WEBSITE = 10002;

--- a/portal-service/src/com/liferay/portal/model/UserNotificationEventModel.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationEventModel.java
@@ -178,6 +178,20 @@ public interface UserNotificationEventModel extends BaseModel<UserNotificationEv
 	public void setTimestamp(long timestamp);
 
 	/**
+	 * Returns the delivery type of this user notification event.
+	 *
+	 * @return the delivery type of this user notification event
+	 */
+	public int getDeliveryType();
+
+	/**
+	 * Sets the delivery type of this user notification event.
+	 *
+	 * @param deliveryType the delivery type of this user notification event
+	 */
+	public void setDeliveryType(int deliveryType);
+
+	/**
 	 * Returns the deliver by of this user notification event.
 	 *
 	 * @return the deliver by of this user notification event

--- a/portal-service/src/com/liferay/portal/model/UserNotificationEventSoap.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationEventSoap.java
@@ -37,6 +37,7 @@ public class UserNotificationEventSoap implements Serializable {
 		soapModel.setUserId(model.getUserId());
 		soapModel.setType(model.getType());
 		soapModel.setTimestamp(model.getTimestamp());
+		soapModel.setDeliveryType(model.getDeliveryType());
 		soapModel.setDeliverBy(model.getDeliverBy());
 		soapModel.setDelivered(model.getDelivered());
 		soapModel.setPayload(model.getPayload());
@@ -152,6 +153,14 @@ public class UserNotificationEventSoap implements Serializable {
 		_timestamp = timestamp;
 	}
 
+	public int getDeliveryType() {
+		return _deliveryType;
+	}
+
+	public void setDeliveryType(int deliveryType) {
+		_deliveryType = deliveryType;
+	}
+
 	public long getDeliverBy() {
 		return _deliverBy;
 	}
@@ -199,6 +208,7 @@ public class UserNotificationEventSoap implements Serializable {
 	private long _userId;
 	private String _type;
 	private long _timestamp;
+	private int _deliveryType;
 	private long _deliverBy;
 	private boolean _delivered;
 	private String _payload;

--- a/portal-service/src/com/liferay/portal/model/UserNotificationEventWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationEventWrapper.java
@@ -59,6 +59,7 @@ public class UserNotificationEventWrapper implements UserNotificationEvent,
 		attributes.put("userId", getUserId());
 		attributes.put("type", getType());
 		attributes.put("timestamp", getTimestamp());
+		attributes.put("deliveryType", getDeliveryType());
 		attributes.put("deliverBy", getDeliverBy());
 		attributes.put("delivered", getDelivered());
 		attributes.put("payload", getPayload());
@@ -110,6 +111,12 @@ public class UserNotificationEventWrapper implements UserNotificationEvent,
 
 		if (timestamp != null) {
 			setTimestamp(timestamp);
+		}
+
+		Integer deliveryType = (Integer)attributes.get("deliveryType");
+
+		if (deliveryType != null) {
+			setDeliveryType(deliveryType);
 		}
 
 		Long deliverBy = (Long)attributes.get("deliverBy");
@@ -317,6 +324,26 @@ public class UserNotificationEventWrapper implements UserNotificationEvent,
 	@Override
 	public void setTimestamp(long timestamp) {
 		_userNotificationEvent.setTimestamp(timestamp);
+	}
+
+	/**
+	* Returns the delivery type of this user notification event.
+	*
+	* @return the delivery type of this user notification event
+	*/
+	@Override
+	public int getDeliveryType() {
+		return _userNotificationEvent.getDeliveryType();
+	}
+
+	/**
+	* Sets the delivery type of this user notification event.
+	*
+	* @param deliveryType the delivery type of this user notification event
+	*/
+	@Override
+	public void setDeliveryType(int deliveryType) {
+		_userNotificationEvent.setDeliveryType(deliveryType);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserNotificationEventLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/UserNotificationEventLocalService.java
@@ -279,6 +279,18 @@ public interface UserNotificationEventLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	public com.liferay.portal.model.UserNotificationEvent addUserNotificationEvent(
+		long userId, java.lang.String type, long timestamp, int deliveryType,
+		long deliverBy, java.lang.String payload, boolean archived,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* @deprecated As of 7.0.0 {@link #addUserNotificationEvent(long, String,
+	long, int, long, String, boolean, ServiceContext)}
+	*/
+	@Deprecated
+	public com.liferay.portal.model.UserNotificationEvent addUserNotificationEvent(
 		long userId, java.lang.String type, long timestamp, long deliverBy,
 		java.lang.String payload, boolean archived,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -370,6 +382,19 @@ public interface UserNotificationEventLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getUserNotificationEventsCount(long userId, boolean archived)
 		throws com.liferay.portal.kernel.exception.SystemException;
+
+	public java.util.List<com.liferay.portal.model.UserNotificationEvent> sendUserNotificationEvents(
+		long userId, java.lang.String portletId, int notificationType,
+		com.liferay.portal.kernel.json.JSONObject notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public java.util.List<com.liferay.portal.model.UserNotificationEvent> sendUserNotificationEvents(
+		long userId, java.lang.String portletId, long classNameId,
+		int notificationType,
+		com.liferay.portal.kernel.json.JSONObject notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
 
 	public com.liferay.portal.model.UserNotificationEvent updateUserNotificationEvent(
 		java.lang.String uuid, long companyId, boolean archive)

--- a/portal-service/src/com/liferay/portal/service/UserNotificationEventLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/UserNotificationEventLocalServiceUtil.java
@@ -312,6 +312,22 @@ public class UserNotificationEventLocalServiceUtil {
 	}
 
 	public static com.liferay.portal.model.UserNotificationEvent addUserNotificationEvent(
+		long userId, java.lang.String type, long timestamp, int deliveryType,
+		long deliverBy, java.lang.String payload, boolean archived,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .addUserNotificationEvent(userId, type, timestamp,
+			deliveryType, deliverBy, payload, archived, serviceContext);
+	}
+
+	/**
+	* @deprecated As of 7.0.0 {@link #addUserNotificationEvent(long, String,
+	long, int, long, String, boolean, ServiceContext)}
+	*/
+	@Deprecated
+	public static com.liferay.portal.model.UserNotificationEvent addUserNotificationEvent(
 		long userId, java.lang.String type, long timestamp, long deliverBy,
 		java.lang.String payload, boolean archived,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -432,6 +448,27 @@ public class UserNotificationEventLocalServiceUtil {
 		boolean archived)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return getService().getUserNotificationEventsCount(userId, archived);
+	}
+
+	public static java.util.List<com.liferay.portal.model.UserNotificationEvent> sendUserNotificationEvents(
+		long userId, java.lang.String portletId, int notificationType,
+		com.liferay.portal.kernel.json.JSONObject notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .sendUserNotificationEvents(userId, portletId,
+			notificationType, notificationEventJSONObject);
+	}
+
+	public static java.util.List<com.liferay.portal.model.UserNotificationEvent> sendUserNotificationEvents(
+		long userId, java.lang.String portletId, long classNameId,
+		int notificationType,
+		com.liferay.portal.kernel.json.JSONObject notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .sendUserNotificationEvents(userId, portletId, classNameId,
+			notificationType, notificationEventJSONObject);
 	}
 
 	public static com.liferay.portal.model.UserNotificationEvent updateUserNotificationEvent(

--- a/portal-service/src/com/liferay/portal/service/UserNotificationEventLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/UserNotificationEventLocalServiceWrapper.java
@@ -329,6 +329,23 @@ public class UserNotificationEventLocalServiceWrapper
 
 	@Override
 	public com.liferay.portal.model.UserNotificationEvent addUserNotificationEvent(
+		long userId, java.lang.String type, long timestamp, int deliveryType,
+		long deliverBy, java.lang.String payload, boolean archived,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _userNotificationEventLocalService.addUserNotificationEvent(userId,
+			type, timestamp, deliveryType, deliverBy, payload, archived,
+			serviceContext);
+	}
+
+	/**
+	* @deprecated As of 7.0.0 {@link #addUserNotificationEvent(long, String,
+	long, int, long, String, boolean, ServiceContext)}
+	*/
+	@Deprecated
+	@Override
+	public com.liferay.portal.model.UserNotificationEvent addUserNotificationEvent(
 		long userId, java.lang.String type, long timestamp, long deliverBy,
 		java.lang.String payload, boolean archived,
 		com.liferay.portal.service.ServiceContext serviceContext)
@@ -468,6 +485,28 @@ public class UserNotificationEventLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return _userNotificationEventLocalService.getUserNotificationEventsCount(userId,
 			archived);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.model.UserNotificationEvent> sendUserNotificationEvents(
+		long userId, java.lang.String portletId, int notificationType,
+		com.liferay.portal.kernel.json.JSONObject notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _userNotificationEventLocalService.sendUserNotificationEvents(userId,
+			portletId, notificationType, notificationEventJSONObject);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.model.UserNotificationEvent> sendUserNotificationEvents(
+		long userId, java.lang.String portletId, long classNameId,
+		int notificationType,
+		com.liferay.portal.kernel.json.JSONObject notificationEventJSONObject)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _userNotificationEventLocalService.sendUserNotificationEvents(userId,
+			portletId, classNameId, notificationType,
+			notificationEventJSONObject);
 	}
 
 	@Override

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -2300,6 +2300,7 @@ create table UserNotificationEvent (
 	userId LONG,
 	type_ VARCHAR(75) null,
 	timestamp LONG,
+	deliveryType INTEGER,
 	deliverBy LONG,
 	delivered BOOLEAN,
 	payload TEXT null,


### PR DESCRIPTION
Please reconsider this pull request. 

We need to use deliveryType (see UserNotificationDelivery in service.xml) to tell the different type of deliveries (see UserNotificationDeliveryConstants.java). The existing type is used for portletId or classname to indicate whether if the notification is blogs, MB, wiki, documents. The field type was legacy, and I would rather keep it the same. I feel like adding a new field is not that bad especially this is for 7.0

For 6.2 we can use a hook like we did in so-activities-hook and achieve the same thing. For 7.0, we should keep it in portal since this is needed for the framework. Later on we can move this to a osgi mdoule.

Thanks
