### PR TITLE
master-qa-8652

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
@@ -109,7 +109,7 @@ public class UserFinderTest {
 			TestPropsValues.getCompanyId(), null,
 			WorkflowConstants.STATUS_APPROVED, params);
 
-		Assert.assertEquals(5, count);
+		Assert.assertEquals(4, count);
 	}
 
 	@Test
@@ -223,7 +223,7 @@ public class UserFinderTest {
 		Assert.assertTrue(users.contains(_organizationUser));
 		Assert.assertTrue(users.contains(_userGroupUser));
 		Assert.assertTrue(users.contains(TestPropsValues.getUser()));
-		Assert.assertEquals(5, users.size());
+		Assert.assertEquals(4, users.size());
 	}
 
 	@Test


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-8652

This commit was originally needed after the commits for LPS-43591 and LPS-45491, but after Jorge's fix for LPS-45900, it looks like the behavior has gone back to the way it was before.

Before LPS-43591 and LPS-45491, it was expecting 4. After those 2 tickets, it was expecting 4 but saw 5, so Cristina fixed it to expect 5.

Now, it's expecting 5 but sees 4 so it should go back to the way it used to be.

https://build.liferay.com/1/view/liferay-portal(ee-6.2.x)/job/liferay-portal-backend(ee-6.2.x)/label_exp=!build-1,test=com.liferay.portal.service.persistence/167/console
