### PR TITLE
LPS-45817 Fix unit tests: avoid initializing UpgradeMessageBoards class until Props has been mocked. Otherwise, java.lang.ExceptionInInitializerError will be thrown

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/upgrade/v7_0_0/UpgradeMessageBoardsTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/v7_0_0/UpgradeMessageBoardsTest.java
@@ -44,6 +44,10 @@ public class UpgradeMessageBoardsTest extends PowerMockito {
 		);
 
 		PropsUtil.setProps(props);
+
+		_portletPreferences = new MockPortletPreferences();
+
+		_upgradeMessageBoards = new UpgradeMessageBoards();
 	}
 
 	@Test
@@ -112,9 +116,7 @@ public class UpgradeMessageBoardsTest extends PowerMockito {
 			values);
 	}
 
-	private PortletPreferences _portletPreferences =
-		new MockPortletPreferences();
-	private UpgradeMessageBoards _upgradeMessageBoards =
-		new UpgradeMessageBoards();
+	private PortletPreferences _portletPreferences;
+	private UpgradeMessageBoards _upgradeMessageBoards;
 
 }


### PR DESCRIPTION
cc /@izaera
