### PR TITLE
LPS-46123 - Please read comments

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/base/AccountLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/AccountLocalServiceBaseImpl.java
@@ -233,7 +233,7 @@ public abstract class AccountLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.AccountLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Account.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -245,7 +245,7 @@ public abstract class AccountLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.AccountLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Account.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/AddressLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/AddressLocalServiceBaseImpl.java
@@ -260,7 +260,7 @@ public abstract class AddressLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.AddressLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Address.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -272,7 +272,7 @@ public abstract class AddressLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.AddressLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Address.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/BackgroundTaskLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/BackgroundTaskLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class BackgroundTaskLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.BackgroundTaskLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BackgroundTask.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class BackgroundTaskLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.BackgroundTaskLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BackgroundTask.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/BrowserTrackerLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/BrowserTrackerLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class BrowserTrackerLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.BrowserTrackerLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BrowserTracker.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class BrowserTrackerLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.BrowserTrackerLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BrowserTracker.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ClassNameLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ClassNameLocalServiceBaseImpl.java
@@ -237,7 +237,7 @@ public abstract class ClassNameLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ClassNameLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ClassName.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -249,7 +249,7 @@ public abstract class ClassNameLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ClassNameLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ClassName.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ClusterGroupLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ClusterGroupLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class ClusterGroupLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ClusterGroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ClusterGroup.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class ClusterGroupLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ClusterGroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ClusterGroup.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/CompanyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/CompanyLocalServiceBaseImpl.java
@@ -253,7 +253,7 @@ public abstract class CompanyLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.CompanyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Company.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -265,7 +265,7 @@ public abstract class CompanyLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.CompanyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Company.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ContactLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ContactLocalServiceBaseImpl.java
@@ -241,7 +241,7 @@ public abstract class ContactLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ContactLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Contact.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -253,7 +253,7 @@ public abstract class ContactLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ContactLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Contact.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/EmailAddressLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/EmailAddressLocalServiceBaseImpl.java
@@ -265,7 +265,7 @@ public abstract class EmailAddressLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.EmailAddressLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(EmailAddress.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -277,7 +277,7 @@ public abstract class EmailAddressLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.EmailAddressLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(EmailAddress.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ExportImportConfigurationLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ExportImportConfigurationLocalServiceBaseImpl.java
@@ -249,7 +249,7 @@ public abstract class ExportImportConfigurationLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ExportImportConfigurationLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExportImportConfiguration.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -262,7 +262,7 @@ public abstract class ExportImportConfigurationLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ExportImportConfigurationLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExportImportConfiguration.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/GroupLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/GroupLocalServiceBaseImpl.java
@@ -310,7 +310,7 @@ public abstract class GroupLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.GroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Group.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -322,7 +322,7 @@ public abstract class GroupLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.GroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Group.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ImageLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ImageLocalServiceBaseImpl.java
@@ -235,7 +235,7 @@ public abstract class ImageLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ImageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Image.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -247,7 +247,7 @@ public abstract class ImageLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ImageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Image.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutBranchLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutBranchLocalServiceBaseImpl.java
@@ -243,7 +243,7 @@ public abstract class LayoutBranchLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutBranchLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutBranch.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -255,7 +255,7 @@ public abstract class LayoutBranchLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutBranchLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutBranch.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutFriendlyURLLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutFriendlyURLLocalServiceBaseImpl.java
@@ -276,7 +276,7 @@ public abstract class LayoutFriendlyURLLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutFriendlyURLLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutFriendlyURL.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -288,7 +288,7 @@ public abstract class LayoutFriendlyURLLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutFriendlyURLLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutFriendlyURL.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutLocalServiceBaseImpl.java
@@ -305,7 +305,7 @@ public abstract class LayoutLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Layout.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -317,7 +317,7 @@ public abstract class LayoutLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Layout.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutPrototypeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutPrototypeLocalServiceBaseImpl.java
@@ -270,7 +270,7 @@ public abstract class LayoutPrototypeLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutPrototypeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutPrototype.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -282,7 +282,7 @@ public abstract class LayoutPrototypeLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutPrototypeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutPrototype.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionLocalServiceBaseImpl.java
@@ -251,7 +251,7 @@ public abstract class LayoutRevisionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutRevisionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutRevision.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -263,7 +263,7 @@ public abstract class LayoutRevisionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutRevisionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutRevision.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetBranchLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetBranchLocalServiceBaseImpl.java
@@ -247,7 +247,7 @@ public abstract class LayoutSetBranchLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutSetBranchLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutSetBranch.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -259,7 +259,7 @@ public abstract class LayoutSetBranchLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutSetBranchLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutSetBranch.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetLocalServiceBaseImpl.java
@@ -245,7 +245,7 @@ public abstract class LayoutSetLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutSetLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutSet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class LayoutSetLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutSetLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutSet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeLocalServiceBaseImpl.java
@@ -270,7 +270,7 @@ public abstract class LayoutSetPrototypeLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutSetPrototypeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutSetPrototype.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -282,7 +282,7 @@ public abstract class LayoutSetPrototypeLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LayoutSetPrototypeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(LayoutSetPrototype.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/LockLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LockLocalServiceBaseImpl.java
@@ -248,7 +248,7 @@ public abstract class LockLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LockLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Lock.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -260,7 +260,7 @@ public abstract class LockLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.LockLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Lock.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/MembershipRequestLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/MembershipRequestLocalServiceBaseImpl.java
@@ -249,7 +249,7 @@ public abstract class MembershipRequestLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.MembershipRequestLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MembershipRequest.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -261,7 +261,7 @@ public abstract class MembershipRequestLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.MembershipRequestLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MembershipRequest.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/OrgLaborLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/OrgLaborLocalServiceBaseImpl.java
@@ -235,7 +235,7 @@ public abstract class OrgLaborLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.OrgLaborLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(OrgLabor.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -247,7 +247,7 @@ public abstract class OrgLaborLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.OrgLaborLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(OrgLabor.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/OrganizationLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/OrganizationLocalServiceBaseImpl.java
@@ -288,7 +288,7 @@ public abstract class OrganizationLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.OrganizationLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Organization.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -300,7 +300,7 @@ public abstract class OrganizationLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.OrganizationLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Organization.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PasswordPolicyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PasswordPolicyLocalServiceBaseImpl.java
@@ -266,7 +266,7 @@ public abstract class PasswordPolicyLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PasswordPolicyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PasswordPolicy.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -278,7 +278,7 @@ public abstract class PasswordPolicyLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PasswordPolicyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PasswordPolicy.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PasswordPolicyRelLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PasswordPolicyRelLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class PasswordPolicyRelLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PasswordPolicyRelLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PasswordPolicyRel.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class PasswordPolicyRelLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PasswordPolicyRelLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PasswordPolicyRel.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PasswordTrackerLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PasswordTrackerLocalServiceBaseImpl.java
@@ -243,7 +243,7 @@ public abstract class PasswordTrackerLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PasswordTrackerLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PasswordTracker.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -255,7 +255,7 @@ public abstract class PasswordTrackerLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PasswordTrackerLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PasswordTracker.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PhoneLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PhoneLocalServiceBaseImpl.java
@@ -258,7 +258,7 @@ public abstract class PhoneLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PhoneLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Phone.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -270,7 +270,7 @@ public abstract class PhoneLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PhoneLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Phone.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PluginSettingLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PluginSettingLocalServiceBaseImpl.java
@@ -243,7 +243,7 @@ public abstract class PluginSettingLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PluginSettingLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PluginSetting.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -255,7 +255,7 @@ public abstract class PluginSettingLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PluginSettingLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PluginSetting.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PortalPreferencesLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PortalPreferencesLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class PortalPreferencesLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortalPreferencesLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PortalPreferences.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class PortalPreferencesLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortalPreferencesLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PortalPreferences.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PortletItemLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PortletItemLocalServiceBaseImpl.java
@@ -242,7 +242,7 @@ public abstract class PortletItemLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortletItemLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PortletItem.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -254,7 +254,7 @@ public abstract class PortletItemLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortletItemLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PortletItem.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PortletLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PortletLocalServiceBaseImpl.java
@@ -241,7 +241,7 @@ public abstract class PortletLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortletLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Portlet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -253,7 +253,7 @@ public abstract class PortletLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortletLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Portlet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/PortletPreferencesLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/PortletPreferencesLocalServiceBaseImpl.java
@@ -243,7 +243,7 @@ public abstract class PortletPreferencesLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortletPreferencesLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PortletPreferences.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -255,7 +255,7 @@ public abstract class PortletPreferencesLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.PortletPreferencesLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PortletPreferences.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ReleaseLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ReleaseLocalServiceBaseImpl.java
@@ -233,7 +233,7 @@ public abstract class ReleaseLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ReleaseLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Release.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -245,7 +245,7 @@ public abstract class ReleaseLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ReleaseLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Release.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/RepositoryEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RepositoryEntryLocalServiceBaseImpl.java
@@ -276,7 +276,7 @@ public abstract class RepositoryEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.RepositoryEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(RepositoryEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -288,7 +288,7 @@ public abstract class RepositoryEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.RepositoryEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(RepositoryEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
@@ -294,7 +294,7 @@ public abstract class RepositoryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.RepositoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Repository.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -306,7 +306,7 @@ public abstract class RepositoryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.RepositoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Repository.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ResourceActionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ResourceActionLocalServiceBaseImpl.java
@@ -241,7 +241,7 @@ public abstract class ResourceActionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceActionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceAction.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -253,7 +253,7 @@ public abstract class ResourceActionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceActionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceAction.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ResourceBlockLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ResourceBlockLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class ResourceBlockLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceBlockLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceBlock.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class ResourceBlockLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceBlockLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceBlock.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ResourceBlockPermissionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ResourceBlockPermissionLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class ResourceBlockPermissionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceBlockPermissionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceBlockPermission.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class ResourceBlockPermissionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceBlockPermissionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceBlockPermission.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ResourcePermissionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ResourcePermissionLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class ResourcePermissionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourcePermissionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourcePermission.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class ResourcePermissionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourcePermissionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourcePermission.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ResourceTypePermissionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ResourceTypePermissionLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class ResourceTypePermissionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceTypePermissionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceTypePermission.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class ResourceTypePermissionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ResourceTypePermissionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ResourceTypePermission.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/RoleLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RoleLocalServiceBaseImpl.java
@@ -280,7 +280,7 @@ public abstract class RoleLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.RoleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Role.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -292,7 +292,7 @@ public abstract class RoleLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.RoleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Role.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ServiceComponentLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ServiceComponentLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class ServiceComponentLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ServiceComponentLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ServiceComponent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class ServiceComponentLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ServiceComponentLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ServiceComponent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/ShardLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/ShardLocalServiceBaseImpl.java
@@ -233,7 +233,7 @@ public abstract class ShardLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ShardLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Shard.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -245,7 +245,7 @@ public abstract class ShardLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.ShardLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Shard.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/SubscriptionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/SubscriptionLocalServiceBaseImpl.java
@@ -250,7 +250,7 @@ public abstract class SubscriptionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.SubscriptionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Subscription.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -262,7 +262,7 @@ public abstract class SubscriptionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.SubscriptionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Subscription.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/SystemEventLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/SystemEventLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class SystemEventLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.SystemEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SystemEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class SystemEventLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.SystemEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SystemEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/TeamLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/TeamLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class TeamLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.TeamLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Team.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class TeamLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.TeamLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Team.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/TicketLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/TicketLocalServiceBaseImpl.java
@@ -234,7 +234,7 @@ public abstract class TicketLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.TicketLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Ticket.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -246,7 +246,7 @@ public abstract class TicketLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.TicketLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Ticket.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserGroupGroupRoleLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserGroupGroupRoleLocalServiceBaseImpl.java
@@ -248,7 +248,7 @@ public abstract class UserGroupGroupRoleLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserGroupGroupRoleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserGroupGroupRole.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -263,7 +263,7 @@ public abstract class UserGroupGroupRoleLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserGroupGroupRoleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserGroupGroupRole.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserGroupLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserGroupLocalServiceBaseImpl.java
@@ -271,7 +271,7 @@ public abstract class UserGroupLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserGroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserGroup.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -283,7 +283,7 @@ public abstract class UserGroupLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserGroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserGroup.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserGroupRoleLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserGroupRoleLocalServiceBaseImpl.java
@@ -247,7 +247,7 @@ public abstract class UserGroupRoleLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserGroupRoleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserGroupRole.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -261,7 +261,7 @@ public abstract class UserGroupRoleLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserGroupRoleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserGroupRole.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserIdMapperLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserIdMapperLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class UserIdMapperLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserIdMapperLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserIdMapper.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class UserIdMapperLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserIdMapperLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserIdMapper.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserLocalServiceBaseImpl.java
@@ -300,7 +300,7 @@ public abstract class UserLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(User.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -312,7 +312,7 @@ public abstract class UserLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(User.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserNotificationDeliveryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserNotificationDeliveryLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class UserNotificationDeliveryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserNotificationDeliveryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserNotificationDelivery.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -259,7 +259,7 @@ public abstract class UserNotificationDeliveryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserNotificationDeliveryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserNotificationDelivery.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserNotificationEventLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserNotificationEventLocalServiceBaseImpl.java
@@ -257,7 +257,7 @@ public abstract class UserNotificationEventLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserNotificationEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserNotificationEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -270,7 +270,7 @@ public abstract class UserNotificationEventLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserNotificationEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserNotificationEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserTrackerLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserTrackerLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class UserTrackerLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserTrackerLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserTracker.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class UserTrackerLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserTrackerLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserTracker.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/UserTrackerPathLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/UserTrackerPathLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class UserTrackerPathLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserTrackerPathLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserTrackerPath.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class UserTrackerPathLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.UserTrackerPathLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(UserTrackerPath.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/VirtualHostLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/VirtualHostLocalServiceBaseImpl.java
@@ -241,7 +241,7 @@ public abstract class VirtualHostLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.VirtualHostLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(VirtualHost.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -253,7 +253,7 @@ public abstract class VirtualHostLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.VirtualHostLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(VirtualHost.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/WebDAVPropsLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/WebDAVPropsLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class WebDAVPropsLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WebDAVPropsLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WebDAVProps.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class WebDAVPropsLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WebDAVPropsLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WebDAVProps.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/WebsiteLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/WebsiteLocalServiceBaseImpl.java
@@ -259,7 +259,7 @@ public abstract class WebsiteLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WebsiteLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Website.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -271,7 +271,7 @@ public abstract class WebsiteLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WebsiteLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(Website.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/WorkflowDefinitionLinkLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/WorkflowDefinitionLinkLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class WorkflowDefinitionLinkLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WorkflowDefinitionLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WorkflowDefinitionLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -259,7 +259,7 @@ public abstract class WorkflowDefinitionLinkLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WorkflowDefinitionLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WorkflowDefinitionLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/service/base/WorkflowInstanceLinkLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/WorkflowInstanceLinkLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class WorkflowInstanceLinkLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WorkflowInstanceLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WorkflowInstanceLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -259,7 +259,7 @@ public abstract class WorkflowInstanceLinkLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portal.service.WorkflowInstanceLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WorkflowInstanceLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_base_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_base_impl.ftl
@@ -395,7 +395,7 @@ import ${packagePath}.service.${entity.name}${sessionTypeName}Service;
 			public ActionableDynamicQuery getActionableDynamicQuery() throws SystemException {
 				ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-				actionableDynamicQuery.setBaseLocalService(this);
+				actionableDynamicQuery.setBaseLocalService(${packagePath}.service.${entity.name}LocalServiceUtil.getService());
 				actionableDynamicQuery.setClass(${entity.name}.class);
 				actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -419,7 +419,7 @@ import ${packagePath}.service.${entity.name}${sessionTypeName}Service;
 			}
 
 			protected void initActionableDynamicQuery(ActionableDynamicQuery actionableDynamicQuery) throws SystemException {
-				actionableDynamicQuery.setBaseLocalService(this);
+				actionableDynamicQuery.setBaseLocalService(${packagePath}.service.${entity.name}LocalServiceUtil.getService());
 				actionableDynamicQuery.setClass(${entity.name}.class);
 				actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/announcements/service/base/AnnouncementsDeliveryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/base/AnnouncementsDeliveryLocalServiceBaseImpl.java
@@ -242,7 +242,7 @@ public abstract class AnnouncementsDeliveryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.announcements.service.AnnouncementsDeliveryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AnnouncementsDelivery.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -254,7 +254,7 @@ public abstract class AnnouncementsDeliveryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.announcements.service.AnnouncementsDeliveryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AnnouncementsDelivery.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/announcements/service/base/AnnouncementsEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/base/AnnouncementsEntryLocalServiceBaseImpl.java
@@ -279,7 +279,7 @@ public abstract class AnnouncementsEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.announcements.service.AnnouncementsEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AnnouncementsEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -291,7 +291,7 @@ public abstract class AnnouncementsEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.announcements.service.AnnouncementsEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AnnouncementsEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/announcements/service/base/AnnouncementsFlagLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/base/AnnouncementsFlagLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class AnnouncementsFlagLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.announcements.service.AnnouncementsFlagLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AnnouncementsFlag.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class AnnouncementsFlagLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.announcements.service.AnnouncementsFlagLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AnnouncementsFlag.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetCategoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetCategoryLocalServiceBaseImpl.java
@@ -287,7 +287,7 @@ public abstract class AssetCategoryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetCategoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetCategory.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -299,7 +299,7 @@ public abstract class AssetCategoryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetCategoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetCategory.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetCategoryPropertyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetCategoryPropertyLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class AssetCategoryPropertyLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetCategoryPropertyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetCategoryProperty.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class AssetCategoryPropertyLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetCategoryPropertyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetCategoryProperty.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetEntryLocalServiceBaseImpl.java
@@ -270,7 +270,7 @@ public abstract class AssetEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -282,7 +282,7 @@ public abstract class AssetEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetLinkLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetLinkLocalServiceBaseImpl.java
@@ -242,7 +242,7 @@ public abstract class AssetLinkLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -254,7 +254,7 @@ public abstract class AssetLinkLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class AssetTagLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetTagLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetTag.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class AssetTagLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetTagLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetTag.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagPropertyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagPropertyLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class AssetTagPropertyLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetTagPropertyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetTagProperty.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class AssetTagPropertyLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetTagPropertyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetTagProperty.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagStatsLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetTagStatsLocalServiceBaseImpl.java
@@ -242,7 +242,7 @@ public abstract class AssetTagStatsLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetTagStatsLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetTagStats.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -254,7 +254,7 @@ public abstract class AssetTagStatsLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetTagStatsLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetTagStats.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/base/AssetVocabularyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/base/AssetVocabularyLocalServiceBaseImpl.java
@@ -283,7 +283,7 @@ public abstract class AssetVocabularyLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetVocabularyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetVocabulary.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -295,7 +295,7 @@ public abstract class AssetVocabularyLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.asset.service.AssetVocabularyLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(AssetVocabulary.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/base/BlogsEntryLocalServiceBaseImpl.java
@@ -303,7 +303,7 @@ public abstract class BlogsEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.blogs.service.BlogsEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BlogsEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -315,7 +315,7 @@ public abstract class BlogsEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.blogs.service.BlogsEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BlogsEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/blogs/service/base/BlogsStatsUserLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/base/BlogsStatsUserLocalServiceBaseImpl.java
@@ -245,7 +245,7 @@ public abstract class BlogsStatsUserLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.blogs.service.BlogsStatsUserLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BlogsStatsUser.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class BlogsStatsUserLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.blogs.service.BlogsStatsUserLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BlogsStatsUser.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksEntryLocalServiceBaseImpl.java
@@ -300,7 +300,7 @@ public abstract class BookmarksEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.bookmarks.service.BookmarksEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BookmarksEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -312,7 +312,7 @@ public abstract class BookmarksEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.bookmarks.service.BookmarksEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BookmarksEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksFolderLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/service/base/BookmarksFolderLocalServiceBaseImpl.java
@@ -296,7 +296,7 @@ public abstract class BookmarksFolderLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.bookmarks.service.BookmarksFolderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BookmarksFolder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -308,7 +308,7 @@ public abstract class BookmarksFolderLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.bookmarks.service.BookmarksFolderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(BookmarksFolder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/calendar/service/base/CalEventLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/calendar/service/base/CalEventLocalServiceBaseImpl.java
@@ -289,7 +289,7 @@ public abstract class CalEventLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.calendar.service.CalEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(CalEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -301,7 +301,7 @@ public abstract class CalEventLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.calendar.service.CalEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(CalEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLContentLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLContentLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class DLContentLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLContentLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLContent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class DLContentLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLContentLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLContent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryLocalServiceBaseImpl.java
@@ -306,7 +306,7 @@ public abstract class DLFileEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -318,7 +318,7 @@ public abstract class DLFileEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryMetadataLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryMetadataLocalServiceBaseImpl.java
@@ -245,7 +245,7 @@ public abstract class DLFileEntryMetadataLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileEntryMetadataLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileEntryMetadata.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class DLFileEntryMetadataLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileEntryMetadataLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileEntryMetadata.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryTypeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileEntryTypeLocalServiceBaseImpl.java
@@ -288,7 +288,7 @@ public abstract class DLFileEntryTypeLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileEntryTypeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileEntryType.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -300,7 +300,7 @@ public abstract class DLFileEntryTypeLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileEntryTypeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileEntryType.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileRankLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileRankLocalServiceBaseImpl.java
@@ -245,7 +245,7 @@ public abstract class DLFileRankLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileRankLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileRank.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class DLFileRankLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileRankLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileRank.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileShortcutLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileShortcutLocalServiceBaseImpl.java
@@ -289,7 +289,7 @@ public abstract class DLFileShortcutLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileShortcutLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileShortcut.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -301,7 +301,7 @@ public abstract class DLFileShortcutLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileShortcutLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileShortcut.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileVersionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFileVersionLocalServiceBaseImpl.java
@@ -283,7 +283,7 @@ public abstract class DLFileVersionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -295,7 +295,7 @@ public abstract class DLFileVersionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFileVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFileVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFolderLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLFolderLocalServiceBaseImpl.java
@@ -292,7 +292,7 @@ public abstract class DLFolderLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFolder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -304,7 +304,7 @@ public abstract class DLFolderLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLFolderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLFolder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLSyncEventLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/base/DLSyncEventLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class DLSyncEventLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLSyncEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLSyncEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class DLSyncEventLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.documentlibrary.service.DLSyncEventLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DLSyncEvent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordLocalServiceBaseImpl.java
@@ -283,7 +283,7 @@ public abstract class DDLRecordLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatalists.service.DDLRecordLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDLRecord.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -295,7 +295,7 @@ public abstract class DDLRecordLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatalists.service.DDLRecordLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDLRecord.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordSetLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/base/DDLRecordSetLocalServiceBaseImpl.java
@@ -284,7 +284,7 @@ public abstract class DDLRecordSetLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatalists.service.DDLRecordSetLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDLRecordSet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -296,7 +296,7 @@ public abstract class DDLRecordSetLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatalists.service.DDLRecordSetLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDLRecordSet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMContentLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMContentLocalServiceBaseImpl.java
@@ -275,7 +275,7 @@ public abstract class DDMContentLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMContentLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMContent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -287,7 +287,7 @@ public abstract class DDMContentLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMContentLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMContent.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStorageLinkLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStorageLinkLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class DDMStorageLinkLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMStorageLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMStorageLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class DDMStorageLinkLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMStorageLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMStorageLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStructureLinkLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStructureLinkLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class DDMStructureLinkLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMStructureLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMStructureLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class DDMStructureLinkLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMStructureLinkLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMStructureLink.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStructureLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMStructureLocalServiceBaseImpl.java
@@ -290,7 +290,7 @@ public abstract class DDMStructureLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMStructure.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -302,7 +302,7 @@ public abstract class DDMStructureLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMStructure.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMTemplateLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/base/DDMTemplateLocalServiceBaseImpl.java
@@ -286,7 +286,7 @@ public abstract class DDMTemplateLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMTemplateLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMTemplate.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -298,7 +298,7 @@ public abstract class DDMTemplateLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.dynamicdatamapping.service.DDMTemplateLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(DDMTemplate.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoColumnLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoColumnLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class ExpandoColumnLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoColumnLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoColumn.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class ExpandoColumnLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoColumnLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoColumn.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoRowLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoRowLocalServiceBaseImpl.java
@@ -245,7 +245,7 @@ public abstract class ExpandoRowLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoRowLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoRow.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class ExpandoRowLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoRowLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoRow.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoTableLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoTableLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class ExpandoTableLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoTableLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoTable.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class ExpandoTableLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoTableLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoTable.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoValueLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoValueLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class ExpandoValueLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoValueLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoValue.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class ExpandoValueLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.expando.service.ExpandoValueLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ExpandoValue.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleImageLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleImageLocalServiceBaseImpl.java
@@ -241,7 +241,7 @@ public abstract class JournalArticleImageLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalArticleImageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalArticleImage.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -253,7 +253,7 @@ public abstract class JournalArticleImageLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalArticleImageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalArticleImage.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleLocalServiceBaseImpl.java
@@ -319,7 +319,7 @@ public abstract class JournalArticleLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalArticle.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -331,7 +331,7 @@ public abstract class JournalArticleLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalArticleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalArticle.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleResourceLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalArticleResourceLocalServiceBaseImpl.java
@@ -257,7 +257,7 @@ public abstract class JournalArticleResourceLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalArticleResourceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalArticleResource.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -269,7 +269,7 @@ public abstract class JournalArticleResourceLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalArticleResourceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalArticleResource.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalContentSearchLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalContentSearchLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class JournalContentSearchLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalContentSearchLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalContentSearch.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class JournalContentSearchLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalContentSearchLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalContentSearch.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFeedLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFeedLocalServiceBaseImpl.java
@@ -281,7 +281,7 @@ public abstract class JournalFeedLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalFeedLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalFeed.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -293,7 +293,7 @@ public abstract class JournalFeedLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalFeedLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalFeed.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFolderLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/base/JournalFolderLocalServiceBaseImpl.java
@@ -299,7 +299,7 @@ public abstract class JournalFolderLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalFolderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalFolder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -311,7 +311,7 @@ public abstract class JournalFolderLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.journal.service.JournalFolderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(JournalFolder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBBanLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBBanLocalServiceBaseImpl.java
@@ -270,7 +270,7 @@ public abstract class MBBanLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBBanLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBBan.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -282,7 +282,7 @@ public abstract class MBBanLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBBanLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBBan.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBCategoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBCategoryLocalServiceBaseImpl.java
@@ -297,7 +297,7 @@ public abstract class MBCategoryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBCategoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBCategory.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -309,7 +309,7 @@ public abstract class MBCategoryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBCategoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBCategory.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBDiscussionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBDiscussionLocalServiceBaseImpl.java
@@ -285,7 +285,7 @@ public abstract class MBDiscussionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBDiscussionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBDiscussion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -297,7 +297,7 @@ public abstract class MBDiscussionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBDiscussionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBDiscussion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMailingListLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMailingListLocalServiceBaseImpl.java
@@ -277,7 +277,7 @@ public abstract class MBMailingListLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBMailingListLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBMailingList.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -289,7 +289,7 @@ public abstract class MBMailingListLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBMailingListLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBMailingList.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMessageLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBMessageLocalServiceBaseImpl.java
@@ -309,7 +309,7 @@ public abstract class MBMessageLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBMessageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBMessage.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -321,7 +321,7 @@ public abstract class MBMessageLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBMessageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBMessage.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBStatsUserLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBStatsUserLocalServiceBaseImpl.java
@@ -248,7 +248,7 @@ public abstract class MBStatsUserLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBStatsUserLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBStatsUser.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -260,7 +260,7 @@ public abstract class MBStatsUserLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBStatsUserLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBStatsUser.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadFlagLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadFlagLocalServiceBaseImpl.java
@@ -276,7 +276,7 @@ public abstract class MBThreadFlagLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBThreadFlagLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBThreadFlag.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -288,7 +288,7 @@ public abstract class MBThreadFlagLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBThreadFlagLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBThreadFlag.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/base/MBThreadLocalServiceBaseImpl.java
@@ -296,7 +296,7 @@ public abstract class MBThreadLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBThreadLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBThread.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -308,7 +308,7 @@ public abstract class MBThreadLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.messageboards.service.MBThreadLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MBThread.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRActionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRActionLocalServiceBaseImpl.java
@@ -278,7 +278,7 @@ public abstract class MDRActionLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRActionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRAction.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -290,7 +290,7 @@ public abstract class MDRActionLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRActionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRAction.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupInstanceLocalServiceBaseImpl.java
@@ -288,7 +288,7 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRRuleGroupInstanceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRRuleGroupInstance.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -300,7 +300,7 @@ public abstract class MDRRuleGroupInstanceLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRRuleGroupInstanceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRRuleGroupInstance.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleGroupLocalServiceBaseImpl.java
@@ -282,7 +282,7 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRRuleGroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRRuleGroup.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -294,7 +294,7 @@ public abstract class MDRRuleGroupLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRRuleGroupLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRRuleGroup.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/mobiledevicerules/service/base/MDRRuleLocalServiceBaseImpl.java
@@ -273,7 +273,7 @@ public abstract class MDRRuleLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRRuleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRRule.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -285,7 +285,7 @@ public abstract class MDRRuleLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.mobiledevicerules.service.MDRRuleLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(MDRRule.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/polls/service/base/PollsChoiceLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/service/base/PollsChoiceLocalServiceBaseImpl.java
@@ -277,7 +277,7 @@ public abstract class PollsChoiceLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.polls.service.PollsChoiceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PollsChoice.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -289,7 +289,7 @@ public abstract class PollsChoiceLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.polls.service.PollsChoiceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PollsChoice.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/polls/service/base/PollsQuestionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/service/base/PollsQuestionLocalServiceBaseImpl.java
@@ -280,7 +280,7 @@ public abstract class PollsQuestionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.polls.service.PollsQuestionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PollsQuestion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -292,7 +292,7 @@ public abstract class PollsQuestionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.polls.service.PollsQuestionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PollsQuestion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/polls/service/base/PollsVoteLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/polls/service/base/PollsVoteLocalServiceBaseImpl.java
@@ -276,7 +276,7 @@ public abstract class PollsVoteLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.polls.service.PollsVoteLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PollsVote.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -288,7 +288,7 @@ public abstract class PollsVoteLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.polls.service.PollsVoteLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(PollsVote.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/ratings/service/base/RatingsEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/service/base/RatingsEntryLocalServiceBaseImpl.java
@@ -276,7 +276,7 @@ public abstract class RatingsEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.ratings.service.RatingsEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(RatingsEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -288,7 +288,7 @@ public abstract class RatingsEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.ratings.service.RatingsEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(RatingsEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/ratings/service/base/RatingsStatsLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ratings/service/base/RatingsStatsLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class RatingsStatsLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.ratings.service.RatingsStatsLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(RatingsStats.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class RatingsStatsLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.ratings.service.RatingsStatsLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(RatingsStats.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingCartLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingCartLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class ShoppingCartLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingCartLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingCart.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class ShoppingCartLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingCartLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingCart.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingCategoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingCategoryLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class ShoppingCategoryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingCategoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingCategory.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class ShoppingCategoryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingCategoryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingCategory.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingCouponLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingCouponLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class ShoppingCouponLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingCouponLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingCoupon.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class ShoppingCouponLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingCouponLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingCoupon.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingItemFieldLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingItemFieldLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class ShoppingItemFieldLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingItemFieldLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingItemField.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class ShoppingItemFieldLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingItemFieldLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingItemField.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingItemLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingItemLocalServiceBaseImpl.java
@@ -247,7 +247,7 @@ public abstract class ShoppingItemLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingItemLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingItem.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -259,7 +259,7 @@ public abstract class ShoppingItemLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingItemLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingItem.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingItemPriceLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingItemPriceLocalServiceBaseImpl.java
@@ -242,7 +242,7 @@ public abstract class ShoppingItemPriceLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingItemPriceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingItemPrice.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -254,7 +254,7 @@ public abstract class ShoppingItemPriceLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingItemPriceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingItemPrice.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingOrderItemLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingOrderItemLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class ShoppingOrderItemLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingOrderItemLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingOrderItem.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class ShoppingOrderItemLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingOrderItemLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingOrderItem.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingOrderLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/shopping/service/base/ShoppingOrderLocalServiceBaseImpl.java
@@ -251,7 +251,7 @@ public abstract class ShoppingOrderLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingOrderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingOrder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -263,7 +263,7 @@ public abstract class ShoppingOrderLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.shopping.service.ShoppingOrderLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(ShoppingOrder.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityAchievementLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityAchievementLocalServiceBaseImpl.java
@@ -249,7 +249,7 @@ public abstract class SocialActivityAchievementLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityAchievementLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivityAchievement.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -262,7 +262,7 @@ public abstract class SocialActivityAchievementLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityAchievementLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivityAchievement.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityCounterLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityCounterLocalServiceBaseImpl.java
@@ -253,7 +253,7 @@ public abstract class SocialActivityCounterLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityCounterLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivityCounter.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -265,7 +265,7 @@ public abstract class SocialActivityCounterLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityCounterLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivityCounter.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityLimitLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityLimitLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class SocialActivityLimitLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityLimitLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivityLimit.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class SocialActivityLimitLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityLimitLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivityLimit.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivityLocalServiceBaseImpl.java
@@ -256,7 +256,7 @@ public abstract class SocialActivityLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivity.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -268,7 +268,7 @@ public abstract class SocialActivityLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivityLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivity.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivitySetLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivitySetLocalServiceBaseImpl.java
@@ -243,7 +243,7 @@ public abstract class SocialActivitySetLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivitySetLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivitySet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -255,7 +255,7 @@ public abstract class SocialActivitySetLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivitySetLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivitySet.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivitySettingLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialActivitySettingLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class SocialActivitySettingLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivitySettingLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivitySetting.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class SocialActivitySettingLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialActivitySettingLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialActivitySetting.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialRelationLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialRelationLocalServiceBaseImpl.java
@@ -258,7 +258,7 @@ public abstract class SocialRelationLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialRelationLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialRelation.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -270,7 +270,7 @@ public abstract class SocialRelationLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialRelationLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialRelation.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/social/service/base/SocialRequestLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/base/SocialRequestLocalServiceBaseImpl.java
@@ -272,7 +272,7 @@ public abstract class SocialRequestLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialRequestLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialRequest.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -284,7 +284,7 @@ public abstract class SocialRequestLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.social.service.SocialRequestLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SocialRequest.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCFrameworkVersionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCFrameworkVersionLocalServiceBaseImpl.java
@@ -245,7 +245,7 @@ public abstract class SCFrameworkVersionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCFrameworkVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCFrameworkVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -257,7 +257,7 @@ public abstract class SCFrameworkVersionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCFrameworkVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCFrameworkVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCLicenseLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCLicenseLocalServiceBaseImpl.java
@@ -239,7 +239,7 @@ public abstract class SCLicenseLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCLicenseLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCLicense.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -251,7 +251,7 @@ public abstract class SCLicenseLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCLicenseLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCLicense.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCProductEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCProductEntryLocalServiceBaseImpl.java
@@ -253,7 +253,7 @@ public abstract class SCProductEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCProductEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCProductEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -265,7 +265,7 @@ public abstract class SCProductEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCProductEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCProductEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCProductScreenshotLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCProductScreenshotLocalServiceBaseImpl.java
@@ -242,7 +242,7 @@ public abstract class SCProductScreenshotLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCProductScreenshotLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCProductScreenshot.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -254,7 +254,7 @@ public abstract class SCProductScreenshotLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCProductScreenshotLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCProductScreenshot.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCProductVersionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/softwarecatalog/service/base/SCProductVersionLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class SCProductVersionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCProductVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCProductVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class SCProductVersionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.softwarecatalog.service.SCProductVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(SCProductVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/trash/service/base/TrashEntryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/base/TrashEntryLocalServiceBaseImpl.java
@@ -246,7 +246,7 @@ public abstract class TrashEntryLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(TrashEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -258,7 +258,7 @@ public abstract class TrashEntryLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.trash.service.TrashEntryLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(TrashEntry.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/trash/service/base/TrashVersionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/base/TrashVersionLocalServiceBaseImpl.java
@@ -244,7 +244,7 @@ public abstract class TrashVersionLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.trash.service.TrashVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(TrashVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -256,7 +256,7 @@ public abstract class TrashVersionLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.trash.service.TrashVersionLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(TrashVersion.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiNodeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiNodeLocalServiceBaseImpl.java
@@ -286,7 +286,7 @@ public abstract class WikiNodeLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.wiki.service.WikiNodeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WikiNode.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -298,7 +298,7 @@ public abstract class WikiNodeLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.wiki.service.WikiNodeLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WikiNode.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiPageLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiPageLocalServiceBaseImpl.java
@@ -303,7 +303,7 @@ public abstract class WikiPageLocalServiceBaseImpl extends BaseLocalServiceImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.wiki.service.WikiPageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WikiPage.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -315,7 +315,7 @@ public abstract class WikiPageLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.wiki.service.WikiPageLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WikiPage.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 

--- a/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiPageResourceLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/base/WikiPageResourceLocalServiceBaseImpl.java
@@ -240,7 +240,7 @@ public abstract class WikiPageResourceLocalServiceBaseImpl
 		throws SystemException {
 		ActionableDynamicQuery actionableDynamicQuery = new DefaultActionableDynamicQuery();
 
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.wiki.service.WikiPageResourceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WikiPageResource.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 
@@ -252,7 +252,7 @@ public abstract class WikiPageResourceLocalServiceBaseImpl
 	protected void initActionableDynamicQuery(
 		ActionableDynamicQuery actionableDynamicQuery)
 		throws SystemException {
-		actionableDynamicQuery.setBaseLocalService(this);
+		actionableDynamicQuery.setBaseLocalService(com.liferay.portlet.wiki.service.WikiPageResourceLocalServiceUtil.getService());
 		actionableDynamicQuery.setClass(WikiPageResource.class);
 		actionableDynamicQuery.setClassLoader(getClassLoader());
 


### PR DESCRIPTION
Hey Brian,

as @matethurzo said in his email we found an issue occures when we use ActionableDynamicQueries in staging and there is no session bound to the given thread (from *DataHandler's when preparing the manifest summary for example). It seems if we roll-back the changes regarding what we set as the base local service all our issues get fixed.

I also checked the plugin repository but it seems LPS-46123 hasn't been committed there so no changes required.

thanks,
Daniel
