### PR TITLE
[TECHNICAL-SUPPORT | May 6]  LPS-46083 Quotation marks in web contents replaced in a lossy way

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -785,7 +785,9 @@ public class HtmlImpl implements Html {
 	}
 
 	private static final String[] _MS_WORD_HTML = new String[] {
-		"&reg;", StringPool.APOSTROPHE, StringPool.QUOTE, StringPool.QUOTE
+		"&reg;", StringPool.RIGHT_SINGLE_QUOTE_ENCODED,
+		StringPool.LEFT_DOUBLE_QUOTE_ENCODED,
+		StringPool.RIGHT_DOUBLE_QUOTE_ENCODED
 	};
 
 	private static final String[] _MS_WORD_UNICODE = new String[] {

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -785,9 +785,7 @@ public class HtmlImpl implements Html {
 	}
 
 	private static final String[] _MS_WORD_HTML = new String[] {
-		"&reg;", StringPool.RIGHT_SINGLE_QUOTE_ENCODED,
-		StringPool.LEFT_DOUBLE_QUOTE_ENCODED,
-		StringPool.RIGHT_DOUBLE_QUOTE_ENCODED
+		"&reg;", StringPool.APOSTROPHE, StringPool.QUOTE, StringPool.QUOTE
 	};
 
 	private static final String[] _MS_WORD_UNICODE = new String[] {

--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -482,7 +482,9 @@ public class HtmlImpl implements Html {
 	 * @param  text the text
 	 * @return the converted text, or <code>null</code> if the text is
 	 *         <code>null</code>
+	 * @deprecated As of 7.0.0, with no direct replacement
 	 */
+	@Deprecated
 	@Override
 	public String replaceMsWordCharacters(String text) {
 		return StringUtil.replace(text, _MS_WORD_UNICODE, _MS_WORD_HTML);

--- a/portal-impl/src/com/liferay/portal/verify/VerifyJournal.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyJournal.java
@@ -23,8 +23,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.service.ResourceLocalServiceUtil;
@@ -305,15 +303,6 @@ public class VerifyJournal extends VerifyProcess {
 			AssetEntryLocalServiceUtil.updateEntry(
 				assetEntry.getClassName(), assetEntry.getClassPK(), null,
 				assetEntry.isVisible());
-		}
-
-		String content = GetterUtil.getString(article.getContent());
-
-		String newContent = HtmlUtil.replaceMsWordCharacters(content);
-
-		if (!content.equals(newContent)) {
-			JournalArticleLocalServiceUtil.updateContent(
-				groupId, articleId, version, newContent);
 		}
 
 		try {

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6012,8 +6012,6 @@ public class JournalArticleLocalServiceImpl
 			_log.error(de, de);
 		}
 
-		content = HtmlUtil.replaceMsWordCharacters(content);
-
 		return content;
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/util/Html.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/Html.java
@@ -48,6 +48,10 @@ public interface Html {
 
 	public String render(String html);
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public String replaceMsWordCharacters(String text);
 
 	public String replaceNewLine(String html);

--- a/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
@@ -177,7 +177,9 @@ public class HtmlUtil {
 	 * @param  text the text
 	 * @return the converted text, or <code>null</code> if the text is
 	 *         <code>null</code>
+	 * @deprecated As of 7.0.0, with no direct replacement
 	 */
+	@Deprecated
 	public static String replaceMsWordCharacters(String text) {
 		return getHtml().replaceMsWordCharacters(text);
 	}

--- a/portal-service/src/com/liferay/portal/kernel/util/StringPool.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringPool.java
@@ -122,6 +122,8 @@ public class StringPool {
 
 	public static final String LAQUO_CHAR = "\u00AB";
 
+	public static final String LEFT_DOUBLE_QUOTE_ENCODED = "&ldquo;";
+
 	public static final String LESS_THAN = "<";
 
 	public static final String LESS_THAN_OR_EQUAL = "<=";
@@ -173,6 +175,10 @@ public class StringPool {
 	public static final String RETURN = "\r";
 
 	public static final String RETURN_NEW_LINE = "\r\n";
+
+	public static final String RIGHT_DOUBLE_QUOTE_ENCODED = "&rdquo;";
+
+	public static final String RIGHT_SINGLE_QUOTE_ENCODED = "&rsquo;";
 
 	public static final String SEMICOLON = ";";
 

--- a/portal-service/src/com/liferay/portal/kernel/util/StringPool.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/StringPool.java
@@ -122,8 +122,6 @@ public class StringPool {
 
 	public static final String LAQUO_CHAR = "\u00AB";
 
-	public static final String LEFT_DOUBLE_QUOTE_ENCODED = "&ldquo;";
-
 	public static final String LESS_THAN = "<";
 
 	public static final String LESS_THAN_OR_EQUAL = "<=";
@@ -175,10 +173,6 @@ public class StringPool {
 	public static final String RETURN = "\r";
 
 	public static final String RETURN_NEW_LINE = "\r\n";
-
-	public static final String RIGHT_DOUBLE_QUOTE_ENCODED = "&rdquo;";
-
-	public static final String RIGHT_SINGLE_QUOTE_ENCODED = "&rsquo;";
 
 	public static final String SEMICOLON = ";";
 


### PR DESCRIPTION
Hey Brian,

https://issues.liferay.com/browse/LPS-46083

@juliocamarero encouraged us (@jozsefilles) to forward this pull directly to you, as you were the author of https://issues.liferay.com/browse/LEP-4868 6 years ago :-), that caused the current issue, and none of us in the team knows about it.

Please, read my commit message: lipusz@4e44b3f

BTW, we don't replace "title" & "description" (the "content" only), DBs unicode incompatibility should not be a problem?, and we couldn't figure out what you meant "...smart Microsoft characters that end up breaking things".

Let us know if you have any concerns.

Regards,
Tibor
