### PR TITLE
LPS-46227 Refactoring SystemEvents a bit

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -609,17 +609,8 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		// Asset
 
-		SystemEventHierarchyEntryThreadLocal.pop(
-			Layout.class, layout.getPlid());
-
-		try {
-			assetEntryLocalService.deleteEntry(
-				Layout.class.getName(), layout.getPlid());
-		}
-		finally {
-			SystemEventHierarchyEntryThreadLocal.push(
-				Layout.class, layout.getPlid());
-		}
+		assetEntryLocalService.deleteEntry(
+			Layout.class.getName(), layout.getPlid());
 
 		// Ratings
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
@@ -191,7 +191,8 @@ public class LayoutPrototypeLocalServiceImpl
 		LayoutPrototype layoutPrototype =
 			layoutPrototypePersistence.findByPrimaryKey(layoutPrototypeId);
 
-		return deleteLayoutPrototype(layoutPrototype);
+		return layoutPrototypeLocalService.deleteLayoutPrototype(
+			layoutPrototype);
 	}
 
 	@Override
@@ -205,7 +206,8 @@ public class LayoutPrototypeLocalServiceImpl
 
 		for (LayoutPrototype layoutPrototype : layoutPrototypes) {
 			if (layoutPrototype.getUserId() != defaultUserId) {
-				deleteLayoutPrototype(layoutPrototype);
+				layoutPrototypeLocalService.deleteLayoutPrototype(
+					layoutPrototype);
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -53,6 +54,7 @@ import com.liferay.portal.model.Region;
 import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.Role;
 import com.liferay.portal.model.RoleConstants;
+import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.model.UserGroupRole;
 import com.liferay.portal.model.impl.OrganizationImpl;
@@ -409,7 +411,7 @@ public class OrganizationLocalServiceImpl
 		Organization organization = organizationPersistence.findByPrimaryKey(
 			organizationId);
 
-		return deleteOrganization(organization);
+		return organizationLocalService.deleteOrganization(organization);
 	}
 
 	/**
@@ -423,6 +425,7 @@ public class OrganizationLocalServiceImpl
 	 * @throws SystemException if a system exception occurred
 	 */
 	@Override
+	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public Organization deleteOrganization(Organization organization)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackRegistryUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -40,6 +41,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.ModelHintsUtil;
 import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.asset.AssetCategoryNameException;
@@ -218,6 +220,7 @@ public class AssetCategoryLocalServiceImpl
 
 	@Indexable(type = IndexableType.DELETE)
 	@Override
+	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public AssetCategory deleteCategory(AssetCategory category)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Group;
-import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
@@ -84,12 +83,6 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 			entry.getEntryId());
 
 		assetEntryPersistence.remove(entry);
-
-		// System event
-
-		systemEventLocalService.addSystemEvent(
-			0, entry.getGroupId(), entry.getClassName(), entry.getClassPK(),
-			entry.getClassUuid(), null, SystemEventConstants.TYPE_DELETE, null);
 
 		// Links
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -26,12 +26,14 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.util.PropsValues;
@@ -220,6 +222,9 @@ public class AssetVocabularyLocalServiceImpl
 
 	@Indexable(type = IndexableType.DELETE)
 	@Override
+	@SystemEvent(
+		action = SystemEventConstants.ACTION_SKIP,
+		type = SystemEventConstants.TYPE_DELETE)
 	public void deleteVocabulary(AssetVocabulary vocabulary)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -45,6 +46,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.settings.LocalizedValuesMap;
@@ -313,6 +315,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 	@Indexable(type = IndexableType.DELETE)
 	@Override
+	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public BlogsEntry deleteEntry(BlogsEntry entry)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/bookmarks/service/impl/BookmarksEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/service/impl/BookmarksEntryLocalServiceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -40,6 +41,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.settings.LocalizedValuesMap;
@@ -165,6 +167,7 @@ public class BookmarksEntryLocalServiceImpl
 
 	@Indexable(type = IndexableType.DELETE)
 	@Override
+	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public BookmarksEntry deleteEntry(BookmarksEntry entry)
 		throws PortalException, SystemException {
 
@@ -214,7 +217,7 @@ public class BookmarksEntryLocalServiceImpl
 		BookmarksEntry entry = bookmarksEntryPersistence.findByPrimaryKey(
 			entryId);
 
-		return deleteEntry(entry);
+		return bookmarksEntryLocalService.deleteEntry(entry);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/bookmarks/service/impl/BookmarksFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/service/impl/BookmarksFolderLocalServiceImpl.java
@@ -108,18 +108,18 @@ public class BookmarksFolderLocalServiceImpl
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
+		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE)
 	public BookmarksFolder deleteFolder(BookmarksFolder folder)
 		throws PortalException, SystemException {
 
-		return deleteFolder(folder, true);
+		return bookmarksFolderLocalService.deleteFolder(folder, true);
 	}
 
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
+		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE)
 	public BookmarksFolder deleteFolder(
 			BookmarksFolder folder, boolean includeTrashedEntries)
@@ -130,7 +130,7 @@ public class BookmarksFolderLocalServiceImpl
 
 		for (BookmarksFolder curFolder : folders) {
 			if (includeTrashedEntries || !curFolder.isInTrashExplicitly()) {
-				deleteFolder(curFolder);
+				bookmarksFolderLocalService.deleteFolder(curFolder);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
-import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackRegistryUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
@@ -1484,16 +1483,7 @@ public class DLAppHelperLocalServiceImpl
 							userId, assetEntry.getEntryId(), assetLinkEntryIds,
 							AssetLinkConstants.TYPE_RELATED);
 
-						SystemEventHierarchyEntryThreadLocal.push(
-							DLFileEntryConstants.getClassName());
-
-						try {
-							assetEntryLocalService.deleteEntry(draftAssetEntry);
-						}
-						finally {
-							SystemEventHierarchyEntryThreadLocal.pop(
-								DLFileEntryConstants.getClassName());
-						}
+						assetEntryLocalService.deleteEntry(draftAssetEntry);
 					}
 				}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -407,14 +407,7 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 
 		dlAppHelperLocalService.deleteFileEntry(fileEntry);
 
-		SystemEventHierarchyEntryThreadLocal.push(FileEntry.class);
-
-		try {
-			localRepository.deleteFileEntry(fileEntryId);
-		}
-		finally {
-			SystemEventHierarchyEntryThreadLocal.pop(FileEntry.class);
-		}
+		localRepository.deleteFileEntry(fileEntryId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryTypeLocalServiceImpl.java
@@ -220,7 +220,7 @@ public class DLFileEntryTypeLocalServiceImpl
 		DLFileEntryType dlFileEntryType =
 			dlFileEntryTypePersistence.findByPrimaryKey(fileEntryTypeId);
 
-		deleteFileEntryType(dlFileEntryType);
+		dlFileEntryTypeLocalService.deleteFileEntryType(dlFileEntryType);
 	}
 
 	@Override
@@ -231,7 +231,7 @@ public class DLFileEntryTypeLocalServiceImpl
 			dlFileEntryTypePersistence.findByGroupId(groupId);
 
 		for (DLFileEntryType dlFileEntryType : dlFileEntryTypes) {
-			deleteFileEntryType(dlFileEntryType);
+			dlFileEntryTypeLocalService.deleteFileEntryType(dlFileEntryType);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileRankLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileRankLocalServiceImpl.java
@@ -102,9 +102,7 @@ public class DLFileRankLocalServiceImpl extends DLFileRankLocalServiceBaseImpl {
 	}
 
 	@Override
-	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
-		type = SystemEventConstants.TYPE_DELETE)
+	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public void deleteFileRank(DLFileRank dlFileRank) throws SystemException {
 		dlFileRankPersistence.remove(dlFileRank);
 	}
@@ -116,7 +114,7 @@ public class DLFileRankLocalServiceImpl extends DLFileRankLocalServiceBaseImpl {
 		DLFileRank dlFileRank = dlFileRankPersistence.findByPrimaryKey(
 			fileRankId);
 
-		deleteFileRank(dlFileRank);
+		dlFileRankLocalService.deleteFileRank(dlFileRank);
 	}
 
 	@Override
@@ -127,7 +125,7 @@ public class DLFileRankLocalServiceImpl extends DLFileRankLocalServiceBaseImpl {
 			fileEntryId);
 
 		for (DLFileRank dlFileRank : dlFileRanks) {
-			deleteFileRank(dlFileRank);
+			dlFileRankLocalService.deleteFileRank(dlFileRank);
 		}
 	}
 
@@ -137,7 +135,7 @@ public class DLFileRankLocalServiceImpl extends DLFileRankLocalServiceBaseImpl {
 			userId);
 
 		for (DLFileRank dlFileRank : dlFileRanks) {
-			deleteFileRank(dlFileRank);
+			dlFileRankLocalService.deleteFileRank(dlFileRank);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -18,9 +18,11 @@ import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.TreePathUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
@@ -165,6 +167,7 @@ public class DLFileShortcutLocalServiceImpl
 	}
 
 	@Override
+	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public void deleteFileShortcut(DLFileShortcut fileShortcut)
 		throws PortalException, SystemException {
 
@@ -205,7 +208,7 @@ public class DLFileShortcutLocalServiceImpl
 		DLFileShortcut fileShortcut =
 			dlFileShortcutLocalService.getDLFileShortcut(fileShortcutId);
 
-		deleteFileShortcut(fileShortcut);
+		dlFileShortcutLocalService.deleteFileShortcut(fileShortcut);
 	}
 
 	@Override
@@ -216,7 +219,7 @@ public class DLFileShortcutLocalServiceImpl
 			dlFileShortcutPersistence.findByToFileEntryId(toFileEntryId);
 
 		for (DLFileShortcut fileShortcut : fileShortcuts) {
-			deleteFileShortcut(fileShortcut);
+			dlFileShortcutLocalService.deleteFileShortcut(fileShortcut);
 		}
 	}
 
@@ -237,7 +240,7 @@ public class DLFileShortcutLocalServiceImpl
 
 		for (DLFileShortcut fileShortcut : fileShortcuts) {
 			if (includeTrashedEntries || !fileShortcut.isInTrashExplicitly()) {
-				deleteFileShortcut(fileShortcut);
+				dlFileShortcutLocalService.deleteFileShortcut(fileShortcut);
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -202,7 +202,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
+		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE)
 	public DLFolder deleteFolder(DLFolder dlFolder)
 		throws PortalException, SystemException {
@@ -213,7 +213,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
+		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE)
 	public DLFolder deleteFolder(
 			DLFolder dlFolder, boolean includeTrashedEntries)

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -896,7 +896,8 @@ public class JournalArticleLocalServiceImpl
 	 */
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false)
+		action = SystemEventConstants.ACTION_SKIP,
+		type = SystemEventConstants.TYPE_DELETE)
 	public JournalArticle deleteArticle(JournalArticle article)
 		throws PortalException, SystemException {
 
@@ -921,7 +922,9 @@ public class JournalArticleLocalServiceImpl
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	@SystemEvent(action = SystemEventConstants.ACTION_SKIP, send = false)
+	@SystemEvent(
+		action = SystemEventConstants.ACTION_SKIP,
+		type = SystemEventConstants.TYPE_DELETE)
 	public JournalArticle deleteArticle(
 			JournalArticle article, String articleURL,
 			ServiceContext serviceContext)
@@ -5316,18 +5319,9 @@ public class JournalArticleLocalServiceImpl
 							userId, assetEntry.getEntryId(), assetLinkEntryIds,
 							AssetLinkConstants.TYPE_RELATED);
 
-						SystemEventHierarchyEntryThreadLocal.push(
-							JournalArticle.class);
-
-						try {
-							assetEntryLocalService.deleteEntry(
-								JournalArticle.class.getName(),
-								article.getPrimaryKey());
-						}
-						finally {
-							SystemEventHierarchyEntryThreadLocal.pop(
-								JournalArticle.class);
-						}
+						assetEntryLocalService.deleteEntry(
+							JournalArticle.class.getName(),
+							article.getPrimaryKey());
 					}
 				}
 

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -119,7 +119,7 @@ public class JournalFolderLocalServiceImpl
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
+		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE)
 	public JournalFolder deleteFolder(JournalFolder folder)
 		throws PortalException, SystemException {
@@ -130,7 +130,7 @@ public class JournalFolderLocalServiceImpl
 	@Indexable(type = IndexableType.DELETE)
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
+		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE)
 	public JournalFolder deleteFolder(
 			JournalFolder folder, boolean includeTrashedEntries)
@@ -143,7 +143,8 @@ public class JournalFolderLocalServiceImpl
 
 		for (JournalFolder curFolder : folders) {
 			if (includeTrashedEntries || !curFolder.isInTrashExplicitly()) {
-				deleteFolder(curFolder, includeTrashedEntries);
+				journalFolderLocalService.deleteFolder(
+					curFolder, includeTrashedEntries);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBBanLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBBanLocalServiceImpl.java
@@ -111,7 +111,7 @@ public class MBBanLocalServiceImpl extends MBBanLocalServiceBaseImpl {
 		List<MBBan> bans = mbBanPersistence.findByBanUserId(banUserId);
 
 		for (MBBan ban : bans) {
-			deleteBan(ban);
+			mbBanLocalService.deleteBan(ban);
 		}
 	}
 
@@ -120,7 +120,7 @@ public class MBBanLocalServiceImpl extends MBBanLocalServiceBaseImpl {
 		List<MBBan> bans = mbBanPersistence.findByGroupId(groupId);
 
 		for (MBBan ban : bans) {
-			deleteBan(ban);
+			mbBanLocalService.deleteBan(ban);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBCategoryLocalServiceImpl.java
@@ -951,7 +951,7 @@ public class MBCategoryLocalServiceImpl extends MBCategoryLocalServiceBaseImpl {
 
 		mbCategoryPersistence.update(toCategory);
 
-		deleteCategory(fromCategory);
+		mbCategoryLocalService.deleteCategory(fromCategory);
 	}
 
 	protected void moveDependentsToTrash(

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -49,6 +50,7 @@ import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.ModelHintsUtil;
 import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.security.auth.PrincipalException;
@@ -486,7 +488,7 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		deleteDiscussionSocialActivities(BlogsEntry.class.getName(), message);
 
-		return deleteMessage(message);
+		return mbMessageLocalService.deleteMessage(message);
 	}
 
 	@Override
@@ -528,11 +530,12 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		MBMessage message = mbMessagePersistence.findByPrimaryKey(messageId);
 
-		return deleteMessage(message);
+		return mbMessageLocalService.deleteMessage(message);
 	}
 
 	@Indexable(type = IndexableType.DELETE)
 	@Override
+	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public MBMessage deleteMessage(MBMessage message)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadFlagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadFlagLocalServiceImpl.java
@@ -102,7 +102,7 @@ public class MBThreadFlagLocalServiceImpl
 		MBThreadFlag threadFlag = mbThreadFlagPersistence.findByPrimaryKey(
 			threadFlagId);
 
-		deleteThreadFlag(threadFlag);
+		mbThreadFlagLocalService.deleteThreadFlag(threadFlag);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -488,7 +488,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	@Override
 	@SystemEvent(
-		action = SystemEventConstants.ACTION_SKIP, send = false,
+		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE)
 	public void deletePage(WikiPage page)
 		throws PortalException, SystemException {


### PR DESCRIPTION
Hey Brian,

We have come across some problems with the system events and I've been performing some changes regarding it.

The primary concern is that the API is not straightforward for a developer, for example the send attribute in the annotation does not mean it's won't send an event because if it has an associated asset entry it will send anyway.

Also due to this asset entry side effect we had to hack with the SystemEventHierarcheEntryThreadLocal in several cases. Now in this pull I've removed these hacks where I could (in some cases we still need these in weird situations)

The third concern is that the SystemEvent annotation is providing a clear, declarative approach to this programming problem, but these hackings and the asset entry side effect is mixing the picture. In some cases we did not have the declaration on a service that is should throw events but it did due to the side effect.

The changes in the pull making the code a bit easier to understand, and maintain.

Thanks,

Máté

reviewed by @danielkocsis
