### PR TITLE
LPS-46445 ServiceBuilder is modifying unmodifiable List

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1963,8 +1963,8 @@ public class ServiceBuilder {
 		JavaClass modelImplJavaClass = _getJavaClass(
 			_outputPath + "/model/impl/" + entity.getName() + "Impl.java");
 
-		List<JavaMethod> methods = Arrays.asList(
-			_getMethods(modelImplJavaClass));
+		List<JavaMethod> methods = new ArrayList<JavaMethod>(
+			Arrays.asList(_getMethods(modelImplJavaClass)));
 
 		Iterator<JavaMethod> itr = methods.iterator();
 


### PR DESCRIPTION
CC @hhuijser

Guys, ServiceBuilder is failing with:
     [echo] java.lang.UnsupportedOperationException
     [echo]     at java.util.AbstractList.remove(AbstractList.java:161)
     [echo]     at java.util.AbstractList$Itr.remove(AbstractList.java:374)
     [echo]     at java.util.AbstractCollection.remove(AbstractCollection.java:293)
     [echo]     at com.liferay.portal.tools.servicebuilder.ServiceBuilder._createExtendedModel(ServiceBuilder.java:1985)
     [echo]     at com.liferay.portal.tools.servicebuilder.ServiceBuilder.<init>(ServiceBuilder.java:758)
     [echo]     at com.liferay.portal.tools.servicebuilder.ServiceBuilder.main(ServiceBuilder.java:251)

I am merely fixing it in order to continue my other works.

We should reconsider this ListUtil.fromArray() -> Arrays.asList(), they are not logically the same(Arrays.asList() creates an unmodifiable List), this replacement may also break in other places, please recheck with them. 
