### PR TITLE
LPS-46486 Query reference elements with the proper class

### DIFF
--- a/portal-impl/src/com/liferay/portlet/wiki/lar/WikiPageStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/wiki/lar/WikiPageStagedModelDataHandler.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portlet.documentlibrary.NoSuchFileException;
 import com.liferay.portlet.documentlibrary.lar.FileEntryUtil;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.wiki.model.WikiNode;
 import com.liferay.portlet.wiki.model.WikiPage;
 import com.liferay.portlet.wiki.service.WikiPageLocalServiceUtil;
@@ -185,7 +186,7 @@ public class WikiPageStagedModelDataHandler
 		if (page.isHead()) {
 			List<Element> attachmentElements =
 				portletDataContext.getReferenceDataElements(
-					pageElement, FileEntry.class,
+					pageElement, DLFileEntry.class,
 					PortletDataContext.REFERENCE_TYPE_WEAK);
 
 			for (Element attachmentElement : attachmentElements) {


### PR DESCRIPTION
Hey Brian,

This is very simple change, we have to query the reference elements with the DLFileEntry.class. We have to do this everywhere in staging, so I'm going to scan everything now to check for this, but I'll open up different tickets for the backport team to make their life easier.

Thanks,

Máté

cc: @sergiogonzalez
