### PR TITLE
master-bc-46537

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -85,13 +85,56 @@
 			</unzip>
 
 			<if>
-				<available file="app.server.${user.name}.properties" />
+				<or>
+					<available file="app.server.${user.name}.properties" />
+					<available file="app.server.${env.COMPUTERNAME}.properties" />
+					<available file="app.server.${env.HOST}.properties" />
+					<available file="app.server.${env.HOSTNAME}.properties" />
+				</or>
 				<then>
-					<copy
-						file="app.server.${user.name}.properties"
-						overwrite="true"
-						tofile="${project.dir}/tools/sdk/build.${user.name}.properties"
-					/>
+					<if>
+						<available file="app.server.${user.name}.properties" />
+						<then>
+							<copy
+								file="app.server.${user.name}.properties"
+								overwrite="true"
+								tofile="${project.dir}/tools/sdk/build.${user.name}.properties"
+							/>
+						</then>
+					</if>
+
+					<if>
+						<available file="app.server.${env.COMPUTERNAME}.properties" />
+						<then>
+							<copy
+								file="app.server.${env.COMPUTERNAME}.properties"
+								overwrite="true"
+								tofile="${project.dir}/tools/sdk/build.${env.COMPUTERNAME}.properties"
+							/>
+						</then>
+					</if>
+
+					<if>
+						<available file="app.server.${env.HOST}.properties" />
+						<then>
+							<copy
+								file="app.server.${env.HOST}.properties"
+								overwrite="true"
+								tofile="${project.dir}/tools/sdk/build.${env.HOST}.properties"
+							/>
+						</then>
+					</if>
+
+					<if>
+						<available file="app.server.${env.HOSTNAME}.properties" />
+						<then>
+							<copy
+								file="app.server.${env.HOSTNAME}.properties"
+								overwrite="true"
+								tofile="${project.dir}/tools/sdk/build.${env.HOSTNAME}.properties"
+							/>
+						</then>
+					</if>
 				</then>
 				<else>
 					<echo file="${project.dir}/tools/sdk/build.${user.name}.properties">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-46537

I talked with Shuyang about this one because it caused build failures for some of us that had both a COMPUTERNAME.properties file and USERNAME.properties file but had our app server parent set in the COMPUTERNAME.properties file.

Shuyang said we should also account for the other types of custom properties files, so we should copy those in as well. This is the solution that Hashi and I worked out - if any of the custom properties files are available, they'll get copied in. Otherwise, it will echo a default one.

Let me know if this isn't the right way or anything.
