### PR TITLE
LPS-45733 Improper PortletDataContext state bug fix

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -1690,21 +1690,10 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 
 	@Override
 	public MissingReferences validateMissingReferences(
-			long userId, long groupId, Map<String, String[]> parameterMap,
-			File file)
+			final PortletDataContext portletDataContext)
 		throws Exception {
 
 		final MissingReferences missingReferences = new MissingReferences();
-
-		Group group = GroupLocalServiceUtil.getGroup(groupId);
-		String userIdStrategy = MapUtil.getString(
-			parameterMap, PortletDataHandlerKeys.USER_ID_STRATEGY);
-		ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
-
-		final PortletDataContext portletDataContext =
-			PortletDataContextFactoryUtil.createImportPortletDataContext(
-				group.getCompanyId(), groupId, parameterMap,
-				getUserIdStrategy(userId, userIdStrategy), zipReader);
 
 		SAXParser saxParser = new SAXParser();
 
@@ -1731,6 +1720,30 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 				portletDataContext.getZipEntryAsInputStream("/manifest.xml")));
 
 		return missingReferences;
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #validateMissingReferences(PortletDataContext)}
+	 */
+	@Deprecated
+	@Override
+	public MissingReferences validateMissingReferences(
+			long userId, long groupId, Map<String, String[]> parameterMap,
+			File file)
+		throws Exception {
+
+		Group group = GroupLocalServiceUtil.getGroup(groupId);
+		String userIdStrategy = MapUtil.getString(
+			parameterMap, PortletDataHandlerKeys.USER_ID_STRATEGY);
+		ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
+
+		PortletDataContext portletDataContext =
+			PortletDataContextFactoryUtil.createImportPortletDataContext(
+				group.getCompanyId(), groupId, parameterMap,
+				getUserIdStrategy(userId, userIdStrategy), zipReader);
+
+		return validateMissingReferences(portletDataContext);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -817,6 +817,19 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 	}
 
 	@Override
+	public UserIdStrategy getUserIdStrategy(long userId, String userIdStrategy)
+		throws PortalException, SystemException {
+
+		User user = UserLocalServiceUtil.getUserById(userId);
+
+		if (UserIdStrategy.ALWAYS_CURRENT_USER_ID.equals(userIdStrategy)) {
+			return new AlwaysCurrentUserIdStrategy(user);
+		}
+
+		return new CurrentUserIdStrategy(user);
+	}
+
+	@Override
 	public boolean isReferenceWithinExportScope(
 		PortletDataContext portletDataContext, StagedModel stagedModel) {
 
@@ -2181,19 +2194,6 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		}
 
 		return null;
-	}
-
-	protected UserIdStrategy getUserIdStrategy(
-			long userId, String userIdStrategy)
-		throws Exception {
-
-		User user = UserLocalServiceUtil.getUserById(userId);
-
-		if (UserIdStrategy.ALWAYS_CURRENT_USER_ID.equals(userIdStrategy)) {
-			return new AlwaysCurrentUserIdStrategy(user);
-		}
-
-		return new CurrentUserIdStrategy(user);
 	}
 
 	protected String replaceExportHostname(

--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -227,7 +227,7 @@ public class LayoutImporter {
 		boolean layoutSetPrototypeLinkEnabled = MapUtil.getBoolean(
 			parameterMap,
 			PortletDataHandlerKeys.LAYOUT_SET_PROTOTYPE_LINK_ENABLED);
-		String userIdStrategy = MapUtil.getString(
+		String userIdStrategyString = MapUtil.getString(
 			parameterMap, PortletDataHandlerKeys.USER_ID_STRATEGY);
 
 		Group group = GroupLocalServiceUtil.getGroup(groupId);
@@ -269,8 +269,9 @@ public class LayoutImporter {
 			ServiceContextThreadLocal.pushServiceContext(serviceContext);
 		}
 
-		UserIdStrategy strategy = ExportImportHelperUtil.getUserIdStrategy(
-			userId, userIdStrategy);
+		UserIdStrategy userIdStrategy =
+			ExportImportHelperUtil.getUserIdStrategy(
+				userId, userIdStrategyString);
 
 		ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
 
@@ -282,7 +283,7 @@ public class LayoutImporter {
 
 		PortletDataContext portletDataContext =
 			PortletDataContextFactoryUtil.createImportPortletDataContext(
-				companyId, groupId, parameterMap, strategy, zipReader);
+				companyId, groupId, parameterMap, userIdStrategy, zipReader);
 
 		portletDataContext.setPrivateLayout(privateLayout);
 

--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -279,7 +279,7 @@ public class LayoutImporter {
 
 		validateFile(companyId, groupId, parameterMap, zipReader);
 
-		// PDC
+		// PortletDataContext
 
 		PortletDataContext portletDataContext =
 			PortletDataContextFactoryUtil.createImportPortletDataContext(

--- a/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
@@ -553,16 +553,6 @@ public class PortletImporter {
 		zipReader.close();
 	}
 
-	protected UserIdStrategy getUserIdStrategy(
-		User user, String userIdStrategy) {
-
-		if (UserIdStrategy.ALWAYS_CURRENT_USER_ID.equals(userIdStrategy)) {
-			return new AlwaysCurrentUserIdStrategy(user);
-		}
-
-		return new CurrentUserIdStrategy(user);
-	}
-
 	protected void importAssetTag(
 			PortletDataContext portletDataContext, Map<Long, Long> assetTagPKs,
 			Element assetTagElement, AssetTag assetTag)

--- a/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
@@ -378,6 +378,8 @@ public class PortletImporter {
 
 		validateFile(layout.getCompanyId(), groupId, portletId, zipReader);
 
+		// PortletDataContext
+
 		PortletDataContext portletDataContext =
 			PortletDataContextFactoryUtil.createImportPortletDataContext(
 				layout.getCompanyId(), groupId, parameterMap, userIdStrategy,

--- a/portal-impl/test/integration/com/liferay/portal/lar/BaseStagedModelDataHandlerTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/BaseStagedModelDataHandlerTestCase.java
@@ -291,9 +291,11 @@ public abstract class BaseStagedModelDataHandlerTestCase {
 			Document document = SAXReaderUtil.createDocument();
 
 			Element rootElement = document.addElement("root");
+
 			rootElement.addElement("header");
 
 			zipWriter.addEntry("/manifest.xml", document.asXML());
+
 			zipReader = ZipReaderFactoryUtil.getZipReader(zipWriter.getFile());
 		}
 

--- a/portal-impl/test/integration/com/liferay/portal/lar/BaseStagedModelDataHandlerTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/BaseStagedModelDataHandlerTestCase.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.zip.ZipReader;
@@ -283,6 +284,18 @@ public abstract class BaseStagedModelDataHandlerTestCase {
 
 		userIdStrategy = new CurrentUserIdStrategy(TestPropsValues.getUser());
 		zipReader = ZipReaderFactoryUtil.getZipReader(zipWriter.getFile());
+
+		String xml = zipReader.getEntryAsString("/manifest.xml");
+
+		if (xml == null) {
+			Document document = SAXReaderUtil.createDocument();
+
+			Element rootElement = document.addElement("root");
+			rootElement.addElement("header");
+
+			zipWriter.addEntry("/manifest.xml", document.asXML());
+			zipReader = ZipReaderFactoryUtil.getZipReader(zipWriter.getFile());
+		}
 
 		portletDataContext =
 			PortletDataContextFactoryUtil.createImportPortletDataContext(

--- a/portal-impl/test/integration/com/liferay/portal/lar/ExportImportHelperUtilTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/ExportImportHelperUtilTest.java
@@ -135,12 +135,13 @@ public class ExportImportHelperUtilTest extends PowerMockito {
 
 		Document document = SAXReaderUtil.createDocument();
 
-		Element rootElement = document.addElement("root");
-		rootElement.addElement("header");
+		Element manifestRootElement = document.addElement("root");
+
+		manifestRootElement.addElement("header");
 
 		testReaderWriter.addEntry("/manifest.xml", document.asXML());
 
-		rootElement = SAXReaderUtil.createElement("root");
+		Element rootElement = SAXReaderUtil.createElement("root");
 
 		_portletDataContextExport.setExportDataRootElement(rootElement);
 

--- a/portal-impl/test/integration/com/liferay/portal/lar/ManifestSummaryTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/ManifestSummaryTest.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.StagedModel;
 import com.liferay.portal.test.Sync;
-import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
 import com.liferay.portlet.dynamicdatamapping.model.DDMTemplate;
@@ -111,9 +110,7 @@ public class ManifestSummaryTest
 		throws Exception {
 
 		ManifestSummary manifestSummary =
-			ExportImportHelperUtil.getManifestSummary(
-				TestPropsValues.getUserId(), liveGroup.getGroupId(),
-				getParameterMap(), zipWriter.getFile());
+			ExportImportHelperUtil.getManifestSummary(portletDataContext);
 
 		Map<String, LongWrapper> modelAdditionCounters =
 			manifestSummary.getModelAdditionCounters();

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
@@ -183,6 +183,11 @@ public interface ExportImportHelper {
 			PortletRequest portletRequest, long targetGroupId)
 		throws PortalException, SystemException;
 
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #getManifestSummary(PortletDataContext)}
+	 */
+	@Deprecated
 	public ManifestSummary getManifestSummary(
 			long userId, long groupId, Map<String, String[]> parameterMap,
 			File file)
@@ -191,6 +196,10 @@ public interface ExportImportHelper {
 	public ManifestSummary getManifestSummary(
 			long userId, long groupId, Map<String, String[]> parameterMap,
 			FileEntry fileEntry)
+		throws Exception;
+
+	public ManifestSummary getManifestSummary(
+			PortletDataContext portletDataContext)
 		throws Exception;
 
 	public List<Layout> getMissingParentLayouts(Layout layout, long liveGroupId)

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
@@ -299,6 +299,15 @@ public interface ExportImportHelper {
 		throws Exception;
 
 	public MissingReferences validateMissingReferences(
+			final PortletDataContext portletDataContext)
+		throws Exception;
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #validateMissingReferences(PortletDataContext)}
+	 */
+	@Deprecated
+	public MissingReferences validateMissingReferences(
 			long userId, long groupId, Map<String, String[]> parameterMap,
 			File file)
 		throws Exception;

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelper.java
@@ -214,6 +214,9 @@ public interface ExportImportHelper {
 			long groupId, long userId, String folderName)
 		throws PortalException, SystemException;
 
+	public UserIdStrategy getUserIdStrategy(long userId, String userIdStrategy)
+		throws PortalException, SystemException;
+
 	public boolean isReferenceWithinExportScope(
 		PortletDataContext portletDataContext, StagedModel stagedModel);
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
@@ -422,6 +422,19 @@ public class ExportImportHelperUtil {
 	}
 
 	public static MissingReferences validateMissingReferences(
+			final PortletDataContext portletDataContext)
+		throws Exception {
+
+		return getExportImportHelper().validateMissingReferences(
+			portletDataContext);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #validateMissingReferences(PortletDataContext)}
+	 */
+	@Deprecated
+	public static MissingReferences validateMissingReferences(
 			long userId, long groupId, Map<String, String[]> parameterMap,
 			File file)
 		throws Exception {

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
@@ -221,6 +221,11 @@ public class ExportImportHelperUtil {
 			portletRequest, targetGroupId);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #getManifestSummary(PortletDataContext)}
+	 */
+	@Deprecated
 	public static ManifestSummary getManifestSummary(
 			long userId, long groupId, Map<String, String[]> parameterMap,
 			File file)
@@ -237,6 +242,13 @@ public class ExportImportHelperUtil {
 
 		return getExportImportHelper().getManifestSummary(
 			userId, groupId, parameterMap, fileEntry);
+	}
+
+	public static ManifestSummary getManifestSummary(
+			PortletDataContext portletDataContext)
+		throws Exception {
+
+		return getExportImportHelper().getManifestSummary(portletDataContext);
 	}
 
 	public static List<Layout> getMissingParentLayouts(

--- a/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/ExportImportHelperUtil.java
@@ -276,6 +276,14 @@ public class ExportImportHelperUtil {
 			groupId, userId, folderName);
 	}
 
+	public static UserIdStrategy getUserIdStrategy(
+			long userId, String userIdStrategy)
+		throws PortalException, SystemException {
+
+		return getExportImportHelper().getUserIdStrategy(
+			userId, userIdStrategy);
+	}
+
 	public static boolean isReferenceWithinExportScope(
 		PortletDataContext portletDataContext, StagedModel stagedModel) {
 


### PR DESCRIPTION
Hey Brian,

This is a bug fix, and @danielkocsis had to reorganize the methods a bit. The bug was that the PortletDataContext had an improper setup and the validation failed due to this fact. The solution was to validate before the PDC is being created, doing this the PDC will be alway a valid state of the export/import process.

Thanks,

Máté
