### PR TITLE
LPS-46132 Consume the new social related methods in UserLocalService from the mentions portlet

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -2900,6 +2900,35 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		return user.getUserId();
 	}
 
+	@Override
+	public List<User> getUsersByGroups(
+			String keywords, long userId, long[] groupIds, int start, int end)
+		throws PortalException, SystemException {
+
+		return userFinder.findByUsersGroups(
+			keywords, userId, groupIds, start, end);
+	}
+
+	@Override
+	public List<User> getUsersBySocialRelationsTypes(
+			String keywords, long userId, int[] types, long[] groupIds,
+			int start, int end)
+		throws PortalException, SystemException {
+
+		return userFinder.findBySocialRelationTypes(
+			keywords, userId, types, start, end);
+	}
+
+	@Override
+	public List<User> getUsersBySocialRelationsTypesGroups(
+			String keywords, long userId, int[] types, long[] groupIds,
+			int start, int end)
+		throws PortalException, SystemException {
+
+		return userFinder.findBySocialRelationTypesGroups(
+			keywords, userId, types, groupIds, start, end);
+	}
+
 	/**
 	 * Returns <code>true</code> if the password policy has been assigned to the
 	 * user.

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -137,11 +137,13 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.SubscriptionSender;
+import com.liferay.portal.util.comparator.UserScreenNameComparator;
 import com.liferay.portlet.messageboards.model.MBMessage;
 import com.liferay.portlet.usersadmin.util.UsersAdminUtil;
 import com.liferay.util.Encryptor;
 import com.liferay.util.EncryptorException;
 import com.liferay.util.PwdGenerator;
+import com.liferay.util.dao.orm.CustomSQLConstants;
 
 import java.io.Serializable;
 
@@ -2905,18 +2907,37 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			String keywords, long userId, long[] groupIds, int start, int end)
 		throws PortalException, SystemException {
 
-		return userFinder.findByUsersGroups(
-			keywords, userId, groupIds, start, end);
+		User user = userPersistence.findByPrimaryKey(userId);
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put("usersGroups", ArrayUtil.toLongArray(groupIds));
+		params.put("wildcardMode", CustomSQLConstants.TRAILING_WILDCARD_MODE);
+
+		return userFinder.findByKeywords(
+			user.getCompanyId(), keywords, WorkflowConstants.STATUS_APPROVED,
+			params, start, end, new UserScreenNameComparator());
 	}
 
 	@Override
 	public List<User> getUsersBySocialRelationsTypes(
-			String keywords, long userId, int[] types, long[] groupIds,
-			int start, int end)
+			String keywords, long userId, int[] types, int start, int end)
 		throws PortalException, SystemException {
 
-		return userFinder.findBySocialRelationTypes(
-			keywords, userId, types, start, end);
+		User user = userPersistence.findByPrimaryKey(userId);
+
+		LinkedHashMap<String, Object> params =
+			new LinkedHashMap<String, Object>();
+
+		params.put(
+			"socialRelationType",
+			new Long[][] {new Long[] {userId}, ArrayUtil.toLongArray(types)});
+		params.put("wildcardMode", CustomSQLConstants.TRAILING_WILDCARD_MODE);
+
+		return userFinder.findByKeywords(
+			user.getCompanyId(), keywords, WorkflowConstants.STATUS_APPROVED,
+			params, start, end, new UserScreenNameComparator());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -75,6 +75,12 @@ public class UserFinderImpl
 	public static final String FIND_BY_C_FN_MN_LN_SN_EA_S =
 		UserFinder.class.getName() + ".findByC_FN_MN_LN_SN_EA_S";
 
+	public static final String FIND_BY_SOCIAL_RELATION_TYPES =
+		UserFinder.class.getName() + ".findBySocialRelationTypes";
+
+	public static final String FIND_BY_USERS_GROUPS =
+		UserFinder.class.getName() + ".findByUsersGroups";
+
 	public static final String JOIN_BY_CONTACT_TWITTER_SN =
 		UserFinder.class.getName() + ".joinByContactTwitterSN";
 
@@ -532,6 +538,330 @@ public class UserFinderImpl
 		finally {
 			closeSession(session);
 		}
+	}
+
+	@Override
+	public List<User> findBySocialRelationTypes(
+			String terms, long userId, int[] types, int start, int end)
+		throws SystemException {
+
+		String sql = getFindBySocialRelationTypesSQL(types);
+
+		String[] keywords = removeLeadingPercent(
+			CustomSQLUtil.keywords(terms, true));
+
+		String[] firstName = keywords;
+		String[] middleName = keywords;
+		String[] lastName = keywords;
+		String[] screenName = keywords;
+		String[] emailAddress = keywords;
+
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.middleName)", StringPool.LIKE, false, middleName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.screenName)", StringPool.LIKE, false, screenName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.emailAddress)", StringPool.LIKE, false,
+			emailAddress);
+
+		sql = CustomSQLUtil.replaceAndOperator(sql, false);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery query = session.createSynchronizedSQLQuery(sql);
+
+			query.addEntity("User_", UserImpl.class);
+
+			QueryPos qPos = QueryPos.getInstance(query);
+
+			qPos.add(userId);
+
+			for (int i = 0; i < types.length; i++) {
+				qPos.add(types[i]);
+			}
+
+			qPos.add(userId);
+			qPos.add(firstName, 2);
+			qPos.add(middleName, 2);
+			qPos.add(lastName, 2);
+			qPos.add(screenName, 2);
+			qPos.add(emailAddress, 2);
+
+			return (List<User>)QueryUtil.list(query, getDialect(), start, end);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	@Override
+	public List<User> findByUsersGroups(
+			String terms, long userId, long[] groupIds, int start, int end)
+		throws SystemException {
+
+		String sql = getFindByUsersGroupsSQL(groupIds);
+
+		String[] keywords = removeLeadingPercent(
+			CustomSQLUtil.keywords(terms, true));
+
+		String[] firstName = keywords;
+		String[] middleName = keywords;
+		String[] lastName = keywords;
+		String[] screenName = keywords;
+		String[] emailAddress = keywords;
+
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.middleName)", StringPool.LIKE, false, middleName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.screenName)", StringPool.LIKE, false, screenName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.emailAddress)", StringPool.LIKE, false,
+			emailAddress);
+
+		sql = CustomSQLUtil.replaceAndOperator(sql, false);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery query = session.createSynchronizedSQLQuery(sql);
+
+			query.addEntity("User_", UserImpl.class);
+
+			QueryPos qPos = QueryPos.getInstance(query);
+
+			qPos.add(userId);
+
+			for (int i = 0; i < groupIds.length; i++) {
+				qPos.add(groupIds[i]);
+			}
+
+			qPos.add(firstName, 2);
+			qPos.add(middleName, 2);
+			qPos.add(lastName, 2);
+			qPos.add(screenName, 2);
+			qPos.add(emailAddress, 2);
+
+			return (List<User>)QueryUtil.list(query, getDialect(), start, end);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	@Override
+	public List<User> findBySocialRelationTypesGroups(
+			String terms, long userId, int[] types, long[] groupIds, int start,
+			int end)
+		throws SystemException {
+
+		String[] keywords = removeLeadingPercent(
+			CustomSQLUtil.keywords(terms, true));
+
+		String[] firstName = keywords;
+		String[] middleName = keywords;
+		String[] lastName = keywords;
+		String[] screenName = keywords;
+		String[] emailAddress = keywords;
+
+		// Groups
+
+		String byGroupsSQL = null;
+
+		if ((groupIds != null) && (groupIds.length > 0)) {
+			byGroupsSQL = getFindByUsersGroupsSQL(groupIds);
+
+			byGroupsSQL = CustomSQLUtil.replaceKeywords(
+				byGroupsSQL, "lower(User_.firstName)", StringPool.LIKE, false,
+				firstName);
+			byGroupsSQL = CustomSQLUtil.replaceKeywords(
+				byGroupsSQL, "lower(User_.middleName)", StringPool.LIKE, false,
+				middleName);
+			byGroupsSQL = CustomSQLUtil.replaceKeywords(
+				byGroupsSQL, "lower(User_.lastName)", StringPool.LIKE, false,
+				lastName);
+			byGroupsSQL = CustomSQLUtil.replaceKeywords(
+				byGroupsSQL, "lower(User_.screenName)", StringPool.LIKE, false,
+				screenName);
+			byGroupsSQL = CustomSQLUtil.replaceKeywords(
+				byGroupsSQL, "lower(User_.emailAddress)", StringPool.LIKE,
+				false, emailAddress);
+		}
+
+		// Social relations
+
+		String byRelationSQL = null;
+
+		if ((types != null) && (types.length > 0)) {
+			byRelationSQL = getFindBySocialRelationTypesSQL(types);
+
+			byRelationSQL = CustomSQLUtil.replaceKeywords(
+				byRelationSQL, "lower(User_.firstName)", StringPool.LIKE, false,
+				firstName);
+			byRelationSQL = CustomSQLUtil.replaceKeywords(
+				byRelationSQL, "lower(User_.middleName)", StringPool.LIKE,
+				false, middleName);
+			byRelationSQL = CustomSQLUtil.replaceKeywords(
+				byRelationSQL, "lower(User_.lastName)", StringPool.LIKE, false,
+				lastName);
+			byRelationSQL = CustomSQLUtil.replaceKeywords(
+				byRelationSQL, "lower(User_.screenName)", StringPool.LIKE,
+				false, screenName);
+			byRelationSQL = CustomSQLUtil.replaceKeywords(
+				byRelationSQL, "lower(User_.emailAddress)", StringPool.LIKE,
+				false, emailAddress);
+		}
+
+		StringBundler sb = new StringBundler();
+
+		if ((groupIds != null) && (groupIds.length > 0)) {
+			sb.append(StringPool.OPEN_PARENTHESIS);
+			sb.append(byGroupsSQL);
+			sb.append(StringPool.CLOSE_PARENTHESIS);
+
+			if (types.length > 0) {
+				sb.append(" UNION ");
+			}
+		}
+
+		if ((types != null) && (types.length > 0)) {
+			sb.append(StringPool.OPEN_PARENTHESIS);
+			sb.append(byRelationSQL);
+			sb.append(StringPool.CLOSE_PARENTHESIS);
+		}
+
+		String sql = sb.toString();
+
+		sql = CustomSQLUtil.replaceAndOperator(sql, false);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery query = session.createSynchronizedSQLQuery(sql);
+
+			query.addEntity("User_", UserImpl.class);
+
+			QueryPos qPos = QueryPos.getInstance(query);
+
+			// Groups
+
+			if ((groupIds != null) && (groupIds.length > 0)) {
+				qPos.add(userId);
+
+				for (int i = 0; i < groupIds.length; i++) {
+					qPos.add(groupIds[i]);
+				}
+
+				qPos.add(firstName, 2);
+				qPos.add(middleName, 2);
+				qPos.add(lastName, 2);
+				qPos.add(screenName, 2);
+				qPos.add(emailAddress, 2);
+			}
+
+			// Relations
+
+			if ((types != null) && (types.length > 0)) {
+				qPos.add(userId);
+
+				for (int i = 0; i < types.length; i++) {
+					qPos.add(types[i]);
+				}
+
+				qPos.add(userId);
+				qPos.add(firstName, 2);
+				qPos.add(middleName, 2);
+				qPos.add(lastName, 2);
+				qPos.add(screenName, 2);
+				qPos.add(emailAddress, 2);
+			}
+
+			return (List<User>)QueryUtil.list(query, getDialect(), start, end);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected String getFindBySocialRelationTypesSQL(int[] types) {
+		String sql = CustomSQLUtil.get(FIND_BY_SOCIAL_RELATION_TYPES);
+
+		if ((types == null) || (types.length == 0)) {
+			return StringUtil.replace(
+				sql, "[$SOCIAL_RELATION_TYPES$]", StringPool.BLANK);
+		}
+
+		StringBundler sb = new StringBundler(types.length * 2 - 1);
+
+		for (int i = 0; i < types.length; i++) {
+			sb.append(StringPool.QUESTION);
+
+			if ((i + 1) < types.length) {
+				sb.append(StringPool.COMMA);
+			}
+		}
+
+		if (types.length > 1) {
+			return StringUtil.replace(
+				sql, "[$SOCIAL_RELATION_TYPES$]",
+				"SocialRelation.type_ IN (" + sb.toString() + ") AND");
+		}
+
+		return StringUtil.replace(
+			sql, "[$SOCIAL_RELATION_TYPES$]",
+			"(SocialRelation.type_ = " + sb.toString() + ") AND");
+	}
+
+	protected String getFindByUsersGroupsSQL(long[] groupIds) {
+		String sql = CustomSQLUtil.get(FIND_BY_USERS_GROUPS);
+
+		if ((groupIds == null) || (groupIds.length == 0)) {
+			return StringUtil.replace(
+				sql, "[$USERS_GROUPS_WHERE$]", StringPool.BLANK);
+		}
+
+		StringBundler sb = new StringBundler(groupIds.length * 2 - 1);
+
+		for (int i = 0; i < groupIds.length; i++) {
+			sb.append(StringPool.QUESTION);
+
+			if ((i + 1) < groupIds.length) {
+				sb.append(StringPool.COMMA);
+			}
+		}
+
+		if (groupIds.length > 1) {
+			return StringUtil.replace(
+				sql, "[$USERS_GROUPS_WHERE$]",
+				"(Users_Groups.groupId IN (" + sb.toString() + ")) AND");
+		}
+
+		return StringUtil.replace(
+			sql, "[$USERS_GROUPS_WHERE$]",
+			"(Users_Groups.groupId = " + sb.toString() + ") AND");
 	}
 
 	@Override
@@ -1203,6 +1533,23 @@ public class UserFinderImpl
 		}
 
 		return join;
+	}
+
+	protected String[] removeLeadingPercent(String[] keywords) {
+		String[] result = new String[keywords.length];
+
+		for (int i = 0; i < keywords.length; i++) {
+			String keyword = keywords[i];
+
+			if (keyword.startsWith(StringPool.PERCENT)) {
+				result[i] = keyword.substring(1);
+			}
+			else {
+				result[i] = keyword;
+			}
+		}
+
+		return result;
 	}
 
 	protected String replaceJoinAndWhere(

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.service.persistence.GroupUtil;
 import com.liferay.portal.service.persistence.RoleUtil;
 import com.liferay.portal.service.persistence.UserFinder;
 import com.liferay.portal.service.persistence.UserUtil;
+import com.liferay.util.dao.orm.CustomSQLConstants;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.ArrayList;
@@ -450,11 +451,15 @@ public class UserFinderImpl
 		boolean andOperator = false;
 
 		if (Validator.isNotNull(keywords)) {
-			firstNames = CustomSQLUtil.keywords(keywords);
-			middleNames = CustomSQLUtil.keywords(keywords);
-			lastNames = CustomSQLUtil.keywords(keywords);
-			screenNames = CustomSQLUtil.keywords(keywords);
-			emailAddresses = CustomSQLUtil.keywords(keywords);
+			int wildcardMode = GetterUtil.getInteger(
+				params.get("wildcardMode"),
+				CustomSQLConstants.SURROUND_WILDCARD_MODE);
+
+			firstNames = CustomSQLUtil.keywords(keywords, wildcardMode);
+			middleNames = CustomSQLUtil.keywords(keywords, wildcardMode);
+			lastNames = CustomSQLUtil.keywords(keywords, wildcardMode);
+			screenNames = CustomSQLUtil.keywords(keywords, wildcardMode);
+			emailAddresses = CustomSQLUtil.keywords(keywords, wildcardMode);
 		}
 		else {
 			andOperator = true;
@@ -541,140 +546,13 @@ public class UserFinderImpl
 	}
 
 	@Override
-	public List<User> findBySocialRelationTypes(
-			String terms, long userId, int[] types, int start, int end)
-		throws SystemException {
-
-		String sql = getFindBySocialRelationTypesSQL(types);
-
-		String[] keywords = removeLeadingPercent(
-			CustomSQLUtil.keywords(terms, true));
-
-		String[] firstName = keywords;
-		String[] middleName = keywords;
-		String[] lastName = keywords;
-		String[] screenName = keywords;
-		String[] emailAddress = keywords;
-
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.middleName)", StringPool.LIKE, false, middleName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.screenName)", StringPool.LIKE, false, screenName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.emailAddress)", StringPool.LIKE, false,
-			emailAddress);
-
-		sql = CustomSQLUtil.replaceAndOperator(sql, false);
-
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			SQLQuery query = session.createSynchronizedSQLQuery(sql);
-
-			query.addEntity("User_", UserImpl.class);
-
-			QueryPos qPos = QueryPos.getInstance(query);
-
-			qPos.add(userId);
-
-			for (int i = 0; i < types.length; i++) {
-				qPos.add(types[i]);
-			}
-
-			qPos.add(userId);
-			qPos.add(firstName, 2);
-			qPos.add(middleName, 2);
-			qPos.add(lastName, 2);
-			qPos.add(screenName, 2);
-			qPos.add(emailAddress, 2);
-
-			return (List<User>)QueryUtil.list(query, getDialect(), start, end);
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	@Override
-	public List<User> findByUsersGroups(
-			String terms, long userId, long[] groupIds, int start, int end)
-		throws SystemException {
-
-		String sql = getFindByUsersGroupsSQL(groupIds);
-
-		String[] keywords = removeLeadingPercent(
-			CustomSQLUtil.keywords(terms, true));
-
-		String[] firstName = keywords;
-		String[] middleName = keywords;
-		String[] lastName = keywords;
-		String[] screenName = keywords;
-		String[] emailAddress = keywords;
-
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.middleName)", StringPool.LIKE, false, middleName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.screenName)", StringPool.LIKE, false, screenName);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.emailAddress)", StringPool.LIKE, false,
-			emailAddress);
-
-		sql = CustomSQLUtil.replaceAndOperator(sql, false);
-
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			SQLQuery query = session.createSynchronizedSQLQuery(sql);
-
-			query.addEntity("User_", UserImpl.class);
-
-			QueryPos qPos = QueryPos.getInstance(query);
-
-			qPos.add(userId);
-
-			for (int i = 0; i < groupIds.length; i++) {
-				qPos.add(groupIds[i]);
-			}
-
-			qPos.add(firstName, 2);
-			qPos.add(middleName, 2);
-			qPos.add(lastName, 2);
-			qPos.add(screenName, 2);
-			qPos.add(emailAddress, 2);
-
-			return (List<User>)QueryUtil.list(query, getDialect(), start, end);
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	@Override
 	public List<User> findBySocialRelationTypesGroups(
 			String terms, long userId, int[] types, long[] groupIds, int start,
 			int end)
 		throws SystemException {
 
-		String[] keywords = removeLeadingPercent(
-			CustomSQLUtil.keywords(terms, true));
+		String[] keywords = CustomSQLUtil.keywords(
+			terms, true, CustomSQLConstants.TRAILING_WILDCARD_MODE);
 
 		String[] firstName = keywords;
 		String[] middleName = keywords;
@@ -806,6 +684,58 @@ public class UserFinderImpl
 		}
 	}
 
+	protected List<Long> countByC_FN_MN_LN_SN_EA_S(
+		Session session, long companyId, String[] firstNames,
+		String[] middleNames, String[] lastNames, String[] screenNames,
+		String[] emailAddresses, int status,
+		LinkedHashMap<String, Object> params, boolean andOperator) {
+
+		String sql = CustomSQLUtil.get(FIND_BY_C_FN_MN_LN_SN_EA_S);
+
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.middleName)", StringPool.LIKE, false,
+			middleNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.screenName)", StringPool.LIKE, false,
+			screenNames);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.emailAddress)", StringPool.LIKE, true,
+			emailAddresses);
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
+		}
+
+		sql = replaceJoinAndWhere(sql, params);
+		sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
+
+		SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+		q.addScalar("userId", Type.LONG);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		setJoin(qPos, params);
+
+		qPos.add(companyId);
+		qPos.add(false);
+		qPos.add(firstNames, 2);
+		qPos.add(middleNames, 2);
+		qPos.add(lastNames, 2);
+		qPos.add(screenNames, 2);
+		qPos.add(emailAddresses, 2);
+
+		if (status != WorkflowConstants.STATUS_ANY) {
+			qPos.add(status);
+		}
+
+		return q.list(true);
+	}
+
 	protected String getFindBySocialRelationTypesSQL(int[] types) {
 		String sql = CustomSQLUtil.get(FIND_BY_SOCIAL_RELATION_TYPES);
 
@@ -833,35 +763,6 @@ public class UserFinderImpl
 		return StringUtil.replace(
 			sql, "[$SOCIAL_RELATION_TYPES$]",
 			"(SocialRelation.type_ = " + sb.toString() + ") AND");
-	}
-
-	protected String getFindByUsersGroupsSQL(long[] groupIds) {
-		String sql = CustomSQLUtil.get(FIND_BY_USERS_GROUPS);
-
-		if ((groupIds == null) || (groupIds.length == 0)) {
-			return StringUtil.replace(
-				sql, "[$USERS_GROUPS_WHERE$]", StringPool.BLANK);
-		}
-
-		StringBundler sb = new StringBundler(groupIds.length * 2 - 1);
-
-		for (int i = 0; i < groupIds.length; i++) {
-			sb.append(StringPool.QUESTION);
-
-			if ((i + 1) < groupIds.length) {
-				sb.append(StringPool.COMMA);
-			}
-		}
-
-		if (groupIds.length > 1) {
-			return StringUtil.replace(
-				sql, "[$USERS_GROUPS_WHERE$]",
-				"(Users_Groups.groupId IN (" + sb.toString() + ")) AND");
-		}
-
-		return StringUtil.replace(
-			sql, "[$USERS_GROUPS_WHERE$]",
-			"(Users_Groups.groupId = " + sb.toString() + ") AND");
 	}
 
 	@Override
@@ -1205,56 +1106,33 @@ public class UserFinderImpl
 		}
 	}
 
-	protected List<Long> countByC_FN_MN_LN_SN_EA_S(
-		Session session, long companyId, String[] firstNames,
-		String[] middleNames, String[] lastNames, String[] screenNames,
-		String[] emailAddresses, int status,
-		LinkedHashMap<String, Object> params, boolean andOperator) {
+	protected String getFindByUsersGroupsSQL(long[] groupIds) {
+		String sql = CustomSQLUtil.get(FIND_BY_USERS_GROUPS);
 
-		String sql = CustomSQLUtil.get(FIND_BY_C_FN_MN_LN_SN_EA_S);
-
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstNames);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.middleName)", StringPool.LIKE, false,
-			middleNames);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastNames);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.screenName)", StringPool.LIKE, false,
-			screenNames);
-		sql = CustomSQLUtil.replaceKeywords(
-			sql, "lower(User_.emailAddress)", StringPool.LIKE, true,
-			emailAddresses);
-
-		if (status == WorkflowConstants.STATUS_ANY) {
-			sql = StringUtil.replace(sql, _STATUS_SQL, StringPool.BLANK);
+		if ((groupIds == null) || (groupIds.length == 0)) {
+			return StringUtil.replace(
+				sql, "[$USERS_GROUPS_WHERE$]", StringPool.BLANK);
 		}
 
-		sql = replaceJoinAndWhere(sql, params);
-		sql = CustomSQLUtil.replaceAndOperator(sql, andOperator);
+		StringBundler sb = new StringBundler(groupIds.length * 2 - 1);
 
-		SQLQuery q = session.createSynchronizedSQLQuery(sql);
+		for (int i = 0; i < groupIds.length; i++) {
+			sb.append(StringPool.QUESTION);
 
-		q.addScalar("userId", Type.LONG);
-
-		QueryPos qPos = QueryPos.getInstance(q);
-
-		setJoin(qPos, params);
-
-		qPos.add(companyId);
-		qPos.add(false);
-		qPos.add(firstNames, 2);
-		qPos.add(middleNames, 2);
-		qPos.add(lastNames, 2);
-		qPos.add(screenNames, 2);
-		qPos.add(emailAddresses, 2);
-
-		if (status != WorkflowConstants.STATUS_ANY) {
-			qPos.add(status);
+			if ((i + 1) < groupIds.length) {
+				sb.append(StringPool.COMMA);
+			}
 		}
 
-		return q.list(true);
+		if (groupIds.length > 1) {
+			return StringUtil.replace(
+				sql, "[$USERS_GROUPS_WHERE$]",
+				"(Users_Groups.groupId IN (" + sb.toString() + ")) AND");
+		}
+
+		return StringUtil.replace(
+			sql, "[$USERS_GROUPS_WHERE$]",
+			"(Users_Groups.groupId = " + sb.toString() + ") AND");
 	}
 
 	protected String getJoin(LinkedHashMap<String, Object> params) {
@@ -1513,7 +1391,31 @@ public class UserFinderImpl
 			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_RELATION);
 		}
 		else if (key.equals("socialRelationType")) {
-			join = CustomSQLUtil.get(JOIN_BY_SOCIAL_RELATION_TYPE);
+			if (value instanceof Long[]) {
+				join = CustomSQLUtil.get(JOIN_BY_SOCIAL_RELATION_TYPE);
+			}
+			else if (value instanceof Long[][]) {
+				Long[][] doubleArrayValue = (Long[][])value;
+
+				Long[] socialRelationTypes = doubleArrayValue[1];
+
+				StringBundler sb = new StringBundler(
+					socialRelationTypes.length * 2 + 1);
+
+				sb.append("WHERE (SocialRelation.userId1 = ?) AND ");
+				sb.append("(SocialRelation.type_ IN (");
+
+				for (long socialRelationType : socialRelationTypes) {
+					sb.append(StringPool.QUESTION);
+					sb.append(StringPool.COMMA);
+				}
+
+				sb.setIndex(sb.index() - 1);
+
+				sb.append("))");
+
+				join = sb.toString();
+			}
 		}
 		else if (value instanceof CustomSQLParam) {
 			CustomSQLParam customSQLParam = (CustomSQLParam)value;
@@ -1533,23 +1435,6 @@ public class UserFinderImpl
 		}
 
 		return join;
-	}
-
-	protected String[] removeLeadingPercent(String[] keywords) {
-		String[] result = new String[keywords.length];
-
-		for (int i = 0; i < keywords.length; i++) {
-			String keyword = keywords[i];
-
-			if (keyword.startsWith(StringPool.PERCENT)) {
-				result[i] = keyword.substring(1);
-			}
-			else {
-				result[i] = keyword;
-			}
-		}
-
-		return result;
 	}
 
 	protected String replaceJoinAndWhere(

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -76,11 +76,8 @@ public class UserFinderImpl
 	public static final String FIND_BY_C_FN_MN_LN_SN_EA_S =
 		UserFinder.class.getName() + ".findByC_FN_MN_LN_SN_EA_S";
 
-	public static final String FIND_BY_SOCIAL_RELATION_TYPES =
-		UserFinder.class.getName() + ".findBySocialRelationTypes";
-
-	public static final String FIND_BY_USERS_GROUPS =
-		UserFinder.class.getName() + ".findByUsersGroups";
+	public static final String FIND_BY_SOCIAL_RELATION_TYPES_GROUPS =
+		UserFinder.class.getName() + ".findBySocialRelationTypesGroups";
 
 	public static final String JOIN_BY_CONTACT_TWITTER_SN =
 		UserFinder.class.getName() + ".joinByContactTwitterSN";
@@ -560,73 +557,26 @@ public class UserFinderImpl
 		String[] screenName = keywords;
 		String[] emailAddress = keywords;
 
-		// Groups
+		String sql = CustomSQLUtil.get(FIND_BY_SOCIAL_RELATION_TYPES_GROUPS);
 
-		String byGroupsSQL = null;
+		sql = replaceValueSet(
+			sql, "[$USERS_GROUPS_WHERE$]", "Users_Groups.groupId",
+			ArrayUtil.toLongArray(groupIds));
+		sql = replaceValueSet(
+			sql, "[$SOCIAL_RELATION_TYPES$]", "SocialRelation.type_",
+			ArrayUtil.toLongArray(types));
 
-		if ((groupIds != null) && (groupIds.length > 0)) {
-			byGroupsSQL = getFindByUsersGroupsSQL(groupIds);
-
-			byGroupsSQL = CustomSQLUtil.replaceKeywords(
-				byGroupsSQL, "lower(User_.firstName)", StringPool.LIKE, false,
-				firstName);
-			byGroupsSQL = CustomSQLUtil.replaceKeywords(
-				byGroupsSQL, "lower(User_.middleName)", StringPool.LIKE, false,
-				middleName);
-			byGroupsSQL = CustomSQLUtil.replaceKeywords(
-				byGroupsSQL, "lower(User_.lastName)", StringPool.LIKE, false,
-				lastName);
-			byGroupsSQL = CustomSQLUtil.replaceKeywords(
-				byGroupsSQL, "lower(User_.screenName)", StringPool.LIKE, false,
-				screenName);
-			byGroupsSQL = CustomSQLUtil.replaceKeywords(
-				byGroupsSQL, "lower(User_.emailAddress)", StringPool.LIKE,
-				false, emailAddress);
-		}
-
-		// Social relations
-
-		String byRelationSQL = null;
-
-		if ((types != null) && (types.length > 0)) {
-			byRelationSQL = getFindBySocialRelationTypesSQL(types);
-
-			byRelationSQL = CustomSQLUtil.replaceKeywords(
-				byRelationSQL, "lower(User_.firstName)", StringPool.LIKE, false,
-				firstName);
-			byRelationSQL = CustomSQLUtil.replaceKeywords(
-				byRelationSQL, "lower(User_.middleName)", StringPool.LIKE,
-				false, middleName);
-			byRelationSQL = CustomSQLUtil.replaceKeywords(
-				byRelationSQL, "lower(User_.lastName)", StringPool.LIKE, false,
-				lastName);
-			byRelationSQL = CustomSQLUtil.replaceKeywords(
-				byRelationSQL, "lower(User_.screenName)", StringPool.LIKE,
-				false, screenName);
-			byRelationSQL = CustomSQLUtil.replaceKeywords(
-				byRelationSQL, "lower(User_.emailAddress)", StringPool.LIKE,
-				false, emailAddress);
-		}
-
-		StringBundler sb = new StringBundler();
-
-		if ((groupIds != null) && (groupIds.length > 0)) {
-			sb.append(StringPool.OPEN_PARENTHESIS);
-			sb.append(byGroupsSQL);
-			sb.append(StringPool.CLOSE_PARENTHESIS);
-
-			if (types.length > 0) {
-				sb.append(" UNION ");
-			}
-		}
-
-		if ((types != null) && (types.length > 0)) {
-			sb.append(StringPool.OPEN_PARENTHESIS);
-			sb.append(byRelationSQL);
-			sb.append(StringPool.CLOSE_PARENTHESIS);
-		}
-
-		String sql = sb.toString();
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.firstName)", StringPool.LIKE, false, firstName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.middleName)", StringPool.LIKE, false, middleName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.lastName)", StringPool.LIKE, false, lastName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.screenName)", StringPool.LIKE, false, screenName);
+		sql = CustomSQLUtil.replaceKeywords(
+			sql, "lower(User_.emailAddress)", StringPool.LIKE, false,
+			emailAddress);
 
 		sql = CustomSQLUtil.replaceAndOperator(sql, false);
 
@@ -641,38 +591,34 @@ public class UserFinderImpl
 
 			QueryPos qPos = QueryPos.getInstance(query);
 
-			// Groups
-
-			if ((groupIds != null) && (groupIds.length > 0)) {
-				qPos.add(userId);
-
-				for (int i = 0; i < groupIds.length; i++) {
-					qPos.add(groupIds[i]);
-				}
-
-				qPos.add(firstName, 2);
-				qPos.add(middleName, 2);
-				qPos.add(lastName, 2);
-				qPos.add(screenName, 2);
-				qPos.add(emailAddress, 2);
-			}
-
 			// Relations
 
-			if ((types != null) && (types.length > 0)) {
-				qPos.add(userId);
+			qPos.add(userId);
 
-				for (int i = 0; i < types.length; i++) {
-					qPos.add(types[i]);
-				}
-
-				qPos.add(userId);
-				qPos.add(firstName, 2);
-				qPos.add(middleName, 2);
-				qPos.add(lastName, 2);
-				qPos.add(screenName, 2);
-				qPos.add(emailAddress, 2);
+			for (int i = 0; i < types.length; i++) {
+				qPos.add(types[i]);
 			}
+
+			qPos.add(firstName, 2);
+			qPos.add(middleName, 2);
+			qPos.add(lastName, 2);
+			qPos.add(screenName, 2);
+			qPos.add(emailAddress, 2);
+
+			// Groups
+
+			qPos.add(userId);
+
+			for (int i = 0; i < groupIds.length; i++) {
+				qPos.add(groupIds[i]);
+			}
+
+			qPos.add(userId);
+			qPos.add(firstName, 2);
+			qPos.add(middleName, 2);
+			qPos.add(lastName, 2);
+			qPos.add(screenName, 2);
+			qPos.add(emailAddress, 2);
 
 			return (List<User>)QueryUtil.list(query, getDialect(), start, end);
 		}
@@ -736,33 +682,28 @@ public class UserFinderImpl
 		return q.list(true);
 	}
 
-	protected String getFindBySocialRelationTypesSQL(int[] types) {
-		String sql = CustomSQLUtil.get(FIND_BY_SOCIAL_RELATION_TYPES);
-
-		if ((types == null) || (types.length == 0)) {
-			return StringUtil.replace(
-				sql, "[$SOCIAL_RELATION_TYPES$]", StringPool.BLANK);
+	protected String getJoin(LinkedHashMap<String, Object> params) {
+		if ((params == null) || params.isEmpty()) {
+			return StringPool.BLANK;
 		}
 
-		StringBundler sb = new StringBundler(types.length * 2 - 1);
+		StringBundler sb = new StringBundler(params.size());
 
-		for (int i = 0; i < types.length; i++) {
-			sb.append(StringPool.QUESTION);
+		for (Map.Entry<String, Object> entry : params.entrySet()) {
+			String key = entry.getKey();
 
-			if ((i + 1) < types.length) {
-				sb.append(StringPool.COMMA);
+			if (key.equals("expandoAttributes")) {
+				continue;
+			}
+
+			Object value = entry.getValue();
+
+			if (Validator.isNotNull(value)) {
+				sb.append(getJoin(key, value));
 			}
 		}
 
-		if (types.length > 1) {
-			return StringUtil.replace(
-				sql, "[$SOCIAL_RELATION_TYPES$]",
-				"SocialRelation.type_ IN (" + sb.toString() + ") AND");
-		}
-
-		return StringUtil.replace(
-			sql, "[$SOCIAL_RELATION_TYPES$]",
-			"(SocialRelation.type_ = " + sb.toString() + ") AND");
+		return sb.toString();
 	}
 
 	@Override
@@ -1104,59 +1045,6 @@ public class UserFinderImpl
 		finally {
 			closeSession(session);
 		}
-	}
-
-	protected String getFindByUsersGroupsSQL(long[] groupIds) {
-		String sql = CustomSQLUtil.get(FIND_BY_USERS_GROUPS);
-
-		if ((groupIds == null) || (groupIds.length == 0)) {
-			return StringUtil.replace(
-				sql, "[$USERS_GROUPS_WHERE$]", StringPool.BLANK);
-		}
-
-		StringBundler sb = new StringBundler(groupIds.length * 2 - 1);
-
-		for (int i = 0; i < groupIds.length; i++) {
-			sb.append(StringPool.QUESTION);
-
-			if ((i + 1) < groupIds.length) {
-				sb.append(StringPool.COMMA);
-			}
-		}
-
-		if (groupIds.length > 1) {
-			return StringUtil.replace(
-				sql, "[$USERS_GROUPS_WHERE$]",
-				"(Users_Groups.groupId IN (" + sb.toString() + ")) AND");
-		}
-
-		return StringUtil.replace(
-			sql, "[$USERS_GROUPS_WHERE$]",
-			"(Users_Groups.groupId = " + sb.toString() + ") AND");
-	}
-
-	protected String getJoin(LinkedHashMap<String, Object> params) {
-		if ((params == null) || params.isEmpty()) {
-			return StringPool.BLANK;
-		}
-
-		StringBundler sb = new StringBundler(params.size());
-
-		for (Map.Entry<String, Object> entry : params.entrySet()) {
-			String key = entry.getKey();
-
-			if (key.equals("expandoAttributes")) {
-				continue;
-			}
-
-			Object value = entry.getValue();
-
-			if (Validator.isNotNull(value)) {
-				sb.append(getJoin(key, value));
-			}
-		}
-
-		return sb.toString();
 	}
 
 	protected String getJoin(String key, Object value) {
@@ -1515,6 +1403,32 @@ public class UserFinderImpl
 				customSQLParam.process(qPos);
 			}
 		}
+	}
+
+	private <T> String replaceValueSet(
+		String sql, String placeholder, String column, T[] values) {
+
+		if ((values == null) || (values.length == 0)) {
+			return StringUtil.replace(sql, placeholder, StringPool.BLANK);
+		}
+
+		StringBundler sb = new StringBundler(values.length * 2 - 1);
+
+		for (int i = 0; i < values.length; i++) {
+			sb.append(StringPool.QUESTION);
+
+			if ((i + 1) < values.length) {
+				sb.append(StringPool.COMMA);
+			}
+		}
+
+		if (values.length > 1) {
+			return StringUtil.replace(
+				sql, placeholder, column + " IN (" + sb.toString() + ") AND");
+		}
+
+		return StringUtil.replace(
+			sql, placeholder, "(" + column + " = " + sb.toString() + ") AND");
 	}
 
 	private static final String _STATUS_SQL = "AND (User_.status = ?)";

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1432,51 +1432,46 @@
 				) AND (User_.status = ?)
 		]]>
 	</sql>
-	<sql id="com.liferay.portal.service.persistence.UserFinder.findBySocialRelationTypes">
+	<sql id="com.liferay.portal.service.persistence.UserFinder.findBySocialRelationTypesGroups">
 		<![CDATA[
-			SELECT DISTINCT
-				{User_.*}
-			FROM
-				User_
-			INNER JOIN
-				SocialRelation ON
-					(SocialRelation.userId2 = User_.userId)
-			WHERE
-				(SocialRelation.userId1 = ?) AND
-				[$SOCIAL_RELATION_TYPES$]
-				(User_.userId != ?) AND
-				(
-					(lower(User_.firstName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.middleName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.lastName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.screenName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.emailAddress) LIKE ? [$AND_OR_NULL_CHECK$])
-				)
-			ORDER BY
-				User_.firstName ASC,
-				User_.middleName ASC,
-				User_.lastName ASC
-		]]>
-	</sql>
-	<sql id="com.liferay.portal.service.persistence.UserFinder.findByUsersGroups">
-		<![CDATA[
-			SELECT DISTINCT
-				{User_.*}
-			FROM
-				User_
-			INNER JOIN
-				Users_Groups ON
-					(Users_Groups.userId = User_.userId)
-			WHERE
-				(User_.userId != ?) AND
-				[$USERS_GROUPS_WHERE$]
-				(
-					(lower(User_.firstName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.middleName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.lastName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.screenName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-					(lower(User_.emailAddress) LIKE ? [$AND_OR_NULL_CHECK$])
-				)
+			(
+				SELECT DISTINCT
+					{User_.*}
+				FROM
+					User_
+				INNER JOIN
+					SocialRelation ON
+						(SocialRelation.userId2 = User_.userId)
+				WHERE
+					(SocialRelation.userId1 = ?) AND
+					[$SOCIAL_RELATION_TYPES$]
+					(User_.userId != ?) AND
+					(
+						(lower(User_.firstName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.middleName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.lastName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.screenName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.emailAddress) LIKE ? [$AND_OR_NULL_CHECK$])
+					)
+			) UNION (
+				SELECT DISTINCT
+					{User_.*}
+				FROM
+					User_
+				INNER JOIN
+					Users_Groups ON
+						(Users_Groups.userId = User_.userId)
+				WHERE
+					(User_.userId != ?) AND
+					[$USERS_GROUPS_WHERE$]
+					(
+						(lower(User_.firstName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.middleName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.lastName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.screenName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+						(lower(User_.emailAddress) LIKE ? [$AND_OR_NULL_CHECK$])
+					)
+			)
 			ORDER BY
 				User_.firstName ASC,
 				User_.middleName ASC,

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1432,6 +1432,57 @@
 				) AND (User_.status = ?)
 		]]>
 	</sql>
+	<sql id="com.liferay.portal.service.persistence.UserFinder.findBySocialRelationTypes">
+		<![CDATA[
+			SELECT DISTINCT
+				{User_.*}
+			FROM
+				User_
+			INNER JOIN
+				SocialRelation ON
+					(SocialRelation.userId2 = User_.userId)
+			WHERE
+				(SocialRelation.userId1 = ?) AND
+				[$SOCIAL_RELATION_TYPES$]
+				(User_.userId != ?) AND
+				(
+					(lower(User_.firstName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.middleName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.lastName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.screenName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.emailAddress) LIKE ? [$AND_OR_NULL_CHECK$])
+				)
+			ORDER BY
+				User_.firstName ASC,
+				User_.middleName ASC,
+				User_.lastName ASC
+		]]>
+	</sql>
+	<sql id="com.liferay.portal.service.persistence.UserFinder.findByUsersGroups">
+		<![CDATA[
+			SELECT DISTINCT
+				{User_.*}
+			FROM
+				User_
+			INNER JOIN
+				Users_Groups ON
+					(Users_Groups.userId = User_.userId)
+			WHERE
+				(User_.userId != ?) AND
+				[$USERS_GROUPS_WHERE$]
+				(
+					(lower(User_.firstName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.middleName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.lastName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.screenName) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+					(lower(User_.emailAddress) LIKE ? [$AND_OR_NULL_CHECK$])
+				)
+			ORDER BY
+				User_.firstName ASC,
+				User_.middleName ASC,
+				User_.lastName ASC
+		]]>
+	</sql>
 	<sql id="com.liferay.portal.service.persistence.UserFinder.joinByContactTwitterSN">
 		<![CDATA[
 			INNER JOIN

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/SocialRelationLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/SocialRelationLocalServiceTest.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.UserLocalServiceUtil;
@@ -28,8 +30,8 @@ import com.liferay.portal.util.UserTestUtil;
 import com.liferay.portal.util.comparator.UserScreenNameComparator;
 import com.liferay.portlet.social.model.SocialRelationConstants;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -256,9 +258,11 @@ public class SocialRelationLocalServiceTest {
 		long[] dlc3GroupIds = dlc3.getGroupIds();
 		long[] dlc4GroupIds = dlc4.getGroupIds();
 
-		Arrays.sort(dlc4GroupIds);
+		Set<Long> groupIdsSet = SetUtil.fromArray(dlc3GroupIds);
 
-		long[] groupIds = intersection(dlc3GroupIds, dlc4GroupIds);
+		groupIdsSet.retainAll(SetUtil.fromArray(dlc4GroupIds));
+
+		long[] groupIds = ArrayUtil.toArray(groupIdsSet.toArray(new Long[]{}));
 
 		List<User> users = UserLocalServiceUtil.getUsersByGroups(
 			"dlc", dlc2.getUserId(), groupIds, QueryUtil.ALL_POS,
@@ -517,20 +521,6 @@ public class SocialRelationLocalServiceTest {
 			new UserScreenNameComparator(true));
 
 		Assert.assertEquals(0, users.size());
-	}
-
-	protected long[] intersection(long[] a, long[] b) {
-		long[] result = new long[Math.min(a.length, b.length)];
-
-		int max = 0;
-
-		for (int i = 0; i < a.length; i++) {
-			if (Arrays.binarySearch(b, a[i]) >= 0) {
-				result[max++] = a[i];
-			}
-		}
-
-		return Arrays.copyOfRange(result, 0, max);
 	}
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/SocialRelationLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/SocialRelationLocalServiceTest.java
@@ -246,17 +246,17 @@ public class SocialRelationLocalServiceTest {
 	public void testGetMultipleGroups()
 		throws PortalException, SystemException {
 
-		User dlc2 = UserLocalServiceUtil.getUserByScreenName(
+		User dlc2User = UserLocalServiceUtil.getUserByScreenName(
 			TestPropsValues.getCompanyId(), "dlc2");
 
-		User dlc3 = UserLocalServiceUtil.getUserByScreenName(
+		User dlc3User = UserLocalServiceUtil.getUserByScreenName(
 			TestPropsValues.getCompanyId(), "dlc3");
 
-		User dlc4 = UserLocalServiceUtil.getUserByScreenName(
+		User dlc4User = UserLocalServiceUtil.getUserByScreenName(
 			TestPropsValues.getCompanyId(), "dlc4");
 
-		long[] dlc3GroupIds = dlc3.getGroupIds();
-		long[] dlc4GroupIds = dlc4.getGroupIds();
+		long[] dlc3GroupIds = dlc3User.getGroupIds();
+		long[] dlc4GroupIds = dlc4User.getGroupIds();
 
 		Set<Long> groupIdsSet = SetUtil.fromArray(dlc3GroupIds);
 
@@ -265,7 +265,7 @@ public class SocialRelationLocalServiceTest {
 		long[] groupIds = ArrayUtil.toArray(groupIdsSet.toArray(new Long[]{}));
 
 		List<User> users = UserLocalServiceUtil.getUsersByGroups(
-			"dlc", dlc2.getUserId(), groupIds, QueryUtil.ALL_POS,
+			"dlc", dlc2User.getUserId(), groupIds, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS);
 
 		Assert.assertEquals(2, users.size());
@@ -275,7 +275,7 @@ public class SocialRelationLocalServiceTest {
 	public void testGetMultipleRelations()
 		throws PortalException, SystemException {
 
-		User dlc2 = UserLocalServiceUtil.getUserByScreenName(
+		User dlc2User = UserLocalServiceUtil.getUserByScreenName(
 			TestPropsValues.getCompanyId(), "dlc2");
 
 		int[] types = {
@@ -284,7 +284,7 @@ public class SocialRelationLocalServiceTest {
 		};
 
 		List<User> users = UserLocalServiceUtil.getUsersBySocialRelationsTypes(
-			"dlc", dlc2.getUserId(), types, null, QueryUtil.ALL_POS,
+			"dlc", dlc2User.getUserId(), types, null, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS);
 
 		// dlc2 should have 1 coworker and 4 friends.

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/SocialRelationLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/SocialRelationLocalServiceTest.java
@@ -29,14 +29,13 @@ import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portal.util.UserTestUtil;
 import com.liferay.portal.util.comparator.UserScreenNameComparator;
 import com.liferay.portlet.social.model.SocialRelationConstants;
-
-import java.util.List;
-import java.util.Set;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Brian Wing Shun Chan
@@ -284,7 +283,7 @@ public class SocialRelationLocalServiceTest {
 		};
 
 		List<User> users = UserLocalServiceUtil.getUsersBySocialRelationsTypes(
-			"dlc", dlc2User.getUserId(), types, null, QueryUtil.ALL_POS,
+			"dlc", dlc2User.getUserId(), types, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS);
 
 		// dlc2 should have 1 coworker and 4 friends.

--- a/portal-service/src/com/liferay/portal/kernel/util/ArrayUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/ArrayUtil.java
@@ -1721,6 +1721,26 @@ public class ArrayUtil {
 		return newArray;
 	}
 
+	public static Long[] toLongArray(int[] array) {
+		Long[] newArray = new Long[array.length];
+
+		for (int i = 0; i < array.length; i++) {
+			newArray[i] = (long)array[i];
+		}
+
+		return newArray;
+	}
+
+	public static Long[] toLongArray(long[] array) {
+		Long[] newArray = new Long[array.length];
+
+		for (int i = 0; i < array.length; i++) {
+			newArray[i] = array[i];
+		}
+
+		return newArray;
+	}
+
 	public static Long[] toLongArray(Object[] array) {
 		Long[] newArray = new Long[array.length];
 

--- a/portal-service/src/com/liferay/portal/service/UserLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalService.java
@@ -2004,6 +2004,27 @@ public interface UserLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.User> getUsersByGroups(
+		java.lang.String keywords, long userId, long[] groupIds, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.User> getUsersBySocialRelationsTypes(
+		java.lang.String keywords, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.User> getUsersBySocialRelationsTypesGroups(
+		java.lang.String keywords, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
 	/**
 	* Returns <code>true</code> if the password policy has been assigned to the
 	* user.

--- a/portal-service/src/com/liferay/portal/service/UserLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalServiceUtil.java
@@ -2296,6 +2296,35 @@ public class UserLocalServiceUtil {
 		return getService().getUserIdByScreenName(companyId, screenName);
 	}
 
+	public static java.util.List<com.liferay.portal.model.User> getUsersByGroups(
+		java.lang.String keywords, long userId, long[] groupIds, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getUsersByGroups(keywords, userId, groupIds, start, end);
+	}
+
+	public static java.util.List<com.liferay.portal.model.User> getUsersBySocialRelationsTypes(
+		java.lang.String keywords, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getUsersBySocialRelationsTypes(keywords, userId, types,
+			groupIds, start, end);
+	}
+
+	public static java.util.List<com.liferay.portal.model.User> getUsersBySocialRelationsTypesGroups(
+		java.lang.String keywords, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getUsersBySocialRelationsTypesGroups(keywords, userId,
+			types, groupIds, start, end);
+	}
+
 	/**
 	* Returns <code>true</code> if the password policy has been assigned to the
 	* user.

--- a/portal-service/src/com/liferay/portal/service/UserLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalServiceWrapper.java
@@ -2430,6 +2430,36 @@ public class UserLocalServiceWrapper implements UserLocalService,
 		return _userLocalService.getUserIdByScreenName(companyId, screenName);
 	}
 
+	@Override
+	public java.util.List<com.liferay.portal.model.User> getUsersByGroups(
+		java.lang.String keywords, long userId, long[] groupIds, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _userLocalService.getUsersByGroups(keywords, userId, groupIds,
+			start, end);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.model.User> getUsersBySocialRelationsTypes(
+		java.lang.String keywords, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _userLocalService.getUsersBySocialRelationsTypes(keywords,
+			userId, types, groupIds, start, end);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.model.User> getUsersBySocialRelationsTypesGroups(
+		java.lang.String keywords, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _userLocalService.getUsersBySocialRelationsTypesGroups(keywords,
+			userId, types, groupIds, start, end);
+	}
+
 	/**
 	* Returns <code>true</code> if the password policy has been assigned to the
 	* user.

--- a/portal-service/src/com/liferay/portal/service/persistence/UserFinder.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/UserFinder.java
@@ -62,6 +62,19 @@ public interface UserFinder {
 	public java.util.List<com.liferay.portal.model.User> findByNoGroups()
 		throws com.liferay.portal.kernel.exception.SystemException;
 
+	public java.util.List<com.liferay.portal.model.User> findBySocialRelationTypes(
+		java.lang.String terms, long userId, int[] types, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	public java.util.List<com.liferay.portal.model.User> findByUsersGroups(
+		java.lang.String terms, long userId, long[] groupIds, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
+	public java.util.List<com.liferay.portal.model.User> findBySocialRelationTypesGroups(
+		java.lang.String terms, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException;
+
 	public java.util.List<com.liferay.portal.model.User> findByC_FN_MN_LN_SN_EA_S(
 		long companyId, java.lang.String firstName,
 		java.lang.String middleName, java.lang.String lastName,

--- a/portal-service/src/com/liferay/portal/service/persistence/UserFinderUtil.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/UserFinderUtil.java
@@ -88,6 +88,28 @@ public class UserFinderUtil {
 		return getFinder().findByNoGroups();
 	}
 
+	public static java.util.List<com.liferay.portal.model.User> findBySocialRelationTypes(
+		java.lang.String terms, long userId, int[] types, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getFinder()
+				   .findBySocialRelationTypes(terms, userId, types, start, end);
+	}
+
+	public static java.util.List<com.liferay.portal.model.User> findByUsersGroups(
+		java.lang.String terms, long userId, long[] groupIds, int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getFinder().findByUsersGroups(terms, userId, groupIds, start, end);
+	}
+
+	public static java.util.List<com.liferay.portal.model.User> findBySocialRelationTypesGroups(
+		java.lang.String terms, long userId, int[] types, long[] groupIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.SystemException {
+		return getFinder()
+				   .findBySocialRelationTypesGroups(terms, userId, types,
+			groupIds, start, end);
+	}
+
 	public static java.util.List<com.liferay.portal.model.User> findByC_FN_MN_LN_SN_EA_S(
 		long companyId, java.lang.String firstName,
 		java.lang.String middleName, java.lang.String lastName,

--- a/util-java/src/com/liferay/util/dao/orm/CustomSQL.java
+++ b/util-java/src/com/liferay/util/dao/orm/CustomSQL.java
@@ -227,10 +227,18 @@ public class CustomSQL {
 	}
 
 	public String[] keywords(String keywords) {
-		return keywords(keywords, true);
+		return keywords(
+			keywords, true, CustomSQLConstants.SURROUND_WILDCARD_MODE);
 	}
 
 	public String[] keywords(String keywords, boolean lowerCase) {
+		return keywords(
+			keywords, lowerCase, CustomSQLConstants.SURROUND_WILDCARD_MODE);
+	}
+
+	public String[] keywords(
+			String keywords, boolean lowerCase, int wildcardMode) {
+
 		if (Validator.isNull(keywords)) {
 			return new String[] {null};
 		}
@@ -262,8 +270,7 @@ public class CustomSQL {
 				if (i > pos) {
 					String keyword = keywords.substring(pos, i);
 
-					keywordsList.add(
-						StringUtil.quote(keyword, StringPool.PERCENT));
+					keywordsList.add(insertWildcard(keyword, wildcardMode));
 				}
 			}
 			else {
@@ -287,11 +294,15 @@ public class CustomSQL {
 
 				String keyword = keywords.substring(pos, i);
 
-				keywordsList.add(StringUtil.quote(keyword, StringPool.PERCENT));
+				keywordsList.add(insertWildcard(keyword, wildcardMode));
 			}
 		}
 
 		return keywordsList.toArray(new String[keywordsList.size()]);
+	}
+
+	public String[] keywords(String keywords, int wildcardMode) {
+		return keywords(keywords, true, wildcardMode);
 	}
 
 	public String[] keywords(String[] keywordsArray) {
@@ -730,6 +741,26 @@ public class CustomSQL {
 		}
 		else {
 			return new String[] {"custom-sql/default.xml"};
+		}
+	}
+
+	protected String insertWildcard(String keyword, int quoteMode) {
+		if (quoteMode ==
+				CustomSQLConstants.SURROUND_WILDCARD_MODE) {
+
+			return StringUtil.quote(keyword, StringPool.PERCENT);
+		}
+		else if (quoteMode ==
+					CustomSQLConstants.TRAILING_WILDCARD_MODE) {
+
+			return keyword + StringPool.PERCENT;
+		}
+		else {
+			throw new IllegalArgumentException(
+				"Expected one of: " +
+				CustomSQLConstants.SURROUND_WILDCARD_MODE + ", " +
+				CustomSQLConstants.TRAILING_WILDCARD_MODE +
+				"; found: " + quoteMode);
 		}
 	}
 

--- a/util-java/src/com/liferay/util/dao/orm/CustomSQLConstants.java
+++ b/util-java/src/com/liferay/util/dao/orm/CustomSQLConstants.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.util.dao.orm;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class CustomSQLConstants {
+
+	public static final int SURROUND_WILDCARD_MODE = 0;
+
+	public static final int TRAILING_WILDCARD_MODE = 1;
+
+}

--- a/util-java/src/com/liferay/util/dao/orm/CustomSQLUtil.java
+++ b/util-java/src/com/liferay/util/dao/orm/CustomSQLUtil.java
@@ -78,6 +78,16 @@ public class CustomSQLUtil {
 		return _instance._customSQL.keywords(keywords, lowerCase);
 	}
 
+	public static String[] keywords(
+		String keywords, boolean lowerCase, int wildcardMode) {
+
+		return _instance._customSQL.keywords(keywords, lowerCase, wildcardMode);
+	}
+
+	public static String[] keywords(String keywords, int wildcardMode) {
+		return _instance._customSQL.keywords(keywords, wildcardMode);
+	}
+
 	public static String[] keywords(String[] keywordsArray) {
 		return _instance._customSQL.keywords(keywordsArray);
 	}


### PR DESCRIPTION
As requested, I've generalized a little bit CustomSQL#keywords to accept an extra parameter to customize the way wildcards are used. Also, I've reused the existing finder where possible; the exception is when we are looking up users both by social relations and groups: in this case we need the union of both, but the findKeywords method returns the intersection (both SocialRelation and UsersGroups tables are included in the same JOIN clause).
