### PR TITLE
Lps 44829

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
+++ b/portal-impl/src/com/liferay/portal/events/GlobalShutdownAction.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.javadoc.JavadocManagerUtil;
 import com.liferay.portal.kernel.log.Jdk14LogFactoryImpl;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.MessageBusUtil;
 import com.liferay.portal.kernel.resiliency.mpi.MPIHelperUtil;
 import com.liferay.portal.kernel.scheduler.SchedulerEngineHelperUtil;
 import com.liferay.portal.kernel.template.TemplateManagerUtil;
@@ -57,10 +58,6 @@ public class GlobalShutdownAction extends SimpleAction {
 
 	@Override
 	public void run(String[] ids) {
-
-		// Portal Resiliency
-
-		MPIHelperUtil.shutdown();
 
 		// Auto deploy
 
@@ -226,6 +223,14 @@ public class GlobalShutdownAction extends SimpleAction {
 		// Portal executors
 
 		PortalExecutorManagerUtil.shutdown(true);
+
+		// Messaging
+
+		MessageBusUtil.shutdown(true);
+
+		// Portal Resiliency
+
+		MPIHelperUtil.shutdown();
 
 		// Programmatically exit
 

--- a/portal-impl/test/unit/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtilTest.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.nio.intraband.Datagram;
 import com.liferay.portal.kernel.nio.intraband.DatagramReceiveHandler;
 import com.liferay.portal.kernel.nio.intraband.Intraband;
 import com.liferay.portal.kernel.nio.intraband.MockIntraband;
-import com.liferay.portal.kernel.nio.intraband.MockRegistrationReference;
 import com.liferay.portal.kernel.nio.intraband.SystemDataType;
 import com.liferay.portal.kernel.nio.intraband.blocking.ExecutorIntraband;
 import com.liferay.portal.kernel.nio.intraband.nonblocking.SelectorIntraband;
@@ -32,8 +31,8 @@ import com.liferay.portal.kernel.nio.intraband.rpc.BootstrapRPCDatagramReceiveHa
 import com.liferay.portal.kernel.nio.intraband.rpc.RPCResponse;
 import com.liferay.portal.kernel.nio.intraband.welder.socket.SocketWelder;
 import com.liferay.portal.kernel.process.ProcessCallable;
-import com.liferay.portal.kernel.process.ProcessExecutor;
 import com.liferay.portal.kernel.resiliency.spi.MockSPI;
+import com.liferay.portal.kernel.resiliency.spi.MockSPIProvider;
 import com.liferay.portal.kernel.resiliency.spi.SPI;
 import com.liferay.portal.kernel.resiliency.spi.SPIConfiguration;
 import com.liferay.portal.kernel.resiliency.spi.SPIRegistryUtil;
@@ -53,7 +52,6 @@ import com.liferay.portal.test.AspectJMockingNewClassLoaderJUnitTestRunner;
 
 import java.io.IOException;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 
@@ -62,7 +60,7 @@ import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
 
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -217,13 +215,6 @@ public class MPIHelperUtilTest {
 	@AdviseWith(adviceClasses = {PropsUtilAdvice.class})
 	@Test
 	public void testShutdownFailWithLog() throws Exception {
-		MockSPI mockSPI = new MockSPI();
-
-		ConcurrentMap<String, Object> attributes =
-			ProcessExecutor.ProcessContext.getAttributes();
-
-		attributes.put(SPI.SPI_INSTANCE_PUBLICATION_KEY, mockSPI);
-
 		UnicastRemoteObject.unexportObject(_getMPIImpl(), true);
 
 		final IOException ioException = new IOException();
@@ -247,28 +238,21 @@ public class MPIHelperUtilTest {
 
 			List<LogRecord> logRecords = captureHandler.getLogRecords();
 
-			Assert.assertEquals(3, logRecords.size());
+			Assert.assertEquals(2, logRecords.size());
 
 			LogRecord logRecord = logRecords.get(0);
 
-			Assert.assertEquals(
-				"Unable to unregister from MPI", logRecord.getMessage());
-
-			Throwable throwable = logRecord.getThrown();
-
-			Assert.assertSame(RemoteException.class, throwable.getClass());
-
-			logRecord = logRecords.get(1);
+			logRecord = logRecords.get(0);
 
 			Assert.assertEquals(
 				"Unable to unexport " + _getMPIImpl(), logRecord.getMessage());
 
-			throwable = logRecord.getThrown();
+			Throwable throwable = logRecord.getThrown();
 
 			Assert.assertSame(
 				NoSuchObjectException.class, throwable.getClass());
 
-			logRecord = logRecords.get(2);
+			logRecord = logRecords.get(1);
 
 			Assert.assertEquals(
 				"Unable to close intraband", logRecord.getMessage());
@@ -282,13 +266,6 @@ public class MPIHelperUtilTest {
 	@AdviseWith(adviceClasses = {PropsUtilAdvice.class})
 	@Test
 	public void testShutdownFailWithoutLog() throws Exception {
-		MockSPI mockSPI = new MockSPI();
-
-		ConcurrentMap<String, Object> attributes =
-			ProcessExecutor.ProcessContext.getAttributes();
-
-		attributes.put(SPI.SPI_INSTANCE_PUBLICATION_KEY, mockSPI);
-
 		UnicastRemoteObject.unexportObject(_getMPIImpl(), true);
 
 		final IOException ioException = new IOException();
@@ -354,25 +331,6 @@ public class MPIHelperUtilTest {
 
 		};
 
-		MockSPI mockSPI = new MockSPI();
-
-		mockSPI.mpi = MPIHelperUtil.getMPI();
-		mockSPI.registrationReference = new MockRegistrationReference(
-			mockIntraband);
-		mockSPI.spiConfiguration = new SPIConfiguration(
-			"spiId", null, -1, null, new String[0], new String[0], null);
-		mockSPI.spiProviderName = "spiProviderName";
-
-		Assert.assertTrue(
-			MPIHelperUtil.registerSPIProvider(
-				new MockSPIProvider(mockSPI.spiProviderName)));
-		Assert.assertTrue(MPIHelperUtil.registerSPI(mockSPI));
-
-		ConcurrentMap<String, Object> attributes =
-			ProcessExecutor.ProcessContext.getAttributes();
-
-		attributes.put(SPI.SPI_INSTANCE_PUBLICATION_KEY, mockSPI);
-
 		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
 			MPIHelperUtil.class.getName(), Level.ALL);
 
@@ -381,39 +339,11 @@ public class MPIHelperUtilTest {
 
 			List<LogRecord> logRecords = captureHandler.getLogRecords();
 
-			Assert.assertEquals(1, logRecords.size());
-
-			LogRecord logRecord = logRecords.get(0);
-
-			Assert.assertEquals(
-				"Unregistered SPI " + mockSPI, logRecord.getMessage());
+			Assert.assertTrue(logRecords.isEmpty());
 		}
 		finally {
 			captureHandler.close();
 		}
-	}
-
-	@AdviseWith(adviceClasses = {PropsUtilAdvice.class})
-	@Test
-	public void testSPIKey() throws Exception {
-
-		// SPI provider name does not match
-
-		Object spiKey1 = _createSPIKey("name1", "id1");
-		Object spiKey2 = _createSPIKey("name2", "id1");
-
-		Assert.assertFalse(spiKey1.equals(spiKey2));
-		Assert.assertEquals("name1#id1", spiKey1.toString());
-		Assert.assertEquals("name2#id1", spiKey2.toString());
-
-		// SPI id does not match
-
-		spiKey1 = _createSPIKey("name1", "id1");
-		spiKey2 = _createSPIKey("name1", "id2");
-
-		Assert.assertFalse(spiKey1.equals(spiKey2));
-		Assert.assertEquals("name1#id1", spiKey1.toString());
-		Assert.assertEquals("name1#id2", spiKey2.toString());
 	}
 
 	@AdviseWith(adviceClasses = {PropsUtilAdvice.class})
@@ -549,6 +479,100 @@ public class MPIHelperUtilTest {
 				MPIHelperUtil.unregisterSPIProvider(mockSPIProvider3));
 			Assert.assertTrue(logRecords.isEmpty());
 
+			// Unregister SPI provider, mismatch instance, with log
+
+			logRecords = captureHandler.resetLogLevel(Level.INFO);
+
+			Assert.assertFalse(
+				MPIHelperUtil.unregisterSPIProvider(
+					new MockSPIProvider(name2)));
+			Assert.assertEquals(1, logRecords.size());
+
+			logRecord1 = logRecords.get(0);
+
+			Assert.assertEquals(
+				"Not unregistering unregistered SPI provider " + name2,
+				logRecord1.getMessage());
+
+			// Unregister SPI provider, mismatch instance, without log
+
+			logRecords = captureHandler.resetLogLevel(Level.OFF);
+
+			Assert.assertFalse(
+				MPIHelperUtil.unregisterSPIProvider(
+					new MockSPIProvider(name2)));
+			Assert.assertTrue(logRecords.isEmpty());
+
+			// Unregister SPI provider, concurrent remove failure, with log
+
+			logRecords = captureHandler.resetLogLevel(Level.INFO);
+
+			ConcurrentMap<String, Object> oldSPIProviderContainers =
+				(ConcurrentMap<String, Object>)ReflectionTestUtil.getFieldValue(
+					MPIHelperUtil.class, "_spiProviderContainers");
+
+			try {
+				ReflectionTestUtil.setFieldValue(
+					MPIHelperUtil.class, "_spiProviderContainers",
+					new ConcurrentHashMap<String, Object>(
+						oldSPIProviderContainers) {
+
+						@Override
+						public boolean remove(Object key, Object value) {
+							return false;
+						}
+
+					});
+
+				Assert.assertFalse(
+					MPIHelperUtil.unregisterSPIProvider(mockSPIProvider2));
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					MPIHelperUtil.class, "_spiProviderContainers",
+					oldSPIProviderContainers);
+			}
+
+			Assert.assertEquals(1, logRecords.size());
+
+			logRecord1 = logRecords.get(0);
+
+			Assert.assertEquals(
+				"Not unregistering unregistered SPI provider " + name2,
+				logRecord1.getMessage());
+
+			// Unregister SPI provider, concurrent remove failure, without log
+
+			logRecords = captureHandler.resetLogLevel(Level.OFF);
+
+			oldSPIProviderContainers =
+				(ConcurrentMap<String, Object>)ReflectionTestUtil.getFieldValue(
+					MPIHelperUtil.class, "_spiProviderContainers");
+
+			try {
+				ReflectionTestUtil.setFieldValue(
+					MPIHelperUtil.class, "_spiProviderContainers",
+					new ConcurrentHashMap<String, Object>(
+						oldSPIProviderContainers) {
+
+						@Override
+						public boolean remove(Object key, Object value) {
+							return false;
+						}
+
+					});
+
+				Assert.assertFalse(
+					MPIHelperUtil.unregisterSPIProvider(mockSPIProvider2));
+			}
+			finally {
+				ReflectionTestUtil.setFieldValue(
+					MPIHelperUtil.class, "_spiProviderContainers",
+					oldSPIProviderContainers);
+			}
+
+			Assert.assertTrue(logRecords.isEmpty());
+
 			// Unregister SPI provider, with no SPI, with log
 
 			logRecords = captureHandler.resetLogLevel(Level.INFO);
@@ -590,14 +614,14 @@ public class MPIHelperUtilTest {
 			mockSPI1.failOnStop = true;
 			mockSPI1.spiProviderName = name1;
 
-			_directResigterSPI("spi1", mockSPI1);
+			MPIHelperUtilTestUtil.directResigterSPI("spi1", mockSPI1);
 
 			MockSPI mockSPI2 = new MockSPI();
 
 			mockSPI2.failOnStop = true;
 			mockSPI2.spiProviderName = name2;
 
-			_directResigterSPI("spi2", mockSPI2);
+			MPIHelperUtilTestUtil.directResigterSPI("spi2", mockSPI2);
 
 			Assert.assertTrue(
 				MPIHelperUtil.unregisterSPIProvider(mockSPIProvider1));
@@ -636,6 +660,43 @@ public class MPIHelperUtilTest {
 			Assert.assertTrue(mockSPI2.stopped);
 			Assert.assertTrue(logRecords.isEmpty());
 
+			// Unregister SPI provider, with SPI, fail on catch, without log
+
+			logRecords = captureHandler.resetLogLevel(Level.OFF);
+
+			mockSPIProvider1 = new MockSPIProvider(name1);
+
+			Assert.assertTrue(
+				MPIHelperUtil.registerSPIProvider(mockSPIProvider1));
+
+			final RuntimeException runtimeException = new RuntimeException();
+
+			mockSPI1 = new MockSPI() {
+
+				@Override
+				public String toString() {
+					throw runtimeException;
+				}
+
+			};
+
+			mockSPI1.failOnStop = false;
+			mockSPI1.failOnDestroy = true;
+			mockSPI1.spiProviderName = name1;
+
+			MPIHelperUtilTestUtil.directResigterSPI(name1, mockSPI1);
+
+			try {
+				MPIHelperUtil.unregisterSPIProvider(mockSPIProvider1);
+
+				Assert.fail();
+			}
+			catch (RuntimeException re) {
+				Assert.assertSame(runtimeException, re);
+			}
+
+			Assert.assertTrue(logRecords.isEmpty());
+
 			// Unregister SPI provider, with SPI, success, with log
 
 			mockSPIProvider1 = new MockSPIProvider(name1);
@@ -653,14 +714,14 @@ public class MPIHelperUtilTest {
 			mockSPI1.failOnDestroy = false;
 			mockSPI1.spiProviderName = name1;
 
-			_directResigterSPI("spi1", mockSPI1);
+			MPIHelperUtilTestUtil.directResigterSPI("spi1", mockSPI1);
 
 			mockSPI2 = new MockSPI();
 
 			mockSPI2.failOnDestroy = false;
 			mockSPI2.spiProviderName = name2;
 
-			_directResigterSPI("spi2", mockSPI2);
+			MPIHelperUtilTestUtil.directResigterSPI("spi2", mockSPI2);
 
 			logRecords = captureHandler.resetLogLevel(Level.INFO);
 
@@ -704,7 +765,7 @@ public class MPIHelperUtilTest {
 
 	@AdviseWith(adviceClasses = {PropsUtilAdvice.class})
 	@Test
-	public void testSPIRegistration() {
+	public void testSPIRegistration() throws Exception {
 		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
 			MPIHelperUtil.class.getName(), Level.WARNING);
 
@@ -886,6 +947,10 @@ public class MPIHelperUtilTest {
 				Assert.assertSame(RemoteException.class, throwable.getClass());
 			}
 
+			// Get SPI, no such SPI provider
+
+			Assert.assertNull(MPIHelperUtil.getSPI("name2", "testId1"));
+
 			// Get SPI, exists
 
 			Assert.assertNotNull(MPIHelperUtil.getSPI(name, "testId1"));
@@ -941,6 +1006,26 @@ public class MPIHelperUtilTest {
 			spis = MPIHelperUtil.getSPIs("name2");
 
 			Assert.assertTrue(spis.isEmpty());
+
+			// Unregister ThreadLocal shortcut, with log
+
+			mockSPI1 = new MockSPI();
+
+			mockSPI1.spiConfiguration = new SPIConfiguration(
+				null, null, 0, null, null, new String[0], null);
+
+			ThreadLocal<SPI> unregisteringSPIThreadLocal =
+				(ThreadLocal<SPI>)ReflectionTestUtil.getFieldValue(
+					MPIHelperUtil.class, "_unregisteringSPIThreadLocal");
+
+			unregisteringSPIThreadLocal.set(mockSPI1);
+
+			try {
+				Assert.assertTrue(MPIHelperUtil.unregisterSPI(mockSPI1));
+			}
+			finally {
+				unregisteringSPIThreadLocal.remove();
+			}
 
 			// Unregister MPI mismatch, with log
 
@@ -1075,32 +1160,6 @@ public class MPIHelperUtilTest {
 		}
 	}
 
-	private static Object _createSPIKey(String spiProviderName, String spiId)
-		throws Exception {
-
-		Class<?> spiKeyClass = Class.forName(
-			MPIHelperUtil.class.getName().concat("$SPIKey"));
-
-		Constructor<?> spiKeyConstructor = spiKeyClass.getConstructor(
-			String.class, String.class);
-
-		return spiKeyConstructor.newInstance(spiProviderName, spiId);
-	}
-
-	private static Object _directResigterSPI(String spiId, SPI spi)
-		throws Exception {
-
-		Map<Object, SPI> spis =
-			(Map<Object, SPI>)ReflectionTestUtil.getFieldValue(
-				MPIHelperUtil.class, "_spis");
-
-		Object spiKey = _createSPIKey(spi.getSPIProviderName(), spiId);
-
-		spis.put(spiKey, spi);
-
-		return spiKey;
-	}
-
 	private static MPI _getMPIImpl() throws Exception {
 		MPI mpiImpl = (MPI)ReflectionTestUtil.getFieldValue(
 			MPIHelperUtil.class, "_mpiImpl");
@@ -1117,25 +1176,6 @@ public class MPIHelperUtilTest {
 			return true;
 		}
 
-	}
-
-	private static class MockSPIProvider implements SPIProvider {
-
-		public MockSPIProvider(String name) {
-			_name = name;
-		}
-
-		@Override
-		public SPI createSPI(SPIConfiguration spiConfiguration) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getName() {
-			return _name;
-		}
-
-		private String _name;
 	}
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/messaging/DefaultMessageBus.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/DefaultMessageBus.java
@@ -54,10 +54,6 @@ public class DefaultMessageBus implements MessageBus {
 		}
 	}
 
-	public void destroy() {
-		shutdown(true);
-	}
-
 	@Override
 	public Destination getDestination(String destinationName) {
 		return _destinations.get(destinationName);

--- a/portal-service/src/com/liferay/portal/kernel/process/ProcessExecutor.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/ProcessExecutor.java
@@ -614,8 +614,7 @@ public class ProcessExecutor {
 					int exitCode = _process.waitFor();
 
 					if (exitCode != 0) {
-						throw new ProcessException(
-							"Subprocess terminated with exit code " + exitCode);
+						throw new TerminationProcessException(exitCode);
 					}
 				}
 				catch (InterruptedException ie) {

--- a/portal-service/src/com/liferay/portal/kernel/process/ProcessUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/ProcessUtil.java
@@ -233,8 +233,7 @@ public class ProcessUtil {
 					int exitCode = _process.waitFor();
 
 					if (exitCode != 0) {
-						throw new ProcessException(
-							"Subprocess terminated with exit code " + exitCode);
+						throw new TerminationProcessException(exitCode);
 					}
 				}
 				catch (InterruptedException ie) {

--- a/portal-service/src/com/liferay/portal/kernel/process/TerminationProcessException.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/TerminationProcessException.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.process;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class TerminationProcessException extends ProcessException {
+
+	public TerminationProcessException(int exitCode) {
+		this("Subprocess terminated with exit code " + exitCode, exitCode);
+	}
+
+	public TerminationProcessException(String message, int exitCode) {
+		super(message);
+
+		_exitCode = exitCode;
+	}
+
+	public int getExitCode() {
+		return _exitCode;
+	}
+
+	private int _exitCode;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/resiliency/spi/remote/RemoteSPI.java
+++ b/portal-service/src/com/liferay/portal/kernel/resiliency/spi/remote/RemoteSPI.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.deploy.hot.DependencyManagementThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.nio.intraband.RegistrationReference;
+import com.liferay.portal.kernel.nio.intraband.rpc.IntrabandRPCUtil;
 import com.liferay.portal.kernel.nio.intraband.welder.Welder;
 import com.liferay.portal.kernel.nio.intraband.welder.WelderFactoryUtil;
 import com.liferay.portal.kernel.process.ProcessCallable;
@@ -46,6 +47,9 @@ import java.rmi.server.UnicastRemoteObject;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Shuyang Zhou
@@ -104,6 +108,22 @@ public abstract class RemoteSPI implements ProcessCallable<SPI>, Remote, SPI {
 	}
 
 	@Override
+	public void destroy() throws RemoteException {
+		try {
+			doDestroy();
+
+			if (countDownLatch != null) {
+				countDownLatch.countDown();
+			}
+		}
+		finally {
+			UnicastRemoteObject.unexportObject(RemoteSPI.this, true);
+		}
+	}
+
+	public abstract void doDestroy() throws RemoteException;
+
+	@Override
 	public MPI getMPI() {
 		return mpi;
 	}
@@ -141,6 +161,7 @@ public abstract class RemoteSPI implements ProcessCallable<SPI>, Remote, SPI {
 		return true;
 	}
 
+	protected transient CountDownLatch countDownLatch;
 	protected final MPI mpi;
 	protected RegistrationReference registrationReference;
 	protected transient volatile SPIAgent spiAgent;
@@ -174,15 +195,112 @@ public abstract class RemoteSPI implements ProcessCallable<SPI>, Remote, SPI {
 
 	}
 
+	protected static class UnregisterSPIProcessCallable
+		implements ProcessCallable<Boolean> {
+
+		public UnregisterSPIProcessCallable(
+			String spiProviderName, String spiId) {
+
+			_spiProviderName = spiProviderName;
+			_spiId = spiId;
+		}
+
+		@Override
+		public Boolean call() {
+			SPI spi = MPIHelperUtil.getSPI(_spiProviderName, _spiId);
+
+			if (spi != null) {
+				return MPIHelperUtil.unregisterSPI(spi);
+			}
+
+			return false;
+		}
+
+		private static final long serialVersionUID = 1L;
+
+		private String _spiProviderName;
+		private String _spiId;
+
+	}
+
 	protected class SPIShutdownHook
 		extends Thread implements ProcessExecutor.ShutdownHook {
 
 		public SPIShutdownHook() {
+			setDaemon(true);
 			setName(SPIShutdownHook.class.getSimpleName());
 		}
 
 		@Override
 		public void run() {
+			if (countDownLatch.getCount() == 0) {
+				return;
+			}
+
+			boolean unregistered = false;
+
+			try {
+				Future<Boolean> future = IntrabandRPCUtil.execute(
+					registrationReference,
+					new UnregisterSPIProcessCallable(
+						getSPIProviderName(), spiConfiguration.getSPIId()));
+
+				unregistered = future.get();
+			}
+			catch (Exception e) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Unable to unregister SPI from MPI", e);
+				}
+			}
+
+			if (unregistered || !waitForMPI()) {
+				doShutdown();
+			}
+		}
+
+		@Override
+		public boolean shutdown(int shutdownCode, Throwable shutdownThrowable) {
+			Runtime runtime = Runtime.getRuntime();
+
+			runtime.removeShutdownHook(this);
+
+			doShutdown();
+
+			return true;
+		}
+
+		private boolean waitForMPI() {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Wait for MPI initiated shutdown, up to " +
+						spiConfiguration.getShutdownTimeout() + " ms");
+			}
+
+			try {
+				if (countDownLatch.await(
+						spiConfiguration.getShutdownTimeout(),
+						TimeUnit.MILLISECONDS)) {
+
+					if (_log.isInfoEnabled()) {
+						_log.info("MPI shutdown request received");
+					}
+
+					return true;
+				}
+			}
+			catch (InterruptedException ie) {
+			}
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"MPI shutdown waiting timed out, preceeding with SPI " +
+						"shutdown");
+			}
+
+			return false;
+		}
+
+		private void doShutdown() {
 			try {
 				RemoteSPI.this.stop();
 			}
@@ -196,17 +314,6 @@ public abstract class RemoteSPI implements ProcessCallable<SPI>, Remote, SPI {
 			catch (RemoteException re) {
 				_log.error("Unable to destroy SPI", re);
 			}
-		}
-
-		@Override
-		public boolean shutdown(int shutdownCode, Throwable shutdownThrowable) {
-			Runtime runtime = Runtime.getRuntime();
-
-			runtime.removeShutdownHook(this);
-
-			run();
-
-			return true;
 		}
 
 	}
@@ -257,6 +364,8 @@ public abstract class RemoteSPI implements ProcessCallable<SPI>, Remote, SPI {
 		// Log4j log file postfix
 
 		System.setProperty("spi.id", "-" + spiConfiguration.getSPIId());
+
+		countDownLatch = new CountDownLatch(1);
 	}
 
 	private void writeObject(ObjectOutputStream objectOutputStream)

--- a/portal-service/test/unit/com/liferay/portal/kernel/nio/intraband/messaging/IntrabandBridgeDestinationTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/nio/intraband/messaging/IntrabandBridgeDestinationTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.nio.intraband.RegistrationReference;
 import com.liferay.portal.kernel.process.ProcessExecutor;
 import com.liferay.portal.kernel.resiliency.mpi.MPIHelperUtil;
 import com.liferay.portal.kernel.resiliency.spi.MockSPI;
+import com.liferay.portal.kernel.resiliency.spi.MockSPIProvider;
 import com.liferay.portal.kernel.resiliency.spi.SPI;
 import com.liferay.portal.kernel.resiliency.spi.SPIConfiguration;
 import com.liferay.portal.kernel.test.CodeCoverageAssertor;
@@ -44,7 +45,6 @@ import java.nio.ByteBuffer;
 import java.rmi.RemoteException;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -389,6 +389,29 @@ public class IntrabandBridgeDestinationTest {
 		Assert.assertNull(message.get(_RECEIVE_KEY));
 	}
 
+	private static void _installSPIs(SPI... spis) throws Exception {
+
+		Map<String, Object> spiProviderContainers =
+			(Map<String, Object>)ReflectionTestUtil.getFieldValue(
+				MPIHelperUtil.class, "_spiProviderContainers");
+
+		for (SPI spi : spis) {
+			MPIHelperUtil.registerSPIProvider(
+				new MockSPIProvider(spi.getSPIProviderName()));
+
+			Object spiProviderContainer = spiProviderContainers.get(
+				spi.getSPIProviderName());
+
+			Map<String, SPI> spiMap =
+				(Map<String, SPI>)ReflectionTestUtil.getFieldValue(
+					spiProviderContainer, "_spis");
+
+			SPIConfiguration spiConfiguration = spi.getSPIConfiguration();
+
+			spiMap.put(spiConfiguration.getSPIId(), spi);
+		}
+	}
+
 	private MessageRoutingBag _createMessageRoutingBag() {
 		Message message = new Message();
 
@@ -413,18 +436,6 @@ public class IntrabandBridgeDestinationTest {
 		mockSPI.spiProviderName = spiProviderName;
 
 		return mockSPI;
-	}
-
-	private void _installSPIs(SPI... spis) throws Exception {
-		Map<String, SPI> spisMap = new ConcurrentHashMap<String, SPI>();
-
-		for (SPI spi : spis) {
-			SPIConfiguration spiConfiguration = spi.getSPIConfiguration();
-
-			spisMap.put(spiConfiguration.getSPIId(), spi);
-		}
-
-		ReflectionTestUtil.setFieldValue(MPIHelperUtil.class, "_spis", spisMap);
 	}
 
 	private String _toRoutingId(SPI spi) throws RemoteException {

--- a/portal-service/test/unit/com/liferay/portal/kernel/process/ProcessExecutorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/process/ProcessExecutorTest.java
@@ -541,10 +541,10 @@ public class ProcessExecutorTest {
 
 		try {
 
-			// Negative one crash
+			// One crash
 
 			KillJVMProcessCallable killJVMProcessCallable =
-				new KillJVMProcessCallable(-1);
+				new KillJVMProcessCallable(1);
 
 			Future<Serializable> future = ProcessExecutor.execute(
 				_classPath, killJVMProcessCallable);
@@ -560,7 +560,17 @@ public class ProcessExecutorTest {
 
 				Throwable throwable = ee.getCause();
 
-				Assert.assertTrue(throwable instanceof ProcessException);
+				Assert.assertSame(
+					TerminationProcessException.class, throwable.getClass());
+				Assert.assertEquals(
+					"Subprocess terminated with exit code 1",
+					throwable.getMessage());
+
+				TerminationProcessException terminationProcessException =
+					(TerminationProcessException)throwable;
+
+				Assert.assertEquals(
+					1, terminationProcessException.getExitCode());
 			}
 
 			// Zero crash
@@ -581,11 +591,11 @@ public class ProcessExecutorTest {
 
 				Throwable throwable = ee.getCause();
 
-				Assert.assertTrue(throwable instanceof ProcessException);
+				Assert.assertSame(ProcessException.class, throwable.getClass());
 
 				throwable = throwable.getCause();
 
-				Assert.assertTrue(throwable instanceof EOFException);
+				Assert.assertSame(EOFException.class, throwable.getClass());
 			}
 		}
 		finally {

--- a/portal-service/test/unit/com/liferay/portal/kernel/process/ProcessUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/process/ProcessUtilTest.java
@@ -268,10 +268,17 @@ public class ProcessUtilTest {
 		catch (ExecutionException ee) {
 			Throwable throwable = ee.getCause();
 
-			Assert.assertEquals(ProcessException.class, throwable.getClass());
+			Assert.assertSame(
+				TerminationProcessException.class, throwable.getClass());
 			Assert.assertEquals(
 				"Subprocess terminated with exit code " + ErrorExit.EXIT_CODE,
 				throwable.getMessage());
+
+			TerminationProcessException terminationProcessException =
+				(TerminationProcessException)throwable;
+
+			Assert.assertEquals(
+				ErrorExit.EXIT_CODE, terminationProcessException.getExitCode());
 		}
 	}
 

--- a/portal-service/test/unit/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtilTestUtil.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/resiliency/mpi/MPIHelperUtilTestUtil.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.resiliency.mpi;
+
+import com.liferay.portal.kernel.resiliency.spi.SPI;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+
+import java.util.Map;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class MPIHelperUtilTestUtil {
+
+	public static void directResigterSPI(String spiId, SPI spi)
+		throws Exception {
+
+		Map<String, Object> spiProviderContainers =
+			(Map<String, Object>)ReflectionTestUtil.getFieldValue(
+				MPIHelperUtil.class, "_spiProviderContainers");
+
+		Object spiProviderContainer = spiProviderContainers.get(
+			spi.getSPIProviderName());
+
+		Map<String, SPI> spis =
+			(Map<String, SPI>)ReflectionTestUtil.getFieldValue(
+				spiProviderContainer, "_spis");
+
+		spis.put(spiId, spi);
+	}
+
+}

--- a/portal-service/test/unit/com/liferay/portal/kernel/resiliency/spi/MockRemoteSPI.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/resiliency/spi/MockRemoteSPI.java
@@ -41,7 +41,7 @@ public class MockRemoteSPI extends RemoteSPI {
 	}
 
 	@Override
-	public void destroy() throws RemoteException {
+	public void doDestroy() throws RemoteException {
 		if (_failOnDestroy) {
 			throw new RemoteException();
 		}
@@ -49,7 +49,7 @@ public class MockRemoteSPI extends RemoteSPI {
 
 	@Override
 	public String getSPIProviderName() {
-		throw new UnsupportedOperationException();
+		return _spiProviderName;
 	}
 
 	@Override
@@ -63,6 +63,10 @@ public class MockRemoteSPI extends RemoteSPI {
 
 	public void setFailOnStop(boolean failOnStop) {
 		_failOnStop = failOnStop;
+	}
+
+	public void setSpiProviderName(String spiProviderName) {
+		_spiProviderName = spiProviderName;
 	}
 
 	@Override
@@ -79,5 +83,6 @@ public class MockRemoteSPI extends RemoteSPI {
 
 	private boolean _failOnDestroy;
 	private boolean _failOnStop;
+	private String _spiProviderName;
 
 }

--- a/portal-service/test/unit/com/liferay/portal/kernel/resiliency/spi/MockSPIProvider.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/resiliency/spi/MockSPIProvider.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.resiliency.spi;
+
+import com.liferay.portal.kernel.resiliency.spi.provider.SPIProvider;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class MockSPIProvider implements SPIProvider {
+
+	public MockSPIProvider() {
+		this(MockSPIProvider.class.getName());
+	}
+
+	public MockSPIProvider(String name) {
+		_name = name;
+	}
+
+	@Override
+	public SPI createSPI(SPIConfiguration spiConfiguration) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getName() {
+		return _name;
+	}
+
+	public void setName(String name) {
+		_name = name;
+	}
+
+	@Override
+	public String toString() {
+		return _name;
+	}
+
+	private String _name;
+
+}

--- a/portal-service/test/unit/com/liferay/portal/kernel/resiliency/spi/remote/RemoteSPITest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/resiliency/spi/remote/RemoteSPITest.java
@@ -14,9 +14,16 @@
 
 package com.liferay.portal.kernel.resiliency.spi.remote;
 
+import com.liferay.portal.kernel.deploy.hot.DependencyManagementThreadLocal;
+import com.liferay.portal.kernel.io.Serializer;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.kernel.nio.intraband.Datagram;
+import com.liferay.portal.kernel.nio.intraband.MockIntraband;
+import com.liferay.portal.kernel.nio.intraband.MockRegistrationReference;
+import com.liferay.portal.kernel.nio.intraband.RegistrationReference;
 import com.liferay.portal.kernel.nio.intraband.blocking.ExecutorIntraband;
+import com.liferay.portal.kernel.nio.intraband.rpc.RPCResponse;
 import com.liferay.portal.kernel.nio.intraband.welder.Welder;
 import com.liferay.portal.kernel.process.ProcessCallable;
 import com.liferay.portal.kernel.process.ProcessException;
@@ -24,31 +31,40 @@ import com.liferay.portal.kernel.process.ProcessExecutor;
 import com.liferay.portal.kernel.process.ProcessExecutor.ProcessContext;
 import com.liferay.portal.kernel.process.log.ProcessOutputStream;
 import com.liferay.portal.kernel.resiliency.mpi.MPIHelperUtil;
+import com.liferay.portal.kernel.resiliency.mpi.MPIHelperUtilTestUtil;
 import com.liferay.portal.kernel.resiliency.spi.MockRemoteSPI;
+import com.liferay.portal.kernel.resiliency.spi.MockSPI;
+import com.liferay.portal.kernel.resiliency.spi.MockSPIProvider;
 import com.liferay.portal.kernel.resiliency.spi.MockWelder;
 import com.liferay.portal.kernel.resiliency.spi.SPI;
 import com.liferay.portal.kernel.resiliency.spi.SPIConfiguration;
+import com.liferay.portal.kernel.resiliency.spi.SPIRegistry;
+import com.liferay.portal.kernel.resiliency.spi.SPIRegistryUtil;
 import com.liferay.portal.kernel.resiliency.spi.agent.MockSPIAgent;
 import com.liferay.portal.kernel.resiliency.spi.agent.SPIAgent;
 import com.liferay.portal.kernel.resiliency.spi.agent.SPIAgentFactoryUtil;
 import com.liferay.portal.kernel.resiliency.spi.provider.SPISynchronousQueueUtil;
 import com.liferay.portal.kernel.resiliency.spi.remote.RemoteSPI.RegisterCallback;
 import com.liferay.portal.kernel.resiliency.spi.remote.RemoteSPI.SPIShutdownHook;
+import com.liferay.portal.kernel.resiliency.spi.remote.RemoteSPI.UnregisterSPIProcessCallable;
 import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.ProxyUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ReflectPermission;
 
+import java.rmi.NoSuchObjectException;
 import java.rmi.RemoteException;
 import java.rmi.server.ExportException;
 import java.rmi.server.UnicastRemoteObject;
@@ -56,12 +72,16 @@ import java.rmi.server.UnicastRemoteObject;
 import java.security.Permission;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -95,11 +115,31 @@ public class RemoteSPITest {
 
 	@Before
 	public void setUp() {
-		_spiConfiguration = new SPIConfiguration(
-			"spiId", MockSPIAgent.class.getName(), 8081, "", new String[0],
-			new String[0], null);
+		_spiConfiguration =
+			new SPIConfiguration(
+				"spiId", null, null, MockSPIAgent.class.getName(), 8081, null,
+				new String[0], new String[0], 5000, 0, 0, null);
 
 		_mockRemoteSPI = new MockRemoteSPI(_spiConfiguration);
+
+		_mockRemoteSPI.countDownLatch = new CountDownLatch(1);
+
+		SPIRegistryUtil spiRegistryUtil = new SPIRegistryUtil();
+
+		spiRegistryUtil.setSPIRegistry(
+			(SPIRegistry)ProxyUtil.newProxyInstance(
+				RemoteSPITest.class.getClassLoader(),
+				new Class<?>[] {SPIRegistry.class},
+				new InvocationHandler() {
+
+					@Override
+					public Object invoke(
+						Object proxy, Method method, Object[] args) {
+
+						return null;
+					}
+
+				}));
 	}
 
 	@Test
@@ -210,6 +250,54 @@ public class RemoteSPITest {
 	}
 
 	@Test
+	public void testDestroy() throws RemoteException {
+
+		// Unexport failure
+
+		try {
+			_mockRemoteSPI.destroy();
+
+			Assert.fail();
+		}
+		catch (RemoteException re) {
+			Assert.assertSame(NoSuchObjectException.class, re.getClass());
+		}
+
+		CountDownLatch countDownLatch = _mockRemoteSPI.countDownLatch;
+
+		Assert.assertEquals(0, countDownLatch.getCount());
+
+		// Destroy failure
+
+		_mockRemoteSPI.setFailOnDestroy(true);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		try {
+			_mockRemoteSPI.destroy();
+
+			Assert.fail();
+		}
+		catch (RemoteException re) {
+			Assert.assertSame(RemoteException.class, re.getClass());
+		}
+
+		assertUnexported();
+
+		// Success destroy
+
+		_mockRemoteSPI.countDownLatch = null;
+
+		_mockRemoteSPI.setFailOnDestroy(false);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		_mockRemoteSPI.destroy();
+
+		assertUnexported();
+	}
+
+	@Test
 	public void testRegisterCallback() throws Exception {
 
 		// Success
@@ -289,7 +377,11 @@ public class RemoteSPITest {
 		ObjectInputStream objectInputStream = new ObjectInputStream(
 			new UnsyncByteArrayInputStream(data));
 
+		Assert.assertTrue(DependencyManagementThreadLocal.isEnabled());
+
 		Object object = objectInputStream.readObject();
+
+		Assert.assertFalse(DependencyManagementThreadLocal.isEnabled());
 
 		Assert.assertSame(MockRemoteSPI.class, object.getClass());
 
@@ -405,30 +497,346 @@ public class RemoteSPITest {
 	}
 
 	@Test
-	public void testSPIShutdownHook() {
+	public void testSPIShutdownHookRun1() {
 
-		// Peaceful shutdown
+		// Shortcut
+
+		_mockRemoteSPI.countDownLatch = new CountDownLatch(0);
 
 		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
 
-		Assert.assertTrue(spiShutdownHook.shutdown(0, null));
-
-		CaptureHandler captureHandler = null;
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.ALL);
 
 		try {
-
-			// Unable to stop with log
-
-			captureHandler = JDKLoggerTestUtil.configureJDKLogger(
-				RemoteSPI.class.getName(), Level.SEVERE);
+			spiShutdownHook.run();
 
 			List<LogRecord> logRecords = captureHandler.getLogRecords();
 
-			_mockRemoteSPI.setFailOnStop(true);
+			Assert.assertTrue(logRecords.isEmpty());
+		}
+		finally {
+			captureHandler.close();
+		}
+	}
 
+	@Test
+	public void testSPIShutdownHookRun2() throws RemoteException {
+
+		// Unable to unregister and MPI waiting timed out, with log
+
+		String spiProviderName = "spiProviderName";
+
+		MockSPIProvider mockSPIProvider = new MockSPIProvider(spiProviderName);
+
+		MPIHelperUtil.registerSPIProvider(mockSPIProvider);
+
+		_mockRemoteSPI.setFailOnStop(false);
+		_mockRemoteSPI.setSpiProviderName(spiProviderName);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		MPIHelperUtil.registerSPI(_mockRemoteSPI);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.ALL);
+
+		try {
+			spiShutdownHook.run();
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertEquals(3, logRecords.size());
+
+			LogRecord logRecord = logRecords.get(0);
+
+			Assert.assertEquals(
+				"Unable to unregister SPI from MPI", logRecord.getMessage());
+
+			Throwable throwable = logRecord.getThrown();
+
+			Assert.assertSame(NullPointerException.class, throwable.getClass());
+
+			logRecord = logRecords.get(1);
+
+			Assert.assertEquals(
+				"Wait for MPI initiated shutdown, up to " +
+					_spiConfiguration.getShutdownTimeout() + " ms",
+				logRecord.getMessage());
+
+			logRecord = logRecords.get(2);
+
+			Assert.assertEquals(
+				"MPI shutdown waiting timed out, preceeding with SPI shutdown",
+				logRecord.getMessage());
+		}
+		finally {
+			captureHandler.close();
+		}
+
+		assertUnexported();
+	}
+
+	@Test
+	public void testSPIShutdownHookRun3() throws RemoteException {
+
+		// Unable to unregister and MPI waiting timed out, without log
+
+		String spiProviderName = "spiProviderName";
+
+		MockSPIProvider mockSPIProvider = new MockSPIProvider(spiProviderName);
+
+		MPIHelperUtil.registerSPIProvider(mockSPIProvider);
+
+		_mockRemoteSPI.setFailOnStop(false);
+		_mockRemoteSPI.setSpiProviderName(spiProviderName);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		MPIHelperUtil.registerSPI(_mockRemoteSPI);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.OFF);
+
+		try {
+			spiShutdownHook.run();
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertTrue(logRecords.isEmpty());
+		}
+		finally {
+			captureHandler.close();
+		}
+
+		assertUnexported();
+	}
+
+	@Test
+	public void testSPIShutdownHookRun4() throws Exception {
+
+		// Unable to unregister and MPI shutdown request received, without log
+
+		String spiProviderName = "spiProviderName";
+
+		MockSPIProvider mockSPIProvider = new MockSPIProvider(spiProviderName);
+
+		MPIHelperUtil.registerSPIProvider(mockSPIProvider);
+
+		_mockRemoteSPI = new MockRemoteSPI(
+			new SPIConfiguration(
+				"spiId", null, null, MockSPIAgent.class.getName(), 8081, null,
+				new String[0], new String[0], 5000, 0, Long.MAX_VALUE, null));
+
+		_mockRemoteSPI.countDownLatch = new CountDownLatch(1);
+
+		_mockRemoteSPI.setFailOnStop(false);
+		_mockRemoteSPI.setSpiProviderName(spiProviderName);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		MPIHelperUtil.registerSPI(_mockRemoteSPI);
+
+		Future<?> future = actionOnMPIWaiting(true);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.OFF);
+
+		try {
+			spiShutdownHook.run();
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertTrue(logRecords.isEmpty());
+		}
+		finally {
+			captureHandler.close();
+		}
+
+		Assert.assertNull(future.get());
+
+		assertUnexported();
+	}
+
+	@Test
+	public void testSPIShutdownHookRun5() throws Exception {
+
+		// Unregister returns false and MPI waiting interrupts, with log
+
+		_mockRemoteSPI = new MockRemoteSPI(
+			new SPIConfiguration(
+				"spiId", null, null, MockSPIAgent.class.getName(), 8081, null,
+				new String[0], new String[0], 5000, 0, Long.MAX_VALUE, null));
+
+		_mockRemoteSPI.countDownLatch = new CountDownLatch(1);
+		_mockRemoteSPI.registrationReference = mockRegistrationReference(false);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		Future<?> future = actionOnMPIWaiting(false);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.ALL);
+
+		try {
+			spiShutdownHook.run();
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertEquals(2, logRecords.size());
+
+			LogRecord logRecord = logRecords.get(0);
+
+			Assert.assertEquals(
+				"Wait for MPI initiated shutdown, up to " + Long.MAX_VALUE +
+					" ms",
+				logRecord.getMessage());
+
+			logRecord = logRecords.get(1);
+
+			Assert.assertEquals(
+				"MPI shutdown waiting timed out, preceeding with SPI shutdown",
+				logRecord.getMessage());
+		}
+		finally {
+			captureHandler.close();
+		}
+
+		Assert.assertNull(future.get());
+
+		assertUnexported();
+	}
+
+	@Test
+	public void testSPIShutdownHookRun6() throws Exception {
+
+		// Unregister returns true and MPI shutdown request received, with log
+
+		_mockRemoteSPI = new MockRemoteSPI(
+			new SPIConfiguration(
+				"spiId", null, null, MockSPIAgent.class.getName(), 8081, null,
+				new String[0], new String[0], 5000, 0, Long.MAX_VALUE, null));
+
+		_mockRemoteSPI.countDownLatch = new CountDownLatch(1);
+		_mockRemoteSPI.registrationReference = mockRegistrationReference(false);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		Future<?> future = actionOnMPIWaiting(true);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.ALL);
+
+		try {
+			spiShutdownHook.run();
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertEquals(2, logRecords.size());
+
+			LogRecord logRecord = logRecords.get(0);
+
+			Assert.assertEquals(
+				"Wait for MPI initiated shutdown, up to " + Long.MAX_VALUE +
+					" ms",
+				logRecord.getMessage());
+
+			logRecord = logRecords.get(1);
+
+			Assert.assertEquals(
+				"MPI shutdown request received", logRecord.getMessage());
+		}
+		finally {
+			captureHandler.close();
+		}
+
+		Assert.assertNull(future.get());
+
+		assertUnexported();
+	}
+
+	@Test
+	public void testSPIShutdownHookRun7() throws Exception {
+
+		// Unregister returns true and MPI waiting timed out, with log
+
+		_mockRemoteSPI.registrationReference = mockRegistrationReference(true);
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.ALL);
+
+		try {
+			spiShutdownHook.run();
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertTrue(logRecords.isEmpty());
+		}
+		finally {
+			captureHandler.close();
+		}
+
+		assertUnexported();
+	}
+
+	@Test
+	public void testSPIShutdownHookShutdown1() throws RemoteException {
+
+		// Peacefully
+
+		UnicastRemoteObject.exportObject(_mockRemoteSPI, 0);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.ALL);
+
+		try {
 			Assert.assertTrue(spiShutdownHook.shutdown(0, null));
 
-			Assert.assertEquals(1, logRecords.size());
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertTrue(logRecords.isEmpty());
+		}
+		finally {
+			captureHandler.close();
+		}
+
+		assertUnexported();
+	}
+
+	@Test
+	public void testSPIShutdownHookShutdown2() {
+
+		// Unable to stop and destroy, with log
+
+		_mockRemoteSPI.setFailOnStop(true);
+
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.SEVERE);
+
+		try {
+			Assert.assertTrue(spiShutdownHook.shutdown(0, null));
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
+
+			Assert.assertEquals(2, logRecords.size());
 
 			LogRecord logRecord = logRecords.get(0);
 
@@ -438,52 +846,155 @@ public class RemoteSPITest {
 
 			Assert.assertSame(RemoteException.class, throwable.getClass());
 
-			// Unable to stop without log
-
-			logRecords = captureHandler.resetLogLevel(Level.OFF);
-
-			_mockRemoteSPI.setFailOnStop(true);
-
-			Assert.assertTrue(spiShutdownHook.shutdown(0, null));
-
-			Assert.assertTrue(logRecords.isEmpty());
-
-			// Unable to destroy with log
-
-			logRecords = captureHandler.resetLogLevel(Level.SEVERE);
-
-			_mockRemoteSPI.setFailOnStop(false);
-			_mockRemoteSPI.setFailOnDestroy(true);
-
-			Assert.assertTrue(spiShutdownHook.shutdown(0, null));
-
-			Assert.assertEquals(1, logRecords.size());
-
-			logRecord = logRecords.get(0);
+			logRecord = logRecords.get(1);
 
 			Assert.assertEquals(
 				"Unable to destroy SPI", logRecord.getMessage());
 
 			throwable = logRecord.getThrown();
 
-			Assert.assertSame(RemoteException.class, throwable.getClass());
+			Assert.assertSame(
+				NoSuchObjectException.class, throwable.getClass());
+		}
+		finally {
+			captureHandler.close();
+		}
+	}
 
-			// Unable to destroy without log
+	@Test
+	public void testSPIShutdownHookShutdown3() {
 
-			logRecords = captureHandler.resetLogLevel(Level.OFF);
+		// Unable to stop and destroy, without log
 
-			_mockRemoteSPI.setFailOnStop(false);
-			_mockRemoteSPI.setFailOnDestroy(true);
+		_mockRemoteSPI.setFailOnStop(true);
 
+		SPIShutdownHook spiShutdownHook = _mockRemoteSPI.new SPIShutdownHook();
+
+		CaptureHandler captureHandler = JDKLoggerTestUtil.configureJDKLogger(
+			RemoteSPI.class.getName(), Level.OFF);
+
+		try {
 			Assert.assertTrue(spiShutdownHook.shutdown(0, null));
+
+			List<LogRecord> logRecords = captureHandler.getLogRecords();
 
 			Assert.assertTrue(logRecords.isEmpty());
 		}
 		finally {
-			if (captureHandler != null) {
-				captureHandler.close();
-			}
+			captureHandler.close();
 		}
+	}
+
+	@Test
+	public void testUnregisterSPIProcessCallable() throws Exception {
+
+		// No such SPI
+
+		String spiProviderName = "spiProviderName";
+		String spiId = "spiId";
+
+		ProcessCallable<Boolean> processCallable =
+			new UnregisterSPIProcessCallable(spiProviderName, spiId);
+
+		Assert.assertFalse(processCallable.call());
+
+		// Unable to unregister SPI
+
+		MPIHelperUtil.registerSPIProvider(new MockSPIProvider(spiProviderName));
+
+		MockSPI mockSPI = new MockSPI();
+
+		mockSPI.spiProviderName = spiProviderName;
+
+		MPIHelperUtilTestUtil.directResigterSPI(spiId, mockSPI);
+
+		Assert.assertFalse(processCallable.call());
+
+		// Successful unregister SPI
+
+		mockSPI.mpi = MPIHelperUtil.getMPI();
+		mockSPI.spiConfiguration = new SPIConfiguration(
+			spiId, null, 0, null, null, new String[0], null);
+
+		Assert.assertTrue(processCallable.call());
+	}
+
+	protected Future<?> actionOnMPIWaiting(final boolean countDownOrInterrupt) {
+		final Thread mainThread = Thread.currentThread();
+
+		FutureTask<?> futureTask = new FutureTask<Object>(
+			new Callable<Object>() {
+
+				@Override
+				public Object call() throws Exception {
+					AbstractQueuedSynchronizer abstractQueuedSynchronizer =
+						(AbstractQueuedSynchronizer)
+							ReflectionTestUtil.getFieldValue(
+								_mockRemoteSPI.countDownLatch, "sync");
+
+					while (true) {
+						Collection<Thread> queuedThreads =
+							abstractQueuedSynchronizer.getQueuedThreads();
+
+						if (queuedThreads.contains(mainThread)) {
+							if (countDownOrInterrupt) {
+								CountDownLatch countDownLatch =
+									_mockRemoteSPI.countDownLatch;
+
+								countDownLatch.countDown();
+							}
+							else {
+								mainThread.interrupt();
+							}
+
+							break;
+						}
+					}
+
+					return null;
+				}
+
+			});
+
+		Thread thread = new Thread(futureTask);
+
+		thread.start();
+
+		return futureTask;
+	}
+
+	protected void assertUnexported() {
+		try {
+			UnicastRemoteObject.unexportObject(_mockRemoteSPI, true);
+		}
+		catch (RemoteException re) {
+			Assert.assertSame(NoSuchObjectException.class, re.getClass());
+		}
+	}
+
+	protected RegistrationReference mockRegistrationReference(
+		final boolean unregistered) {
+
+		MockIntraband mockIntraband = new MockIntraband() {
+
+			@Override
+			protected Datagram processDatagram(Datagram datagram) {
+				try {
+					Serializer serializer = new Serializer();
+
+					serializer.writeObject(new RPCResponse(unregistered));
+
+					return Datagram.createResponseDatagram(
+						datagram, serializer.toByteBuffer());
+				}
+				catch (Exception e) {
+					throw new RuntimeException();
+				}
+			}
+
+		};
+
+		return new MockRegistrationReference(mockIntraband);
 	}
 
 	private static File _currentDir = new File(".");

--- a/util-java/test/unit/com/liferay/util/resiliency/spi/provider/SPIClassPathContextListenerTest.java
+++ b/util-java/test/unit/com/liferay/util/resiliency/spi/provider/SPIClassPathContextListenerTest.java
@@ -18,8 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.process.ClassPathUtil;
 import com.liferay.portal.kernel.resiliency.mpi.MPIHelperUtil;
 import com.liferay.portal.kernel.resiliency.spi.MockSPI;
-import com.liferay.portal.kernel.resiliency.spi.SPI;
-import com.liferay.portal.kernel.resiliency.spi.SPIConfiguration;
+import com.liferay.portal.kernel.resiliency.spi.MockSPIProvider;
 import com.liferay.portal.kernel.resiliency.spi.SPIUtil;
 import com.liferay.portal.kernel.resiliency.spi.provider.SPIProvider;
 import com.liferay.portal.kernel.test.CaptureHandler;
@@ -423,25 +422,6 @@ public class SPIClassPathContextListenerTest {
 		Assert.assertSame(spiProviderReference.get(), spiProviders.get(0));
 
 		embeddedLibDir.delete();
-	}
-
-	public static class MockSPIProvider implements SPIProvider {
-
-		@Override
-		public SPI createSPI(SPIConfiguration spiConfiguration) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getName() {
-			return MockSPIProvider.class.getName();
-		}
-
-		@Override
-		public String toString() {
-			return MockSPIProvider.class.getName();
-		}
-
 	}
 
 	protected void deleteFile(File file) {


### PR DESCRIPTION
Brian, the change to GlobalShutdownAction is not random.
MPIHelperUtil.shutdown(); needs to happen after MessageBus shutdown.

The MessageBus shutdown was in Spring context destroy, which is after GlobalShutdownAction.

So to make sure we are still shutdown MessageBus in a safe way, MessageBusUtil.shutdown(true); goes to the bottom of GlobalShutdownAction, then MPIHelperUtil.shutdown(); right after it.

Although theoretically we could pull up MessageBus shutdown a bit, that will require a detail code review. I am just trying to keep the exist order.

Let me know if you do want to pull up MessageBus shutdown as early as possible, I can check to find out the position.
