### PR TITLE
LPS-46276 Refactoring and simplify to use ExportImportConfigurations

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -82,7 +82,7 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 		long remoteGroupId = MapUtil.getLong(settingsMap, "remoteGroupId");
 		DateRange dateRange = ExportImportDateUtil.getDateRange(
 			exportImportConfiguration);
-		HttpPrincipal httpPrincipal = (HttpPrincipal)settingsMap.get(
+		HttpPrincipal httpPrincipal = (HttpPrincipal)taskContextMap.get(
 			"httpPrincipal");
 
 		clearBackgroundTaskStatus(backgroundTask);

--- a/portal-impl/src/com/liferay/portal/service/http/LayoutServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/LayoutServiceHttp.java
@@ -445,6 +445,125 @@ public class LayoutServiceHttp {
 	}
 
 	public static long exportLayoutsAsFileInBackground(
+		HttpPrincipal httpPrincipal,
+		com.liferay.portal.model.ExportImportConfiguration exportImportConfiguration)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
+					"exportLayoutsAsFileInBackground",
+					_exportLayoutsAsFileInBackgroundParameterTypes10);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					exportImportConfiguration);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Long)returnObj).longValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static long exportLayoutsAsFileInBackground(
+		HttpPrincipal httpPrincipal, long exportImportConfigurationId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
+					"exportLayoutsAsFileInBackground",
+					_exportLayoutsAsFileInBackgroundParameterTypes11);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					exportImportConfigurationId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Long)returnObj).longValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static long exportLayoutsAsFileInBackground(
+		HttpPrincipal httpPrincipal, java.lang.String taskName, long groupId,
+		boolean privateLayout, long[] layoutIds,
+		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
+		java.util.Date startDate, java.util.Date endDate)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
+					"exportLayoutsAsFileInBackground",
+					_exportLayoutsAsFileInBackgroundParameterTypes12);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					taskName, groupId, privateLayout, layoutIds, parameterMap,
+					startDate, endDate);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Long)returnObj).longValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static long exportLayoutsAsFileInBackground(
 		HttpPrincipal httpPrincipal, java.lang.String taskName, long groupId,
 		boolean privateLayout, long[] layoutIds,
 		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
@@ -455,7 +574,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"exportLayoutsAsFileInBackground",
-					_exportLayoutsAsFileInBackgroundParameterTypes10);
+					_exportLayoutsAsFileInBackgroundParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, groupId, privateLayout, layoutIds, parameterMap,
@@ -495,7 +614,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"exportPortletInfo", _exportPortletInfoParameterTypes11);
+					"exportPortletInfo", _exportPortletInfoParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					groupId, portletId, parameterMap, startDate, endDate);
@@ -534,7 +653,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"exportPortletInfo", _exportPortletInfoParameterTypes12);
+					"exportPortletInfo", _exportPortletInfoParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, portletId, parameterMap, startDate, endDate);
@@ -575,7 +694,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"exportPortletInfoAsFile",
-					_exportPortletInfoAsFileParameterTypes13);
+					_exportPortletInfoAsFileParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					groupId, portletId, parameterMap, startDate, endDate);
@@ -615,7 +734,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"exportPortletInfoAsFile",
-					_exportPortletInfoAsFileParameterTypes14);
+					_exportPortletInfoAsFileParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					portletId, parameterMap, startDate, endDate);
@@ -657,7 +776,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"exportPortletInfoAsFileInBackground",
-					_exportPortletInfoAsFileInBackgroundParameterTypes15);
+					_exportPortletInfoAsFileInBackgroundParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, plid, groupId, portletId, parameterMap,
@@ -700,7 +819,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"exportPortletInfoAsFileInBackground",
-					_exportPortletInfoAsFileInBackgroundParameterTypes16);
+					_exportPortletInfoAsFileInBackgroundParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, portletId, parameterMap, startDate, endDate,
@@ -738,7 +857,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getAncestorLayouts", _getAncestorLayoutsParameterTypes17);
+					"getAncestorLayouts", _getAncestorLayoutsParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid);
 
@@ -775,7 +894,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getDefaultPlid", _getDefaultPlidParameterTypes18);
+					"getDefaultPlid", _getDefaultPlidParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					scopeGroupId, privateLayout, portletId);
@@ -812,7 +931,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getDefaultPlid", _getDefaultPlidParameterTypes19);
+					"getDefaultPlid", _getDefaultPlidParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					scopeGroupId, portletId);
@@ -851,7 +970,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"getLayoutByUuidAndGroupId",
-					_getLayoutByUuidAndGroupIdParameterTypes20);
+					_getLayoutByUuidAndGroupIdParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, uuid,
 					groupId, privateLayout);
@@ -889,7 +1008,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getLayoutName", _getLayoutNameParameterTypes21);
+					"getLayoutName", _getLayoutNameParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, languageId);
@@ -927,7 +1046,7 @@ public class LayoutServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getLayoutReferences", _getLayoutReferencesParameterTypes22);
+					"getLayoutReferences", _getLayoutReferencesParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, portletId, preferencesKey, preferencesValue);
@@ -959,7 +1078,7 @@ public class LayoutServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getLayouts", _getLayoutsParameterTypes23);
+					"getLayouts", _getLayoutsParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout);
@@ -992,7 +1111,7 @@ public class LayoutServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getLayouts", _getLayoutsParameterTypes24);
+					"getLayouts", _getLayoutsParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parentLayoutId);
@@ -1026,7 +1145,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"getLayouts", _getLayoutsParameterTypes25);
+					"getLayouts", _getLayoutsParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parentLayoutId, incomplete, start, end);
@@ -1065,7 +1184,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"getTempFileEntryNames",
-					_getTempFileEntryNamesParameterTypes26);
+					_getTempFileEntryNamesParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					tempFolderName);
@@ -1104,7 +1223,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"importLayouts", _importLayoutsParameterTypes27);
+					"importLayouts", _importLayoutsParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parameterMap, bytes);
@@ -1139,7 +1258,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"importLayouts", _importLayoutsParameterTypes28);
+					"importLayouts", _importLayoutsParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parameterMap, file);
@@ -1174,7 +1293,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"importLayouts", _importLayoutsParameterTypes29);
+					"importLayouts", _importLayoutsParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parameterMap, is);
@@ -1210,7 +1329,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"importLayoutsInBackground",
-					_importLayoutsInBackgroundParameterTypes30);
+					_importLayoutsInBackgroundParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, groupId, privateLayout, parameterMap, file);
@@ -1250,7 +1369,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"importLayoutsInBackground",
-					_importLayoutsInBackgroundParameterTypes31);
+					_importLayoutsInBackgroundParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, groupId, privateLayout, parameterMap, inputStream);
@@ -1289,7 +1408,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"importPortletInfo", _importPortletInfoParameterTypes32);
+					"importPortletInfo", _importPortletInfoParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					groupId, portletId, parameterMap, file);
@@ -1324,7 +1443,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"importPortletInfo", _importPortletInfoParameterTypes33);
+					"importPortletInfo", _importPortletInfoParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					groupId, portletId, parameterMap, is);
@@ -1359,7 +1478,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"importPortletInfo", _importPortletInfoParameterTypes34);
+					"importPortletInfo", _importPortletInfoParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					portletId, parameterMap, file);
@@ -1394,7 +1513,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"importPortletInfo", _importPortletInfoParameterTypes35);
+					"importPortletInfo", _importPortletInfoParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					portletId, parameterMap, is);
@@ -1431,7 +1550,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"importPortletInfoInBackground",
-					_importPortletInfoInBackgroundParameterTypes36);
+					_importPortletInfoInBackgroundParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, plid, groupId, portletId, parameterMap, file);
@@ -1472,7 +1591,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"importPortletInfoInBackground",
-					_importPortletInfoInBackgroundParameterTypes37);
+					_importPortletInfoInBackgroundParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, plid, groupId, portletId, parameterMap, is);
@@ -1513,7 +1632,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"importPortletInfoInBackground",
-					_importPortletInfoInBackgroundParameterTypes38);
+					_importPortletInfoInBackgroundParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, portletId, parameterMap, file);
@@ -1550,7 +1669,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"importPortletInfoInBackground",
-					_importPortletInfoInBackgroundParameterTypes39);
+					_importPortletInfoInBackgroundParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					taskName, portletId, parameterMap, is);
@@ -1590,7 +1709,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"schedulePublishToLive",
-					_schedulePublishToLiveParameterTypes40);
+					_schedulePublishToLiveParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					sourceGroupId, targetGroupId, privateLayout, layoutIds,
@@ -1632,7 +1751,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"schedulePublishToLive",
-					_schedulePublishToLiveParameterTypes41);
+					_schedulePublishToLiveParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					sourceGroupId, targetGroupId, privateLayout, layoutIdMap,
@@ -1677,7 +1796,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"schedulePublishToRemote",
-					_schedulePublishToRemoteParameterTypes42);
+					_schedulePublishToRemoteParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					sourceGroupId, privateLayout, layoutIdMap, parameterMap,
@@ -1715,7 +1834,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"setLayouts", _setLayoutsParameterTypes43);
+					"setLayouts", _setLayoutsParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parentLayoutId, layoutIds, serviceContext);
@@ -1749,7 +1868,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"unschedulePublishToLive",
-					_unschedulePublishToLiveParameterTypes44);
+					_unschedulePublishToLiveParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					jobName, groupName);
@@ -1783,7 +1902,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"unschedulePublishToRemote",
-					_unschedulePublishToRemoteParameterTypes45);
+					_unschedulePublishToRemoteParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					jobName, groupName);
@@ -1816,7 +1935,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updateIconImage", _updateIconImageParameterTypes46);
+					"updateIconImage", _updateIconImageParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					bytes);
@@ -1863,7 +1982,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updateLayout", _updateLayoutParameterTypes47);
+					"updateLayout", _updateLayoutParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, parentLayoutId, localeNamesMap,
@@ -1912,7 +2031,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updateLayout", _updateLayoutParameterTypes48);
+					"updateLayout", _updateLayoutParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, parentLayoutId, localeNamesMap,
@@ -1953,7 +2072,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updateLayout", _updateLayoutParameterTypes49);
+					"updateLayout", _updateLayoutParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, typeSettings);
@@ -1992,7 +2111,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updateLookAndFeel", _updateLookAndFeelParameterTypes50);
+					"updateLookAndFeel", _updateLookAndFeelParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, themeId, colorSchemeId, css,
@@ -2031,7 +2150,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updateName", _updateNameParameterTypes51);
+					"updateName", _updateNameParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, name, languageId);
@@ -2069,7 +2188,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updateName", _updateNameParameterTypes52);
+					"updateName", _updateNameParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					name, languageId);
@@ -2108,7 +2227,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"updateParentLayoutId",
-					_updateParentLayoutIdParameterTypes53);
+					_updateParentLayoutIdParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, parentLayoutId);
@@ -2146,7 +2265,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"updateParentLayoutId",
-					_updateParentLayoutIdParameterTypes54);
+					_updateParentLayoutIdParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					parentPlid);
@@ -2184,7 +2303,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updatePriority", _updatePriorityParameterTypes55);
+					"updatePriority", _updatePriorityParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, priority);
@@ -2222,7 +2341,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updatePriority", _updatePriorityParameterTypes56);
+					"updatePriority", _updatePriorityParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, layoutId, nextLayoutId, previousLayoutId);
@@ -2259,7 +2378,7 @@ public class LayoutServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
-					"updatePriority", _updatePriorityParameterTypes57);
+					"updatePriority", _updatePriorityParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					priority);
@@ -2299,7 +2418,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"validateImportLayoutsFile",
-					_validateImportLayoutsFileParameterTypes58);
+					_validateImportLayoutsFileParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parameterMap, file);
@@ -2339,7 +2458,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"validateImportLayoutsFile",
-					_validateImportLayoutsFileParameterTypes59);
+					_validateImportLayoutsFileParameterTypes62);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					privateLayout, parameterMap, inputStream);
@@ -2380,7 +2499,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"validateImportPortletInfo",
-					_validateImportPortletInfoParameterTypes60);
+					_validateImportPortletInfoParameterTypes63);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					groupId, portletId, parameterMap, file);
@@ -2421,7 +2540,7 @@ public class LayoutServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(LayoutServiceUtil.class,
 					"validateImportPortletInfo",
-					_validateImportPortletInfoParameterTypes61);
+					_validateImportPortletInfoParameterTypes64);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, plid,
 					groupId, portletId, parameterMap, inputStream);
@@ -2500,211 +2619,220 @@ public class LayoutServiceHttp {
 			java.util.Date.class, java.util.Date.class
 		};
 	private static final Class<?>[] _exportLayoutsAsFileInBackgroundParameterTypes10 =
+		new Class[] { com.liferay.portal.model.ExportImportConfiguration.class };
+	private static final Class<?>[] _exportLayoutsAsFileInBackgroundParameterTypes11 =
+		new Class[] { long.class };
+	private static final Class<?>[] _exportLayoutsAsFileInBackgroundParameterTypes12 =
+		new Class[] {
+			java.lang.String.class, long.class, boolean.class, long[].class,
+			java.util.Map.class, java.util.Date.class, java.util.Date.class
+		};
+	private static final Class<?>[] _exportLayoutsAsFileInBackgroundParameterTypes13 =
 		new Class[] {
 			java.lang.String.class, long.class, boolean.class, long[].class,
 			java.util.Map.class, java.util.Date.class, java.util.Date.class,
 			java.lang.String.class
 		};
-	private static final Class<?>[] _exportPortletInfoParameterTypes11 = new Class[] {
+	private static final Class<?>[] _exportPortletInfoParameterTypes14 = new Class[] {
 			long.class, long.class, java.lang.String.class, java.util.Map.class,
 			java.util.Date.class, java.util.Date.class
 		};
-	private static final Class<?>[] _exportPortletInfoParameterTypes12 = new Class[] {
+	private static final Class<?>[] _exportPortletInfoParameterTypes15 = new Class[] {
 			long.class, java.lang.String.class, java.util.Map.class,
 			java.util.Date.class, java.util.Date.class
 		};
-	private static final Class<?>[] _exportPortletInfoAsFileParameterTypes13 = new Class[] {
+	private static final Class<?>[] _exportPortletInfoAsFileParameterTypes16 = new Class[] {
 			long.class, long.class, java.lang.String.class, java.util.Map.class,
 			java.util.Date.class, java.util.Date.class
 		};
-	private static final Class<?>[] _exportPortletInfoAsFileParameterTypes14 = new Class[] {
+	private static final Class<?>[] _exportPortletInfoAsFileParameterTypes17 = new Class[] {
 			java.lang.String.class, java.util.Map.class, java.util.Date.class,
 			java.util.Date.class
 		};
-	private static final Class<?>[] _exportPortletInfoAsFileInBackgroundParameterTypes15 =
+	private static final Class<?>[] _exportPortletInfoAsFileInBackgroundParameterTypes18 =
 		new Class[] {
 			java.lang.String.class, long.class, long.class,
 			java.lang.String.class, java.util.Map.class, java.util.Date.class,
 			java.util.Date.class, java.lang.String.class
 		};
-	private static final Class<?>[] _exportPortletInfoAsFileInBackgroundParameterTypes16 =
+	private static final Class<?>[] _exportPortletInfoAsFileInBackgroundParameterTypes19 =
 		new Class[] {
 			java.lang.String.class, java.lang.String.class, java.util.Map.class,
 			java.util.Date.class, java.util.Date.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getAncestorLayoutsParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getAncestorLayoutsParameterTypes20 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getDefaultPlidParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getDefaultPlidParameterTypes21 = new Class[] {
 			long.class, long.class, boolean.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getDefaultPlidParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getDefaultPlidParameterTypes22 = new Class[] {
 			long.class, long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getLayoutByUuidAndGroupIdParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getLayoutByUuidAndGroupIdParameterTypes23 = new Class[] {
 			java.lang.String.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _getLayoutNameParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getLayoutNameParameterTypes24 = new Class[] {
 			long.class, boolean.class, long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getLayoutReferencesParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getLayoutReferencesParameterTypes25 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class
 		};
-	private static final Class<?>[] _getLayoutsParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getLayoutsParameterTypes26 = new Class[] {
 			long.class, boolean.class
 		};
-	private static final Class<?>[] _getLayoutsParameterTypes24 = new Class[] {
+	private static final Class<?>[] _getLayoutsParameterTypes27 = new Class[] {
 			long.class, boolean.class, long.class
 		};
-	private static final Class<?>[] _getLayoutsParameterTypes25 = new Class[] {
+	private static final Class<?>[] _getLayoutsParameterTypes28 = new Class[] {
 			long.class, boolean.class, long.class, boolean.class, int.class,
 			int.class
 		};
-	private static final Class<?>[] _getTempFileEntryNamesParameterTypes26 = new Class[] {
+	private static final Class<?>[] _getTempFileEntryNamesParameterTypes29 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _importLayoutsParameterTypes27 = new Class[] {
+	private static final Class<?>[] _importLayoutsParameterTypes30 = new Class[] {
 			long.class, boolean.class, java.util.Map.class, byte[].class
 		};
-	private static final Class<?>[] _importLayoutsParameterTypes28 = new Class[] {
+	private static final Class<?>[] _importLayoutsParameterTypes31 = new Class[] {
 			long.class, boolean.class, java.util.Map.class, java.io.File.class
 		};
-	private static final Class<?>[] _importLayoutsParameterTypes29 = new Class[] {
+	private static final Class<?>[] _importLayoutsParameterTypes32 = new Class[] {
 			long.class, boolean.class, java.util.Map.class,
 			java.io.InputStream.class
 		};
-	private static final Class<?>[] _importLayoutsInBackgroundParameterTypes30 = new Class[] {
+	private static final Class<?>[] _importLayoutsInBackgroundParameterTypes33 = new Class[] {
 			java.lang.String.class, long.class, boolean.class,
 			java.util.Map.class, java.io.File.class
 		};
-	private static final Class<?>[] _importLayoutsInBackgroundParameterTypes31 = new Class[] {
+	private static final Class<?>[] _importLayoutsInBackgroundParameterTypes34 = new Class[] {
 			java.lang.String.class, long.class, boolean.class,
 			java.util.Map.class, java.io.InputStream.class
 		};
-	private static final Class<?>[] _importPortletInfoParameterTypes32 = new Class[] {
-			long.class, long.class, java.lang.String.class, java.util.Map.class,
-			java.io.File.class
-		};
-	private static final Class<?>[] _importPortletInfoParameterTypes33 = new Class[] {
-			long.class, long.class, java.lang.String.class, java.util.Map.class,
-			java.io.InputStream.class
-		};
-	private static final Class<?>[] _importPortletInfoParameterTypes34 = new Class[] {
-			java.lang.String.class, java.util.Map.class, java.io.File.class
-		};
 	private static final Class<?>[] _importPortletInfoParameterTypes35 = new Class[] {
-			java.lang.String.class, java.util.Map.class,
+			long.class, long.class, java.lang.String.class, java.util.Map.class,
+			java.io.File.class
+		};
+	private static final Class<?>[] _importPortletInfoParameterTypes36 = new Class[] {
+			long.class, long.class, java.lang.String.class, java.util.Map.class,
 			java.io.InputStream.class
 		};
-	private static final Class<?>[] _importPortletInfoInBackgroundParameterTypes36 =
-		new Class[] {
-			java.lang.String.class, long.class, long.class,
+	private static final Class<?>[] _importPortletInfoParameterTypes37 = new Class[] {
 			java.lang.String.class, java.util.Map.class, java.io.File.class
 		};
-	private static final Class<?>[] _importPortletInfoInBackgroundParameterTypes37 =
-		new Class[] {
-			java.lang.String.class, long.class, long.class,
+	private static final Class<?>[] _importPortletInfoParameterTypes38 = new Class[] {
 			java.lang.String.class, java.util.Map.class,
 			java.io.InputStream.class
-		};
-	private static final Class<?>[] _importPortletInfoInBackgroundParameterTypes38 =
-		new Class[] {
-			java.lang.String.class, java.lang.String.class, java.util.Map.class,
-			java.io.File.class
 		};
 	private static final Class<?>[] _importPortletInfoInBackgroundParameterTypes39 =
 		new Class[] {
+			java.lang.String.class, long.class, long.class,
+			java.lang.String.class, java.util.Map.class, java.io.File.class
+		};
+	private static final Class<?>[] _importPortletInfoInBackgroundParameterTypes40 =
+		new Class[] {
+			java.lang.String.class, long.class, long.class,
+			java.lang.String.class, java.util.Map.class,
+			java.io.InputStream.class
+		};
+	private static final Class<?>[] _importPortletInfoInBackgroundParameterTypes41 =
+		new Class[] {
+			java.lang.String.class, java.lang.String.class, java.util.Map.class,
+			java.io.File.class
+		};
+	private static final Class<?>[] _importPortletInfoInBackgroundParameterTypes42 =
+		new Class[] {
 			java.lang.String.class, java.lang.String.class, java.util.Map.class,
 			java.io.InputStream.class
 		};
-	private static final Class<?>[] _schedulePublishToLiveParameterTypes40 = new Class[] {
+	private static final Class<?>[] _schedulePublishToLiveParameterTypes43 = new Class[] {
 			long.class, long.class, boolean.class, long[].class,
 			java.util.Map.class, java.lang.String.class, java.util.Date.class,
 			java.util.Date.class, java.lang.String.class, java.lang.String.class,
 			java.util.Date.class, java.util.Date.class, java.lang.String.class
 		};
-	private static final Class<?>[] _schedulePublishToLiveParameterTypes41 = new Class[] {
+	private static final Class<?>[] _schedulePublishToLiveParameterTypes44 = new Class[] {
 			long.class, long.class, boolean.class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class, java.util.Date.class,
 			java.util.Date.class, java.lang.String.class, java.lang.String.class,
 			java.util.Date.class, java.util.Date.class, java.lang.String.class
 		};
-	private static final Class<?>[] _schedulePublishToRemoteParameterTypes42 = new Class[] {
+	private static final Class<?>[] _schedulePublishToRemoteParameterTypes45 = new Class[] {
 			long.class, boolean.class, java.util.Map.class, java.util.Map.class,
 			java.lang.String.class, int.class, java.lang.String.class,
 			boolean.class, long.class, boolean.class, java.util.Date.class,
 			java.util.Date.class, java.lang.String.class, java.lang.String.class,
 			java.util.Date.class, java.util.Date.class, java.lang.String.class
 		};
-	private static final Class<?>[] _setLayoutsParameterTypes43 = new Class[] {
+	private static final Class<?>[] _setLayoutsParameterTypes46 = new Class[] {
 			long.class, boolean.class, long.class, long[].class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _unschedulePublishToLiveParameterTypes44 = new Class[] {
+	private static final Class<?>[] _unschedulePublishToLiveParameterTypes47 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class
 		};
-	private static final Class<?>[] _unschedulePublishToRemoteParameterTypes45 = new Class[] {
+	private static final Class<?>[] _unschedulePublishToRemoteParameterTypes48 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class
 		};
-	private static final Class<?>[] _updateIconImageParameterTypes46 = new Class[] {
+	private static final Class<?>[] _updateIconImageParameterTypes49 = new Class[] {
 			long.class, byte[].class
 		};
-	private static final Class<?>[] _updateLayoutParameterTypes47 = new Class[] {
+	private static final Class<?>[] _updateLayoutParameterTypes50 = new Class[] {
 			long.class, boolean.class, long.class, long.class,
 			java.util.Map.class, java.util.Map.class, java.util.Map.class,
 			java.util.Map.class, java.util.Map.class, java.lang.String.class,
 			boolean.class, java.util.Map.class, boolean.class, byte[].class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateLayoutParameterTypes48 = new Class[] {
+	private static final Class<?>[] _updateLayoutParameterTypes51 = new Class[] {
 			long.class, boolean.class, long.class, long.class,
 			java.util.Map.class, java.util.Map.class, java.util.Map.class,
 			java.util.Map.class, java.util.Map.class, java.lang.String.class,
 			boolean.class, java.lang.String.class, java.lang.Boolean.class,
 			byte[].class, com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateLayoutParameterTypes49 = new Class[] {
+	private static final Class<?>[] _updateLayoutParameterTypes52 = new Class[] {
 			long.class, boolean.class, long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _updateLookAndFeelParameterTypes50 = new Class[] {
+	private static final Class<?>[] _updateLookAndFeelParameterTypes53 = new Class[] {
 			long.class, boolean.class, long.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class, boolean.class
 		};
-	private static final Class<?>[] _updateNameParameterTypes51 = new Class[] {
+	private static final Class<?>[] _updateNameParameterTypes54 = new Class[] {
 			long.class, boolean.class, long.class, java.lang.String.class,
 			java.lang.String.class
 		};
-	private static final Class<?>[] _updateNameParameterTypes52 = new Class[] {
+	private static final Class<?>[] _updateNameParameterTypes55 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class
 		};
-	private static final Class<?>[] _updateParentLayoutIdParameterTypes53 = new Class[] {
+	private static final Class<?>[] _updateParentLayoutIdParameterTypes56 = new Class[] {
 			long.class, boolean.class, long.class, long.class
 		};
-	private static final Class<?>[] _updateParentLayoutIdParameterTypes54 = new Class[] {
+	private static final Class<?>[] _updateParentLayoutIdParameterTypes57 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _updatePriorityParameterTypes55 = new Class[] {
+	private static final Class<?>[] _updatePriorityParameterTypes58 = new Class[] {
 			long.class, boolean.class, long.class, int.class
 		};
-	private static final Class<?>[] _updatePriorityParameterTypes56 = new Class[] {
+	private static final Class<?>[] _updatePriorityParameterTypes59 = new Class[] {
 			long.class, boolean.class, long.class, long.class, long.class
 		};
-	private static final Class<?>[] _updatePriorityParameterTypes57 = new Class[] {
+	private static final Class<?>[] _updatePriorityParameterTypes60 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _validateImportLayoutsFileParameterTypes58 = new Class[] {
+	private static final Class<?>[] _validateImportLayoutsFileParameterTypes61 = new Class[] {
 			long.class, boolean.class, java.util.Map.class, java.io.File.class
 		};
-	private static final Class<?>[] _validateImportLayoutsFileParameterTypes59 = new Class[] {
+	private static final Class<?>[] _validateImportLayoutsFileParameterTypes62 = new Class[] {
 			long.class, boolean.class, java.util.Map.class,
 			java.io.InputStream.class
 		};
-	private static final Class<?>[] _validateImportPortletInfoParameterTypes60 = new Class[] {
+	private static final Class<?>[] _validateImportPortletInfoParameterTypes63 = new Class[] {
 			long.class, long.class, java.lang.String.class, java.util.Map.class,
 			java.io.File.class
 		};
-	private static final Class<?>[] _validateImportPortletInfoParameterTypes61 = new Class[] {
+	private static final Class<?>[] _validateImportPortletInfoParameterTypes64 = new Class[] {
 			long.class, long.class, java.lang.String.class, java.util.Map.class,
 			java.io.InputStream.class
 		};

--- a/portal-impl/src/com/liferay/portal/service/http/LayoutServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/LayoutServiceSoap.java
@@ -373,6 +373,36 @@ public class LayoutServiceSoap {
 		}
 	}
 
+	public static long exportLayoutsAsFileInBackground(
+		com.liferay.portal.model.ExportImportConfigurationSoap exportImportConfiguration)
+		throws RemoteException {
+		try {
+			long returnValue = LayoutServiceUtil.exportLayoutsAsFileInBackground(com.liferay.portal.model.impl.ExportImportConfigurationModelImpl.toModel(
+						exportImportConfiguration));
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static long exportLayoutsAsFileInBackground(
+		long exportImportConfigurationId) throws RemoteException {
+		try {
+			long returnValue = LayoutServiceUtil.exportLayoutsAsFileInBackground(exportImportConfigurationId);
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	/**
 	* Returns all the ancestor layouts of the layout.
 	*

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -935,7 +935,7 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 	public long exportLayoutsAsFileInBackground(
 			long userId, String taskName, long groupId, boolean privateLayout,
 			long[] layoutIds, Map<String, String[]> parameterMap,
-			Date startDate, Date endDate, String fileName)
+			Date startDate, Date endDate)
 		throws PortalException, SystemException {
 
 		Map<String, Serializable> settingsMap =
@@ -953,6 +953,24 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		return exportLayoutsAsFileInBackground(
 			userId, exportImportConfiguration);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #exportLayoutsAsFileInBackground(long, String, long, boolean,
+	 *             long[], Map, Date, Date)}
+	 */
+	@Deprecated
+	@Override
+	public long exportLayoutsAsFileInBackground(
+			long userId, String taskName, long groupId, boolean privateLayout,
+			long[] layoutIds, Map<String, String[]> parameterMap,
+			Date startDate, Date endDate, String fileName)
+		throws PortalException, SystemException {
+
+		return exportLayoutsAsFileInBackground(
+			userId, taskName, groupId, privateLayout, layoutIds, parameterMap,
+			startDate, endDate);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -907,6 +907,32 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 	@Override
 	public long exportLayoutsAsFileInBackground(
+			long userId, ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException {
+
+		if (!DLStoreUtil.isValidName(exportImportConfiguration.getName())) {
+			throw new LARFileNameException(exportImportConfiguration.getName());
+		}
+
+		Map<String, Serializable> taskContextMap =
+			new HashMap<String, Serializable>();
+
+		taskContextMap.put(
+			"exportImportConfigurationId",
+			exportImportConfiguration.getExportImportConfigurationId());
+
+		BackgroundTask backgroundTask =
+			backgroundTaskLocalService.addBackgroundTask(
+				userId, exportImportConfiguration.getGroupId(),
+				exportImportConfiguration.getName(), null,
+				LayoutExportBackgroundTaskExecutor.class, taskContextMap,
+				new ServiceContext());
+
+		return backgroundTask.getBackgroundTaskId();
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(
 			long userId, String taskName, long groupId, boolean privateLayout,
 			long[] layoutIds, Map<String, String[]> parameterMap,
 			Date startDate, Date endDate, String fileName)

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -938,10 +938,6 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 			Date startDate, Date endDate, String fileName)
 		throws PortalException, SystemException {
 
-		if (!DLStoreUtil.isValidName(fileName)) {
-			throw new LARFileNameException(fileName);
-		}
-
 		Map<String, Serializable> settingsMap =
 			ExportImportConfigurationSettingsMapFactory.buildSettingsMap(
 				userId, groupId, privateLayout, layoutIds, parameterMap,
@@ -955,20 +951,8 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 				ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
 				settingsMap, WorkflowConstants.STATUS_DRAFT, serviceContext);
 
-		Map<String, Serializable> taskContextMap =
-			new HashMap<String, Serializable>();
-
-		taskContextMap.put(
-			"exportImportConfigurationId",
-			exportImportConfiguration.getExportImportConfigurationId());
-
-		BackgroundTask backgroundTask =
-			backgroundTaskLocalService.addBackgroundTask(
-				userId, groupId, taskName, null,
-				LayoutExportBackgroundTaskExecutor.class, taskContextMap,
-				serviceContext);
-
-		return backgroundTask.getBackgroundTaskId();
+		return exportLayoutsAsFileInBackground(
+			userId, exportImportConfiguration);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -933,6 +933,19 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 	@Override
 	public long exportLayoutsAsFileInBackground(
+			long userId, long exportImportConfigurationId)
+		throws PortalException, SystemException {
+
+		ExportImportConfiguration exportImportConfiguration =
+			exportImportConfigurationLocalService.getExportImportConfiguration(
+				exportImportConfigurationId);
+
+		return exportLayoutsAsFileInBackground(
+			userId, exportImportConfiguration);
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(
 			long userId, String taskName, long groupId, boolean privateLayout,
 			long[] layoutIds, Map<String, String[]> parameterMap,
 			Date startDate, Date endDate)

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -459,6 +459,19 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 
 	@Override
 	public long exportLayoutsAsFileInBackground(
+			ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException {
+
+		GroupPermissionUtil.check(
+			getPermissionChecker(), exportImportConfiguration.getGroupId(),
+			ActionKeys.EXPORT_IMPORT_LAYOUTS);
+
+		return layoutLocalService.exportLayoutsAsFileInBackground(
+			getUserId(), exportImportConfiguration);
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(
 			String taskName, long groupId, boolean privateLayout,
 			long[] layoutIds, Map<String, String[]> parameterMap,
 			Date startDate, Date endDate, String fileName)

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -474,6 +474,27 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 	public long exportLayoutsAsFileInBackground(
 			String taskName, long groupId, boolean privateLayout,
 			long[] layoutIds, Map<String, String[]> parameterMap,
+			Date startDate, Date endDate)
+		throws PortalException, SystemException {
+
+		GroupPermissionUtil.check(
+			getPermissionChecker(), groupId, ActionKeys.EXPORT_IMPORT_LAYOUTS);
+
+		return layoutLocalService.exportLayoutsAsFileInBackground(
+			getUserId(), taskName, groupId, privateLayout, layoutIds,
+			parameterMap, startDate, endDate);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #exportLayoutsAsFileInBackground(String, long, boolean,
+	 *             long[], Map, Date, Date)}
+	 */
+	@Deprecated
+	@Override
+	public long exportLayoutsAsFileInBackground(
+			String taskName, long groupId, boolean privateLayout,
+			long[] layoutIds, Map<String, String[]> parameterMap,
 			Date startDate, Date endDate, String fileName)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -472,6 +472,23 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 
 	@Override
 	public long exportLayoutsAsFileInBackground(
+			long exportImportConfigurationId)
+		throws PortalException, SystemException {
+
+		ExportImportConfiguration exportImportConfiguration =
+			exportImportConfigurationLocalService.getExportImportConfiguration(
+				exportImportConfigurationId);
+
+		GroupPermissionUtil.check(
+			getPermissionChecker(), exportImportConfiguration.getGroupId(),
+			ActionKeys.EXPORT_IMPORT_LAYOUTS);
+
+		return layoutLocalService.exportLayoutsAsFileInBackground(
+			getUserId(), exportImportConfigurationId);
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(
 			String taskName, long groupId, boolean privateLayout,
 			long[] layoutIds, Map<String, String[]> parameterMap,
 			Date startDate, Date endDate)

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -367,6 +367,17 @@ public class StagingImpl implements Staging {
 	}
 
 	@Override
+	public void copyRemoteLayouts(long exportImportConfigurationId)
+		throws PortalException, SystemException {
+
+		ExportImportConfiguration exportImportConfiguration =
+			ExportImportConfigurationLocalServiceUtil.
+				getExportImportConfiguration(exportImportConfigurationId);
+
+		copyRemoteLayouts(exportImportConfiguration);
+	}
+
+	@Override
 	public void copyRemoteLayouts(
 			long sourceGroupId, boolean privateLayout,
 			Map<Long, Boolean> layoutIdMap, Map<String, String[]> parameterMap,
@@ -1363,6 +1374,17 @@ public class StagingImpl implements Staging {
 			userId, exportImportConfiguration.getGroupId(), StringPool.BLANK,
 			null, LayoutStagingBackgroundTaskExecutor.class, taskContextMap,
 			new ServiceContext());
+	}
+
+	@Override
+	public void publishLayouts(long userId, long exportImportConfigurationId)
+		throws PortalException, SystemException {
+
+		ExportImportConfiguration exportImportConfiguration =
+			ExportImportConfigurationLocalServiceUtil.
+				getExportImportConfiguration(exportImportConfigurationId);
+
+		publishLayouts(userId, exportImportConfiguration);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -1462,14 +1462,28 @@ public class StagingImpl implements Staging {
 
 	@Override
 	public void publishLayouts(
+			long userId, ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException {
+
+		Map<String, Serializable> taskContextMap =
+			new HashMap<String, Serializable>();
+
+		taskContextMap.put(
+			"exportImportConfigurationId",
+			exportImportConfiguration.getExportImportConfigurationId());
+
+		BackgroundTaskLocalServiceUtil.addBackgroundTask(
+			userId, exportImportConfiguration.getGroupId(), StringPool.BLANK,
+			null, LayoutStagingBackgroundTaskExecutor.class, taskContextMap,
+			new ServiceContext());
+	}
+
+	@Override
+	public void publishLayouts(
 			long userId, long sourceGroupId, long targetGroupId,
 			boolean privateLayout, long[] layoutIds,
 			Map<String, String[]> parameterMap, Date startDate, Date endDate)
 		throws PortalException, SystemException {
-
-		parameterMap.put(
-			PortletDataHandlerKeys.PERFORM_DIRECT_BINARY_IMPORT,
-			new String[] {Boolean.TRUE.toString()});
 
 		Map<String, Serializable> settingsMap =
 			ExportImportConfigurationSettingsMapFactory.buildSettingsMap(

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditExportConfigurationAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditExportConfigurationAction.java
@@ -35,6 +35,7 @@ import com.liferay.portal.model.TrashedModel;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.service.BackgroundTaskLocalServiceUtil;
 import com.liferay.portal.service.ExportImportConfigurationServiceUtil;
+import com.liferay.portal.service.LayoutServiceUtil;
 import com.liferay.portal.struts.PortletAction;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.sites.action.ActionUtil;
@@ -84,8 +85,11 @@ public class EditExportConfigurationAction extends PortletAction {
 				deleteExportImportConfiguration(actionRequest, false);
 			}
 			else if (cmd.equals(Constants.EXPORT)) {
-				ExportImportConfigurationHelper.
-					exportLayoutsByExportImportConfiguration(actionRequest);
+				long exportImportConfigurationId = ParamUtil.getLong(
+					actionRequest, "exportImportConfigurationId");
+
+				LayoutServiceUtil.exportLayoutsAsFileInBackground(
+					exportImportConfigurationId);
 			}
 			else if (cmd.equals(Constants.MOVE_TO_TRASH)) {
 				deleteExportImportConfiguration(actionRequest, true);
@@ -240,9 +244,11 @@ public class EditExportConfigurationAction extends PortletAction {
 		Map<String, Serializable> taskContextMap =
 			backgroundTask.getTaskContextMap();
 
-		ExportImportConfigurationHelper.
-			exportLayoutsByExportImportConfiguration(
-				MapUtil.getLong(taskContextMap, "exportImportConfigurationId"));
+		long exportImportConfigurationId = MapUtil.getLong(
+			taskContextMap, "exportImportConfigurationId");
+
+		LayoutServiceUtil.exportLayoutsAsFileInBackground(
+			exportImportConfigurationId);
 	}
 
 	protected ExportImportConfiguration updateExportConfiguration(

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditPublishConfigurationAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditPublishConfigurationAction.java
@@ -237,7 +237,7 @@ public class EditPublishConfigurationAction
 
 			ExportImportConfigurationHelper.
 				publishRemoteLayoutByExportImportConfiguration(
-					exportImportConfiguration.getExportImportConfigurationId());
+					exportImportConfiguration);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditPublishConfigurationAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditPublishConfigurationAction.java
@@ -228,8 +228,7 @@ public class EditPublishConfigurationAction
 
 			ExportImportConfigurationHelper.
 				publishLocalLayoutByExportImportConfiguration(
-					userId,
-					exportImportConfiguration.getExportImportConfigurationId());
+					userId, exportImportConfiguration);
 		}
 		else if (exportImportConfiguration.getType() ==
 					ExportImportConfigurationConstants.

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditPublishConfigurationAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/EditPublishConfigurationAction.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -92,14 +93,11 @@ public class EditPublishConfigurationAction
 				deleteExportImportConfiguration(actionRequest, true);
 			}
 			else if (cmd.equals(Constants.PUBLISH_TO_LIVE)) {
-				ExportImportConfigurationHelper.
-					publishLocalLayoutByExportImportConfiguration(
-						themeDisplay.getUserId(), exportImportConfigurationId);
+				StagingUtil.publishLayouts(
+					themeDisplay.getUserId(), exportImportConfigurationId);
 			}
 			else if (cmd.equals(Constants.PUBLISH_TO_REMOTE)) {
-				ExportImportConfigurationHelper.
-					publishRemoteLayoutByExportImportConfiguration(
-						exportImportConfigurationId);
+				StagingUtil.copyRemoteLayouts(exportImportConfigurationId);
 			}
 			else if (cmd.equals(Constants.RELAUNCH)) {
 				relaunchPublishLayoutConfiguration(
@@ -226,17 +224,13 @@ public class EditPublishConfigurationAction
 		if (exportImportConfiguration.getType() ==
 				ExportImportConfigurationConstants.TYPE_PUBLISH_LAYOUT_LOCAL) {
 
-			ExportImportConfigurationHelper.
-				publishLocalLayoutByExportImportConfiguration(
-					userId, exportImportConfiguration);
+			StagingUtil.publishLayouts(userId, exportImportConfiguration);
 		}
 		else if (exportImportConfiguration.getType() ==
 					ExportImportConfigurationConstants.
 						TYPE_PUBLISH_LAYOUT_REMOTE) {
 
-			ExportImportConfigurationHelper.
-				publishRemoteLayoutByExportImportConfiguration(
-					exportImportConfiguration);
+			StagingUtil.copyRemoteLayouts(exportImportConfiguration);
 		}
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
@@ -123,6 +123,13 @@ public class ExportImportConfigurationHelper {
 	}
 
 	public static void publishRemoteLayoutByExportImportConfiguration(
+			ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException {
+
+		StagingUtil.copyRemoteLayouts(exportImportConfiguration);
+	}
+
+	public static void publishRemoteLayoutByExportImportConfiguration(
 			long exportImportConfigurationId)
 		throws PortalException, SystemException {
 
@@ -130,33 +137,8 @@ public class ExportImportConfigurationHelper {
 			ExportImportConfigurationLocalServiceUtil.
 				getExportImportConfiguration(exportImportConfigurationId);
 
-		Map<String, Serializable> settingsMap =
-			exportImportConfiguration.getSettingsMap();
-
-		long sourceGroupId = MapUtil.getLong(settingsMap, "sourceGroupId");
-		boolean privateLayout = GetterUtil.getBoolean(
-			settingsMap.get("privateLayout"));
-		Map<Long, Boolean> layoutIdMap = (Map<Long, Boolean>)settingsMap.get(
-			"layoutIdMap");
-		Map<String, String[]> parameterMap =
-			(Map<String, String[]>)settingsMap.get("parameterMap");
-		String remoteAddress = MapUtil.getString(settingsMap, "remoteAddress");
-		int remotePort = MapUtil.getInteger(settingsMap, "remotePort");
-		String remotePathContext = MapUtil.getString(
-			settingsMap, "remotePathContext");
-		boolean secureConnection = MapUtil.getBoolean(
-			settingsMap, "secureConnection");
-		long remoteGroupId = MapUtil.getLong(settingsMap, "remoteGroupId");
-		boolean remotePrivateLayout = MapUtil.getBoolean(
-			settingsMap, "remotePrivateLayout");
-		DateRange dateRange = ExportImportDateUtil.getDateRange(
-			exportImportConfigurationId);
-
-		StagingUtil.copyRemoteLayouts(
-			sourceGroupId, privateLayout, layoutIdMap, parameterMap,
-			remoteAddress, remotePort, remotePathContext, secureConnection,
-			remoteGroupId, remotePrivateLayout, dateRange.getStartDate(),
-			dateRange.getEndDate());
+		publishRemoteLayoutByExportImportConfiguration(
+			exportImportConfiguration);
 	}
 
 	public static ExportImportConfiguration

--- a/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
@@ -92,13 +92,6 @@ public class ExportImportConfigurationHelper {
 	}
 
 	public static void publishLocalLayoutByExportImportConfiguration(
-			long userId, ExportImportConfiguration exportImportConfiguration)
-		throws PortalException, SystemException {
-
-		StagingUtil.publishLayouts(userId, exportImportConfiguration);
-	}
-
-	public static void publishLocalLayoutByExportImportConfiguration(
 			long userId, long exportImportConfigurationId)
 		throws PortalException, SystemException {
 
@@ -106,15 +99,7 @@ public class ExportImportConfigurationHelper {
 			ExportImportConfigurationLocalServiceUtil.
 				getExportImportConfiguration(exportImportConfigurationId);
 
-		publishLocalLayoutByExportImportConfiguration(
-			userId, exportImportConfiguration);
-	}
-
-	public static void publishRemoteLayoutByExportImportConfiguration(
-			ExportImportConfiguration exportImportConfiguration)
-		throws PortalException, SystemException {
-
-		StagingUtil.copyRemoteLayouts(exportImportConfiguration);
+		StagingUtil.publishLayouts(userId, exportImportConfiguration);
 	}
 
 	public static void publishRemoteLayoutByExportImportConfiguration(
@@ -125,8 +110,7 @@ public class ExportImportConfigurationHelper {
 			ExportImportConfigurationLocalServiceUtil.
 				getExportImportConfiguration(exportImportConfigurationId);
 
-		publishRemoteLayoutByExportImportConfiguration(
-			exportImportConfiguration);
+		StagingUtil.copyRemoteLayouts(exportImportConfiguration);
 	}
 
 	public static ExportImportConfiguration

--- a/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
@@ -18,11 +18,7 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.lar.ExportImportDateUtil;
 import com.liferay.portal.kernel.staging.StagingUtil;
-import com.liferay.portal.kernel.util.DateRange;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.ExportImportConfiguration;
@@ -96,6 +92,13 @@ public class ExportImportConfigurationHelper {
 	}
 
 	public static void publishLocalLayoutByExportImportConfiguration(
+			long userId, ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException {
+
+		StagingUtil.publishLayouts(userId, exportImportConfiguration);
+	}
+
+	public static void publishLocalLayoutByExportImportConfiguration(
 			long userId, long exportImportConfigurationId)
 		throws PortalException, SystemException {
 
@@ -103,23 +106,8 @@ public class ExportImportConfigurationHelper {
 			ExportImportConfigurationLocalServiceUtil.
 				getExportImportConfiguration(exportImportConfigurationId);
 
-		Map<String, Serializable> settingsMap =
-			exportImportConfiguration.getSettingsMap();
-
-		long sourceGroupId = MapUtil.getLong(settingsMap, "sourceGroupId");
-		long targetGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
-		boolean privateLayout = GetterUtil.getBoolean(
-			settingsMap.get("privateLayout"));
-		long[] layoutIds = GetterUtil.getLongValues(
-			settingsMap.get("layoutIds"));
-		Map<String, String[]> parameterMap =
-			(Map<String, String[]>)settingsMap.get("parameterMap");
-		DateRange dateRange = ExportImportDateUtil.getDateRange(
-			exportImportConfiguration);
-
-		StagingUtil.publishLayouts(
-			userId, sourceGroupId, targetGroupId, privateLayout, layoutIds,
-			parameterMap, dateRange.getStartDate(), dateRange.getEndDate());
+		publishLocalLayoutByExportImportConfiguration(
+			userId, exportImportConfiguration);
 	}
 
 	public static void publishRemoteLayoutByExportImportConfiguration(

--- a/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
@@ -18,12 +18,10 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.ExportImportConfiguration;
 import com.liferay.portal.service.ExportImportConfigurationLocalServiceUtil;
-import com.liferay.portal.service.LayoutServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.theme.ThemeDisplay;
 
@@ -67,50 +65,6 @@ public class ExportImportConfigurationHelper {
 		return addExportImportConfiguration(
 			portletRequest,
 			ExportImportConfigurationConstants.TYPE_PUBLISH_LAYOUT_REMOTE);
-	}
-
-	public static void exportLayoutsByExportImportConfiguration(
-			long exportImportConfigurationId)
-		throws PortalException, SystemException {
-
-		ExportImportConfiguration exportImportConfiguration =
-			ExportImportConfigurationLocalServiceUtil.
-				getExportImportConfiguration(exportImportConfigurationId);
-
-		LayoutServiceUtil.exportLayoutsAsFileInBackground(
-			exportImportConfiguration);
-	}
-
-	public static void exportLayoutsByExportImportConfiguration(
-			PortletRequest portletRequest)
-		throws PortalException, SystemException {
-
-		long exportImportConfigurationId = ParamUtil.getLong(
-			portletRequest, "exportImportConfigurationId");
-
-		exportLayoutsByExportImportConfiguration(exportImportConfigurationId);
-	}
-
-	public static void publishLocalLayoutByExportImportConfiguration(
-			long userId, long exportImportConfigurationId)
-		throws PortalException, SystemException {
-
-		ExportImportConfiguration exportImportConfiguration =
-			ExportImportConfigurationLocalServiceUtil.
-				getExportImportConfiguration(exportImportConfigurationId);
-
-		StagingUtil.publishLayouts(userId, exportImportConfiguration);
-	}
-
-	public static void publishRemoteLayoutByExportImportConfiguration(
-			long exportImportConfigurationId)
-		throws PortalException, SystemException {
-
-		ExportImportConfiguration exportImportConfiguration =
-			ExportImportConfigurationLocalServiceUtil.
-				getExportImportConfiguration(exportImportConfigurationId);
-
-		StagingUtil.copyRemoteLayouts(exportImportConfiguration);
 	}
 
 	public static ExportImportConfiguration

--- a/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationHelper.java
@@ -81,23 +81,8 @@ public class ExportImportConfigurationHelper {
 			ExportImportConfigurationLocalServiceUtil.
 				getExportImportConfiguration(exportImportConfigurationId);
 
-		Map<String, Serializable> settingsMap =
-			exportImportConfiguration.getSettingsMap();
-
-		long groupId = MapUtil.getLong(settingsMap, "sourceGroupId");
-		boolean privateLayout = GetterUtil.getBoolean(
-			settingsMap.get("privateLayout"));
-		long[] layoutIds = GetterUtil.getLongValues(
-			settingsMap.get("layoutIds"));
-		Map<String, String[]> parameterMap =
-			(Map<String, String[]>)settingsMap.get("parameterMap");
-		DateRange dateRange = ExportImportDateUtil.getDateRange(
-			exportImportConfiguration);
-		String fileName = exportImportConfiguration.getName();
-
 		LayoutServiceUtil.exportLayoutsAsFileInBackground(
-			fileName, groupId, privateLayout, layoutIds, parameterMap,
-			dateRange.getStartDate(), dateRange.getEndDate(), fileName);
+			exportImportConfiguration);
 	}
 
 	public static void exportLayoutsByExportImportConfiguration(

--- a/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationSettingsMapFactory.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/exportimportconfiguration/ExportImportConfigurationSettingsMapFactory.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.lar.ExportImportDateUtil;
 import com.liferay.portal.kernel.lar.ExportImportHelperUtil;
+import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateRange;
@@ -106,6 +107,10 @@ public class ExportImportConfigurationSettingsMapFactory {
 		if (parameterMap != null) {
 			HashMap<String, String[]> serializableParameterMap =
 				new HashMap<String, String[]>(parameterMap);
+
+			serializableParameterMap.put(
+				PortletDataHandlerKeys.PERFORM_DIRECT_BINARY_IMPORT,
+				new String[] {Boolean.TRUE.toString()});
 
 			settingsMap.put("parameterMap", serializableParameterMap);
 		}

--- a/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
@@ -79,6 +79,9 @@ public interface Staging {
 			ExportImportConfiguration exportImportConfiguration)
 		throws PortalException, SystemException;
 
+	public void copyRemoteLayouts(long exportImportConfigurationId)
+		throws PortalException, SystemException;
+
 	public void copyRemoteLayouts(
 			long sourceGroupId, boolean privateLayout,
 			Map<Long, Boolean> layoutIdMap, Map<String, String[]> parameterMap,
@@ -233,6 +236,9 @@ public interface Staging {
 
 	public void publishLayouts(
 			long userId, ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException;
+
+	public void publishLayouts(long userId, long exportImportConfigurationId)
 		throws PortalException, SystemException;
 
 	public void publishLayouts(

--- a/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
@@ -75,6 +75,10 @@ public interface Staging {
 		throws PortalException, SystemException;
 
 	public void copyRemoteLayouts(
+			ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException;
+
+	public void copyRemoteLayouts(
 			long sourceGroupId, boolean privateLayout,
 			Map<Long, Boolean> layoutIdMap, Map<String, String[]> parameterMap,
 			String remoteAddress, int remotePort, String remotePathContext,

--- a/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.model.ExportImportConfiguration;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutRevision;
@@ -228,6 +229,10 @@ public interface Staging {
 
 	public void publishLayout(
 			long userId, long plid, long liveGroupId, boolean includeChildren)
+		throws PortalException, SystemException;
+
+	public void publishLayouts(
+			long userId, ExportImportConfiguration exportImportConfiguration)
 		throws PortalException, SystemException;
 
 	public void publishLayouts(

--- a/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermissio
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.model.ExportImportConfiguration;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutRevision;
@@ -369,6 +370,13 @@ public class StagingUtil {
 		throws PortalException, SystemException {
 
 		getStaging().publishLayout(userId, plid, liveGroupId, includeChildren);
+	}
+
+	public static void publishLayouts(
+			long userId, ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException {
+
+		getStaging().publishLayouts(userId, exportImportConfiguration);
 	}
 
 	public static void publishLayouts(

--- a/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
@@ -109,6 +109,12 @@ public class StagingUtil {
 		getStaging().copyRemoteLayouts(exportImportConfiguration);
 	}
 
+	public static void copyRemoteLayouts(long exportImportConfigurationId)
+		throws PortalException, SystemException {
+
+		getStaging().copyRemoteLayouts(exportImportConfigurationId);
+	}
+
 	public static void copyRemoteLayouts(
 			long sourceGroupId, boolean privateLayout,
 			Map<Long, Boolean> layoutIdMap, Map<String, String[]> parameterMap,
@@ -377,6 +383,13 @@ public class StagingUtil {
 		throws PortalException, SystemException {
 
 		getStaging().publishLayouts(userId, exportImportConfiguration);
+	}
+
+	public static void publishLayouts(
+			long userId, long exportImportConfigurationId)
+		throws PortalException, SystemException {
+
+		getStaging().publishLayouts(userId, exportImportConfigurationId);
 	}
 
 	public static void publishLayouts(

--- a/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
@@ -102,6 +102,13 @@ public class StagingUtil {
 	}
 
 	public static void copyRemoteLayouts(
+			ExportImportConfiguration exportImportConfiguration)
+		throws PortalException, SystemException {
+
+		getStaging().copyRemoteLayouts(exportImportConfiguration);
+	}
+
+	public static void copyRemoteLayouts(
 			long sourceGroupId, boolean privateLayout,
 			Map<Long, Boolean> layoutIdMap, Map<String, String[]> parameterMap,
 			String remoteAddress, int remotePort, String remotePathContext,

--- a/portal-service/src/com/liferay/portal/service/LayoutLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutLocalService.java
@@ -649,6 +649,30 @@ public interface LayoutLocalService extends BaseLocalService,
 			com.liferay.portal.kernel.exception.SystemException;
 
 	public long exportLayoutsAsFileInBackground(long userId,
+		com.liferay.portal.model.ExportImportConfiguration exportImportConfiguration)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public long exportLayoutsAsFileInBackground(long userId,
+		long exportImportConfigurationId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public long exportLayoutsAsFileInBackground(long userId,
+		java.lang.String taskName, long groupId, boolean privateLayout,
+		long[] layoutIds,
+		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
+		java.util.Date startDate, java.util.Date endDate)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#exportLayoutsAsFileInBackground(long, String, long, boolean,
+	long[], Map, Date, Date)}
+	*/
+	@Deprecated
+	public long exportLayoutsAsFileInBackground(long userId,
 		java.lang.String taskName, long groupId, boolean privateLayout,
 		long[] layoutIds,
 		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,

--- a/portal-service/src/com/liferay/portal/service/LayoutLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutLocalServiceUtil.java
@@ -720,6 +720,42 @@ public class LayoutLocalServiceUtil {
 	}
 
 	public static long exportLayoutsAsFileInBackground(long userId,
+		com.liferay.portal.model.ExportImportConfiguration exportImportConfiguration)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .exportLayoutsAsFileInBackground(userId,
+			exportImportConfiguration);
+	}
+
+	public static long exportLayoutsAsFileInBackground(long userId,
+		long exportImportConfigurationId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .exportLayoutsAsFileInBackground(userId,
+			exportImportConfigurationId);
+	}
+
+	public static long exportLayoutsAsFileInBackground(long userId,
+		java.lang.String taskName, long groupId, boolean privateLayout,
+		long[] layoutIds,
+		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
+		java.util.Date startDate, java.util.Date endDate)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .exportLayoutsAsFileInBackground(userId, taskName, groupId,
+			privateLayout, layoutIds, parameterMap, startDate, endDate);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#exportLayoutsAsFileInBackground(long, String, long, boolean,
+	long[], Map, Date, Date)}
+	*/
+	@Deprecated
+	public static long exportLayoutsAsFileInBackground(long userId,
 		java.lang.String taskName, long groupId, boolean privateLayout,
 		long[] layoutIds,
 		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,

--- a/portal-service/src/com/liferay/portal/service/LayoutLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutLocalServiceWrapper.java
@@ -739,6 +739,43 @@ public class LayoutLocalServiceWrapper implements LayoutLocalService,
 
 	@Override
 	public long exportLayoutsAsFileInBackground(long userId,
+		com.liferay.portal.model.ExportImportConfiguration exportImportConfiguration)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _layoutLocalService.exportLayoutsAsFileInBackground(userId,
+			exportImportConfiguration);
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(long userId,
+		long exportImportConfigurationId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _layoutLocalService.exportLayoutsAsFileInBackground(userId,
+			exportImportConfigurationId);
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(long userId,
+		java.lang.String taskName, long groupId, boolean privateLayout,
+		long[] layoutIds,
+		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
+		java.util.Date startDate, java.util.Date endDate)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _layoutLocalService.exportLayoutsAsFileInBackground(userId,
+			taskName, groupId, privateLayout, layoutIds, parameterMap,
+			startDate, endDate);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#exportLayoutsAsFileInBackground(long, String, long, boolean,
+	long[], Map, Date, Date)}
+	*/
+	@Deprecated
+	@Override
+	public long exportLayoutsAsFileInBackground(long userId,
 		java.lang.String taskName, long groupId, boolean privateLayout,
 		long[] layoutIds,
 		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,

--- a/portal-service/src/com/liferay/portal/service/LayoutService.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutService.java
@@ -349,6 +349,29 @@ public interface LayoutService extends BaseService {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 
+	public long exportLayoutsAsFileInBackground(
+		com.liferay.portal.model.ExportImportConfiguration exportImportConfiguration)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public long exportLayoutsAsFileInBackground(
+		long exportImportConfigurationId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	public long exportLayoutsAsFileInBackground(java.lang.String taskName,
+		long groupId, boolean privateLayout, long[] layoutIds,
+		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
+		java.util.Date startDate, java.util.Date endDate)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#exportLayoutsAsFileInBackground(String, long, boolean,
+	long[], Map, Date, Date)}
+	*/
+	@Deprecated
 	public long exportLayoutsAsFileInBackground(java.lang.String taskName,
 		long groupId, boolean privateLayout, long[] layoutIds,
 		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,

--- a/portal-service/src/com/liferay/portal/service/LayoutServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutServiceUtil.java
@@ -386,6 +386,40 @@ public class LayoutServiceUtil {
 	}
 
 	public static long exportLayoutsAsFileInBackground(
+		com.liferay.portal.model.ExportImportConfiguration exportImportConfiguration)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .exportLayoutsAsFileInBackground(exportImportConfiguration);
+	}
+
+	public static long exportLayoutsAsFileInBackground(
+		long exportImportConfigurationId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .exportLayoutsAsFileInBackground(exportImportConfigurationId);
+	}
+
+	public static long exportLayoutsAsFileInBackground(
+		java.lang.String taskName, long groupId, boolean privateLayout,
+		long[] layoutIds,
+		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
+		java.util.Date startDate, java.util.Date endDate)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .exportLayoutsAsFileInBackground(taskName, groupId,
+			privateLayout, layoutIds, parameterMap, startDate, endDate);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#exportLayoutsAsFileInBackground(String, long, boolean,
+	long[], Map, Date, Date)}
+	*/
+	@Deprecated
+	public static long exportLayoutsAsFileInBackground(
 		java.lang.String taskName, long groupId, boolean privateLayout,
 		long[] layoutIds,
 		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,

--- a/portal-service/src/com/liferay/portal/service/LayoutServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutServiceWrapper.java
@@ -380,6 +380,39 @@ public class LayoutServiceWrapper implements LayoutService,
 	}
 
 	@Override
+	public long exportLayoutsAsFileInBackground(
+		com.liferay.portal.model.ExportImportConfiguration exportImportConfiguration)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _layoutService.exportLayoutsAsFileInBackground(exportImportConfiguration);
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(
+		long exportImportConfigurationId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _layoutService.exportLayoutsAsFileInBackground(exportImportConfigurationId);
+	}
+
+	@Override
+	public long exportLayoutsAsFileInBackground(java.lang.String taskName,
+		long groupId, boolean privateLayout, long[] layoutIds,
+		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,
+		java.util.Date startDate, java.util.Date endDate)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _layoutService.exportLayoutsAsFileInBackground(taskName,
+			groupId, privateLayout, layoutIds, parameterMap, startDate, endDate);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#exportLayoutsAsFileInBackground(String, long, boolean,
+	long[], Map, Date, Date)}
+	*/
+	@Deprecated
+	@Override
 	public long exportLayoutsAsFileInBackground(java.lang.String taskName,
 		long groupId, boolean privateLayout, long[] layoutIds,
 		java.util.Map<java.lang.String, java.lang.String[]> parameterMap,


### PR DESCRIPTION
Hey Brian,

This change's purpose is mainly to be able to use the ExportImportConfiguration to kick off a staging or export process, and also to have only one configuration object per process instead of creating multiple.

In this commit: https://github.com/matethurzo/liferay-portal/commit/2efedbe02ebd4d9854bb12b5fa480c61f8d5a9dc on the first glance it might be more obvious if one copyRemoteLayouts method would call the other one with the ExportImportConfiguration parameter, but we need to validate the process first, and if the validation fails we should not create the configuration entity at all. That's why I went for the copyRemoteLayouts - doCopyRemoteLayouts pattern to reuse code.

Thanks,

Máté
