### PR TITLE
LPS-46267 The archived setups always belong to the site even if there are page scopes, so getScopeGroupId() should not be used. Instead use getSiteGroupId()

### DIFF
--- a/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditArchivedSetupsAction.java
+++ b/portal-impl/src/com/liferay/portlet/portletconfiguration/action/EditArchivedSetupsAction.java
@@ -167,7 +167,7 @@ public class EditArchivedSetupsAction extends PortletAction {
 
 		ArchivedSettings archivedSettings =
 			SettingsFactoryUtil.getPortletInstanceArchivedSettings(
-				themeDisplay.getScopeGroupId(), portlet.getRootPortletId(),
+				themeDisplay.getSiteGroupId(), portlet.getRootPortletId(),
 				name);
 
 		archivedSettings.delete();
@@ -183,7 +183,7 @@ public class EditArchivedSetupsAction extends PortletAction {
 
 		ArchivedSettings archivedSettings =
 			SettingsFactoryUtil.getPortletInstanceArchivedSettings(
-				themeDisplay.getScopeGroupId(), portlet.getRootPortletId(),
+				themeDisplay.getSiteGroupId(), portlet.getRootPortletId(),
 				name);
 
 		Settings portletInstanceSettings =
@@ -205,7 +205,7 @@ public class EditArchivedSetupsAction extends PortletAction {
 
 		ArchivedSettings archivedSettings =
 			SettingsFactoryUtil.getPortletInstanceArchivedSettings(
-				themeDisplay.getScopeGroupId(), portlet.getRootPortletId(),
+				themeDisplay.getSiteGroupId(), portlet.getRootPortletId(),
 				name);
 
 		Settings portletInstanceSettings =

--- a/portal-web/docroot/html/portlet/portlet_configuration/archived_setup_action.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/archived_setup_action.jsp
@@ -21,7 +21,7 @@ ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_
 
 Object[] objects = (Object[])row.getObject();
 
-PortletItem portletItem = (PortletItem)objects[0];
+ArchivedSettings archivedSettings = (ArchivedSettings)objects[0];
 portletResource = (String)objects[1];
 %>
 
@@ -31,7 +31,7 @@ portletResource = (String)objects[1];
 		<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.RESTORE %>" />
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 		<portlet:param name="portletResource" value="<%= portletResource %>" />
-		<portlet:param name="name" value="<%= portletItem.getName() %>" />
+		<portlet:param name="name" value="<%= archivedSettings.getName() %>" />
 	</portlet:actionURL>
 
 	<liferay-ui:icon
@@ -45,7 +45,7 @@ portletResource = (String)objects[1];
 		<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.DELETE %>" />
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 		<portlet:param name="portletResource" value="<%= portletResource %>" />
-		<portlet:param name="portletItemId" value="<%= String.valueOf(portletItem.getPortletItemId()) %>" />
+		<portlet:param name="name" value="<%= archivedSettings.getName() %>" />
 	</portlet:actionURL>
 
 	<liferay-ui:icon-delete

--- a/portal-web/docroot/html/portlet/portlet_configuration/edit_archived_setups.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/edit_archived_setups.jsp
@@ -65,38 +65,36 @@ portletURL.setParameter("portletResource", portletResource);
 	headerNames.add("modified-date");
 	headerNames.add(StringPool.BLANK);
 
-	SearchContainer searchContainer = new SearchContainer(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, "there-are-no-archived-setups");
+	SearchContainer<ArchivedSettings> searchContainer = new SearchContainer<ArchivedSettings>(renderRequest, null, null, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_DELTA, portletURL, headerNames, "there-are-no-archived-setups");
 
-	List archivedSetups = PortletItemLocalServiceUtil.getPortletItems(scopeGroupId, selPortlet.getRootPortletId(), com.liferay.portal.model.PortletPreferences.class.getName());
+	List<ArchivedSettings> archivedSettingsList = SettingsFactoryUtil.getPortletInstanceArchivedSettingsList(scopeGroupId, selPortlet.getRootPortletId());
 
-	int total = archivedSetups.size();
+	int total = archivedSettingsList.size();
 
 	searchContainer.setTotal(total);
 
-	List results = ListUtil.subList(archivedSetups, searchContainer.getStart(), searchContainer.getEnd());
+	List<ArchivedSettings> results = ListUtil.subList(archivedSettingsList, searchContainer.getStart(), searchContainer.getEnd());
 
 	searchContainer.setResults(results);
 
-	List resultRows = searchContainer.getResultRows();
+	List<ResultRow> resultRows = searchContainer.getResultRows();
 
 	for (int i = 0; i < results.size(); i++) {
-		PortletItem portletItem = (PortletItem)results.get(i);
+		ArchivedSettings archivedSettings = results.get(i);
 
-		portletItem = portletItem.toEscapedModel();
-
-		ResultRow row = new ResultRow(new Object[] {portletItem, portletResource}, portletItem.getName(), i);
+		ResultRow row = new ResultRow(new Object[] {archivedSettings, portletResource}, archivedSettings.getName(), i);
 
 		// Name
 
-		row.addText(portletItem.getName());
+		row.addText(archivedSettings.getName());
 
 		// User
 
-		row.addText(PortalUtil.getUserName(portletItem));
+		row.addText(archivedSettings.getUserName());
 
 		// Date
 
-		row.addDate(portletItem.getModifiedDate());
+		row.addDate(archivedSettings.getModifiedDate());
 
 		// Action
 

--- a/portal-web/docroot/html/portlet/portlet_configuration/init.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/init.jsp
@@ -43,6 +43,7 @@ page import="com.liferay.portal.lar.backgroundtask.PortletExportBackgroundTaskEx
 page import="com.liferay.portal.lar.backgroundtask.PortletImportBackgroundTaskExecutor" %><%@
 page import="com.liferay.portal.lar.backgroundtask.PortletStagingBackgroundTaskExecutor" %><%@
 page import="com.liferay.portal.service.permission.TeamPermissionUtil" %><%@
+page import="com.liferay.portal.settings.ArchivedSettings" %><%@
 page import="com.liferay.portal.util.ResourcePermissionUtil" %><%@
 page import="com.liferay.portlet.PortletQNameUtil" %><%@
 page import="com.liferay.portlet.backgroundtask.util.comparator.BackgroundTaskComparatorFactoryUtil" %><%@


### PR DESCRIPTION
This depends on pull https://github.com/brianchandotcom/liferay-plugins/pull/3177. After this is accepted we will do deprecation of methods in PortletPreferencesImpl that are no longer needed. Also note that we instanced SettingsHelper instead of using a Util class with static methods because @rotty3000 has explicitely asked to don't use that patter any more /cc @izaera
