### PR TITLE
Source formatting

### DIFF
--- a/portal-impl/src/com/liferay/portal/cache/ehcache/CacheManagerUtil.java
+++ b/portal-impl/src/com/liferay/portal/cache/ehcache/CacheManagerUtil.java
@@ -49,7 +49,7 @@ public class CacheManagerUtil {
 
 			if (JavaDetector.isJDK6()) {
 				blockingQueue = (BlockingQueue<Runnable>)_workQueueField.get(
-					scheduledThreadPoolExecutor);;
+					scheduledThreadPoolExecutor);
 
 				_workQueueField.set(
 					scheduledThreadPoolExecutor,

--- a/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/cache/PortalCacheDatagramReceiveHandlerTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/cache/PortalCacheDatagramReceiveHandlerTest.java
@@ -462,7 +462,7 @@ public class PortalCacheDatagramReceiveHandlerTest {
 
 	private MockIntraband _mockIntraband = new MockIntraband();
 	private MockPortalCacheManager _mockPortalCacheManager =
-		new MockPortalCacheManager();;
+		new MockPortalCacheManager();
 	private MockRegistrationReference _mockRegistrationReference =
 		new MockRegistrationReference(_mockIntraband);
 	private SystemDataType _portalCacheSystemDataType =

--- a/portal-service/test/unit/com/liferay/portal/kernel/io/OutputStreamWriterTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/io/OutputStreamWriterTest.java
@@ -90,7 +90,7 @@ public class OutputStreamWriterTest {
 
 		Assert.assertSame(
 			dummyOutputStream, _getOutputStream(outputStreamWriter));
-		Assert.assertSame(encoding, outputStreamWriter.getEncoding());;
+		Assert.assertSame(encoding, outputStreamWriter.getEncoding());
 		Assert.assertEquals(
 			_getDefaultOutputBufferSize(),
 			_getOutputBufferSize(outputStreamWriter));


### PR DESCRIPTION
@hhuijser can we source formattor this?

The only valid ";;" case in java file, should be inside for loop condition. Others are all invalid.
