### PR TITLE
LPS-46779 Improved query: get the mapped objects from the first query instead of getting userIds first and then iterate to get mapped objects

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -38,14 +38,12 @@ import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.persistence.GroupUtil;
 import com.liferay.portal.service.persistence.RoleUtil;
 import com.liferay.portal.service.persistence.UserFinder;
-import com.liferay.portal.service.persistence.UserUtil;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -854,18 +852,7 @@ public class UserFinderImpl
 				}
 			}
 
-			Set<Long> userIds = new LinkedHashSet<Long>(
-				(List<Long>)QueryUtil.list(q, getDialect(), start, end));
-
-			List<User> users = new ArrayList<User>(userIds.size());
-
-			for (Long userId : userIds) {
-				User user = UserUtil.findByPrimaryKey(userId);
-
-				users.add(user);
-			}
-
-			return users;
+			return (List<User>)QueryUtil.list(q, getDialect(), start, end);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -788,7 +788,7 @@ public class UserFinderImpl
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 
-			q.addScalar("userId", Type.LONG);
+			q.addEntity("User_", UserImpl.class);
 
 			QueryPos qPos = QueryPos.getInstance(q);
 

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1415,7 +1415,7 @@
 	<sql id="com.liferay.portal.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.userId AS userId
+				DISTINCT User_.*
 			FROM
 				User_
 			[$JOIN$]

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.util.RoleTestUtil;
 import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portal.util.UserGroupTestUtil;
 import com.liferay.portal.util.UserTestUtil;
+import com.liferay.portal.util.comparator.UserLastNameComparator;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -160,6 +161,19 @@ public class UserFinderTest {
 			WorkflowConstants.STATUS_APPROVED, _inheritedUserRolesParams);
 
 		Assert.assertEquals(expectedCount + 2, count);
+	}
+
+	@Test
+	public void testFindByC_FN_MN_LN_SN_EA_SWithUnionAndOrderByComparator()
+		throws Exception {
+
+		List<User> users = UserFinderUtil.findByC_FN_MN_LN_SN_EA_S(
+			TestPropsValues.getCompanyId(), (String[])null, null, null, null,
+			null, 0, _inheritedUserGroupsParams, true, 0, 20,
+			new UserLastNameComparator());
+
+		Assert.assertNotNull(users);
+		Assert.assertFalse(users.isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Hey Brian!

I reviewed what you said in https://github.com/brianchandotcom/liferay-portal/pull/18592.
Two things to mention
- We can't use brackets in custom select because that way, all queries must use the Hibernate query with entity, but not with scalar. If you check countByC_FN_MN_LN_SN_EA_S method, it uses the same query but with an scalar (userId) instead of an entity (UserImpl)
- I reviewed my SQLQueryImpl change and it's not needed anymore, so I reverted it. I thought union queries couldn't use table aliases but it seems they can.

Thanks!
