### PR TITLE
LPS-46779 Site memberships - Exceptions is thrown when clicks a summary tab after site member is assigned

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -38,14 +38,12 @@ import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.persistence.GroupUtil;
 import com.liferay.portal.service.persistence.RoleUtil;
 import com.liferay.portal.service.persistence.UserFinder;
-import com.liferay.portal.service.persistence.UserUtil;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -854,18 +852,7 @@ public class UserFinderImpl
 				}
 			}
 
-			Set<Long> userIds = new LinkedHashSet<Long>(
-				(List<Long>)QueryUtil.list(q, getDialect(), start, end));
-
-			List<User> users = new ArrayList<User>(userIds.size());
-
-			for (Long userId : userIds) {
-				User user = UserUtil.findByPrimaryKey(userId);
-
-				users.add(user);
-			}
-
-			return users;
+			return (List<User>)QueryUtil.list(q, getDialect(), start, end);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -788,7 +788,7 @@ public class UserFinderImpl
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 
-			q.addScalar("userId", Type.LONG);
+			q.addEntity("User_", UserImpl.class);
 
 			QueryPos qPos = QueryPos.getInstance(q);
 

--- a/portal-impl/src/com/liferay/portal/settings/PropertiesSettings.java
+++ b/portal-impl/src/com/liferay/portal/settings/PropertiesSettings.java
@@ -104,7 +104,6 @@ public class PropertiesSettings extends BaseSettings {
 		String value = _properties.getProperty(key);
 
 		if (isLocationVariable("resource", value)) {
-		System.out.println("## here [" + getLocation("resource", value) + "]");
 			return ContentUtil.get(getLocation("resource", value));
 		}
 

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1415,7 +1415,7 @@
 	<sql id="com.liferay.portal.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.userId AS userId
+				DISTINCT User_.*
 			FROM
 				User_
 			[$JOIN$]

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1415,7 +1415,22 @@
 	<sql id="com.liferay.portal.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.*
+				DISTINCT User_.mvccVersion, User_.uuid_, User_.userId,
+				User_.companyId, User_.createDate, User_.modifiedDate,
+				User_.defaultUser, User_.contactId, User_.password_,
+				User_.passwordEncrypted, User_.passwordReset,
+				User_.passwordModifiedDate, User_.digest,
+				User_.reminderQueryQuestion, User_.reminderQueryAnswer,
+				User_.graceLoginCount, User_.screenName, User_.emailAddress,
+				User_.facebookId, User_.ldapServerId, User_.openId,
+				User_.portraitId, User_.languageId, User_.timeZoneId,
+				User_.greeting, User_.comments, User_.firstName,
+				User_.middleName, User_.lastName, User_.jobTitle,
+				User_.loginDate, User_.loginIP, User_.lastLoginDate,
+				User_.lastLoginIP, User_.lastFailedLoginDate,
+				User_.failedLoginAttempts, User_.lockout, User_.lockoutDate,
+				User_.agreedToTermsOfUse, User_.emailAddressVerified,
+				User_.status
 			FROM
 				User_
 			[$JOIN$]

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.util.RoleTestUtil;
 import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portal.util.UserGroupTestUtil;
 import com.liferay.portal.util.UserTestUtil;
+import com.liferay.portal.util.comparator.UserLastNameComparator;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -160,6 +161,19 @@ public class UserFinderTest {
 			WorkflowConstants.STATUS_APPROVED, _inheritedUserRolesParams);
 
 		Assert.assertEquals(expectedCount + 2, count);
+	}
+
+	@Test
+	public void testFindByC_FN_MN_LN_SN_EA_SWithUnionAndOrderByComparator()
+		throws Exception {
+
+		List<User> users = UserFinderUtil.findByC_FN_MN_LN_SN_EA_S(
+			TestPropsValues.getCompanyId(), (String[])null, null, null, null,
+			null, 0, _inheritedUserGroupsParams, true, 0, 20,
+			new UserLastNameComparator());
+
+		Assert.assertNotNull(users);
+		Assert.assertFalse(users.isEmpty());
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/settings/PropertiesSettingsTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/settings/PropertiesSettingsTest.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.settings;
 
-import com.liferay.portal.settings.PropertiesSettings;
-
 import java.util.Properties;
 
 import org.junit.Assert;

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/SetUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/SetUtilTest.java
@@ -38,12 +38,10 @@ public class SetUtilTest {
 	public void testIntersectEmptyShortcut() {
 		Assert.assertSame(
 			Collections.emptySet(),
-			SetUtil.intersect(
-				new ArrayList<String>(), Arrays.asList("a")));
+			SetUtil.intersect(new ArrayList<String>(), Arrays.asList("a")));
 		Assert.assertSame(
 			Collections.emptySet(),
-			SetUtil.intersect(
-				Arrays.asList("a"), new ArrayList<String>()));
+			SetUtil.intersect(Arrays.asList("a"), new ArrayList<String>()));
 	}
 
 	@Test


### PR DESCRIPTION
Hey Brian!

I reviewed what you said in https://github.com/brianchandotcom/liferay-portal/pull/18592.
Three things to mention:
- We can't use brackets in custom selects because that way, all Hibernate queries must get each row using an entity (`addEntity`), but won't work using scalar (`addScalar`). If you check `countByC_FN_MN_LN_SN_EA_S` method, it uses the same query but with an scalar (`userId`) instead of an entity (`UserImpl`), so `{User_.*}` will break `countBy_Blah_Blah` method.
- We can't use `User_*` without brackets neither because Oracle construction `(SELECT ... UNION SELECT ...) ORDER BY ...` needs explicit column names in order to work. If you get all columns with *, you cannot sort by those columns. So I added explicitly all columns defined in table `User_`. I'm **not happy** with this solution, because we're adding a weird query in `portal.xml` that nobody will understand. I'd add a comment pointing to [this doc](http://docs.oracle.com/cd/E17952_01/refman-5.1-en/union.html). This way at least devs would understand the decision made. Or even better: I'd write some mechanist in order to have several `custom-sql/model.xml` files (one per DB vendor) and allow devs to define specific _tuned_ queries for specific vendor (in this scenario, we'd have `portal.xml` and `portal-oracle.xml`, the former with common queries for all vendors and the latter with overwritten queries). **UPDATE**: check this proposal for custom specific queries: https://github.com/brianchandotcom/liferay-portal/pull/18608
- I reviewed my `SQLQueryImpl` change and you're right: it's not needed, so I reverted it. I thought union queries couldn't use table aliases but it seems they can.

I hope it's clear enough. If not, just ping me!

Thanks!
