### PR TITLE
[Proof-of-concept] New mechanism to define vendor specific queries in the portal

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -38,14 +38,12 @@ import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.persistence.GroupUtil;
 import com.liferay.portal.service.persistence.RoleUtil;
 import com.liferay.portal.service.persistence.UserFinder;
-import com.liferay.portal.service.persistence.UserUtil;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -854,18 +852,7 @@ public class UserFinderImpl
 				}
 			}
 
-			Set<Long> userIds = new LinkedHashSet<Long>(
-				(List<Long>)QueryUtil.list(q, getDialect(), start, end));
-
-			List<User> users = new ArrayList<User>(userIds.size());
-
-			for (Long userId : userIds) {
-				User user = UserUtil.findByPrimaryKey(userId);
-
-				users.add(user);
-			}
-
-			return users;
+			return (List<User>)QueryUtil.list(q, getDialect(), start, end);
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/UserFinderImpl.java
@@ -788,7 +788,7 @@ public class UserFinderImpl
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 
-			q.addScalar("userId", Type.LONG);
+			q.addEntity("User_", UserImpl.class);
 
 			QueryPos qPos = QueryPos.getInstance(q);
 

--- a/portal-impl/src/com/liferay/portal/settings/PropertiesSettings.java
+++ b/portal-impl/src/com/liferay/portal/settings/PropertiesSettings.java
@@ -104,7 +104,6 @@ public class PropertiesSettings extends BaseSettings {
 		String value = _properties.getProperty(key);
 
 		if (isLocationVariable("resource", value)) {
-		System.out.println("## here [" + getLocation("resource", value) + "]");
 			return ContentUtil.get(getLocation("resource", value));
 		}
 

--- a/portal-impl/src/custom-sql/default.xml
+++ b/portal-impl/src/custom-sql/default.xml
@@ -2,6 +2,7 @@
 
 <custom-sql>
 	<sql file="custom-sql/portal.xml" />
+	<sql file="custom-sql/portal-oracle.xml" />
 	<sql file="custom-sql/announcements.xml" />
 	<sql file="custom-sql/asset.xml" />
 	<sql file="custom-sql/blogs.xml" />

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1415,7 +1415,7 @@
 	<sql id="com.liferay.portal.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.userId AS userId
+				DISTINCT User_.*
 			FROM
 				User_
 			[$JOIN$]

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1415,22 +1415,7 @@
 	<sql id="com.liferay.portal.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.mvccVersion, User_.uuid_, User_.userId,
-				User_.companyId, User_.createDate, User_.modifiedDate,
-				User_.defaultUser, User_.contactId, User_.password_,
-				User_.passwordEncrypted, User_.passwordReset,
-				User_.passwordModifiedDate, User_.digest,
-				User_.reminderQueryQuestion, User_.reminderQueryAnswer,
-				User_.graceLoginCount, User_.screenName, User_.emailAddress,
-				User_.facebookId, User_.ldapServerId, User_.openId,
-				User_.portraitId, User_.languageId, User_.timeZoneId,
-				User_.greeting, User_.comments, User_.firstName,
-				User_.middleName, User_.lastName, User_.jobTitle,
-				User_.loginDate, User_.loginIP, User_.lastLoginDate,
-				User_.lastLoginIP, User_.lastFailedLoginDate,
-				User_.failedLoginAttempts, User_.lockout, User_.lockoutDate,
-				User_.agreedToTermsOfUse, User_.emailAddressVerified,
-				User_.status
+				DISTINCT User_.*
 			FROM
 				User_
 			[$JOIN$]

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1415,7 +1415,22 @@
 	<sql id="com.liferay.portal.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.*
+				DISTINCT User_.mvccVersion, User_.uuid_, User_.userId,
+				User_.companyId, User_.createDate, User_.modifiedDate,
+				User_.defaultUser, User_.contactId, User_.password_,
+				User_.passwordEncrypted, User_.passwordReset,
+				User_.passwordModifiedDate, User_.digest,
+				User_.reminderQueryQuestion, User_.reminderQueryAnswer,
+				User_.graceLoginCount, User_.screenName, User_.emailAddress,
+				User_.facebookId, User_.ldapServerId, User_.openId,
+				User_.portraitId, User_.languageId, User_.timeZoneId,
+				User_.greeting, User_.comments, User_.firstName,
+				User_.middleName, User_.lastName, User_.jobTitle,
+				User_.loginDate, User_.loginIP, User_.lastLoginDate,
+				User_.lastLoginIP, User_.lastFailedLoginDate,
+				User_.failedLoginAttempts, User_.lockout, User_.lockoutDate,
+				User_.agreedToTermsOfUse, User_.emailAddressVerified,
+				User_.status
 			FROM
 				User_
 			[$JOIN$]

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/UserFinderTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.util.RoleTestUtil;
 import com.liferay.portal.util.TestPropsValues;
 import com.liferay.portal.util.UserGroupTestUtil;
 import com.liferay.portal.util.UserTestUtil;
+import com.liferay.portal.util.comparator.UserLastNameComparator;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -160,6 +161,19 @@ public class UserFinderTest {
 			WorkflowConstants.STATUS_APPROVED, _inheritedUserRolesParams);
 
 		Assert.assertEquals(expectedCount + 2, count);
+	}
+
+	@Test
+	public void testFindByC_FN_MN_LN_SN_EA_SWithUnionAndOrderByComparator()
+		throws Exception {
+
+		List<User> users = UserFinderUtil.findByC_FN_MN_LN_SN_EA_S(
+			TestPropsValues.getCompanyId(), (String[])null, null, null, null,
+			null, 0, _inheritedUserGroupsParams, true, 0, 20,
+			new UserLastNameComparator());
+
+		Assert.assertNotNull(users);
+		Assert.assertFalse(users.isEmpty());
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/settings/PropertiesSettingsTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/settings/PropertiesSettingsTest.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.settings;
 
-import com.liferay.portal.settings.PropertiesSettings;
-
 import java.util.Properties;
 
 import org.junit.Assert;

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/SetUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/SetUtilTest.java
@@ -38,12 +38,10 @@ public class SetUtilTest {
 	public void testIntersectEmptyShortcut() {
 		Assert.assertSame(
 			Collections.emptySet(),
-			SetUtil.intersect(
-				new ArrayList<String>(), Arrays.asList("a")));
+			SetUtil.intersect(new ArrayList<String>(), Arrays.asList("a")));
 		Assert.assertSame(
 			Collections.emptySet(),
-			SetUtil.intersect(
-				Arrays.asList("a"), new ArrayList<String>()));
+			SetUtil.intersect(Arrays.asList("a"), new ArrayList<String>()));
 	}
 
 	@Test

--- a/util-java/src/com/liferay/util/dao/orm/CustomSQL.java
+++ b/util-java/src/com/liferay/util/dao/orm/CustomSQL.java
@@ -14,6 +14,8 @@
 
 package com.liferay.util.dao.orm;
 
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
@@ -23,6 +25,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CharPool;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
@@ -759,6 +762,27 @@ public class CustomSQL {
 		}
 	}
 
+	protected boolean isApplicableCustomSQLFile(String file) {
+		DB db = DBFactoryUtil.getDB();
+
+		String fileName = FileUtil.getShortFileName(file);
+
+		if (fileName.contains(StringPool.DASH)) {
+			String dbVendor = StringUtil.split(fileName, CharPool.DASH)[1];
+
+			dbVendor = FileUtil.stripExtension(dbVendor);
+
+			if (db.getType().equals(dbVendor)) {
+				return true;
+			}
+		}
+		else {
+			return true;
+		}
+
+		return false;
+	}
+
 	protected void read(ClassLoader classLoader, String source)
 		throws Exception {
 
@@ -780,7 +804,9 @@ public class CustomSQL {
 			String file = sqlElement.attributeValue("file");
 
 			if (Validator.isNotNull(file)) {
-				read(classLoader, file);
+				if (isApplicableCustomSQLFile(file)) {
+					read(classLoader, file);
+				}
 			}
 			else {
 				String id = sqlElement.attributeValue("id");


### PR DESCRIPTION
Brian, please review and consider this new pattern/mechanism of custom-sql loading.

The aim is allow developers to define custom vendor specific queries. This way we can tune any query using specific vendor capabilities (non-standard functions, constructions, idioms whatever), instead of trying to write standard/agnostic queries all the time (which are usually most inefficient and complex than specific ones)

The approach is quite straightforward: define a new naming pattern for custom-sql xml files: `custom-sql/model.xml` for common queries (standard ones) and `custom-sql/model-vendor.xml` for specific ones. The latter overwrites to former, so when you get one query, you'll have the specific one for current vendor (if exists) or the common one.

Looking forward your feedback!
