### PR TITLE
LPS-46825 addResources reindex the user & contact internally, so we need to create the contact before to add the resources

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -845,8 +845,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		userPersistence.update(user, serviceContext);
 
-		// Resources
-
 		String creatorUserName = StringPool.BLANK;
 
 		if (creatorUserId <= 0) {
@@ -862,10 +860,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			creatorUserName = creatorUser.getFullName();
 		}
-
-		resourceLocalService.addResources(
-			companyId, 0, creatorUserId, User.class.getName(), user.getUserId(),
-			false, false, false);
 
 		// Contact
 
@@ -893,6 +887,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		contact.setJobTitle(jobTitle);
 
 		contactPersistence.update(contact, serviceContext);
+
+		// Resources
+
+		resourceLocalService.addResources(
+			companyId, 0, creatorUserId, User.class.getName(), user.getUserId(),
+			false, false, false);
 
 		// Group
 


### PR DESCRIPTION
I think we should accept this as it fixes the immediate bug. I've asked @jcampoy to create an issue for the double indexing that is still occuring.
