### PR TITLE
LPS-45525 Blogs Entry does not show up in Asset Publisher after being edited

### DIFF
--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -107,7 +107,6 @@ import net.htmlparser.jericho.StartTag;
  */
 public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
-	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public BlogsEntry addEntry(
 			long userId, String title, String description, String content,
@@ -1022,7 +1021,6 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			AssetLinkConstants.TYPE_RELATED);
 	}
 
-	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public BlogsEntry updateEntry(
 			long userId, long entryId, String title, String description,
@@ -1211,9 +1209,8 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 			// Asset
 
-			assetEntryLocalService.updateEntry(
-				BlogsEntry.class.getName(), entryId, entry.getDisplayDate(),
-				true);
+			assetEntryLocalService.updateVisible(
+				BlogsEntry.class.getName(), entryId, true);
 
 			// Social
 


### PR DESCRIPTION
From @marcellustavares 

Hi @sergiogonzalez, the problem on this LPS was that we were indexing the blog entry after add, update and updateStatus operations.

So, when the user was editing the blog entry we changed the entry status back to draft during the update operation, then inside of the update operation we call updateStatus (starWorkflowInstace calls it behind the scenes).

After each updateStatus call we were indexing with the correct status but after the update() the index is called with the wrong status.

So because blog entry has workflow handler associated with, the updateStatus is always called after publish operations, so we just need to index after each status change.

Thanks
