### PR TITLE
LPS-47287 Ensure polling thread already backoff on writable processing b...

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/nonblocking/SelectorIntrabandTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/nonblocking/SelectorIntrabandTest.java
@@ -1180,6 +1180,8 @@ public class SelectorIntrabandTest {
 
 		Queue<Datagram> sendingQueue = channelContext.getSendingQueue();
 
+		while ((writeSelectionKey.interestOps() & SelectionKey.OP_WRITE) != 0);
+
 		synchronized (writeSelectionKey) {
 			synchronized (selector) {
 				wakeUpThread.interrupt();


### PR DESCRIPTION
...efore testing thread starts locking on SelectionKey to prevent deadlock
