### PR TITLE
LPS-47328

### DIFF
--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -48,6 +48,7 @@ import com.liferay.portlet.documentlibrary.service.DLFileVersionLocalService;
 import com.liferay.portlet.documentlibrary.service.DLFileVersionService;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalService;
 import com.liferay.portlet.documentlibrary.service.DLFolderService;
+import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
 import com.liferay.portlet.dynamicdatamapping.storage.Fields;
 
 import java.io.File;
@@ -272,7 +273,7 @@ public class LiferayLocalRepository
 			dlFileEntryLocalService.getGroupFileEntries(
 				getGroupId(), 0, rootFolderId, start, end, obc);
 
-		return toFileEntries(dlFileEntries);
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
@@ -56,6 +56,7 @@ import com.liferay.portlet.documentlibrary.service.DLFileVersionService;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalService;
 import com.liferay.portlet.documentlibrary.service.DLFolderService;
 import com.liferay.portlet.documentlibrary.util.DLSearcher;
+import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
 import com.liferay.portlet.dynamicdatamapping.storage.Fields;
 
 import java.io.File;
@@ -308,7 +309,7 @@ public class LiferayRepository
 		List<DLFileEntry> dlFileEntries = dlFileEntryService.getFileEntries(
 			getGroupId(), toFolderId(folderId), start, end, obc);
 
-		return toFileEntries(dlFileEntries);
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	@Override
@@ -321,7 +322,7 @@ public class LiferayRepository
 			getGroupId(), toFolderId(folderId), fileEntryTypeId, start, end,
 			obc);
 
-		return toFileEntries(dlFileEntries);
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	@Override
@@ -333,7 +334,7 @@ public class LiferayRepository
 		List<DLFileEntry> dlFileEntries = dlFileEntryService.getFileEntries(
 			getGroupId(), toFolderId(folderId), mimeTypes, start, end, obc);
 
-		return toFileEntries(dlFileEntries);
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	@Override
@@ -345,7 +346,8 @@ public class LiferayRepository
 			dlFolderService.getFileEntriesAndFileShortcuts(
 				getGroupId(), toFolderId(folderId), status, start, end);
 
-		return toFileEntriesAndFolders(dlFileEntriesAndFileShortcuts);
+		return RepositoryModelUtil.toFileEntriesAndFolders(
+			dlFileEntriesAndFileShortcuts);
 	}
 
 	@Override
@@ -470,7 +472,7 @@ public class LiferayRepository
 			getGroupId(), toFolderId(parentFolderId), status,
 			includeMountfolders, start, end, obc);
 
-		return toFolders(dlFolders);
+		return RepositoryModelUtil.toFolders(dlFolders);
 	}
 
 	@Override
@@ -484,7 +486,8 @@ public class LiferayRepository
 				getGroupId(), toFolderId(folderId), status, includeMountFolders,
 				start, end, obc);
 
-		return toFileEntriesAndFolders(dlFoldersAndFileEntriesAndFileShortcuts);
+		return RepositoryModelUtil.toFileEntriesAndFolders(
+			dlFoldersAndFileEntriesAndFileShortcuts);
 	}
 
 	@Override
@@ -499,7 +502,8 @@ public class LiferayRepository
 				getGroupId(), toFolderId(folderId), status, mimeTypes,
 				includeMountFolders, start, end, obc);
 
-		return toFileEntriesAndFolders(dlFoldersAndFileEntriesAndFileShortcuts);
+		return RepositoryModelUtil.toFileEntriesAndFolders(
+			dlFoldersAndFileEntriesAndFileShortcuts);
 	}
 
 	@Override
@@ -557,7 +561,7 @@ public class LiferayRepository
 		List<DLFolder> dlFolders = dlFolderService.getMountFolders(
 			getGroupId(), toFolderId(parentFolderId), start, end, obc);
 
-		return toFolders(dlFolders);
+		return RepositoryModelUtil.toFolders(dlFolders);
 	}
 
 	@Override
@@ -579,7 +583,7 @@ public class LiferayRepository
 				getGroupId(), userId, toFolderId(rootFolderId), start, end,
 				obc);
 
-		return toFileEntries(dlFileEntries);
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	@Override
@@ -593,7 +597,7 @@ public class LiferayRepository
 				getGroupId(), userId, getRepositoryId(),
 				toFolderId(rootFolderId), mimeTypes, status, start, end, obc);
 
-		return toFileEntries(dlFileEntries);
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.SortedArrayList;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.repository.liferayrepository.util.LiferayBase;
 import com.liferay.portal.service.RepositoryLocalService;
 import com.liferay.portal.service.RepositoryService;
 import com.liferay.portal.service.ResourceLocalService;
@@ -48,7 +47,7 @@ import java.util.List;
 /**
  * @author Alexander Chow
  */
-public abstract class LiferayRepositoryBase extends LiferayBase {
+public abstract class LiferayRepositoryBase {
 
 	public LiferayRepositoryBase(
 		RepositoryLocalService repositoryLocalService,

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileEntry.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFileEntry.java
@@ -34,6 +34,7 @@ import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.service.DLAppHelperLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileVersionLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.permission.DLFileEntryPermission;
+import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
 import com.liferay.portlet.expando.model.ExpandoBridge;
 
 import java.io.InputStream;
@@ -222,7 +223,8 @@ public class LiferayFileEntry extends LiferayModel implements FileEntry {
 	public List<FileVersion> getFileVersions(int status)
 		throws SystemException {
 
-		return toFileVersions(_dlFileEntry.getFileVersions(status));
+		return RepositoryModelUtil.toFileVersions(
+			_dlFileEntry.getFileVersions(status));
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFolder.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayFolder.java
@@ -23,6 +23,7 @@ import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.service.permission.DLFolderPermission;
+import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
 import com.liferay.portlet.expando.model.ExpandoBridge;
 
 import java.io.Serializable;
@@ -106,7 +107,7 @@ public class LiferayFolder extends LiferayModel implements Folder {
 
 	@Override
 	public List<Folder> getAncestors() throws PortalException, SystemException {
-		return toFolders(_dlFolder.getAncestors());
+		return RepositoryModelUtil.toFolders(_dlFolder.getAncestors());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayModel.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/model/LiferayModel.java
@@ -14,13 +14,12 @@
 
 package com.liferay.portal.repository.liferayrepository.model;
 
-import com.liferay.portal.repository.liferayrepository.util.LiferayBase;
 import com.liferay.portlet.expando.model.ExpandoBridge;
 
 /**
  * @author Alexander Chow
  */
-public abstract class LiferayModel extends LiferayBase {
+public abstract class LiferayModel {
 
 	public abstract long getCompanyId();
 

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/util/LiferayBase.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/util/LiferayBase.java
@@ -17,113 +17,43 @@ package com.liferay.portal.repository.liferayrepository.util;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
-import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
-import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
+import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
- * @author Alexander Chow
+ * @author     Alexander Chow
+ * @deprecated As of 7.0.0, replaced by {@link
+ *             com.liferay.portlet.documentlibrary.util.RepositoryModelUtil}
  */
+@Deprecated
 public abstract class LiferayBase {
 
 	/**
 	 * @see com.liferay.portal.portletfilerepository.PortletFileRepositoryImpl#toFileEntries
 	 */
 	public List<FileEntry> toFileEntries(List<DLFileEntry> dlFileEntries) {
-		List<FileEntry> fileEntries = new ArrayList<FileEntry>(
-			dlFileEntries.size());
-
-		for (DLFileEntry dlFileEntry : dlFileEntries) {
-			FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
-
-			fileEntries.add(fileEntry);
-		}
-
-		if (ListUtil.isUnmodifiableList(dlFileEntries)) {
-			return Collections.unmodifiableList(fileEntries);
-		}
-		else {
-			return fileEntries;
-		}
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	public List<Object> toFileEntriesAndFolders(
 		List<Object> dlFileEntriesAndDLFolders) {
 
-		List<Object> fileEntriesAndFolders = new ArrayList<Object>(
-			dlFileEntriesAndDLFolders.size());
-
-		for (Object object : dlFileEntriesAndDLFolders) {
-			if (object instanceof DLFileEntry) {
-				DLFileEntry dlFileEntry = (DLFileEntry)object;
-
-				FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
-
-				fileEntriesAndFolders.add(fileEntry);
-			}
-			else if (object instanceof DLFolder) {
-				DLFolder dlFolder = (DLFolder)object;
-
-				Folder folder = new LiferayFolder(dlFolder);
-
-				fileEntriesAndFolders.add(folder);
-			}
-			else {
-				fileEntriesAndFolders.add(object);
-			}
-		}
-
-		if (ListUtil.isUnmodifiableList(dlFileEntriesAndDLFolders)) {
-			return Collections.unmodifiableList(fileEntriesAndFolders);
-		}
-		else {
-			return fileEntriesAndFolders;
-		}
+		return RepositoryModelUtil.toFileEntriesAndFolders(
+			dlFileEntriesAndDLFolders);
 	}
 
 	public List<FileVersion> toFileVersions(
 		List<DLFileVersion> dlFileVersions) {
 
-		List<FileVersion> fileVersions = new ArrayList<FileVersion>(
-			dlFileVersions.size());
-
-		for (DLFileVersion dlFileVersion : dlFileVersions) {
-			FileVersion fileVersion = new LiferayFileVersion(dlFileVersion);
-
-			fileVersions.add(fileVersion);
-		}
-
-		if (ListUtil.isUnmodifiableList(dlFileVersions)) {
-			return Collections.unmodifiableList(fileVersions);
-		}
-		else {
-			return fileVersions;
-		}
+		return RepositoryModelUtil.toFileVersions(dlFileVersions);
 	}
 
 	public List<Folder> toFolders(List<DLFolder> dlFolders) {
-		List<Folder> folders = new ArrayList<Folder>(dlFolders.size());
-
-		for (DLFolder dlFolder : dlFolders) {
-			Folder folder = new LiferayFolder(dlFolder);
-
-			folders.add(folder);
-		}
-
-		if (ListUtil.isUnmodifiableList(dlFolders)) {
-			return Collections.unmodifiableList(folders);
-		}
-		else {
-			return folders;
-		}
+		return RepositoryModelUtil.toFolders(dlFolders);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryUtil.java
@@ -75,6 +75,10 @@ public class FileEntryUtil {
 		return new LiferayFileEntry(dlFileEntry);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0
+	 */
+	@Deprecated
 	public static List<FileEntry> findByR_F(long repositoryId, long folderId)
 		throws SystemException {
 
@@ -84,6 +88,10 @@ public class FileEntryUtil {
 		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0
+	 */
+	@Deprecated
 	public static FileEntry findByR_F_T(
 			long repositoryId, long folderId, String title)
 		throws NoSuchFileEntryException, SystemException {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryUtil.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
-import com.liferay.portal.repository.liferayrepository.util.LiferayBase;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
@@ -34,7 +33,7 @@ import java.util.List;
 /**
  * @author Alexander Chow
  */
-public class FileEntryUtil extends LiferayBase {
+public class FileEntryUtil {
 
 	public static FileEntry fetchByPrimaryKey(long fileEntryId)
 		throws SystemException {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FileEntryUtil.java
@@ -25,6 +25,7 @@ import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.service.persistence.DLFileEntryUtil;
 import com.liferay.portlet.documentlibrary.store.DLStoreUtil;
+import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
 
 import java.io.InputStream;
 
@@ -81,7 +82,7 @@ public class FileEntryUtil extends LiferayBase {
 		List<DLFileEntry> dlFileEntries = DLFileEntryUtil.findByG_F(
 			repositoryId, folderId);
 
-		return _instance.toFileEntries(dlFileEntries);
+		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
 
 	public static FileEntry findByR_F_T(
@@ -112,7 +113,5 @@ public class FileEntryUtil extends LiferayBase {
 
 		return is;
 	}
-
-	private static FileEntryUtil _instance = new FileEntryUtil();
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.repository.liferayrepository.util.LiferayBase;
 import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.service.persistence.DLFolderUtil;
+import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
 
 import java.util.List;
 
@@ -69,7 +70,7 @@ public class FolderUtil extends LiferayBase {
 		List<DLFolder> dlFolders = DLFolderUtil.findByG_P(
 			repositoryId, parentFolderId);
 
-		return _instance.toFolders(dlFolders);
+		return RepositoryModelUtil.toFolders(dlFolders);
 	}
 
 	public static List<Folder> findByRepositoryId(long repositoryId)
@@ -77,9 +78,7 @@ public class FolderUtil extends LiferayBase {
 
 		List<DLFolder> dlFolders = DLFolderUtil.findByGroupId(repositoryId);
 
-		return _instance.toFolders(dlFolders);
+		return RepositoryModelUtil.toFolders(dlFolders);
 	}
-
-	private static FolderUtil _instance = new FolderUtil();
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderUtil.java
@@ -63,6 +63,10 @@ public class FolderUtil {
 		return new LiferayFolder(dlFolder);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0
+	 */
+	@Deprecated
 	public static List<Folder> findByR_P(long repositoryId, long parentFolderId)
 		throws SystemException {
 
@@ -72,6 +76,10 @@ public class FolderUtil {
 		return RepositoryModelUtil.toFolders(dlFolders);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0
+	 */
+	@Deprecated
 	public static List<Folder> findByRepositoryId(long repositoryId)
 		throws SystemException {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderUtil.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.documentlibrary.lar;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
-import com.liferay.portal.repository.liferayrepository.util.LiferayBase;
 import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.service.persistence.DLFolderUtil;
@@ -28,7 +27,7 @@ import java.util.List;
 /**
  * @author Alexander Chow
  */
-public class FolderUtil extends LiferayBase {
+public class FolderUtil {
 
 	public static Folder fetchByR_P_N(
 			long groupId, long parentFolderId, String name)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/RepositoryModelUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/RepositoryModelUtil.java
@@ -30,14 +30,17 @@ import java.util.Collections;
 import java.util.List;
 
 /**
+ * @author Adolfo Pérez
  * @author Alexander Chow
  */
-public abstract class RepositoryModelUtil {
+public class RepositoryModelUtil {
 
 	/**
 	 * @see com.liferay.portal.portletfilerepository.PortletFileRepositoryImpl#toFileEntries
 	 */
-	public List<FileEntry> toFileEntries(List<DLFileEntry> dlFileEntries) {
+	public static List<FileEntry> toFileEntries(
+		List<DLFileEntry> dlFileEntries) {
+
 		List<FileEntry> fileEntries = new ArrayList<FileEntry>(
 			dlFileEntries.size());
 
@@ -55,7 +58,7 @@ public abstract class RepositoryModelUtil {
 		}
 	}
 
-	public List<Object> toFileEntriesAndFolders(
+	public static List<Object> toFileEntriesAndFolders(
 		List<Object> dlFileEntriesAndDLFolders) {
 
 		List<Object> fileEntriesAndFolders = new ArrayList<Object>(
@@ -89,7 +92,7 @@ public abstract class RepositoryModelUtil {
 		}
 	}
 
-	public List<FileVersion> toFileVersions(
+	public static List<FileVersion> toFileVersions(
 		List<DLFileVersion> dlFileVersions) {
 
 		List<FileVersion> fileVersions = new ArrayList<FileVersion>(
@@ -109,7 +112,7 @@ public abstract class RepositoryModelUtil {
 		}
 	}
 
-	public List<Folder> toFolders(List<DLFolder> dlFolders) {
+	public static List<Folder> toFolders(List<DLFolder> dlFolders) {
 		List<Folder> folders = new ArrayList<Folder>(dlFolders.size());
 
 		for (DLFolder dlFolder : dlFolders) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/RepositoryModelUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/RepositoryModelUtil.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.util;
+
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.model.DLFileVersion;
+import com.liferay.portlet.documentlibrary.model.DLFolder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Alexander Chow
+ */
+public abstract class RepositoryModelUtil {
+
+	/**
+	 * @see com.liferay.portal.portletfilerepository.PortletFileRepositoryImpl#toFileEntries
+	 */
+	public List<FileEntry> toFileEntries(List<DLFileEntry> dlFileEntries) {
+		List<FileEntry> fileEntries = new ArrayList<FileEntry>(
+			dlFileEntries.size());
+
+		for (DLFileEntry dlFileEntry : dlFileEntries) {
+			FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
+
+			fileEntries.add(fileEntry);
+		}
+
+		if (ListUtil.isUnmodifiableList(dlFileEntries)) {
+			return Collections.unmodifiableList(fileEntries);
+		}
+		else {
+			return fileEntries;
+		}
+	}
+
+	public List<Object> toFileEntriesAndFolders(
+		List<Object> dlFileEntriesAndDLFolders) {
+
+		List<Object> fileEntriesAndFolders = new ArrayList<Object>(
+			dlFileEntriesAndDLFolders.size());
+
+		for (Object object : dlFileEntriesAndDLFolders) {
+			if (object instanceof DLFileEntry) {
+				DLFileEntry dlFileEntry = (DLFileEntry)object;
+
+				FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
+
+				fileEntriesAndFolders.add(fileEntry);
+			}
+			else if (object instanceof DLFolder) {
+				DLFolder dlFolder = (DLFolder)object;
+
+				Folder folder = new LiferayFolder(dlFolder);
+
+				fileEntriesAndFolders.add(folder);
+			}
+			else {
+				fileEntriesAndFolders.add(object);
+			}
+		}
+
+		if (ListUtil.isUnmodifiableList(dlFileEntriesAndDLFolders)) {
+			return Collections.unmodifiableList(fileEntriesAndFolders);
+		}
+		else {
+			return fileEntriesAndFolders;
+		}
+	}
+
+	public List<FileVersion> toFileVersions(
+		List<DLFileVersion> dlFileVersions) {
+
+		List<FileVersion> fileVersions = new ArrayList<FileVersion>(
+			dlFileVersions.size());
+
+		for (DLFileVersion dlFileVersion : dlFileVersions) {
+			FileVersion fileVersion = new LiferayFileVersion(dlFileVersion);
+
+			fileVersions.add(fileVersion);
+		}
+
+		if (ListUtil.isUnmodifiableList(dlFileVersions)) {
+			return Collections.unmodifiableList(fileVersions);
+		}
+		else {
+			return fileVersions;
+		}
+	}
+
+	public List<Folder> toFolders(List<DLFolder> dlFolders) {
+		List<Folder> folders = new ArrayList<Folder>(dlFolders.size());
+
+		for (DLFolder dlFolder : dlFolders) {
+			Folder folder = new LiferayFolder(dlFolder);
+
+			folders.add(folder);
+		}
+
+		if (ListUtil.isUnmodifiableList(dlFolders)) {
+			return Collections.unmodifiableList(folders);
+		}
+		else {
+			return folders;
+		}
+	}
+
+}


### PR DESCRIPTION
For LPS-47325 I'm trying to unify local and non local repositories by creating a common parent class. I cannot do that cleanly because of the `LiferayBase` class: it is used as a superclass for local repositories and other non related classes (`FileEntryUtil`, `FolderUtil` and `RepositoryModel`). As this doesn't make much sense and makes things artificially difficult, I believe we should get rid of it.

Given that all that `LiferayBase` contains are util methods, I've moved them to a proper util class and removed all references to `LiferayBase`.
