### PR TITLE
LPS-46842

### DIFF
--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -56,6 +56,38 @@ import com.liferay.portlet.documentlibrary.service.DLFolderService;
  */
 public abstract class BaseRepositoryFactory<T> {
 
+	public T create(long repositoryId) throws PortalException, SystemException {
+		long classNameId = getRepositoryClassNameId(repositoryId);
+
+		if (classNameId == getDefaultClassNameId()) {
+			return createLiferayRepository(repositoryId);
+		}
+		else {
+			return createExternalRepository(repositoryId, classNameId);
+		}
+	}
+
+	public T create(long folderId, long fileEntryId, long fileVersionId)
+		throws PortalException, SystemException {
+
+		T liferayRepository = createLiferayRepository(
+			folderId, fileEntryId, fileVersionId);
+
+		if (liferayRepository != null) {
+			return liferayRepository;
+		}
+
+		return createExternalRepository(folderId, fileEntryId, fileVersionId);
+	}
+
+	protected abstract T createExternalRepository(
+			long repositoryId, long classNameId)
+		throws PortalException, SystemException;
+
+	protected abstract T createExternalRepository(
+			long folderId, long fileEntryId, long fileVersionId)
+		throws PortalException, SystemException;
+
 	protected BaseRepository createExternalRepositoryImpl(
 			long repositoryId, long classNameId)
 		throws PortalException, SystemException {

--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -156,24 +156,21 @@ public abstract class BaseRepositoryFactory<T> {
 	protected T createLiferayRepository(long repositoryId)
 		throws PortalException, SystemException {
 
-		Repository repository = getRepository(repositoryId);
-
-		long groupId = 0;
-		long actualRepositoryId = 0;
 		long dlFolderId = 0;
+		long groupId = 0;
+
+		Repository repository = getRepository(repositoryId);
 
 		if (repository == null) {
 			groupId = repositoryId;
-			actualRepositoryId = repositoryId;
 		}
 		else {
 			groupId = repository.getGroupId();
-			actualRepositoryId = repository.getRepositoryId();
 			dlFolderId = repository.getDlFolderId();
 		}
 
 		return createLiferayRepositoryInstance(
-			groupId, actualRepositoryId, dlFolderId);
+			groupId, repositoryId, dlFolderId);
 	}
 
 	protected T createLiferayRepository(

--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -158,6 +158,9 @@ public abstract class BaseRepositoryFactory<T> {
 		}
 	}
 
+	protected abstract T createLiferayRepositoryInstance(
+		long groupId, long repositoryId, long dlFolderId);
+
 	protected AssetEntryLocalService getAssetEntryLocalService() {
 		return _assetEntryLocalService;
 	}

--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -38,6 +38,7 @@ import com.liferay.portal.service.RepositoryLocalService;
 import com.liferay.portal.service.RepositoryService;
 import com.liferay.portal.service.ResourceLocalService;
 import com.liferay.portal.service.UserLocalService;
+import com.liferay.portal.util.RepositoryUtil;
 import com.liferay.portlet.asset.service.AssetEntryLocalService;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.NoSuchFileVersionException;
@@ -294,30 +295,6 @@ public abstract class BaseRepositoryFactory<T> {
 			LiferayRepository.class.getName());
 	}
 
-	protected long getRepositoryEntryId(
-			long folderId, long fileEntryId, long fileVersionId)
-		throws RepositoryException {
-
-		long repositoryEntryId = 0;
-
-		if (folderId != 0) {
-			repositoryEntryId = folderId;
-		}
-		else if (fileEntryId != 0) {
-			repositoryEntryId = fileEntryId;
-		}
-		else if (fileVersionId != 0) {
-			repositoryEntryId = fileVersionId;
-		}
-
-		if (repositoryEntryId == 0) {
-			throw new InvalidRepositoryIdException(
-				"Missing a valid ID for folder, file entry, or file version");
-		}
-
-		return repositoryEntryId;
-	}
-
 	protected RepositoryEntryLocalService getRepositoryEntryLocalService() {
 		return _repositoryEntryLocalService;
 	}
@@ -326,7 +303,7 @@ public abstract class BaseRepositoryFactory<T> {
 			long folderId, long fileEntryId, long fileVersionId)
 		throws PortalException, SystemException {
 
-		long repositoryEntryId = getRepositoryEntryId(
+		long repositoryEntryId = RepositoryUtil.getRepositoryEntryId(
 			folderId, fileEntryId, fileVersionId);
 
 		RepositoryEntry repositoryEntry =

--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -53,7 +53,7 @@ import com.liferay.portlet.documentlibrary.service.DLFolderService;
  */
 public abstract class BaseRepositoryFactory {
 
-	protected BaseRepository createRepositoryImpl(
+	protected BaseRepository createExternalRepositoryImpl(
 			long repositoryId, long classNameId)
 		throws PortalException, SystemException {
 

--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -158,14 +158,13 @@ public abstract class BaseRepositoryFactory<T> {
 
 		Repository repository = getRepository(repositoryId);
 
-		long groupId;
-		long actualRepositoryId;
-		long dlFolderId;
+		long groupId = 0;
+		long actualRepositoryId = 0;
+		long dlFolderId = 0;
 
 		if (repository == null) {
 			groupId = repositoryId;
 			actualRepositoryId = repositoryId;
-			dlFolderId = 0;
 		}
 		else {
 			groupId = repository.getGroupId();
@@ -182,7 +181,7 @@ public abstract class BaseRepositoryFactory<T> {
 		throws PortalException, SystemException {
 
 		try {
-			long repositoryId;
+			long repositoryId = 0;
 
 			if (folderId != 0) {
 				repositoryId = getFolderRepositoryId(folderId);
@@ -277,8 +276,7 @@ public abstract class BaseRepositoryFactory<T> {
 	protected abstract long getFolderRepositoryId(long folderId)
 		throws PortalException, SystemException;
 
-	protected abstract com.liferay.portal.model.Repository getRepository(
-			long repositoryId)
+	protected abstract Repository getRepository(long repositoryId)
 		throws PortalException, SystemException;
 
 	protected long getRepositoryClassNameId(long repositoryId)

--- a/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
+++ b/portal-impl/src/com/liferay/portal/repository/BaseRepositoryFactory.java
@@ -120,8 +120,29 @@ public abstract class BaseRepositoryFactory<T> {
 		return baseRepository;
 	}
 
-	protected abstract T createLiferayRepository(long repositoryId)
-		throws PortalException, SystemException;
+	protected T createLiferayRepository(long repositoryId)
+		throws PortalException, SystemException {
+
+		Repository repository = getRepository(repositoryId);
+
+		long groupId;
+		long actualRepositoryId;
+		long dlFolderId;
+
+		if (repository == null) {
+			groupId = repositoryId;
+			actualRepositoryId = repositoryId;
+			dlFolderId = 0;
+		}
+		else {
+			groupId = repository.getGroupId();
+			actualRepositoryId = repository.getRepositoryId();
+			dlFolderId = repository.getDlFolderId();
+		}
+
+		return createLiferayRepositoryInstance(
+			groupId, actualRepositoryId, dlFolderId);
+	}
 
 	protected T createLiferayRepository(
 			long folderId, long fileEntryId, long fileVersionId)

--- a/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
@@ -34,34 +34,6 @@ public class LocalRepositoryFactoryImpl
 	implements LocalRepositoryFactory {
 
 	@Override
-	public LocalRepository create(long repositoryId)
-		throws PortalException, SystemException {
-
-		long classNameId = getRepositoryClassNameId(repositoryId);
-
-		if (classNameId == getDefaultClassNameId()) {
-			return createLiferayRepository(repositoryId);
-		}
-		else {
-			return createExternalRepository(repositoryId, classNameId);
-		}
-	}
-
-	@Override
-	public LocalRepository create(
-			long folderId, long fileEntryId, long fileVersionId)
-		throws PortalException, SystemException {
-
-		LocalRepository localRepository = createLiferayRepository(
-			folderId, fileEntryId, fileVersionId);
-
-		if (localRepository != null) {
-			return localRepository;
-		}
-
-		return createExternalRepository(folderId, fileEntryId, fileVersionId);
-	}
-
 	protected LocalRepository createExternalRepository(
 			long repositoryId, long classNameId)
 		throws PortalException, SystemException {
@@ -72,6 +44,7 @@ public class LocalRepositoryFactoryImpl
 		return baseRepository.getLocalRepository();
 	}
 
+	@Override
 	protected LocalRepository createExternalRepository(
 			long folderId, long fileEntryId, long fileVersionId)
 		throws PortalException, SystemException {

--- a/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
@@ -72,31 +72,6 @@ public class LocalRepositoryFactoryImpl
 	}
 
 	@Override
-	protected LocalRepository createLiferayRepository(long repositoryId)
-		throws PortalException, SystemException {
-
-		Repository repository = getRepository(repositoryId);
-
-		long groupId;
-		long actualRepositoryId;
-		long dlFolderId;
-
-		if (repository == null) {
-			groupId = repositoryId;
-			actualRepositoryId = repositoryId;
-			dlFolderId = 0;
-		}
-		else {
-			groupId = repository.getGroupId();
-			actualRepositoryId = repository.getRepositoryId();
-			dlFolderId = repository.getDlFolderId();
-		}
-
-		return createLiferayRepositoryInstance(
-			groupId, actualRepositoryId, dlFolderId);
-	}
-
-	@Override
 	protected LiferayLocalRepository createLiferayRepositoryInstance(
 		long groupId, long repositoryId, long dlFolderId) {
 

--- a/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
@@ -44,7 +44,7 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 				getResourceLocalService(), repositoryId);
 		}
 		else {
-			BaseRepository baseRepository = createRepositoryImpl(
+			BaseRepository baseRepository = createExternalRepositoryImpl(
 				repositoryId, classNameId);
 
 			return baseRepository.getLocalRepository();

--- a/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
@@ -43,10 +43,7 @@ public class LocalRepositoryFactoryImpl
 			return createLiferayRepository(repositoryId);
 		}
 		else {
-			BaseRepository baseRepository = createExternalRepositoryImpl(
-				repositoryId, classNameId);
-
-			return baseRepository.getLocalRepository();
+			return createExternalRepository(repositoryId, classNameId);
 		}
 	}
 
@@ -61,6 +58,23 @@ public class LocalRepositoryFactoryImpl
 		if (localRepository != null) {
 			return localRepository;
 		}
+
+		return createExternalRepository(folderId, fileEntryId, fileVersionId);
+	}
+
+	protected LocalRepository createExternalRepository(
+			long repositoryId, long classNameId)
+		throws PortalException, SystemException {
+
+		BaseRepository baseRepository = createExternalRepositoryImpl(
+			repositoryId, classNameId);
+
+		return baseRepository.getLocalRepository();
+	}
+
+	protected LocalRepository createExternalRepository(
+			long folderId, long fileEntryId, long fileVersionId)
+		throws PortalException, SystemException {
 
 		long repositoryId = getRepositoryId(
 			folderId, fileEntryId, fileVersionId);

--- a/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
@@ -75,10 +75,9 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 	}
 
 	protected LocalRepository createLiferayRepository(long repositoryId)
-		throws SystemException {
+		throws PortalException, SystemException {
 
-		Repository repository = getRepositoryLocalService().fetchRepository(
-			repositoryId);
+		Repository repository = getRepository(repositoryId);
 
 		long groupId;
 		long actualRepositoryId;
@@ -112,23 +111,13 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 			long repositoryId;
 
 			if (folderId != 0) {
-				DLFolder dlFolder = getDlFolderLocalService().getFolder(
-					folderId);
-
-				repositoryId = dlFolder.getRepositoryId();
+				repositoryId = getFolderRepositoryId(folderId);
 			}
 			else if (fileEntryId != 0) {
-				DLFileEntry dlFileEntry =
-					getDlFileEntryLocalService().getFileEntry(fileEntryId);
-
-				repositoryId = dlFileEntry.getRepositoryId();
+				repositoryId = getFileEntryRepositoryId(fileEntryId);
 			}
 			else if (fileVersionId != 0) {
-				DLFileVersion dlFileVersion =
-					getDlFileVersionLocalService().getFileVersion(
-						fileVersionId);
-
-				repositoryId = dlFileVersion.getRepositoryId();
+				repositoryId = getFileVersionRepositoryId(fileVersionId);
 			}
 			else {
 				throw new InvalidRepositoryIdException(
@@ -147,6 +136,38 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 		catch (NoSuchFileVersionException nsfve) {
 			return null;
 		}
+	}
+
+	private long getFileEntryRepositoryId(long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLFileEntry dlFileEntry =
+			getDlFileEntryLocalService().getFileEntry(fileEntryId);
+
+		return dlFileEntry.getRepositoryId();
+	}
+
+	private long getFileVersionRepositoryId(long fileVersionId)
+		throws PortalException, SystemException {
+
+		DLFileVersion dlFileVersion =
+			getDlFileVersionLocalService().getFileVersion(fileVersionId);
+
+		return dlFileVersion.getRepositoryId();
+	}
+
+	private long getFolderRepositoryId(long folderId)
+		throws PortalException, SystemException {
+
+		DLFolder dlFolder = getDlFolderLocalService().getFolder(folderId);
+
+		return dlFolder.getRepositoryId();
+	}
+
+	private Repository getRepository(long repositoryId)
+		throws PortalException, SystemException {
+
+		return getRepositoryLocalService().fetchRepository(repositoryId);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
@@ -17,15 +17,11 @@ package com.liferay.portal.repository;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.BaseRepository;
-import com.liferay.portal.kernel.repository.InvalidRepositoryIdException;
 import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.LocalRepositoryFactory;
 import com.liferay.portal.kernel.repository.RepositoryFactoryUtil;
 import com.liferay.portal.model.Repository;
 import com.liferay.portal.repository.liferayrepository.LiferayLocalRepository;
-import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
-import com.liferay.portlet.documentlibrary.NoSuchFileVersionException;
-import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
@@ -33,7 +29,8 @@ import com.liferay.portlet.documentlibrary.model.DLFolder;
 /**
  * @author Adolfo Pérez
  */
-public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
+public class LocalRepositoryFactoryImpl
+	extends BaseRepositoryFactory<LocalRepository>
 	implements LocalRepositoryFactory {
 
 	@Override
@@ -74,6 +71,7 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 		return baseRepository.getLocalRepository();
 	}
 
+	@Override
 	protected LocalRepository createLiferayRepository(long repositoryId)
 		throws PortalException, SystemException {
 
@@ -103,42 +101,8 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 			getResourceLocalService(), groupId, actualRepositoryId, dlFolderId);
 	}
 
-	protected LocalRepository createLiferayRepository(
-			long folderId, long fileEntryId, long fileVersionId)
-		throws PortalException, SystemException {
-
-		try {
-			long repositoryId;
-
-			if (folderId != 0) {
-				repositoryId = getFolderRepositoryId(folderId);
-			}
-			else if (fileEntryId != 0) {
-				repositoryId = getFileEntryRepositoryId(fileEntryId);
-			}
-			else if (fileVersionId != 0) {
-				repositoryId = getFileVersionRepositoryId(fileVersionId);
-			}
-			else {
-				throw new InvalidRepositoryIdException(
-					"Missing a valid ID for folder, file entry or file " +
-						"version");
-			}
-
-			return createLiferayRepository(repositoryId);
-		}
-		catch (NoSuchFolderException nsfe) {
-			return null;
-		}
-		catch (NoSuchFileEntryException nsfee) {
-			return null;
-		}
-		catch (NoSuchFileVersionException nsfve) {
-			return null;
-		}
-	}
-
-	private long getFileEntryRepositoryId(long fileEntryId)
+	@Override
+	protected long getFileEntryRepositoryId(long fileEntryId)
 		throws PortalException, SystemException {
 
 		DLFileEntry dlFileEntry =
@@ -147,7 +111,8 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 		return dlFileEntry.getRepositoryId();
 	}
 
-	private long getFileVersionRepositoryId(long fileVersionId)
+	@Override
+	protected long getFileVersionRepositoryId(long fileVersionId)
 		throws PortalException, SystemException {
 
 		DLFileVersion dlFileVersion =
@@ -156,7 +121,8 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 		return dlFileVersion.getRepositoryId();
 	}
 
-	private long getFolderRepositoryId(long folderId)
+	@Override
+	protected long getFolderRepositoryId(long folderId)
 		throws PortalException, SystemException {
 
 		DLFolder dlFolder = getDlFolderLocalService().getFolder(folderId);
@@ -164,7 +130,8 @@ public class LocalRepositoryFactoryImpl extends BaseRepositoryFactory
 		return dlFolder.getRepositoryId();
 	}
 
-	private Repository getRepository(long repositoryId)
+	@Override
+	protected Repository getRepository(long repositoryId)
 		throws PortalException, SystemException {
 
 		return getRepositoryLocalService().fetchRepository(repositoryId);

--- a/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/LocalRepositoryFactoryImpl.java
@@ -92,13 +92,21 @@ public class LocalRepositoryFactoryImpl
 			dlFolderId = repository.getDlFolderId();
 		}
 
+		return createLiferayRepositoryInstance(
+			groupId, actualRepositoryId, dlFolderId);
+	}
+
+	@Override
+	protected LiferayLocalRepository createLiferayRepositoryInstance(
+		long groupId, long repositoryId, long dlFolderId) {
+
 		return new LiferayLocalRepository(
 			getRepositoryLocalService(), getRepositoryService(),
 			getDlAppHelperLocalService(), getDlFileEntryLocalService(),
 			getDlFileEntryService(), getDlFileEntryTypeLocalService(),
 			getDlFileVersionLocalService(), getDlFileVersionService(),
 			getDlFolderLocalService(), getDlFolderService(),
-			getResourceLocalService(), groupId, actualRepositoryId, dlFolderId);
+			getResourceLocalService(), groupId, repositoryId, dlFolderId);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
@@ -69,22 +69,22 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 	protected LiferayRepository createLiferayRepository(long repositoryId)
 		throws PortalException, SystemException {
 
+		com.liferay.portal.model.Repository repository = getRepository(
+			repositoryId);
+
 		long groupId;
 		long actualRepositoryId;
 		long dlFolderId;
 
-		try {
-			com.liferay.portal.model.Repository repository =
-				getRepositoryService().getRepository(repositoryId);
-
-			groupId = repository.getGroupId();
-			actualRepositoryId = repository.getRepositoryId();
-			dlFolderId = repository.getDlFolderId();
-		}
-		catch (NoSuchRepositoryException nsre) {
+		if (repository == null) {
 			groupId = repositoryId;
 			actualRepositoryId = repositoryId;
 			dlFolderId = 0;
+		}
+		else {
+			groupId = repository.getGroupId();
+			actualRepositoryId = repository.getRepositoryId();
+			dlFolderId = repository.getDlFolderId();
 		}
 
 		return new LiferayRepository(
@@ -104,21 +104,13 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 			long repositoryId;
 
 			if (folderId != 0) {
-				DLFolder dlFolder = getDlFolderService().getFolder(folderId);
-
-				repositoryId = dlFolder.getRepositoryId();
+				repositoryId = getFolderRepositoryId(folderId);
 			}
 			else if (fileEntryId != 0) {
-				DLFileEntry dlFileEntry = getDlFileEntryService().getFileEntry(
-					fileEntryId);
-
-				repositoryId = dlFileEntry.getRepositoryId();
+				repositoryId = getFileEntryRepositoryId(fileEntryId);
 			}
 			else if (fileVersionId != 0) {
-				DLFileVersion dlFileVersion =
-					getDlFileVersionService().getFileVersion(fileVersionId);
-
-				repositoryId = dlFileVersion.getRepositoryId();
+				repositoryId = getFileVersionRepositoryId(fileVersionId);
 			}
 			else {
 				throw new InvalidRepositoryIdException(
@@ -137,6 +129,44 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 		catch (NoSuchFileVersionException nsfve) {
 			return null;
 		}
+	}
+
+	protected com.liferay.portal.model.Repository getRepository(
+			long repositoryId)
+		throws PortalException, SystemException {
+
+		try {
+			return getRepositoryService().getRepository(repositoryId);
+		}
+		catch (NoSuchRepositoryException nsre) {
+			return null;
+		}
+	}
+
+	private long getFileEntryRepositoryId(long fileEntryId)
+		throws PortalException, SystemException {
+
+		DLFileEntry dlFileEntry = getDlFileEntryService().getFileEntry(
+			fileEntryId);
+
+		return dlFileEntry.getRepositoryId();
+	}
+
+	private long getFileVersionRepositoryId(long fileVersionId)
+		throws PortalException, SystemException {
+
+		DLFileVersion dlFileVersion =
+			getDlFileVersionService().getFileVersion(fileVersionId);
+
+		return dlFileVersion.getRepositoryId();
+	}
+
+	private long getFolderRepositoryId(long folderId)
+		throws PortalException, SystemException {
+
+		DLFolder dlFolder = getDlFolderService().getFolder(folderId);
+
+		return dlFolder.getRepositoryId();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
@@ -63,32 +63,6 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory<Repository>
 	}
 
 	@Override
-	protected LiferayRepository createLiferayRepository(long repositoryId)
-		throws PortalException, SystemException {
-
-		com.liferay.portal.model.Repository repository = getRepository(
-			repositoryId);
-
-		long groupId;
-		long actualRepositoryId;
-		long dlFolderId;
-
-		if (repository == null) {
-			groupId = repositoryId;
-			actualRepositoryId = repositoryId;
-			dlFolderId = 0;
-		}
-		else {
-			groupId = repository.getGroupId();
-			actualRepositoryId = repository.getRepositoryId();
-			dlFolderId = repository.getDlFolderId();
-		}
-
-		return createLiferayRepositoryInstance(
-			groupId, actualRepositoryId, dlFolderId);
-	}
-
-	@Override
 	protected LiferayRepository createLiferayRepositoryInstance(
 		long groupId, long repositoryId, long dlFolderId) {
 

--- a/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
@@ -32,34 +32,6 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory<Repository>
 	implements RepositoryFactory {
 
 	@Override
-	public Repository create(long repositoryId)
-		throws PortalException, SystemException {
-
-		long classNameId = getRepositoryClassNameId(repositoryId);
-
-		if (classNameId == getDefaultClassNameId()) {
-			return createLiferayRepository(repositoryId);
-		}
-		else {
-			return createExternalRepository(repositoryId, classNameId);
-		}
-	}
-
-	@Override
-	public Repository create(
-			long folderId, long fileEntryId, long fileVersionId)
-		throws PortalException, SystemException {
-
-		Repository liferayRepository = createLiferayRepository(
-			folderId, fileEntryId, fileVersionId);
-
-		if (liferayRepository != null) {
-			return liferayRepository;
-		}
-
-		return createExternalRepository(folderId, fileEntryId, fileVersionId);
-	}
-
 	protected BaseRepository createExternalRepository(
 			long repositoryId, long classNameId)
 		throws PortalException, SystemException {
@@ -67,6 +39,7 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory<Repository>
 		return createExternalRepositoryImpl(repositoryId, classNameId);
 	}
 
+	@Override
 	protected Repository createExternalRepository(
 			long folderId, long fileEntryId, long fileVersionId)
 		throws PortalException, SystemException {

--- a/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.repository;
 import com.liferay.portal.NoSuchRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.BaseRepository;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
 import com.liferay.portal.repository.liferayrepository.LiferayRepository;
@@ -40,7 +41,7 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory<Repository>
 			return createLiferayRepository(repositoryId);
 		}
 		else {
-			return createExternalRepositoryImpl(repositoryId, classNameId);
+			return createExternalRepository(repositoryId, classNameId);
 		}
 	}
 
@@ -55,6 +56,20 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory<Repository>
 		if (liferayRepository != null) {
 			return liferayRepository;
 		}
+
+		return createExternalRepository(folderId, fileEntryId, fileVersionId);
+	}
+
+	protected BaseRepository createExternalRepository(
+			long repositoryId, long classNameId)
+		throws PortalException, SystemException {
+
+		return createExternalRepositoryImpl(repositoryId, classNameId);
+	}
+
+	protected Repository createExternalRepository(
+			long folderId, long fileEntryId, long fileVersionId)
+		throws PortalException, SystemException {
 
 		long repositoryId = getRepositoryId(
 			folderId, fileEntryId, fileVersionId);

--- a/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
@@ -84,13 +84,21 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory<Repository>
 			dlFolderId = repository.getDlFolderId();
 		}
 
+		return createLiferayRepositoryInstance(
+			groupId, actualRepositoryId, dlFolderId);
+	}
+
+	@Override
+	protected LiferayRepository createLiferayRepositoryInstance(
+		long groupId, long repositoryId, long dlFolderId) {
+
 		return new LiferayRepository(
 			getRepositoryLocalService(), getRepositoryService(),
 			getDlAppHelperLocalService(), getDlFileEntryLocalService(),
 			getDlFileEntryService(), getDlFileEntryTypeLocalService(),
 			getDlFileVersionLocalService(), getDlFileVersionService(),
 			getDlFolderLocalService(), getDlFolderService(),
-			getResourceLocalService(), groupId, actualRepositoryId, dlFolderId);
+			getResourceLocalService(), groupId, repositoryId, dlFolderId);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
@@ -39,10 +39,10 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 				getDlFileEntryService(), getDlFileEntryTypeLocalService(),
 				getDlFileVersionLocalService(), getDlFileVersionService(),
 				getDlFolderLocalService(), getDlFolderService(),
-				getResourceLocalService(), repositoryId);
+				getResourceLocalService(), repositoryId, repositoryId, 0);
 		}
 		else {
-			return createRepositoryImpl(repositoryId, classNameId);
+			return createExternalRepositoryImpl(repositoryId, classNameId);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/RepositoryFactoryImpl.java
@@ -17,13 +17,9 @@ package com.liferay.portal.repository;
 import com.liferay.portal.NoSuchRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.repository.InvalidRepositoryIdException;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
 import com.liferay.portal.repository.liferayrepository.LiferayRepository;
-import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
-import com.liferay.portlet.documentlibrary.NoSuchFileVersionException;
-import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
@@ -31,7 +27,7 @@ import com.liferay.portlet.documentlibrary.model.DLFolder;
 /**
  * @author Adolfo Pérez
  */
-public class RepositoryFactoryImpl extends BaseRepositoryFactory
+public class RepositoryFactoryImpl extends BaseRepositoryFactory<Repository>
 	implements RepositoryFactory {
 
 	@Override
@@ -53,7 +49,7 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 			long folderId, long fileEntryId, long fileVersionId)
 		throws PortalException, SystemException {
 
-		LiferayRepository liferayRepository = createLiferayRepository(
+		Repository liferayRepository = createLiferayRepository(
 			folderId, fileEntryId, fileVersionId);
 
 		if (liferayRepository != null) {
@@ -66,6 +62,7 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 		return create(repositoryId);
 	}
 
+	@Override
 	protected LiferayRepository createLiferayRepository(long repositoryId)
 		throws PortalException, SystemException {
 
@@ -96,41 +93,36 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 			getResourceLocalService(), groupId, actualRepositoryId, dlFolderId);
 	}
 
-	protected LiferayRepository createLiferayRepository(
-			long folderId, long fileEntryId, long fileVersionId)
+	@Override
+	protected long getFileEntryRepositoryId(long fileEntryId)
 		throws PortalException, SystemException {
 
-		try {
-			long repositoryId;
+		DLFileEntry dlFileEntry = getDlFileEntryService().getFileEntry(
+			fileEntryId);
 
-			if (folderId != 0) {
-				repositoryId = getFolderRepositoryId(folderId);
-			}
-			else if (fileEntryId != 0) {
-				repositoryId = getFileEntryRepositoryId(fileEntryId);
-			}
-			else if (fileVersionId != 0) {
-				repositoryId = getFileVersionRepositoryId(fileVersionId);
-			}
-			else {
-				throw new InvalidRepositoryIdException(
-					"Missing a valid ID for folder, file entry or file " +
-						"version");
-			}
-
-			return createLiferayRepository(repositoryId);
-		}
-		catch (NoSuchFolderException nsfe) {
-			return null;
-		}
-		catch (NoSuchFileEntryException nsfee) {
-			return null;
-		}
-		catch (NoSuchFileVersionException nsfve) {
-			return null;
-		}
+		return dlFileEntry.getRepositoryId();
 	}
 
+	@Override
+	protected long getFileVersionRepositoryId(long fileVersionId)
+		throws PortalException, SystemException {
+
+		DLFileVersion dlFileVersion =
+			getDlFileVersionService().getFileVersion(fileVersionId);
+
+		return dlFileVersion.getRepositoryId();
+	}
+
+	@Override
+	protected long getFolderRepositoryId(long folderId)
+		throws PortalException, SystemException {
+
+		DLFolder dlFolder = getDlFolderService().getFolder(folderId);
+
+		return dlFolder.getRepositoryId();
+	}
+
+	@Override
 	protected com.liferay.portal.model.Repository getRepository(
 			long repositoryId)
 		throws PortalException, SystemException {
@@ -141,32 +133,6 @@ public class RepositoryFactoryImpl extends BaseRepositoryFactory
 		catch (NoSuchRepositoryException nsre) {
 			return null;
 		}
-	}
-
-	private long getFileEntryRepositoryId(long fileEntryId)
-		throws PortalException, SystemException {
-
-		DLFileEntry dlFileEntry = getDlFileEntryService().getFileEntry(
-			fileEntryId);
-
-		return dlFileEntry.getRepositoryId();
-	}
-
-	private long getFileVersionRepositoryId(long fileVersionId)
-		throws PortalException, SystemException {
-
-		DLFileVersion dlFileVersion =
-			getDlFileVersionService().getFileVersion(fileVersionId);
-
-		return dlFileVersion.getRepositoryId();
-	}
-
-	private long getFolderRepositoryId(long folderId)
-		throws PortalException, SystemException {
-
-		DLFolder dlFolder = getDlFolderService().getFolder(folderId);
-
-		return dlFolder.getRepositoryId();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.SortedArrayList;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.model.Repository;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
@@ -34,9 +33,6 @@ import com.liferay.portal.service.RepositoryLocalService;
 import com.liferay.portal.service.RepositoryService;
 import com.liferay.portal.service.ResourceLocalService;
 import com.liferay.portal.service.ServiceContext;
-import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
-import com.liferay.portlet.documentlibrary.NoSuchFileVersionException;
-import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
@@ -73,36 +69,15 @@ public class LiferayLocalRepository
 		DLFileVersionService dlFileVersionService,
 		DLFolderLocalService dlFolderLocalService,
 		DLFolderService dlFolderService,
-		ResourceLocalService resourceLocalService, long repositoryId) {
+		ResourceLocalService resourceLocalService, long groupId,
+		long repositoryId, long dlFolderId) {
 
 		super(
 			repositoryLocalService, repositoryService, dlAppHelperLocalService,
 			dlFileEntryLocalService, dlFileEntryService,
 			dlFileEntryTypeLocalService, dlFileVersionLocalService,
 			dlFileVersionService, dlFolderLocalService, dlFolderService,
-			resourceLocalService, repositoryId);
-	}
-
-	public LiferayLocalRepository(
-		RepositoryLocalService repositoryLocalService,
-		RepositoryService repositoryService,
-		DLAppHelperLocalService dlAppHelperLocalService,
-		DLFileEntryLocalService dlFileEntryLocalService,
-		DLFileEntryService dlFileEntryService,
-		DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
-		DLFileVersionLocalService dlFileVersionLocalService,
-		DLFileVersionService dlFileVersionService,
-		DLFolderLocalService dlFolderLocalService,
-		DLFolderService dlFolderService,
-		ResourceLocalService resourceLocalService, long folderId,
-		long fileEntryId, long fileVersionId) {
-
-		super(
-			repositoryLocalService, repositoryService, dlAppHelperLocalService,
-			dlFileEntryLocalService, dlFileEntryService,
-			dlFileEntryTypeLocalService, dlFileVersionLocalService,
-			dlFileVersionService, dlFolderLocalService, dlFolderService,
-			resourceLocalService, folderId, fileEntryId, fileVersionId);
+			resourceLocalService, groupId, repositoryId, dlFolderId);
 	}
 
 	@Override
@@ -385,82 +360,6 @@ public class LiferayLocalRepository
 		UnicodeProperties typeSettingsProperties) {
 
 		return typeSettingsProperties;
-	}
-
-	@Override
-	protected void initByFileEntryId(long fileEntryId) {
-		try {
-			DLFileEntry dlFileEntry = dlFileEntryLocalService.getFileEntry(
-				fileEntryId);
-
-			initByRepositoryId(dlFileEntry.getRepositoryId());
-		}
-		catch (Exception e) {
-			if (_log.isTraceEnabled()) {
-				if (e instanceof NoSuchFileEntryException) {
-					_log.trace(e.getMessage());
-				}
-				else {
-					_log.trace(e, e);
-				}
-			}
-		}
-	}
-
-	@Override
-	protected void initByFileVersionId(long fileVersionId) {
-		try {
-			DLFileVersion dlFileVersion =
-				dlFileVersionLocalService.getFileVersion(fileVersionId);
-
-			initByRepositoryId(dlFileVersion.getRepositoryId());
-		}
-		catch (Exception e) {
-			if (_log.isTraceEnabled()) {
-				if (e instanceof NoSuchFileVersionException) {
-					_log.trace(e.getMessage());
-				}
-				else {
-					_log.trace(e, e);
-				}
-			}
-		}
-	}
-
-	@Override
-	protected void initByFolderId(long folderId) {
-		try {
-			DLFolder dlFolder = dlFolderLocalService.getFolder(folderId);
-
-			initByRepositoryId(dlFolder.getRepositoryId());
-		}
-		catch (Exception e) {
-			if (_log.isTraceEnabled()) {
-				if (e instanceof NoSuchFolderException) {
-					_log.trace(e.getMessage());
-				}
-				else {
-					_log.trace(e, e);
-				}
-			}
-		}
-	}
-
-	@Override
-	protected void initByRepositoryId(long repositoryId) {
-		setGroupId(repositoryId);
-		setRepositoryId(repositoryId);
-
-		try {
-			Repository repository = repositoryLocalService.getRepository(
-				repositoryId);
-
-			setDlFolderId(repository.getDlFolderId());
-			setGroupId(repository.getGroupId());
-			setRepositoryId(repository.getRepositoryId());
-		}
-		catch (Exception e) {
-		}
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
@@ -16,8 +16,6 @@ package com.liferay.portal.repository.liferayrepository;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
@@ -41,9 +39,6 @@ import com.liferay.portal.service.RepositoryLocalService;
 import com.liferay.portal.service.RepositoryService;
 import com.liferay.portal.service.ResourceLocalService;
 import com.liferay.portal.service.ServiceContext;
-import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
-import com.liferay.portlet.documentlibrary.NoSuchFileVersionException;
-import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
@@ -81,36 +76,15 @@ public class LiferayRepository
 		DLFileVersionService dlFileVersionService,
 		DLFolderLocalService dlFolderLocalService,
 		DLFolderService dlFolderService,
-		ResourceLocalService resourceLocalService, long repositoryId) {
+		ResourceLocalService resourceLocalService, long groupId,
+		long repositoryId, long dlFolderId) {
 
 		super(
 			repositoryLocalService, repositoryService, dlAppHelperLocalService,
 			dlFileEntryLocalService, dlFileEntryService,
 			dlFileEntryTypeLocalService, dlFileVersionLocalService,
 			dlFileVersionService, dlFolderLocalService, dlFolderService,
-			resourceLocalService, repositoryId);
-	}
-
-	public LiferayRepository(
-		RepositoryLocalService repositoryLocalService,
-		RepositoryService repositoryService,
-		DLAppHelperLocalService dlAppHelperLocalService,
-		DLFileEntryLocalService dlFileEntryLocalService,
-		DLFileEntryService dlFileEntryService,
-		DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
-		DLFileVersionLocalService dlFileVersionLocalService,
-		DLFileVersionService dlFileVersionService,
-		DLFolderLocalService dlFolderLocalService,
-		DLFolderService dlFolderService,
-		ResourceLocalService resourceLocalService, long folderId,
-		long fileEntryId, long fileVersionId) {
-
-		super(
-			repositoryLocalService, repositoryService, dlAppHelperLocalService,
-			dlFileEntryLocalService, dlFileEntryService,
-			dlFileEntryTypeLocalService, dlFileVersionLocalService,
-			dlFileVersionService, dlFolderLocalService, dlFolderService,
-			resourceLocalService, folderId, fileEntryId, fileVersionId);
+			resourceLocalService, groupId, repositoryId, dlFolderId);
 	}
 
 	@Override
@@ -875,83 +849,5 @@ public class LiferayRepository
 		return dlFolderService.verifyInheritableLock(
 			toFolderId(folderId), lockUuid);
 	}
-
-	@Override
-	protected void initByFileEntryId(long fileEntryId) {
-		try {
-			DLFileEntry dlFileEntry = dlFileEntryService.getFileEntry(
-				fileEntryId);
-
-			initByRepositoryId(dlFileEntry.getRepositoryId());
-		}
-		catch (Exception e) {
-			if (_log.isTraceEnabled()) {
-				if (e instanceof NoSuchFileEntryException) {
-					_log.trace(e.getMessage());
-				}
-				else {
-					_log.trace(e, e);
-				}
-			}
-		}
-	}
-
-	@Override
-	protected void initByFileVersionId(long fileVersionId) {
-		try {
-			DLFileVersion dlFileVersion = dlFileVersionService.getFileVersion(
-				fileVersionId);
-
-			initByRepositoryId(dlFileVersion.getRepositoryId());
-		}
-		catch (Exception e) {
-			if (_log.isTraceEnabled()) {
-				if (e instanceof NoSuchFileVersionException) {
-					_log.trace(e.getMessage());
-				}
-				else {
-					_log.trace(e, e);
-				}
-			}
-		}
-	}
-
-	@Override
-	protected void initByFolderId(long folderId) {
-		try {
-			DLFolder dlFolder = dlFolderService.getFolder(folderId);
-
-			initByRepositoryId(dlFolder.getRepositoryId());
-		}
-		catch (Exception e) {
-			if (_log.isTraceEnabled()) {
-				if (e instanceof NoSuchFolderException) {
-					_log.trace(e.getMessage());
-				}
-				else {
-					_log.trace(e, e);
-				}
-			}
-		}
-	}
-
-	@Override
-	protected void initByRepositoryId(long repositoryId) {
-		setGroupId(repositoryId);
-		setRepositoryId(repositoryId);
-
-		try {
-			com.liferay.portal.model.Repository repository =
-				repositoryService.getRepository(repositoryId);
-
-			setDlFolderId(repository.getDlFolderId());
-			setGroupId(repository.getGroupId());
-			setRepositoryId(repository.getRepositoryId());
-		}
-		catch (Exception e) {
-		}
-	}
-
-	private static Log _log = LogFactoryUtil.getLog(LiferayRepository.class);
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
@@ -61,7 +61,8 @@ public abstract class LiferayRepositoryBase extends LiferayBase {
 		DLFileVersionService dlFileVersionService,
 		DLFolderLocalService dlFolderLocalService,
 		DLFolderService dlFolderService,
-		ResourceLocalService resourceLocalService, long repositoryId) {
+		ResourceLocalService resourceLocalService, long groupId,
+		long repositoryId, long dlFolderId) {
 
 		this.repositoryLocalService = repositoryLocalService;
 		this.repositoryService = repositoryService;
@@ -74,45 +75,9 @@ public abstract class LiferayRepositoryBase extends LiferayBase {
 		this.dlFolderLocalService = dlFolderLocalService;
 		this.dlFolderService = dlFolderService;
 		this.resourceLocalService = resourceLocalService;
-
-		initByRepositoryId(repositoryId);
-	}
-
-	public LiferayRepositoryBase(
-		RepositoryLocalService repositoryLocalService,
-		RepositoryService repositoryService,
-		DLAppHelperLocalService dlAppHelperLocalService,
-		DLFileEntryLocalService dlFileEntryLocalService,
-		DLFileEntryService dlFileEntryService,
-		DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
-		DLFileVersionLocalService dlFileVersionLocalService,
-		DLFileVersionService dlFileVersionService,
-		DLFolderLocalService dlFolderLocalService,
-		DLFolderService dlFolderService,
-		ResourceLocalService resourceLocalService, long folderId,
-		long fileEntryId, long fileVersionId) {
-
-		this.repositoryLocalService = repositoryLocalService;
-		this.repositoryService = repositoryService;
-		this.dlAppHelperLocalService = dlAppHelperLocalService;
-		this.dlFileEntryLocalService = dlFileEntryLocalService;
-		this.dlFileEntryService = dlFileEntryService;
-		this.dlFileEntryTypeLocalService = dlFileEntryTypeLocalService;
-		this.dlFileVersionLocalService = dlFileVersionLocalService;
-		this.dlFileVersionService = dlFileVersionService;
-		this.dlFolderLocalService = dlFolderLocalService;
-		this.dlFolderService = dlFolderService;
-		this.resourceLocalService = resourceLocalService;
-
-		if (folderId != 0) {
-			initByFolderId(folderId);
-		}
-		else if (fileEntryId != 0) {
-			initByFileEntryId(fileEntryId);
-		}
-		else if (fileVersionId != 0) {
-			initByFileVersionId(fileVersionId);
-		}
+		this._repositoryId = repositoryId;
+		this._groupId = groupId;
+		this._dlFolderId = dlFolderId;
 	}
 
 	public long getRepositoryId() {
@@ -215,14 +180,6 @@ public abstract class LiferayRepositoryBase extends LiferayBase {
 		return longList;
 	}
 
-	protected abstract void initByFileEntryId(long fileEntryId);
-
-	protected abstract void initByFileVersionId(long fileVersionId);
-
-	protected abstract void initByFolderId(long folderId);
-
-	protected abstract void initByRepositoryId(long repositoryId);
-
 	protected boolean isDefaultRepository() {
 		if (_groupId == _repositoryId) {
 			return true;
@@ -230,18 +187,6 @@ public abstract class LiferayRepositoryBase extends LiferayBase {
 		else {
 			return false;
 		}
-	}
-
-	protected void setDlFolderId(long dlFolderId) {
-		_dlFolderId = dlFolderId;
-	}
-
-	protected void setGroupId(long groupId) {
-		_groupId = groupId;
-	}
-
-	protected void setRepositoryId(long repositoryId) {
-		_repositoryId = repositoryId;
 	}
 
 	protected long toFolderId(long folderId) {

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.repository.InvalidRepositoryIdException;
 import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.LocalRepositoryFactoryUtil;
 import com.liferay.portal.kernel.repository.RepositoryException;
@@ -36,6 +35,7 @@ import com.liferay.portal.model.SystemEventConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.base.RepositoryLocalServiceBaseImpl;
+import com.liferay.portal.util.RepositoryUtil;
 import com.liferay.portlet.documentlibrary.RepositoryNameException;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 
@@ -254,7 +254,7 @@ public class RepositoryLocalServiceImpl
 			long folderId, long fileEntryId, long fileVersionId)
 		throws PortalException, SystemException {
 
-		long repositoryEntryId = getRepositoryEntryId(
+		long repositoryEntryId = RepositoryUtil.getRepositoryEntryId(
 			folderId, fileEntryId, fileVersionId);
 
 		LocalRepository localRepositoryImpl =
@@ -320,7 +320,7 @@ public class RepositoryLocalServiceImpl
 			long folderId, long fileEntryId, long fileVersionId)
 		throws PortalException, SystemException {
 
-		long repositoryEntryId = getRepositoryEntryId(
+		long repositoryEntryId = RepositoryUtil.getRepositoryEntryId(
 			folderId, fileEntryId, fileVersionId);
 
 		com.liferay.portal.kernel.repository.Repository repositoryImpl =
@@ -399,30 +399,6 @@ public class RepositoryLocalServiceImpl
 			description, hidden, serviceContext);
 
 		return dlFolder.getFolderId();
-	}
-
-	protected long getRepositoryEntryId(
-			long folderId, long fileEntryId, long fileVersionId)
-		throws RepositoryException {
-
-		long repositoryEntryId = 0;
-
-		if (folderId != 0) {
-			repositoryEntryId = folderId;
-		}
-		else if (fileEntryId != 0) {
-			repositoryEntryId = fileEntryId;
-		}
-		else if (fileVersionId != 0) {
-			repositoryEntryId = fileVersionId;
-		}
-
-		if (repositoryEntryId == 0) {
-			throw new InvalidRepositoryIdException(
-				"Missing a valid ID for folder, file entry or file version");
-		}
-
-		return repositoryEntryId;
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/util/RepositoryUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/RepositoryUtil.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.repository.InvalidRepositoryIdException;
+import com.liferay.portal.kernel.repository.RepositoryException;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class RepositoryUtil {
+
+	public static long getRepositoryEntryId(
+			long folderId, long fileEntryId, long fileVersionId)
+		throws RepositoryException {
+
+		long repositoryEntryId = 0;
+
+		if (folderId != 0) {
+			repositoryEntryId = folderId;
+		}
+		else if (fileEntryId != 0) {
+			repositoryEntryId = fileEntryId;
+		}
+		else if (fileVersionId != 0) {
+			repositoryEntryId = fileVersionId;
+		}
+
+		if (repositoryEntryId == 0) {
+			throw new InvalidRepositoryIdException(
+				"Missing a valid ID for folder, file entry or file version");
+		}
+
+		return repositoryEntryId;
+	}
+
+}


### PR DESCRIPTION
Hey Brian,

This comes from https://github.com/brianchandotcom/liferay-portal/pull/18890#issuecomment-44613437. We can safely removed the variable.

This is from @adolfopa:
The assignment to the `repositoryId` variable was in the original code before the refactoring (see the `LiferayRepository#initByRepositoryId` method in commit cabf987) so it was kept to guarantee the same behaviour. As it is impossible for the `repositoryId` to be different to the value of `repository.getRepositoryId`, we can remove it safely.
