### PR TITLE
LPS-47400

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/lar/BasePortletDataHandlerTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/BasePortletDataHandlerTestCase.java
@@ -58,6 +58,8 @@ public abstract class BasePortletDataHandlerTestCase {
 
 	@After
 	public void tearDown() throws Exception {
+		deleteStagedModels();
+
 		GroupLocalServiceUtil.deleteGroup(stagingGroup);
 	}
 
@@ -142,6 +144,9 @@ public abstract class BasePortletDataHandlerTestCase {
 	}
 
 	protected abstract PortletDataHandler createPortletDataHandler();
+
+	protected void deleteStagedModels() throws Exception {
+	}
 
 	protected Date getEndDate() {
 		return new Date();

--- a/portal-impl/test/integration/com/liferay/portlet/usergroupsadmin/lar/UserGroupsAdminPortletDataHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usergroupsadmin/lar/UserGroupsAdminPortletDataHandlerTest.java
@@ -17,6 +17,8 @@ package com.liferay.portlet.usergroupsadmin.lar;
 import com.liferay.portal.kernel.lar.PortletDataHandler;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.lar.BasePortletDataHandlerTestCase;
+import com.liferay.portal.model.UserGroup;
+import com.liferay.portal.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
 import com.liferay.portal.test.MainServletExecutionTestListener;
 import com.liferay.portal.util.PortletKeys;
@@ -34,7 +36,7 @@ public class UserGroupsAdminPortletDataHandlerTest
 
 	@Override
 	protected void addStagedModels() throws Exception {
-		UserGroupTestUtil.addUserGroup();
+		userGroup = UserGroupTestUtil.addUserGroup();
 	}
 
 	@Override
@@ -43,8 +45,15 @@ public class UserGroupsAdminPortletDataHandlerTest
 	}
 
 	@Override
+	protected void deleteStagedModels() throws Exception {
+		UserGroupLocalServiceUtil.deleteUserGroup(userGroup);
+	}
+
+	@Override
 	protected String getPortletId() {
 		return PortletKeys.USER_GROUPS_ADMIN;
 	}
+
+	protected UserGroup userGroup;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/lar/UsersAdminPortletDataHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/lar/UsersAdminPortletDataHandlerTest.java
@@ -17,6 +17,8 @@ package com.liferay.portlet.usersadmin.lar;
 import com.liferay.portal.kernel.lar.PortletDataHandler;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.lar.BasePortletDataHandlerTestCase;
+import com.liferay.portal.model.Organization;
+import com.liferay.portal.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.test.LiferayIntegrationJUnitTestRunner;
 import com.liferay.portal.test.MainServletExecutionTestListener;
 import com.liferay.portal.util.PortletKeys;
@@ -34,7 +36,7 @@ public class UsersAdminPortletDataHandlerTest
 
 	@Override
 	protected void addStagedModels() throws Exception {
-		OrganizationTestUtil.addOrganization();
+		organization = OrganizationTestUtil.addOrganization();
 	}
 
 	@Override
@@ -43,8 +45,15 @@ public class UsersAdminPortletDataHandlerTest
 	}
 
 	@Override
+	protected void deleteStagedModels() throws Exception {
+		OrganizationLocalServiceUtil.deleteOrganization(organization);
+	}
+
+	@Override
 	protected String getPortletId() {
 		return PortletKeys.USERS_ADMIN;
 	}
+
+	protected Organization organization;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/lar/UsersAdminPortletDataHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/lar/UsersAdminPortletDataHandlerTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 @ExecutionTestListeners(listeners = {MainServletExecutionTestListener.class})
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
 public class UsersAdminPortletDataHandlerTest
-		extends BasePortletDataHandlerTestCase {
+	extends BasePortletDataHandlerTestCase {
 
 	@Override
 	protected void addStagedModels() throws Exception {


### PR DESCRIPTION
Hey Brian,

These tests were not cleaning up after themselves. Their executing thus ends up in messy data in the DB which can cause failure for others.

Thanks,

Máté

cc: @mdelapenya
