### PR TITLE
LPS-47436 Clean up properly after StagedModelDataHandlerTests

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/layoutprototypes/lar/LayoutPrototypeStagedModelDataHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/layoutprototypes/lar/LayoutPrototypeStagedModelDataHandlerTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.util.test.RandomTestUtil;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -50,16 +51,30 @@ public class LayoutPrototypeStagedModelDataHandlerTest
 	public static TransactionalTestRule transactionalTestRule =
 		new TransactionalTestRule();
 
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+
+		_layoutPrototype =
+			LayoutPrototypeLocalServiceUtil.
+				fetchLayoutPrototypeByUuidAndCompanyId(
+					_layoutPrototype.getUuid(),
+					_layoutPrototype.getCompanyId());
+
+		LayoutPrototypeLocalServiceUtil.deleteLayoutPrototype(_layoutPrototype);
+	}
+
 	@Override
 	protected StagedModel addStagedModel(
 			Group group,
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		LayoutPrototype layoutPrototype = LayoutTestUtil.addLayoutPrototype(
+		_layoutPrototype = LayoutTestUtil.addLayoutPrototype(
 			RandomTestUtil.randomString());
 
-		Layout layout = layoutPrototype.getLayout();
+		Layout layout = _layoutPrototype.getLayout();
 
 		UnicodeProperties typeSettings = layout.getTypeSettingsProperties();
 
@@ -81,7 +96,7 @@ public class LayoutPrototypeStagedModelDataHandlerTest
 			dependentStagedModelsMap, LayoutFriendlyURL.class,
 			layoutFriendlyURLs.get(0));
 
-		return layoutPrototype;
+		return _layoutPrototype;
 	}
 
 	@Override
@@ -160,5 +175,7 @@ public class LayoutPrototypeStagedModelDataHandlerTest
 			layoutFriendlyURL.getFriendlyURL(),
 			importedLayoutFriendlyURL.getFriendlyURL());
 	}
+
+	private LayoutPrototype _layoutPrototype;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/layoutsetprototypes/lar/LayoutSetPrototypeStagedModelDataHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/layoutsetprototypes/lar/LayoutSetPrototypeStagedModelDataHandlerTest.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -65,6 +66,32 @@ public class LayoutSetPrototypeStagedModelDataHandlerTest
 	@ClassRule
 	public static TransactionalTestRule transactionalTestRule =
 		new TransactionalTestRule();
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+
+		// Need to delete LayoutSetPrototype first
+
+		_layoutSetPrototype =
+			LayoutSetPrototypeLocalServiceUtil.
+				fetchLayoutSetPrototypeByUuidAndCompanyId(
+					_layoutSetPrototype.getUuid(),
+					_layoutSetPrototype.getCompanyId());
+
+		LayoutSetPrototypeLocalServiceUtil.deleteLayoutSetPrototype(
+			_layoutSetPrototype);
+
+		_layoutPrototype =
+			LayoutPrototypeLocalServiceUtil.
+				fetchLayoutPrototypeByUuidAndCompanyId(
+					_layoutPrototype.getUuid(),
+					_layoutPrototype.getCompanyId());
+
+			LayoutPrototypeLocalServiceUtil.deleteLayoutPrototype(
+				_layoutPrototype);
+	}
 
 	protected void addLayout(Class<?> clazz, Layout layout) throws Exception {
 		List<Layout> layouts = _layouts.get(clazz.getSimpleName());
@@ -110,14 +137,14 @@ public class LayoutSetPrototypeStagedModelDataHandlerTest
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		LayoutPrototype layoutPrototype = LayoutTestUtil.addLayoutPrototype(
+		_layoutPrototype = LayoutTestUtil.addLayoutPrototype(
 			RandomTestUtil.randomString());
 
 		addDependentStagedModel(
-			dependentStagedModelsMap, LayoutPrototype.class, layoutPrototype);
+			dependentStagedModelsMap, LayoutPrototype.class, _layoutPrototype);
 
 		List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-			layoutPrototype.getGroupId(), true,
+			_layoutPrototype.getGroupId(), true,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
 		Assert.assertEquals(1, layouts.size());
@@ -140,7 +167,7 @@ public class LayoutSetPrototypeStagedModelDataHandlerTest
 
 		addLayoutFriendlyURLs(LayoutPrototype.class, layout.getPlid());
 
-		return layoutPrototype;
+		return _layoutPrototype;
 	}
 
 	@Override
@@ -149,11 +176,11 @@ public class LayoutSetPrototypeStagedModelDataHandlerTest
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		LayoutSetPrototype layoutSetPrototype =
-			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
+		_layoutSetPrototype = LayoutTestUtil.addLayoutSetPrototype(
+			RandomTestUtil.randomString());
 
 		List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-			layoutSetPrototype.getGroupId(), true,
+			_layoutSetPrototype.getGroupId(), true,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
 		Assert.assertEquals(1, layouts.size());
@@ -167,14 +194,14 @@ public class LayoutSetPrototypeStagedModelDataHandlerTest
 			dependentStagedModelsMap);
 
 		Layout prototypedLayout = LayoutTestUtil.addLayout(
-			layoutSetPrototype.getGroupId(), RandomTestUtil.randomString(),
+			_layoutSetPrototype.getGroupId(), RandomTestUtil.randomString(),
 			true, layoutPrototype, true);
 
 		addLayout(LayoutSetPrototype.class, prototypedLayout);
 		addLayoutFriendlyURLs(
 			LayoutSetPrototype.class, prototypedLayout.getPlid());
 
-		return layoutSetPrototype;
+		return _layoutSetPrototype;
 	}
 
 	@Override
@@ -381,7 +408,9 @@ public class LayoutSetPrototypeStagedModelDataHandlerTest
 
 	private Map<String, List<LayoutFriendlyURL>> _layoutFriendlyURLs =
 		new HashMap<String, List<LayoutFriendlyURL>>();
+	private LayoutPrototype _layoutPrototype;
 	private Map<String, List<Layout>> _layouts =
 		new HashMap<String, List<Layout>>();
+	private LayoutSetPrototype _layoutSetPrototype;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/usergroupsadmin/lar/UserGroupStagedModelDataHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usergroupsadmin/lar/UserGroupStagedModelDataHandlerTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.util.test.UserGroupTestUtil;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -43,13 +44,26 @@ public class UserGroupStagedModelDataHandlerTest
 	public static TransactionalTestRule transactionalTestRule =
 		new TransactionalTestRule();
 
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+
+		_userGroup = UserGroupLocalServiceUtil.fetchUserGroupByUuidAndCompanyId(
+			_userGroup.getUuid(), _userGroup.getCompanyId());
+
+		UserGroupLocalServiceUtil.deleteUserGroup(_userGroup);
+	}
+
 	@Override
 	protected StagedModel addStagedModel(
 			Group group,
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		return UserGroupTestUtil.addUserGroup();
+		_userGroup = UserGroupTestUtil.addUserGroup();
+
+		return _userGroup;
 	}
 
 	@Override
@@ -77,5 +91,7 @@ public class UserGroupStagedModelDataHandlerTest
 	protected Class<? extends StagedModel> getStagedModelClass() {
 		return UserGroup.class;
 	}
+
+	private UserGroup _userGroup;
 
 }

--- a/portal-impl/test/integration/com/liferay/portlet/usersadmin/lar/OrganizationStagedModelDataHandlerTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/usersadmin/lar/OrganizationStagedModelDataHandlerTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.util.test.ServiceContextTestUtil;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
@@ -60,54 +61,66 @@ public class OrganizationStagedModelDataHandlerTest
 	public static TransactionalTestRule transactionalTestRule =
 		new TransactionalTestRule();
 
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		super.tearDown();
+
+		_organization =
+			OrganizationLocalServiceUtil.fetchOrganizationByUuidAndCompanyId(
+				_organization.getUuid(), _organization.getCompanyId());
+
+		OrganizationLocalServiceUtil.deleteOrganization(_organization);
+	}
+
 	@Override
 	protected StagedModel addStagedModel(
 			Group group,
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		Organization organization = OrganizationTestUtil.addOrganization();
+		_organization = OrganizationTestUtil.addOrganization();
 
 		Organization suborganization = OrganizationTestUtil.addOrganization(
-			organization.getOrganizationId(), RandomTestUtil.randomString(),
+			_organization.getOrganizationId(), RandomTestUtil.randomString(),
 			false);
 
 		addDependentStagedModel(
 			dependentStagedModelsMap, Organization.class, suborganization);
 
-		Address address = OrganizationTestUtil.addAddress(organization);
+		Address address = OrganizationTestUtil.addAddress(_organization);
 
 		addDependentStagedModel(
 			dependentStagedModelsMap, Address.class, address);
 
 		EmailAddress emailAddress = OrganizationTestUtil.addEmailAddress(
-			organization);
+			_organization);
 
 		addDependentStagedModel(
 			dependentStagedModelsMap, EmailAddress.class, emailAddress);
 
-		OrganizationTestUtil.addOrgLabor(organization);
+		OrganizationTestUtil.addOrgLabor(_organization);
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(group.getGroupId());
 
 		PasswordPolicy passwordPolicy =
 			OrganizationTestUtil.addPasswordPolicyRel(
-				organization, serviceContext);
+				_organization, serviceContext);
 
 		addDependentStagedModel(
 			dependentStagedModelsMap, PasswordPolicy.class, passwordPolicy);
 
-		Phone phone = OrganizationTestUtil.addPhone(organization);
+		Phone phone = OrganizationTestUtil.addPhone(_organization);
 
 		addDependentStagedModel(dependentStagedModelsMap, Phone.class, phone);
 
-		Website website = OrganizationTestUtil.addWebsite(organization);
+		Website website = OrganizationTestUtil.addWebsite(_organization);
 
 		addDependentStagedModel(
 			dependentStagedModelsMap, Website.class, website);
 
-		return organization;
+		return _organization;
 	}
 
 	@Override
@@ -250,5 +263,7 @@ public class OrganizationStagedModelDataHandlerTest
 		Assert.assertEquals(
 			organization.getOrganizationId(), importedWebsite.getClassPK());
 	}
+
+	private Organization _organization;
 
 }


### PR DESCRIPTION
Hey Brian,

Found some more tests in need of cleaning up.

The deleteStagedModel method is being used in the actual test process, I wanted to separate the actual cleanup process from that. The entities are needed to be queried again to make sure we are deleting the right entity after import.

Thanks,

Máté
