### PR TITLE
LPS-46787

### DIFF
--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -557,6 +557,18 @@
 		<field name="replierUserId" type="long" />
 		<field name="statusId" type="int" />
 	</model>
+	<model name="com.liferay.portal.model.NotificationEvent">
+		<field name="mvccVersion" type="long" />
+		<field name="notificationEventId" type="long" />
+		<field name="userId" type="long" />
+		<field name="classNameId" type="long" />
+		<field name="classPK" type="long" />
+		<field name="payload" type="String">
+			<hint-collection name="CLOB" />
+		</field>
+		<field name="timestamp" type="long" />
+		<field name="type" type="String" />
+	</model>
 	<model name="com.liferay.portal.model.Organization">
 		<field name="mvccVersion" type="long" />
 		<field name="uuid" type="String" />
@@ -1095,14 +1107,10 @@
 		<field name="userNotificationEventId" type="long" />
 		<field name="companyId" type="long" />
 		<field name="userId" type="long" />
-		<field name="type" type="String" />
-		<field name="timestamp" type="long" />
+		<field name="notificationEventId" type="long" />
 		<field name="deliveryType" type="int" />
 		<field name="deliverBy" type="long" />
 		<field name="delivered" type="boolean" />
-		<field name="payload" type="String">
-			<hint-collection name="CLOB" />
-		</field>
 		<field name="archived" type="boolean" />
 	</model>
 	<model name="com.liferay.portal.model.UserTracker">

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -1372,6 +1372,30 @@
 		<reference package-path="com.liferay.portal" entity="UserGroup" />
 		<reference package-path="com.liferay.portal" entity="UserGroupRole" />
 	</entity>
+	<entity name="NotificationEvent" local-service="true" remote-service="false">
+
+		<!-- PK fields -->
+
+		<column name="notificationEventId" type="long" primary="true" />
+
+		<!-- Audit fields -->
+
+		<column name="userId" type="long" />
+
+		<!-- Other fields -->
+
+		<column name="classNameId" type="long" />
+		<column name="classPK" type="long" />
+		<column name="payload" type="String" />
+		<column name="timestamp" type="long" />
+		<column name="type" type="String" />
+
+		<!-- Order -->
+
+		<order by="desc">
+			<order-column name="timestamp" />
+		</order>
+	</entity>
 	<entity name="Organization" uuid="true" local-service="true" remote-service="true">
 
 		<!-- PK fields -->
@@ -2987,19 +3011,11 @@
 
 		<!-- Other fields -->
 
-		<column name="type" type="String" />
-		<column name="timestamp" type="long" />
+		<column name="notificationEventId" type="long" />
 		<column name="deliveryType" type="int" />
 		<column name="deliverBy" type="long" />
 		<column name="delivered" type="boolean" />
-		<column name="payload" type="String" />
 		<column name="archived" type="boolean" />
-
-		<!-- Order -->
-
-		<order by="desc">
-			<order-column name="timestamp" />
-		</order>
 
 		<!-- Finder methods -->
 
@@ -3014,9 +3030,20 @@
 			<finder-column name="userId" />
 			<finder-column name="archived" />
 		</finder>
+		<finder name="U_D_D" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="deliveryType" />
+			<finder-column name="delivered" />
+		</finder>
+		<finder name="U_D_A" return-type="Collection">
+			<finder-column name="userId" />
+			<finder-column name="deliveryType" />
+			<finder-column name="archived" />
+		</finder>
 
 		<!-- References -->
 
+		<reference package-path="com.liferay.portal" entity="NotificationEvent" />
 		<reference package-path="com.liferay.portal" entity="User" />
 	</entity>
 	<entity name="UserTracker" local-service="true" remote-service="false">


### PR DESCRIPTION
@brianchandotcom

I want to send you this pull request first to review the new database schema for UserNotificationEvent. We want to split the original table into two tables. One is NotificationEvent, which will store the information of the notification, and the old table will remain as UserNotificationEvent. This will allow one NotificationEvent to be sent to multiple Users. 

However there is already a class in portal called NotificationEvent, so I know we have to change the name for one of them. I want to see if you have any insight on what we should do.

thanks
