### PR TITLE
LPS-47511

### DIFF
--- a/portal-impl/src/com/liferay/portal/repository/capabilities/BaseCapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/BaseCapabilityRepository.java
@@ -28,28 +28,30 @@ public abstract class BaseCapabilityRepository<T>
 
 	public BaseCapabilityRepository(
 		T repository,
-		Map<Class<? extends Capability>, Capability> capabilityMap,
-		Set<Class<? extends Capability>> exportedCapabilities) {
+		Map<Class<? extends Capability>, Capability> supportedCapabilitiesMap,
+		Set<Class<? extends Capability>> exportedCapabilityClasses) {
 
 		Set<Class<? extends Capability>> supportedCapabilities =
-			capabilityMap.keySet();
+			supportedCapabilitiesMap.keySet();
 
-		if (!supportedCapabilities.containsAll(exportedCapabilities)) {
+		if (!supportedCapabilities.containsAll(exportedCapabilityClasses)) {
 			throw new IllegalArgumentException(
 				String.format(
 					"Exporting capabilities not explicitly supported is not " +
-					"allowed. Repository supports %s, but tried to export %s",
-					capabilityMap.keySet(), exportedCapabilities));
+						"allowed. Repository supports %s, but tried to " +
+							"export %s",
+					supportedCapabilitiesMap.keySet(),
+					exportedCapabilityClasses));
 		}
 
 		_repository = repository;
-		_capabilityMap = capabilityMap;
-		_exportedCapabilities = exportedCapabilities;
+		_supportedCapabilitiesMap = supportedCapabilitiesMap;
+		_exportedCapabilityClasses = exportedCapabilityClasses;
 	}
 
 	@Override
 	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
-		if (_exportedCapabilities.contains(capabilityClass)) {
+		if (_exportedCapabilityClasses.contains(capabilityClass)) {
 			return getInternalCapability(capabilityClass);
 		}
 
@@ -63,13 +65,13 @@ public abstract class BaseCapabilityRepository<T>
 	public <T extends Capability> boolean isCapabilityProvided(
 		Class<T> capabilityClass) {
 
-		return _exportedCapabilities.contains(capabilityClass);
+		return _exportedCapabilityClasses.contains(capabilityClass);
 	}
 
 	protected <T extends Capability> T getInternalCapability(
 		Class<T> capabilityClass) {
 
-		Capability capability = _capabilityMap.get(capabilityClass);
+		Capability capability = _supportedCapabilitiesMap.get(capabilityClass);
 
 		if (capability == null) {
 			throw new IllegalArgumentException(
@@ -87,9 +89,9 @@ public abstract class BaseCapabilityRepository<T>
 
 	protected abstract long getRepositoryId();
 
-	private final Map<Class<? extends Capability>, Capability>
-		_capabilityMap;
-	private final Set<Class<? extends Capability>> _exportedCapabilities;
+	private final Set<Class<? extends Capability>> _exportedCapabilityClasses;
 	private final T _repository;
+	private final Map<Class<? extends Capability>, Capability>
+		_supportedCapabilitiesMap;
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/BaseCapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/BaseCapabilityRepository.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities;
+
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Adolfo Pérez
+ */
+public abstract class BaseCapabilityRepository<T>
+	implements CapabilityProvider {
+
+	public BaseCapabilityRepository(
+		T repository,
+		Map<Class<? extends Capability>, Capability> capabilityMap,
+		Set<Class<? extends Capability>> exportedCapabilities) {
+
+		Set<Class<? extends Capability>> supportedCapabilities =
+			capabilityMap.keySet();
+
+		if (!supportedCapabilities.containsAll(exportedCapabilities)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Exporting capabilities not explicitly supported is not " +
+					"allowed. Repository supports %s, but tried to export %s",
+					capabilityMap.keySet(), exportedCapabilities));
+		}
+
+		_repository = repository;
+		_capabilityMap = capabilityMap;
+		_exportedCapabilities = exportedCapabilities;
+	}
+
+	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		if (_exportedCapabilities.contains(capabilityClass)) {
+			return getInternalCapability(capabilityClass);
+		}
+
+		throw new IllegalArgumentException(
+			String.format(
+				"Capability %s not exported by repository %d",
+				capabilityClass.getName(), getRepositoryId()));
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return _exportedCapabilities.contains(capabilityClass);
+	}
+
+	protected <T extends Capability> T getInternalCapability(
+		Class<T> capabilityClass) {
+
+		Capability capability = _capabilityMap.get(capabilityClass);
+
+		if (capability == null) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Capability %s not supported by repository %d",
+					capabilityClass.getName(), getRepositoryId()));
+		}
+
+		return (T)capability;
+	}
+
+	protected T getRepository() {
+		return _repository;
+	}
+
+	protected abstract long getRepositoryId();
+
+	private final Map<Class<? extends Capability>, Capability>
+		_capabilityMap;
+	private final Set<Class<? extends Capability>> _exportedCapabilities;
+	private final T _repository;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class CapabilityLocalRepository implements LocalRepository {
+
+	public CapabilityLocalRepository(
+		LocalRepository localRepository,
+		Map<Class<? extends Capability>, Capability> capabilityMap,
+		Set<Class<? extends Capability>> exportedCapabilities) {
+
+		Set<Class<? extends Capability>> supportedCababilities =
+			capabilityMap.keySet();
+
+		if (!supportedCababilities.containsAll(exportedCapabilities)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Exporting capabilities not explicitly supported is not " +
+					"allowed. Repository supports %s, but tried to export %s",
+					capabilityMap.keySet(), exportedCapabilities));
+		}
+
+		_localRepository = localRepository;
+		_capabilityMap = capabilityMap;
+		_exportedCapabilities = exportedCapabilities;
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long userId, long folderId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog, File file,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.addFileEntry(
+			userId, folderId, sourceFileName, mimeType, title, description,
+			changeLog, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long userId, long folderId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog, InputStream is,
+			long size, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.addFileEntry(
+			userId, folderId, sourceFileName, mimeType, title, description,
+			changeLog, is, size, serviceContext);
+	}
+
+	@Override
+	public Folder addFolder(
+			long userId, long parentFolderId, String title, String description,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.addFolder(
+			userId, parentFolderId, title, description, serviceContext);
+	}
+
+	@Override
+	public void deleteAll() throws PortalException, SystemException {
+		_localRepository.deleteAll();
+	}
+
+	@Override
+	public void deleteFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		_localRepository.deleteFileEntry(fileEntryId);
+	}
+
+	@Override
+	public void deleteFolder(long folderId)
+		throws PortalException, SystemException {
+
+		_localRepository.deleteFolder(folderId);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		return _localRepository.getFileEntry(fileEntryId);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long folderId, String title)
+		throws PortalException, SystemException {
+
+		return _localRepository.getFileEntry(folderId, title);
+	}
+
+	@Override
+	public FileEntry getFileEntryByUuid(String uuid)
+		throws PortalException, SystemException {
+
+		return _localRepository.getFileEntryByUuid(uuid);
+	}
+
+	@Override
+	public FileVersion getFileVersion(long fileVersionId)
+		throws PortalException, SystemException {
+
+		return _localRepository.getFileVersion(fileVersionId);
+	}
+
+	@Override
+	public Folder getFolder(long folderId)
+		throws PortalException, SystemException {
+
+		return _localRepository.getFolder(folderId);
+	}
+
+	@Override
+	public Folder getFolder(long parentFolderId, String title)
+		throws PortalException, SystemException {
+
+		return _localRepository.getFolder(parentFolderId, title);
+	}
+
+	@Override
+	public List<FileEntry> getRepositoryFileEntries(
+			long rootFolderId, int start, int end, OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _localRepository.getRepositoryFileEntries(
+			rootFolderId, start, end, obc);
+	}
+
+	@Override
+	public long getRepositoryId() {
+		return _localRepository.getRepositoryId();
+	}
+
+	@Override
+	public FileEntry moveFileEntry(
+			long userId, long fileEntryId, long newFolderId,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.moveFileEntry(
+			userId, fileEntryId, newFolderId, serviceContext);
+	}
+
+	@Override
+	public Folder moveFolder(
+			long userId, long folderId, long parentFolderId,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.moveFolder(
+			userId, folderId, parentFolderId, serviceContext);
+	}
+
+	@Override
+	public void updateAsset(
+			long userId, FileEntry fileEntry, FileVersion fileVersion,
+			long[] assetCategoryIds, String[] assetTagNames,
+			long[] assetLinkEntryIds)
+		throws PortalException, SystemException {
+
+		_localRepository.updateAsset(
+			userId, fileEntry, fileVersion, assetCategoryIds, assetTagNames,
+			assetLinkEntryIds);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+	}
+
+	@Override
+	public Folder updateFolder(
+			long folderId, long parentFolderId, String title,
+			String description, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _localRepository.updateFolder(
+			folderId, parentFolderId, title, description, serviceContext);
+	}
+
+	protected <T extends Capability<T>> T getCapability(
+		Class<T> capabilityClass) {
+
+		Capability<?> capability = _capabilityMap.get(capabilityClass);
+
+		if (capability == null) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Capability %s not supported by repository %d",
+					capabilityClass.getName(), getRepositoryId()));
+		}
+
+		return (T)capability;
+	}
+
+	private final Map<Class<? extends Capability>, Capability>
+		_capabilityMap;
+	private final Set<Class<? extends Capability>> _exportedCapabilities;
+	private final LocalRepository _localRepository;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -40,10 +40,12 @@ public class CapabilityLocalRepository
 
 	public CapabilityLocalRepository(
 		LocalRepository localRepository,
-		Map<Class<? extends Capability>, Capability> capabilityMap,
-		Set<Class<? extends Capability>> exportedCapabilities) {
+		Map<Class<? extends Capability>, Capability> supportedCapabilitiesMap,
+		Set<Class<? extends Capability>> exportedCapabilityClasses) {
 
-		super(localRepository, capabilityMap, exportedCapabilities);
+		super(
+			localRepository, supportedCapabilitiesMap,
+			exportedCapabilityClasses);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -34,27 +34,16 @@ import java.util.Set;
 /**
  * @author Adolfo Pérez
  */
-public class CapabilityLocalRepository implements LocalRepository {
+public class CapabilityLocalRepository
+	extends BaseCapabilityRepository<LocalRepository>
+	implements LocalRepository {
 
 	public CapabilityLocalRepository(
 		LocalRepository localRepository,
 		Map<Class<? extends Capability>, Capability> capabilityMap,
 		Set<Class<? extends Capability>> exportedCapabilities) {
 
-		Set<Class<? extends Capability>> supportedCababilities =
-			capabilityMap.keySet();
-
-		if (!supportedCababilities.containsAll(exportedCapabilities)) {
-			throw new IllegalArgumentException(
-				String.format(
-					"Exporting capabilities not explicitly supported is not " +
-					"allowed. Repository supports %s, but tried to export %s",
-					capabilityMap.keySet(), exportedCapabilities));
-		}
-
-		_localRepository = localRepository;
-		_capabilityMap = capabilityMap;
-		_exportedCapabilities = exportedCapabilities;
+		super(localRepository, capabilityMap, exportedCapabilities);
 	}
 
 	@Override
@@ -64,7 +53,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.addFileEntry(
+		return getRepository().addFileEntry(
 			userId, folderId, sourceFileName, mimeType, title, description,
 			changeLog, file, serviceContext);
 	}
@@ -76,7 +65,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			long size, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.addFileEntry(
+		return getRepository().addFileEntry(
 			userId, folderId, sourceFileName, mimeType, title, description,
 			changeLog, is, size, serviceContext);
 	}
@@ -87,81 +76,69 @@ public class CapabilityLocalRepository implements LocalRepository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.addFolder(
+		return getRepository().addFolder(
 			userId, parentFolderId, title, description, serviceContext);
 	}
 
 	@Override
 	public void deleteAll() throws PortalException, SystemException {
-		_localRepository.deleteAll();
+		getRepository().deleteAll();
 	}
 
 	@Override
 	public void deleteFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
-		_localRepository.deleteFileEntry(fileEntryId);
+		getRepository().deleteFileEntry(fileEntryId);
 	}
 
 	@Override
 	public void deleteFolder(long folderId)
 		throws PortalException, SystemException {
 
-		_localRepository.deleteFolder(folderId);
-	}
-
-	@Override
-	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
-		if (_exportedCapabilities.contains(capabilityClass)) {
-			return getInternalCapability(capabilityClass);
-		}
-
-		throw new IllegalArgumentException(
-			String.format(
-				"Capability %s not exported by repository %d",
-				capabilityClass.getName(), getRepositoryId()));
+		getRepository().deleteFolder(folderId);
 	}
 
 	@Override
 	public FileEntry getFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
-		return _localRepository.getFileEntry(fileEntryId);
+		return getRepository().getFileEntry(fileEntryId);
 	}
 
 	@Override
 	public FileEntry getFileEntry(long folderId, String title)
 		throws PortalException, SystemException {
 
-		return _localRepository.getFileEntry(folderId, title);
+		return getRepository().getFileEntry(folderId, title);
 	}
 
 	@Override
 	public FileEntry getFileEntryByUuid(String uuid)
 		throws PortalException, SystemException {
 
-		return _localRepository.getFileEntryByUuid(uuid);
+		return getRepository().getFileEntryByUuid(uuid);
 	}
 
 	@Override
 	public FileVersion getFileVersion(long fileVersionId)
 		throws PortalException, SystemException {
 
-		return _localRepository.getFileVersion(fileVersionId);
+		return getRepository().getFileVersion(fileVersionId);
 	}
 
 	@Override
 	public Folder getFolder(long folderId)
 		throws PortalException, SystemException {
 
-		return _localRepository.getFolder(folderId);
+		return getRepository().getFolder(folderId);
 	}
 
 	@Override
 	public Folder getFolder(long parentFolderId, String title)
 		throws PortalException, SystemException {
 
-		return _localRepository.getFolder(parentFolderId, title);
+		return getRepository().getFolder(parentFolderId, title);
 	}
 
 	@Override
@@ -169,20 +146,13 @@ public class CapabilityLocalRepository implements LocalRepository {
 			long rootFolderId, int start, int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _localRepository.getRepositoryFileEntries(
+		return getRepository().getRepositoryFileEntries(
 			rootFolderId, start, end, obc);
 	}
 
 	@Override
 	public long getRepositoryId() {
-		return _localRepository.getRepositoryId();
-	}
-
-	@Override
-	public <T extends Capability> boolean isCapabilityProvided(
-			Class<T> capabilityClass) {
-
-		return _exportedCapabilities.contains(capabilityClass);
+		return getRepository().getRepositoryId();
 	}
 
 	@Override
@@ -191,7 +161,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.moveFileEntry(
+		return getRepository().moveFileEntry(
 			userId, fileEntryId, newFolderId, serviceContext);
 	}
 
@@ -201,7 +171,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.moveFolder(
+		return getRepository().moveFolder(
 			userId, folderId, parentFolderId, serviceContext);
 	}
 
@@ -212,7 +182,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			long[] assetLinkEntryIds)
 		throws PortalException, SystemException {
 
-		_localRepository.updateAsset(
+		getRepository().updateAsset(
 			userId, fileEntry, fileVersion, assetCategoryIds, assetTagNames,
 			assetLinkEntryIds);
 	}
@@ -224,7 +194,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			boolean majorVersion, File file, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.updateFileEntry(
+		return getRepository().updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, description,
 			changeLog, majorVersion, file, serviceContext);
 	}
@@ -237,7 +207,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.updateFileEntry(
+		return getRepository().updateFileEntry(
 			userId, fileEntryId, sourceFileName, mimeType, title, description,
 			changeLog, majorVersion, is, size, serviceContext);
 	}
@@ -248,28 +218,8 @@ public class CapabilityLocalRepository implements LocalRepository {
 			String description, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _localRepository.updateFolder(
+		return getRepository().updateFolder(
 			folderId, parentFolderId, title, description, serviceContext);
 	}
-
-	protected <T extends Capability> T getInternalCapability(
-		Class<T> capabilityClass) {
-
-		Capability<?> capability = _capabilityMap.get(capabilityClass);
-
-		if (capability == null) {
-			throw new IllegalArgumentException(
-				String.format(
-					"Capability %s not supported by repository %d",
-					capabilityClass.getName(), getRepositoryId()));
-		}
-
-		return (T)capability;
-	}
-
-	private final Map<Class<? extends Capability>, Capability>
-		_capabilityMap;
-	private final Set<Class<? extends Capability>> _exportedCapabilities;
-	private final LocalRepository _localRepository;
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -111,6 +111,18 @@ public class CapabilityLocalRepository implements LocalRepository {
 	}
 
 	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		if (_exportedCapabilities.contains(capabilityClass)) {
+			return getInternalCapability(capabilityClass);
+		}
+
+		throw new IllegalArgumentException(
+			String.format(
+				"Capability %s not exported by repository %d",
+				capabilityClass.getName(), getRepositoryId()));
+	}
+
+	@Override
 	public FileEntry getFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
@@ -164,6 +176,13 @@ public class CapabilityLocalRepository implements LocalRepository {
 	@Override
 	public long getRepositoryId() {
 		return _localRepository.getRepositoryId();
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+			Class<T> capabilityClass) {
+
+		return _exportedCapabilities.contains(capabilityClass);
 	}
 
 	@Override
@@ -233,7 +252,7 @@ public class CapabilityLocalRepository implements LocalRepository {
 			folderId, parentFolderId, title, description, serviceContext);
 	}
 
-	protected <T extends Capability<T>> T getCapability(
+	protected <T extends Capability> T getInternalCapability(
 		Class<T> capabilityClass) {
 
 		Capability<?> capability = _capabilityMap.get(capabilityClass);

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -39,27 +39,15 @@ import java.util.Set;
 /**
  * @author Adolfo Pérez
  */
-public class CapabilityRepository implements Repository {
+public class CapabilityRepository
+	extends BaseCapabilityRepository<Repository> implements Repository {
 
 	public CapabilityRepository(
 		Repository repository,
 		Map<Class<? extends Capability>, Capability> capabilityMap,
 		Set<Class<? extends Capability>> exportedCapabilities) {
 
-		Set<Class<? extends Capability>> supportedCapabilities =
-			capabilityMap.keySet();
-
-		if (!supportedCapabilities.containsAll(exportedCapabilities)) {
-			throw new IllegalArgumentException(
-				String.format(
-					"Exporting capabilities not explicitly supported is not " +
-					"allowed. Repository supports %s, but tried to export %s",
-					capabilityMap.keySet(), exportedCapabilities));
-		}
-
-		_repository = repository;
-		_capabilityMap = capabilityMap;
-		_exportedCapabilities = exportedCapabilities;
+		super(repository, capabilityMap, exportedCapabilities);
 	}
 
 	@Override
@@ -69,7 +57,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.addFileEntry(
+		return getRepository().addFileEntry(
 			folderId, sourceFileName, mimeType, title, description, changeLog,
 			file, serviceContext);
 	}
@@ -81,7 +69,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.addFileEntry(
+		return getRepository().addFileEntry(
 			folderId, sourceFileName, mimeType, title, description, changeLog,
 			is, size, serviceContext);
 	}
@@ -92,7 +80,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.addFolder(
+		return getRepository().addFolder(
 			parentFolderId, title, description, serviceContext);
 	}
 
@@ -100,7 +88,7 @@ public class CapabilityRepository implements Repository {
 	public FileVersion cancelCheckOut(long fileEntryId)
 		throws PortalException, SystemException {
 
-		return _repository.cancelCheckOut(fileEntryId);
+		return getRepository().cancelCheckOut(fileEntryId);
 	}
 
 	@Override
@@ -109,7 +97,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		_repository.checkInFileEntry(
+		getRepository().checkInFileEntry(
 			fileEntryId, major, changeLog, serviceContext);
 	}
 
@@ -118,7 +106,7 @@ public class CapabilityRepository implements Repository {
 	public void checkInFileEntry(long fileEntryId, String lockUuid)
 		throws PortalException, SystemException {
 
-		_repository.checkInFileEntry(fileEntryId, lockUuid);
+		getRepository().checkInFileEntry(fileEntryId, lockUuid);
 	}
 
 	@Override
@@ -126,7 +114,7 @@ public class CapabilityRepository implements Repository {
 			long fileEntryId, String lockUuid, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		_repository.checkInFileEntry(fileEntryId, lockUuid, serviceContext);
+		getRepository().checkInFileEntry(fileEntryId, lockUuid, serviceContext);
 	}
 
 	@Override
@@ -134,7 +122,7 @@ public class CapabilityRepository implements Repository {
 			long fileEntryId, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.checkOutFileEntry(fileEntryId, serviceContext);
+		return getRepository().checkOutFileEntry(fileEntryId, serviceContext);
 	}
 
 	@Override
@@ -143,7 +131,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.checkOutFileEntry(
+		return getRepository().checkOutFileEntry(
 			fileEntryId, owner, expirationTime, serviceContext);
 	}
 
@@ -153,7 +141,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.copyFileEntry(
+		return getRepository().copyFileEntry(
 			groupId, fileEntryId, destFolderId, serviceContext);
 	}
 
@@ -161,47 +149,35 @@ public class CapabilityRepository implements Repository {
 	public void deleteFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
-		_repository.deleteFileEntry(fileEntryId);
+		getRepository().deleteFileEntry(fileEntryId);
 	}
 
 	@Override
 	public void deleteFileEntry(long folderId, String title)
 		throws PortalException, SystemException {
 
-		_repository.deleteFileEntry(folderId, title);
+		getRepository().deleteFileEntry(folderId, title);
 	}
 
 	@Override
 	public void deleteFileVersion(long fileEntryId, String version)
 		throws PortalException, SystemException {
 
-		_repository.deleteFileVersion(fileEntryId, version);
+		getRepository().deleteFileVersion(fileEntryId, version);
 	}
 
 	@Override
 	public void deleteFolder(long folderId)
 		throws PortalException, SystemException {
 
-		_repository.deleteFolder(folderId);
+		getRepository().deleteFolder(folderId);
 	}
 
 	@Override
 	public void deleteFolder(long parentFolderId, String title)
 		throws PortalException, SystemException {
 
-		_repository.deleteFolder(parentFolderId, title);
-	}
-
-	@Override
-	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
-		if (_exportedCapabilities.contains(capabilityClass)) {
-			return getInternalCapability(capabilityClass);
-		}
-
-		throw new IllegalArgumentException(
-			String.format(
-				"Capability %s not exported by repository %d",
-				capabilityClass.getName(), getRepositoryId()));
+		getRepository().deleteFolder(parentFolderId, title);
 	}
 
 	@Override
@@ -209,7 +185,7 @@ public class CapabilityRepository implements Repository {
 			long folderId, int start, int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntries(folderId, start, end, obc);
+		return getRepository().getFileEntries(folderId, start, end, obc);
 	}
 
 	@Override
@@ -218,7 +194,7 @@ public class CapabilityRepository implements Repository {
 			OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntries(
+		return getRepository().getFileEntries(
 			folderId, fileEntryTypeId, start, end, obc);
 	}
 
@@ -228,7 +204,8 @@ public class CapabilityRepository implements Repository {
 			OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntries(folderId, mimeTypes, start, end, obc);
+		return getRepository().getFileEntries(
+			folderId, mimeTypes, start, end, obc);
 	}
 
 	@Override
@@ -236,7 +213,7 @@ public class CapabilityRepository implements Repository {
 			long folderId, int status, int start, int end)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntriesAndFileShortcuts(
+		return getRepository().getFileEntriesAndFileShortcuts(
 			folderId, status, start, end);
 	}
 
@@ -244,7 +221,7 @@ public class CapabilityRepository implements Repository {
 	public int getFileEntriesAndFileShortcutsCount(long folderId, int status)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntriesAndFileShortcutsCount(
+		return getRepository().getFileEntriesAndFileShortcutsCount(
 			folderId, status);
 	}
 
@@ -253,7 +230,7 @@ public class CapabilityRepository implements Repository {
 			long folderId, int status, String[] mimeTypes)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntriesAndFileShortcutsCount(
+		return getRepository().getFileEntriesAndFileShortcutsCount(
 			folderId, status, mimeTypes);
 	}
 
@@ -261,63 +238,63 @@ public class CapabilityRepository implements Repository {
 	public int getFileEntriesCount(long folderId)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntriesCount(folderId);
+		return getRepository().getFileEntriesCount(folderId);
 	}
 
 	@Override
 	public int getFileEntriesCount(long folderId, long fileEntryTypeId)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntriesCount(folderId, fileEntryTypeId);
+		return getRepository().getFileEntriesCount(folderId, fileEntryTypeId);
 	}
 
 	@Override
 	public int getFileEntriesCount(long folderId, String[] mimeTypes)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntriesCount(folderId, mimeTypes);
+		return getRepository().getFileEntriesCount(folderId, mimeTypes);
 	}
 
 	@Override
 	public FileEntry getFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntry(fileEntryId);
+		return getRepository().getFileEntry(fileEntryId);
 	}
 
 	@Override
 	public FileEntry getFileEntry(long folderId, String title)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntry(folderId, title);
+		return getRepository().getFileEntry(folderId, title);
 	}
 
 	@Override
 	public FileEntry getFileEntryByUuid(String uuid)
 		throws PortalException, SystemException {
 
-		return _repository.getFileEntryByUuid(uuid);
+		return getRepository().getFileEntryByUuid(uuid);
 	}
 
 	@Override
 	public FileVersion getFileVersion(long fileVersionId)
 		throws PortalException, SystemException {
 
-		return _repository.getFileVersion(fileVersionId);
+		return getRepository().getFileVersion(fileVersionId);
 	}
 
 	@Override
 	public Folder getFolder(long folderId)
 		throws PortalException, SystemException {
 
-		return _repository.getFolder(folderId);
+		return getRepository().getFolder(folderId);
 	}
 
 	@Override
 	public Folder getFolder(long parentFolderId, String title)
 		throws PortalException, SystemException {
 
-		return _repository.getFolder(parentFolderId, title);
+		return getRepository().getFolder(parentFolderId, title);
 	}
 
 	@Override
@@ -326,7 +303,7 @@ public class CapabilityRepository implements Repository {
 			int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getFolders(
+		return getRepository().getFolders(
 			parentFolderId, includeMountFolders, start, end, obc);
 	}
 
@@ -336,7 +313,7 @@ public class CapabilityRepository implements Repository {
 			int start, int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getFolders(
+		return getRepository().getFolders(
 			parentFolderId, status, includeMountFolders, start, end, obc);
 	}
 
@@ -346,7 +323,7 @@ public class CapabilityRepository implements Repository {
 			int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getFoldersAndFileEntriesAndFileShortcuts(
+		return getRepository().getFoldersAndFileEntriesAndFileShortcuts(
 			folderId, status, includeMountFolders, start, end, obc);
 	}
 
@@ -357,7 +334,7 @@ public class CapabilityRepository implements Repository {
 			OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getFoldersAndFileEntriesAndFileShortcuts(
+		return getRepository().getFoldersAndFileEntriesAndFileShortcuts(
 			folderId, status, mimetypes, includeMountFolders, start, end, obc);
 	}
 
@@ -366,7 +343,7 @@ public class CapabilityRepository implements Repository {
 			long folderId, int status, boolean includeMountFolders)
 		throws PortalException, SystemException {
 
-		return _repository.getFoldersAndFileEntriesAndFileShortcutsCount(
+		return getRepository().getFoldersAndFileEntriesAndFileShortcutsCount(
 			folderId, status, includeMountFolders);
 	}
 
@@ -376,7 +353,7 @@ public class CapabilityRepository implements Repository {
 			boolean includeMountFolders)
 		throws PortalException, SystemException {
 
-		return _repository.getFoldersAndFileEntriesAndFileShortcutsCount(
+		return getRepository().getFoldersAndFileEntriesAndFileShortcutsCount(
 			folderId, status, mimetypes, includeMountFolders);
 	}
 
@@ -384,7 +361,8 @@ public class CapabilityRepository implements Repository {
 	public int getFoldersCount(long parentFolderId, boolean includeMountfolders)
 		throws PortalException, SystemException {
 
-		return _repository.getFoldersCount(parentFolderId, includeMountfolders);
+		return getRepository().getFoldersCount(
+			parentFolderId, includeMountfolders);
 	}
 
 	@Override
@@ -392,7 +370,7 @@ public class CapabilityRepository implements Repository {
 			long parentFolderId, int status, boolean includeMountfolders)
 		throws PortalException, SystemException {
 
-		return _repository.getFoldersCount(
+		return getRepository().getFoldersCount(
 			parentFolderId, status, includeMountfolders);
 	}
 
@@ -400,7 +378,7 @@ public class CapabilityRepository implements Repository {
 	public int getFoldersFileEntriesCount(List<Long> folderIds, int status)
 		throws PortalException, SystemException {
 
-		return _repository.getFoldersFileEntriesCount(folderIds, status);
+		return getRepository().getFoldersFileEntriesCount(folderIds, status);
 	}
 
 	@Override
@@ -408,14 +386,14 @@ public class CapabilityRepository implements Repository {
 			long parentFolderId, int start, int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getMountFolders(parentFolderId, start, end, obc);
+		return getRepository().getMountFolders(parentFolderId, start, end, obc);
 	}
 
 	@Override
 	public int getMountFoldersCount(long parentFolderId)
 		throws PortalException, SystemException {
 
-		return _repository.getMountFoldersCount(parentFolderId);
+		return getRepository().getMountFoldersCount(parentFolderId);
 	}
 
 	@Override
@@ -424,7 +402,7 @@ public class CapabilityRepository implements Repository {
 			OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getRepositoryFileEntries(
+		return getRepository().getRepositoryFileEntries(
 			userId, rootFolderId, start, end, obc);
 	}
 
@@ -434,7 +412,7 @@ public class CapabilityRepository implements Repository {
 			int start, int end, OrderByComparator obc)
 		throws PortalException, SystemException {
 
-		return _repository.getRepositoryFileEntries(
+		return getRepository().getRepositoryFileEntries(
 			userId, rootFolderId, mimeTypes, status, start, end, obc);
 	}
 
@@ -442,7 +420,8 @@ public class CapabilityRepository implements Repository {
 	public int getRepositoryFileEntriesCount(long userId, long rootFolderId)
 		throws PortalException, SystemException {
 
-		return _repository.getRepositoryFileEntriesCount(userId, rootFolderId);
+		return getRepository().getRepositoryFileEntriesCount(
+			userId, rootFolderId);
 	}
 
 	@Override
@@ -450,34 +429,27 @@ public class CapabilityRepository implements Repository {
 			long userId, long rootFolderId, String[] mimeTypes, int status)
 		throws PortalException, SystemException {
 
-		return _repository.getRepositoryFileEntriesCount(
+		return getRepository().getRepositoryFileEntriesCount(
 			userId, rootFolderId, mimeTypes, status);
 	}
 
 	@Override
 	public long getRepositoryId() {
-		return _repository.getRepositoryId();
+		return getRepository().getRepositoryId();
 	}
 
 	@Override
 	public void getSubfolderIds(List<Long> folderIds, long folderId)
 		throws PortalException, SystemException {
 
-		_repository.getSubfolderIds(folderIds, folderId);
+		getRepository().getSubfolderIds(folderIds, folderId);
 	}
 
 	@Override
 	public List<Long> getSubfolderIds(long folderId, boolean recurse)
 		throws PortalException, SystemException {
 
-		return _repository.getSubfolderIds(folderId, recurse);
-	}
-
-	@Override
-	public <T extends Capability> boolean isCapabilityProvided(
-		Class<T> capabilityClass) {
-
-		return _exportedCapabilities.contains(capabilityClass);
+		return getRepository().getSubfolderIds(folderId, recurse);
 	}
 
 	@Deprecated
@@ -485,7 +457,7 @@ public class CapabilityRepository implements Repository {
 	public Lock lockFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
-		return _repository.lockFileEntry(fileEntryId);
+		return getRepository().lockFileEntry(fileEntryId);
 	}
 
 	@Deprecated
@@ -494,14 +466,15 @@ public class CapabilityRepository implements Repository {
 			long fileEntryId, String owner, long expirationTime)
 		throws PortalException, SystemException {
 
-		return _repository.lockFileEntry(fileEntryId, owner, expirationTime);
+		return getRepository().lockFileEntry(
+			fileEntryId, owner, expirationTime);
 	}
 
 	@Override
 	public Lock lockFolder(long folderId)
 		throws PortalException, SystemException {
 
-		return _repository.lockFolder(folderId);
+		return getRepository().lockFolder(folderId);
 	}
 
 	@Override
@@ -510,7 +483,7 @@ public class CapabilityRepository implements Repository {
 			long expirationTime)
 		throws PortalException, SystemException {
 
-		return _repository.lockFolder(
+		return getRepository().lockFolder(
 			folderId, owner, inheritable, expirationTime);
 	}
 
@@ -519,7 +492,7 @@ public class CapabilityRepository implements Repository {
 			long fileEntryId, long newFolderId, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.moveFileEntry(
+		return getRepository().moveFileEntry(
 			fileEntryId, newFolderId, serviceContext);
 	}
 
@@ -529,7 +502,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.moveFolder(
+		return getRepository().moveFolder(
 			folderId, newParentFolderId, serviceContext);
 	}
 
@@ -538,7 +511,7 @@ public class CapabilityRepository implements Repository {
 			String lockUuid, long companyId, long expirationTime)
 		throws PortalException, SystemException {
 
-		return _repository.refreshFileEntryLock(
+		return getRepository().refreshFileEntryLock(
 			lockUuid, companyId, expirationTime);
 	}
 
@@ -547,7 +520,7 @@ public class CapabilityRepository implements Repository {
 			String lockUuid, long companyId, long expirationTime)
 		throws PortalException, SystemException {
 
-		return _repository.refreshFolderLock(
+		return getRepository().refreshFolderLock(
 			lockUuid, companyId, expirationTime);
 	}
 
@@ -556,14 +529,14 @@ public class CapabilityRepository implements Repository {
 			long fileEntryId, String version, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		_repository.revertFileEntry(fileEntryId, version, serviceContext);
+		getRepository().revertFileEntry(fileEntryId, version, serviceContext);
 	}
 
 	@Override
 	public Hits search(long creatorUserId, int status, int start, int end)
 		throws PortalException, SystemException {
 
-		return _repository.search(creatorUserId, status, start, end);
+		return getRepository().search(creatorUserId, status, start, end);
 	}
 
 	@Override
@@ -572,34 +545,34 @@ public class CapabilityRepository implements Repository {
 			int start, int end)
 		throws PortalException, SystemException {
 
-		return _repository.search(
+		return getRepository().search(
 			creatorUserId, folderId, mimeTypes, status, start, end);
 	}
 
 	@Override
 	public Hits search(SearchContext searchContext) throws SearchException {
-		return _repository.search(searchContext);
+		return getRepository().search(searchContext);
 	}
 
 	@Override
 	public Hits search(SearchContext searchContext, Query query)
 		throws SearchException {
 
-		return _repository.search(searchContext, query);
+		return getRepository().search(searchContext, query);
 	}
 
 	@Override
 	public void unlockFolder(long folderId, String lockUuid)
 		throws PortalException, SystemException {
 
-		_repository.unlockFolder(folderId, lockUuid);
+		getRepository().unlockFolder(folderId, lockUuid);
 	}
 
 	@Override
 	public void unlockFolder(long parentFolderId, String title, String lockUuid)
 		throws PortalException, SystemException {
 
-		_repository.unlockFolder(parentFolderId, title, lockUuid);
+		getRepository().unlockFolder(parentFolderId, title, lockUuid);
 	}
 
 	@Override
@@ -609,7 +582,7 @@ public class CapabilityRepository implements Repository {
 			boolean majorVersion, File file, ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.updateFileEntry(
+		return getRepository().updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, description,
 			changeLog, majorVersion, file, serviceContext);
 	}
@@ -622,7 +595,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.updateFileEntry(
+		return getRepository().updateFileEntry(
 			fileEntryId, sourceFileName, mimeType, title, description,
 			changeLog, majorVersion, is, size, serviceContext);
 	}
@@ -633,7 +606,7 @@ public class CapabilityRepository implements Repository {
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		return _repository.updateFolder(
+		return getRepository().updateFolder(
 			folderId, title, description, serviceContext);
 	}
 
@@ -641,41 +614,21 @@ public class CapabilityRepository implements Repository {
 	public boolean verifyFileEntryCheckOut(long fileEntryId, String lockUuid)
 		throws PortalException, SystemException {
 
-		return _repository.verifyFileEntryCheckOut(fileEntryId, lockUuid);
+		return getRepository().verifyFileEntryCheckOut(fileEntryId, lockUuid);
 	}
 
 	@Override
 	public boolean verifyFileEntryLock(long fileEntryId, String lockUuid)
 		throws PortalException, SystemException {
 
-		return _repository.verifyFileEntryLock(fileEntryId, lockUuid);
+		return getRepository().verifyFileEntryLock(fileEntryId, lockUuid);
 	}
 
 	@Override
 	public boolean verifyInheritableLock(long folderId, String lockUuid)
 		throws PortalException, SystemException {
 
-		return _repository.verifyInheritableLock(folderId, lockUuid);
+		return getRepository().verifyInheritableLock(folderId, lockUuid);
 	}
-
-	protected <T extends Capability> T getInternalCapability(
-		Class<T> capabilityClass) {
-
-		Capability<?> capability = _capabilityMap.get(capabilityClass);
-
-		if (capability == null) {
-			throw new IllegalArgumentException(
-				String.format(
-					"Capability %s not supported by repository %d",
-					capabilityClass.getName(), getRepositoryId()));
-		}
-
-		return (T)capability;
-	}
-
-	private final Map<Class<? extends Capability>, Capability>
-		_capabilityMap;
-	private final Set<Class<? extends Capability>> _exportedCapabilities;
-	private final Repository _repository;
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -44,10 +44,10 @@ public class CapabilityRepository
 
 	public CapabilityRepository(
 		Repository repository,
-		Map<Class<? extends Capability>, Capability> capabilityMap,
-		Set<Class<? extends Capability>> exportedCapabilities) {
+		Map<Class<? extends Capability>, Capability> supportedCapabilitiesMap,
+		Set<Class<? extends Capability>> exportedCapabilityClasses) {
 
-		super(repository, capabilityMap, exportedCapabilities);
+		super(repository, supportedCapabilitiesMap, exportedCapabilityClasses);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -193,6 +193,18 @@ public class CapabilityRepository implements Repository {
 	}
 
 	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		if (_exportedCapabilities.contains(capabilityClass)) {
+			return getInternalCapability(capabilityClass);
+		}
+
+		throw new IllegalArgumentException(
+			String.format(
+				"Capability %s not exported by repository %d",
+				capabilityClass.getName(), getRepositoryId()));
+	}
+
+	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, int start, int end, OrderByComparator obc)
 		throws PortalException, SystemException {
@@ -461,6 +473,13 @@ public class CapabilityRepository implements Repository {
 		return _repository.getSubfolderIds(folderId, recurse);
 	}
 
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return _exportedCapabilities.contains(capabilityClass);
+	}
+
 	@Deprecated
 	@Override
 	public Lock lockFileEntry(long fileEntryId)
@@ -639,7 +658,7 @@ public class CapabilityRepository implements Repository {
 		return _repository.verifyInheritableLock(folderId, lockUuid);
 	}
 
-	protected <T extends Capability<T>> T getCapability(
+	protected <T extends Capability> T getInternalCapability(
 		Class<T> capabilityClass) {
 
 		Capability<?> capability = _capabilityMap.get(capabilityClass);

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -1,0 +1,662 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.capabilities;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.model.Lock;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class CapabilityRepository implements Repository {
+
+	public CapabilityRepository(
+		Repository repository,
+		Map<Class<? extends Capability>, Capability> capabilityMap,
+		Set<Class<? extends Capability>> exportedCapabilities) {
+
+		Set<Class<? extends Capability>> supportedCapabilities =
+			capabilityMap.keySet();
+
+		if (!supportedCapabilities.containsAll(exportedCapabilities)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Exporting capabilities not explicitly supported is not " +
+					"allowed. Repository supports %s, but tried to export %s",
+					capabilityMap.keySet(), exportedCapabilities));
+		}
+
+		_repository = repository;
+		_capabilityMap = capabilityMap;
+		_exportedCapabilities = exportedCapabilities;
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long folderId, String sourceFileName, String mimeType, String title,
+			String description, String changeLog, File file,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.addFileEntry(
+			folderId, sourceFileName, mimeType, title, description, changeLog,
+			file, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long folderId, String sourceFileName, String mimeType, String title,
+			String description, String changeLog, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.addFileEntry(
+			folderId, sourceFileName, mimeType, title, description, changeLog,
+			is, size, serviceContext);
+	}
+
+	@Override
+	public Folder addFolder(
+			long parentFolderId, String title, String description,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.addFolder(
+			parentFolderId, title, description, serviceContext);
+	}
+
+	@Override
+	public FileVersion cancelCheckOut(long fileEntryId)
+		throws PortalException, SystemException {
+
+		return _repository.cancelCheckOut(fileEntryId);
+	}
+
+	@Override
+	public void checkInFileEntry(
+			long fileEntryId, boolean major, String changeLog,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		_repository.checkInFileEntry(
+			fileEntryId, major, changeLog, serviceContext);
+	}
+
+	@Deprecated
+	@Override
+	public void checkInFileEntry(long fileEntryId, String lockUuid)
+		throws PortalException, SystemException {
+
+		_repository.checkInFileEntry(fileEntryId, lockUuid);
+	}
+
+	@Override
+	public void checkInFileEntry(
+			long fileEntryId, String lockUuid, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		_repository.checkInFileEntry(fileEntryId, lockUuid, serviceContext);
+	}
+
+	@Override
+	public FileEntry checkOutFileEntry(
+			long fileEntryId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.checkOutFileEntry(fileEntryId, serviceContext);
+	}
+
+	@Override
+	public FileEntry checkOutFileEntry(
+			long fileEntryId, String owner, long expirationTime,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.checkOutFileEntry(
+			fileEntryId, owner, expirationTime, serviceContext);
+	}
+
+	@Override
+	public FileEntry copyFileEntry(
+			long groupId, long fileEntryId, long destFolderId,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.copyFileEntry(
+			groupId, fileEntryId, destFolderId, serviceContext);
+	}
+
+	@Override
+	public void deleteFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		_repository.deleteFileEntry(fileEntryId);
+	}
+
+	@Override
+	public void deleteFileEntry(long folderId, String title)
+		throws PortalException, SystemException {
+
+		_repository.deleteFileEntry(folderId, title);
+	}
+
+	@Override
+	public void deleteFileVersion(long fileEntryId, String version)
+		throws PortalException, SystemException {
+
+		_repository.deleteFileVersion(fileEntryId, version);
+	}
+
+	@Override
+	public void deleteFolder(long folderId)
+		throws PortalException, SystemException {
+
+		_repository.deleteFolder(folderId);
+	}
+
+	@Override
+	public void deleteFolder(long parentFolderId, String title)
+		throws PortalException, SystemException {
+
+		_repository.deleteFolder(parentFolderId, title);
+	}
+
+	@Override
+	public List<FileEntry> getFileEntries(
+			long folderId, int start, int end, OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntries(folderId, start, end, obc);
+	}
+
+	@Override
+	public List<FileEntry> getFileEntries(
+			long folderId, long fileEntryTypeId, int start, int end,
+			OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntries(
+			folderId, fileEntryTypeId, start, end, obc);
+	}
+
+	@Override
+	public List<FileEntry> getFileEntries(
+			long folderId, String[] mimeTypes, int start, int end,
+			OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntries(folderId, mimeTypes, start, end, obc);
+	}
+
+	@Override
+	public List<Object> getFileEntriesAndFileShortcuts(
+			long folderId, int status, int start, int end)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntriesAndFileShortcuts(
+			folderId, status, start, end);
+	}
+
+	@Override
+	public int getFileEntriesAndFileShortcutsCount(long folderId, int status)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntriesAndFileShortcutsCount(
+			folderId, status);
+	}
+
+	@Override
+	public int getFileEntriesAndFileShortcutsCount(
+			long folderId, int status, String[] mimeTypes)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntriesAndFileShortcutsCount(
+			folderId, status, mimeTypes);
+	}
+
+	@Override
+	public int getFileEntriesCount(long folderId)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntriesCount(folderId);
+	}
+
+	@Override
+	public int getFileEntriesCount(long folderId, long fileEntryTypeId)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntriesCount(folderId, fileEntryTypeId);
+	}
+
+	@Override
+	public int getFileEntriesCount(long folderId, String[] mimeTypes)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntriesCount(folderId, mimeTypes);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntry(fileEntryId);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long folderId, String title)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntry(folderId, title);
+	}
+
+	@Override
+	public FileEntry getFileEntryByUuid(String uuid)
+		throws PortalException, SystemException {
+
+		return _repository.getFileEntryByUuid(uuid);
+	}
+
+	@Override
+	public FileVersion getFileVersion(long fileVersionId)
+		throws PortalException, SystemException {
+
+		return _repository.getFileVersion(fileVersionId);
+	}
+
+	@Override
+	public Folder getFolder(long folderId)
+		throws PortalException, SystemException {
+
+		return _repository.getFolder(folderId);
+	}
+
+	@Override
+	public Folder getFolder(long parentFolderId, String title)
+		throws PortalException, SystemException {
+
+		return _repository.getFolder(parentFolderId, title);
+	}
+
+	@Override
+	public List<Folder> getFolders(
+			long parentFolderId, boolean includeMountFolders, int start,
+			int end, OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getFolders(
+			parentFolderId, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public List<Folder> getFolders(
+			long parentFolderId, int status, boolean includeMountFolders,
+			int start, int end, OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getFolders(
+			parentFolderId, status, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
+			long folderId, int status, boolean includeMountFolders, int start,
+			int end, OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcuts(
+			folderId, status, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
+			long folderId, int status, String[] mimetypes,
+			boolean includeMountFolders, int start, int end,
+			OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcuts(
+			folderId, status, mimetypes, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public int getFoldersAndFileEntriesAndFileShortcutsCount(
+			long folderId, int status, boolean includeMountFolders)
+		throws PortalException, SystemException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcutsCount(
+			folderId, status, includeMountFolders);
+	}
+
+	@Override
+	public int getFoldersAndFileEntriesAndFileShortcutsCount(
+			long folderId, int status, String[] mimetypes,
+			boolean includeMountFolders)
+		throws PortalException, SystemException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcutsCount(
+			folderId, status, mimetypes, includeMountFolders);
+	}
+
+	@Override
+	public int getFoldersCount(long parentFolderId, boolean includeMountfolders)
+		throws PortalException, SystemException {
+
+		return _repository.getFoldersCount(parentFolderId, includeMountfolders);
+	}
+
+	@Override
+	public int getFoldersCount(
+			long parentFolderId, int status, boolean includeMountfolders)
+		throws PortalException, SystemException {
+
+		return _repository.getFoldersCount(
+			parentFolderId, status, includeMountfolders);
+	}
+
+	@Override
+	public int getFoldersFileEntriesCount(List<Long> folderIds, int status)
+		throws PortalException, SystemException {
+
+		return _repository.getFoldersFileEntriesCount(folderIds, status);
+	}
+
+	@Override
+	public List<Folder> getMountFolders(
+			long parentFolderId, int start, int end, OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getMountFolders(parentFolderId, start, end, obc);
+	}
+
+	@Override
+	public int getMountFoldersCount(long parentFolderId)
+		throws PortalException, SystemException {
+
+		return _repository.getMountFoldersCount(parentFolderId);
+	}
+
+	@Override
+	public List<FileEntry> getRepositoryFileEntries(
+			long userId, long rootFolderId, int start, int end,
+			OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getRepositoryFileEntries(
+			userId, rootFolderId, start, end, obc);
+	}
+
+	@Override
+	public List<FileEntry> getRepositoryFileEntries(
+			long userId, long rootFolderId, String[] mimeTypes, int status,
+			int start, int end, OrderByComparator obc)
+		throws PortalException, SystemException {
+
+		return _repository.getRepositoryFileEntries(
+			userId, rootFolderId, mimeTypes, status, start, end, obc);
+	}
+
+	@Override
+	public int getRepositoryFileEntriesCount(long userId, long rootFolderId)
+		throws PortalException, SystemException {
+
+		return _repository.getRepositoryFileEntriesCount(userId, rootFolderId);
+	}
+
+	@Override
+	public int getRepositoryFileEntriesCount(
+			long userId, long rootFolderId, String[] mimeTypes, int status)
+		throws PortalException, SystemException {
+
+		return _repository.getRepositoryFileEntriesCount(
+			userId, rootFolderId, mimeTypes, status);
+	}
+
+	@Override
+	public long getRepositoryId() {
+		return _repository.getRepositoryId();
+	}
+
+	@Override
+	public void getSubfolderIds(List<Long> folderIds, long folderId)
+		throws PortalException, SystemException {
+
+		_repository.getSubfolderIds(folderIds, folderId);
+	}
+
+	@Override
+	public List<Long> getSubfolderIds(long folderId, boolean recurse)
+		throws PortalException, SystemException {
+
+		return _repository.getSubfolderIds(folderId, recurse);
+	}
+
+	@Deprecated
+	@Override
+	public Lock lockFileEntry(long fileEntryId)
+		throws PortalException, SystemException {
+
+		return _repository.lockFileEntry(fileEntryId);
+	}
+
+	@Deprecated
+	@Override
+	public Lock lockFileEntry(
+			long fileEntryId, String owner, long expirationTime)
+		throws PortalException, SystemException {
+
+		return _repository.lockFileEntry(fileEntryId, owner, expirationTime);
+	}
+
+	@Override
+	public Lock lockFolder(long folderId)
+		throws PortalException, SystemException {
+
+		return _repository.lockFolder(folderId);
+	}
+
+	@Override
+	public Lock lockFolder(
+			long folderId, String owner, boolean inheritable,
+			long expirationTime)
+		throws PortalException, SystemException {
+
+		return _repository.lockFolder(
+			folderId, owner, inheritable, expirationTime);
+	}
+
+	@Override
+	public FileEntry moveFileEntry(
+			long fileEntryId, long newFolderId, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.moveFileEntry(
+			fileEntryId, newFolderId, serviceContext);
+	}
+
+	@Override
+	public Folder moveFolder(
+			long folderId, long newParentFolderId,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.moveFolder(
+			folderId, newParentFolderId, serviceContext);
+	}
+
+	@Override
+	public Lock refreshFileEntryLock(
+			String lockUuid, long companyId, long expirationTime)
+		throws PortalException, SystemException {
+
+		return _repository.refreshFileEntryLock(
+			lockUuid, companyId, expirationTime);
+	}
+
+	@Override
+	public Lock refreshFolderLock(
+			String lockUuid, long companyId, long expirationTime)
+		throws PortalException, SystemException {
+
+		return _repository.refreshFolderLock(
+			lockUuid, companyId, expirationTime);
+	}
+
+	@Override
+	public void revertFileEntry(
+			long fileEntryId, String version, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		_repository.revertFileEntry(fileEntryId, version, serviceContext);
+	}
+
+	@Override
+	public Hits search(long creatorUserId, int status, int start, int end)
+		throws PortalException, SystemException {
+
+		return _repository.search(creatorUserId, status, start, end);
+	}
+
+	@Override
+	public Hits search(
+			long creatorUserId, long folderId, String[] mimeTypes, int status,
+			int start, int end)
+		throws PortalException, SystemException {
+
+		return _repository.search(
+			creatorUserId, folderId, mimeTypes, status, start, end);
+	}
+
+	@Override
+	public Hits search(SearchContext searchContext) throws SearchException {
+		return _repository.search(searchContext);
+	}
+
+	@Override
+	public Hits search(SearchContext searchContext, Query query)
+		throws SearchException {
+
+		return _repository.search(searchContext, query);
+	}
+
+	@Override
+	public void unlockFolder(long folderId, String lockUuid)
+		throws PortalException, SystemException {
+
+		_repository.unlockFolder(folderId, lockUuid);
+	}
+
+	@Override
+	public void unlockFolder(long parentFolderId, String title, String lockUuid)
+		throws PortalException, SystemException {
+
+		_repository.unlockFolder(parentFolderId, title, lockUuid);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+	}
+
+	@Override
+	public Folder updateFolder(
+			long folderId, String title, String description,
+			ServiceContext serviceContext)
+		throws PortalException, SystemException {
+
+		return _repository.updateFolder(
+			folderId, title, description, serviceContext);
+	}
+
+	@Override
+	public boolean verifyFileEntryCheckOut(long fileEntryId, String lockUuid)
+		throws PortalException, SystemException {
+
+		return _repository.verifyFileEntryCheckOut(fileEntryId, lockUuid);
+	}
+
+	@Override
+	public boolean verifyFileEntryLock(long fileEntryId, String lockUuid)
+		throws PortalException, SystemException {
+
+		return _repository.verifyFileEntryLock(fileEntryId, lockUuid);
+	}
+
+	@Override
+	public boolean verifyInheritableLock(long folderId, String lockUuid)
+		throws PortalException, SystemException {
+
+		return _repository.verifyInheritableLock(folderId, lockUuid);
+	}
+
+	protected <T extends Capability<T>> T getCapability(
+		Class<T> capabilityClass) {
+
+		Capability<?> capability = _capabilityMap.get(capabilityClass);
+
+		if (capability == null) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Capability %s not supported by repository %d",
+					capabilityClass.getName(), getRepositoryId()));
+		}
+
+		return (T)capability;
+	}
+
+	private final Map<Class<? extends Capability>, Capability>
+		_capabilityMap;
+	private final Set<Class<? extends Capability>> _exportedCapabilities;
+	private final Repository _repository;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryBase.java
@@ -16,6 +16,8 @@ package com.liferay.portal.repository.liferayrepository;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.SortedArrayList;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -47,7 +49,7 @@ import java.util.List;
 /**
  * @author Alexander Chow
  */
-public abstract class LiferayRepositoryBase {
+public abstract class LiferayRepositoryBase implements CapabilityProvider {
 
 	public LiferayRepositoryBase(
 		RepositoryLocalService repositoryLocalService,
@@ -79,8 +81,23 @@ public abstract class LiferayRepositoryBase {
 		_dlFolderId = dlFolderId;
 	}
 
+	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		throw new IllegalArgumentException(
+			String.format(
+				"Capability %s not supported by repository %d",
+				capabilityClass.getName(), getRepositoryId()));
+	}
+
 	public long getRepositoryId() {
 		return _repositoryId;
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return false;
 	}
 
 	protected void addFileEntryResources(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7398,7 +7398,7 @@
 
     module.framework.web.extender.generated.wabs.store=false
 
-	module.framework.web.extender.generated.wabs.store.dir=${module.framework.base.dir}/wabs
+    module.framework.web.extender.generated.wabs.store.dir=${module.framework.base.dir}/wabs
 
     module.framework.web.extender.headers.DynamicImport-Package=\
         com.liferay.portal.kernel.*,\

--- a/portal-service/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
@@ -17,6 +17,8 @@ package com.liferay.portal.kernel.repository;
 import com.liferay.portal.NoSuchRepositoryEntryException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.repository.search.RepositorySearchQueryBuilderUtil;
@@ -53,7 +55,8 @@ import java.util.List;
  *
  * @author Alexander Chow
  */
-public abstract class BaseRepositoryImpl implements BaseRepository {
+public abstract class BaseRepositoryImpl
+	implements BaseRepository, CapabilityProvider {
 
 	@Override
 	public FileEntry addFileEntry(
@@ -120,6 +123,14 @@ public abstract class BaseRepositoryImpl implements BaseRepository {
 		Folder folder = getFolder(parentFolderId, title);
 
 		deleteFolder(folder.getFolderId());
+	}
+
+	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		throw new IllegalArgumentException(
+			String.format(
+				"Capability %s not supported by repository %d",
+				capabilityClass.getName(), getRepositoryId()));
 	}
 
 	public long getCompanyId() {
@@ -295,6 +306,13 @@ public abstract class BaseRepositoryImpl implements BaseRepository {
 	@Override
 	public abstract void initRepository()
 		throws PortalException, SystemException;
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return false;
+	}
 
 	/**
 	 * @deprecated As of 6.2.0, replaced by {@link #checkOutFileEntry(long,

--- a/portal-service/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.repository;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -94,6 +95,11 @@ public class DefaultLocalRepositoryImpl implements LocalRepository {
 	}
 
 	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		return _repository.getCapability(capabilityClass);
+	}
+
+	@Override
 	public FileEntry getFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
@@ -147,6 +153,13 @@ public class DefaultLocalRepositoryImpl implements LocalRepository {
 	@Override
 	public long getRepositoryId() {
 		return _repository.getRepositoryId();
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return _repository.isCapabilityProvided(capabilityClass);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/repository/LocalRepository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/LocalRepository.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.repository;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -30,7 +31,7 @@ import java.util.List;
 /**
  * @author Alexander Chow
  */
-public interface LocalRepository {
+public interface LocalRepository extends CapabilityProvider {
 
 	public FileEntry addFileEntry(
 			long userId, long folderId, String sourceFileName, String mimeType,

--- a/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.repository;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -35,7 +36,7 @@ import java.util.List;
 /**
  * @author Alexander Chow
  */
-public interface Repository {
+public interface Repository extends CapabilityProvider {
 
 	public FileEntry addFileEntry(
 			long folderId, String sourceFileName, String mimeType, String title,

--- a/portal-service/src/com/liferay/portal/kernel/repository/capabilities/Capability.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/capabilities/Capability.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.repository.capabilities;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface Capability {
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/repository/capabilities/CapabilityProvider.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/capabilities/CapabilityProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.repository.capabilities;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface CapabilityProvider {
+
+	public <T extends Capability> T getCapability(Class<T> capabilityClass);
+
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass);
+
+}

--- a/portal-service/src/com/liferay/portal/repository/proxy/BaseRepositoryProxyBean.java
+++ b/portal-service/src/com/liferay/portal/repository/proxy/BaseRepositoryProxyBean.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.BaseRepository;
 import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -197,6 +198,11 @@ public class BaseRepositoryProxyBean
 		throws PortalException, SystemException {
 
 		_baseRepository.deleteFolder(parentFolderId, title);
+	}
+
+	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		return _baseRepository.getCapability(capabilityClass);
 	}
 
 	@Override
@@ -534,6 +540,13 @@ public class BaseRepositoryProxyBean
 	@Override
 	public void initRepository() throws PortalException, SystemException {
 		_baseRepository.initRepository();
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return _baseRepository.isCapabilityProvided(capabilityClass);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/repository/proxy/LocalRepositoryProxyBean.java
+++ b/portal-service/src/com/liferay/portal/repository/proxy/LocalRepositoryProxyBean.java
@@ -17,6 +17,7 @@ package com.liferay.portal.repository.proxy;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -102,6 +103,11 @@ public class LocalRepositoryProxyBean
 	}
 
 	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		return _localRepository.getCapability(capabilityClass);
+	}
+
+	@Override
 	public FileEntry getFileEntry(long fileEntryId)
 		throws PortalException, SystemException {
 
@@ -166,6 +172,13 @@ public class LocalRepositoryProxyBean
 	@Override
 	public long getRepositoryId() {
 		return _localRepository.getRepositoryId();
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return _localRepository.isCapabilityProvided(capabilityClass);
 	}
 
 	@Override


### PR DESCRIPTION
Hey Brian,

This is the initial commit to support capabilities on different repositories.
The capabilities will decide if repository supports trash, assets, liferay sync, preview... in a more decoupled way. 

Thx!

You can see more from @adolfopa here:

The DL supports a wide range of functionality (permissions, assets, sync, etc.) where some of it is only available for Liferay repositories, while other may be applicable in general. The way this extra functionality is managed right now has a some problems:
- Everything is hardcoded in the DLAppHelper class.
- Coarse granularity: there is no way to support diferent subsets of functionality. You must support everything or nothing.
- Not extensible: the choice of when/where to execute these extra actions is done by checking for concrete classes with "instanceof". This makes any extension effort extremely difficult.
- Heavy code duplication between DLAppService (Repository) and DLAppLocalService (LocalRepository). With the exception of permission checking, they are almost identical.

To solve all this problems we introduce the concept of a repository "Capability". A repository has a core functionality (storage, and nothing more) plus a set of additional capabilities (assets, sync, permissions, etc.). With this approach, we will be able to combine different "core" repositories (LiferayRepository, CMISRepository, etc.) with different sets of capabilities depending on the circumstances:
- To save attachments, LARs, etc. we would use a LiferayRepository with no capabilities.
- For the DL, we would use a repository with all capabilities.
- Different external repositories may support different capabilities (e.g. we could implement a `PermissionCapability` for Alfresco using their propietary API).

Additionally, this will allow us to get rid of the LocalRepository / Repository dichotomy: simply add a `PermissionCapability` where appropriate and you're done. No duplication needed.

Capabilities will play three roles:
- Internal capabilities: a repository may support assets or sync with no need for clients to be aware of this fact (it is an implementation detail of the repository).
- Exported capabilities: in some circumstances, we may want a repository to offer extra operations to their clients without polluting the repository interfaces; capabilities offer a type-safe way of extending a repository. An example of this kind of capability is the `TrashCapability`.
- Hybrid: capabilities that will be used both internally by a repository and exported to the outside world. For example, an Alfresco repository may implement the `PermissionCapability`. The repository would use this capability internally to check permissions before any operation, but will also export it, as clients may also need to use it (to hide/show UI elements, for example).

Initially, the following capabilities are going to be considered: assets, ratings, trash bin, comments, workflow, previews, sync and subscriptions.
