### PR TITLE
LPS-47604 Make junit's forking jvm configurable

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1291,7 +1291,7 @@ rerun your task.
 				<isset property="test.suite.classes.available" />
 			</not>
 			<then>
-				<junit dir="${project.dir}" fork="on" forkmode="perTest" haltonfailure="${junit.halt.on.failure}" printsummary="on">
+				<junit dir="${project.dir}" fork="on" forkmode="perTest" haltonfailure="${junit.halt.on.failure}" jvm="${junit.jvm}" printsummary="on">
 					<sysproperty key="junit.aspectj.dump" file="woven-classes" />
 					<sysproperty key="junit.cobertura.agent" value="${junit.cobertura.agent}" />
 					<sysproperty key="junit.code.coverage" value="${junit.code.coverage}" />
@@ -1313,7 +1313,7 @@ rerun your task.
 				</junit>
 			</then>
 			<else>
-				<junit dir="${project.dir}" fork="on" forkmode="perTest" haltonfailure="${junit.halt.on.failure}" printsummary="on">
+				<junit dir="${project.dir}" fork="on" forkmode="perTest" haltonfailure="${junit.halt.on.failure}" jvm="${junit.jvm}" printsummary="on">
 					<sysproperty key="junit.aspectj.dump" file="woven-classes" />
 					<sysproperty key="junit.cobertura.agent" value="${junit.cobertura.agent}" />
 					<sysproperty key="junit.code.coverage" value="${junit.code.coverage}" />
@@ -1396,7 +1396,7 @@ rerun your task.
 						<equals arg1="${test.with.security.count}" arg2="0" />
 					</not>
 					<then>
-						<junit dir="${project.dir}" fork="on" forkmode="once" haltonfailure="${junit.halt.on.failure}" outputtoformatters="false" printsummary="on" showoutput="true">
+						<junit dir="${project.dir}" fork="on" forkmode="once" haltonfailure="${junit.halt.on.failure}" jvm="${junit.jvm}" outputtoformatters="false" printsummary="on" showoutput="true">
 							<sysproperty key="junit.aspectj.dump" file="woven-classes" />
 							<sysproperty key="junit.cobertura.agent" value="${junit.cobertura.agent}" />
 							<sysproperty key="junit.code.coverage" value="${junit.code.coverage}" />
@@ -1447,7 +1447,7 @@ rerun your task.
 						<equals arg1="${test.without.security.count}" arg2="0" />
 					</not>
 					<then>
-						<junit dir="${project.dir}" fork="on" forkmode="${junit.forkmode}" haltonfailure="${junit.halt.on.failure}" outputtoformatters="false" printsummary="on" showoutput="true">
+						<junit dir="${project.dir}" fork="on" forkmode="${junit.forkmode}" haltonfailure="${junit.halt.on.failure}" jvm="${junit.jvm}" outputtoformatters="false" printsummary="on" showoutput="true">
 							<sysproperty key="junit.aspectj.dump" file="woven-classes" />
 							<sysproperty key="junit.cobertura.agent" value="${junit.cobertura.agent}" />
 							<sysproperty key="junit.code.coverage" value="${junit.code.coverage}" />
@@ -1564,7 +1564,7 @@ rerun your task.
 			replace="com."
 		/>
 
-		<junit dir="${project.dir}" fork="on" forkmode="once" haltonfailure="${junit.halt.on.failure}" outputtoformatters="false" printsummary="on" showoutput="true">
+		<junit dir="${project.dir}" fork="on" forkmode="once" haltonfailure="${junit.halt.on.failure}" jvm="${junit.jvm}" outputtoformatters="false" printsummary="on" showoutput="true">
 			<sysproperty key="junit.aspectj.dump" file="woven-classes" />
 			<sysproperty key="junit.cobertura.agent" value="${junit.cobertura.agent}" />
 			<sysproperty key="junit.code.coverage" value="${junit.code.coverage}" />

--- a/build.properties
+++ b/build.properties
@@ -124,6 +124,7 @@
     junit.halt.on.failure=false
     junit.java.mx=1024m
     junit.java.maxpermsize=256m
+    junit.jvm=java
     junit.test.excludes=(?!)
 
 ##


### PR DESCRIPTION
Brian, you were saying because we run 6.2.x and master on the same test env, it will be a problem to use different jdks to run  tests separately after master moves to jdk7.

So here is a solution, we can make the junit's forking jvm configurable. Before we run the tests, we can generate a build.${user.name}.properties, base on the current testing branch, pointing junit.jvm to different version of jdks.

By default it is loading from env PATH.
