### PR TITLE
LPS-47601 Somehow the new StackMapTable generation changed the way how s...

### DIFF
--- a/portal-service/test/unit/com/liferay/portal/kernel/nio/intraband/rpc/IntrabandRPCUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/nio/intraband/rpc/IntrabandRPCUtilTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.nio.intraband.test.MockIntraband;
 import com.liferay.portal.kernel.nio.intraband.test.MockRegistrationReference;
 import com.liferay.portal.kernel.process.ProcessCallable;
 import com.liferay.portal.kernel.test.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.NewClassLoaderJUnitTestRunner;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
@@ -41,10 +42,12 @@ import java.util.concurrent.Future;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author Shuyang Zhou
  */
+@RunWith(NewClassLoaderJUnitTestRunner.class)
 public class IntrabandRPCUtilTest {
 
 	@ClassRule


### PR DESCRIPTION
...ystem classes are instrumented which broke coverage assert, force test to run with URLClassLoader in order to correctly record coverage info.
