### PR TITLE
[TECH SUPPORT] LPS-47637 Chunks on the live site are not assembled in the correct order

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portal/lar/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -111,19 +111,28 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 
 			int i = 0;
 
+			int j = 0;
+
+			String numberFormat = String.format(
+				"%%0%dd",
+				String.valueOf(
+					(int)(file.length() / bytes.length)).length() + 1);
+
 			while ((i = fileInputStream.read(bytes)) >= 0) {
+				String fileName = file.getName() + String.format(
+					numberFormat, j++);
+
 				if (i < PropsValues.STAGING_REMOTE_TRANSFER_BUFFER_SIZE) {
 					byte[] tempBytes = new byte[i];
 
 					System.arraycopy(bytes, 0, tempBytes, 0, i);
 
 					StagingServiceHttp.updateStagingRequest(
-						httpPrincipal, stagingRequestId, file.getName(),
-						tempBytes);
+						httpPrincipal, stagingRequestId, fileName, tempBytes);
 				}
 				else {
 					StagingServiceHttp.updateStagingRequest(
-						httpPrincipal, stagingRequestId, file.getName(), bytes);
+						httpPrincipal, stagingRequestId, fileName, bytes);
 				}
 
 				bytes =

--- a/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
@@ -386,6 +386,15 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	}
 
 	@Override
+	public List<FileEntry> getPortletFileEntries(
+		long groupId, long folderId, OrderByComparator obc) {
+
+		return toFileEntries(
+			DLFileEntryLocalServiceUtil.getFileEntries(
+				groupId, folderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, obc));
+	}
+
+	@Override
 	public int getPortletFileEntriesCount(long groupId, long folderId) {
 		return DLFileEntryLocalServiceUtil.getFileEntriesCount(
 			groupId, folderId);

--- a/portal-impl/src/com/liferay/portal/service/impl/StagingLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/StagingLocalServiceImpl.java
@@ -63,6 +63,7 @@ import com.liferay.portal.util.PortletKeys;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.NoSuchFolderException;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
+import com.liferay.portlet.documentlibrary.util.comparator.DLFileEntryTitleComparator;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -408,9 +409,6 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 		Folder folder = PortletFileRepositoryUtil.getPortletFolder(
 			stagingRequestId);
 
-		fileName += PortletFileRepositoryUtil.getPortletFileEntriesCount(
-			folder.getGroupId(), folder.getFolderId());
-
 		PortletFileRepositoryUtil.addPortletFileEntry(
 			folder.getGroupId(), userId, Group.class.getName(),
 			folder.getGroupId(), PortletKeys.SITES_ADMIN, folder.getFolderId(),
@@ -745,7 +743,8 @@ public class StagingLocalServiceImpl extends StagingLocalServiceBaseImpl {
 
 			List<FileEntry> fileEntries =
 				PortletFileRepositoryUtil.getPortletFileEntries(
-					folder.getGroupId(), folder.getFolderId());
+					folder.getGroupId(), folder.getFolderId(),
+					new DLFileEntryTitleComparator(true));
 
 			for (FileEntry fileEntry : fileEntries) {
 				InputStream inputStream = fileEntry.getContentStream();

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
@@ -106,8 +106,11 @@ public interface PortletFileRepository {
 		long groupId, long folderId, int status);
 
 	public List<FileEntry> getPortletFileEntries(
-			long groupId, long folderId, int status, int start, int end,
-			OrderByComparator obc);
+		long groupId, long folderId, int status, int start, int end,
+		OrderByComparator obc);
+
+	public List<FileEntry> getPortletFileEntries(
+		long groupId, long folderId, OrderByComparator obc);
 
 	public int getPortletFileEntriesCount(long groupId, long folderId);
 

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
@@ -180,6 +180,13 @@ public class PortletFileRepositoryUtil {
 			groupId, folderId, status, start, end, obc);
 	}
 
+	public static List<FileEntry> getPortletFileEntries(
+		long groupId, long folderId, OrderByComparator obc) {
+
+		return getPortletFileRepository().getPortletFileEntries(
+			groupId, folderId, obc);
+	}
+
 	public static int getPortletFileEntriesCount(long groupId, long folderId) {
 
 		return getPortletFileRepository().getPortletFileEntriesCount(

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryTitleComparator.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryTitleComparator.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.util.comparator;
+
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+
+/**
+ * @author Mate Thurzo
+ */
+public class DLFileEntryTitleComparator extends OrderByComparator {
+
+	public static final String ORDER_BY_ASC = "title ASC";
+
+	public static final String ORDER_BY_DESC = "title DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"title"};
+
+	public DLFileEntryTitleComparator() {
+		this(false);
+	}
+
+	public DLFileEntryTitleComparator(boolean ascending) {
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(Object obj1, Object obj2) {
+		DLFileEntry dlFileEntry1 = (DLFileEntry)obj1;
+		DLFileEntry dlFileEntry2 = (DLFileEntry)obj2;
+
+		String title1 = StringUtil.toLowerCase(dlFileEntry1.getTitle());
+		String title2 = StringUtil.toLowerCase(dlFileEntry2.getTitle());
+
+		int value = title1.compareTo(title2);
+
+		if (_ascending) {
+			return value;
+		}
+		else {
+			return -value;
+		}
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+		else {
+			return ORDER_BY_DESC;
+		}
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private boolean _ascending;
+
+}


### PR DESCRIPTION
Hey Brian,

This is a bug in the staging system for a customer. The basic issue is that as we transfer the smaller LAR chunks from staging to live the assemble order is not guaranteed on the live site, and this will cause errors in the staging. This fix will resolve the issue as we are marking the chunks when splitting the LAR so it can be assembled in the correct order.

@sergiogonzalez: I've added a new helper method to the PortletFileRepository, nothing fancy. I've added a title comparator too, it's pretty much straightforward as well.

Thanks,

Máté
