### PR TITLE
LPS-46955

### DIFF
--- a/portal-web/docroot/html/portlet/message_boards/last_post_question.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/last_post_question.jsp
@@ -32,7 +32,7 @@ User userDisplay = UserLocalServiceUtil.fetchUserById(thread.getLastPostByUserId
 	<div class="portrait">
 		<c:choose>
 			<c:when test="<%= message.isAnonymous() || (userDisplay == null) %>">
-				<img alt="<%= LanguageUtil.get(request, "generic-portrait") %>" class="avatar" src="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), true, 0, StringPool.BLANK) %>" width="60" /></a>
+				<img alt="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(request, "generic-portrait")) %>" class="avatar" src="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), true, 0, StringPool.BLANK) %>" width="60" /></a>
 			</c:when>
 			<c:otherwise>
 				<a href="<%= userDisplay.getDisplayURL(themeDisplay) %>"><img alt="<%= HtmlUtil.escapeAttribute(userDisplay.getFullName()) %>" class="avatar" src="<%= userDisplay.getPortraitURL(themeDisplay) %>" width="60" /></a>

--- a/portal-web/docroot/html/portlet/message_boards/last_post_question.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/last_post_question.jsp
@@ -32,7 +32,7 @@ User userDisplay = UserLocalServiceUtil.fetchUserById(thread.getLastPostByUserId
 	<div class="portrait">
 		<c:choose>
 			<c:when test="<%= message.isAnonymous() || (userDisplay == null) %>">
-				<img alt="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(request, "generic-portrait")) %>" class="avatar" src="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), true, 0, StringPool.BLANK) %>" width="60" /></a>
+				<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="generic-portrait" />" class="avatar" src="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), true, 0, StringPool.BLANK) %>" width="60" /></a>
 			</c:when>
 			<c:otherwise>
 				<a href="<%= userDisplay.getDisplayURL(themeDisplay) %>"><img alt="<%= HtmlUtil.escapeAttribute(userDisplay.getFullName()) %>" class="avatar" src="<%= userDisplay.getPortraitURL(themeDisplay) %>" width="60" /></a>

--- a/portal-web/docroot/html/portlet/message_boards/thread_columns.jspf
+++ b/portal-web/docroot/html/portlet/message_boards/thread_columns.jspf
@@ -22,10 +22,10 @@
 >
 	<c:choose>
 		<c:when test="<%= MBThreadLocalServiceUtil.hasAnswerMessage(thread.getThreadId()) %>">
-			<liferay-ui:message key="resolved" />
+			<liferay-ui:message escapeAttribute="<%= true %>" key="resolved" />
 		</c:when>
 		<c:when test="<%= thread.isQuestion() %>">
-			<liferay-ui:message key="waiting-for-an-answer" />
+			<liferay-ui:message escapeAttribute="<%= true %>" key="waiting-for-an-answer" />
 		</c:when>
 	</c:choose>
 </liferay-ui:search-container-column-text>

--- a/portal-web/docroot/html/portlet/message_boards/view_thread_message.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/view_thread_message.jsp
@@ -320,7 +320,7 @@ MBThread thread = (MBThread)request.getAttribute("edit_message.jsp-thread");
 							%>
 
 									<div>
-										<img alt="<liferay-ui:message key="attachment" />" src="<%= PortletFileRepositoryUtil.getPortletFileEntryURL(themeDisplay, fileEntry, StringPool.BLANK) %>" />
+										<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="attachment" />" src="<%= PortletFileRepositoryUtil.getPortletFileEntryURL(themeDisplay, fileEntry, StringPool.BLANK) %>" />
 									</div>
 
 									<br />

--- a/portal-web/docroot/html/portlet/mobile_device_rules/action/theme.jsp
+++ b/portal-web/docroot/html/portlet/mobile_device_rules/action/theme.jsp
@@ -106,7 +106,7 @@ ColorScheme selColorScheme = ThemeLocalServiceUtil.getColorScheme(company.getCom
 								%>
 
 								<div class="<%= cssClass %> theme-entry">
-									<img alt="<liferay-ui:message key="thumbnail" />" class="modify-link theme-thumbnail" onclick="document.getElementById('<portlet:namespace />ColorSchemeId<%= i %>').checked = true;" src="<%= selTheme.getStaticResourcePath() %><%= HtmlUtil.escapeAttribute(curColorScheme.getColorSchemeThumbnailPath()) %>/thumbnail.png" title="<%= HtmlUtil.escapeAttribute(curColorScheme.getName()) %>" />
+									<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="modify-link theme-thumbnail" onclick="document.getElementById('<portlet:namespace />ColorSchemeId<%= i %>').checked = true;" src="<%= selTheme.getStaticResourcePath() %><%= HtmlUtil.escapeAttribute(curColorScheme.getColorSchemeThumbnailPath()) %>/thumbnail.png" title="<%= HtmlUtil.escapeAttribute(curColorScheme.getName()) %>" />
 
 									<aui:input checked="<%= selColorScheme.getColorSchemeId().equals(curColorScheme.getColorSchemeId()) %>" cssClass="theme-title" id='<%= "ColorSchemeId" + i %>' label="<%= curColorScheme.getName() %>" name="colorSchemeId" type="radio" value="<%= curColorScheme.getColorSchemeId() %>" />
 								</div>

--- a/portal-web/docroot/html/portlet/nested_portlets/configuration.jsp
+++ b/portal-web/docroot/html/portlet/nested_portlets/configuration.jsp
@@ -49,7 +49,7 @@
 				</c:if>
 
 				<td align="center" width="<%= 100 / CELLS_PER_ROW %>%">
-					<img alt="<liferay-ui:message key="thumbnail" />" onclick="document.getElementById('<portlet:namespace />layoutTemplateId<%= i %>').checked = true;" src="<%= layoutTemplate.getStaticResourcePath() %><%= HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>" /><br />
+					<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" onclick="document.getElementById('<portlet:namespace />layoutTemplateId<%= i %>').checked = true;" src="<%= layoutTemplate.getStaticResourcePath() %><%= HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>" /><br />
 
 					<aui:input checked="<%= layoutTemplateId.equals(layoutTemplate.getLayoutTemplateId()) %>" id='<%= "layoutTemplateId" + i %>' label="<%= layoutTemplate.getName(locale) %>" name="preferences--layoutTemplateId--" type="radio" value="<%= layoutTemplate.getLayoutTemplateId() %>" />
 				</td>

--- a/portal-web/docroot/html/portlet/plugins_admin/layout_templates.jspf
+++ b/portal-web/docroot/html/portlet/plugins_admin/layout_templates.jspf
@@ -64,7 +64,7 @@ List layoutTemplates = LayoutTemplateLocalServiceUtil.getLayoutTemplates();
 			name="layout-template"
 		>
 			<aui:a href="<%= showEditPluginHREF ? rowURL.toString() : null %>">
-				<img alt="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(locale, "thumbnail")) %>" class="plugin-thumbnail" src="<%= layoutTemplate.getStaticResourcePath() + HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>" />
+				<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="plugin-thumbnail" src="<%= layoutTemplate.getStaticResourcePath() + HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>" />
 
 				<%= HtmlUtil.escape(layoutTemplate.getName(locale)) %>
 			</aui:a>

--- a/portal-web/docroot/html/portlet/plugins_admin/layout_templates.jspf
+++ b/portal-web/docroot/html/portlet/plugins_admin/layout_templates.jspf
@@ -64,7 +64,7 @@ List layoutTemplates = LayoutTemplateLocalServiceUtil.getLayoutTemplates();
 			name="layout-template"
 		>
 			<aui:a href="<%= showEditPluginHREF ? rowURL.toString() : null %>">
-				<img alt="<%= LanguageUtil.get(locale, "thumbnail") %>" class="plugin-thumbnail" src="<%= layoutTemplate.getStaticResourcePath() + HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>" />
+				<img alt="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(locale, "thumbnail")) %>" class="plugin-thumbnail" src="<%= layoutTemplate.getStaticResourcePath() + HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>" />
 
 				<%= HtmlUtil.escape(layoutTemplate.getName(locale)) %>
 			</aui:a>

--- a/portal-web/docroot/html/portlet/plugins_admin/themes.jspf
+++ b/portal-web/docroot/html/portlet/plugins_admin/themes.jspf
@@ -64,7 +64,7 @@ List themes = ThemeLocalServiceUtil.getThemes(company.getCompanyId());
 			name="themes"
 		>
 			<aui:a href="<%= showEditPluginHREF ? rowURL.toString() : null %>">
-				<img alt="<%= LanguageUtil.get(locale, "thumbnail") %>" class="plugin-thumbnail" src="<%= curTheme.getStaticResourcePath() + HtmlUtil.escapeAttribute(curTheme.getImagesPath()) %>/thumbnail.png" />
+				<img alt="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(locale, "thumbnail")) %>" class="plugin-thumbnail" src="<%= curTheme.getStaticResourcePath() + HtmlUtil.escapeAttribute(curTheme.getImagesPath()) %>/thumbnail.png" />
 			</aui:a>
 
 			<br />
@@ -73,7 +73,7 @@ List themes = ThemeLocalServiceUtil.getThemes(company.getCompanyId());
 
 			<c:choose>
 				<c:when test="<%= pluginPackage == null %>">
-			   		<liferay-ui:message key="unknown" />
+					<liferay-ui:message key="unknown" />
 				</c:when>
 				<c:otherwise>
 					<%= HtmlUtil.escape(pluginPackage.getName()) %>

--- a/portal-web/docroot/html/portlet/plugins_admin/themes.jspf
+++ b/portal-web/docroot/html/portlet/plugins_admin/themes.jspf
@@ -64,7 +64,7 @@ List themes = ThemeLocalServiceUtil.getThemes(company.getCompanyId());
 			name="themes"
 		>
 			<aui:a href="<%= showEditPluginHREF ? rowURL.toString() : null %>">
-				<img alt="<%= HtmlUtil.escapeAttribute(LanguageUtil.get(locale, "thumbnail")) %>" class="plugin-thumbnail" src="<%= curTheme.getStaticResourcePath() + HtmlUtil.escapeAttribute(curTheme.getImagesPath()) %>/thumbnail.png" />
+				<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="plugin-thumbnail" src="<%= curTheme.getStaticResourcePath() + HtmlUtil.escapeAttribute(curTheme.getImagesPath()) %>/thumbnail.png" />
 			</aui:a>
 
 			<br />


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-46955.

NOTE:  When I run `ant format-source`, it edits `portal-web/docroot/html/portlet/mobile_device_rules/action/theme.jsp`, but the changes it makes are invalid. It converts the " to ' for HTML attributes, but the escaping is not needed.

Invalid syntax:

```
<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="modify-link theme-thumbnail" onclick="document.getElementById('<portlet:namespace />ColorSchemeId<%= i %>').checked = true;" src='<%= selTheme.getStaticResourcePath() %><%= HtmlUtil.escapeAttribute(curColorScheme.getColorSchemeThumbnailPath()) %>/thumbnail.png" title="<%= HtmlUtil.escapeAttribute(curColorScheme.getName()) %>' />
```

Please let me know if you have any questions.  Thanks!
