### PR TITLE
LPS-46944

### DIFF
--- a/portal-web/docroot/html/taglib/aui/translation_manager/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/translation_manager/page.jsp
@@ -26,7 +26,7 @@
 			Locale defaultLocale = LocaleUtil.fromLanguageId(defaultLanguageId);
 			%>
 
-			<img alt="<%= defaultLocale.getDisplayName(locale) %>" src='<%= HtmlUtil.escapeAttribute(themeDisplay.getPathThemeImages() + "/language/" + defaultLanguageId + ".png") %>' />
+			<img alt="<%= HtmlUtil.escapeAttribute(defaultLocale.getDisplayName(locale)) %>" src='<%= HtmlUtil.escapeAttribute(themeDisplay.getPathThemeImages() + "/language/" + defaultLanguageId + ".png") %>' />
 
 			<%= defaultLocale.getDisplayName(locale) %>
 		</span>
@@ -96,7 +96,7 @@
 						%>
 
 							<span class="lfr-translation-manager-translation" locale="<%= availableLocales[i] %>">
-								<img alt="<%= availableLocales[i].getDisplayName(locale) %>" src="<%= themeDisplay.getPathThemeImages() %>/language/<%= LocaleUtil.toLanguageId(availableLocales[i]) %>.png">
+								<img alt="<%= HtmlUtil.escapeAttribute(availableLocales[i].getDisplayName(locale)) %>" src="<%= themeDisplay.getPathThemeImages() %>/language/<%= LocaleUtil.toLanguageId(availableLocales[i]) %>.png">
 
 								<%= availableLocales[i].getDisplayName(locale) %>
 

--- a/portal-web/docroot/html/taglib/theme/layout_icon/page.jsp
+++ b/portal-web/docroot/html/taglib/theme/layout_icon/page.jsp
@@ -21,5 +21,5 @@ Layout selLayout = (Layout)request.getAttribute("liferay-theme:layout-icon:layou
 %>
 
 <c:if test="<%= (selLayout != null) && selLayout.isIconImage() %>">
-	<img alt="<liferay-ui:message key="page-icon" />" class="layout-logo-<%= selLayout.getPlid() %>" src="<%= themeDisplay.getPathImage() %>/layout_icon?img_id=<%= selLayout.getIconImageId() %>&t=<%= WebServerServletTokenUtil.getToken(selLayout.getIconImageId()) %>" />
+	<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="page-icon" />" class="layout-logo-<%= selLayout.getPlid() %>" src="<%= themeDisplay.getPathImage() %>/layout_icon?img_id=<%= selLayout.getIconImageId() %>&t=<%= WebServerServletTokenUtil.getToken(selLayout.getIconImageId()) %>" />
 </c:if>

--- a/portal-web/docroot/html/taglib/ui/app_view_entry/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/app_view_entry/page.jsp
@@ -97,11 +97,11 @@ if (showLinkTitle) {
 					</c:choose>
 
 					<c:if test="<%= shortcut %>">
-						<img alt="<liferay-ui:message key="shortcut" />" class="shortcut-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_link.png" />
+						<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="shortcut" />" class="shortcut-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_link.png" />
 					</c:if>
 
 					<c:if test="<%= locked %>">
-						<img alt="<liferay-ui:message key="locked" />" class="locked-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_lock.png" />
+						<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="locked" />" class="locked-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_lock.png" />
 					</c:if>
 
 					<c:if test="<%= !folder && ((status != WorkflowConstants.STATUS_ANY) && (status != WorkflowConstants.STATUS_APPROVED)) %>">
@@ -151,11 +151,11 @@ if (showLinkTitle) {
 					</c:choose>
 
 					<c:if test="<%= shortcut %>">
-						<img alt="<liferay-ui:message key="shortcut" />" class="shortcut-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_link.png" />
+						<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="shortcut" />" class="shortcut-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_link.png" />
 					</c:if>
 
 					<c:if test="<%= locked %>">
-						<img alt="<liferay-ui:message key="locked" />" class="locked-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_lock.png" />
+						<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="locked" />" class="locked-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_lock.png" />
 					</c:if>
 
 					<c:if test="<%= !folder && (status != WorkflowConstants.STATUS_ANY) && (status != WorkflowConstants.STATUS_APPROVED) %>">

--- a/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/app_view_search_entry/page.jsp
@@ -49,7 +49,7 @@ summary.setQueryTerms(queryTerms);
 				<img alt="" class="img-thumbnail" src="<%= HtmlUtil.escapeAttribute(thumbnailSrc) %>" />
 
 				<c:if test="<%= locked %>">
-					<img alt="<liferay-ui:message key="locked" />" class="locked-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_lock.png" />
+					<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="locked" />" class="locked-icon" src="<%= themeDisplay.getPathThemeImages() %>/file_system/large/overlay_lock.png" />
 				</c:if>
 			</div>
 		</c:if>
@@ -120,7 +120,7 @@ summary.setQueryTerms(queryTerms);
 			<div class="entry-attachment">
 				<aui:a class="lfr-discussion-details" href="<%= url %>">
 					<div class="image">
-						<img alt="<%= fileEntry.getTitle() %>" class="attachment" src="<%= DLUtil.getThumbnailSrc(fileEntry, null, themeDisplay) %>" />
+						<img alt="<%= HtmlUtil.escapeAttribute(fileEntry.getTitle()) %>" class="attachment" src="<%= DLUtil.getThumbnailSrc(fileEntry, null, themeDisplay) %>" />
 					</div>
 
 					<span class="title">

--- a/portal-web/docroot/html/taglib/ui/captcha/simplecaptcha.jsp
+++ b/portal-web/docroot/html/taglib/ui/captcha/simplecaptcha.jsp
@@ -36,7 +36,7 @@ catch (CaptchaMaxChallengesException cmce) {
 
 <c:if test="<%= captchaEnabled %>">
 	<div class="taglib-captcha">
-		<img alt="<liferay-ui:message key="text-to-identify" />" class="captcha" id="<portlet:namespace />captcha" src="<%= url %>" />
+		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha" id="<portlet:namespace />captcha" src="<%= url %>" />
 
 		<liferay-ui:icon cssClass="refresh" iconCssClass="icon-refresh" id="refreshCaptcha" label="<%= false %>" localizeMessage="<%= true %>" message="refresh-captcha" url="javascript:;" />
 

--- a/portal-web/docroot/html/taglib/ui/discussion/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/discussion/page.jsp
@@ -487,7 +487,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 
 											<span id="lfr-discussion-reply-user-info">
 												<div class="lfr-discussion-reply-user-avatar">
-													<img alt="<%= parentMessage.getUserName() %>" class="user-status-avatar-image" src="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), male, portraitId, userUuid) %>" width="30" />
+													<img alt="<%= HtmlUtil.escapeAttribute(parentMessage.getUserName()) %>" class="user-status-avatar-image" src="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), male, portraitId, userUuid) %>" width="30" />
 												</div>
 
 												<div class="lfr-discussion-reply-user-name">

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -246,7 +246,7 @@ if ((exception != null) && fieldName.equals(focusField)) {
 
 						<li class="palette-item <%= itemCssClass %>" data-index="<%= index++ %>" data-value="<%= curLanguageId %>" role="menuitem" style="display: inline-block;">
 							<a class="palette-item-inner" href="javascript:void(0);">
-								<img alt="<%= curLocale.getDisplayName(LocaleUtil.fromLanguageId(LanguageUtil.getLanguageId(request))) %> <liferay-ui:message key="translation" />" class="lfr-input-localized-flag" data-languageid="<%= curLanguageId %>" src="<%= themeDisplay.getPathThemeImages() %>/language/<%= curLanguageId %>.png" />
+								<img alt="<%= HtmlUtil.escapeAttribute(curLocale.getDisplayName(LocaleUtil.fromLanguageId(LanguageUtil.getLanguageId(request)))) %> <liferay-ui:message key="translation" />" class="lfr-input-localized-flag" data-languageid="<%= curLanguageId %>" src="<%= themeDisplay.getPathThemeImages() %>/language/<%= curLanguageId %>.png" />
 								<div class='<%= errorLocales.contains(curLocale) ? "lfr-input-localized-state lfr-input-localized-state-error" : "lfr-input-localized-state" %>'></div>
 							</a>
 						</li>

--- a/portal-web/docroot/html/taglib/ui/logo_selector/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/logo_selector/page.jsp
@@ -53,7 +53,7 @@ else {
 <div class="taglib-logo-selector" id="<%= randomNamespace %>taglibLogoSelector">
 	<div class="taglib-logo-selector-content" id="<%= randomNamespace %>taglibLogoSelectorContent">
 		<a class='lfr-change-logo <%= showBackground ? "show-background" : StringPool.BLANK %>' href="javascript:;">
-			<img alt="<liferay-ui:message key="current-image" />" class="avatar img-thumbnail" id="<%= randomNamespace %>avatar" src="<%= HtmlUtil.escape(imageURL) %>" />
+			<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="current-image" />" class="avatar img-thumbnail" id="<%= randomNamespace %>avatar" src="<%= HtmlUtil.escape(imageURL) %>" />
 		</a>
 
 		<div class="portrait-icons">

--- a/portal-web/docroot/html/taglib/ui/toggle/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/toggle/page.jsp
@@ -34,7 +34,7 @@ String defaultMessage = (String)request.getAttribute("liferay-ui:toggle:defaultM
 	</c:when>
 	<c:otherwise>
 		<img
-			alt="<liferay-ui:message key="toggle" />"
+			alt="<liferay-ui:message escapeAttribute="<%= true %>" key="toggle" />"
 			id="<%= id %>_image"
 			onclick="<%= stateVar %>Toggle();"
 			src="<%= defaultImage %>"


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-46944.

NOTE: There is the same issue with the HTML attributes being converted from " to ' when you run `ant format-source`.

Invalid code:
portal-web/docroot/html/taglib/ui/logo_selector/page.jsp

```
<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="current-image" />" class="avatar img-thumbnail" id='<%= randomNamespace %>avatar" src="<%= HtmlUtil.escape(imageURL) %>' />
```

portal-web/docroot/html/portlet/mobile_device_rules/action/theme.jsp

```
<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="modify-link theme-thumbnail" onclick="document.getElementById('<portlet:namespace />ColorSchemeId<%= i %>').checked = true;" src='<%= selTheme.getStaticResourcePath() %><%= HtmlUtil.escapeAttribute(curColorScheme.getColorSchemeThumbnailPath()) %>/thumbnail.png" title="<%= HtmlUtil.escapeAttribute(curColorScheme.getName()) %>' />
```

Please let me know if you have any questions.  Thanks!
