### PR TITLE
master-bc-1952

### DIFF
--- a/build-test-sharepoint.xml
+++ b/build-test-sharepoint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<project name="portal-test-sharepoint" basedir="." default="test" xmlns:antelope="antlib:ise.antelope.tasks">
+<project name="portal-test-sharepoint" basedir="." default="clean-sharepoint-repository" xmlns:antelope="antlib:ise.antelope.tasks">
 	<import file="build-test.xml" />
 
 	<target name="clean-sharepoint-repository">

--- a/build-test-sharepoint.xml
+++ b/build-test-sharepoint.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<project name="portal-test-sharepoint" basedir="." default="test" xmlns:antelope="antlib:ise.antelope.tasks">
+	<import file="build-test.xml" />
+
+	<target name="clean-sharepoint-repository">
+		<ssh-execute>perl C:/Windows/resetsharepointrepo.pl</ssh-execute>
+	</target>
+</project>

--- a/portal-web/test/functional/com/liferay/portalweb2/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/CPSharepoint.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb2/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/CPSharepoint.testcase
@@ -4,6 +4,8 @@
 	<property name="testray.main.component.name" value="Documents Management" />
 
 	<set-up>
+		<execute action="BaseLiferay#antCommand" locator1="build-test-sharepoint.xml" value1="clean-sharepoint-repository" />
+
 		<execute macro="User#firstLoginPG">
 			<var name="authenticationMethod" value="By Screen Name" />
 			<var name="userScreenName" value="test" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-9661
https://issues.liferay.com/browse/LIFERAYQA-9751

The build-test-sharepoint.xml calls a script that Sam wrote that cleans out the sharepoint repository. Right now, it needs https://github.com/brianchandotcom/liferay-jenkins-ee/pull/206 in order to work. I had Albert port the tests over to ee-6.2.x as well. Since we don't have an ee-7.0.x job yet, we won't be able to see if this works unless we use ee-6.2.x. Right now, it's hardcoded to hit cloud-10-0-13-47. Once we know for sure that it'll work on that, we can work on figuring out how to scale it.

After talking with Hashi, we weren't entirely sure if the "clean-sharepoint-repository" target should go into build-test.xml or be in its own xml. Let me know if it should just go into build-test.xml
