### PR TITLE
LPS-47865 Most errors we got here are caused the duplicated premature pe...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -457,7 +457,9 @@ public abstract class BaseIndexer implements Indexer {
 			doReindex(className, classPK);
 		}
 		catch (NoSuchModelException nsme) {
-			_log.error("Unable to index " + className + " " + classPK, nsme);
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to index " + className + " " + classPK, nsme);
+			}
 		}
 		catch (SearchException se) {
 			throw se;


### PR DESCRIPTION
...rmission reindexing, without transactional cascaded indexing support there is no way we can avoid this. And since the second reindex will succeed, the first failure is actually harmless(although very bad for performance). We should downgrade the logging level to warn for now.
