### PR TITLE
Lps 48099

### DIFF
--- a/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryImpl.java
@@ -57,6 +57,7 @@ import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.util.DLAppHelperThreadLocal;
+import com.liferay.portlet.documentlibrary.util.comparator.DLFileEntryOrderByComparator;
 import com.liferay.portlet.trash.util.TrashUtil;
 
 import java.io.File;
@@ -377,20 +378,22 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	@Override
 	public List<FileEntry> getPortletFileEntries(
 		long groupId, long folderId, int status, int start, int end,
-		OrderByComparator obc) {
+		OrderByComparator<FileEntry> obc) {
 
 		return toFileEntries(
 			DLFileEntryLocalServiceUtil.getFileEntries(
-				groupId, folderId, status, start, end, obc));
+				groupId, folderId, status, start, end,
+				new DLFileEntryOrderByComparator(obc)));
 	}
 
 	@Override
 	public List<FileEntry> getPortletFileEntries(
-		long groupId, long folderId, OrderByComparator obc) {
+		long groupId, long folderId, OrderByComparator<FileEntry> obc) {
 
 		return toFileEntries(
 			DLFileEntryLocalServiceUtil.getFileEntries(
-				groupId, folderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, obc));
+				groupId, folderId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				new DLFileEntryOrderByComparator(obc)));
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityLocalRepository.java
@@ -133,7 +133,8 @@ public class CapabilityLocalRepository
 
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
-			long rootFolderId, int start, int end, OrderByComparator obc)
+			long rootFolderId, int start, int end,
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getRepository().getRepositoryFileEntries(

--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -175,7 +175,7 @@ public class CapabilityRepository
 
 	@Override
 	public List<FileEntry> getFileEntries(
-			long folderId, int start, int end, OrderByComparator obc)
+			long folderId, int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getRepository().getFileEntries(folderId, start, end, obc);
@@ -184,7 +184,7 @@ public class CapabilityRepository
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, long fileEntryTypeId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getRepository().getFileEntries(
@@ -194,7 +194,7 @@ public class CapabilityRepository
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getRepository().getFileEntries(
@@ -285,7 +285,7 @@ public class CapabilityRepository
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, boolean includeMountFolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		return getRepository().getFolders(
@@ -295,7 +295,7 @@ public class CapabilityRepository
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, int status, boolean includeMountFolders,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		return getRepository().getFolders(
@@ -305,7 +305,7 @@ public class CapabilityRepository
 	@Override
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, boolean includeMountFolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Object> obc)
 		throws PortalException {
 
 		return getRepository().getFoldersAndFileEntriesAndFileShortcuts(
@@ -316,7 +316,7 @@ public class CapabilityRepository
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, String[] mimetypes,
 			boolean includeMountFolders, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		return getRepository().getFoldersAndFileEntriesAndFileShortcuts(
@@ -368,7 +368,8 @@ public class CapabilityRepository
 
 	@Override
 	public List<Folder> getMountFolders(
-			long parentFolderId, int start, int end, OrderByComparator obc)
+			long parentFolderId, int start, int end,
+			OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		return getRepository().getMountFolders(parentFolderId, start, end, obc);
@@ -384,7 +385,7 @@ public class CapabilityRepository
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getRepository().getRepositoryFileEntries(
@@ -394,7 +395,7 @@ public class CapabilityRepository
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, String[] mimeTypes, int status,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getRepository().getRepositoryFileEntries(

--- a/portal-impl/src/com/liferay/portal/repository/cmis/CMISRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/cmis/CMISRepository.java
@@ -445,7 +445,7 @@ public class CMISRepository extends BaseCmisRepository {
 
 	@Override
 	public List<FileEntry> getFileEntries(
-		long folderId, int start, int end, OrderByComparator obc) {
+		long folderId, int start, int end, OrderByComparator<FileEntry> obc) {
 
 		List<FileEntry> fileEntries = getFileEntries(folderId);
 
@@ -455,7 +455,7 @@ public class CMISRepository extends BaseCmisRepository {
 	@Override
 	public List<FileEntry> getFileEntries(
 		long folderId, long fileEntryTypeId, int start, int end,
-		OrderByComparator obc) {
+		OrderByComparator<FileEntry> obc) {
 
 		return new ArrayList<FileEntry>();
 	}
@@ -463,7 +463,7 @@ public class CMISRepository extends BaseCmisRepository {
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		Map<Long, List<FileEntry>> fileEntriesCache = _fileEntriesCache.get();
@@ -692,7 +692,7 @@ public class CMISRepository extends BaseCmisRepository {
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, boolean includeMountfolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		List<Folder> folders = getFolders(parentFolderId);
@@ -702,7 +702,7 @@ public class CMISRepository extends BaseCmisRepository {
 
 	@Override
 	public List<Object> getFoldersAndFileEntries(
-		long folderId, int start, int end, OrderByComparator obc) {
+		long folderId, int start, int end, OrderByComparator<Object> obc) {
 
 		List<Object> foldersAndFileEntries = getFoldersAndFileEntries(folderId);
 
@@ -712,7 +712,7 @@ public class CMISRepository extends BaseCmisRepository {
 	@Override
 	public List<Object> getFoldersAndFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		Map<Long, List<Object>> foldersAndFileEntriesCache =
@@ -807,7 +807,8 @@ public class CMISRepository extends BaseCmisRepository {
 
 	@Override
 	public List<Folder> getMountFolders(
-		long parentFolderId, int start, int end, OrderByComparator obc) {
+		long parentFolderId, int start, int end,
+		OrderByComparator<Folder> obc) {
 
 		return new ArrayList<Folder>();
 	}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayLocalRepository.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.documentlibrary.service.DLFileVersionService;
 import com.liferay.portlet.documentlibrary.service.DLFolderLocalService;
 import com.liferay.portlet.documentlibrary.service.DLFolderService;
 import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
+import com.liferay.portlet.documentlibrary.util.comparator.DLFileEntryOrderByComparator;
 import com.liferay.portlet.dynamicdatamapping.storage.Fields;
 
 import java.io.File;
@@ -228,11 +229,13 @@ public class LiferayLocalRepository
 
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
-		long rootFolderId, int start, int end, OrderByComparator obc) {
+		long rootFolderId, int start, int end,
+		OrderByComparator<FileEntry> obc) {
 
 		List<DLFileEntry> dlFileEntries =
 			dlFileEntryLocalService.getGroupFileEntries(
-				getGroupId(), 0, rootFolderId, start, end, obc);
+				getGroupId(), 0, rootFolderId, start, end,
+				new DLFileEntryOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepository.java
@@ -51,6 +51,8 @@ import com.liferay.portlet.documentlibrary.service.DLFolderLocalService;
 import com.liferay.portlet.documentlibrary.service.DLFolderService;
 import com.liferay.portlet.documentlibrary.util.DLSearcher;
 import com.liferay.portlet.documentlibrary.util.RepositoryModelUtil;
+import com.liferay.portlet.documentlibrary.util.comparator.DLFileEntryOrderByComparator;
+import com.liferay.portlet.documentlibrary.util.comparator.DLFolderOrderByComparator;
 import com.liferay.portlet.dynamicdatamapping.storage.Fields;
 
 import java.io.File;
@@ -270,11 +272,12 @@ public class LiferayRepository
 
 	@Override
 	public List<FileEntry> getFileEntries(
-			long folderId, int start, int end, OrderByComparator obc)
+			long folderId, int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<DLFileEntry> dlFileEntries = dlFileEntryService.getFileEntries(
-			getGroupId(), toFolderId(folderId), start, end, obc);
+			getGroupId(), toFolderId(folderId), start, end,
+			new DLFileEntryOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
@@ -282,12 +285,12 @@ public class LiferayRepository
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, long fileEntryTypeId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<DLFileEntry> dlFileEntries = dlFileEntryService.getFileEntries(
 			getGroupId(), toFolderId(folderId), fileEntryTypeId, start, end,
-			obc);
+			new DLFileEntryOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
@@ -295,11 +298,12 @@ public class LiferayRepository
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<DLFileEntry> dlFileEntries = dlFileEntryService.getFileEntries(
-			getGroupId(), toFolderId(folderId), mimeTypes, start, end, obc);
+			getGroupId(), toFolderId(folderId), mimeTypes, start, end,
+			new DLFileEntryOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
@@ -411,7 +415,7 @@ public class LiferayRepository
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, boolean includeMountfolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		return getFolders(
@@ -422,12 +426,13 @@ public class LiferayRepository
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, int status, boolean includeMountfolders,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		List<DLFolder> dlFolders = dlFolderService.getFolders(
 			getGroupId(), toFolderId(parentFolderId), status,
-			includeMountfolders, start, end, obc);
+			includeMountfolders, start, end,
+			new DLFolderOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFolders(dlFolders);
 	}
@@ -435,7 +440,7 @@ public class LiferayRepository
 	@Override
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, boolean includeMountFolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Object> obc)
 		throws PortalException {
 
 		List<Object> dlFoldersAndFileEntriesAndFileShortcuts =
@@ -451,7 +456,7 @@ public class LiferayRepository
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, String[] mimeTypes,
 			boolean includeMountFolders, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		List<Object> dlFoldersAndFileEntriesAndFileShortcuts =
@@ -510,11 +515,13 @@ public class LiferayRepository
 
 	@Override
 	public List<Folder> getMountFolders(
-			long parentFolderId, int start, int end, OrderByComparator obc)
+			long parentFolderId, int start, int end,
+			OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		List<DLFolder> dlFolders = dlFolderService.getMountFolders(
-			getGroupId(), toFolderId(parentFolderId), start, end, obc);
+			getGroupId(), toFolderId(parentFolderId), start, end,
+			new DLFolderOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFolders(dlFolders);
 	}
@@ -530,13 +537,13 @@ public class LiferayRepository
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<DLFileEntry> dlFileEntries =
 			dlFileEntryService.getGroupFileEntries(
 				getGroupId(), userId, toFolderId(rootFolderId), start, end,
-				obc);
+				new DLFileEntryOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}
@@ -544,13 +551,14 @@ public class LiferayRepository
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, String[] mimeTypes, int status,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<DLFileEntry> dlFileEntries =
 			dlFileEntryService.getGroupFileEntries(
 				getGroupId(), userId, getRepositoryId(),
-				toFolderId(rootFolderId), mimeTypes, status, start, end, obc);
+				toFolderId(rootFolderId), mimeTypes, status, start, end,
+				new DLFileEntryOrderByComparator(obc));
 
 		return RepositoryModelUtil.toFileEntries(dlFileEntries);
 	}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -1525,7 +1525,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long repositoryId, long folderId, int status,
 			boolean includeMountFolders, int start, int end,
-			OrderByComparator<?> obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		return getFoldersAndFileEntriesAndFileShortcuts(
@@ -1537,7 +1537,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long repositoryId, long folderId, int status, String[] mimeTypes,
 			boolean includeMountFolders, int start, int end,
-			OrderByComparator<?> obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		Repository repository = getRepository(repositoryId);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -523,6 +523,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 		long groupId, long folderId, int status, boolean includeMountFolders,
 		int start, int end, OrderByComparator<?> obc) {
 
+		@SuppressWarnings("unchecked")
 		QueryDefinition<?> queryDefinition = new QueryDefinition<Object>(
 			status, start, end, (OrderByComparator<Object>)obc);
 
@@ -542,6 +543,7 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 		boolean includeMountFolders, int start, int end,
 		OrderByComparator<?> obc) {
 
+		@SuppressWarnings("unchecked")
 		QueryDefinition<?> queryDefinition = new QueryDefinition<Object>(
 			status, start, end, (OrderByComparator<Object>)obc);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderServiceImpl.java
@@ -225,6 +225,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			return Collections.emptyList();
 		}
 
+		@SuppressWarnings("unchecked")
 		QueryDefinition<?> queryDefinition = new QueryDefinition<Object>(
 			status, start, end, (OrderByComparator<Object>)obc);
 
@@ -245,6 +246,7 @@ public class DLFolderServiceImpl extends DLFolderServiceBaseImpl {
 			return Collections.emptyList();
 		}
 
+		@SuppressWarnings("unchecked")
 		QueryDefinition<?> queryDefinition = new QueryDefinition<Object>(
 			status, start, end, (OrderByComparator<Object>)obc);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryOrderByComparator.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryOrderByComparator.java
@@ -20,8 +20,7 @@ import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 
 /**
- *
- * @author wnewbury
+ * @author William Newbury
  */
 public class DLFileEntryOrderByComparator
 	extends OrderByComparator<DLFileEntry> {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryOrderByComparator.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryOrderByComparator.java
@@ -33,12 +33,10 @@ public class DLFileEntryOrderByComparator
 	}
 
 	@Override
-	public int compare(DLFileEntry o1, DLFileEntry o2) {
-		return _orderByComparator.compare(toFileEntry(o1), toFileEntry(o2));
-	}
-
-	protected FileEntry toFileEntry(DLFileEntry dlFileEntry) {
-		return new LiferayFileEntry(dlFileEntry);
+	public int compare(DLFileEntry dlFileEntry1, DLFileEntry dlFileEntry2) {
+		return _orderByComparator.compare(
+			new LiferayFileEntry(dlFileEntry1),
+			new LiferayFileEntry(dlFileEntry2));
 	}
 
 	private OrderByComparator<FileEntry> _orderByComparator;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryOrderByComparator.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFileEntryOrderByComparator.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.util.comparator;
+
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+
+/**
+ *
+ * @author wnewbury
+ */
+public class DLFileEntryOrderByComparator
+	extends OrderByComparator<DLFileEntry> {
+
+	public DLFileEntryOrderByComparator(
+		OrderByComparator<FileEntry> orderByComparator) {
+
+		_orderByComparator = orderByComparator;
+	}
+
+	@Override
+	public int compare(DLFileEntry o1, DLFileEntry o2) {
+		return _orderByComparator.compare(toFileEntry(o1), toFileEntry(o2));
+	}
+
+	protected FileEntry toFileEntry(DLFileEntry dlFileEntry) {
+		return new LiferayFileEntry(dlFileEntry);
+	}
+
+	private OrderByComparator<FileEntry> _orderByComparator;
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFolderOrderByComparator.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFolderOrderByComparator.java
@@ -20,8 +20,7 @@ import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 
 /**
- *
- * @author wnewbury
+ * @author William Newbury
  */
 public class DLFolderOrderByComparator extends OrderByComparator<DLFolder> {
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFolderOrderByComparator.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFolderOrderByComparator.java
@@ -32,12 +32,9 @@ public class DLFolderOrderByComparator extends OrderByComparator<DLFolder> {
 	}
 
 	@Override
-	public int compare(DLFolder o1, DLFolder o2) {
-		return _orderByComparator.compare(toFolder(o1), toFolder(o2));
-	}
-
-	protected Folder toFolder(DLFolder dlFolder) {
-		return new LiferayFolder(dlFolder);
+	public int compare(DLFolder dlFolder1, DLFolder dlFolder2) {
+		return _orderByComparator.compare(
+			new LiferayFolder(dlFolder1), new LiferayFolder(dlFolder2));
 	}
 
 	private OrderByComparator<Folder> _orderByComparator;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFolderOrderByComparator.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/comparator/DLFolderOrderByComparator.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.util.comparator;
+
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
+import com.liferay.portlet.documentlibrary.model.DLFolder;
+
+/**
+ *
+ * @author wnewbury
+ */
+public class DLFolderOrderByComparator extends OrderByComparator<DLFolder> {
+
+	public DLFolderOrderByComparator(
+		OrderByComparator<Folder> orderByComparator) {
+
+		_orderByComparator = orderByComparator;
+	}
+
+	@Override
+	public int compare(DLFolder o1, DLFolder o2) {
+		return _orderByComparator.compare(toFolder(o1), toFolder(o2));
+	}
+
+	protected Folder toFolder(DLFolder dlFolder) {
+		return new LiferayFolder(dlFolder);
+	}
+
+	private OrderByComparator<Folder> _orderByComparator;
+
+}

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -340,6 +340,7 @@ public class JournalFolderLocalServiceImpl
 		long groupId, long folderId, int start, int end,
 		OrderByComparator<?> obc) {
 
+		@SuppressWarnings("unchecked")
 		QueryDefinition<?> queryDefinition = new QueryDefinition<Object>(
 			WorkflowConstants.STATUS_ANY, start, end,
 			(OrderByComparator<Object>)obc);

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalFolderServiceImpl.java
@@ -148,6 +148,7 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 		long groupId, long folderId, int status, int start, int end,
 		OrderByComparator<?> obc) {
 
+		@SuppressWarnings("unchecked")
 		QueryDefinition<?> queryDefinition = new QueryDefinition<Object>(
 			status, start, end, (OrderByComparator<Object>)obc);
 

--- a/portal-service/src/com/liferay/portal/kernel/dao/orm/OrderFactoryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/orm/OrderFactoryUtil.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 public class OrderFactoryUtil {
 
 	public static void addOrderByComparator(
-		DynamicQuery dynamicQuery, OrderByComparator obc) {
+		DynamicQuery dynamicQuery, OrderByComparator<?> obc) {
 
 		if (obc == null) {
 			return;

--- a/portal-service/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
@@ -164,24 +164,24 @@ public abstract class BaseRepositoryImpl
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, int status, boolean includeMountfolders,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		return getFolders(parentFolderId, includeMountfolders, start, end, obc);
 	}
 
 	public abstract List<Object> getFoldersAndFileEntries(
-		long folderId, int start, int end, OrderByComparator obc);
+		long folderId, int start, int end, OrderByComparator<Object> obc);
 
 	public abstract List<Object> getFoldersAndFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException;
 
 	@Override
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long folderId, int status, boolean includeMountFolders, int start,
-		int end, OrderByComparator obc) {
+		int end, OrderByComparator<Object> obc) {
 
 		return getFoldersAndFileEntries(folderId, start, end, obc);
 	}
@@ -190,7 +190,7 @@ public abstract class BaseRepositoryImpl
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, String[] mimeTypes,
 			boolean includeMountFolders, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		return getFoldersAndFileEntries(folderId, mimeTypes, start, end, obc);
@@ -260,7 +260,7 @@ public abstract class BaseRepositoryImpl
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getFileEntries(rootFolderId, start, end, obc);
@@ -269,7 +269,7 @@ public abstract class BaseRepositoryImpl
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, String[] mimeTypes, int status,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return getFileEntries(rootFolderId, mimeTypes, start, end, obc);

--- a/portal-service/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/DefaultLocalRepositoryImpl.java
@@ -132,7 +132,8 @@ public class DefaultLocalRepositoryImpl implements LocalRepository {
 
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
-			long rootFolderId, int start, int end, OrderByComparator obc)
+			long rootFolderId, int start, int end,
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return _repository.getRepositoryFileEntries(

--- a/portal-service/src/com/liferay/portal/kernel/repository/LocalRepository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/LocalRepository.java
@@ -71,7 +71,8 @@ public interface LocalRepository extends CapabilityProvider {
 		throws PortalException;
 
 	public List<FileEntry> getRepositoryFileEntries(
-			long rootFolderId, int start, int end, OrderByComparator obc)
+			long rootFolderId, int start, int end,
+			OrderByComparator<FileEntry> obc)
 		throws PortalException;
 
 	public long getRepositoryId();

--- a/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
@@ -101,17 +101,17 @@ public interface Repository extends CapabilityProvider {
 		throws PortalException;
 
 	public List<FileEntry> getFileEntries(
-			long folderId, int start, int end, OrderByComparator obc)
+			long folderId, int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException;
 
 	public List<FileEntry> getFileEntries(
 			long folderId, long fileEntryTypeId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException;
 
 	public List<FileEntry> getFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException;
 
 	public List<Object> getFileEntriesAndFileShortcuts(
@@ -150,23 +150,23 @@ public interface Repository extends CapabilityProvider {
 
 	public List<Folder> getFolders(
 			long parentFolderId, boolean includeMountFolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Folder> obc)
 		throws PortalException;
 
 	public List<Folder> getFolders(
 			long parentFolderId, int status, boolean includeMountFolders,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<Folder> obc)
 		throws PortalException;
 
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, boolean includeMountFolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Object> obc)
 		throws PortalException;
 
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, String[] mimetypes,
 			boolean includeMountFolders, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException;
 
 	public int getFoldersAndFileEntriesAndFileShortcutsCount(
@@ -189,19 +189,20 @@ public interface Repository extends CapabilityProvider {
 		throws PortalException;
 
 	public List<Folder> getMountFolders(
-			long parentFolderId, int start, int end, OrderByComparator obc)
+			long parentFolderId, int start, int end,
+			OrderByComparator<Folder> obc)
 		throws PortalException;
 
 	public int getMountFoldersCount(long parentFolderId) throws PortalException;
 
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException;
 
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, String[] mimeTypes, int status,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException;
 
 	public int getRepositoryFileEntriesCount(long userId, long rootFolderId)

--- a/portal-service/src/com/liferay/portal/kernel/repository/cmis/CMISRepositoryHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/cmis/CMISRepositoryHandler.java
@@ -137,7 +137,7 @@ public abstract class CMISRepositoryHandler extends BaseRepositoryImpl {
 
 	@Override
 	public List<FileEntry> getFileEntries(
-			long folderId, int start, int end, OrderByComparator obc)
+			long folderId, int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return _baseCmisRepository.getFileEntries(folderId, start, end, obc);
@@ -146,7 +146,7 @@ public abstract class CMISRepositoryHandler extends BaseRepositoryImpl {
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, long fileEntryTypeId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return _baseCmisRepository.getFileEntries(
@@ -156,7 +156,7 @@ public abstract class CMISRepositoryHandler extends BaseRepositoryImpl {
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return _baseCmisRepository.getFileEntries(
@@ -222,7 +222,7 @@ public abstract class CMISRepositoryHandler extends BaseRepositoryImpl {
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, boolean includeMountfolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		return _baseCmisRepository.getFolders(
@@ -231,7 +231,7 @@ public abstract class CMISRepositoryHandler extends BaseRepositoryImpl {
 
 	@Override
 	public List<Object> getFoldersAndFileEntries(
-		long folderId, int start, int end, OrderByComparator obc) {
+		long folderId, int start, int end, OrderByComparator<Object> obc) {
 
 		return _baseCmisRepository.getFoldersAndFileEntries(
 			folderId, start, end, obc);
@@ -240,7 +240,7 @@ public abstract class CMISRepositoryHandler extends BaseRepositoryImpl {
 	@Override
 	public List<Object> getFoldersAndFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		return _baseCmisRepository.getFoldersAndFileEntries(
@@ -312,7 +312,8 @@ public abstract class CMISRepositoryHandler extends BaseRepositoryImpl {
 
 	@Override
 	public List<Folder> getMountFolders(
-			long parentFolderId, int start, int end, OrderByComparator obc)
+			long parentFolderId, int start, int end,
+			OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		return _baseCmisRepository.getMountFolders(

--- a/portal-service/src/com/liferay/portal/kernel/util/TableNameOrderByComparator.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/TableNameOrderByComparator.java
@@ -77,7 +77,7 @@ public class TableNameOrderByComparator<T> extends OrderByComparator<T> {
 		return _orderByComparator.getOrderByFields();
 	}
 
-	public OrderByComparator getWrappedOrderByComparator() {
+	public OrderByComparator<T> getWrappedOrderByComparator() {
 		return _orderByComparator;
 	}
 

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepository.java
@@ -104,10 +104,10 @@ public interface PortletFileRepository {
 
 	public List<FileEntry> getPortletFileEntries(
 		long groupId, long folderId, int status, int start, int end,
-		OrderByComparator obc);
+		OrderByComparator<FileEntry> obc);
 
 	public List<FileEntry> getPortletFileEntries(
-		long groupId, long folderId, OrderByComparator obc);
+		long groupId, long folderId, OrderByComparator<FileEntry> obc);
 
 	public int getPortletFileEntriesCount(long groupId, long folderId);
 

--- a/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-service/src/com/liferay/portal/portletfilerepository/PortletFileRepositoryUtil.java
@@ -174,14 +174,14 @@ public class PortletFileRepositoryUtil {
 
 	public static List<FileEntry> getPortletFileEntries(
 		long groupId, long folderId, int status, int start, int end,
-		OrderByComparator obc) {
+		OrderByComparator<FileEntry> obc) {
 
 		return getPortletFileRepository().getPortletFileEntries(
 			groupId, folderId, status, start, end, obc);
 	}
 
 	public static List<FileEntry> getPortletFileEntries(
-		long groupId, long folderId, OrderByComparator obc) {
+		long groupId, long folderId, OrderByComparator<FileEntry> obc) {
 
 		return getPortletFileRepository().getPortletFileEntries(
 			groupId, folderId, obc);

--- a/portal-service/src/com/liferay/portal/repository/proxy/BaseRepositoryProxyBean.java
+++ b/portal-service/src/com/liferay/portal/repository/proxy/BaseRepositoryProxyBean.java
@@ -200,7 +200,7 @@ public class BaseRepositoryProxyBean
 
 	@Override
 	public List<FileEntry> getFileEntries(
-			long folderId, int start, int end, OrderByComparator obc)
+			long folderId, int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<FileEntry> fileEntries = _baseRepository.getFileEntries(
@@ -212,7 +212,7 @@ public class BaseRepositoryProxyBean
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, long documentTypeId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<FileEntry> fileEntries = _baseRepository.getFileEntries(
@@ -224,7 +224,7 @@ public class BaseRepositoryProxyBean
 	@Override
 	public List<FileEntry> getFileEntries(
 			long folderId, String[] mimeTypes, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<FileEntry> fileEntries = _baseRepository.getFileEntries(
@@ -331,7 +331,7 @@ public class BaseRepositoryProxyBean
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, boolean includeMountfolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		List<Folder> folders = _baseRepository.getFolders(
@@ -343,7 +343,7 @@ public class BaseRepositoryProxyBean
 	@Override
 	public List<Folder> getFolders(
 			long parentFolderId, int status, boolean includeMountfolders,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		List<Folder> folders = _baseRepository.getFolders(
@@ -355,7 +355,7 @@ public class BaseRepositoryProxyBean
 	@Override
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, boolean includeMountFolders, int start,
-			int end, OrderByComparator obc)
+			int end, OrderByComparator<Object> obc)
 		throws PortalException {
 
 		List<Object> objects =
@@ -369,7 +369,7 @@ public class BaseRepositoryProxyBean
 	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
 			long folderId, int status, String[] mimeTypes,
 			boolean includeMountFolders, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<Object> obc)
 		throws PortalException {
 
 		List<Object> objects =
@@ -432,7 +432,8 @@ public class BaseRepositoryProxyBean
 
 	@Override
 	public List<Folder> getMountFolders(
-			long parentFolderId, int start, int end, OrderByComparator obc)
+			long parentFolderId, int start, int end,
+			OrderByComparator<Folder> obc)
 		throws PortalException {
 
 		List<Folder> folders = _baseRepository.getMountFolders(
@@ -455,7 +456,7 @@ public class BaseRepositoryProxyBean
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, int start, int end,
-			OrderByComparator obc)
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<FileEntry> fileEntries = _baseRepository.getRepositoryFileEntries(
@@ -467,7 +468,7 @@ public class BaseRepositoryProxyBean
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
 			long userId, long rootFolderId, String[] mimeTypes, int status,
-			int start, int end, OrderByComparator obc)
+			int start, int end, OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		List<FileEntry> fileEntries = _baseRepository.getRepositoryFileEntries(

--- a/portal-service/src/com/liferay/portal/repository/proxy/LocalRepositoryProxyBean.java
+++ b/portal-service/src/com/liferay/portal/repository/proxy/LocalRepositoryProxyBean.java
@@ -151,7 +151,8 @@ public class LocalRepositoryProxyBean
 
 	@Override
 	public List<FileEntry> getRepositoryFileEntries(
-			long rootFolderId, int start, int end, OrderByComparator obc)
+			long rootFolderId, int start, int end,
+			OrderByComparator<FileEntry> obc)
 		throws PortalException {
 
 		return _localRepository.getRepositoryFileEntries(

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppService.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppService.java
@@ -1046,14 +1046,14 @@ public interface DLAppService extends BaseService {
 	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long repositoryId, long folderId, int status,
 		boolean includeMountFolders, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<?> obc)
+		com.liferay.portal.kernel.util.OrderByComparator<Object> obc)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long repositoryId, long folderId, int status,
 		java.lang.String[] mimeTypes, boolean includeMountFolders, int start,
-		int end, com.liferay.portal.kernel.util.OrderByComparator<?> obc)
+		int end, com.liferay.portal.kernel.util.OrderByComparator<Object> obc)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceUtil.java
@@ -1157,7 +1157,7 @@ public class DLAppServiceUtil {
 	public static java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long repositoryId, long folderId, int status,
 		boolean includeMountFolders, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<?> obc)
+		com.liferay.portal.kernel.util.OrderByComparator<Object> obc)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService()
 				   .getFoldersAndFileEntriesAndFileShortcuts(repositoryId,
@@ -1167,7 +1167,7 @@ public class DLAppServiceUtil {
 	public static java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long repositoryId, long folderId, int status,
 		java.lang.String[] mimeTypes, boolean includeMountFolders, int start,
-		int end, com.liferay.portal.kernel.util.OrderByComparator<?> obc)
+		int end, com.liferay.portal.kernel.util.OrderByComparator<Object>obc)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService()
 				   .getFoldersAndFileEntriesAndFileShortcuts(repositoryId,

--- a/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/service/DLAppServiceWrapper.java
@@ -1179,7 +1179,7 @@ public class DLAppServiceWrapper implements DLAppService,
 	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long repositoryId, long folderId, int status,
 		boolean includeMountFolders, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<?> obc)
+		com.liferay.portal.kernel.util.OrderByComparator<Object> obc)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _dlAppService.getFoldersAndFileEntriesAndFileShortcuts(repositoryId,
 			folderId, status, includeMountFolders, start, end, obc);
@@ -1189,7 +1189,7 @@ public class DLAppServiceWrapper implements DLAppService,
 	public java.util.List<java.lang.Object> getFoldersAndFileEntriesAndFileShortcuts(
 		long repositoryId, long folderId, int status,
 		java.lang.String[] mimeTypes, boolean includeMountFolders, int start,
-		int end, com.liferay.portal.kernel.util.OrderByComparator<?> obc)
+		int end, com.liferay.portal.kernel.util.OrderByComparator<Object> obc)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _dlAppService.getFoldersAndFileEntriesAndFileShortcuts(repositoryId,
 			folderId, status, mimeTypes, includeMountFolders, start, end, obc);

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/TableNameOrderByComparatorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/TableNameOrderByComparatorTest.java
@@ -25,7 +25,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByTableNameWithPeriodReturnsDecoratedTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("column"), "table.");
 
 		Assert.assertEquals(
@@ -35,7 +35,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByWithBlankTableNameReturnsUndecoratedTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("column1, column2"), "");
 
 		Assert.assertEquals(
@@ -45,7 +45,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByWithMultipleColumnNamesReturnsDecoratedTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("column1, column2"), "table");
 
 		Assert.assertEquals(
@@ -56,7 +56,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByWithMultipleTableNameReturnsNewTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("table1.column1, column2"),
 				"table2");
 
@@ -68,7 +68,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByWithNullTableNameReturnsUndecoratedTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("column1, column2"), null);
 
 		Assert.assertEquals(
@@ -78,7 +78,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByWithSingleColumnNameReturnsDecoratedTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("column"), "table");
 
 		Assert.assertEquals(
@@ -88,7 +88,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByWithSingleTableNameReturnsNewTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("table1.column1"), "table2");
 
 		Assert.assertEquals(
@@ -98,7 +98,7 @@ public class TableNameOrderByComparatorTest {
 	@Test
 	public void testGetOrderByWithSortDirectionReturnsDecoratedTableName() {
 		TableNameOrderByComparator<?> tableNameOrderByComparator =
-			new TableNameOrderByComparator(
+			new TableNameOrderByComparator<Object>(
 				new TestGetOrderByComparator("column ASC"), "table");
 
 		Assert.assertEquals(

--- a/portal-web/docroot/html/portlet/bookmarks/view_entries.jspf
+++ b/portal-web/docroot/html/portlet/bookmarks/view_entries.jspf
@@ -27,7 +27,7 @@ else {
 	orderByType = portalPreferences.getValue(PortletKeys.BOOKMARKS, "entries-order-by-type", "asc");
 }
 
-OrderByComparator orderByComparator = BookmarksUtil.getEntryOrderByComparator(orderByCol, orderByType);
+OrderByComparator<BookmarksEntry> orderByComparator = BookmarksUtil.getEntryOrderByComparator(orderByCol, orderByType);
 %>
 
 <liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/document_library/view_entries.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_entries.jsp
@@ -121,7 +121,7 @@ else {
 	}
 }
 
-OrderByComparator orderByComparator = DLUtil.getRepositoryModelOrderByComparator(orderByCol, orderByType);
+OrderByComparator<?> orderByComparator = DLUtil.getRepositoryModelOrderByComparator(orderByCol, orderByType);
 
 searchContainer.setOrderableHeaders(orderableHeaders);
 searchContainer.setOrderByCol(orderByCol);

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/view.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/view.jsp
@@ -62,7 +62,7 @@ portletURL.setParameter("tabs1", tabs1);
 		orderByType = portalPreferences.getValue(PortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-type", "asc");
 	}
 
-	OrderByComparator orderByComparator = DDMUtil.getStructureOrderByComparator(orderByCol, orderByType);
+	OrderByComparator<DDMStructure> orderByComparator = DDMUtil.getStructureOrderByComparator(orderByCol, orderByType);
 	%>
 
 	<liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/view_template.jsp
@@ -84,7 +84,7 @@ String title = ddmDisplay.getViewTemplatesTitle(structure, controlPanel, templat
 		orderByType = portalPreferences.getValue(PortletKeys.DYNAMIC_DATA_MAPPING, "entries-order-by-type", "asc");
 	}
 
-	OrderByComparator orderByComparator = DDMUtil.getTemplateOrderByComparator(orderByCol, orderByType);
+	OrderByComparator<DDMTemplate> orderByComparator = DDMUtil.getTemplateOrderByComparator(orderByCol, orderByType);
 	%>
 
 	<liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/journal/view_entries.jsp
+++ b/portal-web/docroot/html/portlet/journal/view_entries.jsp
@@ -49,7 +49,7 @@ else {
 	}
 }
 
-OrderByComparator orderByComparator = JournalUtil.getArticleOrderByComparator(orderByCol, orderByType);
+OrderByComparator<JournalArticle> orderByComparator = JournalUtil.getArticleOrderByComparator(orderByCol, orderByType);
 
 articleSearchContainer.setOrderByCol(orderByCol);
 articleSearchContainer.setOrderByComparator(orderByComparator);

--- a/portal-web/docroot/html/portlet/journal_articles/init.jsp
+++ b/portal-web/docroot/html/portlet/journal_articles/init.jsp
@@ -27,7 +27,7 @@ int pageDelta = GetterUtil.getInteger(portletPreferences.getValue("pageDelta", S
 String orderByCol = portletPreferences.getValue("orderByCol", StringPool.BLANK);
 String orderByType = portletPreferences.getValue("orderByType", StringPool.BLANK);
 
-OrderByComparator orderByComparator = JournalUtil.getArticleOrderByComparator(orderByCol, orderByType);
+OrderByComparator<JournalArticle> orderByComparator = JournalUtil.getArticleOrderByComparator(orderByCol, orderByType);
 
 DDMStructure ddmStructure = null;
 

--- a/portal-web/docroot/html/portlet/layouts_admin/export_layouts_processes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/export_layouts_processes.jsp
@@ -37,7 +37,7 @@ else {
 	orderByType = portalPreferences.getValue(PortletKeys.BACKGROUND_TASK, "entries-order-by-type", "desc");
 }
 
-OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
+OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
 <liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/layouts_admin/import_layouts_processes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/import_layouts_processes.jsp
@@ -39,7 +39,7 @@ else {
 	orderByType = portalPreferences.getValue(PortletKeys.BACKGROUND_TASK, "entries-order-by-type", "desc");
 }
 
-OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
+OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
 <liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_processes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts_processes.jsp
@@ -47,7 +47,7 @@ else {
 	orderByType = portalPreferences.getValue(PortletKeys.BACKGROUND_TASK, "entries-order-by-type", "desc");
 }
 
-OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
+OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 
 String taskExecutorClassName = localPublishing ? LayoutStagingBackgroundTaskExecutor.class.getName() : LayoutRemoteStagingBackgroundTaskExecutor.class.getName();
 %>

--- a/portal-web/docroot/html/portlet/portlet_configuration/export_portlet_processes.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/export_portlet_processes.jsp
@@ -35,7 +35,7 @@ else {
 	orderByType = portalPreferences.getValue(PortletKeys.BACKGROUND_TASK, "entries-order-by-type", "desc");
 }
 
-OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
+OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
 <liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/portlet_configuration/import_portlet_processes.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/import_portlet_processes.jsp
@@ -35,7 +35,7 @@ else {
 	orderByType = portalPreferences.getValue(PortletKeys.BACKGROUND_TASK, "entries-order-by-type", "desc");
 }
 
-OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
+OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
 <liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/portlet_configuration/publish_portlet_processes.jsp
+++ b/portal-web/docroot/html/portlet/portlet_configuration/publish_portlet_processes.jsp
@@ -35,7 +35,7 @@ else {
 	orderByType = portalPreferences.getValue(PortletKeys.BACKGROUND_TASK, "entries-order-by-type", "desc");
 }
 
-OrderByComparator orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
+OrderByComparator<BackgroundTask> orderByComparator = BackgroundTaskComparatorFactoryUtil.getBackgroundTaskOrderByComparator(orderByCol, orderByType);
 %>
 
 <liferay-ui:search-container

--- a/portal-web/docroot/html/portlet/shopping/categories.jspf
+++ b/portal-web/docroot/html/portlet/shopping/categories.jspf
@@ -185,7 +185,7 @@ portletURL.setParameter("categoryId", String.valueOf(categoryId));
 			orderByType = portalPreferences.getValue(PortletKeys.SHOPPING, "items-order-by-type", "asc");
 		}
 
-		OrderByComparator orderByComparator = ShoppingUtil.getItemOrderByComparator(orderByCol, orderByType);
+		OrderByComparator<ShoppingItem> orderByComparator = ShoppingUtil.getItemOrderByComparator(orderByCol, orderByType);
 
 		List<String> headerNames = new ArrayList<String>();
 

--- a/portal-web/docroot/html/portlet/shopping/view_item.jsp
+++ b/portal-web/docroot/html/portlet/shopping/view_item.jsp
@@ -29,7 +29,7 @@ ShoppingItemPrice[] itemPrices = (ShoppingItemPrice[])ShoppingItemPriceLocalServ
 String orderByCol = portalPreferences.getValue(PortletKeys.SHOPPING, "items-order-by-col", "sku");
 String orderByType = portalPreferences.getValue(PortletKeys.SHOPPING, "items-order-by-type", "asc");
 
-OrderByComparator orderByComparator = ShoppingUtil.getItemOrderByComparator(orderByCol, orderByType);
+OrderByComparator<ShoppingItem> orderByComparator = ShoppingUtil.getItemOrderByComparator(orderByCol, orderByType);
 
 ShoppingItem[] prevAndNext = ShoppingItemServiceUtil.getItemsPrevAndNext(item.getItemId(), orderByComparator);
 %>

--- a/portal-web/docroot/html/portlet/software_catalog/view.jsp
+++ b/portal-web/docroot/html/portlet/software_catalog/view.jsp
@@ -309,7 +309,7 @@ portletURL.setParameter("tabs1", tabs1);
 			orderByType = portalPreferences.getValue(PortletKeys.SOFTWARE_CATALOG, "product-entries-order-by-type", "desc");
 		}
 
-		OrderByComparator orderByComparator = SCUtil.getProductEntryOrderByComparator(orderByCol, orderByType);
+		OrderByComparator<SCProductEntry> orderByComparator = SCUtil.getProductEntryOrderByComparator(orderByCol, orderByType);
 
 		List<String> headerNames = new ArrayList<String>();
 

--- a/portal-web/docroot/html/portlet/wiki/page_iterator.jsp
+++ b/portal-web/docroot/html/portlet/wiki/page_iterator.jsp
@@ -145,7 +145,7 @@ else if (type.equals("tagged_pages")) {
 String orderByCol = ParamUtil.getString(request, "orderByCol");
 String orderByType = ParamUtil.getString(request, "orderByType");
 
-OrderByComparator orderByComparator = WikiUtil.getPageOrderByComparator(orderByCol, orderByType);
+OrderByComparator<WikiPage> orderByComparator = WikiUtil.getPageOrderByComparator(orderByCol, orderByType);
 
 Map orderableHeaders = new HashMap();
 

--- a/util-java/src/com/liferay/util/dao/orm/CustomSQL.java
+++ b/util-java/src/com/liferay/util/dao/orm/CustomSQL.java
@@ -709,7 +709,7 @@ public class CustomSQL {
 		return StringUtil.replace(sql, oldSql.toString(), newSql.toString());
 	}
 
-	public String replaceOrderBy(String sql, OrderByComparator obc) {
+	public String replaceOrderBy(String sql, OrderByComparator<?> obc) {
 		if (obc == null) {
 			return sql;
 		}

--- a/util-java/src/com/liferay/util/dao/orm/CustomSQLUtil.java
+++ b/util-java/src/com/liferay/util/dao/orm/CustomSQLUtil.java
@@ -143,7 +143,7 @@ public class CustomSQLUtil {
 			sql, field, operator, last, values);
 	}
 
-	public static String replaceOrderBy(String sql, OrderByComparator obc) {
+	public static String replaceOrderBy(String sql, OrderByComparator<?> obc) {
 		return _instance._customSQL.replaceOrderBy(sql, obc);
 	}
 


### PR DESCRIPTION
This is the last pull for this ticket. All the OrderByComparator generic warnings should be gone after this.

Please let us know if eclipse is still complaining anything.
