### PR TITLE
LPS-47231:DM is showing "Delete" button instead of "Move to Recycle bin"...

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/js/main.js
+++ b/portal-web/docroot/html/portlet/document_library/js/main.js
@@ -596,7 +596,7 @@ AUI.add(
 						if (trashEnabled) {
 							var repositoryId = instance._appViewSelect.get(STR_SELECTED_FOLDER).repositoryId;
 
-							var scopeGroupId = themeDisplay.getScopeGroupId();
+							var scopeGroupId = instance._config.scopeGroupId;
 
 							trashEnabled = (scopeGroupId === repositoryId);
 						}

--- a/portal-web/docroot/html/portlet/document_library/view.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view.jsp
@@ -258,6 +258,7 @@ if (!defaultFolderView && (folder != null) && (portletName.equals(PortletKeys.DO
 				strutsAction: '/document_library/view'
 			},
 			trashEnabled: <%= TrashUtil.isTrashEnabled(scopeGroupId) %>,
+			scopeGroupId: '<%= scopeGroupId %>',
 			maxFileSize: <%= PrefsPropsUtil.getLong(PropsKeys.DL_FILE_MAX_SIZE) %>,
 			move: {
 				allRowIds: '<%= RowChecker.ALL_ROW_IDS %>',


### PR DESCRIPTION
Hi @brianchandotcom,

/CC @natecavanaugh

I got this review request from @hhuijser and as I have created the issue it and being part of commenting earlier pull request. It did found it's way back to me again.

As I see this fix is good and @daviddotzhang did comment that he has tested all the use cases including CMIS connection. I give trust on him.

I see this is valid since used JavaScript operator is ===  and the value should be String as original themeDisplay.getScopeGroupId(); returns also String and this seems to be pattern on our JavaScript side.

It is always better to use === instead of ==.

Cheers, Sampsa
