### PR TITLE
LPS-48075 We don't need this in the bnd because the portal is already exporting this package.

### DIFF
--- a/modules/util/ip-geocoder/bnd.bnd
+++ b/modules/util/ip-geocoder/bnd.bnd
@@ -1,11 +1,9 @@
 Bundle-ClassPath:\
 	.,\
-	lib/geoip-api.jar,\
-	lib/xz.jar
+	lib/geoip-api.jar
 Bundle-Name: Liferay IP Geocoder
 Export-Package:\
 	com.liferay.ip.geocoder
 Include-Resource:\
 	classes,\
-	{lib/geoip-api.jar=lib/geoip-api.jar},\
-	{lib/xz.jar=lib/xz.jar}
+	{lib/geoip-api.jar=lib/geoip-api.jar}


### PR DESCRIPTION
Hi Brian, 

currently, we are not including any of the jars that the portal is already exporting. The fact that we don't include them doesn't mean people can't use these modules outside of liferay, they just need to deploy those dependencies in the container.

We are also using other jar files in this module and other modules but we don't include them if the portal is already exporting them.

cc @migue
