### PR TITLE
Lps 48418

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -929,6 +929,37 @@ public class ServiceBuilder {
 		return sb.toString();
 	}
 
+	public String getCacheFieldMethodName(JavaField javaField) {
+		Annotation[] annotations = javaField.getAnnotations();
+
+		for (Annotation annotation : annotations) {
+			Type type = annotation.getType();
+
+			String className = type.getFullyQualifiedName();
+
+			if (className.equals(CacheField.class.getName())) {
+				String methodName = null;
+
+				Object namedParameter = annotation.getNamedParameter(
+					"methodName");
+
+				if (namedParameter != null) {
+					methodName = StringUtil.unquote(
+						StringUtil.trim(namedParameter.toString()));
+				}
+
+				if (Validator.isNull(methodName)) {
+					methodName = TextFormatter.format(
+						getVariableName(javaField), TextFormatter.G);
+				}
+
+				return methodName;
+			}
+		}
+
+		throw new IllegalArgumentException(javaField + " is not a cache field");
+	}
+
 	public String getClassName(Type type) {
 		int dimensions = type.getDimensions();
 		String name = type.getValue();

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_cache.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_cache.ftl
@@ -95,7 +95,7 @@ public class ${entity.name}CacheModel implements CacheModel<${entity.name}>, Ext
 		${entity.varName}Impl.resetOriginalValues();
 
 		<#list cacheFields as cacheField>
-			<#assign methodName = textFormatter.format(serviceBuilder.getVariableName(cacheField), 6)>
+			<#assign methodName = serviceBuilder.getCacheFieldMethodName(cacheField)>
 
 			${entity.varName}Impl.set${methodName}(${cacheField.name});
 		</#list>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_impl.ftl
@@ -660,7 +660,7 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 
 	<#list cacheFields as cacheField>
 		<#assign variableName = serviceBuilder.getVariableName(cacheField)>
-		<#assign methodName = textFormatter.format(variableName, 6)>
+		<#assign methodName = serviceBuilder.getCacheFieldMethodName(cacheField)>
 		<#assign typeName = cacheField.getType().getGenericValue()>
 
 		<#if methodName != "DefaultLanguageId">
@@ -1274,7 +1274,7 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 
 		<#list cacheFields as cacheField>
 			<#assign variableName = serviceBuilder.getVariableName(cacheField)>
-			<#assign methodName = textFormatter.format(variableName, 6)>
+			<#assign methodName = serviceBuilder.getCacheFieldMethodName(cacheField)>
 
 			set${methodName}(null);
 		</#list>
@@ -1314,7 +1314,7 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 		</#list>
 
 		<#list cacheFields as cacheField>
-			<#assign methodName = textFormatter.format(serviceBuilder.getVariableName(cacheField), 6)>
+			<#assign methodName = serviceBuilder.getCacheFieldMethodName(cacheField)>
 
 			${entity.varName}CacheModel.${cacheField.name} = get${methodName}();
 		</#list>

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureCacheModel.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureCacheModel.java
@@ -156,7 +156,7 @@ public class DDMStructureCacheModel implements CacheModel<DDMStructure>,
 
 		ddmStructureImpl.resetOriginalValues();
 
-		ddmStructureImpl.setDdmForm(_ddmForm);
+		ddmStructureImpl.setDDMForm(_ddmForm);
 
 		ddmStructureImpl.setLocalizedFieldsMap(_localizedFieldsMap);
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureImpl.java
@@ -750,7 +750,7 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 
 	private static Log _log = LogFactoryUtil.getLog(DDMStructureImpl.class);
 
-	@CacheField
+	@CacheField(methodName = "DDMForm")
 	private DDMForm _ddmForm;
 
 	@CacheField

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureModelImpl.java
@@ -861,11 +861,11 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 		_type = type;
 	}
 
-	public com.liferay.portlet.dynamicdatamapping.model.DDMForm getDdmForm() {
+	public com.liferay.portlet.dynamicdatamapping.model.DDMForm getDDMForm() {
 		return null;
 	}
 
-	public void setDdmForm(
+	public void setDDMForm(
 		com.liferay.portlet.dynamicdatamapping.model.DDMForm ddmForm) {
 	}
 
@@ -1114,7 +1114,7 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 
 		ddmStructureModelImpl._originalDescription = ddmStructureModelImpl._description;
 
-		setDdmForm(null);
+		setDDMForm(null);
 
 		setLocalizedFieldsMap(null);
 
@@ -1217,7 +1217,7 @@ public class DDMStructureModelImpl extends BaseModelImpl<DDMStructure>
 
 		ddmStructureCacheModel.type = getType();
 
-		ddmStructureCacheModel._ddmForm = getDdmForm();
+		ddmStructureCacheModel._ddmForm = getDDMForm();
 
 		ddmStructureCacheModel._localizedFieldsMap = getLocalizedFieldsMap();
 

--- a/portal-service/src/com/liferay/portal/model/CacheField.java
+++ b/portal-service/src/com/liferay/portal/model/CacheField.java
@@ -27,4 +27,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.FIELD)
 public @interface CacheField {
+
+	String methodName() default "";
+
 }


### PR DESCRIPTION
@marcellustavares @mdelapenya @mtambara

This is a regression by the method renaming at 513f96cc40ae1b40ea4223440c1d254017317ee4 which changed "Ddm" to "DDM".

This broke the CacheField generated method's callback contract, causing the ddmForm field is not being cached.

I did not undo the renaming, but make the @CacheField takes in a customized method name to support this kind of unconventional field names.

Now the running time for DLFileEntryFinderTest should get back to normal (It was over 40mins on the CI server)
