### PR TITLE
LPS-48206 Force propagation from site template to site

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -1867,6 +1867,11 @@ public class SitesImpl implements Sites {
 			layoutSetPrototypeUuid);
 
 		LayoutLocalServiceUtil.updatePriorities(groupId, privateLayout);
+
+		// Force propagation from site template to site. See LPS-48206.
+
+		LayoutLocalServiceUtil.getLayouts(
+			groupId, privateLayout, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 	}
 
 	private static final String _TEMP_DIR =

--- a/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/LayoutSetPrototypePropagationTest.java
@@ -389,8 +389,6 @@ public class LayoutSetPrototypePropagationTest
 
 		setLinkEnabled(true);
 
-		propagateChanges(group);
-
 		layout = LayoutLocalServiceUtil.getFriendlyURLLayout(
 			group.getGroupId(), false, prototypeLayout.getFriendlyURL());
 
@@ -613,9 +611,13 @@ public class LayoutSetPrototypePropagationTest
 			LayoutLocalServiceUtil.updateLayout(_layout);
 		}
 
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
 		SitesUtil.updateLayoutSetPrototypesLinks(
 			group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0,
 			linkEnabled, linkEnabled);
+
+		Thread.sleep(2000);
 	}
 
 	protected void testAddChildLayout(boolean layoutSetPrototypeLinkEnabled)


### PR DESCRIPTION
Hey Brian,

I've added a comment to explain what this code is for. This issue affects only to actions (EditGroupAction, EditUserGroupAction, EditOrganizationAction, EditUserAction) so we cannot provide an specific test for it.

However, the LayoutSetPrototypePropagationTest already uses the same mechanism to ensure the propagation of changes programmatically, so it's already covered by our tests. I've just removed the now redundant invocation to propagate changes after updating the link-enabled.

Thanks

@juliocamarero
