### PR TITLE
Revert "LPS-48525 Sort"

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/BrowserLauncher.java
+++ b/portal-impl/src/com/liferay/portal/util/BrowserLauncher.java
@@ -107,7 +107,7 @@ public class BrowserLauncher implements Runnable {
 	}
 
 	private static final String[] _BROWSERS = {
-		"firefox", "mozilla", "konqueror", "opera", "xdg-open"
+		"xdg-open", "firefox", "mozilla", "konqueror", "opera"
 	};
 
 }


### PR DESCRIPTION
The order of elements is important to the implementation, xdg-open will choose the user's
default browser

This reverts commit 7dc584e62cbf3a0ba083ba77abe72c30578c1239.
