### PR TITLE
LPS-48586 Return when linkedToLayoutUuid is null - no reason to continue

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -1001,6 +1001,10 @@ public class LayoutStagedModelDataHandler
 		String linkedToLayoutUuid = layoutElement.attributeValue(
 			"linked-to-layout-uuid");
 
+		if (Validator.isNull(linkedToLayoutUuid)) {
+			return;
+		}
+
 		if (linkToLayoutId <= 0) {
 			updateTypeSettings(importedLayout, layout);
 


### PR DESCRIPTION
Hey Brian,

This is a very small bugfix. When the UUID is null we shouldn't continue here.

Thanks,

Máté
