### PR TITLE
LPS-48733 New registry for registering XStream aliases

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.lar.StagedModelType;
 import com.liferay.portal.kernel.lar.UserIdStrategy;
+import com.liferay.portal.kernel.lar.xstream.XStreamAliasRegistryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -2401,6 +2402,12 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 	protected void initXStream() {
 		_xStream = new XStream();
+
+		Map<Class<?>, String> aliases = XStreamAliasRegistryUtil.getAliases();
+
+		for (Map.Entry<Class<?>, String> alias : aliases.entrySet()) {
+			_xStream.alias(alias.getValue(), alias.getKey());
+		}
 
 		_xStream.omitField(HashMap.class, "cache_bitmask");
 	}

--- a/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/bookmarks/lar/BookmarksPortletDataHandler.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.lar.PortletDataHandlerBoolean;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.lar.StagedModelType;
+import com.liferay.portal.kernel.lar.xstream.XStreamAliasRegistryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
@@ -30,6 +31,8 @@ import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.bookmarks.model.BookmarksEntry;
 import com.liferay.portlet.bookmarks.model.BookmarksFolder;
 import com.liferay.portlet.bookmarks.model.BookmarksFolderConstants;
+import com.liferay.portlet.bookmarks.model.impl.BookmarksEntryImpl;
+import com.liferay.portlet.bookmarks.model.impl.BookmarksFolderImpl;
 import com.liferay.portlet.bookmarks.service.BookmarksEntryLocalServiceUtil;
 import com.liferay.portlet.bookmarks.service.BookmarksFolderLocalServiceUtil;
 import com.liferay.portlet.bookmarks.service.permission.BookmarksPermission;
@@ -63,6 +66,11 @@ public class BookmarksPortletDataHandler extends BasePortletDataHandler {
 		setImportControls(getExportControls());
 		setPublishToLiveByDefault(
 			PropsValues.BOOKMARKS_PUBLISH_TO_LIVE_BY_DEFAULT);
+
+		XStreamAliasRegistryUtil.register(
+			BookmarksEntryImpl.class, "BookmarksEntry");
+		XStreamAliasRegistryUtil.register(
+			BookmarksFolderImpl.class, "BookmarksFolder");
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamAliasRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamAliasRegistryUtil.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceReference;
+import com.liferay.registry.ServiceRegistration;
+import com.liferay.registry.ServiceTracker;
+import com.liferay.registry.ServiceTrackerCustomizer;
+import com.liferay.registry.collections.ServiceRegistrationMap;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author Mate Thurzo
+ */
+public class XStreamAliasRegistryUtil {
+
+	public static Map<Class<?>, String> getAliases() {
+		return _instance._getAliases();
+	}
+
+	public static void register(Class<?> clazz, String alias) {
+		_instance._register(clazz, alias);
+	}
+
+	public static void unregister(Class<?> clazz, String alias) {
+		_instance._unregister(clazz, alias);
+	}
+
+	private XStreamAliasRegistryUtil() {
+		Registry registry = RegistryUtil.getRegistry();
+
+		_serviceTracker = registry.trackServices(
+			XStreamAlias.class, new XStreamAliasServiceTrackerCustomizer());
+
+		_serviceTracker.open();
+	}
+
+	private Map<Class<?>, String> _getAliases() {
+		return _xstreamAliases;
+	}
+
+	private void _register(Class<?> clazz, String alias) {
+		XStreamAlias xStreamAlias = new XStreamAlias(clazz, alias);
+
+		Registry registry = RegistryUtil.getRegistry();
+
+		ServiceRegistration<XStreamAlias> serviceRegistration =
+			registry.registerService(XStreamAlias.class, xStreamAlias);
+
+		_serviceRegistrations.put(xStreamAlias, serviceRegistration);
+	}
+
+	private void _unregister(Class<?> clazz, String alias) {
+		XStreamAlias xStreamAlias = new XStreamAlias(clazz, alias);
+
+		ServiceRegistration<XStreamAlias> serviceRegistration =
+			_serviceRegistrations.remove(xStreamAlias);
+
+		if (serviceRegistration != null) {
+			serviceRegistration.unregister();
+		}
+	}
+
+	private static XStreamAliasRegistryUtil _instance =
+		new XStreamAliasRegistryUtil();
+
+	private ServiceRegistrationMap<XStreamAlias> _serviceRegistrations =
+		new ServiceRegistrationMap<XStreamAlias>();
+	private ServiceTracker<XStreamAlias, XStreamAlias> _serviceTracker;
+	private Map<Class<?>, String> _xstreamAliases =
+		new ConcurrentHashMap<Class<?>, String>();
+
+	private class XStreamAlias {
+
+		public XStreamAlias(Class<?> clazz, String alias) {
+			_aliasClass = clazz;
+			_aliasName = alias;
+		}
+
+		public Class<?> getAliasClass() {
+			return _aliasClass;
+		}
+
+		public String getAliasName() {
+			return _aliasName;
+		}
+
+		private Class<?> _aliasClass;
+		private String _aliasName;
+
+	}
+
+	private class XStreamAliasServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer<XStreamAlias, XStreamAlias> {
+
+		@Override
+		public XStreamAlias addingService(
+			ServiceReference<XStreamAlias> serviceReference) {
+
+			Registry registry = RegistryUtil.getRegistry();
+
+			XStreamAlias xStreamAlias = registry.getService(serviceReference);
+
+			_xstreamAliases.put(
+				xStreamAlias.getAliasClass(), xStreamAlias.getAliasName());
+
+			return xStreamAlias;
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<XStreamAlias> serviceReference,
+			XStreamAlias xStreamAlias) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<XStreamAlias> serviceReference,
+			XStreamAlias xStreamAlias) {
+
+			Registry registry = RegistryUtil.getRegistry();
+
+			registry.ungetService(serviceReference);
+
+			_xstreamAliases.remove(xStreamAlias.getAliasClass());
+		}
+
+	}
+
+}


### PR DESCRIPTION
Hey Brian,

Miguel has removed the possibility for setting aliases during export and import due to modularity concerns, and I was planning to add it back to fit the modular approach.

I've created a registry which makes it possible to register aliases for entities and this will be used to set up XStream during the export/import process.

This pull request contains the registry and some additional code, but I've only applied this to the Bookmarks so far as an example, I'll send the rest later, in a separate pull request.

This was reviewed by Miguel as well here: https://github.com/migue/liferay-portal/pull/284

Thanks,

Máté
