### PR TITLE
LPS-48694 Service context ripped of

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/http/UserServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/UserServiceHttp.java
@@ -1014,8 +1014,7 @@ public class UserServiceHttp {
 
 	public static boolean sendPasswordByEmailAddress(
 		HttpPrincipal httpPrincipal, long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String emailAddress)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(UserServiceUtil.class,
@@ -1023,7 +1022,7 @@ public class UserServiceHttp {
 					_sendPasswordByEmailAddressParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
-					companyId, emailAddress, serviceContext);
+					companyId, emailAddress);
 
 			Object returnObj = null;
 
@@ -1048,9 +1047,7 @@ public class UserServiceHttp {
 	}
 
 	public static boolean sendPasswordByScreenName(
-		HttpPrincipal httpPrincipal, long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		HttpPrincipal httpPrincipal, long companyId, java.lang.String screenName)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(UserServiceUtil.class,
@@ -1058,7 +1055,7 @@ public class UserServiceHttp {
 					_sendPasswordByScreenNameParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
-					companyId, screenName, serviceContext);
+					companyId, screenName);
 
 			Object returnObj = null;
 
@@ -1083,16 +1080,13 @@ public class UserServiceHttp {
 	}
 
 	public static boolean sendPasswordByUserId(HttpPrincipal httpPrincipal,
-		long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		long userId) throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(UserServiceUtil.class,
 					"sendPasswordByUserId",
 					_sendPasswordByUserIdParameterTypes31);
 
-			MethodHandler methodHandler = new MethodHandler(methodKey,
-					companyId, userId, serviceContext);
+			MethodHandler methodHandler = new MethodHandler(methodKey, userId);
 
 			Object returnObj = null;
 
@@ -2089,16 +2083,13 @@ public class UserServiceHttp {
 			long.class, java.lang.String.class, long.class, boolean.class
 		};
 	private static final Class<?>[] _sendPasswordByEmailAddressParameterTypes29 = new Class[] {
-			long.class, java.lang.String.class,
-			com.liferay.portal.service.ServiceContext.class
+			long.class, java.lang.String.class
 		};
 	private static final Class<?>[] _sendPasswordByScreenNameParameterTypes30 = new Class[] {
-			long.class, java.lang.String.class,
-			com.liferay.portal.service.ServiceContext.class
+			long.class, java.lang.String.class
 		};
 	private static final Class<?>[] _sendPasswordByUserIdParameterTypes31 = new Class[] {
-			long.class, long.class,
-			com.liferay.portal.service.ServiceContext.class
+			long.class
 		};
 	private static final Class<?>[] _setRoleUsersParameterTypes32 = new Class[] {
 			long.class, long[].class

--- a/portal-impl/src/com/liferay/portal/service/http/UserServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/UserServiceSoap.java
@@ -966,12 +966,10 @@ public class UserServiceSoap {
 	}
 
 	public static boolean sendPasswordByEmailAddress(long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
-		throws RemoteException {
+		java.lang.String emailAddress) throws RemoteException {
 		try {
 			boolean returnValue = UserServiceUtil.sendPasswordByEmailAddress(companyId,
-					emailAddress, serviceContext);
+					emailAddress);
 
 			return returnValue;
 		}
@@ -983,12 +981,10 @@ public class UserServiceSoap {
 	}
 
 	public static boolean sendPasswordByScreenName(long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
-		throws RemoteException {
+		java.lang.String screenName) throws RemoteException {
 		try {
 			boolean returnValue = UserServiceUtil.sendPasswordByScreenName(companyId,
-					screenName, serviceContext);
+					screenName);
 
 			return returnValue;
 		}
@@ -999,12 +995,10 @@ public class UserServiceSoap {
 		}
 	}
 
-	public static boolean sendPasswordByUserId(long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
+	public static boolean sendPasswordByUserId(long userId)
 		throws RemoteException {
 		try {
-			boolean returnValue = UserServiceUtil.sendPasswordByUserId(companyId,
-					userId, serviceContext);
+			boolean returnValue = UserServiceUtil.sendPasswordByUserId(userId);
 
 			return returnValue;
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -3790,7 +3790,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public boolean sendPasswordByUserId(
-			long companyId, long userId, ServiceContext serviceContext)
+			long userId, ServiceContext serviceContext)
 		throws PortalException {
 
 		User user = userPersistence.findByPrimaryKey(userId);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -133,6 +133,7 @@ import com.liferay.portal.security.pwd.PwdToolkitUtil;
 import com.liferay.portal.security.pwd.RegExpToolkit;
 import com.liferay.portal.service.BaseServiceImpl;
 import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.ServiceContextThreadLocal;
 import com.liferay.portal.service.base.UserLocalServiceBaseImpl;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PrefsPropsUtil;
@@ -3766,38 +3767,35 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 	@Override
 	public boolean sendPasswordByEmailAddress(
-			long companyId, String emailAddress, ServiceContext serviceContext)
+			long companyId, String emailAddress)
 		throws PortalException {
 
 		User user = userPersistence.findByC_EA(companyId, emailAddress);
 
 		return sendPassword(
 			user.getCompanyId(), user.getEmailAddress(), null, null, null, null,
-			serviceContext);
+			ServiceContextThreadLocal.getServiceContext());
 	}
 
 	@Override
-	public boolean sendPasswordByScreenName(
-			long companyId, String screenName, ServiceContext serviceContext)
+	public boolean sendPasswordByScreenName(long companyId, String screenName)
 		throws PortalException {
 
 		User user = userPersistence.findByC_SN(companyId, screenName);
 
 		return sendPassword(
 			user.getCompanyId(), user.getEmailAddress(), null, null, null, null,
-			serviceContext);
+			ServiceContextThreadLocal.getServiceContext());
 	}
 
 	@Override
-	public boolean sendPasswordByUserId(
-			long userId, ServiceContext serviceContext)
-		throws PortalException {
+	public boolean sendPasswordByUserId(long userId) throws PortalException {
 
 		User user = userPersistence.findByPrimaryKey(userId);
 
 		return sendPassword(
 			user.getCompanyId(), user.getEmailAddress(), null, null, null, null,
-			serviceContext);
+			ServiceContextThreadLocal.getServiceContext());
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -1015,30 +1015,20 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 			long companyId, String emailAddress)
 		throws PortalException {
 
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
 		return userLocalService.sendPasswordByEmailAddress(
-			companyId, emailAddress, serviceContext);
+			companyId, emailAddress);
 	}
 
 	@Override
 	public boolean sendPasswordByScreenName(long companyId, String screenName)
 		throws PortalException {
 
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		return userLocalService.sendPasswordByScreenName(
-			companyId, screenName, serviceContext);
+		return userLocalService.sendPasswordByScreenName(companyId, screenName);
 	}
 
 	@Override
 	public boolean sendPasswordByUserId(long userId) throws PortalException {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		return userLocalService.sendPasswordByUserId(userId, serviceContext);
+		return userLocalService.sendPasswordByUserId(userId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -1034,14 +1034,11 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 	}
 
 	@Override
-	public boolean sendPasswordByUserId(long companyId, long userId)
-		throws PortalException {
-
+	public boolean sendPasswordByUserId(long userId) throws PortalException {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		return userLocalService.sendPasswordByUserId(
-			companyId, userId, serviceContext);
+		return userLocalService.sendPasswordByUserId(userId, serviceContext);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -1012,26 +1012,33 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 
 	@Override
 	public boolean sendPasswordByEmailAddress(
-			long companyId, String emailAddress, ServiceContext serviceContext)
+			long companyId, String emailAddress)
 		throws PortalException {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
 
 		return userLocalService.sendPasswordByEmailAddress(
 			companyId, emailAddress, serviceContext);
 	}
 
 	@Override
-	public boolean sendPasswordByScreenName(
-			long companyId, String screenName, ServiceContext serviceContext)
+	public boolean sendPasswordByScreenName(long companyId, String screenName)
 		throws PortalException {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
 
 		return userLocalService.sendPasswordByScreenName(
 			companyId, screenName, serviceContext);
 	}
 
 	@Override
-	public boolean sendPasswordByUserId(
-			long companyId, long userId, ServiceContext serviceContext)
+	public boolean sendPasswordByUserId(long companyId, long userId)
 		throws PortalException {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
 
 		return userLocalService.sendPasswordByUserId(
 			companyId, userId, serviceContext);

--- a/portal-service/src/com/liferay/portal/service/UserLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalService.java
@@ -1990,17 +1990,14 @@ public interface UserLocalService extends BaseLocalService,
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public boolean sendPasswordByEmailAddress(long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String emailAddress)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public boolean sendPasswordByScreenName(long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String screenName)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
-	public boolean sendPasswordByUserId(long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
+	public boolean sendPasswordByUserId(long userId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalServiceUtil.java
@@ -2317,28 +2317,20 @@ public class UserLocalServiceUtil {
 	}
 
 	public static boolean sendPasswordByEmailAddress(long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String emailAddress)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .sendPasswordByEmailAddress(companyId, emailAddress,
-			serviceContext);
+		return getService().sendPasswordByEmailAddress(companyId, emailAddress);
 	}
 
 	public static boolean sendPasswordByScreenName(long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String screenName)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .sendPasswordByScreenName(companyId, screenName,
-			serviceContext);
+		return getService().sendPasswordByScreenName(companyId, screenName);
 	}
 
-	public static boolean sendPasswordByUserId(long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
+	public static boolean sendPasswordByUserId(long userId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .sendPasswordByUserId(companyId, userId, serviceContext);
+		return getService().sendPasswordByUserId(userId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/UserLocalServiceWrapper.java
@@ -2459,28 +2459,23 @@ public class UserLocalServiceWrapper implements UserLocalService,
 
 	@Override
 	public boolean sendPasswordByEmailAddress(long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String emailAddress)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _userLocalService.sendPasswordByEmailAddress(companyId,
-			emailAddress, serviceContext);
+			emailAddress);
 	}
 
 	@Override
 	public boolean sendPasswordByScreenName(long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String screenName)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userLocalService.sendPasswordByScreenName(companyId,
-			screenName, serviceContext);
+		return _userLocalService.sendPasswordByScreenName(companyId, screenName);
 	}
 
 	@Override
-	public boolean sendPasswordByUserId(long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
+	public boolean sendPasswordByUserId(long userId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userLocalService.sendPasswordByUserId(companyId, userId,
-			serviceContext);
+		return _userLocalService.sendPasswordByUserId(userId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserService.java
+++ b/portal-service/src/com/liferay/portal/service/UserService.java
@@ -629,17 +629,14 @@ public interface UserService extends BaseService {
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public boolean sendPasswordByEmailAddress(long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String emailAddress)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public boolean sendPasswordByScreenName(long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String screenName)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
-	public boolean sendPasswordByUserId(long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
+	public boolean sendPasswordByUserId(long userId)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/UserServiceUtil.java
@@ -692,28 +692,20 @@ public class UserServiceUtil {
 	}
 
 	public static boolean sendPasswordByEmailAddress(long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String emailAddress)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .sendPasswordByEmailAddress(companyId, emailAddress,
-			serviceContext);
+		return getService().sendPasswordByEmailAddress(companyId, emailAddress);
 	}
 
 	public static boolean sendPasswordByScreenName(long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String screenName)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .sendPasswordByScreenName(companyId, screenName,
-			serviceContext);
+		return getService().sendPasswordByScreenName(companyId, screenName);
 	}
 
-	public static boolean sendPasswordByUserId(long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
+	public static boolean sendPasswordByUserId(long userId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .sendPasswordByUserId(companyId, userId, serviceContext);
+		return getService().sendPasswordByUserId(userId);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/service/UserServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/UserServiceWrapper.java
@@ -709,28 +709,22 @@ public class UserServiceWrapper implements UserService,
 
 	@Override
 	public boolean sendPasswordByEmailAddress(long companyId,
-		java.lang.String emailAddress,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String emailAddress)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userService.sendPasswordByEmailAddress(companyId, emailAddress,
-			serviceContext);
+		return _userService.sendPasswordByEmailAddress(companyId, emailAddress);
 	}
 
 	@Override
 	public boolean sendPasswordByScreenName(long companyId,
-		java.lang.String screenName,
-		com.liferay.portal.service.ServiceContext serviceContext)
+		java.lang.String screenName)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userService.sendPasswordByScreenName(companyId, screenName,
-			serviceContext);
+		return _userService.sendPasswordByScreenName(companyId, screenName);
 	}
 
 	@Override
-	public boolean sendPasswordByUserId(long companyId, long userId,
-		com.liferay.portal.service.ServiceContext serviceContext)
+	public boolean sendPasswordByUserId(long userId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		return _userService.sendPasswordByUserId(companyId, userId,
-			serviceContext);
+		return _userService.sendPasswordByUserId(userId);
 	}
 
 	/**


### PR DESCRIPTION
@brianchandotcom besides the email from @jorge.ferrer I'd like to note (cc @igorspasic-liferay):
- Remote services are not (or should not be) local services + security. Remote services are intended to be called from remote clients, so all adaptation for that aim should be done there (security check could be one of the adaptations, but others like change the signature is needed too). If we want to improve our remote API, we have to break this imposed constraint (consistency is not above aim, right?).
  - As a nice side effect, our local API would look like a real API: we could have domain-objects or model-objects in the signature. We could pass Company, User... full objects instead of companyId, userId plain ids... saving a lot of db calls and reducing the complex of the methods signature.
- We're mixing several concepts inside ServiceContext: first one is InvocationContext as Jorge said (the metadata to answer "where does this request come from?"). Others are Security/UserContext (all metadata for authenticated user), Page/SiteContext (where page/site, if any, is the source of the request?). We should split each concept in a separated entity/class/bean

Hope it's clear enough!
