### PR TITLE
LPS-47088

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletExporter.java
@@ -172,18 +172,6 @@ public class PortletExporter {
 			return;
 		}
 
-		long lastPublishDate = GetterUtil.getLong(
-			jxPortletPreferences.getValue(
-				"last-publish-date", StringPool.BLANK));
-
-		Date startDate = portletDataContext.getStartDate();
-
-		if ((lastPublishDate > 0) && (startDate != null) &&
-			(lastPublishDate < startDate.getTime())) {
-
-			portletDataContext.setStartDate(new Date(lastPublishDate));
-		}
-
 		String data = null;
 
 		long groupId = portletDataContext.getGroupId();
@@ -204,7 +192,6 @@ public class PortletExporter {
 		}
 		finally {
 			portletDataContext.setGroupId(groupId);
-			portletDataContext.setStartDate(startDate);
 		}
 
 		if (Validator.isNull(data)) {


### PR DESCRIPTION
Hi Brian,

these lines were part of an old fix which tried to prevent to create "holes" in the publish history, but it also causes problems with explicit time frames selected by the publisher. In this first step we remove this old logic, and as a next step we are planning a bigger change to make staging time handling/selection more obvious and robust.

thanks,
Daniel
