### PR TITLE
LPS-49081

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -33,6 +33,8 @@ import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.lar.StagedModelType;
 import com.liferay.portal.kernel.lar.UserIdStrategy;
 import com.liferay.portal.kernel.lar.xstream.XStreamAliasRegistryUtil;
+import com.liferay.portal.kernel.lar.xstream.XStreamConverter;
+import com.liferay.portal.kernel.lar.xstream.XStreamConverterRegistryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -52,6 +54,7 @@ import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
 import com.liferay.portal.kernel.zip.ZipReader;
 import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.lar.xstream.ConverterAdaptor;
 import com.liferay.portal.model.AttachedModel;
 import com.liferay.portal.model.AuditedModel;
 import com.liferay.portal.model.ClassedModel;
@@ -2394,6 +2397,15 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 		for (Map.Entry<Class<?>, String> alias : aliases.entrySet()) {
 			_xStream.alias(alias.getValue(), alias.getKey());
+		}
+
+		Set<XStreamConverter> xStreamConverters =
+			XStreamConverterRegistryUtil.getConverters();
+
+		for (XStreamConverter xStreamConverter : xStreamConverters) {
+			_xStream.registerConverter(
+				new ConverterAdaptor(xStreamConverter),
+				XStream.PRIORITY_VERY_HIGH);
 		}
 
 		_xStream.omitField(HashMap.class, "cache_bitmask");

--- a/portal-impl/src/com/liferay/portal/lar/xstream/ConverterAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/ConverterAdaptor.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.xstream;
+
+import com.liferay.portal.kernel.lar.xstream.XStreamConverter;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * @author Daniel Kocsis
+ */
+public class ConverterAdaptor implements Converter {
+
+	public ConverterAdaptor(XStreamConverter xStreamConverter) {
+		_xStreamConverter = xStreamConverter;
+	}
+
+	@Override
+	public boolean canConvert(Class clazz) {
+		return _xStreamConverter.canConvert(clazz);
+	}
+
+	@Override
+	public void marshal(
+		Object object, HierarchicalStreamWriter hierarchicalStreamWriter,
+		MarshallingContext marshallingContext) {
+
+		try {
+			_xStreamConverter.marshal(
+				object,
+				new XStreamHierarchicalStreamWriterAdaptor(
+					hierarchicalStreamWriter),
+				new XStreamMarshallingContextAdaptor(marshallingContext));
+		}
+		catch (Exception e) {
+			_log.error("Unable to marshal object", e);
+		}
+	}
+
+	@Override
+	public Object unmarshal(
+		HierarchicalStreamReader hierarchicalStreamReader,
+		UnmarshallingContext unmarshallingContext) {
+
+		try {
+			return _xStreamConverter.unmarshal(
+				new XStreamHierarchicalStreamReaderAdaptor(
+					hierarchicalStreamReader),
+				new XStreamUnmarshallingContextAdaptor(unmarshallingContext));
+		}
+		catch (Exception e) {
+			_log.error("Unable to un-marshal object", e);
+
+			return null;
+		}
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(ConverterAdaptor.class);
+
+	private XStreamConverter _xStreamConverter;
+
+}

--- a/portal-impl/src/com/liferay/portal/lar/xstream/XStreamHierarchicalStreamReaderAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/XStreamHierarchicalStreamReaderAdaptor.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.xstream;
+
+import com.liferay.portal.kernel.lar.xstream.XStreamHierarchicalStreamReader;
+
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+
+import java.util.Iterator;
+
+/**
+ * @author Daniel Kocsis
+ */
+public class XStreamHierarchicalStreamReaderAdaptor
+	implements XStreamHierarchicalStreamReader {
+
+	public XStreamHierarchicalStreamReaderAdaptor(
+		HierarchicalStreamReader hierarchicalStreamReader) {
+
+		_hierarchicalStreamReader = hierarchicalStreamReader;
+	}
+
+	@Override
+	public void close() {
+		_hierarchicalStreamReader.close();
+	}
+
+	@Override
+	public String getAttribute(int index) {
+		return _hierarchicalStreamReader.getAttribute(index);
+	}
+
+	@Override
+	public String getAttribute(String name) {
+		return _hierarchicalStreamReader.getAttribute(name);
+	}
+
+	@Override
+	public int getAttributeCount() {
+		return _hierarchicalStreamReader.getAttributeCount();
+	}
+
+	@Override
+	public String getAttributeName(int index) {
+		return _hierarchicalStreamReader.getAttributeName(index);
+	}
+
+	@Override
+	public Iterator getAttributeNames() {
+		return _hierarchicalStreamReader.getAttributeNames();
+	}
+
+	@Override
+	public String getNodeName() {
+		return _hierarchicalStreamReader.getNodeName();
+	}
+
+	@Override
+	public String getValue() {
+		return _hierarchicalStreamReader.getValue();
+	}
+
+	@Override
+	public boolean hasMoreChildren() {
+		return _hierarchicalStreamReader.hasMoreChildren();
+	}
+
+	@Override
+	public void moveDown() {
+		_hierarchicalStreamReader.moveDown();
+	}
+
+	@Override
+	public void moveUp() {
+		_hierarchicalStreamReader.moveUp();
+	}
+
+	@Override
+	public XStreamHierarchicalStreamReader underlyingReader() {
+		return new XStreamHierarchicalStreamReaderAdaptor(
+			_hierarchicalStreamReader.underlyingReader());
+	}
+
+	private HierarchicalStreamReader _hierarchicalStreamReader;
+
+}

--- a/portal-impl/src/com/liferay/portal/lar/xstream/XStreamHierarchicalStreamWriterAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/XStreamHierarchicalStreamWriterAdaptor.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.xstream;
+
+import com.liferay.portal.kernel.lar.xstream.XStreamHierarchicalStreamWriter;
+
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * @author Daniel Kocsis
+ */
+class XStreamHierarchicalStreamWriterAdaptor
+	implements XStreamHierarchicalStreamWriter {
+
+	public XStreamHierarchicalStreamWriterAdaptor(
+		HierarchicalStreamWriter hierarchicalStreamWriter) {
+
+		_hierarchicalStreamWriter = hierarchicalStreamWriter;
+	}
+
+	public void startNode(String name) {
+		_hierarchicalStreamWriter.startNode(name);
+	}
+
+	public void addAttribute(String key, String value) {
+		_hierarchicalStreamWriter.addAttribute(key, value);
+	}
+
+	public void setValue(String text) {
+		_hierarchicalStreamWriter.setValue(text);
+	}
+
+	public void endNode() {
+		_hierarchicalStreamWriter.endNode();
+	}
+
+	public void flush() {
+		_hierarchicalStreamWriter.flush();
+	}
+
+	public void close() {
+		_hierarchicalStreamWriter.close();
+	}
+
+	public XStreamHierarchicalStreamWriterAdaptor underlyingWriter() {
+		return new XStreamHierarchicalStreamWriterAdaptor(
+			_hierarchicalStreamWriter.underlyingWriter());
+	}
+
+	private HierarchicalStreamWriter _hierarchicalStreamWriter;
+
+}

--- a/portal-impl/src/com/liferay/portal/lar/xstream/XStreamHierarchicalStreamWriterAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/XStreamHierarchicalStreamWriterAdaptor.java
@@ -38,8 +38,8 @@ class XStreamHierarchicalStreamWriterAdaptor
 		_hierarchicalStreamWriter.addAttribute(key, value);
 	}
 
-	public void setValue(String text) {
-		_hierarchicalStreamWriter.setValue(text);
+	public void setValue(String value) {
+		_hierarchicalStreamWriter.setValue(value);
 	}
 
 	public void endNode() {

--- a/portal-impl/src/com/liferay/portal/lar/xstream/XStreamMarshallingContextAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/XStreamMarshallingContextAdaptor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.xstream;
+
+import com.liferay.portal.kernel.lar.xstream.XStreamConverter;
+import com.liferay.portal.kernel.lar.xstream.XStreamMarshallingContext;
+
+import com.thoughtworks.xstream.converters.MarshallingContext;
+
+import java.util.Iterator;
+
+/**
+ * @author Daniel Kocsis
+ */
+public class XStreamMarshallingContextAdaptor
+	implements XStreamMarshallingContext {
+
+	public XStreamMarshallingContextAdaptor(
+		MarshallingContext marshallingContext) {
+
+		_marshallingContext = marshallingContext;
+	}
+
+	public void convertAnother(Object nextItem) {
+		_marshallingContext.convertAnother(nextItem);
+	}
+
+	public void convertAnother(
+		Object nextItem, XStreamConverter xStreamConverter) {
+
+		_marshallingContext.convertAnother(
+			nextItem, new ConverterAdaptor(xStreamConverter));
+	}
+
+	public Object get(Object key) {
+		return _marshallingContext.get(key);
+	}
+
+	public Iterator keys() {
+		return _marshallingContext.keys();
+	}
+
+	public void put(Object key, Object value) {
+		_marshallingContext.put(key, value);
+	}
+
+	private MarshallingContext _marshallingContext;
+
+}

--- a/portal-impl/src/com/liferay/portal/lar/xstream/XStreamMarshallingContextAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/XStreamMarshallingContextAdaptor.java
@@ -33,15 +33,15 @@ public class XStreamMarshallingContextAdaptor
 		_marshallingContext = marshallingContext;
 	}
 
-	public void convertAnother(Object nextItem) {
-		_marshallingContext.convertAnother(nextItem);
+	public void convertAnother(Object object) {
+		_marshallingContext.convertAnother(object);
 	}
 
 	public void convertAnother(
-		Object nextItem, XStreamConverter xStreamConverter) {
+		Object object, XStreamConverter xStreamConverter) {
 
 		_marshallingContext.convertAnother(
-			nextItem, new ConverterAdaptor(xStreamConverter));
+			object, new ConverterAdaptor(xStreamConverter));
 	}
 
 	public Object get(Object key) {

--- a/portal-impl/src/com/liferay/portal/lar/xstream/XStreamUnmarshallingContextAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/XStreamUnmarshallingContextAdaptor.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.xstream;
+
+import com.liferay.portal.kernel.lar.xstream.XStreamConverter;
+import com.liferay.portal.kernel.lar.xstream.XStreamUnmarshallingContext;
+
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+
+/**
+ * @author Daniel Kocsis
+ */
+public class XStreamUnmarshallingContextAdaptor
+	implements XStreamUnmarshallingContext {
+
+	public XStreamUnmarshallingContextAdaptor(
+		UnmarshallingContext unmarshallingContext) {
+
+		_unmarshallingContext = unmarshallingContext;
+	}
+
+	@Override
+	public void addCompletionCallback(Runnable work, int priority) {
+		_unmarshallingContext.addCompletionCallback(work, priority);
+	}
+
+	@Override
+	public Object convertAnother(Object current, Class type) {
+		return _unmarshallingContext.convertAnother(current, type);
+	}
+
+	@Override
+	public Object convertAnother(
+		Object current, Class type, XStreamConverter converter) {
+
+		return _unmarshallingContext.convertAnother(
+			current, type, new ConverterAdaptor(converter));
+	}
+
+	@Override
+	public Object currentObject() {
+		return _unmarshallingContext.currentObject();
+	}
+
+	@Override
+	public Object getRequiredType() {
+		return _unmarshallingContext.getRequiredType();
+	}
+
+	private UnmarshallingContext _unmarshallingContext;
+
+}

--- a/portal-impl/src/com/liferay/portal/lar/xstream/XStreamUnmarshallingContextAdaptor.java
+++ b/portal-impl/src/com/liferay/portal/lar/xstream/XStreamUnmarshallingContextAdaptor.java
@@ -37,16 +37,16 @@ public class XStreamUnmarshallingContextAdaptor
 	}
 
 	@Override
-	public Object convertAnother(Object current, Class type) {
-		return _unmarshallingContext.convertAnother(current, type);
+	public Object convertAnother(Object object, Class clazz) {
+		return _unmarshallingContext.convertAnother(object, clazz);
 	}
 
 	@Override
 	public Object convertAnother(
-		Object current, Class type, XStreamConverter converter) {
+		Object object, Class clazz, XStreamConverter xStreamConverter) {
 
 		return _unmarshallingContext.convertAnother(
-			current, type, new ConverterAdaptor(converter));
+			object, clazz, new ConverterAdaptor(xStreamConverter));
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverter.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+/**
+ * @author Daniel Kocsis
+ */
+public interface XStreamConverter {
+
+	public boolean canConvert(Class clazz);
+
+	public void marshal(
+			Object model, XStreamHierarchicalStreamWriter writer,
+			XStreamMarshallingContext context)
+		throws Exception;
+
+	public Object unmarshal(
+			XStreamHierarchicalStreamReader reader,
+			XStreamUnmarshallingContext context)
+		throws Exception;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverter.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverter.java
@@ -22,13 +22,13 @@ public interface XStreamConverter {
 	public boolean canConvert(Class clazz);
 
 	public void marshal(
-			Object model, XStreamHierarchicalStreamWriter writer,
-			XStreamMarshallingContext context)
+			Object object, XStreamHierarchicalStreamWriter writer,
+			XStreamMarshallingContext mashallingContext)
 		throws Exception;
 
 	public Object unmarshal(
 			XStreamHierarchicalStreamReader reader,
-			XStreamUnmarshallingContext context)
+			XStreamUnmarshallingContext unmarshallingContext)
 		throws Exception;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverterRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverterRegistryUtil.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceReference;
+import com.liferay.registry.ServiceRegistration;
+import com.liferay.registry.ServiceTracker;
+import com.liferay.registry.ServiceTrackerCustomizer;
+import com.liferay.registry.collections.ServiceRegistrationMap;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Daniel Kocsis
+ */
+public class XStreamConverterRegistryUtil {
+
+	public static Set<XStreamConverter> getConverters() {
+		return _instance._getConverters();
+	}
+
+	public static void register(XStreamConverter xStreamConverter) {
+		_instance._register(xStreamConverter);
+	}
+
+	public static void unregister(XStreamConverter xStreamConverter) {
+		_instance._unregister(xStreamConverter);
+	}
+
+	private XStreamConverterRegistryUtil() {
+		Registry registry = RegistryUtil.getRegistry();
+
+		_serviceTracker = registry.trackServices(
+			XStreamConverter.class,
+			new XStreamConverterServiceTrackerCustomizer());
+
+		_serviceTracker.open();
+	}
+
+	private Set<XStreamConverter> _getConverters() {
+		return _xStreamConverters;
+	}
+
+	private void _register(XStreamConverter xStreamConverter) {
+		Registry registry = RegistryUtil.getRegistry();
+
+		ServiceRegistration<XStreamConverter> serviceRegistration =
+			registry.registerService(XStreamConverter.class, xStreamConverter);
+
+		_serviceRegistrations.put(xStreamConverter, serviceRegistration);
+	}
+
+	private void _unregister(XStreamConverter xStreamConverter) {
+		ServiceRegistration<XStreamConverter> serviceRegistration =
+			_serviceRegistrations.remove(xStreamConverter);
+
+		if (serviceRegistration != null) {
+			serviceRegistration.unregister();
+		}
+	}
+
+	private static XStreamConverterRegistryUtil _instance =
+		new XStreamConverterRegistryUtil();
+
+	private ServiceRegistrationMap<XStreamConverter> _serviceRegistrations =
+		new ServiceRegistrationMap<XStreamConverter>();
+	private ServiceTracker <XStreamConverter, XStreamConverter> _serviceTracker;
+	private Set<XStreamConverter> _xStreamConverters =
+		new HashSet<XStreamConverter>();
+
+	private class XStreamConverterServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<XStreamConverter, XStreamConverter> {
+
+		@Override
+		public XStreamConverter addingService(
+			ServiceReference<XStreamConverter> serviceReference) {
+
+			Registry registry = RegistryUtil.getRegistry();
+
+			XStreamConverter xStreamConverter = registry.getService(
+				serviceReference);
+
+			_xStreamConverters.add(xStreamConverter);
+
+			return xStreamConverter;
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<XStreamConverter> serviceReference,
+			XStreamConverter xStreamConverter) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<XStreamConverter> serviceReference,
+			XStreamConverter xStreamConverter) {
+
+			Registry registry = RegistryUtil.getRegistry();
+
+			registry.ungetService(serviceReference);
+
+			_xStreamConverters.remove(xStreamConverter);
+		}
+
+	}
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamHierarchicalStreamReader.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamHierarchicalStreamReader.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+import java.util.Iterator;
+
+/**
+ * @author Daniel Kocsis
+ */
+public interface XStreamHierarchicalStreamReader {
+
+	public void close();
+
+	public String getAttribute(int index);
+
+	public String getAttribute(String name);
+
+	public int getAttributeCount();
+
+	public String getAttributeName(int index);
+
+	public Iterator getAttributeNames();
+
+	public String getNodeName();
+
+	public String getValue();
+
+	public boolean hasMoreChildren();
+
+	public void moveDown();
+
+	public void moveUp();
+
+	public XStreamHierarchicalStreamReader underlyingReader();
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamHierarchicalStreamWriter.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamHierarchicalStreamWriter.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+/**
+ * @author Daniel Kocsis
+ */
+public interface XStreamHierarchicalStreamWriter {
+
+	public void addAttribute(String key, String value);
+
+	public void close();
+
+	public void endNode();
+
+	public void flush();
+
+	public void setValue(String text);
+
+	public void startNode(String name);
+
+	public XStreamHierarchicalStreamWriter underlyingWriter();
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamHierarchicalStreamWriter.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamHierarchicalStreamWriter.java
@@ -27,7 +27,7 @@ public interface XStreamHierarchicalStreamWriter {
 
 	public void flush();
 
-	public void setValue(String text);
+	public void setValue(String value);
 
 	public void startNode(String name);
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamMarshallingContext.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamMarshallingContext.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+import java.util.Iterator;
+
+/**
+ * @author Daniel Kocsis
+ */
+public interface XStreamMarshallingContext {
+
+	public void convertAnother(Object nextItem);
+
+	public void convertAnother(
+		Object nextItem, XStreamConverter xStreamConverter);
+
+	public Object get(Object key);
+
+	public Iterator keys();
+
+	public void put(Object key, Object value);
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamMarshallingContext.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamMarshallingContext.java
@@ -21,10 +21,10 @@ import java.util.Iterator;
  */
 public interface XStreamMarshallingContext {
 
-	public void convertAnother(Object nextItem);
+	public void convertAnother(Object object);
 
 	public void convertAnother(
-		Object nextItem, XStreamConverter xStreamConverter);
+		Object object, XStreamConverter xStreamConverter);
 
 	public Object get(Object key);
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamUnmarshallingContext.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamUnmarshallingContext.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+/**
+ * @author Daniel Kocsis
+ */
+public interface XStreamUnmarshallingContext {
+
+	public Object convertAnother(Object current, Class type);
+
+	public Object convertAnother(
+		Object current, Class type, XStreamConverter converter);
+
+	Object currentObject();
+
+	Object getRequiredType();
+
+	void addCompletionCallback(Runnable runnable, int i);
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamUnmarshallingContext.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamUnmarshallingContext.java
@@ -19,10 +19,10 @@ package com.liferay.portal.kernel.lar.xstream;
  */
 public interface XStreamUnmarshallingContext {
 
-	public Object convertAnother(Object current, Class type);
+	public Object convertAnother(Object object, Class clazz);
 
 	public Object convertAnother(
-		Object current, Class type, XStreamConverter converter);
+		Object object, Class clazz, XStreamConverter xStreamConverter);
 
 	Object currentObject();
 


### PR DESCRIPTION
Hey Brian,

This is an other set of changes for customizing the XStream library from our portlet data handlers. This time it's about XStream converters. We would need a custom converter for DL to properly handle the different repository information export/import.

This change is providing a framework for this, using the adapter pattern for the XStream converter, to meet the  modular requirements. Also it is providing a registry so the coders can register their own converters.
We needed a "two way adapter" since we wanted to provide an interface for the developers to implement, but we needed a backwards adapter to be able to "feed" the custom ones to the XStream itself.

We will send the apply in a different pull request, we wanted to push the framework first to master.

Thanks,

Máté
