### PR TITLE
LPS-46754 Custom DL converters for staging

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/DLPortletDataHandler.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.lar.PortletDataHandlerControl;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.lar.StagedModelType;
 import com.liferay.portal.kernel.lar.xstream.XStreamAliasRegistryUtil;
+import com.liferay.portal.kernel.lar.xstream.XStreamConverterRegistryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -48,6 +49,9 @@ import com.liferay.portal.repository.liferayrepository.LiferayRepository;
 import com.liferay.portal.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.documentlibrary.lar.xstream.FileEntryConverter;
+import com.liferay.portlet.documentlibrary.lar.xstream.FileVersionConverter;
+import com.liferay.portlet.documentlibrary.lar.xstream.FolderConverter;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryType;
@@ -124,6 +128,10 @@ public class DLPortletDataHandler extends BasePortletDataHandler {
 		XStreamAliasRegistryUtil.register(RepositoryImpl.class, "Repository");
 		XStreamAliasRegistryUtil.register(
 			RepositoryEntryImpl.class, "RepositoryEntry");
+
+		XStreamConverterRegistryUtil.register(new FileEntryConverter());
+		XStreamConverterRegistryUtil.register(new FileVersionConverter());
+		XStreamConverterRegistryUtil.register(new FolderConverter());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FieldConstants.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FieldConstants.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.lar.xstream;
+
+/**
+ * @author Akos Thurzo
+ */
+public interface FieldConstants {
+
+	public static final String CHANGE_LOG = "changeLog";
+
+	public static final String COMPANY_ID = "companyId";
+
+	public static final String CREATE_DATE = "createDate";
+
+	public static final String DESCRIPTION = "description";
+
+	public static final String ESCAPED_MODEL = "escapedModel";
+
+	public static final String EXTENSION = "extension";
+
+	public static final String EXTRA_SETTINGS = "extraSettings";
+
+	public static final String FILE_ENTRY_ID = "fileEntryId";
+
+	public static final String FILE_VERSION = "fileVersion";
+
+	public static final String FILE_VERSION_ID = "fileVersionId";
+
+	public static final String FOLDER_ID = "folderId";
+
+	public static final String GROUP_ID = "groupId";
+
+	public static final String LAST_POST_DATE = "lastPostDate";
+
+	public static final String MANUAL_CHECK_IN_REQUIRED =
+		"manualCheckInRequired";
+
+	public static final String MIME_TYPE = "mimeType";
+
+	public static final String MODIFIED_DATE = "modifiedDate";
+
+	public static final String MOUNT_POINT = "mountPoint";
+
+	public static final String NAME = "name";
+
+	public static final String PARENT_FOLDER_ID = "parentFolderId";
+
+	public static final String READ_COUNT = "readCount";
+
+	public static final String REPOSITORY_ID = "repositoryId";
+
+	public static final String SIZE = "size";
+
+	public static final String STATUS = "status";
+
+	public static final String STATUS_BY_USER_ID = "statusByUserId";
+
+	public static final String STATUS_BY_USER_NAME = "statusByUserName";
+
+	public static final String STATUS_DATE = "statusDate";
+
+	public static final String TITLE = "title";
+
+	public static final String USER_ID = "userId";
+
+	public static final String USER_NAME = "userName";
+
+	public static final String USER_UUID = "userUuid";
+
+	public static final String UUID = "uuid";
+
+	public static final String VERSION = "version";
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FileEntryConverter.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FileEntryConverter.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.lar.xstream;
+
+import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+import com.liferay.portal.kernel.lar.xstream.BaseXStreamConverter;
+import com.liferay.portal.kernel.lar.xstream.XStreamHierarchicalStreamReader;
+import com.liferay.portal.kernel.lar.xstream.XStreamUnmarshallingContext;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
+import com.liferay.portal.repository.proxy.FileEntryProxyBean;
+import com.liferay.portal.repository.proxy.FileVersionProxyBean;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.model.impl.DLFileEntryImpl;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author Akos Thurzo
+ */
+public class FileEntryConverter extends BaseXStreamConverter {
+
+	@Override
+	public boolean canConvert(Class<?> clazz) {
+		return clazz.equals(FileEntryProxyBean.class);
+	}
+
+	@Override
+	public Object unmarshal(
+			XStreamHierarchicalStreamReader reader,
+			XStreamUnmarshallingContext unmarshallingContext)
+		throws Exception {
+
+		DLFileEntry dlFileEntry = new DLFileEntryImpl();
+
+		LiferayFileVersion liferayFileVersion = null;
+
+		boolean escapedModel = false;
+
+		while (reader.hasMoreChildren()) {
+			reader.moveDown();
+
+			String nodeName = reader.getNodeName();
+
+			Class<?> clazz = BeanPropertiesUtil.getObjectType(
+				dlFileEntry, nodeName);
+
+			if (nodeName.equals(FieldConstants.FILE_VERSION)) {
+				clazz = FileVersionProxyBean.class;
+			}
+
+			Object convertedValue = unmarshallingContext.convertAnother(
+				reader.getValue(), clazz);
+
+			if (fields.contains(nodeName)) {
+				if (nodeName.equals(FieldConstants.ESCAPED_MODEL)) {
+					escapedModel = (Boolean)convertedValue;
+				}
+				else if (nodeName.equals(FieldConstants.FILE_VERSION)) {
+					liferayFileVersion = (LiferayFileVersion)convertedValue;
+				}
+				else {
+					BeanPropertiesUtil.setProperty(
+						dlFileEntry, nodeName, convertedValue);
+				}
+			}
+
+			reader.moveUp();
+		}
+
+		LiferayFileEntry liferayFileEntry = new LiferayFileEntry(
+			dlFileEntry, escapedModel);
+
+		liferayFileEntry.setCachedFileVersion(liferayFileVersion);
+
+		return liferayFileEntry;
+	}
+
+	protected List<String> getFields() {
+		return fields;
+	}
+
+	protected static List<String> fields = new LinkedList<String>();
+
+	static {
+		fields.add(FieldConstants.COMPANY_ID);
+		fields.add(FieldConstants.CREATE_DATE);
+		fields.add(FieldConstants.DESCRIPTION);
+		fields.add(FieldConstants.ESCAPED_MODEL);
+		fields.add(FieldConstants.EXTENSION);
+		fields.add(FieldConstants.FILE_ENTRY_ID);
+		fields.add(FieldConstants.FILE_VERSION);
+		fields.add(FieldConstants.FOLDER_ID);
+		fields.add(FieldConstants.GROUP_ID);
+		fields.add(FieldConstants.MANUAL_CHECK_IN_REQUIRED);
+		fields.add(FieldConstants.MIME_TYPE);
+		fields.add(FieldConstants.MODIFIED_DATE);
+		fields.add(FieldConstants.READ_COUNT);
+		fields.add(FieldConstants.REPOSITORY_ID);
+		fields.add(FieldConstants.SIZE);
+		fields.add(FieldConstants.TITLE);
+		fields.add(FieldConstants.USER_ID);
+		fields.add(FieldConstants.USER_NAME);
+		fields.add(FieldConstants.USER_UUID);
+		fields.add(FieldConstants.UUID);
+		fields.add(FieldConstants.VERSION);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FileVersionConverter.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FileVersionConverter.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.lar.xstream;
+
+import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+import com.liferay.portal.kernel.lar.xstream.BaseXStreamConverter;
+import com.liferay.portal.kernel.lar.xstream.XStreamHierarchicalStreamReader;
+import com.liferay.portal.kernel.lar.xstream.XStreamUnmarshallingContext;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
+import com.liferay.portal.repository.proxy.FileVersionProxyBean;
+import com.liferay.portlet.documentlibrary.model.DLFileVersion;
+import com.liferay.portlet.documentlibrary.model.impl.DLFileVersionImpl;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author Akos Thurzo
+ */
+public class FileVersionConverter extends BaseXStreamConverter {
+
+	@Override
+	public boolean canConvert(Class<?> clazz) {
+		return clazz.equals(FileVersionProxyBean.class);
+	}
+
+	@Override
+	public Object unmarshal(
+			XStreamHierarchicalStreamReader reader,
+			XStreamUnmarshallingContext unmarshallingContext)
+		throws Exception {
+
+		DLFileVersion dlFileVersion = new DLFileVersionImpl();
+
+		boolean escapedModel = false;
+
+		while (reader.hasMoreChildren()) {
+			reader.moveDown();
+
+			String nodeName = reader.getNodeName();
+
+			Class<?> clazz = BeanPropertiesUtil.getObjectType(
+				dlFileVersion, nodeName);
+
+			Object convertedValue = unmarshallingContext.convertAnother(
+				reader.getValue(), clazz);
+
+			if (fields.contains(nodeName)) {
+				if (nodeName.equals(FieldConstants.ESCAPED_MODEL)) {
+					escapedModel = (Boolean)convertedValue;
+				}
+				else {
+					BeanPropertiesUtil.setProperty(
+						dlFileVersion, nodeName, convertedValue);
+				}
+			}
+
+			reader.moveUp();
+		}
+
+		return new LiferayFileVersion(dlFileVersion, escapedModel);
+	}
+
+	protected List<String> getFields() {
+		return fields;
+	}
+
+	protected static List<String> fields = new LinkedList<String>();
+
+	static {
+		fields.add(FieldConstants.CHANGE_LOG);
+		fields.add(FieldConstants.COMPANY_ID);
+		fields.add(FieldConstants.CREATE_DATE);
+		fields.add(FieldConstants.DESCRIPTION);
+		fields.add(FieldConstants.ESCAPED_MODEL);
+		fields.add(FieldConstants.EXTENSION);
+		fields.add(FieldConstants.EXTRA_SETTINGS);
+		fields.add(FieldConstants.FILE_ENTRY_ID);
+		fields.add(FieldConstants.FILE_VERSION_ID);
+		fields.add(FieldConstants.GROUP_ID);
+		fields.add(FieldConstants.MIME_TYPE);
+		fields.add(FieldConstants.MODIFIED_DATE);
+		fields.add(FieldConstants.REPOSITORY_ID);
+		fields.add(FieldConstants.SIZE);
+		fields.add(FieldConstants.STATUS);
+		fields.add(FieldConstants.STATUS_BY_USER_ID);
+		fields.add(FieldConstants.STATUS_BY_USER_NAME);
+		fields.add(FieldConstants.STATUS_DATE);
+		fields.add(FieldConstants.TITLE);
+		fields.add(FieldConstants.USER_ID);
+		fields.add(FieldConstants.USER_NAME);
+		fields.add(FieldConstants.UUID);
+		fields.add(FieldConstants.VERSION);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FolderConverter.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/xstream/FolderConverter.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibrary.lar.xstream;
+
+import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+import com.liferay.portal.kernel.lar.xstream.BaseXStreamConverter;
+import com.liferay.portal.kernel.lar.xstream.XStreamHierarchicalStreamReader;
+import com.liferay.portal.kernel.lar.xstream.XStreamUnmarshallingContext;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFolder;
+import com.liferay.portal.repository.proxy.FolderProxyBean;
+import com.liferay.portlet.documentlibrary.model.DLFolder;
+import com.liferay.portlet.documentlibrary.model.impl.DLFolderImpl;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author Akos Thurzo
+ */
+public class FolderConverter extends BaseXStreamConverter {
+
+	@Override
+	public boolean canConvert(Class<?> clazz) {
+		return clazz.equals(FolderProxyBean.class);
+	}
+
+	@Override
+	public Object unmarshal(
+			XStreamHierarchicalStreamReader reader,
+			XStreamUnmarshallingContext unmarshallingContext)
+		throws Exception {
+
+		DLFolder dlFolder = new DLFolderImpl();
+
+		boolean escapedModel = false;
+
+		while (reader.hasMoreChildren()) {
+			reader.moveDown();
+
+			String nodeName = reader.getNodeName();
+
+			Class<?> clazz = BeanPropertiesUtil.getObjectType(
+				dlFolder, nodeName);
+
+			Object convertedValue = unmarshallingContext.convertAnother(
+				reader.getValue(), clazz);
+
+			if (fields.contains(nodeName)) {
+				if (nodeName.equals(FieldConstants.ESCAPED_MODEL)) {
+					escapedModel = (Boolean)convertedValue;
+				}
+				else {
+					BeanPropertiesUtil.setProperty(
+						dlFolder, nodeName, convertedValue);
+				}
+			}
+
+			reader.moveUp();
+		}
+
+		return new LiferayFolder(dlFolder, escapedModel);
+	}
+
+	protected List<String> getFields() {
+		return fields;
+	}
+
+	protected static List<String> fields = new LinkedList<String>();
+
+	static {
+		fields.add(FieldConstants.COMPANY_ID);
+		fields.add(FieldConstants.CREATE_DATE);
+		fields.add(FieldConstants.DESCRIPTION);
+		fields.add(FieldConstants.ESCAPED_MODEL);
+		fields.add(FieldConstants.FOLDER_ID);
+		fields.add(FieldConstants.GROUP_ID);
+		fields.add(FieldConstants.LAST_POST_DATE);
+		fields.add(FieldConstants.MODIFIED_DATE);
+		fields.add(FieldConstants.MOUNT_POINT);
+		fields.add(FieldConstants.NAME);
+		fields.add(FieldConstants.PARENT_FOLDER_ID);
+		fields.add(FieldConstants.REPOSITORY_ID);
+		fields.add(FieldConstants.USER_ID);
+		fields.add(FieldConstants.USER_NAME);
+		fields.add(FieldConstants.USER_UUID);
+		fields.add(FieldConstants.UUID);
+	}
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/BaseXStreamConverter.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/BaseXStreamConverter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.lar.xstream;
+
+import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+
+import java.util.List;
+
+/**
+ * @author Akos Thurzo
+ */
+public abstract class BaseXStreamConverter implements XStreamConverter {
+
+	@Override
+	public abstract boolean canConvert(Class<?> clazz);
+
+	@Override
+	public void marshal(
+			Object object, XStreamHierarchicalStreamWriter writer,
+			XStreamMarshallingContext marshallingContext)
+		throws Exception {
+
+		for (String field : getFields()) {
+			writer.startNode(field);
+
+			Object value = BeanPropertiesUtil.getObject(object, field);
+
+			if (value != null) {
+				marshallingContext.convertAnother(value);
+			}
+
+			writer.endNode();
+		}
+	}
+
+	@Override
+	public abstract Object unmarshal(
+			XStreamHierarchicalStreamReader reader,
+			XStreamUnmarshallingContext unmarshallingContext)
+		throws Exception;
+
+	protected abstract List<String> getFields();
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverter.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/xstream/XStreamConverter.java
@@ -23,7 +23,7 @@ public interface XStreamConverter {
 
 	public void marshal(
 			Object object, XStreamHierarchicalStreamWriter writer,
-			XStreamMarshallingContext mashallingContext)
+			XStreamMarshallingContext marshallingContext)
 		throws Exception;
 
 	public Object unmarshal(


### PR DESCRIPTION
Hey Brian,

We have recently sent you the adapter for the XStream converters and this pull request contains the actual custom converters for DL.

In some cases (eg. Documentum hook) the file entries are being handled with a proxy object. This caused serialization issues during an export and import (the classloader was serialized, or a documentum specific class, etc). @akosthurzo implemented the solution which was to create custom converters for specific entities. The XStream takes these registered converters and uses them to serialize certain objects (depending on the canConvert method's return value).

While this has been introduced to fix a bug for DL export/import we took to opportunity and provide a framework for developers in case they want to leverage this later on, and Ákos built his solution on the top of this in collaboration with me.

Thanks,

Máté

cc: @sergiogonzalez
