### PR TITLE
LPS-49298 Dont print stack trace unless DEBUG is turned on

### DIFF
--- a/portal-impl/src/com/liferay/portal/poller/PollerServlet.java
+++ b/portal-impl/src/com/liferay/portal/poller/PollerServlet.java
@@ -60,7 +60,7 @@ public class PollerServlet extends HttpServlet {
 			}
 		}
 		catch (Exception e) {
-			_log.error(e, e);
+			_log.error(e.getMessage());
 
 			PortalUtil.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e, request,

--- a/portal-web/docroot/html/portal/status.jsp
+++ b/portal-web/docroot/html/portal/status.jsp
@@ -125,7 +125,11 @@ if (Validator.isNotNull(exception)) {
 			if (value instanceof Exception) {
 				Exception e = (Exception)value;
 
-				_log.error(e, e);
+				_log.error(e.getMessage());
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(e, e);
+				}
 			}
 		}
 		%>


### PR DESCRIPTION
@jonathanmccann this is good but I discovered from Nate that the client can be asked to stop polling by the server when the poller handler has gone away. Can you implement this so that clients don't keep polling a server which can no longer provide responses? thanks
