### PR TITLE
LPS-49294-Constructors

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
@@ -97,6 +97,7 @@ public class PortletImpl extends PortletBaseImpl {
 	 * Constructs a portlet with no parameters.
 	 */
 	public PortletImpl() {
+		this(0, null);
 	}
 
 	/**
@@ -106,36 +107,35 @@ public class PortletImpl extends PortletBaseImpl {
 		setCompanyId(companyId);
 		setPortletId(portletId);
 		setStrutsPath(portletId);
+
 		setActive(true);
-		_indexerClasses = new ArrayList<String>();
-		_schedulerEntries = new ArrayList<SchedulerEntry>();
-		_stagedModelDataHandlerClasses = new ArrayList<String>();
-		_socialActivityInterpreterClasses = new ArrayList<String>();
-		_userNotificationHandlerClasses = new ArrayList<String>();
 		_assetRendererFactoryClasses = new ArrayList<String>();
 		_atomCollectionAdapterClasses = new ArrayList<String>();
-		_customAttributesDisplayClasses = new ArrayList<String>();
-		_trashHandlerClasses = new ArrayList<String>();
-		_workflowHandlerClasses = new ArrayList<String>();
 		_autopropagatedParameters = new LinkedHashSet<String>();
-		_headerPortalCss = new ArrayList<String>();
-		_headerPortletCss = new ArrayList<String>();
-		_headerPortalJavaScript = new ArrayList<String>();
-		_headerPortletJavaScript = new ArrayList<String>();
+		_customAttributesDisplayClasses = new ArrayList<String>();
 		_footerPortalCss = new ArrayList<String>();
-		_footerPortletCss = new ArrayList<String>();
 		_footerPortalJavaScript = new ArrayList<String>();
+		_footerPortletCss = new ArrayList<String>();
 		_footerPortletJavaScript = new ArrayList<String>();
-		_unlinkedRoles = new HashSet<String>();
-		_roleMappers = new LinkedHashMap<String, String>();
+		_headerPortalCss = new ArrayList<String>();
+		_headerPortalJavaScript = new ArrayList<String>();
+		_headerPortletCss = new ArrayList<String>();
+		_headerPortletJavaScript = new ArrayList<String>();
+		_indexerClasses = new ArrayList<String>();
 		_initParams = new HashMap<String, String>();
-		_portletModes = new HashMap<String, Set<String>>();
-		_windowStates = new HashMap<String, Set<String>>();
-		_supportedLocales = new HashSet<String>();
 		_portletFilters = new LinkedHashMap<String, PortletFilter>();
-		_processingEvents = new HashSet<QName>();
-		_publishingEvents = new HashSet<QName>();
-		_publicRenderParameters = new HashSet<PublicRenderParameter>();
+		_portletModes = new HashMap<String, Set<String>>();
+		_roleMappers = new LinkedHashMap<String, String>();
+		_rootPortlet = this;
+		_schedulerEntries = new ArrayList<SchedulerEntry>();
+		_socialActivityInterpreterClasses = new ArrayList<String>();
+		_stagedModelDataHandlerClasses = new ArrayList<String>();
+		_supportedLocales = new HashSet<String>();
+		_trashHandlerClasses = new ArrayList<String>();
+		_unlinkedRoles = new HashSet<String>();
+		_userNotificationHandlerClasses = new ArrayList<String>();
+		_windowStates = new HashMap<String, Set<String>>();
+		_workflowHandlerClasses = new ArrayList<String>();
 	}
 
 	/**
@@ -3943,15 +3943,15 @@ public class PortletImpl extends PortletBaseImpl {
 	}
 
 	/**
+	 * Map of the ready states of all portlets keyed by their root portlet ID.
+	 */
+	private static final Map<String, Boolean> _readyMap =
+		new ConcurrentHashMap<String, Boolean>();
+
+	/**
 	 * Log instance for this class.
 	 */
 	private static Log _log = LogFactoryUtil.getLog(PortletImpl.class);
-
-	/**
-	 * Map of the ready states of all portlets keyed by their root portlet ID.
-	 */
-	private static Map<String, Boolean> _readyMap =
-		new ConcurrentHashMap<String, Boolean>();
 
 	/**
 	 * The action timeout of the portlet.
@@ -4285,25 +4285,25 @@ public class PortletImpl extends PortletBaseImpl {
 	/**
 	 * The supported processing events of the portlet.
 	 */
-	private Set<QName> _processingEvents = new HashSet<QName>();
+	private final Set<QName> _processingEvents = new HashSet<QName>();
 
 	/**
 	 * Map of the supported processing events of the portlet keyed by the QName.
 	 */
-	private Map<String, QName> _processingEventsByQName =
+	private final Map<String, QName> _processingEventsByQName =
 		new HashMap<String, QName>();
 
 	/**
 	 * The supported public render parameters of the portlet.
 	 */
-	private Set<PublicRenderParameter> _publicRenderParameters =
+	private final Set<PublicRenderParameter> _publicRenderParameters =
 		new HashSet<PublicRenderParameter>();
 
 	/**
 	 * Map of the supported public render parameters of the portlet keyed by the
 	 * identifier.
 	 */
-	private Map<String, PublicRenderParameter>
+	private final Map<String, PublicRenderParameter>
 		_publicRenderParametersByIdentifier =
 			new HashMap<String, PublicRenderParameter>();
 
@@ -4311,14 +4311,14 @@ public class PortletImpl extends PortletBaseImpl {
 	 * Map of the supported public render parameters of the portlet keyed by the
 	 * QName.
 	 */
-	private Map<String, PublicRenderParameter>
+	private final Map<String, PublicRenderParameter>
 		_publicRenderParametersByQName =
 			new HashMap<String, PublicRenderParameter>();
 
 	/**
 	 * The supported publishing events of the portlet.
 	 */
-	private Set<QName> _publishingEvents = new HashSet<QName>();
+	private final Set<QName> _publishingEvents = new HashSet<QName>();
 
 	/**
 	 * <code>True</code> if the portlet supports remoting.
@@ -4364,12 +4364,12 @@ public class PortletImpl extends PortletBaseImpl {
 	/**
 	 * The root portlet of this portlet instance.
 	 */
-	private Portlet _rootPortlet = this;
+	private final Portlet _rootPortlet;
 
 	/**
 	 * The scheduler entries of the portlet.
 	 */
-	private List<SchedulerEntry> _schedulerEntries;
+	private final List<SchedulerEntry> _schedulerEntries;
 
 	/**
 	 * <code>True</code> if the portlet supports scoping of data.

--- a/portal-impl/src/com/liferay/portal/parsers/creole/ast/BaseParentableNode.java
+++ b/portal-impl/src/com/liferay/portal/parsers/creole/ast/BaseParentableNode.java
@@ -22,16 +22,15 @@ import java.util.List;
 public abstract class BaseParentableNode extends ASTNode {
 
 	public BaseParentableNode() {
+		this(null, 0);
 	}
 
 	public BaseParentableNode(CollectionNode collectionNode) {
-		if (collectionNode != null) {
-			_collectionNode = collectionNode;
-		}
+		this(collectionNode, 0);
 	}
 
 	public BaseParentableNode(int tokenType) {
-		super(tokenType);
+		this(null, tokenType);
 	}
 
 	public void addChildASTNode(ASTNode astNode) {
@@ -50,6 +49,17 @@ public abstract class BaseParentableNode extends ASTNode {
 		return _collectionNode.size();
 	}
 
-	private CollectionNode _collectionNode = new CollectionNode();
+	protected BaseParentableNode(CollectionNode collectionNode, int tokenType) {
+		super(tokenType);
+
+		if (collectionNode != null) {
+			_collectionNode = collectionNode;
+		}
+		else {
+			_collectionNode = new CollectionNode();
+		}
+	}
+
+	private final CollectionNode _collectionNode;
 
 }

--- a/portal-impl/src/com/liferay/portal/parsers/creole/ast/CollectionNode.java
+++ b/portal-impl/src/com/liferay/portal/parsers/creole/ast/CollectionNode.java
@@ -25,14 +25,15 @@ import java.util.List;
 public class CollectionNode extends ASTNode {
 
 	public CollectionNode() {
+		this(0, null);
 	}
 
 	public CollectionNode(int token) {
-		super(token);
+		this(token, null);
 	}
 
 	public CollectionNode(List<ASTNode> astNodes) {
-		_astNodes = astNodes;
+		this(0, astNodes);
 	}
 
 	@Override
@@ -56,6 +57,17 @@ public class CollectionNode extends ASTNode {
 		return _astNodes.size();
 	}
 
-	private List<ASTNode> _astNodes = new ArrayList<ASTNode>();
+	protected CollectionNode(int token, List<ASTNode> astNodes) {
+		super(token);
+
+		if (astNodes != null) {
+			_astNodes = astNodes;
+		}
+		else {
+			_astNodes = new ArrayList<ASTNode>();
+		}
+	}
+
+	private final List<ASTNode> _astNodes;
 
 }

--- a/portal-impl/src/com/liferay/portal/parsers/creole/ast/ItemNode.java
+++ b/portal-impl/src/com/liferay/portal/parsers/creole/ast/ItemNode.java
@@ -20,17 +20,14 @@ package com.liferay.portal.parsers.creole.ast;
 public abstract class ItemNode extends BaseParentableNode {
 
 	public ItemNode(int tokenType) {
-		super(tokenType);
+		this(tokenType, 0, null, null);
 	}
 
 	public ItemNode(
 		int level, BaseParentableNode baseParentableNode,
 		CollectionNode collectionNode) {
 
-		super(collectionNode);
-
-		_level = level;
-		_baseParentableNode = baseParentableNode;
+		this(0, level, baseParentableNode, collectionNode);
 	}
 
 	public BaseParentableNode getBaseParentableNode() {
@@ -45,7 +42,17 @@ public abstract class ItemNode extends BaseParentableNode {
 		_baseParentableNode = baseParentableNode;
 	}
 
+	protected ItemNode(
+		int tokenType, int level, BaseParentableNode baseParentableNode,
+		CollectionNode collectionNode) {
+
+		super(collectionNode, tokenType);
+
+		_level = level;
+		_baseParentableNode = baseParentableNode;
+	}
+
 	private BaseParentableNode _baseParentableNode;
-	private int _level;
+	private final int _level;
 
 }

--- a/portal-impl/src/com/liferay/portal/parsers/creole/ast/ParagraphNode.java
+++ b/portal-impl/src/com/liferay/portal/parsers/creole/ast/ParagraphNode.java
@@ -22,6 +22,7 @@ import com.liferay.portal.parsers.creole.visitor.ASTVisitor;
 public class ParagraphNode extends BaseParentableNode {
 
 	public ParagraphNode() {
+		this(null);
 	}
 
 	public ParagraphNode(CollectionNode collectionNode) {

--- a/portal-impl/src/com/liferay/portal/parsers/creole/ast/TextNode.java
+++ b/portal-impl/src/com/liferay/portal/parsers/creole/ast/TextNode.java
@@ -20,15 +20,15 @@ package com.liferay.portal.parsers.creole.ast;
 public abstract class TextNode extends BaseParentableNode {
 
 	public TextNode(ASTNode astNode) {
-		super((CollectionNode)astNode);
+		this(astNode, 0, null);
 	}
 
 	public TextNode(int tokenType) {
-		super(tokenType);
+		this(null, tokenType, null);
 	}
 
 	public TextNode(String content) {
-		_content = content;
+		this(null, 0, content);
 	}
 
 	public String getContent() {
@@ -44,6 +44,12 @@ public abstract class TextNode extends BaseParentableNode {
 		}
 	}
 
-	private String _content;
+	protected TextNode(ASTNode astNode, int tokenType, String content) {
+		super((CollectionNode)astNode, tokenType);
+
+		_content = content;
+	}
+
+	private final String _content;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
@@ -81,6 +81,10 @@ public class SearchContainer<R> {
 	public static final int MAX_DELTA = 200;
 
 	public SearchContainer() {
+		_curParam = DEFAULT_CUR_PARAM;
+		_displayTerms = null;
+		_portletRequest = null;
+		_searchTerms = null;
 	}
 
 	public SearchContainer(
@@ -521,11 +525,11 @@ public class SearchContainer<R> {
 
 	private String _className;
 	private int _cur;
-	private String _curParam = DEFAULT_CUR_PARAM;
+	private final String _curParam;
 	private int _delta = DEFAULT_DELTA;
 	private boolean _deltaConfigurable = DEFAULT_DELTA_CONFIGURABLE;
 	private String _deltaParam = DEFAULT_DELTA_PARAM;
-	private DisplayTerms _displayTerms;
+	private final DisplayTerms _displayTerms;
 	private String _emptyResultsMessage;
 	private int _end;
 	private List<String> _headerNames;
@@ -547,12 +551,12 @@ public class SearchContainer<R> {
 	private String _orderByJS;
 	private String _orderByType;
 	private String _orderByTypeParam = DEFAULT_ORDER_BY_TYPE_PARAM;
-	private PortletRequest _portletRequest;
+	private final PortletRequest _portletRequest;
 	private int _resultEnd;
-	private List<ResultRow> _resultRows = new ArrayList<ResultRow>();
+	private final List<ResultRow> _resultRows = new ArrayList<ResultRow>();
 	private List<R> _results = new ArrayList<R>();
 	private RowChecker _rowChecker;
-	private DisplayTerms _searchTerms;
+	private final DisplayTerms _searchTerms;
 	private int _start;
 	private int _total;
 	private String _totalVar;

--- a/portal-service/src/com/liferay/portal/kernel/jmx/model/Domain.java
+++ b/portal-service/src/com/liferay/portal/kernel/jmx/model/Domain.java
@@ -29,11 +29,15 @@ public class Domain implements Serializable {
 
 	public Domain(String domainName) {
 		_domainName = domainName;
+
+		_loaded = false;
+		_mBeans = null;
 	}
 
 	public Domain(String domainName, List<MBean> mBeans) {
 		_domainName = domainName;
 		_mBeans = mBeans;
+
 		_loaded = true;
 	}
 
@@ -77,8 +81,8 @@ public class Domain implements Serializable {
 		return _loaded;
 	}
 
-	private String _domainName;
-	private boolean _loaded;
-	private List<MBean> _mBeans;
+	private final String _domainName;
+	private final boolean _loaded;
+	private final List<MBean> _mBeans;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/jmx/model/MBean.java
+++ b/portal-service/src/com/liferay/portal/kernel/jmx/model/MBean.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.HashCode;
 import com.liferay.portal.kernel.util.HashCodeFactoryUtil;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -29,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.management.MBeanInfo;
-import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
 /**
@@ -38,21 +36,21 @@ import javax.management.ObjectName;
 public class MBean implements Serializable {
 
 	public MBean(ObjectName objectName) {
-		this(objectName.getDomain(), objectName.getKeyPropertyListString());
-
 		_objectName = objectName;
+
+		_domainName = objectName.getDomain();
+		_mBeanName = objectName.getKeyPropertyListString();
+		_loaded = false;
+		_mBeanInfo = null;
 	}
 
 	public MBean(ObjectName objectName, MBeanInfo mBeanInfo) {
+		_objectName = objectName;
+		_mBeanInfo = mBeanInfo;
+
 		_domainName = objectName.getDomain();
 		_mBeanName = objectName.getKeyPropertyListString();
-		_mBeanInfo = mBeanInfo;
 		_loaded = true;
-	}
-
-	public MBean(String domainName, String mBeanName) {
-		_domainName = domainName;
-		_mBeanName = mBeanName;
 	}
 
 	@Override
@@ -88,12 +86,7 @@ public class MBean implements Serializable {
 		return _mBeanName;
 	}
 
-	public ObjectName getObjectName() throws MalformedObjectNameException {
-		if (_objectName == null) {
-			_objectName = new ObjectName(
-				_domainName.concat(StringPool.COLON).concat(_mBeanName));
-		}
-
+	public ObjectName getObjectName() {
 		return _objectName;
 	}
 
@@ -134,11 +127,11 @@ public class MBean implements Serializable {
 
 	private static Log _log = LogFactoryUtil.getLog(MBean.class);
 
-	private String _domainName;
-	private boolean _loaded;
-	private MBeanInfo _mBeanInfo;
-	private String _mBeanName;
-	private ObjectName _objectName;
+	private final String _domainName;
+	private final boolean _loaded;
+	private final MBeanInfo _mBeanInfo;
+	private final String _mBeanName;
+	private final ObjectName _objectName;
 	private List<String> _path;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/messaging/proxy/ProxyRequest.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/proxy/ProxyRequest.java
@@ -43,6 +43,7 @@ public class ProxyRequest implements Externalizable {
 	 * not use this for any other purpose.
 	 */
 	public ProxyRequest() {
+		_local = false;
 	}
 
 	public ProxyRequest(Method method, Object[] arguments) throws Exception {
@@ -156,12 +157,12 @@ public class ProxyRequest implements Externalizable {
 		objectOutput.writeBoolean(_synchronous);
 	}
 
-	private static Map<Method, boolean[]> _localAndSynchronousMap =
+	private static final Map<Method, boolean[]> _localAndSynchronousMap =
 		new ConcurrentHashMap<Method, boolean[]>();
 
 	private Object[] _arguments;
 	private boolean _hasReturnValue;
-	private boolean _local;
+	private final boolean _local;
 	private Method _method;
 	private boolean _synchronous;
 

--- a/portal-service/src/com/liferay/portal/kernel/poller/comet/BaseCometRequest.java
+++ b/portal-service/src/com/liferay/portal/kernel/poller/comet/BaseCometRequest.java
@@ -83,7 +83,7 @@ public abstract class BaseCometRequest implements CometRequest {
 
 	private long _companyId;
 	private String _pathInfo;
-	private HttpServletRequest _request;
+	private final HttpServletRequest _request;
 	private long _timestamp = System.currentTimeMillis();
 	private long _userId;
 

--- a/portal-service/src/com/liferay/portal/kernel/scheduler/messaging/ReceiverKey.java
+++ b/portal-service/src/com/liferay/portal/kernel/scheduler/messaging/ReceiverKey.java
@@ -29,6 +29,7 @@ public class ReceiverKey implements Serializable {
 	 * not use this for any other purpose.
 	 */
 	public ReceiverKey() {
+		this(null, null);
 	}
 
 	public ReceiverKey(String jobName, String groupName) {
@@ -70,7 +71,7 @@ public class ReceiverKey implements Serializable {
 		return _jobName.hashCode() + (_groupName.hashCode() * 11);
 	}
 
-	private String _groupName;
-	private String _jobName;
+	private final String _groupName;
+	private final String _jobName;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/template/TemplateVariableDefinition.java
+++ b/portal-service/src/com/liferay/portal/kernel/template/TemplateVariableDefinition.java
@@ -35,23 +35,18 @@ public class TemplateVariableDefinition {
 		String accessor, String help, boolean repeatable,
 		TemplateVariableCodeHandler templateVariableCodeHandler) {
 
-		_label = label;
-		_clazz = clazz;
-		_dataType = dataType;
-		_name = name;
-		_accessor = accessor;
-		_help = help;
-		_repeatable = repeatable;
-		_templateVariableCodeHandler = templateVariableCodeHandler;
+		this(
+			label, clazz, dataType, name, accessor, help, repeatable,
+			templateVariableCodeHandler, null);
 	}
 
 	public TemplateVariableDefinition(
 		String label, Class<?> clazz, String name,
 		TemplateVariableDefinition itemTemplateVariableDefinition) {
 
-		this(label, clazz, name, StringPool.BLANK);
-
-		_itemTemplateVariableDefinition = itemTemplateVariableDefinition;
+		this(
+			label, clazz, StringPool.BLANK, name, StringPool.BLANK,
+			label.concat("-help"), false, null, itemTemplateVariableDefinition);
 	}
 
 	@Override
@@ -128,14 +123,31 @@ public class TemplateVariableDefinition {
 		return _repeatable;
 	}
 
-	private String _accessor;
-	private Class<?> _clazz;
-	private String _dataType;
-	private String _help;
-	private TemplateVariableDefinition _itemTemplateVariableDefinition;
-	private String _label;
-	private String _name;
-	private boolean _repeatable;
+	protected TemplateVariableDefinition(
+		String label, Class<?> clazz, String dataType, String name,
+		String accessor, String help, boolean repeatable,
+		TemplateVariableCodeHandler templateVariableCodeHandler,
+		TemplateVariableDefinition itemTemplateVariableDefinition) {
+
+		_label = label;
+		_clazz = clazz;
+		_dataType = dataType;
+		_name = name;
+		_accessor = accessor;
+		_help = help;
+		_repeatable = repeatable;
+		_templateVariableCodeHandler = templateVariableCodeHandler;
+		_itemTemplateVariableDefinition = itemTemplateVariableDefinition;
+	}
+
+	private final String _accessor;
+	private final Class<?> _clazz;
+	private final String _dataType;
+	private final String _help;
+	private final TemplateVariableDefinition _itemTemplateVariableDefinition;
+	private final String _label;
+	private final String _name;
+	private final boolean _repeatable;
 	private TemplateVariableCodeHandler _templateVariableCodeHandler;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/template/TemplateVariableGroup.java
+++ b/portal-service/src/com/liferay/portal/kernel/template/TemplateVariableGroup.java
@@ -26,12 +26,11 @@ import java.util.LinkedHashSet;
 public class TemplateVariableGroup {
 
 	public TemplateVariableGroup(String label) {
-		_label = label;
+		this(label, null);
 	}
 
 	public TemplateVariableGroup(String label, String[] restrictedVariables) {
-		this(label);
-
+		_label = label;
 		_restrictedVariables = restrictedVariables;
 	}
 
@@ -155,8 +154,8 @@ public class TemplateVariableGroup {
 
 	private boolean _autocompleteEnabled = true;
 	private String _label;
-	private String[] _restrictedVariables;
-	private Collection<TemplateVariableDefinition>
+	private final String[] _restrictedVariables;
+	private final Collection<TemplateVariableDefinition>
 		_templateVariableDefinitions =
 			new LinkedHashSet<TemplateVariableDefinition>();
 

--- a/portal-service/src/com/liferay/portal/model/PortletInfo.java
+++ b/portal-service/src/com/liferay/portal/model/PortletInfo.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 public class PortletInfo implements Serializable {
 
 	public PortletInfo() {
+		this(null, null, null, null);
 	}
 
 	public PortletInfo(
@@ -50,9 +51,9 @@ public class PortletInfo implements Serializable {
 		return _title;
 	}
 
-	private String _description;
-	private String _keywords;
-	private String _shortTitle;
-	private String _title;
+	private final String _description;
+	private final String _keywords;
+	private final String _shortTitle;
+	private final String _title;
 
 }


### PR DESCRIPTION
I have changed the node files to order arguments in contructors according to the order of constructors themselves, enforced by source formatter. Upon review, there is inconsitency with regards to this ordering according to to capitalization - it appears that source formatter ignores the case of arguments when ordering constructors and methods. If this is still unnacceptable, then we can look into getting in touch with Mr. Huijser solving this root of the problem.
