### PR TITLE
LPS-49189 don't ignore redirects when session message present

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -86,11 +86,9 @@ public class LiferayPortlet extends GenericPortlet {
 				return;
 			}
 
-			if (!SessionMessages.isEmpty(actionRequest)) {
-				return;
+			if (SessionMessages.isEmpty(actionRequest)) {
+				addSuccessMessage(actionRequest, actionResponse);
 			}
-
-			addSuccessMessage(actionRequest, actionResponse);
 
 			sendRedirect(actionRequest, actionResponse);
 		}


### PR DESCRIPTION
Hi Brian,

Currently, when the portlet defines a custom session message the redirect (if any) is always ignored, and the dev. has no way to change this behaviour other than overriding the method. This makes it difficult to avoid POST-on-refresh problems when a custom message is defined (e.g. KnowledgeBase).

I believe it is an error, but I'm not sure as it seems this behaviour was introduced in LPS-9570 for some concrete reason. In case you feel the old behaviour is correct, I'll send another PR with a refactor of the `processAction` method so that it's easier to override this behaviour.

In case you merge this commit, please don't close the ticket, as I need to do further work on plugins.

Thanks!
