### PR TITLE
LPS-49771 Decoupling Bookmarks from export/import tests

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -1938,6 +1938,10 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 		ExpandoBridge expandoBridge = classedModel.getExpandoBridge();
 
+		if (expandoBridge == null) {
+			return;
+		}
+
 		Map<String, Serializable> expandoBridgeAttributes =
 			expandoBridge.getAttributes();
 

--- a/portal-impl/test/integration/com/liferay/portal/lar/PermissionExportImportTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/PermissionExportImportTest.java
@@ -214,6 +214,6 @@ public class PermissionExportImportTest extends PowerMockito {
 	private static final String[] _ACTION_IDS =
 		{ActionKeys.ADD_TO_PAGE, ActionKeys.VIEW};
 
-	private static final String _PORTLET_ID = PortletKeys.BOOKMARKS;
+	private static final String _PORTLET_ID = PortletKeys.LAYOUTS_ADMIN;
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/lar/PortletDataContextReferencesTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/PortletDataContextReferencesTest.java
@@ -128,15 +128,17 @@ public class PortletDataContextReferencesTest {
 
 	@Test
 	public void testMissingNotMissingReference() throws Exception {
-		Element bookmarksEntryElement =
+		Element mockBookmarksEntryElement =
 			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, true);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			true);
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, false);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			false);
 
 		Element missingReferencesElement =
 			_portletDataContext.getMissingReferencesElement();
@@ -149,12 +151,13 @@ public class PortletDataContextReferencesTest {
 
 	@Test
 	public void testMissingReference() throws Exception {
-		Element bookmarksEntryElement =
+		Element mockBookmarksEntryElement =
 			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, true);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			true);
 
 		Element missingReferencesElement =
 			_portletDataContext.getMissingReferencesElement();
@@ -176,24 +179,27 @@ public class PortletDataContextReferencesTest {
 
 	@Test
 	public void testMultipleMissingNotMissingReference() throws Exception {
-		Element bookmarksEntryElement1 =
+		Element mockBookmarksEntryElement1 =
 			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement1, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, true);
+			_mockBookmarksEntry, mockBookmarksEntryElement1,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			true);
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement1, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, false);
+			_mockBookmarksEntry, mockBookmarksEntryElement1,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			false);
 
-		MockBookmarksEntry bookmarksEntry = new MockBookmarksEntry();
+		MockBookmarksEntry mockBookmarksEntry = new MockBookmarksEntry();
 
-		Element bookmarksEntryElement2 =
-			_portletDataContext.getExportDataElement(bookmarksEntry);
+		Element mockBookmarksEntryElement2 =
+			_portletDataContext.getExportDataElement(mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			bookmarksEntry, bookmarksEntryElement2, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, true);
+			mockBookmarksEntry, mockBookmarksEntryElement2,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			true);
 
 		Element missingReferencesElement =
 			_portletDataContext.getMissingReferencesElement();
@@ -239,15 +245,17 @@ public class PortletDataContextReferencesTest {
 
 	@Test
 	public void testNotMissingMissingReference() throws Exception {
-		Element bookmarksEntryElement =
+		Element mockBookmarksEntryElement =
 			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, false);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			false);
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, true);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			true);
 
 		Element missingReferencesElement =
 			_portletDataContext.getMissingReferencesElement();
@@ -260,12 +268,13 @@ public class PortletDataContextReferencesTest {
 
 	@Test
 	public void testNotMissingReference() throws Exception {
-		Element bookmarksEntryElement =
+		Element mockBookmarksEntryElement =
 			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_PARENT, false);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_PARENT,
+			false);
 
 		Element missingReferencesElement =
 			_portletDataContext.getMissingReferencesElement();
@@ -282,20 +291,20 @@ public class PortletDataContextReferencesTest {
 
 		_portletDataContext.setZipWriter(zipWriter);
 
-		Element bookmarksEntryElement =
+		Element mockBookmarksEntryElement =
 			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addClassedModel(
-			bookmarksEntryElement,
+			mockBookmarksEntryElement,
 			ExportImportPathUtil.getModelPath(_mockBookmarksEntry),
 			_mockBookmarksEntry);
 
-		Element bookmarksFolderElement =
+		Element mockBookmarksFolderElement =
 			_portletDataContext.getExportDataElement(_mockBookmarksFolder);
 
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksFolder, bookmarksFolderElement, _mockBookmarksEntry,
-			PortletDataContext.REFERENCE_TYPE_CHILD, true);
+			_mockBookmarksFolder, mockBookmarksFolderElement,
+			_mockBookmarksEntry, PortletDataContext.REFERENCE_TYPE_CHILD, true);
 
 		Element missingReferencesElement =
 			_portletDataContext.getMissingReferencesElement();
@@ -308,18 +317,20 @@ public class PortletDataContextReferencesTest {
 
 	@Test
 	public void testSameMissingReferenceMultipleTimes() throws Exception {
-		Element bookmarksEntryElement =
+		Element mockBookmarksEntryElement =
 			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
-		bookmarksEntryElement.addAttribute(
+		mockBookmarksEntryElement.addAttribute(
 			"path", ExportImportPathUtil.getModelPath(_mockBookmarksEntry));
 
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
+			true);
 		_portletDataContext.addReferenceElement(
-			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
-			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+			_mockBookmarksEntry, mockBookmarksEntryElement,
+			_mockBookmarksFolder, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
+			true);
 
 		Element missingReferencesElement =
 			_portletDataContext.getMissingReferencesElement();

--- a/portal-impl/test/integration/com/liferay/portal/lar/PortletDataContextReferencesTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/PortletDataContextReferencesTest.java
@@ -25,8 +25,11 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.kernel.zip.ZipWriterFactoryUtil;
+import com.liferay.portal.lar.mock.MockBookmarksEntry;
+import com.liferay.portal.lar.mock.MockBookmarksFolder;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Portlet;
+import com.liferay.portal.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.test.DeleteAfterTestRun;
 import com.liferay.portal.test.listeners.MainServletExecutionTestListener;
@@ -34,14 +37,10 @@ import com.liferay.portal.test.listeners.ResetDatabaseExecutionTestListener;
 import com.liferay.portal.test.runners.LiferayIntegrationJUnitTestRunner;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.test.GroupTestUtil;
-import com.liferay.portal.util.test.RandomTestUtil;
 import com.liferay.portal.util.test.TestPropsValues;
 import com.liferay.portlet.asset.model.AssetCategory;
 import com.liferay.portlet.asset.model.AssetVocabulary;
 import com.liferay.portlet.asset.util.test.AssetTestUtil;
-import com.liferay.portlet.bookmarks.model.BookmarksEntry;
-import com.liferay.portlet.bookmarks.model.BookmarksFolder;
-import com.liferay.portlet.bookmarks.util.test.BookmarksTestUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -64,6 +63,11 @@ public class PortletDataContextReferencesTest {
 
 	@Before
 	public void setUp() throws Exception {
+		ClassNameLocalServiceUtil.addClassName(
+			MockBookmarksEntry.class.getName());
+		ClassNameLocalServiceUtil.addClassName(
+			MockBookmarksFolder.class.getName());
+
 		_group = GroupTestUtil.addGroup();
 
 		ZipWriter zipWriter = ZipWriterFactoryUtil.getZipWriter();
@@ -86,9 +90,8 @@ public class PortletDataContextReferencesTest {
 		_portletDataContext.setMissingReferencesElement(
 			missingReferencesElement);
 
-		_bookmarksEntry = BookmarksTestUtil.addEntry(_group.getGroupId(), true);
-		_bookmarksFolder = BookmarksTestUtil.addFolder(
-			_group.getGroupId(), RandomTestUtil.randomString());
+		_mockBookmarksEntry = new MockBookmarksEntry();
+		_mockBookmarksFolder = new MockBookmarksFolder();
 	}
 
 	@Test
@@ -126,13 +129,13 @@ public class PortletDataContextReferencesTest {
 	@Test
 	public void testMissingNotMissingReference() throws Exception {
 		Element bookmarksEntryElement =
-			_portletDataContext.getExportDataElement(_bookmarksEntry);
+			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, true);
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, false);
 
 		Element missingReferencesElement =
@@ -147,10 +150,10 @@ public class PortletDataContextReferencesTest {
 	@Test
 	public void testMissingReference() throws Exception {
 		Element bookmarksEntryElement =
-			_portletDataContext.getExportDataElement(_bookmarksEntry);
+			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, true);
 
 		Element missingReferencesElement =
@@ -164,32 +167,32 @@ public class PortletDataContextReferencesTest {
 		Element missingReferenceElement = missingReferenceElements.get(0);
 
 		Assert.assertEquals(
-			_bookmarksFolder.getModelClassName(),
+			_mockBookmarksFolder.getModelClassName(),
 			missingReferenceElement.attributeValue("class-name"));
 		Assert.assertEquals(
-			String.valueOf(_bookmarksFolder.getPrimaryKeyObj()),
+			String.valueOf(_mockBookmarksFolder.getPrimaryKeyObj()),
 			missingReferenceElement.attributeValue("class-pk"));
 	}
 
 	@Test
 	public void testMultipleMissingNotMissingReference() throws Exception {
 		Element bookmarksEntryElement1 =
-			_portletDataContext.getExportDataElement(_bookmarksEntry);
+			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement1, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement1, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, true);
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement1, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement1, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, false);
 
-		BookmarksEntry bookmarksEntry = BookmarksTestUtil.addEntry(true);
+		MockBookmarksEntry bookmarksEntry = new MockBookmarksEntry();
 
 		Element bookmarksEntryElement2 =
 			_portletDataContext.getExportDataElement(bookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			bookmarksEntry, bookmarksEntryElement2, _bookmarksFolder,
+			bookmarksEntry, bookmarksEntryElement2, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, true);
 
 		Element missingReferencesElement =
@@ -208,11 +211,11 @@ public class PortletDataContextReferencesTest {
 
 		_portletDataContext.addReferenceElement(
 			portlet, _portletDataContext.getExportDataRootElement(),
-			_bookmarksEntry, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
+			_mockBookmarksEntry, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
 			true);
 		_portletDataContext.addReferenceElement(
 			portlet, _portletDataContext.getExportDataRootElement(),
-			_bookmarksEntry, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
+			_mockBookmarksEntry, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
 			true);
 
 		Element missingReferencesElement =
@@ -227,23 +230,23 @@ public class PortletDataContextReferencesTest {
 		Element missingReferenceElement = missingReferenceElements.get(0);
 
 		Assert.assertEquals(
-			BookmarksEntry.class.getName(),
+			MockBookmarksEntry.class.getName(),
 			missingReferenceElement.attributeValue("class-name"));
 		Assert.assertEquals(
-			String.valueOf(_bookmarksEntry.getEntryId()),
+			String.valueOf(_mockBookmarksEntry.getPrimaryKeyObj()),
 			missingReferenceElement.attributeValue("class-pk"));
 	}
 
 	@Test
 	public void testNotMissingMissingReference() throws Exception {
 		Element bookmarksEntryElement =
-			_portletDataContext.getExportDataElement(_bookmarksEntry);
+			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, false);
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, true);
 
 		Element missingReferencesElement =
@@ -258,10 +261,10 @@ public class PortletDataContextReferencesTest {
 	@Test
 	public void testNotMissingReference() throws Exception {
 		Element bookmarksEntryElement =
-			_portletDataContext.getExportDataElement(_bookmarksEntry);
+			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_PARENT, false);
 
 		Element missingReferencesElement =
@@ -280,18 +283,18 @@ public class PortletDataContextReferencesTest {
 		_portletDataContext.setZipWriter(zipWriter);
 
 		Element bookmarksEntryElement =
-			_portletDataContext.getExportDataElement(_bookmarksEntry);
+			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		_portletDataContext.addClassedModel(
 			bookmarksEntryElement,
-			ExportImportPathUtil.getModelPath(_bookmarksEntry),
-			_bookmarksEntry);
+			ExportImportPathUtil.getModelPath(_mockBookmarksEntry),
+			_mockBookmarksEntry);
 
 		Element bookmarksFolderElement =
-			_portletDataContext.getExportDataElement(_bookmarksFolder);
+			_portletDataContext.getExportDataElement(_mockBookmarksFolder);
 
 		_portletDataContext.addReferenceElement(
-			_bookmarksFolder, bookmarksFolderElement, _bookmarksEntry,
+			_mockBookmarksFolder, bookmarksFolderElement, _mockBookmarksEntry,
 			PortletDataContext.REFERENCE_TYPE_CHILD, true);
 
 		Element missingReferencesElement =
@@ -306,16 +309,16 @@ public class PortletDataContextReferencesTest {
 	@Test
 	public void testSameMissingReferenceMultipleTimes() throws Exception {
 		Element bookmarksEntryElement =
-			_portletDataContext.getExportDataElement(_bookmarksEntry);
+			_portletDataContext.getExportDataElement(_mockBookmarksEntry);
 
 		bookmarksEntryElement.addAttribute(
-			"path", ExportImportPathUtil.getModelPath(_bookmarksEntry));
+			"path", ExportImportPathUtil.getModelPath(_mockBookmarksEntry));
 
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
 		_portletDataContext.addReferenceElement(
-			_bookmarksEntry, bookmarksEntryElement, _bookmarksFolder,
+			_mockBookmarksEntry, bookmarksEntryElement, _mockBookmarksFolder,
 			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
 
 		Element missingReferencesElement =
@@ -328,7 +331,7 @@ public class PortletDataContextReferencesTest {
 
 		List<Element> referencesElements =
 			_portletDataContext.getReferenceElements(
-				_bookmarksEntry, BookmarksFolder.class);
+				_mockBookmarksEntry, MockBookmarksFolder.class);
 
 		Assert.assertEquals(2, referencesElements.size());
 
@@ -339,12 +342,11 @@ public class PortletDataContextReferencesTest {
 		}
 	}
 
-	private BookmarksEntry _bookmarksEntry;
-	private BookmarksFolder _bookmarksFolder;
-
 	@DeleteAfterTestRun
 	private Group _group;
 
+	private MockBookmarksEntry _mockBookmarksEntry;
+	private MockBookmarksFolder _mockBookmarksFolder;
 	private PortletDataContext _portletDataContext;
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/lar/mock/MockBookmarksEntry.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/mock/MockBookmarksEntry.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.mock;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.lar.StagedModelType;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.model.StagedModel;
+import com.liferay.portal.util.test.RandomTestUtil;
+import com.liferay.portal.util.test.TestPropsValues;
+import com.liferay.portlet.expando.model.ExpandoBridge;
+
+import java.io.Serializable;
+
+import java.util.Date;
+
+/**
+ * @author Mate Thurzo
+ */
+public class MockBookmarksEntry implements StagedModel {
+
+	@Override
+	public Object clone() {
+		return null;
+	}
+
+	@Override
+	public long getCompanyId() {
+		try {
+			return TestPropsValues.getCompanyId();
+		}
+		catch (PortalException pe) {
+			return 0;
+		}
+	}
+
+	@Override
+	public Date getCreateDate() {
+		return null;
+	}
+
+	@Override
+	public ExpandoBridge getExpandoBridge() {
+		return null;
+	}
+
+	@Override
+	public Class<?> getModelClass() {
+		return MockBookmarksEntry.class;
+	}
+
+	@Override
+	public String getModelClassName() {
+		return MockBookmarksEntry.class.getName();
+	}
+
+	@Override
+	public Date getModifiedDate() {
+		return null;
+	}
+
+	@Override
+	public Serializable getPrimaryKeyObj() {
+		if (_primaryKeyObj == null) {
+			try {
+				_primaryKeyObj = RandomTestUtil.nextLong();
+			}
+			catch (Exception e) {
+				_primaryKeyObj = 1L;
+			}
+		}
+
+		return _primaryKeyObj;
+	}
+
+	@Override
+	public StagedModelType getStagedModelType() {
+		return new StagedModelType(MockBookmarksEntry.class.getName());
+	}
+
+	@Override
+	public String getUuid() {
+		if (Validator.isNull(_uuid)) {
+			_uuid = PortalUUIDUtil.generate();
+		}
+
+		return _uuid;
+	}
+
+	@Override
+	public void setCompanyId(long companyId) {
+	}
+
+	@Override
+	public void setCreateDate(Date date) {
+	}
+
+	@Override
+	public void setModifiedDate(Date date) {
+	}
+
+	@Override
+	public void setPrimaryKeyObj(Serializable primaryKeyObj) {
+	}
+
+	@Override
+	public void setUuid(String uuid) {
+	}
+
+	private Serializable _primaryKeyObj;
+	private String _uuid;
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/lar/mock/MockBookmarksFolder.java
+++ b/portal-impl/test/integration/com/liferay/portal/lar/mock/MockBookmarksFolder.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lar.mock;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.lar.StagedModelType;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.model.StagedModel;
+import com.liferay.portal.util.test.RandomTestUtil;
+import com.liferay.portal.util.test.TestPropsValues;
+import com.liferay.portlet.expando.model.ExpandoBridge;
+
+import java.io.Serializable;
+
+import java.util.Date;
+
+/**
+ * @author Mate Thurzo
+ */
+public class MockBookmarksFolder implements StagedModel {
+
+	@Override
+	public Object clone() {
+		return null;
+	}
+
+	@Override
+	public long getCompanyId() {
+		try {
+			return TestPropsValues.getCompanyId();
+		}
+		catch (PortalException pe) {
+			return 0;
+		}
+	}
+
+	@Override
+	public Date getCreateDate() {
+		return null;
+	}
+
+	@Override
+	public ExpandoBridge getExpandoBridge() {
+		return null;
+	}
+
+	@Override
+	public Class<?> getModelClass() {
+		return MockBookmarksFolder.class;
+	}
+
+	@Override
+	public String getModelClassName() {
+		return MockBookmarksFolder.class.getName();
+	}
+
+	@Override
+	public Date getModifiedDate() {
+		return null;
+	}
+
+	@Override
+	public Serializable getPrimaryKeyObj() {
+		if (_primaryKeyObj == null) {
+			try {
+				_primaryKeyObj = RandomTestUtil.nextLong();
+			}
+			catch (Exception e) {
+				_primaryKeyObj = 2L;
+			}
+		}
+
+		return _primaryKeyObj;
+	}
+
+	@Override
+	public StagedModelType getStagedModelType() {
+		return new StagedModelType(MockBookmarksFolder.class.getName());
+	}
+
+	@Override
+	public String getUuid() {
+		if (Validator.isNull(_uuid)) {
+			_uuid = PortalUUIDUtil.generate();
+		}
+
+		return _uuid;
+	}
+
+	@Override
+	public void setCompanyId(long companyId) {
+	}
+
+	@Override
+	public void setCreateDate(Date date) {
+	}
+
+	@Override
+	public void setModifiedDate(Date date) {
+	}
+
+	@Override
+	public void setPrimaryKeyObj(Serializable primaryKeyObj) {
+	}
+
+	@Override
+	public void setUuid(String uuid) {
+	}
+
+	private Serializable _primaryKeyObj;
+	private String _uuid;
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
@@ -28,6 +28,7 @@ import com.liferay.portal.model.TypedModel;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -168,6 +169,10 @@ public class StagedModelDataHandlerUtil {
 
 		StagedModelDataHandler<StagedModel> stagedModelDataHandler =
 			_getStagedModelDataHandler(stagedModel);
+
+		if (stagedModelDataHandler == null) {
+			return Collections.emptyMap();
+		}
 
 		return stagedModelDataHandler.getReferenceAttributes(
 			portletDataContext, stagedModel);


### PR DESCRIPTION
Hey Brian,

These changes decoupling the bookmarks from two staging tests: PortletDataContextReferencesTest and PermissionExportImportTest.

Since the PortletDataContextReferencesTest is serializing during the test, I had to create individual mock classes instead of private classes to avoid serializing the container class - the test class itself - as well.

I've also added some minor failsafe tweaks.

The changes were reviewed by @migue

Thanks,

Máté
