### PR TITLE
LPS-49805 Automatic reference importing

### DIFF
--- a/modules/apps/polls/polls-service/bnd.bnd
+++ b/modules/apps/polls/polls-service/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Polls Service
 Bundle-SymbolicName: com.liferay.polls.service
 Bundle-Version: 1.0.0
 Export-Package:\
-	com.liferay.polls.configurator,\
+	com.liferay.polls.service.configuration.configurator,\
 	com.liferay.polls.lar
 Include-Resource: classes
 Liferay-Service: true

--- a/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletDataContextImpl.java
@@ -1073,7 +1073,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 		Element parentElement, Class<?> clazz, long classPK) {
 
 		List<Element> referenceElements = getReferenceElements(
-			parentElement, clazz, 0, null, classPK, null);
+			parentElement, clazz.getName(), 0, null, classPK, null);
 
 		List<Element> referenceDataElements = getReferenceDataElements(
 			referenceElements, clazz);
@@ -1090,7 +1090,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 		Element parentElement, Class<?> clazz, long groupId, String uuid) {
 
 		List<Element> referenceElements = getReferenceElements(
-			parentElement, clazz, groupId, uuid, 0, null);
+			parentElement, clazz.getName(), groupId, uuid, 0, null);
 
 		List<Element> referenceDataElements = getReferenceDataElements(
 			referenceElements, clazz);
@@ -1139,7 +1139,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 		Element parentElement, Class<?> clazz, String referenceType) {
 
 		List<Element> referenceElements = getReferenceElements(
-			parentElement, clazz, 0, null, 0, referenceType);
+			parentElement, clazz.getName(), 0, null, 0, referenceType);
 
 		return getReferenceDataElements(referenceElements, clazz);
 	}
@@ -1156,7 +1156,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 		StagedModel parentStagedModel, Class<?> clazz, String referenceType) {
 
 		List<Element> referenceElements = getReferenceElements(
-			parentStagedModel, clazz, 0, referenceType);
+			parentStagedModel, clazz.getName(), 0, referenceType);
 
 		return getReferenceDataElements(referenceElements, clazz);
 	}
@@ -1167,7 +1167,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 		String referenceType) {
 
 		List<Element> referenceElements = getReferenceElements(
-			parentElement, clazz, groupId, uuid, 0, referenceType);
+			parentElement, clazz.getName(), groupId, uuid, 0, referenceType);
 
 		if (!referenceElements.isEmpty()) {
 			return referenceElements.get(0);
@@ -1180,8 +1180,15 @@ public class PortletDataContextImpl implements PortletDataContext {
 	public Element getReferenceElement(
 		StagedModel parentStagedModel, Class<?> clazz, long classPK) {
 
+		return getReferenceElement(parentStagedModel, clazz.getName(), classPK);
+	}
+
+	@Override
+	public Element getReferenceElement(
+		StagedModel parentStagedModel, String className, long classPK) {
+
 		List<Element> referenceElements = getReferenceElements(
-			parentStagedModel, clazz, classPK, null);
+			parentStagedModel, className, classPK, null);
 
 		if (!referenceElements.isEmpty()) {
 			return referenceElements.get(0);
@@ -1194,7 +1201,8 @@ public class PortletDataContextImpl implements PortletDataContext {
 	public List<Element> getReferenceElements(
 		StagedModel parentStagedModel, Class<?> clazz) {
 
-		return getReferenceElements(parentStagedModel, clazz, 0, null);
+		return getReferenceElements(
+			parentStagedModel, clazz.getName(), 0, null);
 	}
 
 	/**
@@ -2309,7 +2317,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 	}
 
 	protected List<Element> getReferenceElements(
-		Element parentElement, Class<?> clazz, long groupId, String uuid,
+		Element parentElement, String className, long groupId, String uuid,
 		long classPK, String referenceType) {
 
 		if (parentElement == null) {
@@ -2325,7 +2333,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 		StringBundler sb = new StringBundler(13);
 
 		sb.append("reference[@class-name=");
-		sb.append(HtmlUtil.escapeXPathAttribute(clazz.getName()));
+		sb.append(HtmlUtil.escapeXPathAttribute(className));
 
 		if (groupId > 0) {
 			sb.append(" and @group-id='");
@@ -2359,14 +2367,14 @@ public class PortletDataContextImpl implements PortletDataContext {
 	}
 
 	protected List<Element> getReferenceElements(
-		StagedModel parentStagedModel, Class<?> clazz, long classPK,
+		StagedModel parentStagedModel, String className, long classPK,
 		String referenceType) {
 
 		Element stagedModelElement = getImportDataStagedModelElement(
 			parentStagedModel);
 
 		return getReferenceElements(
-			stagedModelElement, clazz, 0, null, classPK, referenceType);
+			stagedModelElement, className, 0, null, classPK, referenceType);
 	}
 
 	protected String getReferenceKey(ClassedModel classedModel) {

--- a/portal-impl/src/com/liferay/portlet/asset/lar/AssetCategoryStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/asset/lar/AssetCategoryStagedModelDataHandler.java
@@ -188,19 +188,6 @@ public class AssetCategoryStagedModelDataHandler
 
 		long userId = portletDataContext.getUserId(category.getUserUuid());
 
-		if (category.getParentCategoryId() !=
-				AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID) {
-
-			StagedModelDataHandlerUtil.importReferenceStagedModel(
-				portletDataContext, category, AssetCategory.class,
-				category.getParentCategoryId());
-		}
-		else {
-			StagedModelDataHandlerUtil.importReferenceStagedModel(
-				portletDataContext, category, AssetVocabulary.class,
-				category.getVocabularyId());
-		}
-
 		Map<Long, Long> vocabularyIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				AssetVocabulary.class);

--- a/portal-impl/src/com/liferay/portlet/layoutprototypes/lar/LayoutPrototypeStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutprototypes/lar/LayoutPrototypeStagedModelDataHandler.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.portal.kernel.lar.ExportImportPathUtil;
 import com.liferay.portal.kernel.lar.PortletDataContext;
+import com.liferay.portal.kernel.lar.PortletDataException;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.model.Group;
@@ -202,6 +203,13 @@ public class LayoutPrototypeStagedModelDataHandler
 			portletDataContext.setPrivateLayout(privateLayout);
 			portletDataContext.setScopeGroupId(scopeGroupId);
 		}
+	}
+
+	@Override
+	protected void importReferenceStagedModels(
+			PortletDataContext portletDataContext,
+			LayoutPrototype layoutPrototype)
+		throws PortletDataException {
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -1086,6 +1086,12 @@ public class LayoutStagedModelDataHandler
 		updateTypeSettings(importedLayout, layout);
 	}
 
+	@Override
+	protected void importReferenceStagedModels(
+			PortletDataContext portletDataContext, Layout layout)
+		throws PortletDataException {
+	}
+
 	protected void importTheme(
 			PortletDataContext portletDataContext, Layout layout,
 			Layout importedLayout)

--- a/portal-impl/src/com/liferay/portlet/layoutsetprototypes/lar/LayoutSetPrototypeStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsetprototypes/lar/LayoutSetPrototypeStagedModelDataHandler.java
@@ -313,4 +313,11 @@ public class LayoutSetPrototypeStagedModelDataHandler
 		}
 	}
 
+	@Override
+	protected void importReferenceStagedModels(
+			PortletDataContext portletDataContext,
+			LayoutSetPrototype layoutSetPrototype)
+		throws PortletDataException {
+	}
+
 }

--- a/portal-impl/src/com/liferay/portlet/messageboards/lar/MBBanStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/lar/MBBanStagedModelDataHandler.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.portal.kernel.lar.ExportImportPathUtil;
 import com.liferay.portal.kernel.lar.PortletDataContext;
+import com.liferay.portal.kernel.lar.PortletDataException;
 import com.liferay.portal.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -120,6 +121,12 @@ public class MBBanStagedModelDataHandler
 		serviceContext.setUuid(ban.getUuid());
 
 		MBBanLocalServiceUtil.addBan(userId, user.getUserId(), serviceContext);
+	}
+
+	@Override
+	protected void importReferenceStagedModels(
+			PortletDataContext portletDataContext, MBBan ban)
+		throws PortletDataException {
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portlet/usersadmin/lar/OrganizationStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/lar/OrganizationStagedModelDataHandler.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.portal.kernel.lar.ExportImportPathUtil;
 import com.liferay.portal.kernel.lar.PortletDataContext;
+import com.liferay.portal.kernel.lar.PortletDataException;
 import com.liferay.portal.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
@@ -471,6 +472,12 @@ public class OrganizationStagedModelDataHandler
 		UsersAdminUtil.updatePhones(
 			Organization.class.getName(),
 			importedOrganization.getOrganizationId(), phones);
+	}
+
+	@Override
+	protected void importReferenceStagedModels(
+			PortletDataContext portletDataContext, Organization organization)
+		throws PortletDataException {
 	}
 
 	protected void importWebsites(

--- a/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/BaseStagedModelDataHandler.java
@@ -287,6 +287,8 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 
 			importAssetCategories(portletDataContext, stagedModel);
 
+			importReferenceStagedModels(portletDataContext, stagedModel);
+
 			doImportStagedModel(portletDataContext, stagedModel);
 
 			importComments(portletDataContext, stagedModel);
@@ -550,6 +552,39 @@ public abstract class BaseStagedModelDataHandler<T extends StagedModel>
 
 		StagedModelDataHandlerUtil.importReferenceStagedModels(
 			portletDataContext, stagedModel, RatingsEntry.class);
+	}
+
+	protected void importReferenceStagedModels(
+			PortletDataContext portletDataContext, T stagedModel)
+		throws PortletDataException {
+
+		Element stagedModelElement =
+			portletDataContext.getImportDataStagedModelElement(stagedModel);
+
+		Element referencesElement = stagedModelElement.element("references");
+
+		if (referencesElement == null) {
+			return;
+		}
+
+		List<Element> referenceElements = referencesElement.elements();
+
+		for (Element referenceElement : referenceElements) {
+			String className = referenceElement.attributeValue("class-name");
+
+			if (className.equals(AssetCategory.class.getName()) ||
+				className.equals(RatingsEntry.class.getName()) ||
+				className.equals(MBMessage.class.getName())) {
+
+				continue;
+			}
+
+			long classPK = GetterUtil.getLong(
+				referenceElement.attributeValue("class-pk"));
+
+			StagedModelDataHandlerUtil.importReferenceStagedModel(
+				portletDataContext, stagedModel, className, classPK);
+		}
 	}
 
 	protected void validateExport(

--- a/portal-service/src/com/liferay/portal/kernel/lar/PortletDataContext.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/PortletDataContext.java
@@ -439,6 +439,9 @@ public interface PortletDataContext extends Serializable {
 	public Element getReferenceElement(
 		StagedModel parentStagedModel, Class<?> clazz, long classPK);
 
+	public Element getReferenceElement(
+		StagedModel parentStagedModel, String className, long classPK);
+
 	public List<Element> getReferenceElements(
 		StagedModel parentStagedModel, Class<?> clazz);
 

--- a/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/StagedModelDataHandlerUtil.java
@@ -183,8 +183,18 @@ public class StagedModelDataHandlerUtil {
 			Class<?> stagedModelClass, long classPK)
 		throws PortletDataException {
 
+		importReferenceStagedModel(
+			portletDataContext, referrerStagedModel, stagedModelClass.getName(),
+			classPK);
+	}
+
+	public static <T extends StagedModel> void importReferenceStagedModel(
+			PortletDataContext portletDataContext, T referrerStagedModel,
+			String stagedModelClassName, long classPK)
+		throws PortletDataException {
+
 		Element referenceElement = portletDataContext.getReferenceElement(
-			referrerStagedModel, stagedModelClass, classPK);
+			referrerStagedModel, stagedModelClassName, classPK);
 
 		if (referenceElement == null) {
 			return;
@@ -196,7 +206,7 @@ public class StagedModelDataHandlerUtil {
 		if (missing) {
 			StagedModelDataHandler<?> stagedModelDataHandler =
 				StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
-					stagedModelClass.getName());
+					stagedModelClassName);
 
 			stagedModelDataHandler.importMissingReference(
 				portletDataContext, referenceElement);


### PR DESCRIPTION
Hey Brian,

I've been working on the automatic reference importing in the different staged model data handlers. This change will allow the developers to omit the explicit calls always, which is basically mirrored in every SMDH. This change helps the developers maintaining their components' respective SMDHs. This is part of the making the SMDH leaner progress we have been making.

I've currently applied the changes for the Asset related SMDH and for some others caused test failures due to special logic. I'm going to send the different component changes in separate pulls so I can cc the owner on it.

The change was reviewed by @danielkocsis

Thanks,

Máté
