### PR TITLE
master-qa-10678

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1547,9 +1547,13 @@ create database lportal2 character set utf8;</echo>
 		<if>
 			<isset property="jenkins.shared.results.dir" />
 			<then>
-				<copy todir="${env.JENKINS_HOME}/userContent/jobs">
-					<fileset dir="${jenkins.shared.results.dir}/${env.BUILD_FLOW_JOB_NAME}_${env.BUILD_NUMBER}" />
-				</copy>
+				<zip basedir="${jenkins.shared.results.dir}/${env.BUILD_FLOW_JOB_NAME}_${env.BUILD_NUMBER}" destfile="${jenkins.shared.results.dir}/${env.BUILD_FLOW_JOB_NAME}_${env.BUILD_NUMBER}.zip" />
+
+				<copy file="${jenkins.shared.results.dir}/${env.BUILD_FLOW_JOB_NAME}_${env.BUILD_NUMBER}.zip" todir="${env.JENKINS_HOME}/userContent/jobs" />
+
+				<unzip dest="${env.JENKINS_HOME}/userContent/jobs" src="${env.JENKINS_HOME}/userContent/jobs/${env.BUILD_FLOW_JOB_NAME}_${env.BUILD_NUMBER}.zip" />
+
+				<delete file="${env.JENKINS_HOME}/userContent/jobs/${env.BUILD_FLOW_JOB_NAME}_${env.BUILD_NUMBER}.zip" />
 			</then>
 		</if>
 


### PR DESCRIPTION
http://issues.liferay.com/browse/LIFERAYQA-10678

Moving all of the files takes too long, because there are over 3000 individual files that are being copied.

I remember that one time we wanted to move lots of files and it was taking a really long time.  Minhchau told us to zip it up then transfer it and unzip it.  He said it's faster when needing to move many files.

One question about performance is i'm not sure how long it'll take to zip something within a shared directory, as opposed to zipping something locally.  But it takes like 50 minutes to use the current process.    Hopefully this will fix it.
