### PR TITLE
LPS-49970 allow redundant closes when deleteOnClose = true

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/io/ByteArrayFileInputStream.java
+++ b/portal-service/src/com/liferay/portal/kernel/io/ByteArrayFileInputStream.java
@@ -66,7 +66,7 @@ public class ByteArrayFileInputStream extends InputStream {
 			data = null;
 			fileInputStream = null;
 
-			if (deleteOnClose) {
+			if (deleteOnClose && (file != null)) {
 				file.delete();
 			}
 


### PR DESCRIPTION
ByteArrayFileInputStream allowed closing the stream multiple
time _except_ when `deleteOnClose` was enabled.

It seems all Liferay custom InputStreams allow closing an already closed
stream; this commit makes ByteArrayFileInputStream follow that same
pattern also when `deleteOnClose` is enabled.
