### PR TITLE
master-bc-2512

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/seleniumbuilder/SeleniumBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/seleniumbuilder/SeleniumBuilder.java
@@ -458,14 +458,6 @@ public class SeleniumBuilder {
 			}
 		}
 
-		sb.append("\nTEST_CASE_METHOD_NAMES=");
-
-		String testCaseMethodNamesString = StringUtil.merge(
-			testCaseMethodNames.toArray(new String[testCaseMethodNames.size()]),
-			StringPool.SPACE);
-
-		sb.append(testCaseMethodNamesString);
-
 		_seleniumBuilderFileUtil.writeFile(
 			"../../../test.case.method.names.properties", sb.toString(), false);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-11269

Hi Brian. Currently all the master frontend tests are failing. Kiyoshi has a fix for it. Here is his comment:

This will remove the code that creates the property **TEST_CASE_METHOD_NAMES** which contains a list of all the test case method names. This property is 131,823 characters, which is greater than the [upper limit](https://wiki.debian.org/CommonErrorMessages/ArgumentListTooLong) that shell can process (131,072). This caused all our tests in the master branch to fail as shell would return the following error:

```
java.io.IOException: Cannot run program "/bin/bash" (in directory "/opt/dev/projects/github/liferay-portal-ee"): error=7, Argument list too long
```

Removing this line will allow shell to process through the file and run our tests.
