### PR TITLE
LPS-50185 Cron task for clean up temp files

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/messaging/TemporaryFilesMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/messaging/TemporaryFilesMessageListener.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portlet.documentlibraryadmin.messaging;
+package com.liferay.portlet.documentlibrary.messaging;
 
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;

--- a/portal-impl/src/com/liferay/portlet/documentlibraryadmin/messaging/TemporaryFilesMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibraryadmin/messaging/TemporaryFilesMessageListener.java
@@ -46,8 +46,9 @@ public class TemporaryFilesMessageListener implements MessageListener {
 			catch (Exception e) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Unable to try to cleanup temporary files in "+
-							"repository " + repository.getRepositoryId(), e);
+						"Unable to try to cleanup temporary files in " +
+							"repository " + repository.getRepositoryId(),
+						e);
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portlet/documentlibraryadmin/messaging/TemporaryFilesMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibraryadmin/messaging/TemporaryFilesMessageListener.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.documentlibraryadmin.messaging;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.MessageListenerException;
+import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.capabilities.TemporaryFileEntriesCapability;
+import com.liferay.portal.model.Repository;
+import com.liferay.portal.service.RepositoryLocalServiceUtil;
+
+import java.util.List;
+
+/**
+ * @author Ivan Zaera
+ */
+public class TemporaryFilesMessageListener implements MessageListener {
+
+	@Override
+	public void receive(Message message) throws MessageListenerException {
+		List<Repository> repositories =
+			RepositoryLocalServiceUtil.getRepositories(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (Repository repository : repositories) {
+			try {
+				deleteExpiredTemporaryFileEntries(repository);
+			}
+			catch (Exception e) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to try to cleanup temporary files in "+
+							"repository " + repository.getRepositoryId(), e);
+				}
+			}
+		}
+	}
+
+	protected void deleteExpiredTemporaryFileEntries(Repository repository)
+		throws PortalException {
+
+		LocalRepository localRepository =
+			RepositoryLocalServiceUtil.getLocalRepositoryImpl(
+				repository.getRepositoryId());
+
+		if (localRepository.isCapabilityProvided(
+				TemporaryFileEntriesCapability.class)) {
+
+			TemporaryFileEntriesCapability temporaryFileEntriesCapability =
+				localRepository.getCapability(
+					TemporaryFileEntriesCapability.class);
+
+			temporaryFileEntriesCapability.deleteExpiredTemporaryFileEntries();
+		}
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(
+		TemporaryFilesMessageListener.class);
+
+}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9891,6 +9891,12 @@
     dl.publish.to.live.by.default=true
 
     #
+    # Set the interval in hours on how often TemporaryFilesMessageListener will
+    # run to check temp files to be cleaned up.
+    #
+    dl.temp.file.cleanup.check.interval=1
+
+    #
     # Input a list of comma delimited class names of the third party
     # repositories that extend
     # com.liferay.portal.kernel.repository.BaseRepositoryImpl.

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -2098,6 +2098,15 @@
 		<struts-path>document_library_admin</struts-path>
 		<parent-struts-path>document_library</parent-struts-path>
 		<configuration-action-class>com.liferay.portlet.documentlibraryadmin.action.ConfigurationActionImpl</configuration-action-class>
+		<scheduler-entry>
+			<scheduler-event-listener-class>com.liferay.portlet.documentlibraryadmin.messaging.TemporaryFilesMessageListener</scheduler-event-listener-class>
+			<trigger>
+				<simple>
+					<simple-trigger-value>1</simple-trigger-value>
+					<time-unit>hour</time-unit>
+				</simple>
+			</trigger>
+		</scheduler-entry>
 		<portlet-data-handler-class>com.liferay.portlet.documentlibrary.lar.DLPortletDataHandler</portlet-data-handler-class>
 		<control-panel-entry-category>site_administration.content</control-panel-entry-category>
 		<control-panel-entry-weight>3.0</control-panel-entry-weight>

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -2099,7 +2099,7 @@
 		<parent-struts-path>document_library</parent-struts-path>
 		<configuration-action-class>com.liferay.portlet.documentlibraryadmin.action.ConfigurationActionImpl</configuration-action-class>
 		<scheduler-entry>
-			<scheduler-event-listener-class>com.liferay.portlet.documentlibraryadmin.messaging.TemporaryFilesMessageListener</scheduler-event-listener-class>
+			<scheduler-event-listener-class>com.liferay.portlet.documentlibrary.messaging.TemporaryFilesMessageListener</scheduler-event-listener-class>
 			<trigger>
 				<simple>
 					<property-key>dl.temp.file.cleanup.check.interval</property-key>

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -2102,7 +2102,7 @@
 			<scheduler-event-listener-class>com.liferay.portlet.documentlibraryadmin.messaging.TemporaryFilesMessageListener</scheduler-event-listener-class>
 			<trigger>
 				<simple>
-					<simple-trigger-value>1</simple-trigger-value>
+					<property-key>dl.temp.file.cleanup.check.interval</property-key>
 					<time-unit>hour</time-unit>
 				</simple>
 			</trigger>


### PR DESCRIPTION
From Iván: 
Please don't change the name of the TemporaryFilesMessageListener class to anything larger because it will prevent the portal from loading it. I've filed https://issues.liferay.com/browse/LPS-50217 to see if it can be fixed, but until then we must keep this class name < 80 chars wide.

Feel free to provide any solutions you may come up with.

Thanks.
