### PR TITLE
LPS-50325 Arbitrary code execution

### DIFF
--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/util/XSLContentUtil.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/util/XSLContentUtil.java
@@ -17,11 +17,13 @@ package com.liferay.xsl.content.web.util;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.IOException;
 
 import java.net.URL;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -48,6 +50,10 @@ public class XSLContentUtil {
 
 		TransformerFactory transformerFactory =
 			TransformerFactory.newInstance();
+
+		transformerFactory.setFeature(
+			XMLConstants.FEATURE_SECURE_PROCESSING,
+			PropsValues.XSL_CONTENT_SECURE_PROCESSING_ENABLED);
 
 		Transformer transformer = transformerFactory.newTransformer(xslSource);
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1978,6 +1978,10 @@ public class PropsValues {
 
 	public static final boolean XML_VALIDATION_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.XML_VALIDATION_ENABLED));
 
+	public static final boolean XSL_CONTENT_SECURE_PROCESSING_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.XSL_CONTENT_SECURE_PROCESSING_ENABLED));
+
+	public static final boolean XSL_TEMPLATE_SECURE_PROCESSING_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.XSL_TEMPLATE_SECURE_PROCESSING_ENABLED));
+
 	public static final boolean XUGGLER_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.XUGGLER_ENABLED));
 
 	public static final String XUGGLER_JAR_URL = PropsUtil.get(PropsKeys.XUGGLER_JAR_URL);

--- a/portal-impl/src/com/liferay/portal/xsl/XSLTemplate.java
+++ b/portal-impl/src/com/liferay/portal/xsl/XSLTemplate.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.template.TemplateContextHelper;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.Writer;
 
@@ -37,7 +38,9 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
@@ -64,7 +67,16 @@ public class XSLTemplate implements Template {
 		_xslTemplateResource = xslTemplateResource;
 		_errorTemplateResource = errorTemplateResource;
 		_templateContextHelper = templateContextHelper;
+
 		_transformerFactory = TransformerFactory.newInstance();
+
+		try {
+			_transformerFactory.setFeature(
+				XMLConstants.FEATURE_SECURE_PROCESSING,
+				PropsValues.XSL_TEMPLATE_SECURE_PROCESSING_ENABLED);
+		}
+		catch (TransformerConfigurationException tce) {
+		}
 
 		_context = new HashMap<String, Object>();
 	}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8411,6 +8411,16 @@
     xml.validation.enabled=true
 
 ##
+## XSL
+##
+
+    #
+    # Set this to true to process XSL templates securely. Set this to false to
+    # process XSL according to the specifications.
+    #
+    xsl.template.secure.processing.enabled=true
+
+##
 ## Xuggler
 ##
 
@@ -11062,3 +11072,13 @@
     wiki.email.page.updated.body=${resource:com/liferay/portlet/wiki/dependencies/email_page_updated_body.tmpl}
 
     wiki.rss.abstract.length=200
+
+##
+## XSL Content
+##
+
+    #
+    # Set this to true to process XSL securely. Set this to false to process XSL
+    # according to the specifications.
+    #
+    xsl.content.secure.processing.enabled=true

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2833,6 +2833,10 @@ public interface PropsKeys {
 
 	public static final String XML_VALIDATION_ENABLED = "xml.validation.enabled";
 
+	public static final String XSL_CONTENT_SECURE_PROCESSING_ENABLED = "xsl.content.secure.processing.enabled";
+
+	public static final String XSL_TEMPLATE_SECURE_PROCESSING_ENABLED = "xsl.template.secure.processing.enabled";
+
 	public static final String XUGGLER_ENABLED = "xuggler.enabled";
 
 	public static final String XUGGLER_FFPRESET = "xuggler.ffpreset.";


### PR DESCRIPTION
Brian,

This is essentially the same code that use to be in the portal (LPS-14726). However, it was rollback because it was decided that we should use permission to control who can add the XSL Content portlet.

Tomas (@topolik) and I revisited this issue and decided that permission isn't good enough. Even if a user has permission to use the XSL Content portlet, we shouldn't allow the user to execute _any_ code they want.

Same issues also applies the web content templates, so it's also fixed here.

~~Also, doing a partial rollback of LPS-49451 since it's not needed after this.~~
