### PR TITLE
LPS-51123 Nested NamespaceServletRequest wrapping lost namespaces.

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/NamespaceServletRequest.java
+++ b/portal-impl/src/com/liferay/portal/servlet/NamespaceServletRequest.java
@@ -150,6 +150,14 @@ public class NamespaceServletRequest extends DynamicServletRequest {
 		}
 	}
 
+	@Override
+	protected void injectInto(DynamicServletRequest dynamicServletRequest) {
+		dynamicServletRequest.setRequest(
+			new NamespaceServletRequest(
+				(HttpServletRequest)getRequest(), _attrNamespace,
+				_paramNamespace));
+	}
+
 	private boolean _isReservedParam(String name) {
 		if (reservedAttrs.contains(name)) {
 			return true;

--- a/portal-service/src/com/liferay/portal/kernel/servlet/DynamicServletRequest.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/DynamicServletRequest.java
@@ -132,7 +132,7 @@ public class DynamicServletRequest extends HttpServletRequestWrapper {
 			DynamicServletRequest dynamicRequest =
 				(DynamicServletRequest)request;
 
-			setRequest(dynamicRequest.getRequest());
+			dynamicRequest.injectInto(this);
 
 			params = dynamicRequest.getDynamicParameterMap();
 
@@ -240,6 +240,10 @@ public class DynamicServletRequest extends HttpServletRequestWrapper {
 
 	public void setParameterValues(String name, String[] values) {
 		_params.put(name, values);
+	}
+
+	protected void injectInto(DynamicServletRequest dynamicServletRequest) {
+		dynamicServletRequest.setRequest(getRequest());
 	}
 
 	private final boolean _inherit;


### PR DESCRIPTION
@kameshsampath and @rotty3000

I was right about the guessing, this has nothing to do with DynamicServletRequest, but a problem of its subclass NamespaceServletRequest.

You did not lose any attribute, like I explained in https://github.com/shuyangzhou/liferay-portal/pull/781, you simply lost the namespaces during the unwrap/rewrap process, which makes your attribute fetching with old names failed.

And removing the "setRequest(dynamicRequest.getRequest());" is not acceptable, see how it will break things that I explained in https://github.com/shuyangzhou/liferay-portal/pull/781

This fix simply allows NamespaceServletRequest to reattach its namespaces during unwrap/rewrap process, it should fix your issue.

Let me know if you still see any problem.
