### PR TITLE
master-qa-11785

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -58,38 +58,44 @@
 			<if>
 				<isset property="app.server.bundles.size" />
 				<then>
-					<var name="bundles.size" value="1" />
+					<var name="app.server.bundle.index" value="1" />
 
 					<antelope:repeat count="${app.server.bundles.size}">
-						<delete dir="${app.server.parent.dir}-${bundles.size}" />
+						<set-app-server-properties
+							app.server.bundle.index="${app.server.bundle.index}"
+						/>
 
-						<copy todir="${app.server.parent.dir}-${bundles.size}/${app.server.type}-${app.server.version}">
+						<delete dir="${test.app.server.parent.dir}" />
+
+						<copy todir="${test.app.server.dir}">
 							<fileset dir="${app.server.dir}" />
 						</copy>
 
 						<if>
 	  					 	<available file="${liferay.home}/osgi" />
 							<then>
-								<copy todir="${app.server.parent.dir}-${bundles.size}/osgi">
+								<copy todir="${test.app.server.parent.dir}/osgi">
 									<fileset dir="${liferay.home}/osgi" />
 								</copy>
 							</then>
 						</if>
 
 						<chmod perm="a+x">
-							<fileset dir="${app.server.parent.dir}-${bundles.size}/${app.server.type}-${app.server.version}/bin">
+							<fileset dir="${test.app.server.bin.dir}">
 								<include name="*.sh" />
 							</fileset>
 						</chmod>
 
 						<math
 							datatype="int"
-							operand1="${bundles.size}"
+							operand1="${app.server.bundle.index}"
 							operand2="1"
 							operation="+"
-							result="bundles.size"
+							result="app.server.bundle.index"
 						/>
 					</antelope:repeat>
+
+					<var name="app.server.bundle.index" unset="true" />
 				</then>
 			</if>
 		</sequential>

--- a/build-test.xml
+++ b/build-test.xml
@@ -86,6 +86,19 @@
 							</fileset>
 						</chmod>
 
+						<replaceregexp
+							file="${test.app.server.dir}/conf/server.xml"
+							flags="g"
+							match="=&quot;8(\d\d\d)&quot;"
+							replace="=&quot;${test.app.server.leading.port.number}\1&quot;"
+						/>
+
+						<replace
+							file="${test.app.server.classes.portal.dir}/portal-ext.properties"
+							token="liferay.home=${liferay.home}"
+							value="liferay.home=${test.app.server.parent.dir}"
+						/>
+
 						<math
 							datatype="int"
 							operand1="${app.server.bundle.index}"
@@ -213,23 +226,10 @@
 							app.server.bundle.index="${app.server.bundle.index}"
 						/>
 
-						<replaceregexp
-							file="${test.app.server.dir}/conf/server.xml"
-							flags="g"
-							match="=&quot;8(\d\d\d)&quot;"
-							replace="=&quot;${test.app.server.leading.port.number}\1&quot;"
-						/>
-
 						<replace
 							file="${test.app.server.dir}/conf/server.xml"
 							token="&lt;Engine name=&quot;Catalina&quot; defaultHost=&quot;localhost&quot;&gt;"
 							value="&lt;Engine name=&quot;Catalina&quot; defaultHost=&quot;localhost&quot; jvmRoute=&quot;${test.app.server.leading.port.number}&quot;&gt;"
-						/>
-
-						<replace
-							file="${test.app.server.classes.portal.dir}/portal-ext.properties"
-							token="liferay.home=${liferay.home}"
-							value="liferay.home=${test.app.server.parent.dir}"
 						/>
 
 						<math
@@ -3509,10 +3509,15 @@ if (ppstate.equals("normal")) {
 		</if>
 
 		<if>
-			<equals arg1="${cluster.enabled}" arg2="true" />
+			<isset property="app.server.bundles.size" />
 			<then>
 				<prepare-additional-bundles />
+			</then>
+		</if>
 
+		<if>
+			<equals arg1="${cluster.enabled}" arg2="true" />
+			<then>
 				<prepare-test-cluster-properties />
 			</then>
 		</if>
@@ -3671,7 +3676,7 @@ if (ppstate.equals("normal")) {
 		<start-app-server />
 
 		<if>
-			<equals arg1="${cluster.enabled}" arg2="true" />
+			<isset property="app.server.bundles.size" />
 			<then>
 				<var name="app.server.bundle.index" value="1" />
 
@@ -3769,7 +3774,7 @@ if (ppstate.equals("normal")) {
 		<stop-app-server />
 
 		<if>
-			<equals arg1="${cluster.enabled}" arg2="true" />
+			<isset property="app.server.bundles.size" />
 			<then>
 				<var name="app.server.bundle.index" value="1" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -111,6 +111,35 @@
 					<var name="app.server.bundle.index" unset="true" />
 				</then>
 			</if>
+
+			<if>
+				<isset property="databases.size" />
+				<then>
+					<var name="database.index" value="1" />
+
+					<antelope:repeat count="${databases.size}">
+						<set-app-server-properties
+							app.server.bundle.index="${database.index}"
+						/>
+
+						<replace
+							file="${test.app.server.classes.portal.dir}/portal-ext.properties"
+							token="lportal"
+							value="lportal${database.index}"
+						/>
+
+						<math
+							datatype="int"
+							operand1="${database.index}"
+							operand2="1"
+							operation="+"
+							result="database.index"
+						/>
+					</antelope:repeat>
+
+					<var name="database.index" unset="true" />
+				</then>
+			</if>
 		</sequential>
 	</macrodef>
 
@@ -705,17 +734,31 @@
 			<then>
 				<if>
 					<and>
+						<isset property="databases.size" />
 						<equals arg1="${database.type}" arg2="mysql" />
-						<equals arg1="${database.sharding}" arg2="true" />
 					</and>
 					<then>
-						<echo file="create.sql">
-drop database if exists lportal;
-drop database if exists lportal1;
-drop database if exists lportal2;
-create database lportal character set utf8;
-create database lportal1 character set utf8;
-create database lportal2 character set utf8;</echo>
+						<var name="database.index" value="1" />
+
+						<echo file="create.sql">drop database if exists lportal;
+create database lportal character set utf8;</echo>
+
+						<antelope:repeat count="${databases.size}">
+							<echo append="true" file="create.sql">
+
+drop database if exists lportal${database.index};
+create database lportal${database.index} character set utf8;</echo>
+
+							<math
+								datatype="int"
+								operand1="${database.index}"
+								operand2="1"
+								operation="+"
+								result="database.index"
+							/>
+						</antelope:repeat>
+
+						<var name="database.index" unset="true" />
 					</then>
 					<else>
 						<if>

--- a/build-test.xml
+++ b/build-test.xml
@@ -62,7 +62,7 @@
 
 					<antelope:repeat count="${app.server.bundles.size}">
 						<set-app-server-properties
-							app.server.bundle.index="${app.server.bundle.index}"
+							index="${app.server.bundle.index}"
 						/>
 
 						<delete dir="${test.app.server.parent.dir}" />
@@ -119,7 +119,7 @@
 
 					<antelope:repeat count="${databases.size}">
 						<set-app-server-properties
-							app.server.bundle.index="${database.index}"
+							index="${database.index}"
 						/>
 
 						<replace
@@ -252,7 +252,7 @@
 
 					<antelope:repeat count="${app.server.bundles.size}">
 						<set-app-server-properties
-							app.server.bundle.index="${app.server.bundle.index}"
+							index="${app.server.bundle.index}"
 						/>
 
 						<replace
@@ -458,7 +458,7 @@
 
 	<macrodef name="set-app-server-properties">
 		<attribute default="${app.server.bin.dir}" name="app.server.bin.dir" />
-		<attribute default="0" name="app.server.bundle.index" />
+		<attribute default="0" name="index" />
 
 		<sequential>
 			<var name="test.app.server.bin.dir" unset="true" />
@@ -470,14 +470,14 @@
 
 			<math
 				datatype="int"
-				operand1="@{app.server.bundle.index}"
+				operand1="@{index}"
 				operand2="8"
 				operation="+"
 				result="test.app.server.leading.port.number"
 			/>
 
 			<if>
-				 <equals arg1="@{app.server.bundle.index}" arg2="0" />
+				 <equals arg1="@{index}" arg2="0" />
 				 <then>
 					<var name="test.app.server.bin.dir" value="@{app.server.bin.dir}" />
 					<var name="test.app.server.classes.portal.dir" value="${app.server.classes.portal.dir}" />
@@ -487,23 +487,23 @@
 				 </then>
 				 <else>
 					<antelope:stringutil property="test.app.server.bin.dir" string="@{app.server.bin.dir}">
-						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{app.server.bundle.index}$2" />
+						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{index}$2" />
 					</antelope:stringutil>
 
 					<antelope:stringutil property="test.app.server.classes.portal.dir" string="${app.server.classes.portal.dir}">
-						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{app.server.bundle.index}$2" />
+						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{index}$2" />
 					</antelope:stringutil>
 
 					<antelope:stringutil property="test.app.server.deploy.dir" string="${app.server.deploy.dir}">
-						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{app.server.bundle.index}$2" />
+						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{index}$2" />
 					</antelope:stringutil>
 
 					<antelope:stringutil property="test.app.server.dir" string="${app.server.dir}">
-						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{app.server.bundle.index}$2" />
+						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{index}$2" />
 					</antelope:stringutil>
 
 					<antelope:stringutil property="test.app.server.parent.dir" string="${app.server.parent.dir}">
-						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{app.server.bundle.index}$2" />
+						<antelope:replace regex="(${app.server.parent.dir})(.*)" replacement="$1-@{index}$2" />
 					</antelope:stringutil>
 				 </else>
 			</if>
@@ -543,7 +543,7 @@
 		<sequential>
 			<set-app-server-properties
 				app.server.bin.dir="@{app.server.bin.dir}"
-				app.server.bundle.index="@{app.server.bundle.index}"
+				index="@{app.server.bundle.index}"
 			/>
 
 			<if>
@@ -631,7 +631,7 @@
 		<sequential>
 			<set-app-server-properties
 				app.server.bin.dir="@{app.server.bin.dir}"
-				app.server.bundle.index="@{app.server.bundle.index}"
+				index="@{app.server.bundle.index}"
 			/>
 
 			<antcall target="clean-up-logs" />

--- a/portal-web/test/functional/com/liferay/portalweb/development/tools/testinginfrastructure/DatabaseSharding.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/development/tools/testinginfrastructure/DatabaseSharding.testcase
@@ -1,5 +1,6 @@
 <definition component-name="portal-tools">
 	<property name="database.sharding" value="true" />
+	<property name="databases.size" value="2" />
 	<property name="testray.main.component.name" value="Tools" />
 
 	<command name="Smoke" priority="5">

--- a/test.properties
+++ b/test.properties
@@ -715,6 +715,7 @@
         custom.properties,\
         data.archive.type,\
         database.sharding,\
+        databases.size,\
         default.layout.template.id,\
         hook.plugins.includes,\
         ignore.errors,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-11785

Hi Brian, this pull is to allow us to write SAML tests that require 2 separate instances of liferay on 2 separate databases.

I wasn't able to cherry pick into ee-6.1.x from ee-6.2.x, and I wasn't able to cherry-pick from ee-6.1.x into ee-6.1.30, so you'll have to specifically fetch the ee-6.1.x and ee-6.1.30 pulls.

In my pull, I did the following (broken up by these commits)
1. I renamed the variables in "prepare-additional-bundles" to match the variables from "run-simple-server"
2. I split up "app.server.bundles.size" and "cluster.enabled" because they don't always go together. There will be times when we want multiple instances of liferay but not for clustering.
3. I added the logic for creating multiple databases. I followed the same format as what was already existing in "run-simple-server" and "prepare-additional-bundles". That's why I used "databases.size" and "database.index". Let me know if you prefer different names.
4. Since I wanted to reuse "set-app-server-properties", I renamed "app.server.bundle.index" to "index" to be more generic because I was also passing in "database.index". I talked this over with Hashi and "index" seemed to be ok since that attribute is only being used in that specific macrodef. Let me know if this should be changed back to app.server.bundle.index.
