### PR TITLE
LPS-50962 remove file size validation from DLStore

### DIFF
--- a/portal-impl/src/com/liferay/portal/image/DLHook.java
+++ b/portal-impl/src/com/liferay/portal/image/DLHook.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Image;
 import com.liferay.portlet.documentlibrary.NoSuchFileException;
 import com.liferay.portlet.documentlibrary.store.DLStoreUtil;
+import com.liferay.portlet.documentlibrary.util.DLValidatorUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -75,6 +76,8 @@ public class DLHook extends BaseHook {
 		throws PortalException {
 
 		String fileName = getFileName(image.getImageId(), image.getType());
+
+		DLValidatorUtil.validateFileSize(fileName, bytes);
 
 		if (DLStoreUtil.hasFile(_COMPANY_ID, _REPOSITORY_ID, fileName)) {
 			DLStoreUtil.deleteFile(_COMPANY_ID, _REPOSITORY_ID, fileName);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -75,7 +75,7 @@ public class DLStoreImpl implements DLStore {
 			boolean validateFileExtension, byte[] bytes)
 		throws PortalException {
 
-		validate(fileName, validateFileExtension, bytes);
+		validate(fileName, validateFileExtension);
 
 		if (PropsValues.DL_STORE_ANTIVIRUS_ENABLED) {
 			AntivirusScannerUtil.scan(bytes);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -480,8 +480,9 @@ public class DLStoreImpl implements DLStore {
 		throws PortalException {
 
 		validate(
-			fileName, fileExtension, sourceFileName, validateFileExtension,
-			file, versionLabel);
+			fileName, fileExtension, sourceFileName, validateFileExtension);
+
+		DLValidatorUtil.validateVersionLabel(versionLabel);
 
 		if (PropsValues.DL_STORE_ANTIVIRUS_ENABLED) {
 			AntivirusScannerUtil.scan(file);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -512,8 +512,9 @@ public class DLStoreImpl implements DLStore {
 		}
 
 		validate(
-			fileName, fileExtension, sourceFileName, validateFileExtension, is,
-			versionLabel);
+			fileName, fileExtension, sourceFileName, validateFileExtension);
+
+		DLValidatorUtil.validateVersionLabel(versionLabel);
 
 		if (!PropsValues.DL_STORE_ANTIVIRUS_ENABLED ||
 			!AntivirusScannerUtil.isActive()) {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -90,7 +90,7 @@ public class DLStoreImpl implements DLStore {
 			boolean validateFileExtension, File file)
 		throws PortalException {
 
-		validate(fileName, validateFileExtension, file);
+		validate(fileName, validateFileExtension);
 
 		if (PropsValues.DL_STORE_ANTIVIRUS_ENABLED) {
 			AntivirusScannerUtil.scan(file);

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/store/DLStoreImpl.java
@@ -117,7 +117,7 @@ public class DLStoreImpl implements DLStore {
 			return;
 		}
 
-		validate(fileName, validateFileExtension, is);
+		validate(fileName, validateFileExtension);
 
 		if (!PropsValues.DL_STORE_ANTIVIRUS_ENABLED ||
 			!AntivirusScannerUtil.isActive()) {


### PR DESCRIPTION
Hey Brian,

We are removing file size validation from DLStore because that's tooooo low in the layers and we don't want to do it at that layer. The thing is that we want to control the file size at a repository level, so we could have one repository for LAR files with a really big file size, then maybe another repository with smaller max file size for message boards attachments, other repository with different settings for DL, etc...
