### PR TITLE
LPS-51165 Don't create empty <dynamic-element>, it causes xml validation failure

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/io/DDMFormXSDSerializerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/io/DDMFormXSDSerializerImpl.java
@@ -80,12 +80,21 @@ public class DDMFormXSDSerializerImpl implements DDMFormXSDSerializer {
 	protected void addDynamicElementElement(
 		DDMFormField ddmFormField, Element element) {
 
+		List<DDMFormField> nestedDDMFormFields =
+			ddmFormField.getNestedDDMFormFields();
+
+		Map<Locale, Map<String, String>> metadataMap =
+			getDDMFormFieldMetadataMap(ddmFormField);
+
+		if (nestedDDMFormFields.isEmpty() && metadataMap.isEmpty()) {
+			return;
+		}
+
 		Element dynamicElementElement = element.addElement("dynamic-element");
 
 		addDynamicElementAttributes(ddmFormField, dynamicElementElement);
 
-		addDynamicElementElements(
-			ddmFormField.getNestedDDMFormFields(), dynamicElementElement);
+		addDynamicElementElements(nestedDDMFormFields, dynamicElementElement);
 
 		String ddmFormFieldType = ddmFormField.getType();
 
@@ -95,9 +104,6 @@ public class DDMFormXSDSerializerImpl implements DDMFormXSDSerializer {
 			addOptionsDynamicElements(
 				ddmFormField.getDDMFormFieldOptions(), dynamicElementElement);
 		}
-
-		Map<Locale, Map<String, String>> metadataMap =
-			getDDMFormFieldMetadataMap(ddmFormField);
 
 		addMetadataElements(metadataMap, dynamicElementElement);
 	}


### PR DESCRIPTION
Fix for StagingImplTest

CC @marcellustavares

I don't really know this, but I feel it should be the way to fix it.

Basically, DDMFormXSDSerializerImpl generates an empty <dynamic-element> and saved into db, later when we read it back, it breaks on DDMXMLImpl.validateXML(String)
