### PR TITLE
LPS-51279 ZipWriterImpl is gc tracking on the wrong file object

### DIFF
--- a/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
+++ b/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
@@ -49,7 +49,8 @@ public class ZipWriterImpl implements ZipWriter {
 		_file.mkdir();
 
 		FinalizeManager.register(
-			_file, new DeleteFileFinalizeAction(_file.getAbsolutePath()),
+			_file.getDelegate(),
+			new DeleteFileFinalizeAction(_file.getAbsolutePath()),
 			FinalizeManager.PHANTOM_REFERENCE_FACTORY);
 	}
 


### PR DESCRIPTION
Fix for https://test-14-1.liferay.com/job/test-portal-pullrequest-backend(master)/287/org.jenkins-ci.plugins%24ghprb/testReport/junit/com.liferay.portal.lar/LayoutSetPrototypePropagationTest/testAddChildLayoutWithLinkDisabled
