### PR TITLE
LPS-51290 BaseAssetSearchTestCase's poor expiration date generation mayb...

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/BaseAssetSearchTestCase.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/BaseAssetSearchTestCase.java
@@ -17,10 +17,12 @@ package com.liferay.portlet.asset.service.persistence;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.service.ServiceContext;
@@ -922,8 +924,7 @@ public abstract class BaseAssetSearchTestCase {
 
 		for (int i = 0; i < size; i++) {
 			Date date = new Date(
-				startDate.getTime() +
-				(long)(Math.random() * 60 * 60 * 24 * 365));
+				startDate.getTime() + (RandomUtil.nextInt(365) + 1) * Time.DAY);
 
 			Calendar calendar = new GregorianCalendar();
 


### PR DESCRIPTION
...e too close to current time causing JournalArticle validation to fail

Fix for https://test-14-2.liferay.com/job/test-portal-pullrequest-backend%28master%29/325/group=22,label_exp=!test-14-2/testReport/junit/com.liferay.portlet.journal.asset/JournalArticleAssetSearchTest/testOrderByExpirationDateAsc/
