### PR TITLE
Revert part of "LPS-48545 Apply the previous test rule to the tests whic...

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/dao/orm/SQLNullTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/dao/orm/SQLNullTest.java
@@ -21,8 +21,10 @@ import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
+import com.liferay.portal.kernel.test.ExecutionTestListeners;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.test.TransactionalTestRule;
+import com.liferay.portal.test.listeners.MainServletExecutionTestListener;
 import com.liferay.portal.test.runners.LiferayIntegrationJUnitTestRunner;
 
 import java.util.List;
@@ -436,6 +438,7 @@ import org.junit.runner.RunWith;
  *
  * @author Shuyang Zhou
  */
+@ExecutionTestListeners(listeners = {MainServletExecutionTestListener.class})
 @RunWith(LiferayIntegrationJUnitTestRunner.class)
 public class SQLNullTest {
 


### PR DESCRIPTION
...h are using it". Makes it so SQLNullTest can run on it's own outside of an integration test.
