### PR TITLE
master-qa-11740

### DIFF
--- a/build-test-plugins.xml
+++ b/build-test-plugins.xml
@@ -11,7 +11,7 @@
 app.server.type=${app.server.type}
 app.server.jboss.dir=${app.server.dir}
 
-auto.deploy.dir=${liferay.home}/deploy
+auto.deploy.dir=${auto.deploy.dir}
 
 plugins.includes=${plugins.includes}</echo>
 			</then>
@@ -19,7 +19,7 @@ plugins.includes=${plugins.includes}</echo>
 				<echo file="${lp.plugins.dir}/build.${user.name}.properties">app.server.parent.dir=${app.server.parent.dir}
 app.server.type=${app.server.type}
 
-auto.deploy.dir=${liferay.home}/deploy
+auto.deploy.dir=${auto.deploy.dir}
 
 plugins.includes=${plugins.includes}</echo>
 			</else>

--- a/test.properties
+++ b/test.properties
@@ -85,6 +85,12 @@
     app.server.websphere.stop.executable.arg.line=server1
 
 ##
+## Auto Deploy
+##
+
+    auto.deploy.dir=${liferay.home}/deploy
+
+##
 ## Browser
 ##
 


### PR DESCRIPTION
http://issues.liferay.com/browse/LIFERAYQA-11740

@brianchandotcom 
The reason we are moving the 'auto.deploy.dir' out into it's own property is because in these new OSGi Jenkins Jobs we need to distinguish that directory from the 'liferay.home'
