### PR TITLE
LPS-51439 Expose test.type as an attribute for setup-test-classpath

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -987,6 +987,8 @@ Please set the environment variable ANT_OPTS to the recommended value of
 	</macrodef>
 
 	<macrodef name="setup-test-classpath">
+		<attribute name="test.type" />
+
 		<sequential>
 			<ivy:resolve log="download-only">
 				<dependency name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.2.Final" />
@@ -999,7 +1001,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 			</path>
 
 			<path id="test.classpath">
-				<pathelement path="test-classes/${test.type}" />
+				<pathelement path="test-classes/@{test.type}" />
 				<pathelement path="${classpath}" />
 				<pathelement path="${test.additional.classpath}" />
 				<path refid="test-ivy.classpath" />
@@ -1103,7 +1105,9 @@ rerun your task.
 		<if>
 			<available file="test/${test.type}" type="dir" />
 			<then>
-				<setup-test-classpath />
+				<setup-test-classpath
+					test.type="${test.type}"
+				/>
 
 				<mkdir dir="test-classes/${test.type}" />
 				<mkdir dir="test-results/${test.type}" />
@@ -1334,7 +1338,9 @@ rerun your task.
 			setonempty="false"
 		/>
 
-		<setup-test-classpath />
+		<setup-test-classpath
+			test.type="${test.type}"
+		/>
 
 		<if>
 			<not>
@@ -1431,7 +1437,9 @@ rerun your task.
 			</then>
 		</if>
 
-		<setup-test-classpath />
+		<setup-test-classpath
+			test.type="${test.type}"
+		/>
 
 		<if>
 			<available file="test/${test.dir}" type="dir" />
@@ -1624,7 +1632,9 @@ rerun your task.
 			replace="com."
 		/>
 
-		<setup-test-classpath />
+		<setup-test-classpath
+			test.type="${test.type}"
+		/>
 
 		<junit dir="${project.dir}" fork="on" forkmode="once" haltonfailure="${junit.halt.on.failure}" jvm="${junit.jvm}" outputtoformatters="false" printsummary="on" showoutput="true">
 			<sysproperty key="junit.aspectj.dump" file="woven-classes" />


### PR DESCRIPTION
ee-6.2.x backport pull at https://github.com/brianchandotcom/liferay-portal-ee/pull/7694

Plugins do not need this classpath separation feature, so there is no counterpart in plugin for this.
