### PR TITLE
LPS-51469 portal-service does not have integration test, should not extract MANIFEST.MF for it

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1143,15 +1143,6 @@ rerun your task.
 				<include name="META-INF/MANIFEST.MF" />
 			</patternset>
 		</unzip>
-
-		<unzip
-			dest="${project.dir}/portal-service/test-classes/integration"
-			src="${project.dir}/portal-service/portal-service.jar"
-		>
-			<patternset>
-				<include name="META-INF/MANIFEST.MF" />
-			</patternset>
-		</unzip>
 	</target>
 
 	<target name="compile-test-unit">


### PR DESCRIPTION
CC @cgoncas

This is a partial revert of LPS-48707 f303611e435ec8c1df1f7363de92e4d4b0d6c009

portal-service does not have integration test, it does not make sense to extract MANIFEST.MF for it, as no one will try to load it.

I also tried to remove the portal-impl MANIFEST.MF extraction locally, integration tests are still working fine.

Cristina, are you sure this is really needed to extract any MANIFEST.MF at all?

What error did you see without those MANIFEST.MF?

If they are not really needed, please go ahead remove the portal-impl one too.

Thanks
Shuyang
