### PR TITLE
LPS-51358 Move workflow logic to repository level

### DIFF
--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -680,6 +680,51 @@ public class CapabilityRepository
 
 	@Override
 	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		Repository repository = getRepository();
+
+		FileEntry fileEntry = repository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+
+		_repositoryEventTrigger.trigger(
+			RepositoryEventType.Update.class, FileEntry.class, fileEntry);
+
+		return fileEntry;
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		Repository repository = getRepository();
+
+		FileEntry fileEntry = repository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+
+		_repositoryEventTrigger.trigger(
+			RepositoryEventType.Update.class, FileEntry.class, fileEntry);
+
+		return fileEntry;
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.File, com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String description, String changeLog,
 			boolean majorVersion, File file, ServiceContext serviceContext)
@@ -697,6 +742,13 @@ public class CapabilityRepository
 		return fileEntry;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.InputStream, long,
+	 *             com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,

--- a/portal-impl/src/com/liferay/portal/repository/cmis/CMISRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/cmis/CMISRepository.java
@@ -1274,8 +1274,8 @@ public class CMISRepository extends BaseCmisRepository {
 
 	@Override
 	public FileEntry updateFileEntry(
-			long fileEntryId, String sourceFileName, String mimeType,
-			String title, String description, String changeLog,
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
 			boolean majorVersion, InputStream is, long size,
 			ServiceContext serviceContext)
 		throws PortalException {

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayRepositoryDefiner.java
@@ -14,7 +14,10 @@
 
 package com.liferay.portal.repository.liferayrepository;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.DocumentRepository;
+import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.Repository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
 import com.liferay.portal.kernel.repository.capabilities.BulkOperationCapability;
 import com.liferay.portal.kernel.repository.capabilities.SyncCapability;
@@ -79,7 +82,8 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 	}
 
 	public void setRepositoryFactory(RepositoryFactory repositoryFactory) {
-		_repositoryFactory = repositoryFactory;
+		_repositoryFactory = new LiferayRepositoryFactoryWrapper(
+			repositoryFactory);
 	}
 
 	private final LiferaySyncCapability _liferaySyncCapability =
@@ -87,5 +91,34 @@ public class LiferayRepositoryDefiner extends BaseRepositoryDefiner {
 	private final LiferayTrashCapability _liferayTrashCapability =
 		new LiferayTrashCapability();
 	private RepositoryFactory _repositoryFactory;
+
+	private final class LiferayRepositoryFactoryWrapper
+		implements RepositoryFactory {
+
+		public LiferayRepositoryFactoryWrapper(
+			RepositoryFactory repositoryFactory) {
+
+			_repositoryFactory = repositoryFactory;
+		}
+
+		@Override
+		public LocalRepository createLocalRepository(long repositoryId)
+			throws PortalException {
+
+			return new LiferayWorkflowLocalRepositoryWrapper(
+				_repositoryFactory.createLocalRepository(repositoryId));
+		}
+
+		@Override
+		public Repository createRepository(long repositoryId)
+			throws PortalException {
+
+			return new LiferayWorkflowRepositoryWrapper(
+				_repositoryFactory.createRepository(repositoryId));
+		}
+
+		private final RepositoryFactory _repositoryFactory;
+
+	}
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowLocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowLocalRepositoryWrapper.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.liferayrepository;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.repository.util.LocalRepositoryWrapper;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class LiferayWorkflowLocalRepositoryWrapper
+	extends LocalRepositoryWrapper {
+
+	public LiferayWorkflowLocalRepositoryWrapper(
+		LocalRepository localRepository) {
+
+		super(localRepository);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		return super.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return super.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowRepositoryWrapper.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.liferayrepository;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.repository.util.RepositoryWrapper;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class LiferayWorkflowRepositoryWrapper extends RepositoryWrapper {
+
+	public LiferayWorkflowRepositoryWrapper(Repository repository) {
+		super(repository);
+	}
+
+	@Override
+	public void revertFileEntry(
+			long fileEntryId, String version, ServiceContext serviceContext)
+		throws PortalException {
+
+		super.revertFileEntry(fileEntryId, version, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		return super.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return super.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/liferayrepository/LiferayWorkflowRepositoryWrapper.java
@@ -61,8 +61,8 @@ public class LiferayWorkflowRepositoryWrapper extends RepositoryWrapper {
 
 	@Override
 	public FileEntry updateFileEntry(
-			long fileEntryId, String sourceFileName, String mimeType,
-			String title, String description, String changeLog,
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
 			boolean majorVersion, File file, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -70,18 +70,18 @@ public class LiferayWorkflowRepositoryWrapper extends RepositoryWrapper {
 			fileEntryId, serviceContext);
 
 		FileEntry fileEntry = super.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, description,
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
 			changeLog, majorVersion, file, serviceContext);
 
-		_startWorkflowInstance(_getUserId(), dlFileVersion, serviceContext);
+		_startWorkflowInstance(userId, dlFileVersion, serviceContext);
 
 		return fileEntry;
 	}
 
 	@Override
 	public FileEntry updateFileEntry(
-			long fileEntryId, String sourceFileName, String mimeType,
-			String title, String description, String changeLog,
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
 			boolean majorVersion, InputStream is, long size,
 			ServiceContext serviceContext)
 		throws PortalException {
@@ -90,12 +90,50 @@ public class LiferayWorkflowRepositoryWrapper extends RepositoryWrapper {
 			fileEntryId, serviceContext);
 
 		FileEntry fileEntry = super.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, description,
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
 			changeLog, majorVersion, is, size, serviceContext);
 
-		_startWorkflowInstance(_getUserId(), dlFileVersion, serviceContext);
+		_startWorkflowInstance(userId, dlFileVersion, serviceContext);
 
 		return fileEntry;
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.File, com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		return updateFileEntry(
+			_getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, file, serviceContext);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.InputStream, long,
+	 *             com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return updateFileEntry(
+			_getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, is, size, serviceContext);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/LocalRepositoryWrapper.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.LocalRepository;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class LocalRepositoryWrapper implements LocalRepository {
+
+	public LocalRepositoryWrapper(LocalRepository localRepository) {
+		_localRepository = localRepository;
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long userId, long folderId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog, File file,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.addFileEntry(
+			userId, folderId, sourceFileName, mimeType, title, description,
+			changeLog, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long userId, long folderId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog, InputStream is,
+			long size, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.addFileEntry(
+			userId, folderId, sourceFileName, mimeType, title, description,
+			changeLog, is, size, serviceContext);
+	}
+
+	@Override
+	public Folder addFolder(
+			long userId, long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.addFolder(
+			userId, parentFolderId, name, description, serviceContext);
+	}
+
+	@Override
+	public void deleteAll() throws PortalException {
+		_localRepository.deleteAll();
+	}
+
+	@Override
+	public void deleteFileEntry(long fileEntryId) throws PortalException {
+		_localRepository.deleteFileEntry(fileEntryId);
+	}
+
+	@Override
+	public void deleteFolder(long folderId) throws PortalException {
+		_localRepository.deleteFolder(folderId);
+	}
+
+	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		return _localRepository.getCapability(capabilityClass);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long fileEntryId) throws PortalException {
+		return _localRepository.getFileEntry(fileEntryId);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long folderId, String title)
+		throws PortalException {
+
+		return _localRepository.getFileEntry(folderId, title);
+	}
+
+	@Override
+	public FileEntry getFileEntryByUuid(String uuid) throws PortalException {
+		return _localRepository.getFileEntryByUuid(uuid);
+	}
+
+	@Override
+	public FileVersion getFileVersion(long fileVersionId)
+		throws PortalException {
+
+		return _localRepository.getFileVersion(fileVersionId);
+	}
+
+	@Override
+	public Folder getFolder(long folderId) throws PortalException {
+		return _localRepository.getFolder(folderId);
+	}
+
+	@Override
+	public Folder getFolder(long parentFolderId, String name)
+		throws PortalException {
+
+		return _localRepository.getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public List<FileEntry> getRepositoryFileEntries(
+			long rootFolderId, int start, int end,
+			OrderByComparator<FileEntry> obc)
+		throws PortalException {
+
+		return _localRepository.getRepositoryFileEntries(
+			rootFolderId, start, end, obc);
+	}
+
+	@Override
+	public long getRepositoryId() {
+		return _localRepository.getRepositoryId();
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return _localRepository.isCapabilityProvided(capabilityClass);
+	}
+
+	@Override
+	public FileEntry moveFileEntry(
+			long userId, long fileEntryId, long newFolderId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.moveFileEntry(
+			userId, fileEntryId, newFolderId, serviceContext);
+	}
+
+	@Override
+	public Folder moveFolder(
+			long userId, long folderId, long parentFolderId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.moveFolder(
+			userId, folderId, parentFolderId, serviceContext);
+	}
+
+	@Override
+	public void updateAsset(
+			long userId, FileEntry fileEntry, FileVersion fileVersion,
+			long[] assetCategoryIds, String[] assetTagNames,
+			long[] assetLinkEntryIds)
+		throws PortalException {
+
+		_localRepository.updateAsset(
+			userId, fileEntry, fileVersion, assetCategoryIds, assetTagNames,
+			assetLinkEntryIds);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+	}
+
+	@Override
+	public Folder updateFolder(
+			long folderId, long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _localRepository.updateFolder(
+			folderId, parentFolderId, name, description, serviceContext);
+	}
+
+	private final LocalRepository _localRepository;
+
+}

--- a/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
@@ -560,6 +560,37 @@ public class RepositoryWrapper implements Repository {
 
 	@Override
 	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.File, com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String description, String changeLog,
 			boolean majorVersion, File file, ServiceContext serviceContext)
@@ -570,6 +601,13 @@ public class RepositoryWrapper implements Repository {
 			changeLog, majorVersion, file, serviceContext);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.InputStream, long,
+	 *             com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,

--- a/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/RepositoryWrapper.java
@@ -1,0 +1,619 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.repository.util;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.model.Lock;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.List;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class RepositoryWrapper implements Repository {
+
+	public RepositoryWrapper(Repository repository) {
+		_repository = repository;
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long folderId, String sourceFileName, String mimeType, String title,
+			String description, String changeLog, File file,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.addFileEntry(
+			folderId, sourceFileName, mimeType, title, description, changeLog,
+			file, serviceContext);
+	}
+
+	@Override
+	public FileEntry addFileEntry(
+			long folderId, String sourceFileName, String mimeType, String title,
+			String description, String changeLog, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.addFileEntry(
+			folderId, sourceFileName, mimeType, title, description, changeLog,
+			is, size, serviceContext);
+	}
+
+	@Override
+	public Folder addFolder(
+			long parentFolderId, String name, String description,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.addFolder(
+			parentFolderId, name, description, serviceContext);
+	}
+
+	@Override
+	public FileVersion cancelCheckOut(long fileEntryId) throws PortalException {
+		return _repository.cancelCheckOut(fileEntryId);
+	}
+
+	@Override
+	public void checkInFileEntry(
+			long fileEntryId, boolean major, String changeLog,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_repository.checkInFileEntry(
+			fileEntryId, major, changeLog, serviceContext);
+	}
+
+	@Deprecated
+	@Override
+	public void checkInFileEntry(long fileEntryId, String lockUuid)
+		throws PortalException {
+
+		_repository.checkInFileEntry(fileEntryId, lockUuid);
+	}
+
+	@Override
+	public void checkInFileEntry(
+			long fileEntryId, String lockUuid, ServiceContext serviceContext)
+		throws PortalException {
+
+		_repository.checkInFileEntry(fileEntryId, lockUuid, serviceContext);
+	}
+
+	@Override
+	public FileEntry checkOutFileEntry(
+			long fileEntryId, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.checkOutFileEntry(fileEntryId, serviceContext);
+	}
+
+	@Override
+	public FileEntry checkOutFileEntry(
+			long fileEntryId, String owner, long expirationTime,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.checkOutFileEntry(
+			fileEntryId, owner, expirationTime, serviceContext);
+	}
+
+	@Override
+	public FileEntry copyFileEntry(
+			long groupId, long fileEntryId, long destFolderId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.copyFileEntry(
+			groupId, fileEntryId, destFolderId, serviceContext);
+	}
+
+	@Override
+	public void deleteFileEntry(long fileEntryId) throws PortalException {
+		_repository.deleteFileEntry(fileEntryId);
+	}
+
+	@Override
+	public void deleteFileEntry(long folderId, String title)
+		throws PortalException {
+
+		_repository.deleteFileEntry(folderId, title);
+	}
+
+	@Override
+	public void deleteFileVersion(long fileEntryId, String version)
+		throws PortalException {
+
+		_repository.deleteFileVersion(fileEntryId, version);
+	}
+
+	@Override
+	public void deleteFolder(long folderId) throws PortalException {
+		_repository.deleteFolder(folderId);
+	}
+
+	@Override
+	public void deleteFolder(long parentFolderId, String name)
+		throws PortalException {
+
+		_repository.deleteFolder(parentFolderId, name);
+	}
+
+	@Override
+	public <T extends Capability> T getCapability(Class<T> capabilityClass) {
+		return _repository.getCapability(capabilityClass);
+	}
+
+	@Override
+	public List<FileEntry> getFileEntries(
+			long folderId, int start, int end, OrderByComparator<FileEntry> obc)
+		throws PortalException {
+
+		return _repository.getFileEntries(folderId, start, end, obc);
+	}
+
+	@Override
+	public List<FileEntry> getFileEntries(
+			long folderId, long fileEntryTypeId, int start, int end,
+			OrderByComparator<FileEntry> obc)
+		throws PortalException {
+
+		return _repository.getFileEntries(
+			folderId, fileEntryTypeId, start, end, obc);
+	}
+
+	@Override
+	public List<FileEntry> getFileEntries(
+			long folderId, String[] mimeTypes, int start, int end,
+			OrderByComparator<FileEntry> obc)
+		throws PortalException {
+
+		return _repository.getFileEntries(folderId, mimeTypes, start, end, obc);
+	}
+
+	@Override
+	public List<Object> getFileEntriesAndFileShortcuts(
+			long folderId, int status, int start, int end)
+		throws PortalException {
+
+		return _repository.getFileEntriesAndFileShortcuts(
+			folderId, status, start, end);
+	}
+
+	@Override
+	public int getFileEntriesAndFileShortcutsCount(long folderId, int status)
+		throws PortalException {
+
+		return _repository.getFileEntriesAndFileShortcutsCount(
+			folderId, status);
+	}
+
+	@Override
+	public int getFileEntriesAndFileShortcutsCount(
+			long folderId, int status, String[] mimeTypes)
+		throws PortalException {
+
+		return _repository.getFileEntriesAndFileShortcutsCount(
+			folderId, status, mimeTypes);
+	}
+
+	@Override
+	public int getFileEntriesCount(long folderId) throws PortalException {
+		return _repository.getFileEntriesCount(folderId);
+	}
+
+	@Override
+	public int getFileEntriesCount(long folderId, long fileEntryTypeId)
+		throws PortalException {
+
+		return _repository.getFileEntriesCount(folderId, fileEntryTypeId);
+	}
+
+	@Override
+	public int getFileEntriesCount(long folderId, String[] mimeTypes)
+		throws PortalException {
+
+		return _repository.getFileEntriesCount(folderId, mimeTypes);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long fileEntryId) throws PortalException {
+		return _repository.getFileEntry(fileEntryId);
+	}
+
+	@Override
+	public FileEntry getFileEntry(long folderId, String title)
+		throws PortalException {
+
+		return _repository.getFileEntry(folderId, title);
+	}
+
+	@Override
+	public FileEntry getFileEntryByUuid(String uuid) throws PortalException {
+		return _repository.getFileEntryByUuid(uuid);
+	}
+
+	@Override
+	public FileVersion getFileVersion(long fileVersionId)
+		throws PortalException {
+
+		return _repository.getFileVersion(fileVersionId);
+	}
+
+	@Override
+	public Folder getFolder(long folderId) throws PortalException {
+		return _repository.getFolder(folderId);
+	}
+
+	@Override
+	public Folder getFolder(long parentFolderId, String name)
+		throws PortalException {
+
+		return _repository.getFolder(parentFolderId, name);
+	}
+
+	@Override
+	public List<Folder> getFolders(
+			long parentFolderId, boolean includeMountFolders, int start,
+			int end, OrderByComparator<Folder> obc)
+		throws PortalException {
+
+		return _repository.getFolders(
+			parentFolderId, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public List<Folder> getFolders(
+			long parentFolderId, int status, boolean includeMountFolders,
+			int start, int end, OrderByComparator<Folder> obc)
+		throws PortalException {
+
+		return _repository.getFolders(
+			parentFolderId, status, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
+			long folderId, int status, boolean includeMountFolders, int start,
+			int end, OrderByComparator<?> obc)
+		throws PortalException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcuts(
+			folderId, status, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public List<Object> getFoldersAndFileEntriesAndFileShortcuts(
+			long folderId, int status, String[] mimetypes,
+			boolean includeMountFolders, int start, int end,
+			OrderByComparator<?> obc)
+		throws PortalException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcuts(
+			folderId, status, mimetypes, includeMountFolders, start, end, obc);
+	}
+
+	@Override
+	public int getFoldersAndFileEntriesAndFileShortcutsCount(
+			long folderId, int status, boolean includeMountFolders)
+		throws PortalException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcutsCount(
+			folderId, status, includeMountFolders);
+	}
+
+	@Override
+	public int getFoldersAndFileEntriesAndFileShortcutsCount(
+			long folderId, int status, String[] mimetypes,
+			boolean includeMountFolders)
+		throws PortalException {
+
+		return _repository.getFoldersAndFileEntriesAndFileShortcutsCount(
+			folderId, status, mimetypes, includeMountFolders);
+	}
+
+	@Override
+	public int getFoldersCount(long parentFolderId, boolean includeMountfolders)
+		throws PortalException {
+
+		return _repository.getFoldersCount(parentFolderId, includeMountfolders);
+	}
+
+	@Override
+	public int getFoldersCount(
+			long parentFolderId, int status, boolean includeMountfolders)
+		throws PortalException {
+
+		return _repository.getFoldersCount(
+			parentFolderId, status, includeMountfolders);
+	}
+
+	@Override
+	public int getFoldersFileEntriesCount(List<Long> folderIds, int status)
+		throws PortalException {
+
+		return _repository.getFoldersFileEntriesCount(folderIds, status);
+	}
+
+	@Override
+	public List<Folder> getMountFolders(
+			long parentFolderId, int start, int end,
+			OrderByComparator<Folder> obc)
+		throws PortalException {
+
+		return _repository.getMountFolders(parentFolderId, start, end, obc);
+	}
+
+	@Override
+	public int getMountFoldersCount(long parentFolderId)
+		throws PortalException {
+
+		return _repository.getMountFoldersCount(parentFolderId);
+	}
+
+	@Override
+	public List<FileEntry> getRepositoryFileEntries(
+			long userId, long rootFolderId, int start, int end,
+			OrderByComparator<FileEntry> obc)
+		throws PortalException {
+
+		return _repository.getRepositoryFileEntries(
+			userId, rootFolderId, start, end, obc);
+	}
+
+	@Override
+	public List<FileEntry> getRepositoryFileEntries(
+			long userId, long rootFolderId, String[] mimeTypes, int status,
+			int start, int end, OrderByComparator<FileEntry> obc)
+		throws PortalException {
+
+		return _repository.getRepositoryFileEntries(
+			userId, rootFolderId, mimeTypes, status, start, end, obc);
+	}
+
+	@Override
+	public int getRepositoryFileEntriesCount(long userId, long rootFolderId)
+		throws PortalException {
+
+		return _repository.getRepositoryFileEntriesCount(userId, rootFolderId);
+	}
+
+	@Override
+	public int getRepositoryFileEntriesCount(
+			long userId, long rootFolderId, String[] mimeTypes, int status)
+		throws PortalException {
+
+		return _repository.getRepositoryFileEntriesCount(
+			userId, rootFolderId, mimeTypes, status);
+	}
+
+	@Override
+	public long getRepositoryId() {
+		return _repository.getRepositoryId();
+	}
+
+	@Override
+	public void getSubfolderIds(List<Long> folderIds, long folderId)
+		throws PortalException {
+
+		_repository.getSubfolderIds(folderIds, folderId);
+	}
+
+	@Override
+	public List<Long> getSubfolderIds(long folderId, boolean recurse)
+		throws PortalException {
+
+		return _repository.getSubfolderIds(folderId, recurse);
+	}
+
+	@Override
+	public <T extends Capability> boolean isCapabilityProvided(
+		Class<T> capabilityClass) {
+
+		return _repository.isCapabilityProvided(capabilityClass);
+	}
+
+	@Deprecated
+	@Override
+	public Lock lockFileEntry(long fileEntryId) throws PortalException {
+		return _repository.lockFileEntry(fileEntryId);
+	}
+
+	@Deprecated
+	@Override
+	public Lock lockFileEntry(
+			long fileEntryId, String owner, long expirationTime)
+		throws PortalException {
+
+		return _repository.lockFileEntry(fileEntryId, owner, expirationTime);
+	}
+
+	@Override
+	public Lock lockFolder(long folderId) throws PortalException {
+		return _repository.lockFolder(folderId);
+	}
+
+	@Override
+	public Lock lockFolder(
+			long folderId, String owner, boolean inheritable,
+			long expirationTime)
+		throws PortalException {
+
+		return _repository.lockFolder(
+			folderId, owner, inheritable, expirationTime);
+	}
+
+	@Override
+	public FileEntry moveFileEntry(
+			long fileEntryId, long newFolderId, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.moveFileEntry(
+			fileEntryId, newFolderId, serviceContext);
+	}
+
+	@Override
+	public Folder moveFolder(
+			long folderId, long newParentFolderId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.moveFolder(
+			folderId, newParentFolderId, serviceContext);
+	}
+
+	@Override
+	public Lock refreshFileEntryLock(
+			String lockUuid, long companyId, long expirationTime)
+		throws PortalException {
+
+		return _repository.refreshFileEntryLock(
+			lockUuid, companyId, expirationTime);
+	}
+
+	@Override
+	public Lock refreshFolderLock(
+			String lockUuid, long companyId, long expirationTime)
+		throws PortalException {
+
+		return _repository.refreshFolderLock(
+			lockUuid, companyId, expirationTime);
+	}
+
+	@Override
+	public void revertFileEntry(
+			long fileEntryId, String version, ServiceContext serviceContext)
+		throws PortalException {
+
+		_repository.revertFileEntry(fileEntryId, version, serviceContext);
+	}
+
+	@Override
+	public Hits search(long creatorUserId, int status, int start, int end)
+		throws PortalException {
+
+		return _repository.search(creatorUserId, status, start, end);
+	}
+
+	@Override
+	public Hits search(
+			long creatorUserId, long folderId, String[] mimeTypes, int status,
+			int start, int end)
+		throws PortalException {
+
+		return _repository.search(
+			creatorUserId, folderId, mimeTypes, status, start, end);
+	}
+
+	@Override
+	public Hits search(SearchContext searchContext) throws SearchException {
+		return _repository.search(searchContext);
+	}
+
+	@Override
+	public Hits search(SearchContext searchContext, Query query)
+		throws SearchException {
+
+		return _repository.search(searchContext, query);
+	}
+
+	@Override
+	public void unlockFolder(long folderId, String lockUuid)
+		throws PortalException {
+
+		_repository.unlockFolder(folderId, lockUuid);
+	}
+
+	@Override
+	public void unlockFolder(long parentFolderId, String name, String lockUuid)
+		throws PortalException {
+
+		_repository.unlockFolder(parentFolderId, name, lockUuid);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.updateFileEntry(
+			fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+	}
+
+	@Override
+	public Folder updateFolder(
+			long folderId, String name, String description,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return _repository.updateFolder(
+			folderId, name, description, serviceContext);
+	}
+
+	@Override
+	public boolean verifyFileEntryCheckOut(long fileEntryId, String lockUuid)
+		throws PortalException {
+
+		return _repository.verifyFileEntryCheckOut(fileEntryId, lockUuid);
+	}
+
+	@Override
+	public boolean verifyFileEntryLock(long fileEntryId, String lockUuid)
+		throws PortalException {
+
+		return _repository.verifyFileEntryLock(fileEntryId, lockUuid);
+	}
+
+	@Override
+	public boolean verifyInheritableLock(long folderId, String lockUuid)
+		throws PortalException {
+
+		return _repository.verifyInheritableLock(folderId, lockUuid);
+	}
+
+	private final Repository _repository;
+
+}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.java
@@ -2918,8 +2918,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository repository = getFileEntryRepository(fileEntryId);
 
 		FileEntry fileEntry = repository.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, description,
-			changeLog, majorVersion, file, serviceContext);
+			getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, file, serviceContext);
 
 		DLProcessorRegistryUtil.cleanUp(fileEntry.getLatestFileVersion());
 
@@ -3009,8 +3009,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		FileVersion oldFileVersion = oldFileEntry.getFileVersion();
 
 		FileEntry fileEntry = repository.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, description,
-			changeLog, majorVersion, is, size, serviceContext);
+			getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, is, size, serviceContext);
 
 		if (is != null) {
 			DLProcessorRegistryUtil.cleanUp(fileEntry.getLatestFileVersion());
@@ -3041,8 +3041,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		Repository repository = getFileEntryRepository(fileEntryId);
 
 		FileEntry fileEntry = repository.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, description,
-			changeLog, majorVersion, file, serviceContext);
+			getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, file, serviceContext);
 
 		DLProcessorRegistryUtil.cleanUp(fileEntry.getLatestFileVersion());
 
@@ -3071,8 +3071,8 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 		FileVersion oldFileVersion = oldFileEntry.getFileVersion();
 
 		FileEntry fileEntry = repository.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, description,
-			changeLog, majorVersion, is, size, serviceContext);
+			getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, is, size, serviceContext);
 
 		if (is != null) {
 			DLProcessorRegistryUtil.cleanUp(fileEntry.getLatestFileVersion());
@@ -3245,7 +3245,7 @@ public class DLAppServiceImpl extends DLAppServiceBaseImpl {
 
 			try {
 				destinationFileEntry = toRepository.updateFileEntry(
-					destinationFileEntry.getFileEntryId(),
+					getUserId(), destinationFileEntry.getFileEntryId(),
 					fileVersion.getTitle(), fileVersion.getMimeType(),
 					fileVersion.getTitle(), fileVersion.getDescription(),
 					StringPool.BLANK,

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2474,21 +2474,6 @@ public class DLFileEntryLocalServiceImpl
 						fileEntryId, majorVersion, changeLog, serviceContext);
 				}
 			}
-			else if (!checkedOut &&
-					 (serviceContext.getWorkflowAction() ==
-						WorkflowConstants.ACTION_PUBLISH)) {
-
-				String syncEvent = DLSyncConstants.EVENT_UPDATE;
-
-				if (dlFileVersion.getVersion().equals(
-						DLFileEntryConstants.VERSION_DEFAULT)) {
-
-					syncEvent = DLSyncConstants.EVENT_ADD;
-				}
-
-				DLUtil.startWorkflowInstance(
-					userId, dlFileVersion, syncEvent, serviceContext);
-			}
 		}
 		catch (PortalException pe) {
 			if (autoCheckIn) {

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.workflow.test.WorkflowHandlerInvocationCounter;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.permission.DoAsUserThread;
 import com.liferay.portal.service.ServiceContext;
@@ -54,6 +55,7 @@ import com.liferay.portal.util.test.UserTestUtil;
 import com.liferay.portlet.asset.model.AssetEntry;
 import com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.DuplicateFileException;
+import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.model.DLSyncConstants;
@@ -63,6 +65,7 @@ import java.io.File;
 import java.io.InputStream;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.util.JDBCExceptionReporter;
@@ -110,6 +113,21 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 
 			AssertUtils.assertEqualsSorted(
 				assetTagNames, assetEntry.getTagNames());
+		}
+
+		@Test
+		public void shouldCallWorkflowHandler() throws Exception {
+			try (WorkflowHandlerInvocationCounter<DLFileEntry>
+					invocationCounter = new WorkflowHandlerInvocationCounter<>(
+						DLFileEntryConstants.getClassName())) {
+
+				addFileEntry(group.getGroupId(), parentFolder.getFolderId());
+
+				Assert.assertEquals(
+					1,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
+			}
 		}
 
 		@Test(expected = DuplicateFileException.class)

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
@@ -974,6 +974,27 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 		}
 
 		@Test
+		public void shouldCallWorkflowHandler() throws Exception {
+			try (WorkflowHandlerInvocationCounter<DLFileEntry>
+					invocationCounter =
+						new WorkflowHandlerInvocationCounter<>(
+							DLFileEntryConstants.getClassName())) {
+
+				FileEntry fileEntry = addFileEntry(
+					group.getGroupId(), parentFolder.getFolderId());
+
+				updateFileEntry(
+					group.getGroupId(), fileEntry.getFileEntryId(),
+					RandomTestUtil.randomString(), true);
+
+				Assert.assertEquals(
+					2,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
+			}
+		}
+
+		@Test
 		public void shouldFireSyncEvent() throws Exception {
 			AtomicInteger counter = registerDLSyncEventProcessorMessageListener(
 				DLSyncConstants.EVENT_UPDATE);

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
@@ -186,7 +186,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 		public void shouldHaveDefaultVersion() throws Exception {
 			String fileName = RandomTestUtil.randomString();
 
-			FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			FileEntry fileEntry = addFileEntry(
 				group.getGroupId(), parentFolder.getFolderId(), fileName);
 
 			Assert.assertEquals(
@@ -336,7 +336,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 			@Override
 			protected void doRun() throws Exception {
 				try {
-					FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+					FileEntry fileEntry = addFileEntry(
 						group.getGroupId(), parentFolder.getFolderId(),
 						"Test-" + _index + ".txt");
 
@@ -517,9 +517,8 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 			AtomicInteger counter = registerDLSyncEventProcessorMessageListener(
 				DLSyncConstants.EVENT_UPDATE);
 
-			FileEntry fileEntry = DLAppTestUtil.addFileEntry(
-				group.getGroupId(), parentFolder.getRepositoryId(),
-				parentFolder.getFolderId());
+			FileEntry fileEntry = addFileEntry(
+				group.getGroupId(), parentFolder.getFolderId());
 
 			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(group.getGroupId());
@@ -762,7 +761,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 				registerDLSyncEventProcessorMessageListener(
 					DLSyncConstants.EVENT_DELETE);
 
-			FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			FileEntry fileEntry = addFileEntry(
 				group.getGroupId(), parentFolder.getFolderId(),
 				RandomTestUtil.randomString());
 
@@ -1013,7 +1012,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 		public void shouldIncrementMajorVersion() throws Exception {
 			String fileName = "TestVersion.txt";
 
-			FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			FileEntry fileEntry = addFileEntry(
 				group.getGroupId(), parentFolder.getFolderId(), fileName);
 
 			fileEntry = updateFileEntry(
@@ -1031,7 +1030,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 		public void shouldIncrementMinorVersion() throws Exception {
 			String fileName = "TestVersion.txt";
 
-			FileEntry fileEntry = DLAppTestUtil.addFileEntry(
+			FileEntry fileEntry = addFileEntry(
 				group.getGroupId(), parentFolder.getFolderId(), fileName);
 
 			fileEntry = updateFileEntry(

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
@@ -817,6 +817,46 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 		})
 	@RunWith(LiferayIntegrationJUnitTestRunner.class)
 	@Sync
+	public static class WhenRevertingAFileEntry extends BaseDLAppTestCase {
+
+		@Test
+		public void shouldCallWorkflowHandler() throws Exception {
+			try (WorkflowHandlerInvocationCounter<FileEntry>
+					invocationCounter = new WorkflowHandlerInvocationCounter<>(
+						DLFileEntryConstants.getClassName())) {
+
+				FileEntry fileEntry = addFileEntry(
+					group.getGroupId(), parentFolder.getFolderId());
+
+				String version = fileEntry.getVersion();
+
+				updateFileEntry(
+					group.getGroupId(), fileEntry.getFileEntryId(),
+					RandomTestUtil.randomString(), true);
+
+				ServiceContext serviceContext =
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId());
+
+				DLAppServiceUtil.revertFileEntry(
+					fileEntry.getFileEntryId(), version, serviceContext);
+
+				Assert.assertEquals(
+					3,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
+			}
+		}
+
+	}
+
+	@ExecutionTestListeners(
+		listeners = {
+			MainServletExecutionTestListener.class,
+			SynchronousDestinationExecutionTestListener.class
+		})
+	@RunWith(LiferayIntegrationJUnitTestRunner.class)
+	@Sync
 	public static class WhenSearchingFileEntries extends BaseDLAppTestCase {
 
 		@Test

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
@@ -457,6 +457,11 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 				FileEntry fileEntry = addFileEntry(
 					group.getGroupId(), parentFolder.getFolderId());
 
+				Assert.assertEquals(
+					1,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
+
 				ServiceContext serviceContext =
 					ServiceContextTestUtil.getServiceContext(
 						group.getGroupId());
@@ -464,9 +469,19 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 				DLAppServiceUtil.checkOutFileEntry(
 					fileEntry.getFileEntryId(), serviceContext);
 
+				Assert.assertEquals(
+					1,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
+
 				updateFileEntry(
 					group.getGroupId(), fileEntry.getFileEntryId(),
 					RandomTestUtil.randomString(), true);
+
+				Assert.assertEquals(
+					1,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
 
 				DLAppServiceUtil.checkInFileEntry(
 					fileEntry.getFileEntryId(), false,
@@ -475,8 +490,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 				Assert.assertEquals(
 					2,
 					invocationCounter.getCount(
-						"updateStatus", int.class, Map.class)
-				);
+						"updateStatus", int.class, Map.class));
 			}
 		}
 
@@ -556,6 +570,11 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 					serviceContext);
 
 				addFileEntry(group.getGroupId(), folder.getFolderId());
+
+				Assert.assertEquals(
+					1,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
 
 				DLAppServiceUtil.copyFolder(
 					folder.getRepositoryId(), folder.getFolderId(),
@@ -827,11 +846,21 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 				FileEntry fileEntry = addFileEntry(
 					group.getGroupId(), parentFolder.getFolderId());
 
+				Assert.assertEquals(
+					1,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
+
 				String version = fileEntry.getVersion();
 
 				updateFileEntry(
 					group.getGroupId(), fileEntry.getFileEntryId(),
 					RandomTestUtil.randomString(), true);
+
+				Assert.assertEquals(
+					2,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
 
 				ServiceContext serviceContext =
 					ServiceContextTestUtil.getServiceContext(
@@ -981,6 +1010,11 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 
 				FileEntry fileEntry = addFileEntry(
 					group.getGroupId(), parentFolder.getFolderId());
+
+				Assert.assertEquals(
+					1,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
 
 				updateFileEntry(
 					group.getGroupId(), fileEntry.getFileEntryId(),

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLAppServiceTest.java
@@ -511,6 +511,35 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 	public static class WhenCopyingAFolder extends BaseDLAppTestCase {
 
 		@Test
+		public void shouldCallWorkflowHandler() throws Exception {
+			try (WorkflowHandlerInvocationCounter<DLFileEntry>
+					invocationCounter = new WorkflowHandlerInvocationCounter<>(
+						DLFileEntryConstants.getClassName())) {
+
+				ServiceContext serviceContext =
+					ServiceContextTestUtil.getServiceContext(
+						group.getGroupId());
+
+				Folder folder = DLAppServiceUtil.addFolder(
+					group.getGroupId(), parentFolder.getFolderId(),
+					RandomTestUtil.randomString(), StringPool.BLANK,
+					serviceContext);
+
+				addFileEntry(group.getGroupId(), folder.getFolderId());
+
+				DLAppServiceUtil.copyFolder(
+					folder.getRepositoryId(), folder.getFolderId(),
+					parentFolder.getParentFolderId(), folder.getName(),
+					folder.getDescription(), serviceContext);
+
+				Assert.assertEquals(
+					2,
+					invocationCounter.getCount(
+						"updateStatus", int.class, Map.class));
+			}
+		}
+
+		@Test
 		public void shouldFireSyncEvent() throws Exception {
 			AtomicInteger counter = registerDLSyncEventProcessorMessageListener(
 				DLSyncConstants.EVENT_ADD);

--- a/portal-service/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/BaseRepositoryImpl.java
@@ -29,10 +29,14 @@ import com.liferay.portal.kernel.search.SearchEngineUtil;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Lock;
 import com.liferay.portal.model.RepositoryEntry;
+import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.service.BaseServiceImpl;
 import com.liferay.portal.service.CompanyLocalService;
 import com.liferay.portal.service.RepositoryEntryLocalService;
 import com.liferay.portal.service.ServiceContext;
@@ -415,8 +419,8 @@ public abstract class BaseRepositoryImpl
 
 	@Override
 	public FileEntry updateFileEntry(
-			long fileEntryId, String sourceFileName, String mimeType,
-			String title, String description, String changeLog,
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
 			boolean majorVersion, File file, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -428,8 +432,8 @@ public abstract class BaseRepositoryImpl
 			size = file.length();
 
 			return updateFileEntry(
-				fileEntryId, sourceFileName, mimeType, title, description,
-				changeLog, majorVersion, is, size, serviceContext);
+				userId, fileEntryId, sourceFileName, mimeType, title,
+				description, changeLog, majorVersion, is, size, serviceContext);
 		}
 		catch (IOException ioe) {
 			throw new SystemException(ioe);
@@ -443,6 +447,43 @@ public abstract class BaseRepositoryImpl
 				}
 			}
 		}
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.InputStream, long,
+	 *             com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		return updateFileEntry(
+			_getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, file, serviceContext);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.File, com.liferay.portal.service.ServiceContext)}
+	 */
+	@Override
+	public FileEntry updateFileEntry(
+			long fileEntryId, String sourceFileName, String mimeType,
+			String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return updateFileEntry(
+			_getUserId(), fileEntryId, sourceFileName, mimeType, title,
+			description, changeLog, majorVersion, is, size, serviceContext);
 	}
 
 	@Override
@@ -500,6 +541,34 @@ public abstract class BaseRepositoryImpl
 	protected DLAppHelperLocalService dlAppHelperLocalService;
 	protected RepositoryEntryLocalService repositoryEntryLocalService;
 	protected UserLocalService userLocalService;
+
+	/**
+	 * See {@link com.liferay.portal.service.BaseServiceImpl#getUserId()}
+	 */
+	private long _getUserId() throws PrincipalException {
+		String name = PrincipalThreadLocal.getName();
+
+		if (name == null) {
+			throw new PrincipalException();
+		}
+
+		if (Validator.isNull(name)) {
+			throw new PrincipalException("Principal is null");
+		}
+		else {
+			for (int i = 0; i < BaseServiceImpl.ANONYMOUS_NAMES.length; i++) {
+				if (StringUtil.equalsIgnoreCase(
+						name, BaseServiceImpl.ANONYMOUS_NAMES[i])) {
+
+					throw new PrincipalException(
+						"Principal cannot be " +
+							BaseServiceImpl.ANONYMOUS_NAMES[i]);
+				}
+			}
+		}
+
+		return GetterUtil.getLong(name);
+	}
 
 	private long _companyId;
 	private long _groupId;

--- a/portal-service/src/com/liferay/portal/kernel/repository/DocumentRepository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/DocumentRepository.java
@@ -14,7 +14,13 @@
 
 package com.liferay.portal.kernel.repository;
 
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.service.ServiceContext;
+
+import java.io.File;
+import java.io.InputStream;
 
 /**
  * @author Iván Zaera
@@ -22,5 +28,18 @@ import com.liferay.portal.kernel.repository.capabilities.CapabilityProvider;
 public interface DocumentRepository extends CapabilityProvider {
 
 	public long getRepositoryId();
+
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException;
+
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException;
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/repository/LocalRepository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/LocalRepository.java
@@ -90,19 +90,6 @@ public interface LocalRepository extends DocumentRepository {
 			long[] assetLinkEntryIds)
 		throws PortalException;
 
-	public FileEntry updateFileEntry(
-			long userId, long fileEntryId, String sourceFileName,
-			String mimeType, String title, String description, String changeLog,
-			boolean majorVersion, File file, ServiceContext serviceContext)
-		throws PortalException;
-
-	public FileEntry updateFileEntry(
-			long userId, long fileEntryId, String sourceFileName,
-			String mimeType, String title, String description, String changeLog,
-			boolean majorVersion, InputStream is, long size,
-			ServiceContext serviceContext)
-		throws PortalException;
-
 	public Folder updateFolder(
 			long folderId, long parentFolderId, String name, String description,
 			ServiceContext serviceContext)

--- a/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
@@ -281,11 +281,37 @@ public interface Repository extends DocumentRepository {
 		throws PortalException;
 
 	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException;
+
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.File, com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
+	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String description, String changeLog,
 			boolean majorVersion, File file, ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.InputStream, long,
+	 *             com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
 	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String description, String changeLog,

--- a/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
@@ -280,19 +280,6 @@ public interface Repository extends DocumentRepository {
 	public void unlockFolder(long parentFolderId, String name, String lockUuid)
 		throws PortalException;
 
-	public FileEntry updateFileEntry(
-			long userId, long fileEntryId, String sourceFileName,
-			String mimeType, String title, String description, String changeLog,
-			boolean majorVersion, File file, ServiceContext serviceContext)
-		throws PortalException;
-
-	public FileEntry updateFileEntry(
-			long userId, long fileEntryId, String sourceFileName,
-			String mimeType, String title, String description, String changeLog,
-			boolean majorVersion, InputStream is, long size,
-			ServiceContext serviceContext)
-		throws PortalException;
-
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
 	 *             String, String, String, String, String, boolean,

--- a/portal-service/src/com/liferay/portal/kernel/repository/cmis/CMISRepositoryHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/cmis/CMISRepositoryHandler.java
@@ -505,14 +505,14 @@ public abstract class CMISRepositoryHandler
 
 	@Override
 	public FileEntry updateFileEntry(
-			long fileEntryId, String sourceFileName, String mimeType,
-			String title, String description, String changeLog,
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
 			boolean majorVersion, InputStream is, long size,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		return _baseCmisRepository.updateFileEntry(
-			fileEntryId, sourceFileName, mimeType, title, description,
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
 			changeLog, majorVersion, is, size, serviceContext);
 	}
 

--- a/portal-service/src/com/liferay/portal/repository/proxy/BaseRepositoryProxyBean.java
+++ b/portal-service/src/com/liferay/portal/repository/proxy/BaseRepositoryProxyBean.java
@@ -739,6 +739,41 @@ public class BaseRepositoryProxyBean
 
 	@Override
 	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, File file, ServiceContext serviceContext)
+		throws PortalException {
+
+		FileEntry fileEntry = _baseRepository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, file, serviceContext);
+
+		return newFileEntryProxyBean(fileEntry);
+	}
+
+	@Override
+	public FileEntry updateFileEntry(
+			long userId, long fileEntryId, String sourceFileName,
+			String mimeType, String title, String description, String changeLog,
+			boolean majorVersion, InputStream is, long size,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		FileEntry fileEntry = _baseRepository.updateFileEntry(
+			userId, fileEntryId, sourceFileName, mimeType, title, description,
+			changeLog, majorVersion, is, size, serviceContext);
+
+		return newFileEntryProxyBean(fileEntry);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.File, com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,
 			String title, String description, String changeLog,
 			boolean majorVersion, File file, ServiceContext serviceContext)
@@ -751,6 +786,13 @@ public class BaseRepositoryProxyBean
 		return newFileEntryProxyBean(fileEntry);
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #updateFileEntry(long, long,
+	 *             String, String, String, String, String, boolean,
+	 *             java.io.InputStream, long,
+	 *             com.liferay.portal.service.ServiceContext)}
+	 */
+	@Deprecated
 	@Override
 	public FileEntry updateFileEntry(
 			long fileEntryId, String sourceFileName, String mimeType,

--- a/portal-test/src/com/liferay/portal/kernel/workflow/test/WorkflowHandlerInvocationCounter.java
+++ b/portal-test/src/com/liferay/portal/kernel/workflow/test/WorkflowHandlerInvocationCounter.java
@@ -56,7 +56,11 @@ public class WorkflowHandlerInvocationCounter<T> implements AutoCloseable {
 
 		AtomicInteger count = _countMap.get(method);
 
-		return (count == null) ? 0 : count.get();
+		if (count == null) {
+			return 0;
+		}
+
+		return count.get();
 	}
 
 	private WorkflowHandler<T> _createInvocationCounterWorkflowHandler(
@@ -66,7 +70,7 @@ public class WorkflowHandlerInvocationCounter<T> implements AutoCloseable {
 		ClassLoader classLoader = currentThread.getContextClassLoader();
 
 		return (WorkflowHandler<T>)ProxyUtil.newProxyInstance(
-			classLoader, new Class<?>[]{WorkflowHandler.class},
+			classLoader, new Class<?>[] {WorkflowHandler.class},
 			new InvocationHandler() {
 
 				@Override
@@ -77,6 +81,7 @@ public class WorkflowHandlerInvocationCounter<T> implements AutoCloseable {
 
 					if (count == null) {
 						count = new AtomicInteger();
+
 						_countMap.put(method, count);
 					}
 

--- a/portal-test/src/com/liferay/portal/kernel/workflow/test/WorkflowHandlerInvocationCounter.java
+++ b/portal-test/src/com/liferay/portal/kernel/workflow/test/WorkflowHandlerInvocationCounter.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.workflow.test;
+
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class WorkflowHandlerInvocationCounter<T> implements AutoCloseable {
+
+	public WorkflowHandlerInvocationCounter(String className) {
+		WorkflowHandler<T> workflowHandler =
+			WorkflowHandlerRegistryUtil.getWorkflowHandler(className);
+
+		_countMap = new HashMap<>();
+
+		WorkflowHandler<T> delegateWorkflowHandler =
+			_createInvocationCounterWorkflowHandler(workflowHandler);
+
+		_workflowHandlerReplacer = new WorkflowHandlerReplacer<>(
+			className, delegateWorkflowHandler);
+	}
+
+	@Override
+	public void close() throws Exception {
+		_workflowHandlerReplacer.close();
+	}
+
+	public int getCount(String methodName, Class<?>... parameterTypes)
+		throws Exception {
+
+		Method method = WorkflowHandler.class.getMethod(
+			methodName, parameterTypes);
+
+		AtomicInteger count = _countMap.get(method);
+
+		return (count == null) ? 0 : count.get();
+	}
+
+	private WorkflowHandler<T> _createInvocationCounterWorkflowHandler(
+		final WorkflowHandler<T> workflowHandler) {
+
+		Thread currentThread = Thread.currentThread();
+		ClassLoader classLoader = currentThread.getContextClassLoader();
+
+		return (WorkflowHandler<T>)ProxyUtil.newProxyInstance(
+			classLoader, new Class<?>[]{WorkflowHandler.class},
+			new InvocationHandler() {
+
+				@Override
+				public Object invoke(Object proxy, Method method, Object[] args)
+					throws Throwable {
+
+					AtomicInteger count = _countMap.get(method);
+
+					if (count == null) {
+						count = new AtomicInteger();
+						_countMap.put(method, count);
+					}
+
+					count.incrementAndGet();
+
+					return method.invoke(workflowHandler, args);
+				}
+
+			}
+		);
+	}
+
+	private final Map<Method, AtomicInteger> _countMap;
+	private final WorkflowHandlerReplacer<T> _workflowHandlerReplacer;
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/workflow/test/WorkflowHandlerReplacer.java
+++ b/portal-test/src/com/liferay/portal/kernel/workflow/test/WorkflowHandlerReplacer.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.workflow.test;
+
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class WorkflowHandlerReplacer<T> implements AutoCloseable {
+
+	public WorkflowHandlerReplacer(
+		String className, WorkflowHandler<T> replacementWorkflowHandler) {
+
+		_originalWorkflowHandler =
+			WorkflowHandlerRegistryUtil.getWorkflowHandler(className);
+		_replacementWorkflowHandler = replacementWorkflowHandler;
+
+		WorkflowHandlerRegistryUtil.unregister(_originalWorkflowHandler);
+		WorkflowHandlerRegistryUtil.register(_replacementWorkflowHandler);
+	}
+
+	@Override
+	public void close() throws Exception {
+		WorkflowHandlerRegistryUtil.unregister(_replacementWorkflowHandler);
+		WorkflowHandlerRegistryUtil.register(_originalWorkflowHandler);
+	}
+
+	private final WorkflowHandler<T> _originalWorkflowHandler;
+	private final WorkflowHandler<T> _replacementWorkflowHandler;
+
+}


### PR DESCRIPTION
Hey Brian,

There are 2 rough spots in this pull but they will be fixed in the upcoming future as you can see here https://github.com/adolfopa/liferay-portal/commits/LPS-51502 :
1. We have duplicated some logic in LiferayWorkflowLocalRepositoryWrapper and LiferayWorkflowRepositoryWrapper. You can see the final solution here that we will send you in the next pull: https://github.com/adolfopa/liferay-portal/commit/4438fd0129745fc6b66711dc3903ea16fd9f3a89
2. There's a method _getUserId that will be invoked only from deprecated methods and we need it to keep backwards compatibility with the deprecated methods. In this pull that method is also invoked from LiferayWorkflowRepositoryWrapper.revertFileEntry but we will fix that by adding the userId as part of the API for that method.

Let us know if you need anything in the review.

Thx

cc/ @adolfopa 
