### PR TITLE
LPS-51439 Detect test.type base on java file rather than class file, so ...

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1006,7 +1006,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 						<available file="test/functional" type="dir" />
 						<then>
 							<resourcecount property="test.functional.count">
-								<fileset dir="test-classes/functional" includes="**/${test.class}.class" />
+								<fileset dir="test/functional" includes="**/${test.class}.java" />
 							</resourcecount>
 						</then>
 					</if>
@@ -1015,7 +1015,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 						<available file="test/functional-generated" type="dir" />
 						<then>
 							<resourcecount property="test.functional-generated.count">
-								<fileset dir="test-classes/functional-generated" includes="**/${test.class}.class" />
+								<fileset dir="test/functional-generated" includes="**/${test.class}.java" />
 							</resourcecount>
 						</then>
 					</if>
@@ -1024,7 +1024,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 						<available file="test/integration" type="dir" />
 						<then>
 							<resourcecount property="test.integration.count">
-								<fileset dir="test-classes/integration" includes="**/${test.class}.class" />
+								<fileset dir="test/integration" includes="**/${test.class}.java" />
 							</resourcecount>
 						</then>
 					</if>
@@ -1033,14 +1033,14 @@ Please set the environment variable ANT_OPTS to the recommended value of
 						<available file="test/unit" type="dir" />
 						<then>
 							<resourcecount property="test.unit.count">
-								<fileset dir="test-classes/unit" includes="**/${test.class}.class" />
+								<fileset dir="test/unit" includes="**/${test.class}.java" />
 							</resourcecount>
 						</then>
 					</if>
 				</then>
 				<else>
 					<resourcecount property="test.${test.type}.count">
-						<fileset dir="test-classes/${test.type}" includes="**/${test.class}.class" />
+						<fileset dir="test/${test.type}" includes="**/${test.class}.java" />
 					</resourcecount>
 				</else>
 			</if>


### PR DESCRIPTION
...that we don't need to run compile before the detection

Backport pull at https://github.com/brianchandotcom/liferay-portal-ee/pull/7756

Plugins has no such function
