### PR TITLE
LPS-51543 TrashEntryServiceImpl.deleteEntries() needs to do a recheck before deleting the TrashEntry, because of cascaded removing from previous TrashEntry deleting may already removed the current one

### DIFF
--- a/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/trash/service/impl/TrashEntryServiceImpl.java
@@ -68,6 +68,12 @@ public class TrashEntryServiceImpl extends TrashEntryServiceBaseImpl {
 		PermissionChecker permissionChecker = getPermissionChecker();
 
 		for (TrashEntry entry : entries) {
+			entry = trashEntryPersistence.fetchByPrimaryKey(entry.getEntryId());
+
+			if (entry == null) {
+				continue;
+			}
+
 			try {
 				TrashHandler trashHandler =
 					TrashHandlerRegistryUtil.getTrashHandler(


### PR DESCRIPTION
This is a tough one, it breaks in a very tricky way, but fix it very simple.
Please see the ticket https://issues.liferay.com/browse/LPS-51543 for explanation

Fix for https://test-14-2.liferay.com/job/test-portal-pullrequest-backend%28master%29/387/group=14,label_exp=!test-14-2/testReport/junit/com.liferay.portlet.wiki.trash/WikiPageTrashHandlerTest/testTrashBaseModelAndParentAndDeleteGroupTrashEntries/
