### PR TITLE
master-qa-12161

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3842,6 +3842,33 @@ if (ppstate.equals("normal")) {
 		</if>
 
 		<if>
+			<isset property="app.server.bundles.size" />
+			<then>
+				<var name="app.server.bundle.index" value="1" />
+
+				<antelope:repeat count="${app.server.bundles.size}">
+					<set-app-server-properties
+						app.server.bundle.index="${app.server.bundle.index}"
+					/>
+
+					<copy todir="${test.app.server.parent.dir}/deploy">
+						<fileset dir="${liferay.home}/deploy" />
+					</copy>
+
+					<math
+						datatype="int"
+						operand1="${app.server.bundle.index}"
+						operand2="1"
+						operation="+"
+						result="app.server.bundle.index"
+					/>
+				</antelope:repeat>
+
+				<var name="app.server.bundle.index" unset="true" />
+			</then>
+		</if>
+
+		<if>
 			<isset property="web.xml.timeout" />
 			<then>
 				<replace


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-12161

Hi Brian. What this does is when our tests set up additional liferay bundles, the plugins from the deploy folder for the default bundle will also get copied over to the additional bundles. By default, since we deploy the marketplace portlet in the default bundle, there will always at least be the marketplace portlet war file already in the default bundle's deploy folder.

We need this to test things like SAML where you need two liferay bundles but both need SAML deployed on them.
