### PR TITLE
LPS-51568 Fix broken regex which cause stack overflow error on PortletImpl constructor

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaClass.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/JavaClass.java
@@ -667,7 +667,8 @@ public class JavaClass {
 		String javaTermContent = "\n" + javaTerm.getContent();
 
 		Pattern methodNameAndParametersPattern = Pattern.compile(
-			"\n" + _indent + "(private |protected |public )(.|\n)*?(\\{|;)\n");
+			"\n" + _indent + "(private |protected |public ).*?(\\{|;)\n",
+			Pattern.DOTALL);
 
 		Matcher matcher = methodNameAndParametersPattern.matcher(
 			javaTermContent);


### PR DESCRIPTION
@brianchandotcom 
This is for the stack overflow error.

@hhuijser
For your reference, a bit detail.
At 40ef03e0f158080d5337e880eb0da95f9f08cb73, I made the change to join back the sf threads to rethrow the errors, so that the SourceFormatterTest can actually fail on broken source code, as it used to just print out stack, the junit does not consider that can a failure, so that our ci server just think it is passing.

Then it exposed a stack overflow error on a regex processing.

A little digging lead me to the fix in this pull. The regex I changed in this pull, without the change, it will choke on PortletImpl line 142, the largest constructor, raising the stack overflow error.

I think my change does not affact the required logic here, and source formatter is working fine. But please double check on it.

Thanks
