### PR TITLE
LPS-51568 Bump up unit test thread stack size

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -899,6 +899,7 @@ Please set the environment variable ANT_OPTS to the recommended value of
 				<jvmarg line="${junit.cobertura.agent}" />
 				<jvmarg line="${junit.debug.jpda}" />
 				<jvmarg value="-Xmx${junit.java.mx}" />
+				<jvmarg value="-Xss2m" />
 				<jvmarg value="-XX:MaxPermSize=${junit.java.maxpermsize}" />
 				<jvmarg value="-Dexternal-properties=${test.properties}" />
 				<jvmarg value="-Dfile.encoding=UTF-8" />


### PR DESCRIPTION
CC @hhuijser

Ugh, I was being dumb, it turned out those stack overflow regex in SF are fine. Just when we ran in ant format-source, we give it Xss2m, but when ran it in junit, we use system default. On a 32bit linux jvm, that is only 320k (that's why it fails locally for me and on Spain's CI server even after 3f35ef4fc15f1fddb28b16cf9f8025ed8982cb7b). On a 64bit linux jvm, the default size is 1m(I guess LA CI servers are all 64bit, therefore it works fine here after 3f35ef4fc15f1fddb28b16cf9f8025ed8982cb7b)
Some how the regex in 3f35ef4fc15f1fddb28b16cf9f8025ed8982cb7b, before my change requires a stack size in between 1m~2m(as a result it breaks on all machines with default stack size), after the change it went down under 320k.

So bump it up to the same 2m size in junit tests will make the SourceFormatterTest working fine.

But I did not revert 3f35ef4fc15f1fddb28b16cf9f8025ed8982cb7b, I think it did not change the logic, and it just simplified the regex to make it faster and working under 320k stack.

Hugo, please feel free to revert 3f35ef4fc15f1fddb28b16cf9f8025ed8982cb7b, if it did change any logic that I did not see As we are on 2m stack now, it will still be fine.
