### PR TITLE
Lps 51439

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -725,8 +725,8 @@ Please set the environment variable ANT_OPTS to the recommended value of
 				test.type="integration"
 			/>
 
-			<ant dir="${project.dir}/portal-service" target="jar" />
-			<ant dir="${project.dir}/portal-impl" target="jar" />
+			<ant dir="${project.dir}/portal-service" target="jar" inheritAll="false" />
+			<ant dir="${project.dir}/portal-impl" target="jar" inheritAll="false" />
 
 			<delete dir="${java.io.tmpdir}/osgi" />
 		</sequential>

--- a/build-common.xml
+++ b/build-common.xml
@@ -726,7 +726,15 @@ Please set the environment variable ANT_OPTS to the recommended value of
 			/>
 
 			<ant dir="${project.dir}/portal-service" target="jar" inheritAll="false" />
-			<ant dir="${project.dir}/portal-impl" target="jar" inheritAll="false" />
+
+			<if>
+				<uptodate targetfile="${project.dir}/portal-impl/portal-impl.jar">
+					<srcfiles dir= "${project.dir}/portal-impl/classes" includes="**/*" />
+				</uptodate>
+				<else>
+					<ant dir="${project.dir}/portal-impl" target="jar" inheritAll="false" />
+				</else>
+			</if>
 
 			<delete dir="${java.io.tmpdir}/osgi" />
 		</sequential>


### PR DESCRIPTION
Brian, the first commit is necessary.

The second one, is shortcuting the portal-impl/build.xml jar's logic which costs about 5 seconds to run. But this is not necessary, just nicer to have it. If you like to keep the build simple, you can drop the second commit.
