### PR TITLE
Lps 51760

### DIFF
--- a/modules/portal/portal-spring-extender/src/com/liferay/portal/spring/extender/internal/hibernate/session/ModuleSessionFactory.java
+++ b/modules/portal/portal-spring-extender/src/com/liferay/portal/spring/extender/internal/hibernate/session/ModuleSessionFactory.java
@@ -48,7 +48,6 @@ public class ModuleSessionFactory
 		ModuleHibernateConfiguration moduleHibernateConfiguration =
 			new ModuleHibernateConfiguration(_classLoader);
 
-		moduleHibernateConfiguration.setBeanFactory(getBeanFactory());
 		moduleHibernateConfiguration.setDataSource(dataSource);
 
 		try {

--- a/portal-impl/src/META-INF/hibernate-spring.xml
+++ b/portal-impl/src/META-INF/hibernate-spring.xml
@@ -8,6 +8,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd"
 >
+	<bean id="shardDetector" class="com.liferay.portal.dao.shard.ShardDetector" />
 	<bean id="counterHibernateSessionFactory" class="com.liferay.portal.spring.hibernate.PortalHibernateConfiguration">
 		<property name="dataSource" ref="counterDataSource" />
 		<property name="mvccEnabled" value="false" />
@@ -21,6 +22,7 @@
 	</bean>
 	<bean id="liferayHibernateSessionFactory" class="com.liferay.portal.spring.hibernate.PortalHibernateConfiguration">
 		<property name="dataSource" ref="liferayDataSource" />
+		<property name="shardEnabled" value="#{shardDetector.shardEnabled}" />
 	</bean>
 	<bean id="liferaySessionFactory" class="com.liferay.portal.dao.orm.hibernate.SessionFactoryImpl">
 		<property name="sessionFactoryClassLoader">
@@ -31,10 +33,14 @@
 	<bean id="counterTransactionManager" class="com.liferay.portal.spring.transaction.TransactionManagerFactory" factory-method="createTransactionManager">
 		<constructor-arg ref="counterDataSource" />
 		<constructor-arg ref="counterHibernateSessionFactory" />
+		<constructor-arg>
+			<null />
+		</constructor-arg>
 	</bean>
 	<bean id="liferayTransactionManager" class="com.liferay.portal.spring.transaction.TransactionManagerFactory" factory-method="createTransactionManager">
 		<constructor-arg ref="liferayDataSource" />
 		<constructor-arg ref="liferayHibernateSessionFactory" />
+		<constructor-arg name="shardSessionFactoryTargetSource" value="#{shardDetector.shardSessionFactoryTargetSource}" />
 	</bean>
 	<bean id="hibernateMBeanExporter" class="org.springframework.jmx.export.MBeanExporter">
 		<property name="beans">

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/util/DataSourceSwapper.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/util/DataSourceSwapper.java
@@ -27,15 +27,13 @@ import javax.sql.DataSource;
 
 import org.hibernate.engine.SessionFactoryImplementor;
 
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.orm.hibernate3.HibernateTransactionManager;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 
 /**
  * @author Shuyang Zhou
  */
-public class DataSourceSwapper implements BeanFactoryAware {
+public class DataSourceSwapper {
 
 	public static void swapCounterDataSource(Properties properties)
 		throws Exception {
@@ -101,11 +99,6 @@ public class DataSourceSwapper implements BeanFactoryAware {
 		_reinitializeHibernate("liferaySessionFactory", newDataSource);
 	}
 
-	@Override
-	public void setBeanFactory(BeanFactory beanFactory) {
-		_beanFactory = beanFactory;
-	}
-
 	public void setCounterDataSourceWrapper(
 		DataSourceWrapper counterDataSourceWrapper) {
 
@@ -125,7 +118,6 @@ public class DataSourceSwapper implements BeanFactoryAware {
 		PortalHibernateConfiguration portalHibernateConfiguration =
 			new PortalHibernateConfiguration();
 
-		portalHibernateConfiguration.setBeanFactory(_beanFactory);
 		portalHibernateConfiguration.setDataSource(dataSource);
 
 		portalHibernateConfiguration.afterPropertiesSet();
@@ -163,7 +155,6 @@ public class DataSourceSwapper implements BeanFactoryAware {
 	private static final Log _log = LogFactoryUtil.getLog(
 		DataSourceSwapper.class);
 
-	private static BeanFactory _beanFactory;
 	private static DataSourceWrapper _counterDataSourceWrapper;
 	private static DataSourceWrapper _liferayDataSourceWrapper;
 

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/PortletSessionFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/PortletSessionFactoryImpl.java
@@ -36,16 +36,11 @@ import javax.sql.DataSource;
 
 import org.hibernate.SessionFactory;
 
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
-
 /**
  * @author Shuyang Zhou
  * @author Alexander Chow
  */
-public class PortletSessionFactoryImpl
-	extends SessionFactoryImpl implements BeanFactoryAware {
+public class PortletSessionFactoryImpl extends SessionFactoryImpl {
 
 	@Override
 	public void closeSession(Session session) throws ORMException {
@@ -91,11 +86,6 @@ public class PortletSessionFactoryImpl
 		return wrapSession(session);
 	}
 
-	@Override
-	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-		_beanFactory = beanFactory;
-	}
-
 	public void setDataSource(DataSource dataSource) {
 		_dataSource = dataSource;
 	}
@@ -113,7 +103,6 @@ public class PortletSessionFactoryImpl
 			PortletHibernateConfiguration portletHibernateConfiguration =
 				new PortletHibernateConfiguration();
 
-			portletHibernateConfiguration.setBeanFactory(_beanFactory);
 			portletHibernateConfiguration.setDataSource(dataSource);
 
 			SessionFactory sessionFactory = null;
@@ -133,10 +122,6 @@ public class PortletSessionFactoryImpl
 		finally {
 			PortletClassLoaderUtil.setServletContextName(servletContextName);
 		}
-	}
-
-	protected BeanFactory getBeanFactory() {
-		return _beanFactory;
 	}
 
 	protected DataSource getDataSource() {
@@ -196,7 +181,6 @@ public class PortletSessionFactoryImpl
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortletSessionFactoryImpl.class);
 
-	private BeanFactory _beanFactory;
 	private DataSource _dataSource;
 	private final Map<DataSource, SessionFactory> _sessionFactories =
 		new HashMap<DataSource, SessionFactory>();

--- a/portal-impl/src/com/liferay/portal/dao/shard/ShardDetector.java
+++ b/portal-impl/src/com/liferay/portal/dao/shard/ShardDetector.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.shard;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ShardDetector implements BeanFactoryAware {
+
+	public ShardSessionFactoryTargetSource
+		getShardSessionFactoryTargetSource() {
+
+		return _shardSessionFactoryTargetSource;
+	}
+
+	public boolean isShardEnabled() {
+		if (_shardSessionFactoryTargetSource != null) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) {
+		if (beanFactory.containsBean("shardSessionFactoryTargetSource")) {
+			_shardSessionFactoryTargetSource = beanFactory.getBean(
+				"shardSessionFactoryTargetSource",
+				ShardSessionFactoryTargetSource.class);
+		}
+	}
+
+	private ShardSessionFactoryTargetSource _shardSessionFactoryTargetSource;
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/shard/ShardLastSessionRecorderHibernateTransactionManager.java
+++ b/portal-impl/src/com/liferay/portal/dao/shard/ShardLastSessionRecorderHibernateTransactionManager.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.dao.shard;
+
+import com.liferay.portal.spring.hibernate.LastSessionRecorderHibernateTransactionManager;
+
+import org.hibernate.SessionFactory;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ShardLastSessionRecorderHibernateTransactionManager
+	extends LastSessionRecorderHibernateTransactionManager {
+
+	public ShardLastSessionRecorderHibernateTransactionManager(
+		ShardSessionFactoryTargetSource shardSessionFactoryTargetSource) {
+
+		_shardSessionFactoryTargetSource = shardSessionFactoryTargetSource;
+	}
+
+	@Override
+	public SessionFactory getSessionFactory() {
+		return _shardSessionFactoryTargetSource.getSessionFactory();
+	}
+
+	private final ShardSessionFactoryTargetSource
+		_shardSessionFactoryTargetSource;
+
+}

--- a/portal-impl/src/com/liferay/portal/dao/shard/ShardSessionFactoryTargetSource.java
+++ b/portal-impl/src/com/liferay/portal/dao/shard/ShardSessionFactoryTargetSource.java
@@ -26,15 +26,12 @@ import javax.sql.DataSource;
 import org.hibernate.SessionFactory;
 
 import org.springframework.aop.TargetSource;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 
 /**
  * @author Michael Young
  * @author Alexander Chow
  */
-public class ShardSessionFactoryTargetSource
-	implements BeanFactoryAware, TargetSource {
+public class ShardSessionFactoryTargetSource implements TargetSource {
 
 	public void afterPropertiesSet() throws Exception {
 		Map<String, DataSource> dataSources =
@@ -46,7 +43,6 @@ public class ShardSessionFactoryTargetSource
 			PortalHibernateConfiguration portalHibernateConfiguration =
 				new PortalHibernateConfiguration();
 
-			portalHibernateConfiguration.setBeanFactory(_beanFactory);
 			portalHibernateConfiguration.setDataSource(dataSource);
 
 			SessionFactory sessionFactory =
@@ -83,11 +79,6 @@ public class ShardSessionFactoryTargetSource
 	public void releaseTarget(Object target) throws Exception {
 	}
 
-	@Override
-	public void setBeanFactory(BeanFactory beanFactory) {
-		_beanFactory = beanFactory;
-	}
-
 	public void setSessionFactory(String shardName) {
 		_sessionFactory.set(_sessionFactories.get(shardName));
 	}
@@ -111,7 +102,6 @@ public class ShardSessionFactoryTargetSource
 
 	};
 
-	private BeanFactory _beanFactory;
 	private ShardDataSourceTargetSource _shardDataSourceTargetSource;
 
 }

--- a/portal-impl/src/com/liferay/portal/dao/shard/advice/ShardGloballyAdvice.java
+++ b/portal-impl/src/com/liferay/portal/dao/shard/advice/ShardGloballyAdvice.java
@@ -49,7 +49,7 @@ public class ShardGloballyAdvice implements MethodInterceptor {
 							methodInvocation.toString());
 				}
 
-				ShardUtil.setTargetSource(shardName);
+				String previousShardName = ShardUtil.setTargetSource(shardName);
 
 				_shardAdvice.pushCompanyService(shardName);
 
@@ -62,6 +62,8 @@ public class ShardGloballyAdvice implements MethodInterceptor {
 				}
 				finally {
 					_shardAdvice.popCompanyService();
+
+					ShardUtil.setTargetSource(previousShardName);
 
 					CacheRegistryUtil.clear();
 				}

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java
@@ -19,7 +19,6 @@ import com.liferay.portal.dao.orm.hibernate.event.NestableAutoFlushEventListener
 import com.liferay.portal.dao.shard.ShardSpringSessionContext;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
-import com.liferay.portal.kernel.dao.shard.ShardUtil;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -54,8 +53,6 @@ import org.hibernate.event.AutoFlushEventListener;
 import org.hibernate.event.EventListeners;
 import org.hibernate.event.PostUpdateEventListener;
 
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.orm.hibernate3.LocalSessionFactoryBean;
 
 /**
@@ -64,8 +61,7 @@ import org.springframework.orm.hibernate3.LocalSessionFactoryBean;
  * @author Shuyang Zhou
  * @author Tomas Polesovsky
  */
-public class PortalHibernateConfiguration
-	extends LocalSessionFactoryBean implements BeanFactoryAware {
+public class PortalHibernateConfiguration extends LocalSessionFactoryBean {
 
 	@Override
 	public SessionFactory buildSessionFactory() throws Exception {
@@ -79,11 +75,6 @@ public class PortalHibernateConfiguration
 		setBeanClassLoader(null);
 
 		super.destroy();
-	}
-
-	@Override
-	public void setBeanFactory(BeanFactory beanFactory) {
-		_beanFactory = beanFactory;
 	}
 
 	public void setHibernateConfigurationConverter(
@@ -203,9 +194,7 @@ public class PortalHibernateConfiguration
 
 		Properties hibernateProperties = getHibernateProperties();
 
-		if (_shardEnabled &&
-			_beanFactory.containsBean(ShardUtil.class.getName())) {
-
+		if (_shardEnabled) {
 			hibernateProperties.setProperty(
 				Environment.CURRENT_SESSION_CONTEXT_CLASS,
 				ShardSpringSessionContext.class.getName());
@@ -339,9 +328,8 @@ public class PortalHibernateConfiguration
 			};
 	}
 
-	private BeanFactory _beanFactory;
 	private Converter<String> _hibernateConfigurationConverter;
 	private boolean _mvccEnabled = true;
-	private boolean _shardEnabled = true;
+	private boolean _shardEnabled;
 
 }

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -88,7 +88,7 @@
         portal-impl/src/com/liferay/portal/fabric/netty/client/NettyFabricClientConfig.java@69,\
         portal-impl/src/com/liferay/portal/parsers/creole/parser/Creole10Lexer.java,\
         portal-impl/src/com/liferay/portal/parsers/creole/parser/Creole10Parser.java,\
-        portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java@298,\
+        portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java@287,\
         portal-impl/src/com/liferay/portal/tools/LangBuilder.java@445,\
         portal-impl/src/com/liferay/portal/tools/LangBuilder.java@452,\
         portal-impl/src/com/liferay/portal/tools/WebXML23Converter.java@81,\


### PR DESCRIPTION
@lipusz
Finally had sometime to look into this, and once again it makes me feel sick. I really wish I don't have to read any sharding code. It is just so... ugh... anyway.

Ok, enough complaining, back to the problem,

The problem you saw in 6.2 actually exists in master too, just in a less serious form, so I fixed it in master. It is now your turn to bring it back 6.2 :) (I did my part, have fun on backporting, this is a complex one)

The issue has 2 parts, first 3 commits are for part 1, in https://issues.liferay.com/browse/LPS-47099, I added tx manager to shard, but apparently shard is more broken than that. Its SessionFactory proxy completely broke Spring's inner thread local tx resource binding mechanism. Which is the same cause of https://issues.liferay.com/browse/LPS-48194. But apparently LPS-48194 itself is not enough, shard's code is scatter out, now in this ticket one more hole to fix.

The 2nd part is actually a regression caused by LPS-31817 755e603 and c228769, whiclh is a threadlocal leaking, after calls from there, every following service calls go through wrong SessionFactory. We did not notice this early, because the missing tx manager and broken SessionFactory thing completely covered it up. It is really amazing to see how all the sharding bugs wire up together to produce a "working system".

I tested on master, now cluster with sharding boot up fine, the LockLocalService usage from scheduler is running in new tx correctly.
