### PR TITLE
master-qa-12235

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1310,10 +1310,23 @@ create database lportal${database.index} character set utf8;</echo>
 	</target>
 
 	<target name="deploy-required-plugins">
-		<ant antfile="build-test-plugins.xml" target="deploy-simple-server-plugins">
-			<property name="plugin.types" value="portlets" />
-			<property name="plugins.includes" value="marketplace-portlet" />
-		</ant>
+		<if>
+			<equals arg1="marketplace.staging.enabled" arg2="true" />
+			<then>
+				<mkdir dir="${liferay.home}/deploy" />
+
+				<get
+					dest="${liferay.home}/deploy/marketplace-staging-portlet.war"
+					src="${test.build.marketplace.staging.portlet.war.zip.url}"
+				/>
+			</then>
+			<else>
+				<ant antfile="build-test-plugins.xml" target="deploy-simple-server-plugins">
+					<property name="plugin.types" value="portlets" />
+					<property name="plugins.includes" value="marketplace-portlet" />
+				</ant>
+			</else>
+		</if>
 	</target>
 
 	<target name="deploy-specified-plugins">


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-12235

Hi Brian. We at some point would like to automate marketplace staging tests. In order to avoid having to  deploy marketplace, edit its properties to point to marketplace staging, and restart a number of times, Jeffrey suggested having a marketplace war that has already been updated and points to staging and just downloading that to the deploy folder. We could probably upload this war to mirrors. The implementation would be similar to what we do when we need to deploy a license.

I didn't send pulls for this for ee-6.1.x and ee-6.1.30 because the "deploy-required-plugins" target doesn't exist there because marketplace isn't required there. If we want this to be in the 6.1 branches we would probably need to rename the target.

Let me know if we shouldn't do things this way or if you have questions.
