### PR TITLE
LPS-51026

### DIFF
--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/configuration/NestedPortletsConfiguration.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/configuration/NestedPortletsConfiguration.java
@@ -29,13 +29,14 @@ public interface NestedPortletsConfiguration {
 	public static final String TEMPLATE_ID = "TEMPLATE_ID";
 
 	@Meta.AD(
-		id = "layout.template.default", deflt = "2_columns_i", required = false
+		deflt = "2_columns_i", id = "nested.portlets.layout.template.default",
+		required = false
 	)
 	public String getLayoutTemplateDefault();
 
 	@Meta.AD(
-		id = "layout.template.unsupported", deflt = "freeform,1_column",
-		required = false
+		deflt = "freeform,1_column",
+		id = "nested.portlets.layout.template.unsupported", required = false
 	)
 	public String[] getLayoutTemplatesUnsupported();
 

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
@@ -29,13 +29,7 @@
 	<liferay-ui:error key="transformation" message="an-error-occurred-while-processing-your-xml-and-xsl" />
 
 	<%
-	String portletResource = ParamUtil.getString(request, "portletResource");
-
-	Portlet xslPortlet = PortletLocalServiceUtil.getPortletById(portletResource);
-
-	Map initParams = xslPortlet.getInitParams();
-
-	String validUrlPrefixes = (String)initParams.get("valid.url.prefixes");
+	String validUrlPrefixes = xslContentConfiguration.getValidUrlPrefixes();
 
 	validUrlPrefixes = StringUtil.replace(validUrlPrefixes, new String[] {"@portal_url@", "@portlet_context_url@"}, new String[] {themeDisplay.getPortalURL(), themeDisplay.getPortalURL() + request.getContextPath()});
 	%>

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
@@ -29,9 +29,7 @@
 	<liferay-ui:error key="transformation" message="an-error-occurred-while-processing-your-xml-and-xsl" />
 
 	<%
-	String validUrlPrefixes = xslContentConfiguration.getValidUrlPrefixes();
-
-	validUrlPrefixes = StringUtil.replace(validUrlPrefixes, new String[] {"@portal_url@", "@portlet_context_url@"}, new String[] {themeDisplay.getPortalURL(), themeDisplay.getPortalURL() + request.getContextPath()});
+	String validUrlPrefixes = XSLContentUtil.replaceUrlTokens(themeDisplay, xslContentConfiguration.getValidUrlPrefixes());
 	%>
 
 	<c:if test="<%= Validator.isNotNull(validUrlPrefixes) %>">

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
@@ -28,6 +28,24 @@
 	<liferay-ui:error key="xslUrl" message="please-enter-a-valid-xsl-url" />
 	<liferay-ui:error key="transformation" message="an-error-occurred-while-processing-your-xml-and-xsl" />
 
+	<%
+	String portletResource = ParamUtil.getString(request, "portletResource");
+
+	Portlet xslPortlet = PortletLocalServiceUtil.getPortletById(portletResource);
+
+	Map initParams = xslPortlet.getInitParams();
+
+	String validUrlPrefixes = (String)initParams.get("valid.url.prefixes");
+
+	validUrlPrefixes = StringUtil.replace(validUrlPrefixes, new String[] {"@portal_url@", "@portlet_context_url@"}, new String[] {themeDisplay.getPortalURL(), themeDisplay.getPortalURL() + request.getContextPath()});
+	%>
+
+	<c:if test="<%= Validator.isNotNull(validUrlPrefixes) %>">
+		<div class="alert alert-info">
+			<liferay-ui:message arguments="<%= validUrlPrefixes %>" key="urls-must-begin-with-one-of-the-following" />
+		</div>
+	</c:if>
+
 	<aui:fieldset>
 		<aui:input cssClass="lfr-input-text-container" name="preferences--xmlUrl--" type="text" value="<%= xmlUrl %>" />
 

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/configuration.jsp
@@ -29,7 +29,7 @@
 	<liferay-ui:error key="transformation" message="an-error-occurred-while-processing-your-xml-and-xsl" />
 
 	<%
-	String validUrlPrefixes = XSLContentUtil.replaceUrlTokens(themeDisplay, xslContentConfiguration.getValidUrlPrefixes());
+	String validUrlPrefixes = xslContentConfiguration.getValidUrlPrefixes();
 	%>
 
 	<c:if test="<%= Validator.isNotNull(validUrlPrefixes) %>">

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
@@ -48,6 +48,8 @@ page import="com.liferay.xsl.content.web.util.XSLContentUtil" %>
 <portlet:defineObjects />
 
 <%
+XSLContentConfiguration xslContentConfiguration = (XSLContentConfiguration)request.getAttribute(XSLContentConfiguration.class.getName());
+
 String xmlUrl = portletPreferences.getValue("xmlUrl", "@portal_url@" + request.getContextPath() + XSLContentUtil.DEFAULT_XML_URL);
 String xslUrl = portletPreferences.getValue("xslUrl", "@portal_url@" + request.getContextPath() + XSLContentUtil.DEFAULT_XSL_URL);
 %>

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
@@ -46,8 +46,8 @@ page import="com.liferay.xsl.content.web.util.XSLContentUtil" %>
 <%
 XSLContentConfiguration xslContentConfiguration = (XSLContentConfiguration)request.getAttribute(XSLContentConfiguration.class.getName());
 
-String xmlUrl = portletPreferences.getValue("xmlUrl", "@portal_url@" + request.getContextPath() + XSLContentUtil.DEFAULT_XML_URL);
-String xslUrl = portletPreferences.getValue("xslUrl", "@portal_url@" + request.getContextPath() + XSLContentUtil.DEFAULT_XSL_URL);
+String xmlUrl = portletPreferences.getValue("xmlUrl", "@portlet_context_url@" + XSLContentUtil.DEFAULT_XML_URL);
+String xslUrl = portletPreferences.getValue("xslUrl", "@portlet_context_url@" + XSLContentUtil.DEFAULT_XSL_URL);
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
@@ -29,8 +29,6 @@ page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
-page import="com.liferay.portal.model.Portlet" %><%@
-page import="com.liferay.portal.service.PortletLocalServiceUtil" %><%@
 page import="com.liferay.portlet.asset.NoSuchTagException" %><%@
 page import="com.liferay.portlet.asset.NoSuchTagPropertyException" %><%@
 page import="com.liferay.portlet.asset.model.AssetTag" %><%@
@@ -41,8 +39,6 @@ page import="com.liferay.xsl.content.web.configuration.XSLContentConfiguration" 
 page import="com.liferay.xsl.content.web.util.XSLContentUtil" %>
 
 <%@ page import="java.net.URL" %>
-
-<%@ page import="java.util.Map" %>
 
 <liferay-theme:defineObjects />
 <portlet:defineObjects />

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/init.jsp
@@ -28,6 +28,9 @@ page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %><%@
+page import="com.liferay.portal.model.Portlet" %><%@
+page import="com.liferay.portal.service.PortletLocalServiceUtil" %><%@
 page import="com.liferay.portlet.asset.NoSuchTagException" %><%@
 page import="com.liferay.portlet.asset.NoSuchTagPropertyException" %><%@
 page import="com.liferay.portlet.asset.model.AssetTag" %><%@
@@ -38,6 +41,8 @@ page import="com.liferay.xsl.content.web.configuration.XSLContentConfiguration" 
 page import="com.liferay.xsl.content.web.util.XSLContentUtil" %>
 
 <%@ page import="java.net.URL" %>
+
+<%@ page import="java.util.Map" %>
 
 <liferay-theme:defineObjects />
 <portlet:defineObjects />

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/view.jsp
@@ -21,8 +21,8 @@ try {
 	String variablePropertyKey = StringPool.BLANK;
 	String variablePropertyValue = StringPool.BLANK;
 
-	xmlUrl = StringUtil.replace(xmlUrl, new String[] {"@portal_url@", "@portlet_context_url@"}, new String[] {themeDisplay.getPortalURL(), themeDisplay.getPortalURL() + request.getContextPath()});
-	xslUrl = StringUtil.replace(xslUrl, new String[] {"@portal_url@", "@portlet_context_url@"}, new String[] {themeDisplay.getPortalURL(), themeDisplay.getPortalURL() + request.getContextPath()});
+	xmlUrl = XSLContentUtil.replaceUrlTokens(themeDisplay, xmlUrl);
+	xslUrl = XSLContentUtil.replaceUrlTokens(themeDisplay, xslUrl);
 
 	int bracketBegin = xmlUrl.indexOf("[");
 	int bracketEnd = -1;

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/view.jsp
@@ -21,8 +21,8 @@ try {
 	String variablePropertyKey = StringPool.BLANK;
 	String variablePropertyValue = StringPool.BLANK;
 
-	xmlUrl = StringUtil.replace(xmlUrl,"@portal_url@", themeDisplay.getPortalURL());
-	xslUrl = StringUtil.replace(xslUrl,"@portal_url@", themeDisplay.getPortalURL());
+	xmlUrl = StringUtil.replace(xmlUrl, new String[] {"@portal_url@", "@portlet_context_url@"}, new String[] {themeDisplay.getPortalURL(), themeDisplay.getPortalURL() + request.getContextPath()});
+	xslUrl = StringUtil.replace(xslUrl, new String[] {"@portal_url@", "@portlet_context_url@"}, new String[] {themeDisplay.getPortalURL(), themeDisplay.getPortalURL() + request.getContextPath()});
 
 	int bracketBegin = xmlUrl.indexOf("[");
 	int bracketEnd = -1;

--- a/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/xsl-content/xsl-content-web/src/META-INF/resources/view.jsp
@@ -82,8 +82,6 @@ try {
 		}
 	}
 
-	XSLContentConfiguration xslContentConfiguration = (XSLContentConfiguration)request.getAttribute(XSLContentConfiguration.class.getName());
-
 	String content = XSLContentUtil.transform(xslContentConfiguration, new URL(xmlUrl), new URL(xslUrl));
 %>
 

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/configuration/XSLContentConfiguration.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/configuration/XSLContentConfiguration.java
@@ -22,7 +22,9 @@ import aQute.bnd.annotation.metatype.Meta;
 @Meta.OCD(id = "com.liferay.xsl.content.web", localization = "content.Language")
 public interface XSLContentConfiguration {
 
-	@Meta.AD(deflt = "@portlet_context_url@", id = "valid.url.prefixes")
+	@Meta.AD(
+		deflt = "@portlet_context_url@", id = "xsl.content.valid.url.prefixes"
+	)
 	public String getValidUrlPrefixes();
 
 	@Meta.AD(deflt = "false", id = "xml.doctype.declaration.allowed")

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/configuration/XSLContentConfiguration.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/configuration/XSLContentConfiguration.java
@@ -27,16 +27,26 @@ public interface XSLContentConfiguration {
 	)
 	public String getValidUrlPrefixes();
 
-	@Meta.AD(deflt = "false", id = "xml.doctype.declaration.allowed")
+	@Meta.AD(
+		deflt = "false", id = "xsl.content.xml.doctype.declaration.allowed"
+	)
 	public boolean isXmlDoctypeDeclarationAllowed();
 
-	@Meta.AD(deflt = "false", id = "xml.external.general.entities.allowed")
+	@Meta.AD(
+		deflt = "false",
+		id = "xsl.content.xml.external.general.entities.allowed"
+	)
 	public boolean isXmlExternalGeneralEntitiesAllowed();
 
-	@Meta.AD(deflt = "false", id = "xml.external.parameter.entities.allowed")
+	@Meta.AD(
+		deflt = "false",
+		id = "xsl.content.xml.external.parameter.entities.allowed"
+	)
 	public boolean isXmlExternalParameterEntitiesAllowed();
 
-	@Meta.AD(deflt = "true", id = "xsl.secure.processing.enabled")
+	@Meta.AD(
+		deflt = "true", id = "xsl.content.xsl.secure.processing.enabled"
+	)
 	public boolean isXslSecureProcessingEnabled();
 
 }

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/configuration/XSLContentConfiguration.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/configuration/XSLContentConfiguration.java
@@ -22,6 +22,9 @@ import aQute.bnd.annotation.metatype.Meta;
 @Meta.OCD(id = "com.liferay.xsl.content.web", localization = "content.Language")
 public interface XSLContentConfiguration {
 
+	@Meta.AD(deflt = "@portlet_context_url@", id = "valid.url.prefixes")
+	public String getValidUrlPrefixes();
+
 	@Meta.AD(deflt = "false", id = "xml.doctype.declaration.allowed")
 	public boolean isXmlDoctypeDeclarationAllowed();
 

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
@@ -53,7 +53,6 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.expiration-cache=0",
 		"javax.portlet.init-param.config-template=/configuration.jsp",
 		"javax.portlet.init-param.template-path=/",
-		"javax.portlet.init-param.valid.url.prefixes=@portlet_context_url@",
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.resource-bundle=content.Language",
 		"javax.portlet.security-role-ref=administrator",

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
@@ -53,7 +53,7 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.expiration-cache=0",
 		"javax.portlet.init-param.config-template=/configuration.jsp",
 		"javax.portlet.init-param.template-path=/",
-		"javax.portlet.init-param.valid.url.prefixes=@portal_url@",
+		"javax.portlet.init-param.valid.url.prefixes=@portlet_context_url@",
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.resource-bundle=content.Language",
 		"javax.portlet.security-role-ref=administrator",

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
@@ -53,6 +53,7 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.expiration-cache=0",
 		"javax.portlet.init-param.config-template=/configuration.jsp",
 		"javax.portlet.init-param.template-path=/",
+		"javax.portlet.init-param.valid.url.prefixes=@portal_url@",
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.resource-bundle=content.Language",
 		"javax.portlet.security-role-ref=administrator",

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/XSLContentPortlet.java
@@ -57,10 +57,10 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.resource-bundle=content.Language",
 		"javax.portlet.security-role-ref=administrator",
 		"javax.portlet.supported-public-render-parameter=tags",
-		"xml.doctype.declaration.allowed=false",
-		"xml.external.general.entities.allowed=false",
-		"xml.external.parameter.entities.allowed=false",
-		"xsl.secure.processing.enabled=true"
+		"xsl.content.xml.doctype.declaration.allowed=false",
+		"xsl.content.xml.external.general.entities.allowed=false",
+		"xsl.content.xml.external.parameter.entities.allowed=false",
+		"xsl.content.xsl.secure.processing.enabled=true"
 	},
 	service = Portlet.class
 )

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
@@ -46,7 +46,7 @@ import org.osgi.service.component.annotations.Modified;
 	configurationPid = "com.liferay.xsl.content.web", immediate = true,
 	property = {
 		"javax.portlet.name=com_liferay_xsl_content_web_portlet_XSLContentPortlet",
-		"valid.url.prefixes=@portlet_context_url@"
+		"xsl.content.valid.url.prefixes=@portlet_context_url@"
 	},
 	service = ConfigurationAction.class
 )

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
@@ -18,11 +18,13 @@ import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.xsl.content.web.util.XSLContentUtil;
 
 import java.util.Map;
 
@@ -30,6 +32,8 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -57,6 +61,18 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		super.processAction(portletConfig, actionRequest, actionResponse);
 	}
 
+	protected String getPortletContextUrl(ThemeDisplay themeDisplay) {
+		Bundle bundle = FrameworkUtil.getBundle(XSLContentUtil.class);
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(themeDisplay.getPortalURL());
+		sb.append("/o/");
+		sb.append(bundle.getBundleId());
+
+		return sb.toString();
+	}
+
 	protected String[] getValidUrlPrefixes(ActionRequest actionRequest) {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -71,8 +87,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 
 		String validUrlPrefixes = (String)initParams.get("valid.url.prefixes");
 
-		validUrlPrefixes = StringUtil.replace(
-			validUrlPrefixes, "@portal_url@", themeDisplay.getPortalURL());
+		validUrlPrefixes = replaceTokens(themeDisplay, validUrlPrefixes);
 
 		return StringUtil.split(validUrlPrefixes);
 	}
@@ -91,6 +106,14 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		return false;
 	}
 
+	protected String replaceTokens(ThemeDisplay themeDisplay, String url) {
+		return StringUtil.replace(
+			url, new String[] {"@portal_url@", "@portlet_context_url@"},
+			new String[] {
+				themeDisplay.getPortalURL(), getPortletContextUrl(themeDisplay)
+			});
+	}
+
 	protected void validateUrls(ActionRequest actionRequest) {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -99,8 +122,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 
 		String xmlUrl = getParameter(actionRequest, "xmlUrl");
 
-		xmlUrl = StringUtil.replace(
-			xmlUrl, "@portal_url@", themeDisplay.getPortalURL());
+		xmlUrl = replaceTokens(themeDisplay, xmlUrl);
 
 		if (!hasValidUrlPrefix(validUrlPrefixes, xmlUrl)) {
 			SessionErrors.add(actionRequest, "xmlUrl");
@@ -108,8 +130,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 
 		String xslUrl = getParameter(actionRequest, "xslUrl");
 
-		xslUrl = StringUtil.replace(
-			xslUrl, "@portal_url@", themeDisplay.getPortalURL());
+		xslUrl = replaceTokens(themeDisplay, xslUrl);
 
 		if (!hasValidUrlPrefix(validUrlPrefixes, xslUrl)) {
 			SessionErrors.add(actionRequest, "xslUrl");

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
@@ -19,12 +19,9 @@ import aQute.bnd.annotation.metatype.Configurable;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.model.Portlet;
-import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.xsl.content.web.configuration.XSLContentConfiguration;
 import com.liferay.xsl.content.web.util.XSLContentUtil;
@@ -51,7 +48,8 @@ import org.osgi.service.component.annotations.Modified;
 @Component(
 	configurationPid = "com.liferay.xsl.content.web", immediate = true,
 	property = {
-		"javax.portlet.name=com_liferay_xsl_content_web_portlet_XSLContentPortlet"
+		"javax.portlet.name=com_liferay_xsl_content_web_portlet_XSLContentPortlet",
+		"valid.url.prefixes=@portlet_context_url@"
 	},
 	service = ConfigurationAction.class
 )
@@ -99,19 +97,9 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		return sb.toString();
 	}
 
-	protected String[] getValidUrlPrefixes(ActionRequest actionRequest) {
-		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		String portletResource = ParamUtil.getString(
-			actionRequest, "portletResource");
-
-		Portlet xslPortlet = PortletLocalServiceUtil.getPortletById(
-			portletResource);
-
-		Map initParams = xslPortlet.getInitParams();
-
-		String validUrlPrefixes = (String)initParams.get("valid.url.prefixes");
+	protected String[] getValidUrlPrefixes(ThemeDisplay themeDisplay) {
+		String validUrlPrefixes =
+			_xslContentConfiguration.getValidUrlPrefixes();
 
 		validUrlPrefixes = replaceTokens(themeDisplay, validUrlPrefixes);
 
@@ -144,7 +132,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String[] validUrlPrefixes = getValidUrlPrefixes(actionRequest);
+		String[] validUrlPrefixes = getValidUrlPrefixes(themeDisplay);
 
 		String xmlUrl = getParameter(actionRequest, "xmlUrl");
 

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
@@ -18,12 +18,17 @@ import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.Portlet;
+import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import java.util.Map;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -34,6 +39,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Brian Wing Shun Chan
  * @author Hugo Huijser
+ * @author Samuel Kong
  */
 @Component(
 	immediate = true,
@@ -55,6 +61,26 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		super.processAction(portletConfig, actionRequest, actionResponse);
 	}
 
+	protected String[] getValidUrlPrefixes(ActionRequest actionRequest) {
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String portletResource = ParamUtil.getString(
+			actionRequest, "portletResource");
+
+		Portlet xslPortlet = PortletLocalServiceUtil.getPortletById(
+			portletResource);
+
+		Map initParams = xslPortlet.getInitParams();
+
+		String validUrlPrefixes = (String)initParams.get("valid.url.prefixes");
+
+		validUrlPrefixes = StringUtil.replace(
+			validUrlPrefixes, "@portal_url@", themeDisplay.getPortalURL());
+
+		return StringUtil.split(validUrlPrefixes);
+	}
+
 	protected boolean hasAllowedProtocol(String xmlURL) {
 		try {
 			URL url = new URL(xmlURL);
@@ -72,16 +98,34 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		return false;
 	}
 
+	protected boolean hasValidUrlPrefix(String[] validUrlPrefixes, String url) {
+		if (validUrlPrefixes.length == 0) {
+			return true;
+		}
+
+		for (String validUrlPrefix : validUrlPrefixes) {
+			if (StringUtil.startsWith(url, validUrlPrefix)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	protected void validateUrls(ActionRequest actionRequest) {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
+
+		String[] validUrlPrefixes = getValidUrlPrefixes(actionRequest);
 
 		String xmlUrl = getParameter(actionRequest, "xmlUrl");
 
 		xmlUrl = StringUtil.replace(
 			xmlUrl, "@portal_url@", themeDisplay.getPortalURL());
 
-		if (!hasAllowedProtocol(xmlUrl)) {
+		if (!hasAllowedProtocol(xmlUrl) ||
+			!hasValidUrlPrefix(validUrlPrefixes, xmlUrl)) {
+
 			SessionErrors.add(actionRequest, "xmlUrl");
 		}
 
@@ -90,7 +134,9 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		xslUrl = StringUtil.replace(
 			xslUrl, "@portal_url@", themeDisplay.getPortalURL());
 
-		if (!hasAllowedProtocol(xslUrl)) {
+		if (!hasAllowedProtocol(xslUrl) ||
+			!hasValidUrlPrefix(validUrlPrefixes, xslUrl)) {
+
 			SessionErrors.add(actionRequest, "xslUrl");
 		}
 	}

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
@@ -17,16 +17,12 @@ package com.liferay.xsl.content.web.portlet.action;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.theme.ThemeDisplay;
-
-import java.net.MalformedURLException;
-import java.net.URL;
 
 import java.util.Map;
 
@@ -81,23 +77,6 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		return StringUtil.split(validUrlPrefixes);
 	}
 
-	protected boolean hasAllowedProtocol(String xmlURL) {
-		try {
-			URL url = new URL(xmlURL);
-
-			String protocol = url.getProtocol();
-
-			if (ArrayUtil.contains(_PROTOCOLS, protocol)) {
-				return true;
-			}
-		}
-		catch (MalformedURLException murle) {
-			return false;
-		}
-
-		return false;
-	}
-
 	protected boolean hasValidUrlPrefix(String[] validUrlPrefixes, String url) {
 		if (validUrlPrefixes.length == 0) {
 			return true;
@@ -123,9 +102,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		xmlUrl = StringUtil.replace(
 			xmlUrl, "@portal_url@", themeDisplay.getPortalURL());
 
-		if (!hasAllowedProtocol(xmlUrl) ||
-			!hasValidUrlPrefix(validUrlPrefixes, xmlUrl)) {
-
+		if (!hasValidUrlPrefix(validUrlPrefixes, xmlUrl)) {
 			SessionErrors.add(actionRequest, "xmlUrl");
 		}
 
@@ -134,13 +111,9 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		xslUrl = StringUtil.replace(
 			xslUrl, "@portal_url@", themeDisplay.getPortalURL());
 
-		if (!hasAllowedProtocol(xslUrl) ||
-			!hasValidUrlPrefix(validUrlPrefixes, xslUrl)) {
-
+		if (!hasValidUrlPrefix(validUrlPrefixes, xslUrl)) {
 			SessionErrors.add(actionRequest, "xslUrl");
 		}
 	}
-
-	private static final String[] _PROTOCOLS = {"http", "https"};
 
 }

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
@@ -14,6 +14,8 @@
 
 package com.liferay.xsl.content.web.portlet.action;
 
+import aQute.bnd.annotation.metatype.Configurable;
+
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -24,6 +26,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.xsl.content.web.configuration.XSLContentConfiguration;
 import com.liferay.xsl.content.web.util.XSLContentUtil;
 
 import java.util.Map;
@@ -31,10 +34,14 @@ import java.util.Map;
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletConfig;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 
 /**
  * @author Brian Wing Shun Chan
@@ -42,7 +49,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Samuel Kong
  */
 @Component(
-	immediate = true,
+	configurationPid = "com.liferay.xsl.content.web", immediate = true,
 	property = {
 		"javax.portlet.name=com_liferay_xsl_content_web_portlet_XSLContentPortlet"
 	},
@@ -59,6 +66,25 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		validateUrls(actionRequest);
 
 		super.processAction(portletConfig, actionRequest, actionResponse);
+	}
+
+	@Override
+	public String render(
+			PortletConfig portletConfig, RenderRequest renderRequest,
+			RenderResponse renderResponse)
+		throws Exception {
+
+		renderRequest.setAttribute(
+			XSLContentConfiguration.class.getName(), _xslContentConfiguration);
+
+		return super.render(portletConfig, renderRequest, renderResponse);
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_xslContentConfiguration = Configurable.createConfigurable(
+			XSLContentConfiguration.class, properties);
 	}
 
 	protected String getPortletContextUrl(ThemeDisplay themeDisplay) {
@@ -136,5 +162,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 			SessionErrors.add(actionRequest, "xslUrl");
 		}
 	}
+
+	private volatile XSLContentConfiguration _xslContentConfiguration;
 
 }

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/portlet/action/XSLContentConfigurationAction.java
@@ -19,7 +19,6 @@ import aQute.bnd.annotation.metatype.Configurable;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.theme.ThemeDisplay;
@@ -34,8 +33,6 @@ import javax.portlet.PortletConfig;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
@@ -85,23 +82,9 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 			XSLContentConfiguration.class, properties);
 	}
 
-	protected String getPortletContextUrl(ThemeDisplay themeDisplay) {
-		Bundle bundle = FrameworkUtil.getBundle(XSLContentUtil.class);
-
-		StringBundler sb = new StringBundler(3);
-
-		sb.append(themeDisplay.getPortalURL());
-		sb.append("/o/");
-		sb.append(bundle.getBundleId());
-
-		return sb.toString();
-	}
-
 	protected String[] getValidUrlPrefixes(ThemeDisplay themeDisplay) {
-		String validUrlPrefixes =
-			_xslContentConfiguration.getValidUrlPrefixes();
-
-		validUrlPrefixes = replaceTokens(themeDisplay, validUrlPrefixes);
+		String validUrlPrefixes = XSLContentUtil.replaceUrlTokens(
+			themeDisplay, _xslContentConfiguration.getValidUrlPrefixes());
 
 		return StringUtil.split(validUrlPrefixes);
 	}
@@ -120,14 +103,6 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 		return false;
 	}
 
-	protected String replaceTokens(ThemeDisplay themeDisplay, String url) {
-		return StringUtil.replace(
-			url, new String[] {"@portal_url@", "@portlet_context_url@"},
-			new String[] {
-				themeDisplay.getPortalURL(), getPortletContextUrl(themeDisplay)
-			});
-	}
-
 	protected void validateUrls(ActionRequest actionRequest) {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -136,7 +111,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 
 		String xmlUrl = getParameter(actionRequest, "xmlUrl");
 
-		xmlUrl = replaceTokens(themeDisplay, xmlUrl);
+		xmlUrl = XSLContentUtil.replaceUrlTokens(themeDisplay, xmlUrl);
 
 		if (!hasValidUrlPrefix(validUrlPrefixes, xmlUrl)) {
 			SessionErrors.add(actionRequest, "xmlUrl");
@@ -144,7 +119,7 @@ public class XSLContentConfigurationAction extends DefaultConfigurationAction {
 
 		String xslUrl = getParameter(actionRequest, "xslUrl");
 
-		xslUrl = replaceTokens(themeDisplay, xslUrl);
+		xslUrl = XSLContentUtil.replaceUrlTokens(themeDisplay, xslUrl);
 
 		if (!hasValidUrlPrefix(validUrlPrefixes, xslUrl)) {
 			SessionErrors.add(actionRequest, "xslUrl");

--- a/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/util/XSLContentUtil.java
+++ b/modules/apps/xsl-content/xsl-content-web/src/com/liferay/xsl/content/web/util/XSLContentUtil.java
@@ -16,6 +16,9 @@ package com.liferay.xsl.content.web.util;
 
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.xsl.content.web.configuration.XSLContentConfiguration;
 
 import java.io.ByteArrayInputStream;
@@ -31,6 +34,9 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
 import org.w3c.dom.Document;
 
 /**
@@ -42,6 +48,24 @@ public class XSLContentUtil {
 	public static final String DEFAULT_XML_URL = "/example.xml";
 
 	public static final String DEFAULT_XSL_URL = "/example.xsl";
+
+	public static String replaceUrlTokens(
+		ThemeDisplay themeDisplay, String url) {
+
+		Bundle bundle = FrameworkUtil.getBundle(XSLContentUtil.class);
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(themeDisplay.getPortalURL());
+		sb.append("/o/");
+		sb.append(bundle.getBundleId());
+
+		String portletContextUrl = sb.toString();
+
+		return StringUtil.replace(
+			url, new String[] {"@portal_url@", "@portlet_context_url@"},
+			new String[] {themeDisplay.getPortalURL(), portletContextUrl});
+	}
 
 	public static String transform(
 			XSLContentConfiguration xslContentConfiguration, URL xmlUrl,

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -345,6 +345,19 @@ public class VerifyProperties extends VerifyProcess {
 			"publish.to.live.by.default", "com.liferay.journal.content.web"
 		},
 
+		// Nested portlets
+
+		new String[] {
+			"nested.portlets.layout.template.default",
+			"nested.portlets.layout.template.default",
+			"com.liferay.nested.portlets.web"
+		},
+		new String[] {
+			"nested.portlets.layout.template.unsupported",
+			"nested.portlets.layout.template.unsupported",
+			"com.liferay.nested.portlets.web"
+		},
+
 		// Polls
 
 		new String[] {
@@ -435,9 +448,7 @@ public class VerifyProperties extends VerifyProcess {
 		"memory.cluster.scheduler.lock.cache.enabled",
 		"message.boards.email.message.added.signature",
 		"message.boards.email.message.updated.signature",
-		"message.boards.thread.locking.enabled",
-		"nested.portlets.layout.template.default",
-		"nested.portlets.layout.template.unsupported", "portal.ctx",
+		"message.boards.thread.locking.enabled", "portal.ctx",
 		"portal.security.manager.enable", "permissions.list.filter",
 		"permissions.thread.local.cache.max.size",
 		"permissions.user.check.algorithm", "persistence.provider",

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -356,21 +356,23 @@ public class VerifyProperties extends VerifyProcess {
 
 		new String[] {
 			"xsl.content.xml.doctype.declaration.allowed",
-			"xml.doctype.declaration.allowed", "com.liferay.xsl.content.web"
+			"xsl.content.xml.doctype.declaration.allowed",
+			"com.liferay.xsl.content.web"
 		},
 		new String[] {
 			"xsl.content.xml.external.general.entities.allowed",
-			"xml.external.general.entities.allowed",
+			"xsl.content.xml.external.general.entities.allowed",
 			"com.liferay.xsl.content.web"
 		},
 		new String[] {
 			"xsl.content.xml.external.parameter.entities.allowed",
-			"xml.external.parameter.entities.allowed",
+			"xsl.content.xml.external.parameter.entities.allowed",
 			"com.liferay.xsl.content.web"
 		},
 		new String[] {
 			"xsl.content.xsl.secure.processing.enabled",
-			"xsl.secure.processing.enabled", "com.liferay.xsl.content.web"
+			"xsl.content.xsl.secure.processing.enabled",
+			"com.liferay.xsl.content.web"
 		}
 	};
 

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -6600,6 +6600,7 @@ url-does-not-point-to-a-valid-wsrp-producer=URL does not point to a valid WSRP p
 url-example=URL Example
 url-information=URL Information
 url-tracker=URL Tracker
+urls-must-begin-with-one-of-the-following=URLs must begin with one of the following: {0}
 usages=Usages
 use-a-background-image=Use a Background Image
 use-a-secure-network-connection=Use a Secure Network Connection


### PR DESCRIPTION
Brian,

Here's the change you requested, but it doesn't seem correct. Shouldn't OSGI keep the property names isolated from each other? We've been removing the prefixes as we moved properties into modules. See Nested Portlets, Bookmarks, and Polls.

I didn't add the prefix to properties for Bookmarks and Polls since these changes aren't exactly the same as XSL Content and Nested Portlet. So let me know if you want to add the prefix to these portlets also.
