### PR TITLE
LPS-51894 Broken DB generation with too small initial counter value

### DIFF
--- a/sql/portal-data-counter.sql
+++ b/sql/portal-data-counter.sql
@@ -1,1 +1,1 @@
-insert into Counter (name, currentId) values ('com.liferay.counter.model.Counter', 10000);
+insert into Counter (name, currentId) values ('com.liferay.counter.model.Counter', 20000);


### PR DESCRIPTION
Brian, I found this while I am optimizing CI server build.

Since I am change the test execution order, by a random chance ListTypePersistenceTest got move to the first running test in a batch. Exposed this issue.

Just see portal-data-common.sql the last line, we are already using up to 12020 for ListType pk, but portal-data-counter.sql were still using initial value of 10000.

We did not see this, because, when you run other tests ahead, they use counter (for other tables), even we technically are generating duplicate pk values, but they are for different tables. When the tests reach ListTypePersistenceTest, it already passed over 12020, therefore we got lucky to pass them all the time.
