### PR TITLE
LPS-51886 Render templates through a taglib to support ADT in OSGi portlets

### DIFF
--- a/portal-web/docroot/html/portlet/asset_categories_navigation/view.jsp
+++ b/portal-web/docroot/html/portlet/asset_categories_navigation/view.jsp
@@ -17,44 +17,34 @@
 <%@ include file="/html/portlet/asset_categories_navigation/init.jsp" %>
 
 <%
-long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(displayStyleGroupId, displayStyle);
+List<AssetVocabulary> ddmTemplateAssetVocabularies = new ArrayList<AssetVocabulary>();
+
+if (allAssetVocabularies) {
+	ddmTemplateAssetVocabularies = assetVocabularies;
+}
+else {
+	for (long assetVocabularyId : assetVocabularyIds) {
+		try {
+			ddmTemplateAssetVocabularies.add(AssetVocabularyServiceUtil.getVocabulary(assetVocabularyId));
+		}
+		catch (NoSuchVocabularyException nsve) {
+		}
+	}
+}
 %>
 
-<c:choose>
-	<c:when test="<%= portletDisplayDDMTemplateId > 0 %>">
-
-		<%
-		List<AssetVocabulary> ddmTemplateAssetVocabularies = new ArrayList<AssetVocabulary>();
-
-		if (allAssetVocabularies) {
-			ddmTemplateAssetVocabularies = assetVocabularies;
-		}
-		else {
-			for (long assetVocabularyId : assetVocabularyIds) {
-				try {
-					ddmTemplateAssetVocabularies.add(AssetVocabularyServiceUtil.getVocabulary(assetVocabularyId));
-				}
-				catch (NoSuchVocabularyException nsve) {
-				}
-			}
-		}
-		%>
-
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, ddmTemplateAssetVocabularies) %>
-	</c:when>
-	<c:otherwise>
-		<c:choose>
-			<c:when test="<%= allAssetVocabularies %>">
-				<liferay-ui:asset-categories-navigation
-					hidePortletWhenEmpty="<%= true %>"
-				/>
-			</c:when>
-			<c:otherwise>
-				<liferay-ui:asset-categories-navigation
-					hidePortletWhenEmpty="<%= true %>"
-					vocabularyIds="<%= assetVocabularyIds %>"
-				/>
-			</c:otherwise>
-		</c:choose>
-	</c:otherwise>
-</c:choose>
+<liferay-ui:ddm-template-renderer displayStyle="<%= displayStyle %>" displayStyleGroupId="<%= displayStyleGroupId %>" entries="<%= ddmTemplateAssetVocabularies %>">
+	<c:choose>
+		<c:when test="<%= allAssetVocabularies %>">
+			<liferay-ui:asset-categories-navigation
+				hidePortletWhenEmpty="<%= true %>"
+			/>
+		</c:when>
+		<c:otherwise>
+			<liferay-ui:asset-categories-navigation
+				hidePortletWhenEmpty="<%= true %>"
+				vocabularyIds="<%= assetVocabularyIds %>"
+			/>
+		</c:otherwise>
+	</c:choose>
+</liferay-ui:ddm-template-renderer>

--- a/portal-web/docroot/html/portlet/asset_publisher/view_dynamic_list.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/view_dynamic_list.jspf
@@ -72,14 +72,9 @@ if (!portletName.equals(PortletKeys.RELATED_ASSETS) || (assetEntryQuery.getLinke
 
 				<h3 class="asset-entries-group-label"><%= assetCategory.getTitle(locale) %></h3>
 
-				<c:choose>
-					<c:when test="<%= assetPublisherDisplayContext.getPortletDisplayDDMTemplateId() > 0 %>">
-						<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, assetPublisherDisplayContext.getPortletDisplayDDMTemplateId(), results, contextObjects) %>
-					</c:when>
-					<c:otherwise>
-						<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
-					</c:otherwise>
-				</c:choose>
+				<liferay-ui:ddm-template-renderer contextObjects="<%= contextObjects %>" displayStyle="<%= assetPublisherDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= assetPublisherDisplayContext.getDisplayStyleGroupId() %>" entries="<%= results %>">
+					<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
+				</liferay-ui:ddm-template-renderer>
 
 <%
 			}
@@ -136,14 +131,9 @@ if (!portletName.equals(PortletKeys.RELATED_ASSETS) || (assetEntryQuery.getLinke
 			request.setAttribute("view.jsp-results", results);
 %>
 
-			<c:choose>
-				<c:when test="<%= assetPublisherDisplayContext.getPortletDisplayDDMTemplateId() > 0 %>">
-					<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, assetPublisherDisplayContext.getPortletDisplayDDMTemplateId(), results, contextObjects) %>
-				</c:when>
-				<c:otherwise>
-					<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
-				</c:otherwise>
-			</c:choose>
+			<liferay-ui:ddm-template-renderer contextObjects="<%= contextObjects %>" displayStyle="<%= assetPublisherDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= assetPublisherDisplayContext.getDisplayStyleGroupId() %>" entries="<%= results %>">
+				<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
+			</liferay-ui:ddm-template-renderer>
 
 <%
 		 }
@@ -185,14 +175,9 @@ if (!portletName.equals(PortletKeys.RELATED_ASSETS) || (assetEntryQuery.getLinke
 
 				<h3 class="asset-entries-group-label"><%= ResourceActionsUtil.getModelResource(locale, groupAssetRendererFactory.getClassName()) %></h3>
 
-				<c:choose>
-					<c:when test="<%= assetPublisherDisplayContext.getPortletDisplayDDMTemplateId() > 0 %>">
-						<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, assetPublisherDisplayContext.getPortletDisplayDDMTemplateId(), results, contextObjects) %>
-					</c:when>
-					<c:otherwise>
-						<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
-					</c:otherwise>
-				</c:choose>
+				<liferay-ui:ddm-template-renderer contextObjects="<%= contextObjects %>" displayStyle="<%= assetPublisherDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= assetPublisherDisplayContext.getDisplayStyleGroupId() %>" entries="<%= results %>">
+					<%@ include file="/html/portlet/asset_publisher/view_dynamic_list_asset.jspf" %>
+				</liferay-ui:ddm-template-renderer>
 
 <%
 			}
@@ -225,29 +210,24 @@ if (!portletName.equals(PortletKeys.RELATED_ASSETS) || (assetEntryQuery.getLinke
 %>
 
 <c:if test="<%= total == 0 %>">
-	<c:choose>
-		<c:when test="<%= assetPublisherDisplayContext.getPortletDisplayDDMTemplateId() > 0 %>">
-			<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, assetPublisherDisplayContext.getPortletDisplayDDMTemplateId(), results, contextObjects) %>
-		</c:when>
-		<c:otherwise>
-			<c:if test="<%= !hasAddPortletURLs && !((assetCategoryId > 0) || Validator.isNotNull(assetTagName)) %>">
+	<liferay-ui:ddm-template-renderer contextObjects="<%= contextObjects %>" displayStyle="<%= assetPublisherDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= assetPublisherDisplayContext.getDisplayStyleGroupId() %>" entries="<%= results %>">
+		<c:if test="<%= !hasAddPortletURLs && !((assetCategoryId > 0) || Validator.isNotNull(assetTagName)) %>">
 
-				<%
-				renderRequest.setAttribute(WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
-				%>
+			<%
+			renderRequest.setAttribute(WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
+			%>
 
-			</c:if>
+		</c:if>
 
-			<div class="alert alert-info">
-				<c:choose>
-					<c:when test="<%= !portletName.equals(PortletKeys.RELATED_ASSETS) %>">
-						<liferay-ui:message key="there-are-no-results" />
-					</c:when>
-					<c:otherwise>
-						<liferay-ui:message key="there-are-no-related-assets" />
-					</c:otherwise>
-				</c:choose>
-			</div>
-		</c:otherwise>
-	</c:choose>
+		<div class="alert alert-info">
+			<c:choose>
+				<c:when test="<%= !portletName.equals(PortletKeys.RELATED_ASSETS) %>">
+					<liferay-ui:message key="there-are-no-results" />
+				</c:when>
+				<c:otherwise>
+					<liferay-ui:message key="there-are-no-related-assets" />
+				</c:otherwise>
+			</c:choose>
+		</div>
+	</liferay-ui:ddm-template-renderer>
 </c:if>

--- a/portal-web/docroot/html/portlet/asset_publisher/view_manual.jspf
+++ b/portal-web/docroot/html/portlet/asset_publisher/view_manual.jspf
@@ -26,48 +26,43 @@ searchContainer.setResults(assetEntries);
 request.setAttribute("view.jsp-results", assetEntries);
 %>
 
-<c:choose>
-	<c:when test="<%= assetPublisherDisplayContext.getPortletDisplayDDMTemplateId() > 0 %>">
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, assetPublisherDisplayContext.getPortletDisplayDDMTemplateId(), assetEntries, contextObjects) %>
-	</c:when>
-	<c:otherwise>
+<liferay-ui:ddm-template-renderer contextObjects="<%= contextObjects %>" displayStyle="<%= assetPublisherDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= assetPublisherDisplayContext.getDisplayStyleGroupId() %>" entries="<%= assetEntries %>">
 
-		<%
-		for (int assetEntryIndex = 0; assetEntryIndex < assetEntries.size(); assetEntryIndex++) {
-			AssetEntry assetEntry = assetEntries.get(assetEntryIndex);
+	<%
+	for (int assetEntryIndex = 0; assetEntryIndex < assetEntries.size(); assetEntryIndex++) {
+		AssetEntry assetEntry = assetEntries.get(assetEntryIndex);
 
-			AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(assetEntry.getClassName());
+		AssetRendererFactory assetRendererFactory = AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(assetEntry.getClassName());
 
-			AssetRenderer assetRenderer = assetRendererFactory.getAssetRenderer(assetEntry.getClassPK());
+		AssetRenderer assetRenderer = assetRendererFactory.getAssetRenderer(assetEntry.getClassPK());
 
-			String title = assetRenderer.getTitle(locale);
+		String title = assetRenderer.getTitle(locale);
 
-			boolean show = true;
-			boolean print = false;
+		boolean show = true;
+		boolean print = false;
 
-			request.setAttribute("view.jsp-assetEntryIndex", new Integer(assetEntryIndex));
+		request.setAttribute("view.jsp-assetEntryIndex", new Integer(assetEntryIndex));
 
-			request.setAttribute("view.jsp-assetEntry", assetEntry);
-			request.setAttribute("view.jsp-assetRendererFactory", assetRendererFactory);
-			request.setAttribute("view.jsp-assetRenderer", assetRenderer);
+		request.setAttribute("view.jsp-assetEntry", assetEntry);
+		request.setAttribute("view.jsp-assetRendererFactory", assetRendererFactory);
+		request.setAttribute("view.jsp-assetRenderer", assetRenderer);
 
-			request.setAttribute("view.jsp-title", title);
+		request.setAttribute("view.jsp-title", title);
 
-			request.setAttribute("view.jsp-show", new Boolean(show));
-			request.setAttribute("view.jsp-print", new Boolean(print));
+		request.setAttribute("view.jsp-show", new Boolean(show));
+		request.setAttribute("view.jsp-print", new Boolean(print));
 
-			try {
-		%>
+		try {
+	%>
 
-				<%@ include file="/html/portlet/asset_publisher/view_display.jspf" %>
+			<%@ include file="/html/portlet/asset_publisher/view_display.jspf" %>
 
-		<%
-			}
-			catch (Exception e) {
-				_log.error(e.getMessage());
-			}
+	<%
 		}
-		%>
+		catch (Exception e) {
+			_log.error(e.getMessage());
+		}
+	}
+	%>
 
-	</c:otherwise>
-</c:choose>
+</liferay-ui:ddm-template-renderer>

--- a/portal-web/docroot/html/portlet/asset_tags_navigation/view.jsp
+++ b/portal-web/docroot/html/portlet/asset_tags_navigation/view.jsp
@@ -17,39 +17,29 @@
 <%@ include file="/html/portlet/asset_tags_navigation/init.jsp" %>
 
 <%
-long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(displayStyleGroupId, displayStyle);
+List<AssetTag> assetTags = null;
+
+if (showAssetCount && (classNameId > 0)) {
+	assetTags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
+}
+else {
+	assetTags = AssetTagServiceUtil.getGroupTags(themeDisplay.getSiteGroupId(), 0, maxAssetTags, new AssetTagCountComparator());
+}
+
+assetTags = ListUtil.sort(assetTags);
+
+Map<String, Object> contextObjects = new HashMap<String, Object>();
+
+contextObjects.put("scopeGroupId", new Long(scopeGroupId));
 %>
 
-<c:choose>
-	<c:when test="<%= portletDisplayDDMTemplateId > 0 %>">
-
-		<%
-		List<AssetTag> assetTags = null;
-
-		if (showAssetCount && (classNameId > 0)) {
-			assetTags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
-		}
-		else {
-			assetTags = AssetTagServiceUtil.getGroupTags(themeDisplay.getSiteGroupId(), 0, maxAssetTags, new AssetTagCountComparator());
-		}
-
-		assetTags = ListUtil.sort(assetTags);
-
-		Map<String, Object> contextObjects = new HashMap<String, Object>();
-
-		contextObjects.put("scopeGroupId", new Long(scopeGroupId));
-		%>
-
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, assetTags, contextObjects) %>
-	</c:when>
-	<c:otherwise>
-		<liferay-ui:asset-tags-navigation
-			classNameId="<%= classNameId %>"
-			displayStyle="<%= displayStyle %>"
-			hidePortletWhenEmpty="<%= true %>"
-			maxAssetTags="<%= maxAssetTags %>"
-			showAssetCount="<%= showAssetCount %>"
-			showZeroAssetCount="<%= showZeroAssetCount %>"
-		/>
-	</c:otherwise>
-</c:choose>
+<liferay-ui:ddm-template-renderer contextObjects="<%= contextObjects %>" displayStyle="<%= displayStyle %>" displayStyleGroupId="<%= displayStyleGroupId %>" entries="<%= assetTags %>">
+	<liferay-ui:asset-tags-navigation
+		classNameId="<%= classNameId %>"
+		displayStyle="<%= displayStyle %>"
+		hidePortletWhenEmpty="<%= true %>"
+		maxAssetTags="<%= maxAssetTags %>"
+		showAssetCount="<%= showAssetCount %>"
+		showZeroAssetCount="<%= showZeroAssetCount %>"
+	/>
+</liferay-ui:ddm-template-renderer>

--- a/portal-web/docroot/html/portlet/blogs/view_entries.jspf
+++ b/portal-web/docroot/html/portlet/blogs/view_entries.jspf
@@ -112,19 +112,9 @@ showSearch = showSearch && !results.isEmpty();
 	portletURL="<%= portletURL %>"
 />
 
-<%
-long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(blogsPortletInstanceSettings.getDisplayStyleGroupId(themeDisplay.getScopeGroupId()), blogsPortletInstanceSettings.getDisplayStyle());
+<liferay-ui:ddm-template-renderer displayStyle="<%= blogsPortletInstanceSettings.getDisplayStyle() %>" displayStyleGroupId="<%= blogsPortletInstanceSettings.getDisplayStyleGroupId(themeDisplay.getScopeGroupId()) %>" entries="<%= _convertToBlogEntries(results) %>">
 
-if (portletDisplayDDMTemplateId > 0) {
-%>
-
-	<div class="entry-body">
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, _convertToBlogEntries(results)) %>
-	</div>
-
-<%
-}
-else {
+	<%
 	int index = 0;
 
 	for (Object result : results) {
@@ -156,18 +146,19 @@ else {
 		request.setAttribute("view_entry_content.jsp-entry", entry);
 
 		request.setAttribute("view_entry_content.jsp-assetEntry", assetEntry);
-%>
+	%>
 
-	<liferay-util:include page="/html/portlet/blogs/view_entry_content.jsp" />
+<liferay-util:include page="/html/portlet/blogs/view_entry_content.jsp" />
 
-	<c:if test="<%= index < searchContainer.getTotal() %>">
-		<div class="separator"><!-- --></div>
-	</c:if>
+<c:if test="<%= index < searchContainer.getTotal() %>">
+	<div class="separator"><!-- --></div>
+</c:if>
 
 <%
-	}
 }
 %>
+
+</liferay-ui:ddm-template-renderer>
 
 <liferay-ui:search-paginator searchContainer="<%= searchContainer %>" />
 

--- a/portal-web/docroot/html/portlet/breadcrumb/view.jsp
+++ b/portal-web/docroot/html/portlet/breadcrumb/view.jsp
@@ -17,48 +17,38 @@
 <%@ include file="/html/portlet/breadcrumb/init.jsp" %>
 
 <%
-long portletDisplayTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(displayStyleGroupId, displayStyle);
+List<Integer> breadcrumbEntryTypes = new ArrayList<Integer>();
+
+if (showCurrentGroup) {
+	breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_CURRENT_GROUP);
+}
+
+if (showGuestGroup) {
+	breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_GUEST_GROUP);
+}
+
+if (showLayout) {
+	breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_LAYOUT);
+}
+
+if (showParentGroups) {
+	breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_PARENT_GROUP);
+}
+
+if (showPortletBreadcrumb) {
+	breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_PORTLET);
+}
+
+List<BreadcrumbEntry> breadcrumbEntries = BreadcrumbUtil.getBreadcrumbEntries(request, ArrayUtil.toIntArray(breadcrumbEntryTypes));
 %>
 
-<c:choose>
-	<c:when test="<%= portletDisplayTemplateId > 0 %>">
-
-		<%
-		List<Integer> breadcrumbEntryTypes = new ArrayList<Integer>();
-
-		if (showCurrentGroup) {
-			breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_CURRENT_GROUP);
-		}
-
-		if (showGuestGroup) {
-			breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_GUEST_GROUP);
-		}
-
-		if (showLayout) {
-			breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_LAYOUT);
-		}
-
-		if (showParentGroups) {
-			breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_PARENT_GROUP);
-		}
-
-		if (showPortletBreadcrumb) {
-			breadcrumbEntryTypes.add(BreadcrumbUtil.ENTRY_TYPE_PORTLET);
-		}
-
-		List<BreadcrumbEntry> breadcrumbEntries = BreadcrumbUtil.getBreadcrumbEntries(request, ArrayUtil.toIntArray(breadcrumbEntryTypes));
-		%>
-
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayTemplateId, breadcrumbEntries) %>
-	</c:when>
-	<c:otherwise>
-		<liferay-ui:breadcrumb
-			displayStyle="<%= displayStyle %>"
-			showCurrentGroup="<%= showCurrentGroup %>"
-			showGuestGroup="<%= showGuestGroup %>"
-			showLayout="<%= showLayout %>"
-			showParentGroups="<%= showParentGroups %>"
-			showPortletBreadcrumb="<%= showPortletBreadcrumb %>"
-		/>
-	</c:otherwise>
-</c:choose>
+<liferay-ui:ddm-template-renderer displayStyle="<%= displayStyle %>" displayStyleGroupId="<%= displayStyleGroupId %>" entries="<%= breadcrumbEntries %>">
+	<liferay-ui:breadcrumb
+		displayStyle="<%= displayStyle %>"
+		showCurrentGroup="<%= showCurrentGroup %>"
+		showGuestGroup="<%= showGuestGroup %>"
+		showLayout="<%= showLayout %>"
+		showParentGroups="<%= showParentGroups %>"
+		showPortletBreadcrumb="<%= showPortletBreadcrumb %>"
+	/>
+</liferay-ui:ddm-template-renderer>

--- a/portal-web/docroot/html/portlet/language/view.jsp
+++ b/portal-web/docroot/html/portlet/language/view.jsp
@@ -17,16 +17,9 @@
 <%@ include file="/html/portlet/language/init.jsp" %>
 
 <%
-long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(displayStyleGroupId, displayStyle);
-
 Locale[] locales = LocaleUtil.fromLanguageIds(languageIds);
 %>
 
-<c:choose>
-	<c:when test="<%= portletDisplayDDMTemplateId > 0 %>">
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, ListUtil.fromArray(locales)) %>
-	</c:when>
-	<c:otherwise>
-		<liferay-ui:language displayCurrentLocale="<%= displayCurrentLocale %>" displayStyle="<%= displayStyle %>" languageIds="<%= languageIds %>" />
-	</c:otherwise>
-</c:choose>
+<liferay-ui:ddm-template-renderer displayStyle="<%= displayStyle %>" displayStyleGroupId="<%= displayStyleGroupId %>" entries="<%= ListUtil.fromArray(locales) %>">
+	<liferay-ui:language displayCurrentLocale="<%= displayCurrentLocale %>" displayStyle="<%= displayStyle %>" languageIds="<%= languageIds %>" />
+</liferay-ui:ddm-template-renderer>

--- a/portal-web/docroot/html/portlet/rss/view.jsp
+++ b/portal-web/docroot/html/portlet/rss/view.jsp
@@ -17,35 +17,28 @@
 <%@ include file="/html/portlet/rss/init.jsp" %>
 
 <%
-long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(rssDisplayContext.getDisplayStyleGroupId(), rssDisplayContext.getDisplayStyle());
-
 List<RSSFeed> rssFeeds = rssDisplayContext.getRSSFeeds();
 %>
 
-<c:choose>
-	<c:when test="<%= portletDisplayDDMTemplateId > 0 %>">
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, rssFeeds) %>
-	</c:when>
-	<c:otherwise>
+<liferay-ui:ddm-template-renderer displayStyle="<%= rssDisplayContext.getDisplayStyle() %>" displayStyleGroupId="<%= rssDisplayContext.getDisplayStyleGroupId() %>" entries="<%= rssFeeds %>">
 
-		<%
-		for (int i = 0; i < rssFeeds.size(); i++) {
-			RSSFeed rssFeed = rssFeeds.get(i);
+	<%
+	for (int i = 0; i < rssFeeds.size(); i++) {
+		RSSFeed rssFeed = rssFeeds.get(i);
 
-			boolean last = false;
+		boolean last = false;
 
-			if (i == (rssFeeds.size() - 1)) {
-				last = true;
-			}
-
-			SyndFeed syndFeed = rssFeed.getSyndFeed();
-		%>
-
-			<%@ include file="/html/portlet/rss/feed.jspf" %>
-
-		<%
+		if (i == (rssFeeds.size() - 1)) {
+			last = true;
 		}
-		%>
 
-	</c:otherwise>
-</c:choose>
+		SyndFeed syndFeed = rssFeed.getSyndFeed();
+	%>
+
+		<%@ include file="/html/portlet/rss/feed.jspf" %>
+
+	<%
+	}
+	%>
+
+</liferay-ui:ddm-template-renderer>

--- a/portal-web/docroot/html/portlet/site_map/view.jsp
+++ b/portal-web/docroot/html/portlet/site_map/view.jsp
@@ -18,25 +18,19 @@
 
 <%
 List<Layout> rootLayouts = LayoutLocalServiceUtil.getLayouts(layout.getGroupId(), layout.isPrivateLayout(), rootLayoutId);
-
-long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(displayStyleGroupId, displayStyle);
 %>
 
-<c:choose>
-	<c:when test="<%= portletDisplayDDMTemplateId > 0 %>">
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, rootLayouts) %>
-	</c:when>
-	<c:otherwise>
+<liferay-ui:ddm-template-renderer displayStyle="<%= displayStyle %>" displayStyleGroupId="<%= displayStyleGroupId %>" entries="<%= rootLayouts %>">
 
-		<%
-		StringBundler sb = new StringBundler();
+	<%
+	StringBundler sb = new StringBundler();
 
-		_buildSiteMap(layout, rootLayouts, rootLayout, includeRootInTree, displayDepth, showCurrentPage, useHtmlTitle, showHiddenPages, 1, themeDisplay, sb);
-		%>
+	_buildSiteMap(layout, rootLayouts, rootLayout, includeRootInTree, displayDepth, showCurrentPage, useHtmlTitle, showHiddenPages, 1, themeDisplay, sb);
+	%>
 
-		<%= sb.toString() %>
-	</c:otherwise>
-</c:choose>
+	<%= sb.toString() %>
+
+</liferay-ui:ddm-template-renderer>
 
 <%!
 private void _buildLayoutView(Layout layout, String cssClass, boolean useHtmlTitle, ThemeDisplay themeDisplay, StringBundler sb) throws Exception {

--- a/portal-web/docroot/html/portlet/wiki/edit_page.jsp
+++ b/portal-web/docroot/html/portlet/wiki/edit_page.jsp
@@ -155,6 +155,11 @@ if (Validator.isNull(redirect)) {
 	<liferay-ui:message key="preview" />:
 
 	<div class="preview">
+
+		<%
+		String formattedContent = null;
+		%>
+
 		<%@ include file="/html/portlet/wiki/view_page_content.jspf" %>
 	</div>
 

--- a/portal-web/docroot/html/portlet/wiki/view.jsp
+++ b/portal-web/docroot/html/portlet/wiki/view.jsp
@@ -152,239 +152,228 @@ if (wikiPage != null) {
 <liferay-util:include page="/html/portlet/wiki/top_links.jsp" />
 
 <%
-long portletDisplayDDMTemplateId = PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(wikiPortletInstanceSettings.getDisplayStyleGroupId(themeDisplay.getScopeGroupId()), wikiPortletInstanceSettings.getDisplayStyle());
+List entries = new ArrayList();
+
+entries.add(wikiPage);
+
+String formattedContent = null;
+
+try {
+	formattedContent = WikiUtil.getFormattedContent(renderRequest, renderResponse, wikiPage, viewPageURL, editPageURL, title, preview);
+}
+catch (Exception e) {
+	formattedContent = wikiPage.getContent();
+}
+
+Map<String, Object> contextObjects = new HashMap<String, Object>();
+
+contextObjects.put("assetEntry", layoutAssetEntry);
+contextObjects.put("formattedContent", formattedContent);
 %>
 
-<c:choose>
-	<c:when test="<%= portletDisplayDDMTemplateId > 0 %>">
+<liferay-ui:ddm-template-renderer contextObjects="<%= contextObjects %>" displayStyle="<%= wikiPortletInstanceSettings.getDisplayStyle() %>" displayStyleGroupId="<%= wikiPortletInstanceSettings.getDisplayStyleGroupId(themeDisplay.getScopeGroupId()) %>" entries="<%= entries %>">
+	<liferay-ui:header
+		backLabel="<%= parentTitle %>"
+		backURL="<%= (viewParentPageURL != null) ? viewParentPageURL.toString() : null %>"
+		localizeTitle="<%= false %>"
+		title="<%= title %>"
+	/>
 
-		<%
-		List entries = new ArrayList();
-
-		entries.add(wikiPage);
-
-		String formattedContent = null;
-
-		try {
-			formattedContent = WikiUtil.getFormattedContent(renderRequest, renderResponse, wikiPage, viewPageURL, editPageURL, title, preview);
-		}
-		catch (Exception e) {
-			formattedContent = wikiPage.getContent();
-		}
-
-		Map<String, Object> contextObjects = new HashMap<String, Object>();
-
-		contextObjects.put("assetEntry", layoutAssetEntry);
-		contextObjects.put("formattedContent", formattedContent);
-		%>
-
-		<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, entries, contextObjects) %>
-	</c:when>
-	<c:otherwise>
-
-		<liferay-ui:header
-			backLabel="<%= parentTitle %>"
-			backURL="<%= (viewParentPageURL != null) ? viewParentPageURL.toString() : null %>"
-			localizeTitle="<%= false %>"
-			title="<%= title %>"
-		/>
-
-		<c:if test="<%= !print %>">
-			<div class="page-actions top-actions">
-				<c:if test="<%= WikiPagePermission.contains(permissionChecker, wikiPage, ActionKeys.UPDATE) %>">
-					<c:if test="<%= followRedirect || (redirectPage == null) %>">
-						<liferay-ui:icon
-							iconCssClass="icon-edit"
-							label="<%= true %>"
-							message="edit"
-							url="<%= editPageURL.toString() %>"
-						/>
-					</c:if>
+	<c:if test="<%= !print %>">
+		<div class="page-actions top-actions">
+			<c:if test="<%= WikiPagePermission.contains(permissionChecker, wikiPage, ActionKeys.UPDATE) %>">
+				<c:if test="<%= followRedirect || (redirectPage == null) %>">
+					<liferay-ui:icon
+						iconCssClass="icon-edit"
+						label="<%= true %>"
+						message="edit"
+						url="<%= editPageURL.toString() %>"
+					/>
 				</c:if>
-
-				<%
-				PortletURL viewPageDetailsURL = PortletURLUtil.clone(viewPageURL, renderResponse);
-
-				viewPageDetailsURL.setParameter("struts_action", "/wiki/view_page_details");
-				viewPageDetailsURL.setParameter("redirect", currentURL);
-				%>
-
-				<liferay-ui:icon
-					iconCssClass="icon-file-alt"
-					label="<%= true %>"
-					message="details"
-					method="get"
-					url="<%= viewPageDetailsURL.toString() %>"
-				/>
-
-				<liferay-ui:icon
-					iconCssClass="icon-print"
-					label="<%= true %>"
-					message="print"
-					url='<%= "javascript:" + renderResponse.getNamespace() + "printPage();" %>'
-				/>
-			</div>
-		</c:if>
-
-		<c:if test="<%= originalPage != null %>">
+			</c:if>
 
 			<%
-			PortletURL originalViewPageURL = renderResponse.createRenderURL();
+			PortletURL viewPageDetailsURL = PortletURLUtil.clone(viewPageURL, renderResponse);
 
-			originalViewPageURL.setParameter("struts_action", "/wiki/view");
-			originalViewPageURL.setParameter("nodeName", node.getName());
-			originalViewPageURL.setParameter("title", originalPage.getTitle());
-			originalViewPageURL.setParameter("followRedirect", "false");
+			viewPageDetailsURL.setParameter("struts_action", "/wiki/view_page_details");
+			viewPageDetailsURL.setParameter("redirect", currentURL);
 			%>
 
-			<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
-				(<%= LanguageUtil.format(request, "redirected-from-x", originalPage.getTitle(), false) %>)
-			</div>
-		</c:if>
-
-		<c:if test="<%= !wikiPage.isHead() %>">
-			<div class="page-old-version">
-				(<liferay-ui:message key="you-are-viewing-an-archived-version-of-this-page" /> (<%= wikiPage.getVersion() %>), <aui:a href="<%= viewPageURL.toString() %>" label="go-to-the-latest-version" />)
-			</div>
-		</c:if>
-
-		<div class="page-categorization">
-			<div class="page-categories">
-				<liferay-ui:asset-categories-summary
-					className="<%= WikiPage.class.getName() %>"
-					classPK="<%= wikiPage.getResourcePrimKey() %>"
-					portletURL="<%= PortletURLUtil.clone(categorizedPagesURL, renderResponse) %>"
-				/>
-			</div>
-
-			<div class="page-tags">
-				<liferay-ui:asset-tags-summary
-					className="<%= WikiPage.class.getName() %>"
-					classPK="<%= wikiPage.getResourcePrimKey() %>"
-					message="tags"
-					portletURL="<%= PortletURLUtil.clone(taggedPagesURL, renderResponse) %>"
-				/>
-			</div>
-		</div>
-
-		<div>
-			<%@ include file="/html/portlet/wiki/view_page_content.jspf" %>
-		</div>
-
-		<liferay-ui:custom-attributes-available className="<%= WikiPage.class.getName() %>">
-			<liferay-ui:custom-attribute-list
-				className="<%= WikiPage.class.getName() %>"
-				classPK="<%= (wikiPage != null) ? wikiPage.getPrimaryKey() : 0 %>"
-				editable="<%= false %>"
+			<liferay-ui:icon
+				iconCssClass="icon-file-alt"
 				label="<%= true %>"
+				message="details"
+				method="get"
+				url="<%= viewPageDetailsURL.toString() %>"
 			/>
-		</liferay-ui:custom-attributes-available>
 
-		<c:if test="<%= (wikiPage != null) && Validator.isNotNull(formattedContent) && (followRedirect || (redirectPage == null)) %>">
-			<c:if test="<%= !childPages.isEmpty() %>">
-				<div class="child-pages">
-					<h2><liferay-ui:message key="children-pages" /></h2>
+			<liferay-ui:icon
+				iconCssClass="icon-print"
+				label="<%= true %>"
+				message="print"
+				url='<%= "javascript:" + renderResponse.getNamespace() + "printPage();" %>'
+			/>
+		</div>
+	</c:if>
 
-					<ul>
+	<c:if test="<%= originalPage != null %>">
 
-						<%
-						PortletURL curPageURL = PortletURLUtil.clone(viewPageURL, renderResponse);
+		<%
+		PortletURL originalViewPageURL = renderResponse.createRenderURL();
 
-						for (int i = 0; i < childPages.size(); i++) {
-							WikiPage curPage = (WikiPage)childPages.get(i);
+		originalViewPageURL.setParameter("struts_action", "/wiki/view");
+		originalViewPageURL.setParameter("nodeName", node.getName());
+		originalViewPageURL.setParameter("title", originalPage.getTitle());
+		originalViewPageURL.setParameter("followRedirect", "false");
+		%>
 
-							curPageURL.setParameter("title", curPage.getTitle());
-						%>
+		<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
+			(<%= LanguageUtil.format(request, "redirected-from-x", originalPage.getTitle(), false) %>)
+		</div>
+	</c:if>
 
-							<c:if test="<%= Validator.isNull(curPage.getRedirectTitle()) %>">
-								<li>
-									<aui:a href="<%= curPageURL.toString() %>"><%= curPage.getTitle() %></aui:a>
-								</li>
-							</c:if>
+	<c:if test="<%= !wikiPage.isHead() %>">
+		<div class="page-old-version">
+			(<liferay-ui:message key="you-are-viewing-an-archived-version-of-this-page" /> (<%= wikiPage.getVersion() %>), <aui:a href="<%= viewPageURL.toString() %>" label="go-to-the-latest-version" />)
+		</div>
+	</c:if>
 
-						<%
-						}
-						%>
+	<div class="page-categorization">
+		<div class="page-categories">
+			<liferay-ui:asset-categories-summary
+				className="<%= WikiPage.class.getName() %>"
+				classPK="<%= wikiPage.getResourcePrimKey() %>"
+				portletURL="<%= PortletURLUtil.clone(categorizedPagesURL, renderResponse) %>"
+			/>
+		</div>
 
-					</ul>
-				</div>
-			</c:if>
+		<div class="page-tags">
+			<liferay-ui:asset-tags-summary
+				className="<%= WikiPage.class.getName() %>"
+				classPK="<%= wikiPage.getResourcePrimKey() %>"
+				message="tags"
+				portletURL="<%= PortletURLUtil.clone(taggedPagesURL, renderResponse) %>"
+			/>
+		</div>
+	</div>
 
-			<div class="page-actions">
-				<div class="article-actions">
-					<c:if test="<%= WikiNodePermission.contains(permissionChecker, node, ActionKeys.ADD_PAGE) %>">
-						<liferay-ui:icon
-							iconCssClass="icon-plus"
-							label="<%= true %>"
-							message="add-child-page"
-							method="get"
-							url="<%= addPageURL.toString() %>"
-						/>,
-					</c:if>
+	<div>
+		<%@ include file="/html/portlet/wiki/view_page_content.jspf" %>
+	</div>
 
-					<liferay-ui:icon
-						iconCssClass="icon-paperclip"
-						label="<%= true %>"
-						message='<%= attachmentsFileEntriesCount + " " + LanguageUtil.get(request, (attachmentsFileEntriesCount == 1) ? "attachment" : "attachments") %>' method="get" url="<%= viewAttachmentsURL.toString() %>"
-					/>
-				</div>
+	<liferay-ui:custom-attributes-available className="<%= WikiPage.class.getName() %>">
+		<liferay-ui:custom-attribute-list
+			className="<%= WikiPage.class.getName() %>"
+			classPK="<%= (wikiPage != null) ? wikiPage.getPrimaryKey() : 0 %>"
+			editable="<%= false %>"
+			label="<%= true %>"
+		/>
+	</liferay-ui:custom-attributes-available>
 
-				<div class="stats">
+	<c:if test="<%= (wikiPage != null) && Validator.isNotNull(formattedContent) && (followRedirect || (redirectPage == null)) %>">
+		<c:if test="<%= !childPages.isEmpty() %>">
+			<div class="child-pages">
+				<h2><liferay-ui:message key="children-pages" /></h2>
+
+				<ul>
 
 					<%
-					AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
+					PortletURL curPageURL = PortletURLUtil.clone(viewPageURL, renderResponse);
+
+					for (int i = 0; i < childPages.size(); i++) {
+						WikiPage curPage = (WikiPage)childPages.get(i);
+
+						curPageURL.setParameter("title", curPage.getTitle());
 					%>
 
-					<c:choose>
-						<c:when test="<%= assetEntry.getViewCount() == 1 %>">
-							<%= assetEntry.getViewCount() %> <liferay-ui:message key="view" />
-						</c:when>
-						<c:when test="<%= assetEntry.getViewCount() > 1 %>">
-							<%= assetEntry.getViewCount() %> <liferay-ui:message key="views" />
-						</c:when>
-					</c:choose>
-				</div>
+						<c:if test="<%= Validator.isNull(curPage.getRedirectTitle()) %>">
+							<li>
+								<aui:a href="<%= curPageURL.toString() %>"><%= curPage.getTitle() %></aui:a>
+							</li>
+						</c:if>
+
+					<%
+					}
+					%>
+
+				</ul>
+			</div>
+		</c:if>
+
+		<div class="page-actions">
+			<div class="article-actions">
+				<c:if test="<%= WikiNodePermission.contains(permissionChecker, node, ActionKeys.ADD_PAGE) %>">
+					<liferay-ui:icon
+						iconCssClass="icon-plus"
+						label="<%= true %>"
+						message="add-child-page"
+						method="get"
+						url="<%= addPageURL.toString() %>"
+					/>,
+				</c:if>
+
+				<liferay-ui:icon
+					iconCssClass="icon-paperclip"
+					label="<%= true %>"
+					message='<%= attachmentsFileEntriesCount + " " + LanguageUtil.get(request, (attachmentsFileEntriesCount == 1) ? "attachment" : "attachments") %>' method="get" url="<%= viewAttachmentsURL.toString() %>"
+				/>
 			</div>
 
-			<c:if test="<%= wikiPortletInstanceSettings.isEnableRelatedAssets() %>">
-				<div class="entry-links">
-					<liferay-ui:asset-links
-						assetEntryId="<%= assetEntry.getEntryId() %>"
-					/>
-				</div>
-			</c:if>
+			<div class="stats">
 
-			<c:if test="<%= wikiPortletInstanceSettings.isEnablePageRatings() %>">
-				<div class="page-ratings">
-					<liferay-ui:ratings
+				<%
+				AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(WikiPage.class.getName(), wikiPage.getResourcePrimKey());
+				%>
+
+				<c:choose>
+					<c:when test="<%= assetEntry.getViewCount() == 1 %>">
+						<%= assetEntry.getViewCount() %> <liferay-ui:message key="view" />
+					</c:when>
+					<c:when test="<%= assetEntry.getViewCount() > 1 %>">
+						<%= assetEntry.getViewCount() %> <liferay-ui:message key="views" />
+					</c:when>
+				</c:choose>
+			</div>
+		</div>
+
+		<c:if test="<%= wikiPortletInstanceSettings.isEnableRelatedAssets() %>">
+			<div class="entry-links">
+				<liferay-ui:asset-links
+					assetEntryId="<%= assetEntry.getEntryId() %>"
+				/>
+			</div>
+		</c:if>
+
+		<c:if test="<%= wikiPortletInstanceSettings.isEnablePageRatings() %>">
+			<div class="page-ratings">
+				<liferay-ui:ratings
+					className="<%= WikiPage.class.getName() %>"
+					classPK="<%= wikiPage.getResourcePrimKey() %>"
+				/>
+			</div>
+		</c:if>
+
+		<c:if test="<%= wikiPortletInstanceSettings.isEnableComments() %>">
+			<liferay-ui:panel-container extended="<%= false %>" id="wikiCommentsPanelContainer" persistState="<%= true %>">
+				<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="wikiCommentsPanel" persistState="<%= true %>" title="comments">
+					<portlet:actionURL var="discussionURL">
+						<portlet:param name="struts_action" value="/wiki/edit_page_discussion" />
+					</portlet:actionURL>
+
+					<liferay-ui:discussion
 						className="<%= WikiPage.class.getName() %>"
 						classPK="<%= wikiPage.getResourcePrimKey() %>"
+						formAction="<%= discussionURL %>"
+						formName="fm2"
+						ratingsEnabled="<%= wikiPortletInstanceSettings.isEnableCommentRatings() %>"
+						redirect="<%= currentURL %>"
+						userId="<%= wikiPage.getUserId() %>"
 					/>
-				</div>
-			</c:if>
-
-			<c:if test="<%= wikiPortletInstanceSettings.isEnableComments() %>">
-				<liferay-ui:panel-container extended="<%= false %>" id="wikiCommentsPanelContainer" persistState="<%= true %>">
-					<liferay-ui:panel collapsible="<%= true %>" extended="<%= true %>" id="wikiCommentsPanel" persistState="<%= true %>" title="comments">
-						<portlet:actionURL var="discussionURL">
-							<portlet:param name="struts_action" value="/wiki/edit_page_discussion" />
-						</portlet:actionURL>
-
-						<liferay-ui:discussion
-							className="<%= WikiPage.class.getName() %>"
-							classPK="<%= wikiPage.getResourcePrimKey() %>"
-							formAction="<%= discussionURL %>"
-							formName="fm2"
-							ratingsEnabled="<%= wikiPortletInstanceSettings.isEnableCommentRatings() %>"
-							redirect="<%= currentURL %>"
-							userId="<%= wikiPage.getUserId() %>"
-						/>
-					</liferay-ui:panel>
-				</liferay-ui:panel-container>
-			</c:if>
+				</liferay-ui:panel>
+			</liferay-ui:panel-container>
 		</c:if>
-	</c:otherwise>
-</c:choose>
+	</c:if>
+</liferay-ui:ddm-template-renderer>
 
 <aui:script sandbox="<%= true %>">
 	var toc = $('#p_p_id<portlet:namespace /> .toc');

--- a/portal-web/docroot/html/portlet/wiki/view_page_content.jspf
+++ b/portal-web/docroot/html/portlet/wiki/view_page_content.jspf
@@ -15,8 +15,6 @@
 --%>
 
 <%
-String formattedContent = null;
-
 try {
 	formattedContent = WikiUtil.getFormattedContent(renderRequest, renderResponse, wikiPage, viewPageURL, editPageURL, title, preview);
 %>

--- a/portal-web/docroot/html/taglib/ui/ddm_template_renderer/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/ddm_template_renderer/page.jsp
@@ -1,0 +1,27 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/taglib/init.jsp" %>
+
+<%
+Map<String,Object> contextObjects = ((Map<String,Object>)request.getAttribute("liferay-ui:ddm-template-renderer:contextObjects"));
+List<?> entries = (List<?>)request.getAttribute("liferay-ui:ddm-template-renderer:entries");
+long portletDisplayDDMTemplateId = GetterUtil.getLong((String)request.getAttribute("liferay-ui:ddm-template-renderer:portletDisplayDDMTemplateId"));
+%>
+
+<c:if test="<%= portletDisplayDDMTemplateId > 0 %>">
+	<%= PortletDisplayTemplateUtil.renderDDMTemplate(request, response, portletDisplayDDMTemplateId, entries, contextObjects) %>
+</c:if>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -806,6 +806,31 @@
 		</attribute>
 	</tag>
 	<tag>
+		<name>ddm-template-renderer</name>
+		<tag-class>com.liferay.taglib.ui.DDMTemplateRendererTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>contextObjects</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>displayStyle</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>displayStyleGroupId</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>entries</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	<tag>
 		<name>ddm-template-selector</name>
 		<tag-class>com.liferay.taglib.ui.DDMTemplateSelectorTag</tag-class>
 		<body-content>JSP</body-content>

--- a/util-taglib/src/com/liferay/taglib/ui/DDMTemplateRendererTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/DDMTemplateRendererTag.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.taglib.ui;
+
+import com.liferay.portlet.portletdisplaytemplate.util.PortletDisplayTemplateUtil;
+import com.liferay.taglib.util.IncludeTag;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eduardo Garcia
+ */
+public class DDMTemplateRendererTag extends IncludeTag {
+
+	@Override
+	public int processStartTag() throws Exception {
+		_portletDisplayDDMTemplateId =
+			PortletDisplayTemplateUtil.getPortletDisplayTemplateDDMTemplateId(
+				_displayStyleGroupId, _displayStyle);
+
+		if (_portletDisplayDDMTemplateId > 0) {
+			return SKIP_BODY;
+		}
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	public void setContextObjects(Map<String, Object> contextObjects) {
+		_contextObjects = contextObjects;
+	}
+
+	public void setDisplayStyle(String displayStyle) {
+		_displayStyle = displayStyle;
+	}
+
+	public void setDisplayStyleGroupId(long displayStyleGroupId) {
+		_displayStyleGroupId = displayStyleGroupId;
+	}
+
+	public void setEntries(List<?> entries) {
+		_entries = entries;
+	}
+
+	@Override
+	protected void cleanUp() {
+		_contextObjects = new HashMap<String, Object>();
+		_displayStyle = null;
+		_displayStyleGroupId = 0;
+		_entries = null;
+		_portletDisplayDDMTemplateId = 0;
+	}
+
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	@Override
+	protected void setAttributes(HttpServletRequest request) {
+		request.setAttribute(
+			"liferay-ui:ddm-template-renderer:contextObjects", _contextObjects);
+		request.setAttribute(
+			"liferay-ui:ddm-template-renderer:entries", _entries);
+		request.setAttribute(
+			"liferay-ui:ddm-template-renderer:portletDisplayDDMTemplateId",
+			String.valueOf(_portletDisplayDDMTemplateId));
+	}
+
+	private static final String _PAGE =
+		"/html/taglib/ui/ddm_template_renderer/page.jsp";
+
+	private Map<String, Object> _contextObjects = new HashMap<String, Object>();
+	private String _displayStyle;
+	private long _displayStyleGroupId;
+	private List<?> _entries;
+	private long _portletDisplayDDMTemplateId;
+
+}


### PR DESCRIPTION
Hey @brianchandotcom,

This change suggested by @rotty3000 allows to render Freemarker ADTs that contain JSP taglibs in OSGi portlets. @ealonso has tested it with the RSS portlet, which he's extracting as an OSGi module and it works.

Thx

@juliocamarero @migue
