### PR TITLE
LPS-52070 Fix left over garbage data from GroupServiceTest

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/GroupServiceTest.java
@@ -357,14 +357,24 @@ public class GroupServiceTest {
 			parentOrganization.getOrganizationId(),
 			RandomTestUtil.randomString(), false);
 
+		_organizations.add(organization);
+		_organizations.add(parentOrganization);
+
 		UserLocalServiceUtil.addOrganizationUsers(
 			organization.getOrganizationId(),
 			new long[] {TestPropsValues.getUserId()});
 
-		List<Group> groups = GroupServiceUtil.getUserSitesGroups(
-			TestPropsValues.getUserId(), null, false, QueryUtil.ALL_POS);
+		try {
+			List<Group> groups = GroupServiceUtil.getUserSitesGroups(
+				TestPropsValues.getUserId(), null, false, QueryUtil.ALL_POS);
 
-		Assert.assertTrue(groups.contains(parentOrganizationGroup));
+			Assert.assertTrue(groups.contains(parentOrganizationGroup));
+		}
+		finally {
+			UserLocalServiceUtil.unsetOrganizationUsers(
+				organization.getOrganizationId(),
+				new long[] {TestPropsValues.getUserId()});
+		}
 	}
 
 	@Test
@@ -1055,5 +1065,9 @@ public class GroupServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@DeleteAfterTestRun
+	private final List<Organization> _organizations =
+		new ArrayList<Organization>();
 
 }


### PR DESCRIPTION
Fix for http://ci.liferay.org.es/jenkins/job/liferay-portal-master/429/testReport/junit/com.liferay.portal.service/OrganizationLocalServiceTest/testGetNoAssetOrganizations/
