### PR TITLE
LPS-52171 NewEnvTestRule.RunInNewClassLoaderStatement should reset Metho...

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/NewEnvTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/NewEnvTestRule.java
@@ -356,6 +356,8 @@ public class NewEnvTestRule implements TestRule {
 				}
 
 				currentThread.setContextClassLoader(contextClassLoader);
+
+				MethodCache.reset();
 			}
 		}
 


### PR DESCRIPTION
...dCache after run, to release references to the new classloader, so that it can be gced properly
