### PR TITLE
LPS-52185 Optimize FindActionTest to not use ResetDatabaseTestRule, but ...

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/RoleLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/RoleLocalServiceTest.java
@@ -25,9 +25,9 @@ import com.liferay.portal.model.Role;
 import com.liferay.portal.model.RoleConstants;
 import com.liferay.portal.model.Team;
 import com.liferay.portal.model.User;
+import com.liferay.portal.test.DeleteAfterTestRun;
 import com.liferay.portal.test.LiferayIntegrationTestRule;
 import com.liferay.portal.test.MainServletTestRule;
-import com.liferay.portal.test.ResetDatabaseTestRule;
 import com.liferay.portal.util.comparator.RoleRoleIdComparator;
 import com.liferay.portal.util.test.GroupTestUtil;
 import com.liferay.portal.util.test.LayoutTestUtil;
@@ -55,8 +55,7 @@ public class RoleLocalServiceTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
-			new LiferayIntegrationTestRule(), MainServletTestRule.INSTANCE,
-			ResetDatabaseTestRule.INSTANCE);
+			new LiferayIntegrationTestRule(), MainServletTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() {
@@ -194,6 +193,8 @@ public class RoleLocalServiceTest {
 				OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
 				RandomTestUtil.randomString(), false);
 
+		_organizations.add(organization);
+
 		Team team = TeamLocalServiceUtil.addTeam(
 			user.getUserId(), organization.getGroupId(),
 			RandomTestUtil.randomString(), null);
@@ -218,5 +219,9 @@ public class RoleLocalServiceTest {
 			Assert.assertFalse(teamRoleMap.containsKey(team));
 		}
 	}
+
+	@DeleteAfterTestRun
+	private final List<Organization> _organizations =
+		new ArrayList<Organization>();
 
 }


### PR DESCRIPTION
...do @DeleteAfterTestRun, cut down runtime from 21sec to 2sec
