### PR TITLE
LPS-52169 Compile portal-impl depends on compile util-taglib

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -252,10 +252,11 @@
 			<ant dir="util-slf4j" target="compile" inheritAll="false" />
 		</parallel>
 
+		<ant dir="util-taglib" target="compile" inheritAll="false" />
+
 		<parallel failonany="true" threadcount="${parallel.thread.count}">
 			<ant dir="portal-impl" target="compile" inheritAll="false" />
 			<ant dir="portal-test" target="compile" inheritAll="false" />
-			<ant dir="util-taglib" target="compile" inheritAll="false" />
 		</parallel>
 
 		<parallel failonany="true" threadcount="${parallel.thread.count}">


### PR DESCRIPTION
This typically wouldn't cause a build failure due to the fact that util-taglib compiles so much faster than portal-impl and they're both running in parallel, but of course we shouldn't rely on that
