### PR TITLE
LPS-52169 Fix regression caused by bb73172dfcf71c945542c76b31c546a27cf37f6f, concurrently remove the same file breaks ant build.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -177,13 +177,6 @@
 				/>
 			</delete>
 
-			<delete failonerror="false">
-				<fileset
-					dir="${app.server.lib.portal.dir}"
-					excludes="${jdbc.drivers}"
-				/>
-			</delete>
-
 			<if>
 				<equals arg1="${clean.log.dir}" arg2="true" />
 				<then>
@@ -202,6 +195,14 @@
 					<delete dir="${app.server.portal.dir}" />
 					<delete file="${app.server.portal.dir}" />
 				</then>
+				<else>
+					<delete failonerror="false">
+						<fileset
+							dir="${app.server.lib.portal.dir}"
+							excludes="${jdbc.drivers}"
+						/>
+					</delete>
+				</else>
 			</if>
 
 			<if>


### PR DESCRIPTION
Fix randomly breaking build like this http://ci.liferay.org.es/jenkins/job/liferay-portal-master/520/

CC @CAustin582
