### PR TITLE
LPS-52170

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5811,10 +5811,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			}
 		}
 
+		if (resultsMap != null) {
+			resultsMap.put("userId", user.getUserId());
+		}
+
 		if (authResult == Authenticator.SUCCESS) {
-			if (resultsMap != null) {
-				resultsMap.put("userId", user.getUserId());
-			}
 
 			// Update digest
 

--- a/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
+++ b/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.login.util;
 
+import com.liferay.portal.UserLockoutException;
 import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.cluster.ClusterNode;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -149,7 +150,15 @@ public class LoginUtil {
 			}
 
 			if (authResult != Authenticator.SUCCESS) {
-				throw new AuthException();
+				User user = UserLocalServiceUtil.fetchUser(userId);
+
+				if ((user != null) && user.isLockout()) {
+					throw new UserLockoutException.PasswordPolicyLockout(
+						user, user.getPasswordPolicy());
+				}
+				else {
+					throw new AuthException();
+				}
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
+++ b/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
@@ -152,13 +152,11 @@ public class LoginUtil {
 			if (authResult != Authenticator.SUCCESS) {
 				User user = UserLocalServiceUtil.fetchUser(userId);
 
-				if ((user != null) && user.isLockout()) {
-					throw new UserLockoutException.PasswordPolicyLockout(
-						user, user.getPasswordPolicy());
+				if (user != null) {
+					UserLocalServiceUtil.checkLockout(user);
 				}
-				else {
-					throw new AuthException();
-				}
+
+				throw new AuthException();
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
+++ b/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portlet.login.util;
 
-import com.liferay.portal.UserLockoutException;
 import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.cluster.ClusterNode;
 import com.liferay.portal.kernel.exception.PortalException;


### PR DESCRIPTION
This seems to be the only viable fix without a major refactor pulling the authentication code out of UserLocalServiceImpl. If you try to throw the UserLockoutException in UserLocalServiceImpl when the lockout happens it will cause the transaction to rollback and thus the lockout is not saved in database allowing the user to try to login again.

CC @jonathanmccann
