### PR TITLE
LPS-52663 MBThread's last post time should be set to last message's modi...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
@@ -102,7 +102,7 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 			thread.setLastPostByUserId(message.getUserId());
 		}
 
-		thread.setLastPostDate(message.getCreateDate());
+		thread.setLastPostDate(message.getModifiedDate());
 
 		if (message.getPriority() != MBThreadConstants.PRIORITY_NOT_GIVEN) {
 			thread.setPriority(message.getPriority());


### PR DESCRIPTION
Fix for https://test-1-2.liferay.com/job/test-portal-pullrequest-backend%28master%29/group=20,label_exp=!test-1-2/212/testReport/junit/com.liferay.portlet.messageboards.service/MBMessageLocalServiceTest/testThreadLastPostDate/
