### PR TITLE
master-qa-sourceformatter

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/sourceformatter/PropertiesSourceProcessor.java
+++ b/portal-impl/src/com/liferay/portal/tools/sourceformatter/PropertiesSourceProcessor.java
@@ -51,7 +51,7 @@ public class PropertiesSourceProcessor extends BaseSourceProcessor {
 			formatPortalProperties(fileName, content);
 		}
 
-		return formatWhitespace(content);
+		return content;
 	}
 
 	@Override
@@ -91,7 +91,31 @@ public class PropertiesSourceProcessor extends BaseSourceProcessor {
 
 		String content = fileUtil.read(file);
 
-		String newContent = formatWhitespace(content);
+		StringBundler sb = new StringBundler();
+
+		try (UnsyncBufferedReader unsyncBufferedReader =
+				new UnsyncBufferedReader(new UnsyncStringReader(content))) {
+
+			String line = null;
+
+			while ((line = unsyncBufferedReader.readLine()) != null) {
+				line = trimLine(line, true);
+
+				if (line.startsWith(StringPool.TAB)) {
+					line = line.replaceFirst(
+						StringPool.TAB, StringPool.FOUR_SPACES);
+				}
+
+				sb.append(line);
+				sb.append("\n");
+			}
+		}
+
+		String newContent = sb.toString();
+
+		if (newContent.endsWith("\n")) {
+			newContent = newContent.substring(0, newContent.length() - 1);
+		}
 
 		processFormattedFile(file, fileName, content, newContent);
 
@@ -201,36 +225,6 @@ public class PropertiesSourceProcessor extends BaseSourceProcessor {
 				}
 			}
 		}
-	}
-
-	protected String formatWhitespace(String content) throws Exception {
-		StringBundler sb = new StringBundler();
-
-		try (UnsyncBufferedReader unsyncBufferedReader =
-				new UnsyncBufferedReader(new UnsyncStringReader(content))) {
-
-			String line = null;
-
-			while ((line = unsyncBufferedReader.readLine()) != null) {
-				line = trimLine(line, true);
-
-				if (line.startsWith(StringPool.TAB)) {
-					line = line.replaceFirst(
-						StringPool.TAB, StringPool.FOUR_SPACES);
-				}
-
-				sb.append(line);
-				sb.append("\n");
-			}
-		}
-
-		String newContent = sb.toString();
-
-		if (newContent.endsWith("\n")) {
-			newContent = newContent.substring(0, newContent.length() - 1);
-		}
-
-		return newContent;
 	}
 
 	private String _portalPortalPropertiesContent;


### PR DESCRIPTION
Revert SourceFormatter white space changes.

We also need to instead ignore white space within xml files when they are surrounded by a CDATA.

Otherwise, we won't have to use [tabs] for things that get generated, and when they generate things used in '*-ext.properties' files.

This will throw an error for those files because they need to use [4 spaces] instead of tabs.
