### PR TITLE
master-bc-3335

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2706,15 +2706,13 @@ module.framework.properties.osgi.console=11312</echo>
 					<then>
 						<exec executable="/bin/bash" os="${os.unix}" outputproperty="sharepoint.vm.host.name">
 							<arg value="-c" />
-							<arg value="curl" />
-							<arg value="&quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2Esharepoint2010&quot;" />
+							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2Esharepoint2010&quot;" />
 						</exec>
 					</then>
 					<else>
 						<exec executable="cmd" outputproperty="sharepoint.vm.host.name">
 							<arg value="/c" />
-							<arg value="curl" />
-							<arg value="&quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2Esharepoint2010&quot;" />
+							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2Esharepoint2010&quot;" />
 						</exec>
 					</else>
 				</if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LIFERAYQA-12996

This combines the last two <arg> elements in the sharepoint section of build-test.xml. When the last two elements are separated the "curl" brings up the help information and the last argument doesn't seem to affect anything.
