### PR TITLE
LPS-52913 Fix XML namespace for liferay-ui.tld

### DIFF
--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -2,7 +2,7 @@
 
 <taglib
 	version="2.1"
-	xmlns="http://java.sun.com/xml/ns/j2ee"
+	xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
 >


### PR DESCRIPTION
This fix allows us to build the taglib docs for liferay-ui.tld.

Please see https://issues.liferay.com/browse/LPS-52913

CC @chasaustin582

Thanks
