### PR TITLE
Initial pass at fixing Javadoc warnings

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/JSONServiceAction.java
+++ b/portal-impl/src/com/liferay/portal/action/JSONServiceAction.java
@@ -424,7 +424,8 @@ public class JSONServiceAction extends JSONAction {
 	}
 
 	/**
-	 * @see com.liferay.portal.jsonwebservice.JSONWebServiceServiceAction#getCSRFOrigin(HttpServletRequest)
+	 * @see com.liferay.portal.jsonwebservice.JSONWebServiceServiceAction#getCSRFOrigin(
+	 *      HttpServletRequest)
 	 */
 	@Override
 	protected String getCSRFOrigin(HttpServletRequest request) {

--- a/portal-impl/src/com/liferay/portal/action/JSONServiceAction.java
+++ b/portal-impl/src/com/liferay/portal/action/JSONServiceAction.java
@@ -424,7 +424,7 @@ public class JSONServiceAction extends JSONAction {
 	}
 
 	/**
-	 * @see JSONWebServiceServiceAction#getCSRFOrigin(HttpServletRequest)
+	 * @see com.liferay.portal.jsonwebservice.JSONWebServiceServiceAction#getCSRFOrigin(HttpServletRequest)
 	 */
 	@Override
 	protected String getCSRFOrigin(HttpServletRequest request) {

--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -137,7 +137,8 @@ public class GroupImpl extends GroupBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             #getChildrenWithLayouts(boolean, int, int, OrderByComparator)}
+	 *             #getChildrenWithLayouts(boolean, int, int,
+	 *             OrderByComparator)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/GroupImpl.java
@@ -137,8 +137,7 @@ public class GroupImpl extends GroupBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             #getChildrenWithLayouts(boolean, int, int,
-	 *             OrderByComparator)}
+	 *             #getChildrenWithLayouts(boolean, int, int, OrderByComparator)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/http/LayoutServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/LayoutServiceSoap.java
@@ -261,9 +261,9 @@ public class LayoutServiceSoap {
 	* @param parentLayoutId the primary key of the parent layout (optionally
 	{@link
 	com.liferay.portal.model.LayoutConstants#DEFAULT_PARENT_LAYOUT_ID})
-	* @param name Map the layout's locales and localized names
-	* @param title Map the layout's locales and localized titles
-	* @param description Map the layout's locales and localized descriptions
+	* @param name the layout's locales and localized names
+	* @param title the layout's locales and localized titles
+	* @param description the layout's locales and localized descriptions
 	* @param type the layout's type (optionally {@link
 	com.liferay.portal.model.LayoutConstants#TYPE_PORTLET}). The
 	possible types can be found in {@link

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -1296,7 +1296,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             Group#getDescriptiveName(Locale)
+	 *             Group#getDescriptiveName(Locale)}
 	 */
 	@Deprecated
 	@Override
@@ -1308,7 +1308,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             Group#getDescriptiveName(Locale)
+	 *             Group#getDescriptiveName(Locale)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -237,9 +237,9 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 	 * @param  parentLayoutId the primary key of the parent layout (optionally
 	 *         {@link
 	 *         com.liferay.portal.model.LayoutConstants#DEFAULT_PARENT_LAYOUT_ID})
-	 * @param  name Map the layout's locales and localized names
-	 * @param  title Map the layout's locales and localized titles
-	 * @param  description Map the layout's locales and localized descriptions
+	 * @param  name the layout's locales and localized names
+	 * @param  title the layout's locales and localized titles
+	 * @param  description the layout's locales and localized descriptions
 	 * @param  type the layout's type (optionally {@link
 	 *         com.liferay.portal.model.LayoutConstants#TYPE_PORTLET}). The
 	 *         possible types can be found in {@link

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -3784,12 +3784,12 @@ public class ServiceBuilder {
 			sb.append(tag.getName());
 			sb.append(" ");
 
-			if (classType.equals("ServiceSoap") &&
-					tagValue.startsWith("PortalException")
-					) {
+			if (classType.equals("ServiceSoap") && tagValue.startsWith(
+					"com.liferay.portal.kernel.exception.PortalException")) {
 
 				String remoteValue = tagValue.replaceFirst(
-						"PortalException", "RemoteException");
+						"com.liferay.portal.kernel.exception.PortalException", 
+						"RemoteException");
 
 				sb.append(remoteValue);
 			}
@@ -3800,7 +3800,6 @@ public class ServiceBuilder {
 						"PrincipalException", "RemoteException");
 
 				sb.append(remoteValue);
-
 			}
 			else {
 				sb.append(tagValue);
@@ -4271,9 +4270,9 @@ public class ServiceBuilder {
 
 			if (text.contains(classImport)) {
 				int classImportIndex = text.indexOf(classImport);
-
 				int endOfClassImportIndex = classImportIndex + classImport.length();
 
+				String begOfImport = StringPool.BLANK;
 				String endOfImport = StringPool.BLANK;
 
 				if (text.length() > endOfClassImportIndex) {
@@ -4282,16 +4281,15 @@ public class ServiceBuilder {
 				}
 
 				if (classImportIndex > 0) {
-					String begOfImport = text.substring(
+					begOfImport = text.substring(
 							classImportIndex - 1, classImportIndex);
+				}
 
-					if (!begOfImport.matches("[a-zA-Z_0-9;\\.]") &&
-							!endOfImport.matches("[a-zA-Z_0-9\\.]") &&
-							!endOfImport.equals(" ")) {
+				if (!begOfImport.matches("[a-zA-Z_0-9;\\.]") &&
+						!endOfImport.matches("[a-zA-Z_0-9\\.]") &&
+						(!endOfImport.equals(" ") || classImportIndex == 0)) {
 
-						text = text.replaceAll(
-								classImport, fullImport);
-					}
+					text = text.replaceAll(classImport, fullImport);
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -5233,16 +5233,19 @@ public class ServiceBuilder {
 			String className = importedClass.substring(
 				importedClass.lastIndexOf(StringPool.PERIOD) + 1);
 
-			if (text.contains(className)) {
-				int pos = text.indexOf(className);
-				int endPos = pos + className.length();
+			int fromIndex = 0;
+			int pos = text.indexOf(className, fromIndex);
 
+			for (; pos > -1; pos = text.indexOf(className, fromIndex))
+			{
 				String charBefore = StringPool.BLANK;
 				String charAfter = StringPool.BLANK;
 
 				if (pos > 0) {
 					charBefore = text.substring(pos - 1, pos);
 				}
+
+				int endPos = pos + className.length();
 
 				if (text.length() > endPos) {
 					charAfter = text.substring(endPos, endPos + 1);
@@ -5253,7 +5256,15 @@ public class ServiceBuilder {
 					(!charAfter.equals(StringPool.BLANK) ||
 						(pos == 0)))
 				{
-					text = text.replaceAll(className, importedClass);
+					text = StringUtil.replaceFirst(
+						text, className, importedClass, pos);
+
+					fromIndex = pos + importedClass.length();
+				}
+
+				else
+				{
+					fromIndex = endPos;
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -4246,7 +4246,7 @@ public class ServiceBuilder {
 		JavaSource javaSource = javaClass.getSource();
 		String[] imports = javaSource.getImports();
 
-		JavaClass parentJavaClass = javaClass.getSuperJavaClass();
+		JavaClass parentJavaClass = _getParentJavaClass(javaClass);
 		JavaSource parentJavaSource = parentJavaClass.getSource();
 		String[] parentImports = parentJavaSource.getImports();
 
@@ -4336,6 +4336,29 @@ public class ServiceBuilder {
 		}
 
 		return methods;
+	}
+
+	private JavaClass _getParentJavaClass(JavaClass javaClass)
+		throws IOException {
+
+		String parentJavaClassString = javaClass.getSuperJavaClass().toString();
+		int parentJavaClassIndex = parentJavaClassString.indexOf("com.");
+
+		String parentClassPath = parentJavaClassString.substring(
+				parentJavaClassIndex, parentJavaClassString.length());
+		parentClassPath = parentClassPath.replaceAll("\\.", "/");
+
+		int parentOutputPathIndex = _outputPath.indexOf("com/");
+		String parentOutputPath = _outputPath.substring(
+				parentOutputPathIndex, _outputPath.length());
+
+		String finalParentClassPath = _outputPath.replace(
+				parentOutputPath, parentClassPath);
+		finalParentClassPath = finalParentClassPath + ".java";
+
+		JavaClass parentJavaClass = _getJavaClass(finalParentClassPath);
+
+		return parentJavaClass;
 	}
 
 	private String _getSessionTypeName(int sessionType) {

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -3775,11 +3775,12 @@ public class ServiceBuilder {
 
 				sb.append(remoteValue);
 			}
-			else if (classType.equals("ServiceSoap") &&
-					tagValue.startsWith("PrincipalException")
+			else if (classType.equals("ServiceSoap") && tagValue.startsWith(
+						"com.liferay.portal.security.auth.PrincipalException")
 					) {
 				String remoteValue = tagValue.replaceFirst(
-						"PrincipalException", "RemoteException");
+						"com.liferay.portal.security.auth.PrincipalException",
+						"RemoteException");
 
 				sb.append(remoteValue);
 			}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -3750,11 +3750,11 @@ public class ServiceBuilder {
 		sb.append(indentation);
 		sb.append("/**\n");
 
-		String[] imports = _getJavadocImports(entityName, sessionTypeName);
+		String[] imports = _getImports(entityName, sessionTypeName);
 
 		if (Validator.isNotNull(comment)) {
 			comment = comment.replaceAll("(?m)^", indentation + " * ");
-			comment = _getJavadocPackages(comment, imports);
+			comment = _useFullyQualifiedClassNames(comment, imports);
 
 			sb.append(comment);
 			sb.append("\n");
@@ -3768,7 +3768,7 @@ public class ServiceBuilder {
 		for (DocletTag tag : tags) {
 			String tagValue = tag.getValue();
 
-			tagValue = _getJavadocPackages(tagValue, imports);
+			tagValue = _useFullyQualifiedClassNames(tagValue, imports);
 
 			sb.append(indentation);
 			sb.append(" * @");
@@ -4220,6 +4220,41 @@ public class ServiceBuilder {
 		return dimensions;
 	}
 
+	private String[] _getImports(String entityName, String sessionTypeName)
+		throws IOException {
+
+		JavaClass javaClass = null;
+		String serviceImplPath = _outputPath + "/service/impl/" + entityName;
+
+		if (sessionTypeName.equals("Local")) {
+			javaClass = _getJavaClass(
+				serviceImplPath + "LocalServiceImpl.java");
+		}
+		else {
+			File serviceImplFile = new File(
+				serviceImplPath + "ServiceImpl.java");
+
+			if (serviceImplFile.exists()) {
+				javaClass = _getJavaClass(serviceImplPath + "ServiceImpl.java");
+			}
+			else {
+				javaClass = _getJavaClass(
+					_outputPath + "/model/impl/" + entityName + "Impl.java");
+			}
+		}
+
+		JavaSource javaSource = javaClass.getSource();
+		String[] imports = javaSource.getImports();
+
+		JavaClass parentJavaClass = javaClass.getSuperJavaClass();
+		JavaSource parentJavaSource = parentJavaClass.getSource();
+		String[] parentImports = parentJavaSource.getImports();
+
+		String[] allImports = ArrayUtils.addAll(imports, parentImports);
+
+		return allImports;
+	}
+
 	private JavaClass _getJavaClass(String fileName) throws IOException {
 		int pos = fileName.indexOf(_implDir + "/");
 
@@ -4257,74 +4292,6 @@ public class ServiceBuilder {
 		}
 
 		return javaClass;
-	}
-
-	private String[] _getJavadocImports(String entityName, String sessionTypeName)
-		throws IOException {
-
-		JavaClass javaClass = null;
-		String serviceImplPath = _outputPath + "/service/impl/" + entityName;
-
-		if (sessionTypeName.equals("Local")) {
-			javaClass = _getJavaClass(
-				serviceImplPath + "LocalServiceImpl.java");
-		}
-		else {
-			File serviceImplFile = new File(
-				serviceImplPath + "ServiceImpl.java");
-
-			if (serviceImplFile.exists()) {
-				javaClass = _getJavaClass(serviceImplPath + "ServiceImpl.java");
-			}
-			else {
-				javaClass = _getJavaClass(
-					_outputPath + "/model/impl/" + entityName + "Impl.java");
-			}
-		}
-
-		JavaSource javaSource = javaClass.getSource();
-		String[] imports = javaSource.getImports();
-
-		JavaClass parentJavaClass = javaClass.getSuperJavaClass();
-		JavaSource parentJavaSource = parentJavaClass.getSource();
-		String[] parentImports = parentJavaSource.getImports();
-
-		String[] allImports = ArrayUtils.addAll(imports, parentImports);
-
-		return allImports;
-	}
-
-	private String _getJavadocPackages(String text, String[] imports) {
-		for (String importedClass : imports) {
-			String className = importedClass.substring(
-				importedClass.lastIndexOf(StringPool.PERIOD) + 1);
-
-			if (text.contains(className)) {
-				int pos = text.indexOf(className);
-				int endPos = pos + className.length();
-
-				String charBefore = StringPool.BLANK;
-				String charAfter = StringPool.BLANK;
-
-				if (pos > 0) {
-					charBefore = text.substring(pos - 1, pos);
-				}
-
-				if (text.length() > endPos) {
-					charAfter = text.substring(endPos, endPos + 1);
-				}
-
-				if (!charBefore.matches("[a-zA-Z_0-9;\\.]") &&
-					!charAfter.matches("[a-zA-Z_0-9\\.]") &&
-					(!charAfter.equals(StringPool.BLANK) ||
-						(pos == 0)))
-				{
-					text = text.replaceAll(className, importedClass);
-				}
-			}
-		}
-
-		return text;
 	}
 
 	private String _getMethodKey(JavaMethod javaMethod) {
@@ -5259,6 +5226,39 @@ public class ServiceBuilder {
 		if (updateSQLFile.exists()) {
 			_createSQLTables(updateSQLFile, createTableSQL, entity, false);
 		}
+	}
+
+	private String _useFullyQualifiedClassNames(String text, String[] imports) {
+		for (String importedClass : imports) {
+			String className = importedClass.substring(
+				importedClass.lastIndexOf(StringPool.PERIOD) + 1);
+
+			if (text.contains(className)) {
+				int pos = text.indexOf(className);
+				int endPos = pos + className.length();
+
+				String charBefore = StringPool.BLANK;
+				String charAfter = StringPool.BLANK;
+
+				if (pos > 0) {
+					charBefore = text.substring(pos - 1, pos);
+				}
+
+				if (text.length() > endPos) {
+					charAfter = text.substring(endPos, endPos + 1);
+				}
+
+				if (!charBefore.matches("[a-zA-Z_0-9;\\.]") &&
+					!charAfter.matches("[a-zA-Z_0-9\\.]") &&
+					(!charAfter.equals(StringPool.BLANK) ||
+						(pos == 0)))
+				{
+					text = text.replaceAll(className, importedClass);
+				}
+			}
+		}
+
+		return text;
 	}
 
 	private static final int _SESSION_TYPE_LOCAL = 1;

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -104,6 +104,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.ArrayUtils;
+
 import org.dom4j.DocumentException;
 
 /**
@@ -118,6 +119,7 @@ import org.dom4j.DocumentException;
  * @author Shuyang Zhou
  * @author James Lefeu
  * @author Miguel Pastor
+ * @author Cody Hoag
  */
 public class ServiceBuilder {
 
@@ -1222,12 +1224,18 @@ public class ServiceBuilder {
 
 	public String getJavadocComment(JavaClass javaClass) throws IOException {
 		return _formatComment(
-			javaClass.getComment(), javaClass.getTags(), null, StringPool.BLANK, null, null);
+			javaClass.getComment(), javaClass.getTags(), StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK);
 	}
 
-	public String getJavadocComment(JavaMethod javaMethod, String classType, String entityName, String sessionTypeName) throws IOException {
+	public String getJavadocComment(
+			JavaMethod javaMethod, String classType, String entityName,
+			String sessionTypeName)
+		throws IOException {
+
 		return _formatComment(
-			javaMethod.getComment(), javaMethod.getTags(), entityName, StringPool.TAB, classType, sessionTypeName);
+			javaMethod.getComment(), javaMethod.getTags(), entityName,
+			StringPool.TAB, classType, sessionTypeName);
 	}
 
 	public String getListActualTypeArguments(Type type) {
@@ -3729,8 +3737,9 @@ public class ServiceBuilder {
 	}
 
 	private String _formatComment(
-		String comment, DocletTag[] tags, String entityName, String indentation,
-		String classType, String sessionTypeName) throws IOException {
+			String comment, DocletTag[] tags, String entityName,
+			String indentation, String classType, String sessionTypeName)
+		throws IOException {
 
 		StringBundler sb = new StringBundler();
 
@@ -3770,7 +3779,7 @@ public class ServiceBuilder {
 					"com.liferay.portal.kernel.exception.PortalException")) {
 
 				String remoteValue = tagValue.replaceFirst(
-						"com.liferay.portal.kernel.exception.PortalException", 
+						"com.liferay.portal.kernel.exception.PortalException",
 						"RemoteException");
 
 				sb.append(remoteValue);
@@ -3787,6 +3796,7 @@ public class ServiceBuilder {
 			else {
 				sb.append(tagValue);
 			}
+
 			sb.append("\n");
 		}
 
@@ -4246,10 +4256,12 @@ public class ServiceBuilder {
 		return javaClass;
 	}
 
-	private String[] _getJavadocImports(String entityName, String sessionTypeName) throws IOException {
-		String path = _outputPath + "/service/impl/" + entityName;
+	private String[] _getJavadocImports(
+			String entityName, String sessionTypeName)
+		throws IOException {
 
 		JavaClass javaClass = null;
+		String path = _outputPath + "/service/impl/" + entityName;
 		File serviceImplFile = new File(path + "ServiceImpl.java");
 
 		if (sessionTypeName.equals("Local")) {
@@ -4258,7 +4270,7 @@ public class ServiceBuilder {
 		else if (serviceImplFile.exists()) {
 			javaClass = _getJavaClass(path + "ServiceImpl.java");
 		}
-		else  {
+		else {
 			javaClass = _getJavaClass(_outputPath + "/model/impl/" +
 				entityName + "Impl.java");
 		}
@@ -4278,28 +4290,29 @@ public class ServiceBuilder {
 	private String _getJavadocPackages(String text, String[] imports) {
 		for (String fullImport : imports) {
 			String classImport = fullImport.substring(
-					fullImport.lastIndexOf(".") + 1);
+				fullImport.lastIndexOf(".") + 1);
 
 			if (text.contains(classImport)) {
 				int classImportIndex = text.indexOf(classImport);
-				int endOfClassImportIndex = classImportIndex + classImport.length();
+				int endOfClassImportIndex = classImportIndex +
+					classImport.length();
 
 				String begOfImport = StringPool.BLANK;
 				String endOfImport = StringPool.BLANK;
 
 				if (text.length() > endOfClassImportIndex) {
 					endOfImport = text.substring(
-							endOfClassImportIndex, endOfClassImportIndex + 1);
+						endOfClassImportIndex, endOfClassImportIndex + 1);
 				}
 
 				if (classImportIndex > 0) {
 					begOfImport = text.substring(
-							classImportIndex - 1, classImportIndex);
+						classImportIndex - 1, classImportIndex);
 				}
 
 				if (!begOfImport.matches("[a-zA-Z_0-9;\\.]") &&
-						!endOfImport.matches("[a-zA-Z_0-9\\.]") &&
-						(!endOfImport.equals(" ") || classImportIndex == 0)) {
+					!endOfImport.matches("[a-zA-Z_0-9\\.]") &&
+					(!endOfImport.equals(" ") || classImportIndex == 0)) {
 
 					text = text.replaceAll(classImport, fullImport);
 				}
@@ -4353,17 +4366,22 @@ public class ServiceBuilder {
 		return methods;
 	}
 
-	private JavaClass _getParentJavaClass(JavaClass javaClass) throws IOException {
+	private JavaClass _getParentJavaClass(JavaClass javaClass)
+		throws IOException {
+
 		String parentJavaClassString = javaClass.getSuperJavaClass().toString();
 		int parentJavaClassIndex = parentJavaClassString.indexOf("com.");
 
-		String parentClassPath = parentJavaClassString.substring(parentJavaClassIndex, parentJavaClassString.length());
+		String parentClassPath = parentJavaClassString.substring(
+				parentJavaClassIndex, parentJavaClassString.length());
 		parentClassPath = parentClassPath.replaceAll("\\.", "/");
 
 		int parentOutputPathIndex = _outputPath.indexOf("com/");
-		String parentOutputPath = _outputPath.substring(parentOutputPathIndex, _outputPath.length());
+		String parentOutputPath = _outputPath.substring(
+				parentOutputPathIndex, _outputPath.length());
 
-		String finalParentClassPath = _outputPath.replace(parentOutputPath, parentClassPath);
+		String finalParentClassPath = _outputPath.replace(
+				parentOutputPath, parentClassPath);
 		finalParentClassPath = finalParentClassPath + ".java";
 
 		JavaClass parentJavaClass = _getJavaClass(finalParentClassPath);

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -3726,7 +3726,7 @@ public class ServiceBuilder {
 	private String _fixSpringXml(String content) {
 		return StringUtil.replace(content, ".service.spring.", ".service.");
 	}
-	
+
 	private String _formatComment(
 		String comment, DocletTag[] tags, String entityName, String indentation,
 		String classType) throws IOException {
@@ -3755,7 +3755,7 @@ public class ServiceBuilder {
 		}
 		else  {
 			javaClass = _getJavaClass(_outputPath + "/model/impl/" +
-		entityName + "Impl.java");
+				entityName + "Impl.java");
 		}
 
 			JavaSource javaSource = javaClass.getSource();
@@ -3777,25 +3777,36 @@ public class ServiceBuilder {
 			
 			String tagValue = tag.getValue();
 				
-				for (String fullImport : imports) {
-					String classImport = fullImport.substring(
-							fullImport.lastIndexOf(".") + 1);
-					
-					if (tagValue.contains(classImport)) {
-						int classImportIndex = tagValue.indexOf(classImport);
+			for (String fullImport : imports) {
+				String classImport = fullImport.substring(
+						fullImport.lastIndexOf(".") + 1);
+
+				if (tagValue.contains(classImport)) {
+					int classImportIndex = tagValue.indexOf(classImport);
+
+					int endOfClassImportIndex = classImportIndex + classImport.length();
+
+					String endOfImport = StringPool.BLANK;
+
+					if (tagValue.length() > endOfClassImportIndex) {
+						endOfImport = tagValue.substring(
+								endOfClassImportIndex, endOfClassImportIndex + 1);
+					}
 
 						if (classImportIndex > 0) {
 							String begOfImport = tagValue.substring(
 									classImportIndex - 1, classImportIndex);
 
-							if (begOfImport.equals(" ") ||
-									begOfImport.equals("(")) {
+							if ((begOfImport.equals(" ") ||
+									begOfImport.equals("(")) &&
+									!endOfImport.matches("[a-zA-Z]") &&
+									!endOfImport.equals(" ")) {
 								tagValue = tagValue.replaceAll(
 										classImport, fullImport);
 							}
 						}
-					}
 				}
+			}
 			
 			sb.append(indentation);
 			sb.append(" * @");

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1221,12 +1221,12 @@ public class ServiceBuilder {
 
 	public String getJavadocComment(JavaClass javaClass) {
 		return _formatComment(
-			javaClass.getComment(), javaClass.getTags(), StringPool.BLANK);
+			javaClass.getComment(), javaClass.getTags(), StringPool.BLANK, null);
 	}
 
-	public String getJavadocComment(JavaMethod javaMethod) {
+	public String getJavadocComment(JavaMethod javaMethod, String classType) {
 		return _formatComment(
-			javaMethod.getComment(), javaMethod.getTags(), StringPool.TAB);
+			javaMethod.getComment(), javaMethod.getTags(), StringPool.TAB, classType);
 	}
 
 	public String getListActualTypeArguments(Type type) {
@@ -3728,7 +3728,7 @@ public class ServiceBuilder {
 	}
 
 	private String _formatComment(
-		String comment, DocletTag[] tags, String indentation) {
+		String comment, DocletTag[] tags, String indentation, String classType) {
 
 		StringBundler sb = new StringBundler();
 
@@ -3756,7 +3756,19 @@ public class ServiceBuilder {
 			sb.append(" * @");
 			sb.append(tag.getName());
 			sb.append(" ");
-			sb.append(tag.getValue());
+
+			if (classType.equals("ServiceSoap") &&
+					tag.getValue().startsWith("PortalException")
+					) {
+
+				String remoteValue = tag.getValue().replaceFirst(
+						"PortalException", "RemoteException");
+
+				sb.append(remoteValue);
+			}
+			else {
+				sb.append(tag.getValue());
+			}
 			sb.append("\n");
 		}
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -3741,36 +3741,11 @@ public class ServiceBuilder {
 		sb.append(indentation);
 		sb.append("/**\n");
 
-		String path = _outputPath + "/service/impl/" + entityName;
-
-		JavaClass javaClass = null;
-
-		File file1 = new File(path + "LocalServiceImpl.java");
-		File file2 = new File(path + "ServiceImpl.java");
-
-		if (file1.exists()) {
-			javaClass = _getJavaClass(path + "LocalServiceImpl.java");
-		}
-		else if (file2.exists()) {
-			javaClass = _getJavaClass(path + "ServiceImpl.java");
-		}
-		else  {
-			javaClass = _getJavaClass(_outputPath + "/model/impl/" +
-				entityName + "Impl.java");
-		}
-
-			JavaSource javaSource = javaClass.getSource();
-			String[] imports = javaSource.getImports();
-
-			JavaClass parentJavaClass = _getParentJavaClass(javaClass);
-			JavaSource parentJavaSource = parentJavaClass.getSource();
-			String[] parentImports = parentJavaSource.getImports();
-
-			String[] allImports = ArrayUtils.addAll(imports, parentImports);
+		String[] imports = _getJavadocImports(entityName);
 
 		if (Validator.isNotNull(comment)) {
 			comment = comment.replaceAll("(?m)^", indentation + " * ");
-			comment = _getJavadocPackages(comment, allImports);
+			comment = _getJavadocPackages(comment, imports);
 
 			sb.append(comment);
 			sb.append("\n");
@@ -3784,7 +3759,7 @@ public class ServiceBuilder {
 		for (DocletTag tag : tags) {
 			String tagValue = tag.getValue();
 
-			tagValue = _getJavadocPackages(tagValue, allImports);
+			tagValue = _getJavadocPackages(tagValue, imports);
 
 			sb.append(indentation);
 			sb.append(" * @");
@@ -4268,6 +4243,37 @@ public class ServiceBuilder {
 		}
 
 		return javaClass;
+	}
+
+	private String[] _getJavadocImports(String entityName) throws IOException {
+		String path = _outputPath + "/service/impl/" + entityName;
+
+		JavaClass javaClass = null;
+
+		File file1 = new File(path + "LocalServiceImpl.java");
+		File file2 = new File(path + "ServiceImpl.java");
+
+		if (file1.exists()) {
+			javaClass = _getJavaClass(path + "LocalServiceImpl.java");
+		}
+		else if (file2.exists()) {
+			javaClass = _getJavaClass(path + "ServiceImpl.java");
+		}
+		else  {
+			javaClass = _getJavaClass(_outputPath + "/model/impl/" +
+				entityName + "Impl.java");
+		}
+
+			JavaSource javaSource = javaClass.getSource();
+			String[] imports = javaSource.getImports();
+
+			JavaClass parentJavaClass = _getParentJavaClass(javaClass);
+			JavaSource parentJavaSource = parentJavaClass.getSource();
+			String[] parentImports = parentJavaSource.getImports();
+
+			String[] allImports = ArrayUtils.addAll(imports, parentImports);
+
+		return allImports;
 	}
 
 	private String _getJavadocPackages(String text, String[] imports) {

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -4278,7 +4278,7 @@ public class ServiceBuilder {
 			JavaSource javaSource = javaClass.getSource();
 			String[] imports = javaSource.getImports();
 
-			JavaClass parentJavaClass = _getParentJavaClass(javaClass);
+			JavaClass parentJavaClass = javaClass.getSuperJavaClass();
 			JavaSource parentJavaSource = parentJavaClass.getSource();
 			String[] parentImports = parentJavaSource.getImports();
 
@@ -4364,29 +4364,6 @@ public class ServiceBuilder {
 		}
 
 		return methods;
-	}
-
-	private JavaClass _getParentJavaClass(JavaClass javaClass)
-		throws IOException {
-
-		String parentJavaClassString = javaClass.getSuperJavaClass().toString();
-		int parentJavaClassIndex = parentJavaClassString.indexOf("com.");
-
-		String parentClassPath = parentJavaClassString.substring(
-				parentJavaClassIndex, parentJavaClassString.length());
-		parentClassPath = parentClassPath.replaceAll("\\.", "/");
-
-		int parentOutputPathIndex = _outputPath.indexOf("com/");
-		String parentOutputPath = _outputPath.substring(
-				parentOutputPathIndex, _outputPath.length());
-
-		String finalParentClassPath = _outputPath.replace(
-				parentOutputPath, parentClassPath);
-		finalParentClassPath = finalParentClassPath + ".java";
-
-		JavaClass parentJavaClass = _getJavaClass(finalParentClassPath);
-
-		return parentJavaClass;
 	}
 
 	private String _getSessionTypeName(int sessionType) {

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -3775,7 +3775,7 @@ public class ServiceBuilder {
 			sb.append(tag.getName());
 			sb.append(" ");
 
-			if (classType.equals("ServiceSoap") && tagValue.startsWith(
+			if (classType.equals("serviceSoap") && tagValue.startsWith(
 					"com.liferay.portal.kernel.exception.PortalException")) {
 
 				String remoteValue = tagValue.replaceFirst(
@@ -3784,7 +3784,7 @@ public class ServiceBuilder {
 
 				sb.append(remoteValue);
 			}
-			else if (classType.equals("ServiceSoap") && tagValue.startsWith(
+			else if (classType.equals("serviceSoap") && tagValue.startsWith(
 						"com.liferay.portal.security.auth.PrincipalException")
 					) {
 				String remoteValue = tagValue.replaceFirst(

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1222,12 +1222,12 @@ public class ServiceBuilder {
 
 	public String getJavadocComment(JavaClass javaClass) throws IOException {
 		return _formatComment(
-			javaClass.getComment(), javaClass.getTags(), null, StringPool.BLANK, null);
+			javaClass.getComment(), javaClass.getTags(), null, StringPool.BLANK, null, null);
 	}
 
-	public String getJavadocComment(JavaMethod javaMethod, String classType, String entityName) throws IOException {
+	public String getJavadocComment(JavaMethod javaMethod, String classType, String entityName, String sessionTypeName) throws IOException {
 		return _formatComment(
-			javaMethod.getComment(), javaMethod.getTags(), entityName, StringPool.TAB, classType);
+			javaMethod.getComment(), javaMethod.getTags(), entityName, StringPool.TAB, classType, sessionTypeName);
 	}
 
 	public String getListActualTypeArguments(Type type) {
@@ -3730,7 +3730,7 @@ public class ServiceBuilder {
 
 	private String _formatComment(
 		String comment, DocletTag[] tags, String entityName, String indentation,
-		String classType) throws IOException {
+		String classType, String sessionTypeName) throws IOException {
 
 		StringBundler sb = new StringBundler();
 
@@ -3741,7 +3741,7 @@ public class ServiceBuilder {
 		sb.append(indentation);
 		sb.append("/**\n");
 
-		String[] imports = _getJavadocImports(entityName);
+		String[] imports = _getJavadocImports(entityName, sessionTypeName);
 
 		if (Validator.isNotNull(comment)) {
 			comment = comment.replaceAll("(?m)^", indentation + " * ");
@@ -4245,18 +4245,16 @@ public class ServiceBuilder {
 		return javaClass;
 	}
 
-	private String[] _getJavadocImports(String entityName) throws IOException {
+	private String[] _getJavadocImports(String entityName, String sessionTypeName) throws IOException {
 		String path = _outputPath + "/service/impl/" + entityName;
 
 		JavaClass javaClass = null;
+		File serviceImplFile = new File(path + "ServiceImpl.java");
 
-		File file1 = new File(path + "LocalServiceImpl.java");
-		File file2 = new File(path + "ServiceImpl.java");
-
-		if (file1.exists()) {
+		if (sessionTypeName.equals("Local")) {
 			javaClass = _getJavaClass(path + "LocalServiceImpl.java");
 		}
-		else if (file2.exists()) {
+		else if (serviceImplFile.exists()) {
 			javaClass = _getJavaClass(path + "ServiceImpl.java");
 		}
 		else  {

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -3775,8 +3775,10 @@ public class ServiceBuilder {
 			sb.append(tag.getName());
 			sb.append(" ");
 
-			if (classType.equals("serviceSoap") && tagValue.startsWith(
-					"com.liferay.portal.kernel.exception.PortalException")) {
+			if (classType.equals("serviceSoap") &&
+				tagValue.startsWith(
+					"com.liferay.portal.kernel.exception.PortalException"))
+			{
 
 				String remoteValue = tagValue.replaceFirst(
 						"com.liferay.portal.kernel.exception.PortalException",
@@ -3784,12 +3786,13 @@ public class ServiceBuilder {
 
 				sb.append(remoteValue);
 			}
-			else if (classType.equals("serviceSoap") && tagValue.startsWith(
-						"com.liferay.portal.security.auth.PrincipalException")
-					) {
+			else if (classType.equals("serviceSoap") &&
+					 tagValue.startsWith(
+						"com.liferay.portal.security.auth.PrincipalException"))
+			{
 				String remoteValue = tagValue.replaceFirst(
-						"com.liferay.portal.security.auth.PrincipalException",
-						"RemoteException");
+					"com.liferay.portal.security.auth.PrincipalException",
+					"RemoteException");
 
 				sb.append(remoteValue);
 			}
@@ -4256,65 +4259,67 @@ public class ServiceBuilder {
 		return javaClass;
 	}
 
-	private String[] _getJavadocImports(
-			String entityName, String sessionTypeName)
+	private String[] _getJavadocImports(String entityName, String sessionTypeName)
 		throws IOException {
 
 		JavaClass javaClass = null;
-		String path = _outputPath + "/service/impl/" + entityName;
-		File serviceImplFile = new File(path + "ServiceImpl.java");
+		String serviceImplPath = _outputPath + "/service/impl/" + entityName;
 
 		if (sessionTypeName.equals("Local")) {
-			javaClass = _getJavaClass(path + "LocalServiceImpl.java");
-		}
-		else if (serviceImplFile.exists()) {
-			javaClass = _getJavaClass(path + "ServiceImpl.java");
+			javaClass = _getJavaClass(
+				serviceImplPath + "LocalServiceImpl.java");
 		}
 		else {
-			javaClass = _getJavaClass(_outputPath + "/model/impl/" +
-				entityName + "Impl.java");
+			File serviceImplFile = new File(
+				serviceImplPath + "ServiceImpl.java");
+
+			if (serviceImplFile.exists()) {
+				javaClass = _getJavaClass(serviceImplPath + "ServiceImpl.java");
+			}
+			else {
+				javaClass = _getJavaClass(
+					_outputPath + "/model/impl/" + entityName + "Impl.java");
+			}
 		}
 
-			JavaSource javaSource = javaClass.getSource();
-			String[] imports = javaSource.getImports();
+		JavaSource javaSource = javaClass.getSource();
+		String[] imports = javaSource.getImports();
 
-			JavaClass parentJavaClass = javaClass.getSuperJavaClass();
-			JavaSource parentJavaSource = parentJavaClass.getSource();
-			String[] parentImports = parentJavaSource.getImports();
+		JavaClass parentJavaClass = javaClass.getSuperJavaClass();
+		JavaSource parentJavaSource = parentJavaClass.getSource();
+		String[] parentImports = parentJavaSource.getImports();
 
-			String[] allImports = ArrayUtils.addAll(imports, parentImports);
+		String[] allImports = ArrayUtils.addAll(imports, parentImports);
 
 		return allImports;
 	}
 
 	private String _getJavadocPackages(String text, String[] imports) {
-		for (String fullImport : imports) {
-			String classImport = fullImport.substring(
-				fullImport.lastIndexOf(".") + 1);
+		for (String importedClass : imports) {
+			String className = importedClass.substring(
+				importedClass.lastIndexOf(StringPool.PERIOD) + 1);
 
-			if (text.contains(classImport)) {
-				int classImportIndex = text.indexOf(classImport);
-				int endOfClassImportIndex = classImportIndex +
-					classImport.length();
+			if (text.contains(className)) {
+				int pos = text.indexOf(className);
+				int endPos = pos + className.length();
 
-				String begOfImport = StringPool.BLANK;
-				String endOfImport = StringPool.BLANK;
+				String charBefore = StringPool.BLANK;
+				String charAfter = StringPool.BLANK;
 
-				if (text.length() > endOfClassImportIndex) {
-					endOfImport = text.substring(
-						endOfClassImportIndex, endOfClassImportIndex + 1);
+				if (pos > 0) {
+					charBefore = text.substring(pos - 1, pos);
 				}
 
-				if (classImportIndex > 0) {
-					begOfImport = text.substring(
-						classImportIndex - 1, classImportIndex);
+				if (text.length() > endPos) {
+					charAfter = text.substring(endPos, endPos + 1);
 				}
 
-				if (!begOfImport.matches("[a-zA-Z_0-9;\\.]") &&
-					!endOfImport.matches("[a-zA-Z_0-9\\.]") &&
-					(!endOfImport.equals(" ") || classImportIndex == 0)) {
-
-					text = text.replaceAll(classImport, fullImport);
+				if (!charBefore.matches("[a-zA-Z_0-9;\\.]") &&
+					!charAfter.matches("[a-zA-Z_0-9\\.]") &&
+					(!charAfter.equals(StringPool.BLANK) ||
+						(pos == 0)))
+				{
+					text = text.replaceAll(className, importedClass);
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/export_actionable_dynamic_query.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/export_actionable_dynamic_query.ftl
@@ -22,7 +22,7 @@ import com.liferay.portal.util.PortalUtil;
 
 /**
  * @author ${author}
- * @deprecated As of 7.0.0, replaced by {@link ${packagePath}.service.${entity.name}LocalServiceUtil#getExportActionableDynamicQuery()}
+ * @deprecated As of 7.0.0, replaced by {@link ${packagePath}.service.${entity.name}LocalServiceUtil#getExportActionableDynamicQuery(PortletDataContext)}
  * @generated
  */
 @Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name} extends
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
-			${serviceBuilder.getJavadocComment(method, "ExtendedModel", entity.name, "")}
+			${serviceBuilder.getJavadocComment(method, "extendedModel", entity.name, "")}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name} extends
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
-			${serviceBuilder.getJavadocComment(method, "ExtendedModel", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "ExtendedModel", entity.name, "")}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name} extends
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
-			${serviceBuilder.getJavadocComment(method, "ExtendedModel")}
+			${serviceBuilder.getJavadocComment(method, "ExtendedModel", entity.name)}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name} extends
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "ExtendedModel")}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -88,7 +88,7 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method, "ModelWrapper")}
+			${serviceBuilder.getJavadocComment(method, "ModelWrapper", entity.name)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -88,7 +88,7 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method, "ModelWrapper", entity.name, "")}
+			${serviceBuilder.getJavadocComment(method, "modelWrapper", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -88,7 +88,7 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "ModelWrapper")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -88,7 +88,7 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method, "ModelWrapper", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "ModelWrapper", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -19,7 +19,7 @@ import java.util.Date;
  * </p>
  *
  * @author ${author}
- * @see ${entity.name}PersistenceImpl
+ * @see ${packagePath}.service.persistence.impl.${entity.name}PersistenceImpl
  * @see ${entity.name}Util
  * @generated
  */

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -35,7 +35,7 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "Persistence")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -35,7 +35,7 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "Persistence")}
+			${serviceBuilder.getJavadocComment(method, "Persistence", entity.name)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -35,7 +35,7 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "Persistence", entity.name, "")}
+			${serviceBuilder.getJavadocComment(method, "persistence", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -35,7 +35,7 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "Persistence", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "Persistence", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -108,7 +108,7 @@ import java.util.Set;
  *
  * @author ${author}
  * @see ${entity.name}Persistence
- * @see ${entity.name}Util
+ * @see ${packagePath}.service.persistence.${entity.name}Util
  * @generated
  */
 @ProviderType

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -19,7 +19,7 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
- * The persistence utility for the ${entity.humanName} service. This utility wraps {@link ${entity.name}PersistenceImpl} and provides direct access to the database for CRUD operations. This utility should only be used by the service layer, as it must operate within a transaction. Never access this utility in a JSP, controller, model, or other front-end class.
+ * The persistence utility for the ${entity.humanName} service. This utility wraps {@link ${packagePath}.service.persistence.impl.${entity.name}PersistenceImpl} and provides direct access to the database for CRUD operations. This utility should only be used by the service layer, as it must operate within a transaction. Never access this utility in a JSP, controller, model, or other front-end class.
  *
  * <p>
  * Caching information and settings can be found in <code>portal.properties</code>
@@ -27,7 +27,7 @@ import org.osgi.util.tracker.ServiceTracker;
  *
  * @author ${author}
  * @see ${entity.name}Persistence
- * @see ${entity.name}PersistenceImpl
+ * @see ${packagePath}.service.persistence.impl.${entity.name}PersistenceImpl
  * @generated
  */
 @ProviderType

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -97,7 +97,7 @@ public class ${entity.name}Util {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "PersistenceUtil", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "PersistenceUtil", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -97,7 +97,7 @@ public class ${entity.name}Util {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "PersistenceUtil")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -97,7 +97,7 @@ public class ${entity.name}Util {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "PersistenceUtil")}
+			${serviceBuilder.getJavadocComment(method, "PersistenceUtil", entity.name)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -97,7 +97,7 @@ public class ${entity.name}Util {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "PersistenceUtil", entity.name, "")}
+			${serviceBuilder.getJavadocComment(method, "persistenceUtil", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name}${sessionTypeName}Service
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "Service", entity.name, sessionTypeName)}
+			${serviceBuilder.getJavadocComment(method, "service", entity.name, sessionTypeName)}
 
 			<#list method.annotations as annotation>
 				<#if (annotation.type != "java.lang.Override") && (annotation.type != "java.lang.SuppressWarnings")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name}${sessionTypeName}Service
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "Service")}
+			${serviceBuilder.getJavadocComment(method, "Service", entity.name)}
 
 			<#list method.annotations as annotation>
 				<#if (annotation.type != "java.lang.Override") && (annotation.type != "java.lang.SuppressWarnings")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name}${sessionTypeName}Service
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "Service", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "Service", entity.name, sessionTypeName)}
 
 			<#list method.annotations as annotation>
 				<#if (annotation.type != "java.lang.Override") && (annotation.type != "java.lang.SuppressWarnings")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name}${sessionTypeName}Service
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "Service")}
 
 			<#list method.annotations as annotation>
 				<#if (annotation.type != "java.lang.Override") && (annotation.type != "java.lang.SuppressWarnings")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -82,7 +82,7 @@ public class ${entity.name}ServiceSoap {
 			<#assign extendedModelName = packagePath + ".model." + entity.name>
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
 
-			${serviceBuilder.getJavadocComment(method, "ServiceSoap")}
+			${serviceBuilder.getJavadocComment(method, "ServiceSoap", entity.name)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -82,7 +82,7 @@ public class ${entity.name}ServiceSoap {
 			<#assign extendedModelName = packagePath + ".model." + entity.name>
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
 
-			${serviceBuilder.getJavadocComment(method, "ServiceSoap", entity.name, "")}
+			${serviceBuilder.getJavadocComment(method, "serviceSoap", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -82,7 +82,7 @@ public class ${entity.name}ServiceSoap {
 			<#assign extendedModelName = packagePath + ".model." + entity.name>
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
 
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "ServiceSoap")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -82,7 +82,7 @@ public class ${entity.name}ServiceSoap {
 			<#assign extendedModelName = packagePath + ".model." + entity.name>
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
 
-			${serviceBuilder.getJavadocComment(method, "ServiceSoap", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "ServiceSoap", entity.name, "")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -64,7 +64,7 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "ServiceUtil", entity.name, sessionTypeName)}
+			${serviceBuilder.getJavadocComment(method, "serviceUtil", entity.name, sessionTypeName)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -64,7 +64,7 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "ServiceUtil")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -64,7 +64,7 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "ServiceUtil")}
+			${serviceBuilder.getJavadocComment(method, "ServiceUtil", entity.name)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -64,7 +64,7 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "ServiceUtil", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "ServiceUtil", entity.name, sessionTypeName)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -28,7 +28,7 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "ServiceWrapper")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -28,7 +28,7 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "ServiceWrapper", entity.name, sessionTypeName)}
+			${serviceBuilder.getJavadocComment(method, "serviceWrapper", entity.name, sessionTypeName)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -28,7 +28,7 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "ServiceWrapper")}
+			${serviceBuilder.getJavadocComment(method, "ServiceWrapper", entity.name)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -28,7 +28,7 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method, "ServiceWrapper", entity.name)}
+			${serviceBuilder.getJavadocComment(method, "ServiceWrapper", entity.name, sessionTypeName)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8289,7 +8289,7 @@ public class PortalImpl implements Portal {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             #notifyPortalInetSocketAddressEventListeners(
-	 *             InetSocketAddress, boolean)}
+	 *             InetSocketAddress, boolean, boolean)}
 	 */
 	@Deprecated
 	protected void notifyPortalPortEventListeners(int portalPort) {

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
@@ -617,7 +617,7 @@ public class AssetPublisherImpl implements AssetPublisher {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             AssetEntryLocalServiceUtil#getEntriesCount(long[], long[],
-	 *             String, String, String, String, boolean, boolean, int, int)}
+	 *             String, String, String, String, boolean, boolean)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/util/AssetPublisherImpl.java
@@ -352,8 +352,8 @@ public class AssetPublisherImpl implements AssetPublisher {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             AssetEntryLocalServiceUtil#getEntries(long[], long[], String,
-	 *             String, String, String, boolean, boolean, int, int,
-	 *             String, String, String, String)}
+	 *             String, String, String, boolean, boolean, int, int, String,
+	 *             String, String, String)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -145,7 +145,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #addEntry(long, String,
 	 *             String, String, String, int, int, int, int, int, boolean,
-	 *             boolean, String[], boolean, String, String, InputStream,
+	 *             boolean, String[], ImageSelector, ImageSelector,
 	 *             ServiceContext)}
 	 */
 	@Deprecated
@@ -1083,7 +1083,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #updateEntry(long, long,
 	 *             String, String, String, String, int, int, int, int, int,
-	 *             boolean, boolean, String[], boolean, String, long,
+	 *             boolean, boolean, String[], ImageSelector, ImageSelector,
 	 *             ServiceContext)}
 	 */
 	@Deprecated

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -71,8 +71,7 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #addEntry(String, String,
 	 *             String, String, int, int, int, int, int, boolean, boolean,
-	 *             String[], boolean, String, String, InputStream,
-	 *             ServiceContext)}
+	 *             String[], ImageSelector, ImageSelector, ServiceContext)}
 	 */
 	@Deprecated
 	@Override
@@ -446,7 +445,8 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #updateEntry(long, String,
 	 *             String, String, String, int, int, int, int, int, boolean,
-	 *             boolean, String[], boolean, String, long, ServiceContext)}
+	 *             boolean, String[], ImageSelector, ImageSelector,
+	 *             ServiceContext)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/lar/FolderStagedModelDataHandler.java
@@ -332,12 +332,6 @@ public class FolderStagedModelDataHandler
 			"defaultFileEntryTypeUuid", defaultFileEntryTypeUuid);
 	}
 
-	/**
-	 * @see com.liferay.portal.lar.PortletImporter#getAssetCategoryName(String,
-	 *      long, long, String, long, int)
-	 * @see com.liferay.portal.lar.PortletImporter#getAssetVocabularyName(
-	 *      String, long, String, int)
-	 */
 	protected String getFolderName(
 			String uuid, long groupId, long parentFolderId, String name,
 			int count)

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -2201,7 +2201,9 @@ public class DLFileEntryLocalServiceImpl
 
 	/**
 	 * @see com.liferay.portlet.dynamicdatalists.service.impl.DDLRecordLocalServiceImpl#isKeepRecordVersionLabel(
-	 *      DDLRecordVersion, DDLRecordVersion, ServiceContext)
+	 *      com.liferay.portlet.dynamicdatalists.model.DDLRecordVersion,
+	 *      com.liferay.portlet.dynamicdatalists.model.DDLRecordVersion,
+	 *      ServiceContext)
 	 */
 	protected boolean isKeepFileVersionLabel(
 			DLFileEntry dlFileEntry, DLFileVersion lastDLFileVersion,

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordLocalServiceImpl.java
@@ -269,7 +269,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             DDLRecordVersionLocalServiceImpl#getLatestRecordVersion(
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getLatestRecordVersion(
 	 *             long)}
 	 */
 	@Deprecated
@@ -327,7 +327,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             DDLRecordVersionLocalServiceImpl#getRecordVersion(long)}
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersion(long)}
 	 */
 	@Deprecated
 	@Override
@@ -339,7 +339,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             DDLRecordVersionLocalServiceImpl#getRecordVersion(long,
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersion(long,
 	 *             String)}
 	 */
 	@Deprecated
@@ -352,7 +352,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             DDLRecordVersionLocalServiceImpl#getRecordVersions(long, int,
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersions(long, int,
 	 *             int, OrderByComparator)}
 	 */
 	@Deprecated
@@ -367,7 +367,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             DDLRecordVersionLocalServiceImpl#getRecordVersionsCount(
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersionsCount(
 	 *             long)}
 	 */
 	@Deprecated
@@ -749,7 +749,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @see com.liferay.portlet.documentlibrary.service.impl.DLFileEntryLocalServiceImpl#isKeepFileVersionLabel(
-	 *      DLFileEntry, DLFileVersion, DLFileVersion, ServiceContext)
+	 *      com.liferay.portlet.documentlibrary.model.DLFileEntry, com.liferay.portlet.documentlibrary.model.DLFileVersion, com.liferay.portlet.documentlibrary.model.DLFileVersion, ServiceContext)
 	 */
 	protected boolean isKeepRecordVersionLabel(
 			DDLRecordVersion lastRecordVersion,

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordLocalServiceImpl.java
@@ -327,7 +327,8 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersion(long)}
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersion(
+	 *             long)}
 	 */
 	@Deprecated
 	@Override
@@ -339,8 +340,8 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersion(long,
-	 *             String)}
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersion(
+	 *             long, String)}
 	 */
 	@Deprecated
 	@Override
@@ -352,8 +353,8 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersions(long, int,
-	 *             int, OrderByComparator)}
+	 *             com.liferay.portlet.dynamicdatalists.service.DDLRecordVersionLocalService#getRecordVersions(
+	 *             long, int, int, OrderByComparator)}
 	 */
 	@Deprecated
 	@Override
@@ -749,7 +750,10 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 	/**
 	 * @see com.liferay.portlet.documentlibrary.service.impl.DLFileEntryLocalServiceImpl#isKeepFileVersionLabel(
-	 *      com.liferay.portlet.documentlibrary.model.DLFileEntry, com.liferay.portlet.documentlibrary.model.DLFileVersion, com.liferay.portlet.documentlibrary.model.DLFileVersion, ServiceContext)
+	 *      com.liferay.portlet.documentlibrary.model.DLFileEntry,
+	 *      com.liferay.portlet.documentlibrary.model.DLFileVersion,
+	 *      com.liferay.portlet.documentlibrary.model.DLFileVersion,
+	 *      ServiceContext)
 	 */
 	protected boolean isKeepRecordVersionLabel(
 			DDLRecordVersion lastRecordVersion,

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordServiceImpl.java
@@ -129,8 +129,8 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of 7.0.0, replaced by {@link #revertRecord(long,
-	 *             String, ServiceContext)}
+	 * @deprecated As of 7.0.0, replaced by {@link #revertRecord(long, String,
+	 *             ServiceContext)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatalists/service/impl/DDLRecordServiceImpl.java
@@ -129,7 +129,7 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of 7.0.0, replaced by {@link #revertRecord(long, long,
+	 * @deprecated As of 7.0.0, replaced by {@link #revertRecord(long,
 	 *             String, ServiceContext)}
 	 */
 	@Deprecated

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalCreationStrategyImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalCreationStrategyImpl.java
@@ -23,7 +23,7 @@ import com.liferay.portlet.journal.model.JournalArticle;
  * this class is to return zero for the author and approval user IDs, which
  * causes the default user ID import strategy to be used. Content will be added
  * as is with no transformations.
- * 
+ *
  * <p>
  * For a better understanding of this class, see
  * <code>com.liferay.journal.content.web.lar.JournalContentPortletDataHandler</code>

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalCreationStrategyImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalCreationStrategyImpl.java
@@ -18,12 +18,16 @@ import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portlet.journal.model.JournalArticle;
 
 /**
- * <p>
  * Provides the strategy for creating new content when new Journal content is
  * imported into a layout set from a LAR. The default strategy implemented by
  * this class is to return zero for the author and approval user IDs, which
  * causes the default user ID import strategy to be used. Content will be added
  * as is with no transformations.
+ * 
+ * <p>
+ * For a better understanding of this class, see
+ * <code>com.liferay.journal.content.web.lar.JournalContentPortletDataHandler</code>
+ * located in Liferay Portal's external <code>modules</code> directory.
  * </p>
  *
  * @author Joel Kozikowski

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalCreationStrategyImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalCreationStrategyImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portlet.journal.model.JournalArticle;
  * </p>
  *
  * @author Joel Kozikowski
- * @see    com.liferay.portlet.journal.lar.JournalContentPortletDataHandler
  * @see    com.liferay.portlet.journal.lar.JournalPortletDataHandler
  */
 public class JournalCreationStrategyImpl implements JournalCreationStrategy {

--- a/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/journal/lar/JournalPortletDataHandler.java
@@ -57,7 +57,6 @@ import java.util.List;
 import javax.portlet.PortletPreferences;
 
 /**
- * <p>
  * Provides the Journal portlet export and import functionality, which is to
  * clone all articles, structures, and templates associated with the layout's
  * group. Upon import, new instances of the corresponding articles, structures,
@@ -66,13 +65,18 @@ import javax.portlet.PortletPreferences;
  * JournalCreationStrategy class defined in <i>portal.properties</i>. That
  * strategy also allows the text of the journal article to be modified prior to
  * import.
- * </p>
  *
  * <p>
  * This <code>PortletDataHandler</code> differs from
  * <code>JournalContentPortletDataHandlerImpl</code> in that it exports all
  * articles owned by the group whether or not they are actually displayed in a
  * portlet in the layout set.
+ * </p>
+ *
+ * <p>
+ * For a better understanding of this class, see
+ * <code>com.liferay.journal.content.web.lar.JournalContentPortletDataHandler</code>
+ * located in Liferay Portal's external <code>modules</code> directory.
  * </p>
  *
  * @author Raymond Augé
@@ -85,7 +89,6 @@ import javax.portlet.PortletPreferences;
  * @author Daniel Kocsis
  * @author László Csontos
  * @see    com.liferay.portal.kernel.lar.PortletDataHandler
- * @see    com.liferay.portlet.journal.lar.JournalContentPortletDataHandler
  * @see    com.liferay.portlet.journal.lar.JournalCreationStrategy
  */
 public class JournalPortletDataHandler extends BasePortletDataHandler {

--- a/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalFeedImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/model/impl/JournalFeedImpl.java
@@ -47,7 +47,8 @@ public class JournalFeedImpl extends JournalFeedBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of 7.0.0, replaced by {@link #setRendererTemplateKey()}
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #setDDMRendererTemplateKey(String)}
 	 */
 	@Deprecated
 	@Override
@@ -56,7 +57,7 @@ public class JournalFeedImpl extends JournalFeedBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of 7.0.0, replaced by {@link #setDDMStructureKey()}
+	 * @deprecated As of 7.0.0, replaced by {@link #setDDMStructureKey(String)}
 	 */
 	@Deprecated
 	@Override
@@ -65,7 +66,7 @@ public class JournalFeedImpl extends JournalFeedBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of 7.0.0, replaced by {@link #setDDMTemplateKey()}
+	 * @deprecated As of 7.0.0, replaced by {@link #setDDMTemplateKey(String)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -164,25 +164,6 @@ import javax.portlet.PortletPreferences;
  * Provides the local service for accessing, adding, deleting, and updating web
  * content articles.
  *
- * <p>
- * The web content articles hold HTML content wrapped in XML. The XML lets you
- * specify the article's default locale and available locales. Here is a content
- * example:
- * </p>
- *
- * <p>
- * <pre>
- * <code>
- * &lt;?xml version='1.0' encoding='UTF-8'?&gt;
- * &lt;root default-locale="en_US" available-locales="en_US"&gt;
- * 	&lt;static-content language-id="en_US"&gt;
- * 		&lt;![CDATA[&lt;p&gt;&lt;b&gt;&lt;i&gt;test&lt;i&gt; content&lt;b&gt;&lt;/p&gt;]]&gt;
- * 	&lt;/static-content&gt;
- * &lt;/root&gt;
- * </code>
- * </pre>
- * </p>
- *
  * @author Brian Wing Shun Chan
  * @author Raymond Augé
  * @author Bruno Farache
@@ -194,6 +175,25 @@ public class JournalArticleLocalServiceImpl
 
 	/**
 	 * Adds a web content article with additional parameters.
+	 *
+	 * <p>
+	 * The web content articles hold HTML content wrapped in XML. The XML lets
+	 * you specify the article's default locale and available locales. Here is a
+	 * content example:
+	 * </p>
+	 *
+	 * <p>
+	 * <pre>
+	 * <code>
+	 * &lt;?xml version='1.0' encoding='UTF-8'?&gt;
+	 * &lt;root default-locale="en_US" available-locales="en_US"&gt;
+	 * 	&lt;static-content language-id="en_US"&gt;
+	 * 		&lt;![CDATA[&lt;p&gt;&lt;b&gt;&lt;i&gt;test&lt;i&gt; content&lt;b&gt;&lt;/p&gt;]]&gt;
+	 * 	&lt;/static-content&gt;
+	 * &lt;/root&gt;
+	 * </code>
+	 * </pre>
+	 * </p>
 	 *
 	 * @param  userId the primary key of the web content article's creator/owner
 	 * @param  groupId the primary key of the web content article's group
@@ -213,9 +213,7 @@ public class JournalArticleLocalServiceImpl
 	 * @param  titleMap the web content article's locales and localized titles
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
-	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 * @param  content the HTML content wrapped in XML
 	 * @param  ddmStructureKey the primary key of the web content article's DDM
 	 *         structure, if the article is related to a DDM structure, or
 	 *         <code>null</code> otherwise
@@ -487,8 +485,11 @@ public class JournalArticleLocalServiceImpl
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #addArticle(long, long,
+	 *         long, long, long, String, boolean, double, Map, Map, String,
+	 *         String, String, String, int, int, int, int, int, int, int, int,
+	 *         int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 *         boolean, String, File, Map, String, ServiceContext) description.
 	 * @param  ddmStructureKey the primary key of the web content article's DDM
 	 *         structure, if the article is related to a DDM structure, or
 	 *         <code>null</code> otherwise
@@ -4757,8 +4758,11 @@ public class JournalArticleLocalServiceImpl
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #addArticle(long, long,
+	 *         long, long, long, String, boolean, double, Map, Map, String,
+	 *         String, String, String, int, int, int, int, int, int, int, int,
+	 *         int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 *         boolean, String, File, Map, String, ServiceContext) description.
 	 * @param  layoutUuid the unique string identifying the web content
 	 *         article's display page
 	 * @param  serviceContext the service context to be applied. Can set the
@@ -4893,8 +4897,11 @@ public class JournalArticleLocalServiceImpl
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #addArticle(long, long,
+	 *         long, long, long, String, boolean, double, Map, Map, String,
+	 *         String, String, String, int, int, int, int, int, int, int, int,
+	 *         int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 *         boolean, String, File, Map, String, ServiceContext) description.
 	 * @param  ddmStructureKey the primary key of the web content article's DDM
 	 *         structure, if the article is related to a DDM structure, or
 	 *         <code>null</code> otherwise
@@ -5197,8 +5204,11 @@ public class JournalArticleLocalServiceImpl
 	 * @param  articleId the primary key of the web content article
 	 * @param  version the web content article's version
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #addArticle(long, long,
+	 *         long, long, long, String, boolean, double, Map, Map, String,
+	 *         String, String, String, int, int, int, int, int, int, int, int,
+	 *         int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 *         boolean, String, File, Map, String, ServiceContext) description.
 	 * @param  serviceContext the service context to be applied. Can set the
 	 *         modification date, expando bridge attributes, asset category IDs,
 	 *         asset tag names, asset link entry IDs, workflow actions, the and
@@ -5256,8 +5266,11 @@ public class JournalArticleLocalServiceImpl
 	 * @param  title the translated web content article title
 	 * @param  description the translated web content article description
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #addArticle(long, long,
+	 *         long, long, long, String, boolean, double, Map, Map, String,
+	 *         String, String, String, int, int, int, int, int, int, int, int,
+	 *         int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 *         boolean, String, File, Map, String, ServiceContext) description.
 	 * @param  images the web content's images
 	 * @param  serviceContext the service context to be applied. Can set the
 	 *         modification date and "urlTitle" attribute for the web content
@@ -5461,8 +5474,11 @@ public class JournalArticleLocalServiceImpl
 	 * @param  articleId the primary key of the web content article
 	 * @param  version the web content article's version
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #addArticle(long, long,
+	 *         long, long, long, String, boolean, double, Map, Map, String,
+	 *         String, String, String, int, int, int, int, int, int, int, int,
+	 *         int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 *         boolean, String, File, Map, String, ServiceContext) description.
 	 * @return the updated web content article
 	 * @throws PortalException if a matching web content article could not be
 	 *         found

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleServiceImpl.java
@@ -1456,7 +1456,8 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * start</code> instances. <code>start</code> and <code>end</code> are not
 	 * primary keys, they are indexes in the result set. Thus, <code>0</code>
 	 * refers to the first result in the set. Setting both <code>start</code>
-	 * and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full
+	 * and <code>end</code> to {@link
+	 * com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS} will return the full
 	 * result set.
 	 * </p>
 	 *

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleServiceImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portlet.journal.service.permission.JournalPermission;
 
 import java.io.File;
 import java.io.Serializable;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -73,8 +72,8 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
 	 * @param  ddmStructureKey the primary key of the web content article's DDM
 	 *         structure, if the article is related to a DDM structure, or
 	 *         <code>null</code> otherwise
@@ -182,9 +181,7 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @param  titleMap the web content article's locales and localized titles
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
-	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 * @param  content the HTML content wrapped in XML
 	 * @param  ddmStructureKey the primary key of the web content article's DDM
 	 *         structure, if the article is related to a DDM structure, or
 	 *         <code>null</code> otherwise
@@ -1945,8 +1942,8 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
 	 * @param  layoutUuid the unique string identifying the web content
 	 *         article's display page
 	 * @param  serviceContext the service context to be applied. Can set the
@@ -1987,8 +1984,8 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @param  descriptionMap the web content article's locales and localized
 	 *         descriptions
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
 	 * @param  ddmStructureKey the primary key of the web content article's DDM
 	 *         structure, if the article is related to a DDM structure, or
 	 *         <code>null</code> otherwise
@@ -2092,13 +2089,30 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * Updates the web content article matching the version, replacing its
 	 * folder and content.
 	 *
+	 * <p>
+	 * The web content articles hold HTML content wrapped in XML. The XML lets
+	 * you specify the article's default locale and available locales. Here is a
+	 * content example:
+	 * </p>
+	 *
+	 * <p>
+	 * <pre>
+	 * <code>
+	 * &lt;?xml version='1.0' encoding='UTF-8'?&gt;
+	 * &lt;root default-locale="en_US" available-locales="en_US"&gt;
+	 * 	&lt;static-content language-id="en_US"&gt;
+	 * 		&lt;![CDATA[&lt;p&gt;&lt;b&gt;&lt;i&gt;test&lt;i&gt; content&lt;b&gt;&lt;/p&gt;]]&gt;
+	 * 	&lt;/static-content&gt;
+	 * &lt;/root&gt;
+	 * </code>
+	 * </pre>
+	 * </p>
+	 *
 	 * @param  groupId the primary key of the web content article's group
 	 * @param  folderId the primary key of the web content article folder
 	 * @param  articleId the primary key of the web content article
 	 * @param  version the web content article's version
-	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 * @param  content the HTML content wrapped in XML.
 	 * @param  serviceContext the service context to be applied. Can set the
 	 *         modification date, expando bridge attributes, asset category IDs,
 	 *         asset tag names, asset link entry IDs, workflow actions, the and
@@ -2157,8 +2171,8 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @param  title the translated web content article title
 	 * @param  description the translated web content article description
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
 	 * @param  images the web content's images
 	 * @param  serviceContext the service context to be applied. Can set the
 	 *         modification date and "urlTitle" attribute for the web content
@@ -2193,8 +2207,8 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @param  articleId the primary key of the web content article
 	 * @param  version the web content article's version
 	 * @param  content the HTML content wrapped in XML. For more information,
-	 *         see the content example in the class description for {@link
-	 *         JournalArticleLocalServiceImpl}.
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
 	 * @return the updated web content article
 	 * @throws PortalException if the user did not have permission to update the
 	 *         web content article or if a matching web content article could

--- a/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/journal/service/impl/JournalArticleServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portlet.journal.service.permission.JournalPermission;
 
 import java.io.File;
 import java.io.Serializable;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -938,8 +938,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 	}
 
 	/**
-	 * @deprecated As of 7.0.0, replaced by {@link #getDiscussionMessageDisplay(
-	 *             long, long, String, long, int)}
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #getDiscussionMessageDisplay(long, long, String, long, int)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/bean/AutoEscapeBeanHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/bean/AutoEscapeBeanHandler.java
@@ -30,8 +30,7 @@ import java.lang.reflect.Method;
  * For a usage example see {@link
  * com.liferay.portlet.shopping.util.ShoppingUtil#getBreadcrumbs(
  * com.liferay.portlet.shopping.model.ShoppingCategory,
- * javax.portlet.RenderRequest, javax.portlet.RenderResponse)
- * ShoppingUtil#getBreadcrumbs}.
+ * javax.portlet.RenderRequest, javax.portlet.RenderResponse)}.
  * </p>
  *
  * @author Shuyang Zhou

--- a/portal-service/src/com/liferay/portal/kernel/concurrent/RejectedExecutionHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/concurrent/RejectedExecutionHandler.java
@@ -16,15 +16,15 @@ package com.liferay.portal.kernel.concurrent;
 
 /**
  * Provides the same interface as {@link
- * java.util.concurrent.ThreadPoolExecutor.RejectedExecutionHandler}.
+ * java.util.concurrent.RejectedExecutionHandler}.
  *
  * @author Shuyang Zhou
- * @see    java.util.concurrent.ThreadPoolExecutor.RejectedExecutionHandler
+ * @see    java.util.concurrent.RejectedExecutionHandler
  */
 public interface RejectedExecutionHandler {
 
 	/**
-	 * @see java.util.concurrent.ThreadPoolExecutor.RejectedExecutionHandler#rejectedExecution(
+	 * @see java.util.concurrent.RejectedExecutionHandler#rejectedExecution(
 	 *      Runnable, java.util.concurrent.ThreadPoolExecutor)
 	 */
 	public void rejectedExecution(

--- a/portal-service/src/com/liferay/portal/kernel/lar/PortletDataContextListener.java
+++ b/portal-service/src/com/liferay/portal/kernel/lar/PortletDataContextListener.java
@@ -15,8 +15,9 @@
 package com.liferay.portal.kernel.lar;
 
 /**
- * @author Raymond Augé
- * @deprecated As of 7.0.0, see {@link com.liferay.portal.kernel.lar.lifecycle.ExportImportLifecycleEvent}
+ * @author     Raymond Augé
+ * @deprecated As of 7.0.0, see {@link
+ *             com.liferay.portal.kernel.lar.lifecycle.ExportImportLifecycleEvent}
  */
 @Deprecated
 public interface PortletDataContextListener {

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
@@ -40,9 +40,8 @@ import javax.portlet.WindowState;
  * </p>
  *
  * <p>
- * If you do need to extend this class, the key
- * methods to override are {@link #buildPath(LiferayPortletURL)} and {@link
- * #populateParams(String, Map, Map)}.
+ * If you do need to extend this class, the key methods to override are {@link
+ * #buildPath(LiferayPortletURL)} and {@link #populateParams(String, Map, Map)}.
  * </p>
  *
  * @author Connor McKay

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
@@ -40,8 +40,7 @@ import javax.portlet.WindowState;
  * </p>
  *
  * <p>
- * If you do need to extend this class, use {@link
- * com.liferay.util.bridges.alloy.AlloyFriendlyURLMapper} as a guide. The key
+ * If you do need to extend this class, the key
  * methods to override are {@link #buildPath(LiferayPortletURL)} and {@link
  * #populateParams(String, Map, Map)}.
  * </p>

--- a/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/Staging.java
@@ -58,8 +58,9 @@ public interface Staging {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portal.service.StagingLocalServiceUtil#checkDefaultLayoutSetBranches(
-	 *             long, Group, boolean, boolean, boolean, ServiceContext)}
+	 *             com.liferay.portal.service.StagingLocalServiceUtil#
+	 *             checkDefaultLayoutSetBranches(long, Group, boolean, boolean,
+	 *             boolean, ServiceContext)}
 	 */
 	@Deprecated
 	public void checkDefaultLayoutSetBranches(

--- a/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/staging/StagingUtil.java
@@ -68,8 +68,9 @@ public class StagingUtil {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portal.service.StagingLocalServiceUtil#checkDefaultLayoutSetBranches(
-	 *             long, Group, boolean, boolean, boolean, ServiceContext)}
+	 *             com.liferay.portal.service.StagingLocalServiceUtil#
+	 *             checkDefaultLayoutSetBranches(long, Group, boolean, boolean,
+	 *             boolean, ServiceContext)}
 	 */
 	@Deprecated
 	public static void checkDefaultLayoutSetBranches(

--- a/portal-service/src/com/liferay/portal/kernel/template/TemplateHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/template/TemplateHandler.java
@@ -69,9 +69,9 @@ public interface TemplateHandler {
 	 *
 	 * @param  language the template's scripting language. Acceptable values for
 	 *         the FreeMarker, Velocity, or XSL languages are {@link
-	 *         TemplateConstants.LANG_TYPE_FTL}, {@link
-	 *         TemplateConstants.LANG_TYPE_VM}, or {@link
-	 *         TemplateConstants.LANG_TYPE_XSL}, respectively.
+	 *         TemplateConstants#LANG_TYPE_FTL}, {@link
+	 *         TemplateConstants#LANG_TYPE_VM}, or {@link
+	 *         TemplateConstants#LANG_TYPE_XSL}, respectively.
 	 * @return the restricted variables that are excluded from the template's
 	 *         context
 	 */
@@ -83,9 +83,9 @@ public interface TemplateHandler {
 	 *
 	 * @param  language the template's scripting language. Acceptable values for
 	 *         the FreeMarker, Velocity, or XSL languages are {@link
-	 *         TemplateConstants.LANG_TYPE_FTL}, {@link
-	 *         TemplateConstants.LANG_TYPE_VM}, or {@link
-	 *         TemplateConstants.LANG_TYPE_XSL}, respectively.
+	 *         TemplateConstants#LANG_TYPE_FTL}, {@link
+	 *         TemplateConstants#LANG_TYPE_VM}, or {@link
+	 *         TemplateConstants#LANG_TYPE_XSL}, respectively.
 	 * @return initial template content for helping the user create a new
 	 *         template
 	 */
@@ -96,9 +96,9 @@ public interface TemplateHandler {
 	 *
 	 * @param  language the template's scripting language. Acceptable values for
 	 *         the FreeMarker, Velocity, or XSL languages are {@link
-	 *         TemplateConstants.LANG_TYPE_FTL}, {@link
-	 *         TemplateConstants.LANG_TYPE_VM}, or {@link
-	 *         TemplateConstants.LANG_TYPE_XSL}, respectively.
+	 *         TemplateConstants#LANG_TYPE_FTL}, {@link
+	 *         TemplateConstants#LANG_TYPE_VM}, or {@link
+	 *         TemplateConstants#LANG_TYPE_XSL}, respectively.
 	 * @return the path to the template's help content
 	 */
 	public String getTemplatesHelpPath(String language);
@@ -128,9 +128,9 @@ public interface TemplateHandler {
 	 *         primary key of the structure associated to the template.
 	 * @param  language the template's scripting language. Acceptable values for
 	 *         the FreeMarker, Velocity, or XSL languages are {@link
-	 *         TemplateConstants.LANG_TYPE_FTL}, {@link
-	 *         TemplateConstants.LANG_TYPE_VM}, or {@link
-	 *         TemplateConstants.LANG_TYPE_XSL}, respectively.
+	 *         TemplateConstants#LANG_TYPE_FTL}, {@link
+	 *         TemplateConstants#LANG_TYPE_VM}, or {@link
+	 *         TemplateConstants#LANG_TYPE_XSL}, respectively.
 	 * @param  locale the locale of the variable groups to get
 	 * @return the template's map of script variable groups for which hints are
 	 *         displayed in the template editor palette

--- a/portal-service/src/com/liferay/portal/kernel/trash/BaseTrashRenderer.java
+++ b/portal-service/src/com/liferay/portal/kernel/trash/BaseTrashRenderer.java
@@ -53,7 +53,7 @@ public abstract class BaseTrashRenderer implements TrashRenderer {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #getSummary(PortletRequest,
-	 *             PortletResponse)}
+	 *             javax.portlet.PortletResponse)}
 	 */
 	@Deprecated
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/trash/TrashHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/trash/TrashHandler.java
@@ -55,10 +55,6 @@ import javax.portlet.PortletRequest;
  * BlogsEntry via {@link com.liferay.portlet.blogs.trash.BlogsEntryTrashHandler}
  * </li>
  * <li>
- * BookmarksEntry via {@link
- * com.liferay.portlet.bookmarks.trash.BookmarksEntryTrashHandler}
- * </li>
- * <li>
  * DLFileEntry via {@link
  * com.liferay.portlet.documentlibrary.trash.DLFileEntryTrashHandler}
  * </li>

--- a/portal-service/src/com/liferay/portal/kernel/trash/TrashHandler.java
+++ b/portal-service/src/com/liferay/portal/kernel/trash/TrashHandler.java
@@ -55,6 +55,11 @@ import javax.portlet.PortletRequest;
  * BlogsEntry via {@link com.liferay.portlet.blogs.trash.BlogsEntryTrashHandler}
  * </li>
  * <li>
+ * BookmarksEntry via
+ * <code>com.liferay.bookmarks.trash.BookmarksEntryTrashHandler</code>
+ * located in Liferay Portal's external <code>modules</code> directory.
+ * </li>
+ * <li>
  * DLFileEntry via {@link
  * com.liferay.portlet.documentlibrary.trash.DLFileEntryTrashHandler}
  * </li>
@@ -71,12 +76,12 @@ import javax.portlet.PortletRequest;
  * com.liferay.portlet.messageboards.trash.MBThreadTrashHandler}
  * </li>
  * <li>
- * WikiNode via {@link
- * com.liferay.portlet.wiki.trash.WikiNodeTrashHandler}
+ * WikiNode via <code>com.liferay.wiki.trash.WikiNodeTrashHandler</code> located
+ * in Liferay Portal's external <code>modules</code> directory.
  * </li>
  * <li>
- * WikiPage via {@link
- * com.liferay.portlet.wiki.trash.WikiPageTrashHandler}
+ * WikiPage via <code>com.liferay.wiki.trash.WikiPageTrashHandler</code> located
+ * in Liferay Portal's external <code>modules</code> directory.
  * </li>
  * </ul>
  *

--- a/portal-service/src/com/liferay/portal/service/BaseServiceImpl.java
+++ b/portal-service/src/com/liferay/portal/service/BaseServiceImpl.java
@@ -88,10 +88,6 @@ public abstract class BaseServiceImpl implements BaseService {
 		return UserLocalServiceUtil.getUserById(getUserId());
 	}
 
-	/**
-	 * See {@link
-	 * com.liferay.portal.kernel.repository.util.RepositoryUserUtil#getUserId()}
-	 */
 	public long getUserId() throws PrincipalException {
 		String name = PrincipalThreadLocal.getName();
 

--- a/portal-service/src/com/liferay/portal/service/LayoutService.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutService.java
@@ -177,9 +177,9 @@ public interface LayoutService extends BaseService {
 	* @param parentLayoutId the primary key of the parent layout (optionally
 	{@link
 	com.liferay.portal.model.LayoutConstants#DEFAULT_PARENT_LAYOUT_ID})
-	* @param name Map the layout's locales and localized names
-	* @param title Map the layout's locales and localized titles
-	* @param description Map the layout's locales and localized descriptions
+	* @param name the layout's locales and localized names
+	* @param title the layout's locales and localized titles
+	* @param description the layout's locales and localized descriptions
 	* @param type the layout's type (optionally {@link
 	com.liferay.portal.model.LayoutConstants#TYPE_PORTLET}). The
 	possible types can be found in {@link

--- a/portal-service/src/com/liferay/portal/service/LayoutServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutServiceUtil.java
@@ -182,9 +182,9 @@ public class LayoutServiceUtil {
 	* @param parentLayoutId the primary key of the parent layout (optionally
 	{@link
 	com.liferay.portal.model.LayoutConstants#DEFAULT_PARENT_LAYOUT_ID})
-	* @param name Map the layout's locales and localized names
-	* @param title Map the layout's locales and localized titles
-	* @param description Map the layout's locales and localized descriptions
+	* @param name the layout's locales and localized names
+	* @param title the layout's locales and localized titles
+	* @param description the layout's locales and localized descriptions
 	* @param type the layout's type (optionally {@link
 	com.liferay.portal.model.LayoutConstants#TYPE_PORTLET}). The
 	possible types can be found in {@link

--- a/portal-service/src/com/liferay/portal/service/LayoutServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutServiceWrapper.java
@@ -171,9 +171,9 @@ public class LayoutServiceWrapper implements LayoutService,
 	* @param parentLayoutId the primary key of the parent layout (optionally
 	{@link
 	com.liferay.portal.model.LayoutConstants#DEFAULT_PARENT_LAYOUT_ID})
-	* @param name Map the layout's locales and localized names
-	* @param title Map the layout's locales and localized titles
-	* @param description Map the layout's locales and localized descriptions
+	* @param name the layout's locales and localized names
+	* @param title the layout's locales and localized titles
+	* @param description the layout's locales and localized descriptions
 	* @param type the layout's type (optionally {@link
 	com.liferay.portal.model.LayoutConstants#TYPE_PORTLET}). The
 	possible types can be found in {@link

--- a/portal-service/src/com/liferay/portal/service/persistence/BatchSession.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/BatchSession.java
@@ -27,7 +27,8 @@ import com.liferay.portal.model.BaseModel;
  * usage examples see {@link
  * com.liferay.portal.service.impl.LayoutLocalServiceImpl#importLayouts(long,
  * long, boolean, java.util.Map, java.io.File)}, and {@link
- * com.liferay.portal.verify.VerifyProcessUtil#verifyProcess(boolean, boolean, boolean)}.
+ * com.liferay.portal.verify.VerifyProcessUtil#verifyProcess(boolean, boolean,
+ * boolean)}.
  * </p>
  *
  * @author     Raymond Augé

--- a/portal-service/src/com/liferay/portal/service/persistence/BatchSession.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/BatchSession.java
@@ -27,8 +27,7 @@ import com.liferay.portal.model.BaseModel;
  * usage examples see {@link
  * com.liferay.portal.service.impl.LayoutLocalServiceImpl#importLayouts(long,
  * long, boolean, java.util.Map, java.io.File)}, and {@link
- * com.liferay.portal.verify.VerifyProcessUtil#verifyProcess(boolean, boolean,
- * boolean)}.
+ * com.liferay.portal.verify.VerifyProcessUtil#verifyProcess(boolean, boolean, boolean)}.
  * </p>
  *
  * @author     Raymond Augé

--- a/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisher.java
+++ b/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisher.java
@@ -79,8 +79,8 @@ public interface AssetPublisher {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             AssetEntryLocalServiceUtil#getEntries(long[], long[], String,
-	 *             String, String, String, boolean, boolean, int, int,
-	 *             String, String, String, String)}
+	 *             String, String, String, boolean, boolean, int, int, String,
+	 *             String, String, String)}
 	 */
 	@Deprecated
 	public List<AssetEntry> getAssetEntries(
@@ -142,8 +142,9 @@ public interface AssetPublisher {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntriesCount(long[], long[],
-	 *             String, String, String, String, boolean, boolean, int, int)}
+	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntriesCount(
+	 *             long[], long[], String, String, String, String, boolean,
+	 *             boolean, int, int)}
 	 */
 	@Deprecated
 	public int getAssetEntriesCount(

--- a/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisher.java
+++ b/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisher.java
@@ -142,7 +142,7 @@ public interface AssetPublisher {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             AssetEntryLocalServiceUtil#getEntriesCount(long[], long[],
+	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntriesCount(long[], long[],
 	 *             String, String, String, String, boolean, boolean, int, int)}
 	 */
 	@Deprecated

--- a/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisherUtil.java
+++ b/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisherUtil.java
@@ -92,9 +92,9 @@ public class AssetPublisherUtil {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntries(long[], long[], String,
-	 *             String, String, String, boolean, boolean, int, int,
-	 *             String, String, String, String)}
+	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntries(
+	 *             long[], long[], String, String, String, String, boolean,
+	 *             boolean, int, int, String, String, String, String)}
 	 */
 	@Deprecated
 	public static List<AssetEntry> getAssetEntries(
@@ -188,8 +188,9 @@ public class AssetPublisherUtil {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntriesCount(long[], long[],
-	 *             String, String, String, String, boolean, boolean, int, int)}
+	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntriesCount(
+	 *             long[], long[], String, String, String, String, boolean,
+	 *             boolean, int, int)}
 	 */
 	@Deprecated
 	public static int getAssetEntriesCount(

--- a/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisherUtil.java
+++ b/portal-service/src/com/liferay/portlet/assetpublisher/util/AssetPublisherUtil.java
@@ -92,7 +92,7 @@ public class AssetPublisherUtil {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             AssetEntryLocalServiceUtil#getEntries(long[], long[], String,
+	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntries(long[], long[], String,
 	 *             String, String, String, boolean, boolean, int, int,
 	 *             String, String, String, String)}
 	 */
@@ -188,7 +188,7 @@ public class AssetPublisherUtil {
 
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
-	 *             AssetEntryLocalServiceUtil#getEntriesCount(long[], long[],
+	 *             com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil#getEntriesCount(long[], long[],
 	 *             String, String, String, String, boolean, boolean, int, int)}
 	 */
 	@Deprecated

--- a/portal-service/src/com/liferay/portlet/portletdisplaytemplate/util/PortletDisplayTemplateUtil.java
+++ b/portal-service/src/com/liferay/portlet/portletdisplaytemplate/util/PortletDisplayTemplateUtil.java
@@ -112,12 +112,17 @@ public class PortletDisplayTemplateUtil {
 	 *
 	 * @param  language the portlet display template's scripting language.
 	 *         Acceptable values for the FreeMarker, Velocity, or XSL languages
-	 *         are {@link com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_FTL}, {@link
-	 *         com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_VM}, or {@link
-	 *         com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_XSL}, respectively.
+	 *         are {@link
+	 *         com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_FTL},
+	 *         {@link
+	 *         com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_VM},
+	 *         or {@link
+	 *         com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_XSL},
+	 *         respectively.
 	 * @return the portlet display template's map of script variable groups for
 	 *         which hints are displayed in the template editor palette
-	 * @see    TemplateHandler#getTemplateVariableGroups(long, String, java.util.Locale)
+	 * @see    TemplateHandler#getTemplateVariableGroups(long, String,
+	 *         java.util.Locale)
 	 */
 	public static Map<String, TemplateVariableGroup>
 		getTemplateVariableGroups(String language) {

--- a/portal-service/src/com/liferay/portlet/portletdisplaytemplate/util/PortletDisplayTemplateUtil.java
+++ b/portal-service/src/com/liferay/portlet/portletdisplaytemplate/util/PortletDisplayTemplateUtil.java
@@ -112,12 +112,12 @@ public class PortletDisplayTemplateUtil {
 	 *
 	 * @param  language the portlet display template's scripting language.
 	 *         Acceptable values for the FreeMarker, Velocity, or XSL languages
-	 *         are {@link TemplateConstants.LANG_TYPE_FTL}, {@link
-	 *         TemplateConstants.LANG_TYPE_VM}, or {@link
-	 *         TemplateConstants.LANG_TYPE_XSL}, respectively.
+	 *         are {@link com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_FTL}, {@link
+	 *         com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_VM}, or {@link
+	 *         com.liferay.portal.kernel.template.TemplateConstants#LANG_TYPE_XSL}, respectively.
 	 * @return the portlet display template's map of script variable groups for
 	 *         which hints are displayed in the template editor palette
-	 * @see    TemplateHandler#getTemplateVariableGroups(long, String, Locale)
+	 * @see    TemplateHandler#getTemplateVariableGroups(long, String, java.util.Locale)
 	 */
 	public static Map<String, TemplateVariableGroup>
 		getTemplateVariableGroups(String language) {

--- a/util-taglib/src/com/liferay/taglib/ui/InputPermissionsParamsTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputPermissionsParamsTag.java
@@ -42,7 +42,6 @@ import javax.servlet.jsp.tagext.TagSupport;
 /**
  * @author Brian Wing Shun Chan
  * @author Jorge Ferrer
- * @see    com.liferay.portal.servlet.taglib.ui.InputPermissionsParamsTagUtil
  */
 public class InputPermissionsParamsTag extends TagSupport {
 

--- a/util-taglib/src/com/liferay/taglib/ui/InputPermissionsTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputPermissionsTag.java
@@ -28,7 +28,6 @@ import javax.servlet.jsp.PageContext;
 /**
  * @author Brian Wing Shun Chan
  * @author Wilson S. Man
- * @see    com.liferay.portal.servlet.taglib.ui.InputPermissionsTagUtil
  */
 public class InputPermissionsTag extends IncludeTag {
 


### PR DESCRIPTION
Hi Brian,

As @codyhoag explained to me, these edits take a huge chunk out of Portal's Javadoc errors. Many of the edits were done in our FreeMarker templates and ServiceBuilder class to fix Javadoc that's created in the generated classes.

I've reviewed all of the code and have built the services. But I thought I'd leave out the services so you can see the manual changes. 
