### PR TITLE
LPS-53217 Make portal-test module to export junit and hamcrest packages, so that testing modules can consume them

### DIFF
--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -2,7 +2,10 @@ Bundle-Name: Liferay Portal Test
 Bundle-Version: 6.2.0
 Export-Package:\
 	com.liferay.portal.test.randomizerbumpers,\
-	com.liferay.portal.util.test
+	com.liferay.portal.util.test,\
+	junit.*,\
+	org.hamcrest.*,\
+	org.junit.*
 Include-Resource:\
 	classes,\
 	@${project.dir}/../lib/development/dumbster.jar,\


### PR DESCRIPTION
arquillian-extension-liferay pull at https://github.com/cgoncas/arquillian-extension-liferay/pull/4

This portal side change is totally harmless.
I think the arquillian-extension-liferay is the right thing to do, this way, we globally only have one copy of junit and hamcrest loaded, we won't end up with any class cast exception. But it is totally your call about whether to merge in the arquillian-extension-liferay pull.

CC @cgoncas @csierra @jorgeFerrer, @mdelapenya
