### PR TITLE
master-test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/document_library/DocumentLibraryEditDocument.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/document_library/DocumentLibraryEditDocument.path
@@ -1,0 +1,39 @@
+<html>
+<head>
+<title>DocumentLibraryEditDocument</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">DocumentLibraryEditDocument</td></tr>
+</thead>
+<tbody>
+<tr>
+	<td>PAGE_NAME</td>
+	<td></td>
+	<td>DocumentLibraryEditDocument</td>
+</tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>EXTEND_ACTION_PATH</td>
+	<td>DocumentLibrarySelectDocument</td>
+	<td></td>
+</tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILE_FIELD</td>
+	<td>//input[contains(@id,'file')]</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/document_library/DocumentLibrarySelectDocument.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/document_library/DocumentLibrarySelectDocument.path
@@ -1,0 +1,101 @@
+<html>
+<head>
+<title>DocumentLibrarySelectDocument</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">DocumentLibrarySelectDocument</td></tr>
+</thead>
+<tbody>
+<tr>
+	<td>PAGE_NAME</td>
+	<td></td>
+	<td>DocumentLibrarySelectDocument</td>
+</tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>SELECT_DOCUMENT_IFRAME</td>
+	<td>//iframe[contains(@id,'_selectDocumentLibrary_iframe_')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>INFO_MESSAGE_1</td>
+	<td>xPath=(//div[@class='alert alert-info'])[1]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>INFO_MESSAGE_2</td>
+	<td>xPath=(//div[@class='alert alert-info'])[3]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TOOLBAR_ADD</td>
+	<td>//a[@title='Add']/span</td>
+	<td></td>
+</tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<!--ADD_MENULIST-->
+<tr>
+	<td>ADD_MENULIST_FOLDER</td>
+	<td>//a[@role='menuitem' and contains(.,'Folder')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ADD_MENULIST_BASIC_DOCUMENT</td>
+	<td>//a[@role='menuitem' and contains(.,'Basic Document')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ADD_MENULIST_CONTRACT</td>
+	<td>//a[@role='menuitem' and contains(.,'Contract')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ADD_MENULIST_MARKETING_BANNER</td>
+	<td>//a[@role='menuitem' and contains(.,'Marketing Banner')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ADD_MENULIST_ONLINE_TRAINING</td>
+	<td>//a[@role='menuitem' and contains(.,'Online Training')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ADD_MENULIST_SALES_PRESENTATION</td>
+	<td>//a[@role='menuitem' and contains(.,'Sales Presentation')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<!--DOCUMENTS_TABLE-->
+<tr>
+	<td>DOCUMENTS_TABLE_DOCUMENT</td>
+	<td>//tr[contains(.,'${key_documentTitle}')]/td[1]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>DOCUMENTS_TABLE_CHOOSE</td>
+	<td>//tr[contains(.,'${key_documentTitle}')]/td/button[contains(.,'Choose')]</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
This pull is for you to see what it looks like.

We want to change our path folder structure to be parallel to the structure here:
https://github.com/liferay/liferay-portal/tree/master/portal-web/docroot/html

This would help us reduce the amount of duplicate identifiers that we have for the frontend tests.

We saw that the folders in docroot had underscores. Can we use those? If not, that's also fine and we'll just use the same names but without underscores (e.g. documentlibrary, dynamicdatalists instead of document_library, dynamic_data_lists).
