### PR TITLE
LPS-52822 Model adapters

### DIFF
--- a/portal-impl/src/META-INF/staging-spring.xml
+++ b/portal-impl/src/META-INF/staging-spring.xml
@@ -54,4 +54,6 @@
 		<aop:advisor advice-ref="com.liferay.portal.service.impl.LayoutSetLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.LayoutSetLocalService)" />
 		<aop:advisor advice-ref="com.liferay.portal.service.impl.PortletPreferencesLocalServiceStagingAdvice" pointcut="bean(com.liferay.portal.service.PortletPreferencesLocalService)" />
 	</aop:config>
+	<bean id="com.liferay.portlet.sitesadmin.lar.StagedGroupModelAdapterBuilder" class="com.liferay.portlet.sitesadmin.lar.StagedGroupModelAdapterBuilder" />
+	<bean id="com.liferay.portlet.layoutsadmin.lar.StagedThemeModelAdapterBuilder" class="com.liferay.portlet.layoutsadmin.lar.StagedThemeModelAdapterBuilder" />
 </beans>

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -28,6 +28,7 @@
 			<bean class="com.liferay.portal.audit.AuditMessageFactoryImpl" />
 		</property>
 	</bean>
+	<bean id="com.liferay.portal.modeladapter.ServiceTrackerMapModelAdapterBuilderLocator" class="com.liferay.portal.modeladapter.ServiceTrackerMapModelAdapterBuilderLocator" />
 	<bean id="com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistry" class="com.liferay.portal.backgroundtask.BackgroundTaskStatusRegistryImpl" />
 	<bean id="com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistryUtil" class="com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistryUtil">
 		<property name="backgroundTaskStatusRegistry" ref="com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistry" />

--- a/portal-impl/src/com/liferay/portal/lar/ThemeExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/ThemeExporter.java
@@ -18,12 +18,13 @@ import com.liferay.portal.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.modeladapter.ModelAdapterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.model.LayoutSet;
 import com.liferay.portal.model.LayoutSetBranch;
+import com.liferay.portal.model.Theme;
 import com.liferay.portlet.layoutsadmin.lar.StagedTheme;
-import com.liferay.portlet.layoutsadmin.lar.StagedThemeImpl;
 
 /**
  * @author Mate Thurzo
@@ -50,7 +51,8 @@ public class ThemeExporter {
 			return;
 		}
 
-		StagedTheme stagedTheme = new StagedThemeImpl(layoutSet.getTheme());
+		StagedTheme stagedTheme = ModelAdapterUtil.adapt(
+			layoutSet.getTheme(), Theme.class, StagedTheme.class);
 
 		if (!portletDataContext.isPerformDirectBinaryImport()) {
 			Element layoutSetElement = portletDataContext.getExportDataElement(
@@ -83,8 +85,8 @@ public class ThemeExporter {
 			return;
 		}
 
-		StagedTheme stagedTheme = new StagedThemeImpl(
-			layoutSetBranch.getTheme());
+		StagedTheme stagedTheme = ModelAdapterUtil.adapt(
+			layoutSetBranch.getTheme(), Theme.class, StagedTheme.class);
 
 		if (!portletDataContext.isPerformDirectBinaryImport()) {
 			Element layoutSetBranchElement =

--- a/portal-impl/src/com/liferay/portal/modeladapter/ServiceTrackerMapModelAdapterBuilderLocator.java
+++ b/portal-impl/src/com/liferay/portal/modeladapter/ServiceTrackerMapModelAdapterBuilderLocator.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.modeladapter;
+
+import com.liferay.portal.kernel.modeladapter.ModelAdapterBuilder;
+import com.liferay.portal.kernel.modeladapter.ModelAdapterBuilderLocator;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ReflectionUtil;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceReference;
+import com.liferay.registry.collections.ServiceReferenceMapper;
+import com.liferay.registry.collections.ServiceTrackerCollections;
+import com.liferay.registry.collections.ServiceTrackerMap;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class ServiceTrackerMapModelAdapterBuilderLocator<T, V>
+	implements ModelAdapterBuilderLocator<T, V>, Closeable {
+
+	public ServiceTrackerMapModelAdapterBuilderLocator() {
+		_modelAdaptersMap.open();
+	}
+
+	@Override
+	public void close() throws IOException {
+		_modelAdaptersMap.close();
+	}
+
+	@Override
+	public ModelAdapterBuilder<T, V> locate(
+		Class<T> adapteeModelClass, Class<V> adaptedModelClass) {
+
+		return _modelAdaptersMap.getService(
+			getKey(adapteeModelClass, adaptedModelClass));
+	}
+
+	private String getKey(
+		Class<T> adapteeModelClass, Class<V> adaptedModelClass) {
+
+		return adapteeModelClass.getName() + "->" + adaptedModelClass.getName();
+	}
+
+	private final ServiceTrackerMap<String, ModelAdapterBuilder>
+		_modelAdaptersMap =
+			ServiceTrackerCollections.singleValueMap(
+				ModelAdapterBuilder.class, null,
+				new ServiceReferenceMapper<String, ModelAdapterBuilder>() {
+
+					@Override
+					public void map(
+						ServiceReference<ModelAdapterBuilder> serviceReference,
+						Emitter<String> emitter) {
+
+						Registry registry = RegistryUtil.getRegistry();
+
+						ModelAdapterBuilder modelAdapterBuilder =
+							registry.getService(serviceReference);
+
+						Type genericInterface =
+							ReflectionUtil.getGenericInterface(
+								modelAdapterBuilder, ModelAdapterBuilder.class);
+
+						if ((genericInterface == null) ||
+							!(genericInterface instanceof ParameterizedType)) {
+
+							return;
+						}
+
+						ParameterizedType parameterizedType =
+							(ParameterizedType)genericInterface;
+
+						Type[] typeArguments =
+							parameterizedType.getActualTypeArguments();
+
+						if (ArrayUtil.isEmpty(typeArguments)) {
+							return;
+						}
+
+						try {
+							Class adapteeModelClass = (Class)typeArguments[0];
+							Class adaptedModelClass = (Class)typeArguments[1];
+
+							emitter.emit(
+								getKey(adapteeModelClass, adaptedModelClass));
+						}
+						catch (ClassCastException cce) {
+							return;
+						}
+					}
+				});
+
+}

--- a/portal-impl/src/com/liferay/portal/modeladapter/ServiceTrackerMapModelAdapterBuilderLocator.java
+++ b/portal-impl/src/com/liferay/portal/modeladapter/ServiceTrackerMapModelAdapterBuilderLocator.java
@@ -92,7 +92,9 @@ public class ServiceTrackerMapModelAdapterBuilderLocator<T, V>
 						Type[] typeArguments =
 							parameterizedType.getActualTypeArguments();
 
-						if (ArrayUtil.isEmpty(typeArguments)) {
+						if (ArrayUtil.isEmpty(typeArguments) ||
+							(typeArguments.length != 2)) {
+
 							return;
 						}
 

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/StagedThemeModelAdapterBuilder.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/StagedThemeModelAdapterBuilder.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.layoutsadmin.lar;
+
+import com.liferay.portal.kernel.modeladapter.ModelAdapterBuilder;
+import com.liferay.portal.model.Theme;
+
+/**
+ * @author Mate Thurzo
+ */
+public class StagedThemeModelAdapterBuilder
+	implements ModelAdapterBuilder<Theme, StagedTheme> {
+
+	@Override
+	public StagedTheme build(Theme theme) {
+		return new StagedThemeImpl(theme);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portlet/sitesadmin/lar/StagedGroupModelAdapterBuilder.java
+++ b/portal-impl/src/com/liferay/portlet/sitesadmin/lar/StagedGroupModelAdapterBuilder.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.sitesadmin.lar;
+
+import com.liferay.portal.kernel.modeladapter.ModelAdapterBuilder;
+import com.liferay.portal.model.Group;
+
+/**
+ * @author Mate Thurzo
+ */
+public class StagedGroupModelAdapterBuilder
+	implements ModelAdapterBuilder<Group, StagedGroup> {
+
+	@Override
+	public StagedGroup build(Group group) {
+		return new StagedGroupImpl(group);
+	}
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterBuilder.java
+++ b/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterBuilder.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.modeladapter;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public interface ModelAdapterBuilder<T, V> {
+
+	V build(T adapteeModel);
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterBuilderLocator.java
+++ b/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterBuilderLocator.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.modeladapter;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public interface ModelAdapterBuilderLocator<T, V> {
+
+	public ModelAdapterBuilder<T, V> locate(
+		Class<T> adapteeModelClass, Class<V> adaptedModelClass);
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterUtil.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.modeladapter;
+
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+
+/**
+ * @author Mate Thurzo
+ */
+public class ModelAdapterUtil {
+
+	public static <T, V> V adapt(
+		T adapteeModel, Class<T> adapteeModelClass,
+		Class<V> adaptedModelClass) {
+
+		return doAdapt(adapteeModel, adapteeModelClass, adaptedModelClass);
+	}
+
+	public static <T, V> V adapt(T adapteeModel, Class<V> adaptedModelClass) {
+		Class<T> adapteeModelClass = (Class<T>)adapteeModel.getClass();
+
+		return doAdapt(adapteeModel, adapteeModelClass, adaptedModelClass);
+	}
+
+	protected static <T, V> V doAdapt(
+		T adapteeModel, Class<T> adapteeModelClass,
+		Class<V> adaptedModelClass) {
+
+		Registry registry = RegistryUtil.getRegistry();
+
+		ModelAdapterBuilderLocator modelAdapterBuilderLocator =
+			registry.getService(ModelAdapterBuilderLocator.class);
+
+		if (modelAdapterBuilderLocator == null) {
+			return null;
+		}
+
+		ModelAdapterBuilder<T, V> modelAdapterBuilder =
+			(ModelAdapterBuilder<T, V>)modelAdapterBuilderLocator.locate(
+				adapteeModelClass, adaptedModelClass);
+
+		return modelAdapterBuilder.build(adapteeModel);
+	}
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/modeladapter/ModelAdapterUtil.java
@@ -14,8 +14,8 @@
 
 package com.liferay.portal.kernel.modeladapter;
 
-import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceTracker;
 
 /**
  * @author Mate Thurzo
@@ -39,10 +39,8 @@ public class ModelAdapterUtil {
 		T adapteeModel, Class<T> adapteeModelClass,
 		Class<V> adaptedModelClass) {
 
-		Registry registry = RegistryUtil.getRegistry();
-
 		ModelAdapterBuilderLocator modelAdapterBuilderLocator =
-			registry.getService(ModelAdapterBuilderLocator.class);
+			_serviceTracker.getService();
 
 		if (modelAdapterBuilderLocator == null) {
 			return null;
@@ -53,6 +51,15 @@ public class ModelAdapterUtil {
 				adapteeModelClass, adaptedModelClass);
 
 		return modelAdapterBuilder.build(adapteeModel);
+	}
+
+	private static final
+		ServiceTracker<ModelAdapterBuilderLocator, ModelAdapterBuilderLocator>
+			_serviceTracker = RegistryUtil.getRegistry().trackServices(
+				ModelAdapterBuilderLocator.class);
+
+	static {
+		_serviceTracker.open();
 	}
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/util/ReflectionUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/ReflectionUtil.java
@@ -73,6 +73,32 @@ public class ReflectionUtil {
 		return method;
 	}
 
+	public static Type getGenericInterface(
+		Object object, Class<?> interfaceClass) {
+
+		Class<?> clazz = object.getClass();
+
+		Type genericInterface = _getGenericInterface(clazz, interfaceClass);
+
+		if (genericInterface != null) {
+			return genericInterface;
+		}
+
+		Class<?> superClass = clazz.getSuperclass();
+
+		while (superClass != null) {
+			genericInterface = _getGenericInterface(superClass, interfaceClass);
+
+			if (genericInterface != null) {
+				return genericInterface;
+			}
+
+			superClass = superClass.getSuperclass();
+		}
+
+		return null;
+	}
+
 	public static Class<?> getGenericSuperType(Class<?> clazz) {
 		try {
 			ParameterizedType parameterizedType =
@@ -200,6 +226,29 @@ public class ReflectionUtil {
 		throws E {
 
 		throw (E)throwable;
+	}
+
+	private static Type _getGenericInterface(
+		Class<?> clazz, Class<?> interfaceClass) {
+
+		Type[] genericInterfaces = clazz.getGenericInterfaces();
+
+		for (Type genericInterface : genericInterfaces) {
+			if (!(genericInterface instanceof ParameterizedType)) {
+				continue;
+			}
+
+			ParameterizedType parameterizedType =
+				(ParameterizedType)genericInterface;
+
+			Type rawType = parameterizedType.getRawType();
+
+			if (rawType.equals(interfaceClass)) {
+				return parameterizedType;
+			}
+		}
+
+		return null;
 	}
 
 	private static void _getInterfaces(


### PR DESCRIPTION
Hey Brian,

This is re-sending the model adapter builders. I've moved them to the modeladapter package, I think it reflects more what is the purpose of this stuff.

The ModelAdapterBuilder can be generic purpose tool it can build StagedModels, but other models too, that's why I didn't wanted to merge with the lar package or else.

The behind the naming is that the model adapter itself in this case is the StagedTheme, and we need a build which can build a StagedTheme from a Theme in an OSGi conform way. Those are the ModelAdapterBuilders having the single method build as the contract. The ModelAdapterBuilderLocator is a class to serve the queries toward this framework, currently having one single implementation but there can be more in the future, initially @csierra had more, but we have decided to go with only this for now.

Thanks,

Máté
