### PR TITLE
LPS-53352 Prevent JS error when uploading a file that causes warning messages after validation

### DIFF
--- a/portal-web/docroot/html/js/liferay/upload.js
+++ b/portal-web/docroot/html/js/liferay/upload.js
@@ -66,7 +66,7 @@ AUI.add(
 				'</tpl>',
 				'<tpl if="values.warningMessages && (values.warningMessages.length > 0)">',
 					'<li class="alert upload-error" data-fileId="{id}" id="{id}">',
-						'<span class="error-message" title="{[ LString.escapeHTML(values.error) ]}">{[ values.error ? this.strings.warningFailureText : this.strings.warningText ]}</span>',
+						'<span class="error-message" title="{[ LString.escapeHTML(values.error ? this.strings.warningFailureText : this.strings.warningText) ]}">{[ values.error ? this.strings.warningFailureText : this.strings.warningText ]}</span>',
 						'<ul class="error-list-items">',
 							'<tpl for="warningMessages">',
 								'<li>{[ LString.escapeHTML(values.type) ]} <strong>({size})</strong>:',


### PR DESCRIPTION
Hi,

QA found this issue while testing export/import with Audience Targeting in EE-6.2.x, but it's actually in the portal (also in master).

Regards

@juliocamarero
@matethurzo
@topolik
@natecavanaugh
