### PR TITLE
ServiceBuilder - SOAP classs methods to throw RemoteException

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1227,8 +1227,8 @@ public class ServiceBuilder {
 
 	public String getJavadocComment(JavaMethod javaMethod, String classType) {
 		return _formatComment(
-			javaMethod.getComment(), javaMethod.getTags(), StringPool.TAB,
-			classType);
+			javaMethod.getComment(), javaMethod.getTags(), classType,
+			StringPool.TAB);
 	}
 
 	public String getListActualTypeArguments(Type type) {
@@ -3740,8 +3740,8 @@ public class ServiceBuilder {
 	}
 
 	private String _formatComment(
-		String comment, DocletTag[] tags, String indentation,
-		String classType) {
+		String comment, DocletTag[] tags, String classType,
+		String indentation) {
 
 		StringBundler sb = new StringBundler();
 
@@ -3772,30 +3772,24 @@ public class ServiceBuilder {
 			sb.append(tag.getName());
 			sb.append(" ");
 
-			if (classType.equals("serviceSoap") &&
-				tagValue.startsWith(
-					"com.liferay.portal.kernel.exception.PortalException"))
-			{
-
-				String remoteValue = tagValue.replaceFirst(
+			if (classType.equals("serviceSoap")) {
+				if (tagValue.startsWith(
+						"com.liferay.portal.kernel.exception.PortalException"))
+				{
+					tagValue = tagValue.replaceFirst(
 						"com.liferay.portal.kernel.exception.PortalException",
 						"RemoteException");
+				}
+				else if (tagValue.startsWith(
+							"com.liferay.portal.security.auth.PrincipalException"))
+				{
+					tagValue = tagValue.replaceFirst(
+						"com.liferay.portal.security.auth.PrincipalException",
+						"RemoteException");
+				}
+			}
 
-				sb.append(remoteValue);
-			}
-			else if (classType.equals("serviceSoap") &&
-					 tagValue.startsWith(
-						"com.liferay.portal.security.auth.PrincipalException"))
-			{
-				String remoteValue = tagValue.replaceFirst(
-					"com.liferay.portal.security.auth.PrincipalException",
-					"RemoteException");
-
-				sb.append(remoteValue);
-			}
-			else {
-				sb.append(tagValue);
-			}
+			sb.append(tagValue);
 
 			sb.append("\n");
 		}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1221,12 +1221,14 @@ public class ServiceBuilder {
 
 	public String getJavadocComment(JavaClass javaClass) {
 		return _formatComment(
-			javaClass.getComment(), javaClass.getTags(), StringPool.BLANK);
+			javaClass.getComment(), javaClass.getTags(), StringPool.BLANK,
+			StringPool.BLANK);
 	}
 
-	public String getJavadocComment(JavaMethod javaMethod) {
+	public String getJavadocComment(JavaMethod javaMethod, String classType) {
 		return _formatComment(
-			javaMethod.getComment(), javaMethod.getTags(), StringPool.TAB);
+			javaMethod.getComment(), javaMethod.getTags(), StringPool.TAB,
+			classType);
 	}
 
 	public String getListActualTypeArguments(Type type) {
@@ -3738,7 +3740,8 @@ public class ServiceBuilder {
 	}
 
 	private String _formatComment(
-		String comment, DocletTag[] tags, String indentation) {
+		String comment, DocletTag[] tags, String indentation,
+		String classType) {
 
 		StringBundler sb = new StringBundler();
 
@@ -3762,11 +3765,38 @@ public class ServiceBuilder {
 		}
 
 		for (DocletTag tag : tags) {
+			String tagValue = tag.getValue();
+
 			sb.append(indentation);
 			sb.append(" * @");
 			sb.append(tag.getName());
 			sb.append(" ");
-			sb.append(tag.getValue());
+
+			if (classType.equals("serviceSoap") &&
+				tagValue.startsWith(
+					"com.liferay.portal.kernel.exception.PortalException"))
+			{
+
+				String remoteValue = tagValue.replaceFirst(
+						"com.liferay.portal.kernel.exception.PortalException",
+						"RemoteException");
+
+				sb.append(remoteValue);
+			}
+			else if (classType.equals("serviceSoap") &&
+					 tagValue.startsWith(
+						"com.liferay.portal.security.auth.PrincipalException"))
+			{
+				String remoteValue = tagValue.replaceFirst(
+					"com.liferay.portal.security.auth.PrincipalException",
+					"RemoteException");
+
+				sb.append(remoteValue);
+			}
+			else {
+				sb.append(tagValue);
+			}
+
 			sb.append("\n");
 		}
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name} extends
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "extendedModel")}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -88,7 +88,7 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "modelWrapper")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -35,7 +35,7 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "persistence")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -97,7 +97,7 @@ public class ${entity.name}Util {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "persistenceUtil")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name}${sessionTypeName}Service
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "service")}
 
 			<#list method.annotations as annotation>
 				<#if (annotation.type != "java.lang.Override") && (annotation.type != "java.lang.SuppressWarnings")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -82,7 +82,7 @@ public class ${entity.name}ServiceSoap {
 			<#assign extendedModelName = packagePath + ".model." + entity.name>
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
 
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "serviceSoap")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -64,7 +64,7 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "serviceUtil")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -28,7 +28,7 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, "serviceWrapper")}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated


### PR DESCRIPTION
Hi Brian,

I'm sending you the first installment of Cody's ServiceBuilder and FTL improvements that resolve tons of the Javadoc warnings. This first one replaces the PortalException and PrincipalException references found in the propagated Javadoc comments, with RemoteException, since that is the exception the generated SOAP methods throw.

Note, the PortalException and PrincipalException are matched in fully qualified form, as the PRs that will follow use them that way.

\cc @codyhoag
