### PR TITLE
LPS-53183 Fix registry tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3953,8 +3953,6 @@ if (ppstate.equals("normal")) {
 							"modules/apps/polls/polls-test/test/integration/**/*Test.java",
 							"modules/apps/social/social-networking-test/test/integration/**/*Test.java",
 							"modules/apps/wiki/wiki-test/test/integration/**/*Test.java",
-							"modules/core/osgi-service-tracker-map/test/integration/**/*Test.java",
-							"modules/core/registry-test/test/integration/**/*Test.java",
 							"modules/portal/portal-json-web-service-extender/test/integration/**/*Test.java",
 							"modules/portal/portal-template-freemarker/test/integration/**/*Test.java",
 							"modules/util/osgi-util/test/integration/**/*Test.java",

--- a/modules/core/osgi-service-tracker-map/ivy.xml
+++ b/modules/core/osgi-service-tracker-map/ivy.xml
@@ -20,7 +20,7 @@
 		<dependency name="org.osgi.core" org="org.osgi" rev="5.0.0" />
 		<dependency conf="test->default" name="arquillian-container-felix-embedded" org="org.jboss.arquillian.container" rev="2.1.0.CR15" />
 		<dependency conf="test->default" name="arquillian-deployment-generator-bnd" org="org.arquillian.liferay" rev="1.0.0.Alpha1" />
-		<dependency conf="test->default" name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.6.Final" />
+		<dependency conf="test->default" name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.3.Final" />
 		<dependency conf="test->default" name="org.apache.felix.framework" org="org.apache.felix" rev="4.4.0" />
 		<dependency conf="test->default" name="org.apache.felix.main" org="org.apache.felix" rev="4.4.0" />
 		<dependency conf="test->default" name="junit" org="junit" rev="4.11" />

--- a/modules/core/osgi-service-tracker-map/ivy.xml
+++ b/modules/core/osgi-service-tracker-map/ivy.xml
@@ -19,7 +19,7 @@
 	<dependencies defaultconf="default">
 		<dependency name="org.osgi.core" org="org.osgi" rev="5.0.0" />
 		<dependency conf="test->default" name="arquillian-container-felix-embedded" org="org.jboss.arquillian.container" rev="2.1.0.CR15" />
-		<dependency conf="test->default" name="arquillian-deployment-generator-bnd" org="com.liferay.arquillian" rev="latest.integration" />
+		<dependency conf="test->default" name="arquillian-deployment-generator-bnd" org="org.arquillian.liferay" rev="1.0.0.Alpha1" />
 		<dependency conf="test->default" name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.6.Final" />
 		<dependency conf="test->default" name="org.apache.felix.framework" org="org.apache.felix" rev="4.4.0" />
 		<dependency conf="test->default" name="org.apache.felix.main" org="org.apache.felix" rev="4.4.0" />

--- a/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ListServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ListServiceTrackerMapTest.java
@@ -14,7 +14,6 @@
 
 package com.liferay.osgi.service.tracker.map.test;
 
-import org.arquillian.liferay.deploymentscenario.annotations.BndFile;
 import com.liferay.osgi.service.tracker.map.ServiceReferenceMapper;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMapFactory;
@@ -28,6 +27,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.arquillian.liferay.deploymentscenario.annotations.BndFile;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;

--- a/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ListServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ListServiceTrackerMapTest.java
@@ -14,7 +14,7 @@
 
 package com.liferay.osgi.service.tracker.map.test;
 
-import com.liferay.arquillian.deploymentscenario.annotations.BndFile;
+import org.arquillian.liferay.deploymentscenario.annotations.BndFile;
 import com.liferay.osgi.service.tracker.map.ServiceReferenceMapper;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMapFactory;

--- a/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ObjectServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ObjectServiceTrackerMapTest.java
@@ -14,7 +14,6 @@
 
 package com.liferay.osgi.service.tracker.map.test;
 
-import org.arquillian.liferay.deploymentscenario.annotations.BndFile;
 import com.liferay.osgi.service.tracker.map.ServiceReferenceMapper;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMapFactory;
@@ -28,6 +27,8 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.arquillian.liferay.deploymentscenario.annotations.BndFile;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;

--- a/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ObjectServiceTrackerMapTest.java
+++ b/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ObjectServiceTrackerMapTest.java
@@ -14,7 +14,7 @@
 
 package com.liferay.osgi.service.tracker.map.test;
 
-import com.liferay.arquillian.deploymentscenario.annotations.BndFile;
+import org.arquillian.liferay.deploymentscenario.annotations.BndFile;
 import com.liferay.osgi.service.tracker.map.ServiceReferenceMapper;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.map.ServiceTrackerMapFactory;

--- a/modules/core/registry-test/ivy.xml
+++ b/modules/core/registry-test/ivy.xml
@@ -13,7 +13,7 @@
 	<dependencies defaultconf="default">
 		<dependency conf="test->default" name="arquillian-container-felix-embedded" org="org.jboss.arquillian.container" rev="2.1.0.CR15" />
 		<dependency conf="test->default" name="arquillian-deployment-generator-bnd" org="org.arquillian.liferay" rev="1.0.0.Alpha1" />
-		<dependency conf="test->default" name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.6.Final" />
+		<dependency conf="test->default" name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.3.Final" />
 		<dependency conf="test->default" name="org.apache.felix.framework" org="org.apache.felix" rev="4.4.0" />
 		<dependency conf="test->default" name="org.apache.felix.main" org="org.apache.felix" rev="4.4.0" />
 	</dependencies>


### PR DESCRIPTION
Hey @brianchandotcom @michaelhashimoto

The current SDK in master is starting an app server for these tests. This is totally unnecessary since these modules do not depend on portal. Actually they can't be run once the portal is started. 

We are using an arquillian OSGi container to run the tests. You can see that in the ivy.xml file. 

The app server is not making the tests fall (currently) but put an unnecessary extra time in the execution. 
