### PR TITLE
Service Builder / ftl - Gather imported classes

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1220,9 +1220,7 @@ public class ServiceBuilder {
 		return idType;
 	}
 
-	public String getJavadocComment(JavaClass javaClass)
-		throws IOException {
-
+	public String getJavadocComment(JavaClass javaClass) throws IOException {
 		return _formatComment(
 			javaClass.getComment(), javaClass.getTags(), StringPool.BLANK,
 			StringPool.BLANK, StringPool.EMPTY_ARRAY, StringPool.BLANK);
@@ -3761,7 +3759,7 @@ public class ServiceBuilder {
 		sb.append("/**\n");
 
 		String[] importedClassesFromImpl = _getImportedClassesFromImpl(
-				entityName, sessionTypeName, existingImports);
+			entityName, sessionTypeName, existingImports);
 
 		if (Validator.isNotNull(comment)) {
 			comment = comment.replaceAll("(?m)^", indentation + " * ");
@@ -4347,27 +4345,27 @@ public class ServiceBuilder {
 	}
 
 	private JavaClass _getParentJavaClass(JavaClass javaClass)
-			throws IOException {
+		throws IOException {
 
-			String parentJavaClassString = javaClass.getSuperJavaClass().toString();
-			int pos = parentJavaClassString.indexOf("com.");
+		String parentJavaClassString = javaClass.getSuperJavaClass().toString();
+		int pos = parentJavaClassString.indexOf("com.");
 
-			String parentClassPath = parentJavaClassString.substring(
-					pos, parentJavaClassString.length());
-			parentClassPath = parentClassPath.replaceAll("\\.", "/");
+		String parentClassPath = parentJavaClassString.substring(
+			pos, parentJavaClassString.length());
+		parentClassPath = parentClassPath.replaceAll("\\.", "/");
 
-			int outputPathPos = _outputPath.indexOf("com/");
-			String parentOutputPath = _outputPath.substring(
-					outputPathPos, _outputPath.length());
+		int outputPathPos = _outputPath.indexOf("com/");
+		String parentOutputPath = _outputPath.substring(
+			outputPathPos, _outputPath.length());
 
-			String finalParentClassPath = _outputPath.replace(
-					parentOutputPath, parentClassPath);
-			finalParentClassPath = finalParentClassPath + ".java";
+		String finalParentClassPath = _outputPath.replace(
+			parentOutputPath, parentClassPath);
+		finalParentClassPath = finalParentClassPath + ".java";
 
-			JavaClass parentJavaClass = _getJavaClass(finalParentClassPath);
+		JavaClass parentJavaClass = _getJavaClass(finalParentClassPath);
 
-			return parentJavaClass;
-		}
+		return parentJavaClass;
+	}
 
 	private String _getSessionTypeName(int sessionType) {
 		if (sessionType == _SESSION_TYPE_LOCAL) {

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1225,16 +1225,17 @@ public class ServiceBuilder {
 
 		return _formatComment(
 			javaClass.getComment(), javaClass.getTags(), StringPool.BLANK,
-			StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, StringPool.EMPTY_ARRAY, StringPool.BLANK);
 	}
 
 	public String getJavadocComment(
-			JavaMethod javaMethod, String entityName, String sessionType)
+			JavaMethod javaMethod, String entityName, String sessionType,
+			String[] existingImports)
 		throws IOException {
 
 		return _formatComment(
 			javaMethod.getComment(), javaMethod.getTags(), entityName,
-			sessionType,  StringPool.TAB);
+			sessionType, existingImports, StringPool.TAB);
 	}
 
 	public String getListActualTypeArguments(Type type) {
@@ -3747,7 +3748,7 @@ public class ServiceBuilder {
 
 	private String _formatComment(
 			String comment, DocletTag[] tags, String entityName,
-			String sessionType, String indentation)
+			String sessionType, String[] existingImports, String indentation)
 		throws IOException {
 
 		StringBundler sb = new StringBundler();
@@ -3760,7 +3761,7 @@ public class ServiceBuilder {
 		sb.append("/**\n");
 
 		String[] importedClassesFromImpl = _getImportedClassesFromImpl(
-				entityName, sessionType);
+				entityName, sessionType, existingImports);
 
 		if (Validator.isNotNull(comment)) {
 			comment = comment.replaceAll("(?m)^", indentation + " * ");
@@ -4224,7 +4225,7 @@ public class ServiceBuilder {
 	}
 
 	private String[] _getImportedClassesFromImpl(
-			String entityName, String sessionType)
+			String entityName, String sessionType, String[] classesToExclude)
 		throws IOException {
 
 		JavaClass javaClass = null;
@@ -4256,6 +4257,12 @@ public class ServiceBuilder {
 
 		String[] allImports = new String[imports.length + parentImports.length];
 		ArrayUtil.combine(imports, parentImports, allImports);
+
+		for (String classToExclude : classesToExclude) {
+			if (ArrayUtil.contains(allImports, classToExclude, false)) {
+				allImports = ArrayUtil.remove(allImports, classToExclude);
+			}
+		}
 
 		return allImports;
 	}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -1229,13 +1229,13 @@ public class ServiceBuilder {
 	}
 
 	public String getJavadocComment(
-			JavaMethod javaMethod, String entityName, String sessionType,
+			JavaMethod javaMethod, String entityName, String sessionTypeName,
 			String[] existingImports)
 		throws IOException {
 
 		return _formatComment(
 			javaMethod.getComment(), javaMethod.getTags(), entityName,
-			sessionType, existingImports, StringPool.TAB);
+			sessionTypeName, existingImports, StringPool.TAB);
 	}
 
 	public String getListActualTypeArguments(Type type) {
@@ -3748,7 +3748,7 @@ public class ServiceBuilder {
 
 	private String _formatComment(
 			String comment, DocletTag[] tags, String entityName,
-			String sessionType, String[] existingImports, String indentation)
+			String sessionTypeName, String[] existingImports, String indentation)
 		throws IOException {
 
 		StringBundler sb = new StringBundler();
@@ -3761,7 +3761,7 @@ public class ServiceBuilder {
 		sb.append("/**\n");
 
 		String[] importedClassesFromImpl = _getImportedClassesFromImpl(
-				entityName, sessionType, existingImports);
+				entityName, sessionTypeName, existingImports);
 
 		if (Validator.isNotNull(comment)) {
 			comment = comment.replaceAll("(?m)^", indentation + " * ");
@@ -3875,9 +3875,6 @@ public class ServiceBuilder {
 		context.put("beanLocatorUtilShortName", _beanLocatorUtilShortName);
 		context.put("hbmFileName", _hbmFileName);
 		context.put("implDir", _implDir);
-		context.put(
-			"localSessionType",
-			this._getSessionTypeName(_SESSION_TYPE_LOCAL));
 		context.put("modelHintsFileName", _modelHintsFileName);
 		context.put("modelHintsUtil", ModelHintsUtil.getModelHints());
 		context.put("osgiModule", _osgiModule);
@@ -3888,9 +3885,6 @@ public class ServiceBuilder {
 		context.put("portletPackageName", _portletPackageName);
 		context.put("portletShortName", _portletShortName);
 		context.put("propsUtil", _propsUtil);
-		context.put(
-			"remoteSessionType",
-			this._getSessionTypeName(_SESSION_TYPE_REMOTE));
 		context.put(
 			"resourceActionsUtil", ResourceActionsUtil.getResourceActions());
 		context.put("serviceBuilder", this);
@@ -4225,13 +4219,15 @@ public class ServiceBuilder {
 	}
 
 	private String[] _getImportedClassesFromImpl(
-			String entityName, String sessionType, String[] classesToExclude)
+			String entityName, String sessionTypeName, String[] classesToExclude)
 		throws IOException {
 
 		JavaClass javaClass = null;
 		String serviceImplPath = _outputPath + "/service/impl/" + entityName;
 
-		if (sessionType.equals("Local")) {
+		if (Validator.isNotNull(sessionTypeName) &&
+			sessionTypeName.equals("Local")) {
+
 			javaClass = _getJavaClass(
 				serviceImplPath + "LocalServiceImpl.java");
 		}

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -99,7 +99,7 @@ public interface ${entity.name} extends
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
 			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.util.Accessor", "com.liferay.portal.kernel.util.LocaleThreadLocal", "com.liferay.portal.model.NestedSetsTreeNodeModel", "com.liferay.portal.model.PermissionedModel", "com.liferay.portal.model.PersistedModel", "com.liferay.portal.model.TreeModel"]>
 
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
+			${serviceBuilder.getJavadocComment(method, entity.name, "", existingImports)}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -97,7 +97,7 @@ public interface ${entity.name} extends
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/extended_model.ftl
@@ -97,7 +97,9 @@ public interface ${entity.name} extends
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic()>
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.util.Accessor", "com.liferay.portal.kernel.util.LocaleThreadLocal", "com.liferay.portal.model.NestedSetsTreeNodeModel", "com.liferay.portal.model.PermissionedModel", "com.liferay.portal.model.PersistedModel", "com.liferay.portal.model.TreeModel"]>
+
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 
 			<#assign parameters = method.parameters>
 

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -89,7 +89,7 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.lar.StagedModelType", "com.liferay.portal.kernel.util.Validator", "com.liferay.portal.model.ModelWrapper", "com.liferay.portal.service.ServiceContext", "com.liferay.portlet.expando.model.ExpandoBridge", "com.liferay.portlet.expando.util.ExpandoBridgeFactoryUtil", "java.io.Serializable", "java.sql.Blob", "java.util.Date", "java.util.HashMap", "java.util.Map"]>
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
+			${serviceBuilder.getJavadocComment(method, entity.name, "", existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -88,7 +88,7 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/model_wrapper.ftl
@@ -86,9 +86,10 @@ public class ${entity.name}Wrapper implements ${entity.name}, ModelWrapper<${ent
 				<#assign hasGetStagedModelTypeMethod = true>
 			</#if>
 
+			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.lar.StagedModelType", "com.liferay.portal.kernel.util.Validator", "com.liferay.portal.model.ModelWrapper", "com.liferay.portal.service.ServiceContext", "com.liferay.portlet.expando.model.ExpandoBridge", "com.liferay.portlet.expando.util.ExpandoBridgeFactoryUtil", "java.io.Serializable", "java.sql.Blob", "java.util.Date", "java.util.HashMap", "java.util.Map"]>
 			<#assign parameters = method.parameters>
 
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -37,7 +37,7 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
 			<#assign existingImports = [packagePath + ".model." + entity.name, "aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.exception.PortalException", "com.liferay.portal.kernel.transaction.Propagation", "com.liferay.portal.kernel.transaction.Transactional", "com.liferay.portal.service.persistence.BasePersistence", "java.util.Date"]>
 
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
+			${serviceBuilder.getJavadocComment(method, entity.name, "", existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -35,7 +35,7 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence.ftl
@@ -35,7 +35,9 @@ public interface ${entity.name}Persistence extends BasePersistence<${entity.name
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			<#assign existingImports = [packagePath + ".model." + entity.name, "aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.exception.PortalException", "com.liferay.portal.kernel.transaction.Propagation", "com.liferay.portal.kernel.transaction.Transactional", "com.liferay.portal.service.persistence.BasePersistence", "java.util.Date"]>
+
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -99,7 +99,7 @@ public class ${entity.name}Util {
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
 			<#assign existingImports = [packagePath + ".model." + entity.name, "aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.bean.PortalBeanLocatorUtil", "com.liferay.portal.kernel.bean.PortletBeanLocatorUtil", "com.liferay.portal.kernel.dao.orm.DynamicQuery", "com.liferay.portal.kernel.util.OrderByComparator", "com.liferay.portal.kernel.util.ReferenceRegistry", "com.liferay.portal.service.ServiceContext", "java.util.Date", "java.util.List", "org.osgi.framework.Bundle", "org.osgi.framework.FrameworkUtil", "org.osgi.util.tracker.ServiceTracker"]>
 
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
+			${serviceBuilder.getJavadocComment(method, entity.name, "", existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -97,7 +97,7 @@ public class ${entity.name}Util {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_util.ftl
@@ -97,7 +97,9 @@ public class ${entity.name}Util {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method) && !serviceBuilder.isBasePersistenceMethod(method)>
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			<#assign existingImports = [packagePath + ".model." + entity.name, "aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.bean.PortalBeanLocatorUtil", "com.liferay.portal.kernel.bean.PortletBeanLocatorUtil", "com.liferay.portal.kernel.dao.orm.DynamicQuery", "com.liferay.portal.kernel.util.OrderByComparator", "com.liferay.portal.kernel.util.ReferenceRegistry", "com.liferay.portal.service.ServiceContext", "java.util.Date", "java.util.List", "org.osgi.framework.Bundle", "org.osgi.framework.FrameworkUtil", "org.osgi.util.tracker.ServiceTracker"]>
+
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -99,11 +99,7 @@ public interface ${entity.name}${sessionTypeName}Service
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
 			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.exception.PortalException", "com.liferay.portal.kernel.exception.SystemException", "com.liferay.portal.kernel.jsonwebservice.JSONWebService", "com.liferay.portal.kernel.transaction.Isolation", "com.liferay.portal.kernel.transaction.Propagation", "com.liferay.portal.kernel.transaction.Transactional", "com.liferay.portal.security.ac.AccessControlled", "com.liferay.portal.service.Base" + sessionTypeName + "Service", "com.liferay.portal.service.Invokable" + sessionTypeName + "Service", "com.liferay.portal.service.PermissionedModelLocalService", "com.liferay.portal.service.PersistedModelLocalService"]>
 
-			<#if sessionTypeName == "Local">
-				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType, existingImports)}
-			<#else>
-				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
-			</#if>
+			${serviceBuilder.getJavadocComment(method, entity.name, sessionTypeName, existingImports)}
 
 			<#list method.annotations as annotation>
 				<#if (annotation.type != "java.lang.Override") && (annotation.type != "java.lang.SuppressWarnings")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -97,10 +97,12 @@ public interface ${entity.name}${sessionTypeName}Service
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
+			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.exception.PortalException", "com.liferay.portal.kernel.exception.SystemException", "com.liferay.portal.kernel.jsonwebservice.JSONWebService", "com.liferay.portal.kernel.transaction.Isolation", "com.liferay.portal.kernel.transaction.Propagation", "com.liferay.portal.kernel.transaction.Transactional", "com.liferay.portal.security.ac.AccessControlled", "com.liferay.portal.service.Base" + sessionTypeName + "Service", "com.liferay.portal.service.Invokable" + sessionTypeName + "Service", "com.liferay.portal.service.PermissionedModelLocalService", "com.liferay.portal.service.PersistedModelLocalService"]>
+
 			<#if sessionTypeName == "Local">
-				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType)}
+				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType, existingImports)}
 			<#else>
-				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 			</#if>
 
 			<#list method.annotations as annotation>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service.ftl
@@ -97,7 +97,11 @@ public interface ${entity.name}${sessionTypeName}Service
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			<#if sessionTypeName == "Local">
+				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType)}
+			<#else>
+				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			</#if>
 
 			<#list method.annotations as annotation>
 				<#if (annotation.type != "java.lang.Override") && (annotation.type != "java.lang.SuppressWarnings")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -83,7 +83,7 @@ public class ${entity.name}ServiceSoap {
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
 			<#assign existingImports = [packagePath + ".service." + entity.name + "ServiceUtil", "aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.log.Log", "com.liferay.portal.kernel.log.LogFactoryUtil", "com.liferay.portal.kernel.util.ListUtil", "com.liferay.portal.kernel.util.LocaleUtil", "com.liferay.portal.kernel.util.LocalizationUtil", "java.rmi.RemoteException", "java.util.Locale", "java.util.Map"]>
 
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
+			${serviceBuilder.getJavadocComment(method, entity.name, "", existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -81,8 +81,9 @@ public class ${entity.name}ServiceSoap {
 			<#assign returnTypeGenericsName = serviceBuilder.getTypeGenericsName(method.returns)>
 			<#assign extendedModelName = packagePath + ".model." + entity.name>
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
+			<#assign existingImports = [packagePath + ".service." + entity.name + "ServiceUtil", "aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.log.Log", "com.liferay.portal.kernel.log.LogFactoryUtil", "com.liferay.portal.kernel.util.ListUtil", "com.liferay.portal.kernel.util.LocaleUtil", "com.liferay.portal.kernel.util.LocalizationUtil", "java.rmi.RemoteException", "java.util.Locale", "java.util.Map"]>
 
-			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_soap.ftl
@@ -82,7 +82,7 @@ public class ${entity.name}ServiceSoap {
 			<#assign extendedModelName = packagePath + ".model." + entity.name>
 			<#assign soapModelName = packagePath + ".model." + entity.name + "Soap">
 
-			${serviceBuilder.getJavadocComment(method)}
+			${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -66,11 +66,7 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
 			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.bean.PortalBeanLocatorUtil", "com.liferay.portal.kernel.bean.PortletBeanLocatorUtil", "com.liferay.portal.kernel.util.ReferenceRegistry", "com.liferay.portal.service.Invokable" + sessionTypeName + "Service", "org.osgi.framework.Bundle", "org.osgi.framework.FrameworkUtil", "org.osgi.util.tracker.ServiceTracker"]>
 
-			<#if sessionTypeName == "Local">
-				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType, existingImports)}
-			<#else>
-				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
-			</#if>
+			${serviceBuilder.getJavadocComment(method, entity.name, sessionTypeName, existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -64,7 +64,11 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			<#if sessionTypeName == "Local">
+				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType)}
+			<#else>
+				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			</#if>
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_util.ftl
@@ -64,10 +64,12 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 
 	<#list methods as method>
 		<#if !method.isConstructor() && !method.isStatic() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
+			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.kernel.bean.PortalBeanLocatorUtil", "com.liferay.portal.kernel.bean.PortletBeanLocatorUtil", "com.liferay.portal.kernel.util.ReferenceRegistry", "com.liferay.portal.service.Invokable" + sessionTypeName + "Service", "org.osgi.framework.Bundle", "org.osgi.framework.FrameworkUtil", "org.osgi.util.tracker.ServiceTracker"]>
+
 			<#if sessionTypeName == "Local">
-				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType)}
+				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType, existingImports)}
 			<#else>
-				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 			</#if>
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -30,11 +30,7 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
 			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.service.ServiceWrapper"]>
 
-			<#if sessionTypeName == "Local">
-				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType, existingImports)}
-			<#else>
-				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
-			</#if>
+			${serviceBuilder.getJavadocComment(method, entity.name, sessionTypeName, existingImports)}
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -28,10 +28,12 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
+			<#assign existingImports = ["aQute.bnd.annotation.ProviderType", "com.liferay.portal.service.ServiceWrapper"]>
+
 			<#if sessionTypeName == "Local">
-				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType)}
+				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType, existingImports)}
 			<#else>
-				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType, existingImports)}
 			</#if>
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>

--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/service_wrapper.ftl
@@ -28,7 +28,11 @@ public class ${entity.name}${sessionTypeName}ServiceWrapper implements ${entity.
 
 	<#list methods as method>
 		<#if !method.isConstructor() && method.isPublic() && serviceBuilder.isCustomMethod(method)>
-			${serviceBuilder.getJavadocComment(method)}
+			<#if sessionTypeName == "Local">
+				${serviceBuilder.getJavadocComment(method, entity.name, localSessionType)}
+			<#else>
+				${serviceBuilder.getJavadocComment(method, entity.name, remoteSessionType)}
+			</#if>
 
 			<#if serviceBuilder.hasAnnotation(method, "Deprecated")>
 				@Deprecated


### PR DESCRIPTION
Hi Brian,

This is part II of III PRs with changes to resolve Javadoc warnings. This PR's ftl files pass to SB an array of classes that it imports. We'll be able to use this array to make sure that a comment doesn't unnecessarily use a class's fully qualified path in an \@see or link reference.

This PR also gathers up a listing of classes accessible to the impl. The reason we're doing this is so we CAN use a class's fully qualified path if the generated class references it in a comment, but doesn't import the class. Often, an impl's comments will reference classes that the generated class (e.g. generated *SOAP class) doesn't import. 

Thanks,
Jim

code to gather up classes that a class imports and that 
