### PR TITLE
LPS-53386 PACLTestRule and CodeCoverageAssertor will never be used insid...

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/BaseTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/BaseTestRule.java
@@ -53,7 +53,7 @@ public class BaseTestRule<C, M> implements TestRule {
 				}
 
 				try {
-					invokeStatement(statement, description);
+					statement.evaluate();
 				}
 				finally {
 					if (methodName == null) {
@@ -120,12 +120,6 @@ public class BaseTestRule<C, M> implements TestRule {
 		}
 
 		throw new IllegalStateException("Unknow statement " + statement);
-	}
-
-	protected void invokeStatement(Statement statement, Description description)
-		throws Throwable {
-
-		statement.evaluate();
 	}
 
 	protected void setInstance(Object instance) {

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/CodeCoverageAssertor.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/CodeCoverageAssertor.java
@@ -28,12 +28,14 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 /**
  * @author Shuyang Zhou
  */
-public class CodeCoverageAssertor extends BaseTestRule<String, Object> {
+public class CodeCoverageAssertor implements TestRule {
 
 	public static final CodeCoverageAssertor INSTANCE =
 		new CodeCoverageAssertor();
@@ -54,6 +56,30 @@ public class CodeCoverageAssertor extends BaseTestRule<String, Object> {
 	}
 
 	@Override
+	public Statement apply(
+		final Statement statement, final Description description) {
+
+		if (description.getMethodName() != null) {
+			return statement;
+		}
+
+		return new Statement() {
+
+			@Override
+			public void evaluate() throws Throwable {
+				String className = beforeClass(description);
+
+				try {
+					statement.evaluate();
+				}
+				finally {
+					afterClass(description, className);
+				}
+			}
+
+		};
+	}
+
 	protected void afterClass(Description description, String className)
 		throws Exception {
 
@@ -74,7 +100,6 @@ public class CodeCoverageAssertor extends BaseTestRule<String, Object> {
 			assertClasses.toArray(new Class<?>[assertClasses.size()]));
 	}
 
-	@Override
 	protected String beforeClass(Description description) throws Exception {
 		String className = description.getClassName();
 


### PR DESCRIPTION
...e arquillian context, cut them out from the TestRule inheritance chain, so that they won't get into the way of TestRule logic extraction
