### PR TITLE
master-qa-12860

### DIFF
--- a/modules/test/poshi-runner/build.xml
+++ b/modules/test/poshi-runner/build.xml
@@ -13,7 +13,7 @@
 				<get
 					dest="lib/opencv-linux-x86_64.jar"
 					skipexisting="true"
-					src="https://search.maven.org/remotecontent?filepath=org/bytedeco/javacpp-presets/opencv/2.4.9-0.9/opencv-2.4.9-0.9-linux-x86_64.jar"
+					src="https://repo1.maven.org/maven2/org/bytedeco/javacpp-presets/opencv/2.4.9-0.9/opencv-2.4.9-0.9-linux-x86_64.jar"
 				/>
 			</then>
 		</if>

--- a/modules/test/poshi-runner/build.xml
+++ b/modules/test/poshi-runner/build.xml
@@ -6,7 +6,20 @@
 
 	<!--<property name="auto.deploy.dir" value="${liferay.home}/osgi/modules" />-->
 
-	<target name="start-poshi-runner" depends="compile">
+	<target name="prepare-sikuli" depends="compile">
+		<if>
+			<os family="unix" />
+			<then>
+				<get
+					dest="lib/opencv-linux-x86_64.jar"
+					skipexisting="true"
+					src="https://search.maven.org/remotecontent?filepath=org/bytedeco/javacpp-presets/opencv/2.4.9-0.9/opencv-2.4.9-0.9-linux-x86_64.jar"
+				/>
+			</then>
+		</if>
+	</target>
+
+	<target name="start-poshi-runner" depends="prepare-sikuli">
 		<fail message="Please set the property ${test.case.name}." unless="test.case.name" />
 
 		<mkdir dir="test-results" />

--- a/modules/test/poshi-runner/ivy.xml
+++ b/modules/test/poshi-runner/ivy.xml
@@ -24,5 +24,6 @@
 		<dependency name="junit" org="junit" rev="4.12" />
 		<dependency name="net.jsourcerer.webdriver.JSErrorCollector" org="com.liferay" rev="0.5-atlassian-2" />
 		<dependency name="selenium-java" org="org.seleniumhq.selenium" rev="2.44.0" />
+		<dependency name="sikuli-api" org="org.sikuli" rev="1.2.0" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
http://issues.liferay.com/browse/LIFERAYQA-12860

From @kenjiheigel 

<pre>@michaelhashimoto, a couple things I want to note.

The ivy dependency stuff requires michaelhashimoto/liferay-plugins-ee#19,
or else it will be missing javacpp.jar

I'm a little wary of how I went about getting the native linux dependency.
I'm not sure if we want all our servers hitting the maven repo, and I'm not sure
if we have our own repo that could potentially store that .jar file. I'm not sure
what other options we have though, but I think this could be improved.</pre>


@brianchandotcom -

I changed the URL to use this instead:
https://repo1.maven.org/maven2/org/bytedeco/javacpp-presets/opencv/2.4.9-0.9/opencv-2.4.9-0.9-linux-x86_64.jar

Because I noticed that we have a similar directory in mirrors:
http://mirrors/repo1.maven.org/maven2/org/

If we potentially add this jar to mirrors we can check before downloading directly from maven.

Let me know what you think!  Thanks!
