### PR TITLE
LPS-50479 This is actually not necessary, as PortalBeanLocatorUtil.locat...

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/test/BeanLocatorTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/test/BeanLocatorTest.java
@@ -162,7 +162,7 @@ public class BeanLocatorTest {
 	@Test
 	public void testPortal4() throws Exception {
 		try {
-			PortalBeanLocatorUtil.locate(SAXReader.class);
+			PortalBeanLocatorUtil.locate(SAXReaderUtil.class);
 		}
 		catch (SecurityException se) {
 			Assert.fail();


### PR DESCRIPTION
...e(Class<?>) does not fail on missing beans. But let's keep code consistent.
