### PR TITLE
LPS-53602 portal-ldap - LDAP User importer never imports portrait image

### DIFF
--- a/modules/portal/portal-ldap/src/com/liferay/portal/ldap/exportimport/LDAPUserImporterImpl.java
+++ b/modules/portal/portal-ldap/src/com/liferay/portal/ldap/exportimport/LDAPUserImporterImpl.java
@@ -1380,7 +1380,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 	private static final String[] _USER_PROPERTY_NAMES = {
 		"comments", "emailAddress", "firstName", "greeting", "jobTitle",
-		"languageId", "lastName", "middleName", "openId", "timeZoneId"
+		"languageId", "lastName", "middleName", "openId", "portraitId",
+		"timeZoneId"
 	};
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
Hi Brian, Im resolving one ticket for LCS and it led me to this problem. Im submitting this to master, but Im not sure how to port it to ee-6.2.x to be able to use this at LCS Portal. Thank you. @ivicac PS. Im also updating vLdap plugin, but it is different PR.
