### PR TITLE
LPS-52728 Structure field types are not sorted correctly in the Asset Publisher

### DIFF
--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/ElasticsearchIndexSearcher.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/ElasticsearchIndexSearcher.java
@@ -341,7 +341,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 			return;
 		}
 
-		Set<String> sortFieldNames = new HashSet<>();
+		Set<String> sortFieldNames = new HashSet<>(sorts.length);
 
 		for (Sort sort : sorts) {
 			if (sort == null) {

--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/document/DefaultElasticsearchDocumentFactory.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/document/DefaultElasticsearchDocumentFactory.java
@@ -197,10 +197,9 @@ public class DefaultElasticsearchDocumentFactory
 		else {
 			Class<?> numericClass = field.getNumericClass();
 
-			if (numericClass.equals(BigDecimal.class)) {
-				return new BigDecimal(value);
-			}
-			else if (numericClass.equals(Double.class)) {
+			if (numericClass.equals(BigDecimal.class) ||
+				numericClass.equals(Double.class)) {
+
 				return Double.valueOf(value);
 			}
 			else if (numericClass.equals(Float.class)) {

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -76,7 +76,7 @@ import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.dynamicdatalists.model.DDLRecord;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
 import com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalServiceUtil;
-import com.liferay.portlet.dynamicdatamapping.util.DDMIndexerImpl;
+import com.liferay.portlet.dynamicdatamapping.util.DDMIndexer;
 import com.liferay.portlet.journal.model.JournalArticle;
 
 import java.io.Serializable;
@@ -820,11 +820,9 @@ public class AssetUtil {
 
 		int sortType = getSortType(sortField);
 
-		if (sortField.startsWith(
-				DDMIndexerImpl.DDM_FIELD_NAMESPACE +
-					StringPool.DOUBLE_UNDERLINE)) {
-
-			String[] sortFields = sortField.split(StringPool.DOUBLE_UNDERLINE);
+		if (sortField.startsWith(DDMIndexer.DDM_FIELD_PREFIX)) {
+			String[] sortFields = sortField.split(
+				DDMIndexer.DDM_FIELD_SEPARATOR);
 
 			long ddmStructureId = GetterUtil.getLong(sortFields[1]);
 			String fieldName = sortFields[2];

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLFileEntryIndexer.java
@@ -73,6 +73,7 @@ import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
 import com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
 import com.liferay.portlet.dynamicdatamapping.storage.StorageEngineUtil;
+import com.liferay.portlet.dynamicdatamapping.util.DDMIndexer;
 import com.liferay.portlet.dynamicdatamapping.util.DDMIndexerUtil;
 import com.liferay.portlet.dynamicdatamapping.util.DDMUtil;
 import com.liferay.portlet.expando.model.ExpandoBridge;
@@ -207,7 +208,7 @@ public class DLFileEntryIndexer extends BaseIndexer {
 			Validator.isNotNull(ddmStructureFieldValue)) {
 
 			String[] ddmStructureFieldNameParts = StringUtil.split(
-				ddmStructureFieldName, StringPool.DOUBLE_UNDERLINE);
+				ddmStructureFieldName, DDMIndexer.DDM_FIELD_SEPARATOR);
 
 			DDMStructure structure = DDMStructureLocalServiceUtil.getStructure(
 				GetterUtil.getLong(ddmStructureFieldNameParts[1]));

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/model/impl/DDMStructureImpl.java
@@ -124,7 +124,8 @@ public class DDMStructureImpl extends DDMStructureBaseImpl {
 		DDMFormField ddmFormField = ddmFormFieldsMap.get(fieldName);
 
 		if (ddmFormField == null) {
-			throw new StructureFieldException();
+			throw new StructureFieldException(
+				"Unable to find field " + fieldName);
 		}
 
 		return ddmFormField;

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -1524,15 +1524,13 @@ public class DDMStructureLocalServiceImpl
 
 		// Indexer
 
-		Indexer indexer = IndexerRegistryUtil.getIndexer(
+		Indexer indexer = IndexerRegistryUtil.nullSafeGetIndexer(
 			structure.getClassName());
 
-		if (indexer != null) {
-			List<Long> ddmStructureIds = getChildrenStructureIds(
-				structure.getGroupId(), structure.getStructureId());
+		List<Long> ddmStructureIds = getChildrenStructureIds(
+			structure.getGroupId(), structure.getStructureId());
 
-			indexer.reindexDDMStructures(ddmStructureIds);
-		}
+		indexer.reindexDDMStructures(ddmStructureIds);
 
 		return structure;
 	}

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
@@ -276,6 +276,11 @@ public class DDMIndexerImpl implements DDMIndexer {
 		return sb.toString();
 	}
 
+	@Override
+	public boolean isSortableFieldName(String fieldName) {
+		return fieldName.startsWith(DDMIndexer.DDM_FIELD_PREFIX);
+	}
+
 	protected Fields toFields(
 		DDMStructure ddmStructure, DDMFormValues ddmFormValues) {
 

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
@@ -38,6 +38,8 @@ import com.liferay.portlet.dynamicdatamapping.storage.Fields;
 
 import java.io.Serializable;
 
+import java.math.BigDecimal;
+
 import java.text.Format;
 
 import java.util.Date;
@@ -75,7 +77,13 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 					Serializable value = field.getValue(locale);
 
-					if (value instanceof Boolean) {
+					if (value instanceof BigDecimal) {
+						document.addNumber(name, (BigDecimal)value);
+					}
+					else if (value instanceof BigDecimal[]) {
+						document.addNumber(name, (BigDecimal[])value);
+					}
+					else if (value instanceof Boolean) {
 						document.addKeyword(name, (Boolean)value);
 					}
 					else if (value instanceof Boolean[]) {

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
@@ -177,10 +177,9 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 		StringBundler sb = new StringBundler(7);
 
-		sb.append(DDM_FIELD_NAMESPACE);
-		sb.append(StringPool.DOUBLE_UNDERLINE);
+		sb.append(DDM_FIELD_PREFIX);
 		sb.append(ddmStructureId);
-		sb.append(StringPool.DOUBLE_UNDERLINE);
+		sb.append(DDM_FIELD_SEPARATOR);
 		sb.append(fieldName);
 
 		if (locale != null) {

--- a/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoBridgeImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoBridgeImpl.java
@@ -397,15 +397,13 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 			return;
 		}
 
-		Indexer indexer = IndexerRegistryUtil.getIndexer(_className);
+		Indexer indexer = IndexerRegistryUtil.nullSafeGetIndexer(_className);
 
-		if (indexer != null) {
-			try {
-				indexer.reindex(_className, _classPK);
-			}
-			catch (Exception e) {
-				throw new RuntimeException(e);
-			}
+		try {
+			indexer.reindex(_className, _classPK);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/journal/util/JournalArticleIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/journal/util/JournalArticleIndexer.java
@@ -54,6 +54,7 @@ import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
 import com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
 import com.liferay.portlet.dynamicdatamapping.storage.Fields;
+import com.liferay.portlet.dynamicdatamapping.util.DDMIndexer;
 import com.liferay.portlet.dynamicdatamapping.util.DDMIndexerUtil;
 import com.liferay.portlet.dynamicdatamapping.util.DDMUtil;
 import com.liferay.portlet.dynamicdatamapping.util.FieldsToDDMFormValuesConverterUtil;
@@ -156,7 +157,7 @@ public class JournalArticleIndexer extends BaseIndexer {
 			Validator.isNotNull(ddmStructureFieldValue)) {
 
 			String[] ddmStructureFieldNameParts = StringUtil.split(
-				ddmStructureFieldName, StringPool.DOUBLE_UNDERLINE);
+				ddmStructureFieldName, DDMIndexer.DDM_FIELD_SEPARATOR);
 
 			DDMStructure structure = DDMStructureLocalServiceUtil.getStructure(
 				GetterUtil.getLong(ddmStructureFieldNameParts[1]));

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
@@ -134,43 +134,37 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 				searchContext));
 	}
 
-	@Override
-	protected BaseModel<?> addBaseModelWithDDMStructure(
-			BaseModel<?> parentBaseModel, String keywords,
+	protected BaseModel<?> addBaseModel(
+			String keywords, DDMStructure ddmStructure,
 			ServiceContext serviceContext)
 		throws Exception {
 
-		String definition = DDMStructureTestUtil.getSampleStructureDefinition(
-			"name");
-
-		_ddmStructure = DDMStructureTestUtil.addStructure(
-			serviceContext.getScopeGroupId(), DLFileEntry.class.getName(),
-			definition);
+		_ddmStructure = ddmStructure;
 
 		DLFileEntryType dlFileEntryType =
 			DLFileEntryTypeLocalServiceUtil.addFileEntryType(
 				TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
 				"Structure", StringPool.BLANK,
-				new long[] {_ddmStructure.getStructureId()}, serviceContext);
+				new long[] {ddmStructure.getStructureId()}, serviceContext);
 
 		String content = "Content: Enterprise. Open Source. For Life.";
 
 		Fields fields = new Fields();
 
 		Field textField = new Field(
-			_ddmStructure.getStructureId(), "name", getSearchKeywords());
+			ddmStructure.getStructureId(), "name", keywords);
 
 		textField.setDefaultLocale(LocaleUtil.US);
 
 		fields.put(textField);
 
 		DDMFormValues ddmFormValues =
-			FieldsToDDMFormValuesConverterUtil.convert(_ddmStructure, fields);
+			FieldsToDDMFormValuesConverterUtil.convert(ddmStructure, fields);
 
 		serviceContext.setAttribute(
 			"fileEntryTypeId",dlFileEntryType.getFileEntryTypeId());
 		serviceContext.setAttribute(
-			DDMFormValues.class.getName() + _ddmStructure.getStructureId(),
+			DDMFormValues.class.getName() + ddmStructure.getStructureId(),
 			ddmFormValues);
 
 		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
@@ -180,6 +174,22 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			WorkflowConstants.ACTION_PUBLISH, serviceContext);
 
 		return (DLFileEntry)fileEntry.getModel();
+	}
+
+	@Override
+	protected BaseModel<?> addBaseModelWithDDMStructure(
+			BaseModel<?> parentBaseModel, String keywords,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		String definition = DDMStructureTestUtil.getSampleStructureDefinition(
+			"name");
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			serviceContext.getScopeGroupId(), DLFileEntry.class.getName(),
+			definition);
+
+		return addBaseModel(keywords, ddmStructure, serviceContext);
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
@@ -107,7 +107,6 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		orderTestHelper.orderByDDMIntegerField();
 	}
 
-	@Ignore
 	@Test
 	public void testOrderByDDMNumberField() throws Exception {
 		TestOrderHelper orderTestHelper = new DLFileEntrySearchTestOrderHelper(

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
@@ -35,10 +35,12 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.search.test.BaseSearchTestCase;
+import com.liferay.portal.search.test.TestOrderHelper;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.MainServletTestRule;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
+import com.liferay.portlet.documentlibrary.model.DLFileEntryMetadata;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryType;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
@@ -51,6 +53,7 @@ import com.liferay.portlet.dynamicdatamapping.io.DDMFormXSDDeserializerUtil;
 import com.liferay.portlet.dynamicdatamapping.model.DDMForm;
 import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayout;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
+import com.liferay.portlet.dynamicdatamapping.model.DDMTemplate;
 import com.liferay.portlet.dynamicdatamapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
 import com.liferay.portlet.dynamicdatamapping.storage.Field;
@@ -86,6 +89,41 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	@Override
 	@Test
 	public void testLocalizedSearch() throws Exception {
+	}
+
+	@Ignore
+	@Test
+	public void testOrderByDDMBooleanField() throws Exception {
+		TestOrderHelper orderTestHelper = new DLFileEntrySearchTestOrderHelper(
+			group);
+
+		orderTestHelper.orderByDDMBooleanField();
+	}
+
+	@Test
+	public void testOrderByDDMIntegerField() throws Exception {
+		TestOrderHelper orderTestHelper = new DLFileEntrySearchTestOrderHelper(
+			group);
+
+		orderTestHelper.orderByDDMIntegerField();
+	}
+
+	@Ignore
+	@Test
+	public void testOrderByDDMNumberField() throws Exception {
+		TestOrderHelper orderTestHelper = new DLFileEntrySearchTestOrderHelper(
+			group);
+
+		orderTestHelper.orderByDDMNumberField();
+	}
+
+	@Ignore
+	@Test
+	public void testOrderByDDMTextField() throws Exception {
+		TestOrderHelper orderTestHelper = new DLFileEntrySearchTestOrderHelper(
+			group);
+
+		orderTestHelper.orderByDDMTextField();
 	}
 
 	@Ignore()
@@ -162,16 +200,22 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			FieldsToDDMFormValuesConverterUtil.convert(ddmStructure, fields);
 
 		serviceContext.setAttribute(
-			"fileEntryTypeId",dlFileEntryType.getFileEntryTypeId());
+			"fileEntryTypeId", dlFileEntryType.getFileEntryTypeId());
 		serviceContext.setAttribute(
 			DDMFormValues.class.getName() + ddmStructure.getStructureId(),
 			ddmFormValues);
 
+		long repositoryId = serviceContext.getScopeGroupId();
+		long folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+		String sourceFileName = "Text.txt";
+		String mimeType = ContentTypes.TEXT_PLAIN;
+		String title = RandomTestUtil.randomString();
+		byte[] bytes = content.getBytes();
+		int workflowAction = WorkflowConstants.ACTION_PUBLISH;
+
 		FileEntry fileEntry = DLAppTestUtil.addFileEntry(
-			serviceContext.getScopeGroupId(),
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, "Text.txt",
-			ContentTypes.TEXT_PLAIN, "Title", content.getBytes(),
-			WorkflowConstants.ACTION_PUBLISH, serviceContext);
+			repositoryId, folderId, sourceFileName, mimeType, title, bytes,
+			workflowAction, serviceContext);
 
 		return (DLFileEntry)fileEntry.getModel();
 	}
@@ -341,6 +385,44 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 			_ddmStructure.getParentStructureId(), _ddmStructure.getNameMap(),
 			_ddmStructure.getDescriptionMap(), ddmForm, ddmFormLayout,
 			serviceContext);
+	}
+
+	protected class DLFileEntrySearchTestOrderHelper extends TestOrderHelper {
+
+		protected DLFileEntrySearchTestOrderHelper(Group group)
+			throws Exception {
+
+			super(group);
+		}
+
+		@Override
+		protected BaseModel<?> addSearchableAsset(
+				BaseModel<?> parentBaseModel, String keywords,
+				DDMStructure ddmStructure, DDMTemplate ddmTemplate,
+				ServiceContext serviceContext)
+			throws Exception {
+
+			return addBaseModel(keywords, ddmStructure, serviceContext);
+		}
+
+		@Override
+		protected String getSearchableAssetClassName() {
+			return getBaseModelClassName();
+		}
+
+		@Override
+		protected BaseModel<?> getSearchableAssetParentBaseModel(
+				Group group, ServiceContext serviceContext)
+			throws Exception {
+
+			return getParentBaseModel(group, serviceContext);
+		}
+
+		@Override
+		protected String getSearchableAssetStructureClassName() {
+			return DLFileEntryMetadata.class.getName();
+		}
+
 	}
 
 	private static final int _FOLDER_NAME_MAX_LENGTH = 100;

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFileEntrySearchTest.java
@@ -91,7 +91,6 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	public void testLocalizedSearch() throws Exception {
 	}
 
-	@Ignore
 	@Test
 	public void testOrderByDDMBooleanField() throws Exception {
 		TestOrderHelper orderTestHelper = new DLFileEntrySearchTestOrderHelper(
@@ -117,7 +116,6 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 		orderTestHelper.orderByDDMNumberField();
 	}
 
-	@Ignore
 	@Test
 	public void testOrderByDDMTextField() throws Exception {
 		TestOrderHelper orderTestHelper = new DLFileEntrySearchTestOrderHelper(

--- a/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
@@ -94,7 +94,6 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 		assertEquals(0, query, searchContext);
 	}
 
-	@Ignore
 	@Test
 	public void testOrderByDDMBooleanField() throws Exception {
 		TestOrderHelper orderTestHelper =
@@ -120,7 +119,6 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 		orderTestHelper.orderByDDMNumberField();
 	}
 
-	@Ignore
 	@Test
 	public void testOrderByDDMTextField() throws Exception {
 		TestOrderHelper orderTestHelper =

--- a/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
@@ -99,30 +99,43 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 	public void testSearchAttachments() throws Exception {
 	}
 
+	protected BaseModel<?> addBaseModel(
+			BaseModel<?> parentBaseModel, String keywords,
+			DDMStructure ddmStructure, DDMTemplate ddmTemplate,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		_ddmStructure = ddmStructure;
+
+		JournalFolder folder = (JournalFolder)parentBaseModel;
+
+		String content = DDMStructureTestUtil.getSampleStructuredContent(
+			"name", keywords);
+
+		return JournalTestUtil.addArticleWithXMLContent(
+			folder.getFolderId(), content, ddmStructure.getStructureKey(),
+			ddmTemplate.getTemplateKey(), serviceContext);
+	}
+
 	@Override
 	protected BaseModel<?> addBaseModelWithDDMStructure(
 			BaseModel<?> parentBaseModel, String keywords,
 			ServiceContext serviceContext)
 		throws Exception {
 
-		JournalFolder folder = (JournalFolder)parentBaseModel;
-
 		String definition = DDMStructureTestUtil.getSampleStructureDefinition(
 			"name");
 
-		_ddmStructure = DDMStructureTestUtil.addStructure(
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			serviceContext.getScopeGroupId(), JournalArticle.class.getName(),
 			definition);
 
 		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
-			serviceContext.getScopeGroupId(), _ddmStructure.getStructureId());
+			serviceContext.getScopeGroupId(), ddmStructure.getStructureId());
 
-		String content = DDMStructureTestUtil.getSampleStructuredContent(
-			"name", getSearchKeywords());
-
-		return JournalTestUtil.addArticleWithXMLContent(
-			folder.getFolderId(), content, _ddmStructure.getStructureKey(),
-			ddmTemplate.getTemplateKey(), serviceContext);
+		return addBaseModel(
+			parentBaseModel, keywords, ddmStructure, ddmTemplate,
+			serviceContext);
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
@@ -110,7 +110,6 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 		orderTestHelper.orderByDDMIntegerField();
 	}
 
-	@Ignore
 	@Test
 	public void testOrderByDDMNumberField() throws Exception {
 		TestOrderHelper orderTestHelper =

--- a/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/journal/search/JournalArticleSearchTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.model.ClassedModel;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.search.test.BaseSearchTestCase;
+import com.liferay.portal.search.test.TestOrderHelper;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.MainServletTestRule;
@@ -91,6 +92,41 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 		query.addTerm("title", RandomTestUtil.randomString());
 
 		assertEquals(0, query, searchContext);
+	}
+
+	@Ignore
+	@Test
+	public void testOrderByDDMBooleanField() throws Exception {
+		TestOrderHelper orderTestHelper =
+			new JournalArticleSearchTestOrderHelper(group);
+
+		orderTestHelper.orderByDDMBooleanField();
+	}
+
+	@Test
+	public void testOrderByDDMIntegerField() throws Exception {
+		TestOrderHelper orderTestHelper =
+			new JournalArticleSearchTestOrderHelper(group);
+
+		orderTestHelper.orderByDDMIntegerField();
+	}
+
+	@Ignore
+	@Test
+	public void testOrderByDDMNumberField() throws Exception {
+		TestOrderHelper orderTestHelper =
+			new JournalArticleSearchTestOrderHelper(group);
+
+		orderTestHelper.orderByDDMNumberField();
+	}
+
+	@Ignore
+	@Test
+	public void testOrderByDDMTextField() throws Exception {
+		TestOrderHelper orderTestHelper =
+			new JournalArticleSearchTestOrderHelper(group);
+
+		orderTestHelper.orderByDDMTextField();
 	}
 
 	@Ignore()
@@ -328,6 +364,47 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 			_ddmStructure.getParentStructureId(), _ddmStructure.getNameMap(),
 			_ddmStructure.getDescriptionMap(), ddmForm, ddmFormLayout,
 			serviceContext);
+	}
+
+	protected class JournalArticleSearchTestOrderHelper
+		extends TestOrderHelper {
+
+		protected JournalArticleSearchTestOrderHelper(Group group)
+			throws Exception {
+
+			super(group);
+		}
+
+		@Override
+		protected BaseModel<?> addSearchableAsset(
+				BaseModel<?> parentBaseModel, String keywords,
+				DDMStructure ddmStructure, DDMTemplate ddmTemplate,
+				ServiceContext serviceContext)
+			throws Exception {
+
+			return addBaseModel(
+				parentBaseModel, keywords, ddmStructure, ddmTemplate,
+				serviceContext);
+		}
+
+		@Override
+		protected String getSearchableAssetClassName() {
+			return getBaseModelClassName();
+		}
+
+		@Override
+		protected BaseModel<?> getSearchableAssetParentBaseModel(
+				Group group, ServiceContext serviceContext)
+			throws Exception {
+
+			return getParentBaseModel(group, serviceContext);
+		}
+
+		@Override
+		protected String getSearchableAssetStructureClassName() {
+			return getBaseModelClassName();
+		}
+
 	}
 
 	private DDMStructure _ddmStructure;

--- a/portal-service/src/com/liferay/portal/kernel/search/Document.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/Document.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
+import java.math.BigDecimal;
+
 import java.text.ParseException;
 
 import java.util.Date;
@@ -126,6 +128,10 @@ public interface Document extends Cloneable, Serializable {
 	 */
 	@Deprecated
 	public void addModifiedDate(Date modifiedDate);
+
+	public void addNumber(String name, BigDecimal value);
+
+	public void addNumber(String name, BigDecimal[] values);
 
 	public void addNumber(String name, double value);
 

--- a/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -78,23 +78,17 @@ public class DocumentImpl implements Document {
 
 		String fieldName = sort.getFieldName();
 
-		if (fieldName.endsWith(_SORTABLE_FIELD_SUFFIX)) {
+		if (DocumentImpl.isSortableFieldName(fieldName)) {
 			return fieldName;
 		}
 
-		String sortFieldName = null;
+		if ((sort.getType() == Sort.STRING_TYPE) &&
+			!DocumentImpl.isSortableTextField(fieldName)) {
 
-		if (DocumentImpl.isSortableTextField(fieldName) ||
-			(sort.getType() != Sort.STRING_TYPE)) {
-
-			sortFieldName = DocumentImpl.getSortableFieldName(fieldName);
+			return scoreFieldName;
 		}
 
-		if (Validator.isNull(sortFieldName)) {
-			sortFieldName = scoreFieldName;
-		}
-
-		return sortFieldName;
+		return DocumentImpl.getSortableFieldName(fieldName);
 	}
 
 	public static boolean isSortableFieldName(String name) {

--- a/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -36,6 +36,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.Format;
 import java.text.ParseException;
@@ -453,6 +455,16 @@ public class DocumentImpl implements Document {
 	@Override
 	public void addModifiedDate(Date modifiedDate) {
 		addDate(Field.MODIFIED, modifiedDate);
+	}
+
+	@Override
+	public void addNumber(String name, BigDecimal value) {
+		addNumber(name, String.valueOf(value), BigDecimal.class);
+	}
+
+	@Override
+	public void addNumber(String name, BigDecimal[] values) {
+		addNumber(name, ArrayUtil.toStringArray(values), BigDecimal.class);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portlet.dynamicdatamapping.util.DDMIndexerUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -79,6 +80,10 @@ public class DocumentImpl implements Document {
 		String fieldName = sort.getFieldName();
 
 		if (DocumentImpl.isSortableFieldName(fieldName)) {
+			return fieldName;
+		}
+
+		if (DDMIndexerUtil.isSortableFieldName(fieldName)) {
 			return fieldName;
 		}
 

--- a/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/persistence/AssetEntryQuery.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -59,9 +58,7 @@ public class AssetEntryQuery {
 	public static String checkOrderByCol(String orderByCol) {
 		if (ArrayUtil.contains(ORDER_BY_COLUMNS, orderByCol) ||
 			((orderByCol != null) &&
-			 orderByCol.startsWith(
-				DDMIndexer.DDM_FIELD_NAMESPACE +
-					StringPool.DOUBLE_UNDERLINE))) {
+			 orderByCol.startsWith(DDMIndexer.DDM_FIELD_PREFIX))) {
 
 			return orderByCol;
 		}

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexer.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexer.java
@@ -46,4 +46,6 @@ public interface DDMIndexer {
 	public String extractIndexableAttributes(
 		DDMStructure ddmStructure, DDMFormValues ddmFormValues, Locale locale);
 
+	public boolean isSortableFieldName(String fieldName);
+
 }

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexer.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexer.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.dynamicdatamapping.util;
 
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
 import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
 
@@ -26,6 +27,12 @@ import java.util.Locale;
 public interface DDMIndexer {
 
 	public static final String DDM_FIELD_NAMESPACE = "ddm";
+
+	public static final String DDM_FIELD_PREFIX =
+		DDMIndexer.DDM_FIELD_NAMESPACE + DDMIndexer.DDM_FIELD_SEPARATOR;
+
+	public static final String DDM_FIELD_SEPARATOR =
+		StringPool.DOUBLE_UNDERLINE;
 
 	public void addAttributes(
 		Document document, DDMStructure ddmStructure,

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerUtil.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerUtil.java
@@ -56,6 +56,10 @@ public class DDMIndexerUtil {
 		return _ddmIndexer;
 	}
 
+	public static boolean isSortableFieldName(String fieldName) {
+		return getDDMIndexer().isSortableFieldName(fieldName);
+	}
+
 	public void setDDMIndexer(DDMIndexer ddmIndexer) {
 		PortalRuntimePermission.checkSetBeanProperty(getClass());
 

--- a/portal-test-internal/src/com/liferay/portal/search/test/TestOrderHelper.java
+++ b/portal-test-internal/src/com/liferay/portal/search/test/TestOrderHelper.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.test.IdempotentRetryAssert;
+import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.model.BaseModel;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.service.ServiceContext;
+import com.liferay.portlet.asset.AssetRendererFactoryRegistryUtil;
+import com.liferay.portlet.asset.model.AssetEntry;
+import com.liferay.portlet.asset.model.AssetRenderer;
+import com.liferay.portlet.asset.model.AssetRendererFactory;
+import com.liferay.portlet.asset.model.DDMFormValuesReader;
+import com.liferay.portlet.asset.service.persistence.AssetEntryQuery;
+import com.liferay.portlet.asset.service.persistence.test.AssetEntryQueryTestUtil;
+import com.liferay.portlet.asset.util.AssetUtil;
+import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
+import com.liferay.portlet.dynamicdatamapping.model.DDMTemplate;
+import com.liferay.portlet.dynamicdatamapping.model.Value;
+import com.liferay.portlet.dynamicdatamapping.storage.DDMFormFieldValue;
+import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
+import com.liferay.portlet.dynamicdatamapping.util.DDMIndexerUtil;
+import com.liferay.portlet.dynamicdatamapping.util.test.DDMStructureTestUtil;
+import com.liferay.portlet.dynamicdatamapping.util.test.DDMTemplateTestUtil;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+
+/**
+ * @author Preston Crary
+ * @author André de Oliveira
+ */
+public abstract class TestOrderHelper {
+
+	public void orderByDDMBooleanField() throws Exception {
+		orderByDDMField(
+			new String[] {"false", "true", "false", "true"},
+			new String[] {"false", "false", "true", "true"}, "boolean",
+			"checkbox");
+	}
+
+	public void orderByDDMIntegerField() throws Exception {
+		orderByDDMField(
+			new String[] {"1", "10", "3", "2"},
+			new String[] {"1", "2", "3", "10"}, "integer", "ddm-integer");
+	}
+
+	public void orderByDDMNumberField() throws Exception {
+		orderByDDMField(
+			new String[] {"3", "3.14", "12.34", "2.72", "1.41", "23.45", "20"},
+			new String[] {"1.41", "2.72", "3", "3.14", "12.34", "20", "23.45"},
+			"number", "ddm-number");
+	}
+
+	public void orderByDDMTextField() throws Exception {
+		orderByDDMField(
+			new String[] {"A", "D", "C", "B"},
+			new String[] {"A", "B", "C", "D"}, "string", "text");
+	}
+
+	protected TestOrderHelper(Group group) throws Exception {
+		_group = group;
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			group.getGroupId());
+	}
+
+	protected abstract BaseModel<?> addSearchableAsset(
+			BaseModel<?> parentBaseModel, String keywords,
+			DDMStructure ddmStructure, DDMTemplate ddmTemplate,
+			ServiceContext serviceContext)
+		throws Exception;
+
+	protected abstract String getSearchableAssetClassName();
+
+	protected abstract BaseModel<?> getSearchableAssetParentBaseModel(
+		Group group, ServiceContext serviceContext) throws Exception;
+
+	protected abstract String getSearchableAssetStructureClassName();
+
+	protected void orderByDDMField(
+			String[] unsortedValues, final String[] sortedValues,
+			String dataType, String type)
+		throws Exception {
+
+		DDMStructure ddmStructure = _addStructure(dataType, type);
+
+		DDMTemplate ddmTemplate = _addTemplate(ddmStructure);
+
+		_addSearchableAssets(unsortedValues, ddmStructure, ddmTemplate);
+
+		final AssetEntryQuery assetEntryQuery = _createAssetEntryQuery(
+			ddmStructure);
+
+		final AssetRendererFactory assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				getSearchableAssetClassName());
+
+		IdempotentRetryAssert.retryAssert(
+			3, TimeUnit.SECONDS,
+			new Callable<Void>() {
+
+				@Override
+				public Void call() throws Exception {
+					_assertArrayEquals(
+						sortedValues, assetEntryQuery, assetRendererFactory);
+
+					return null;
+				}
+
+			});
+	}
+
+	private void _addSearchableAssets(
+			String[] unsortedValues, DDMStructure ddmStructure,
+			DDMTemplate ddmTemplate)
+		throws Exception {
+
+		BaseModel<?> parentBaseModel = getSearchableAssetParentBaseModel(
+			_group, _serviceContext);
+
+		for (String unsortedValue : unsortedValues) {
+			addSearchableAsset(
+				parentBaseModel, unsortedValue, ddmStructure, ddmTemplate,
+				_serviceContext);
+		}
+	}
+
+	private DDMStructure _addStructure(String dataType, String type)
+		throws Exception {
+
+		String definition = DDMStructureTestUtil.getSampleStructureDefinition(
+			"name", dataType, false, type, new Locale[] {LocaleUtil.US},
+			LocaleUtil.US);
+
+		return DDMStructureTestUtil.addStructure(
+			_serviceContext.getScopeGroupId(),
+			getSearchableAssetStructureClassName(), definition);
+	}
+
+	private DDMTemplate _addTemplate(DDMStructure ddmStructure)
+		throws Exception {
+
+		return DDMTemplateTestUtil.addTemplate(
+			_serviceContext.getScopeGroupId(), ddmStructure.getStructureId());
+	}
+
+	private void _assertArrayEquals(
+			String[] sortedValues, AssetEntryQuery assetEntryQuery,
+			AssetRendererFactory assetRendererFactory)
+		throws Exception {
+
+		Hits hits = _search(assetEntryQuery);
+
+		List<AssetEntry> assetEntries = AssetUtil.getAssetEntries(hits);
+
+		String[] values = new String[assetEntries.size()];
+
+		for (int i = 0; i < assetEntries.size(); i++) {
+			AssetEntry assetEntry = assetEntries.get(i);
+
+			AssetRenderer assetRenderer = assetRendererFactory.getAssetRenderer(
+				assetEntry.getClassPK());
+
+			values[i] = _getValue(assetRenderer);
+		}
+
+		Assert.assertArrayEquals(sortedValues, values);
+	}
+
+	private AssetEntryQuery _createAssetEntryQuery(DDMStructure ddmStructure)
+		throws Exception {
+
+		AssetEntryQuery assetEntryQuery =
+			AssetEntryQueryTestUtil.createAssetEntryQuery(
+				_group.getGroupId(),
+				new String[]{getSearchableAssetClassName()});
+
+		String orderByCol1 = DDMIndexerUtil.encodeName(
+			ddmStructure.getStructureId(), "name");
+
+		assetEntryQuery.setOrderByCol1(orderByCol1);
+		assetEntryQuery.setOrderByType1("asc");
+
+		return assetEntryQuery;
+	}
+
+	private String _getValue(AssetRenderer assetRenderer) throws Exception {
+		DDMFormValuesReader ddmFormValuesReader =
+			assetRenderer.getDDMFormValuesReader();
+
+		DDMFormValues ddmFormValues = ddmFormValuesReader.getDDMFormValues();
+
+		Map<String, List<DDMFormFieldValue>> map =
+			ddmFormValues.getDDMFormFieldValuesMap();
+
+		List<DDMFormFieldValue> list = map.get("name");
+
+		DDMFormFieldValue ddmFormFieldValue = list.get(0);
+
+		Value value = ddmFormFieldValue.getValue();
+
+		return value.getString(LocaleUtil.getDefault());
+	}
+
+	private Hits _search(AssetEntryQuery assetEntryQuery) throws Exception {
+		SearchContext searchContext = SearchContextTestUtil.getSearchContext();
+
+		searchContext.setGroupIds(assetEntryQuery.getGroupIds());
+
+		return AssetUtil.search(
+			searchContext, assetEntryQuery, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS);
+	}
+
+	private final Group _group;
+	private final ServiceContext _serviceContext;
+
+}

--- a/portal-test-internal/src/com/liferay/portal/search/test/TestOrderHelper.java
+++ b/portal-test-internal/src/com/liferay/portal/search/test/TestOrderHelper.java
@@ -17,6 +17,8 @@ package com.liferay.portal.search.test;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngine;
+import com.liferay.portal.kernel.search.SearchEngineUtil;
 import com.liferay.portal.kernel.test.IdempotentRetryAssert;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -48,6 +50,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
+import org.junit.Assume;
 
 /**
  * @author Preston Crary
@@ -69,6 +72,8 @@ public abstract class TestOrderHelper {
 	}
 
 	public void orderByDDMNumberField() throws Exception {
+		Assume.assumeTrue(isOrderByDDMNumberFieldImplementedForSearchEngine());
+
 		orderByDDMField(
 			new String[] {"3", "3.14", "12.34", "2.72", "1.41", "23.45", "20"},
 			new String[] {"1.41", "2.72", "3", "3.14", "12.34", "20", "23.45"},
@@ -100,6 +105,19 @@ public abstract class TestOrderHelper {
 		Group group, ServiceContext serviceContext) throws Exception;
 
 	protected abstract String getSearchableAssetStructureClassName();
+
+	protected boolean isOrderByDDMNumberFieldImplementedForSearchEngine() {
+		SearchEngine searchEngine = SearchEngineUtil.getSearchEngine(
+			SearchEngineUtil.getDefaultSearchEngineId());
+
+		String vendor = searchEngine.getVendor();
+
+		if (vendor.equals("Elasticsearch") || vendor.equals("SOLR")) {
+			return true;
+		}
+
+		return false;
+	}
 
 	protected void orderByDDMField(
 			String[] unsortedValues, final String[] sortedValues,

--- a/portal-test/src/com/liferay/portlet/dynamicdatamapping/util/test/DDMStructureTestUtil.java
+++ b/portal-test/src/com/liferay/portlet/dynamicdatamapping/util/test/DDMStructureTestUtil.java
@@ -249,6 +249,14 @@ public class DDMStructureTestUtil {
 	public static String getSampleStructureDefinition(
 		String name, Locale[] availableLocales, Locale defaultLocale) {
 
+		return getSampleStructureDefinition(
+			name, "string", true, "text", availableLocales, defaultLocale);
+	}
+
+	public static String getSampleStructureDefinition(
+		String name, String dataType, boolean repeatable, String type,
+		Locale[] availableLocales, Locale defaultLocale) {
+
 		Document document = createDocumentStructure(
 			availableLocales, defaultLocale);
 
@@ -257,12 +265,13 @@ public class DDMStructureTestUtil {
 		Element dynamicElementElement = rootElement.addElement(
 			"dynamic-element");
 
-		dynamicElementElement.addAttribute("dataType", "string");
+		dynamicElementElement.addAttribute("dataType", dataType);
 		dynamicElementElement.addAttribute("indexType", "text");
 		dynamicElementElement.addAttribute("name", name);
-		dynamicElementElement.addAttribute("repeatable", "true");
+		dynamicElementElement.addAttribute(
+			"repeatable", Boolean.toString(repeatable));
 		dynamicElementElement.addAttribute("required", "false");
-		dynamicElementElement.addAttribute("type", "text");
+		dynamicElementElement.addAttribute("type", type);
 
 		Element metaDataElement = dynamicElementElement.addElement("meta-data");
 


### PR DESCRIPTION
Re-sending, addressing concerns from https://github.com/brianchandotcom/liferay-portal/pull/24122#issuecomment-74812735.

Scrapped the testcase interface, now following to the letter the successful inner test helper pattern from:

https://github.com/liferay/liferay-portal/blob/master/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/search/WikiPageSearchTest.java#L220-L284

https://github.com/liferay/liferay-portal/blob/master/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/search/WikiPageSearchTest.java#L107-L113

(Introduced [here](https://github.com/brianchandotcom/liferay-portal/pull/23121#issuecomment-69221159))

I agree it did seem strange before... looks simpler now. Thanks :)

Author: @Preston-Crary
Reviewer: @arboliveira
