### PR TITLE
LPS-53669 Set cluster property to false in portal tools to allow automated clustering tests to run

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/dependencies/portal-tools.properties
+++ b/portal-impl/src/com/liferay/portal/tools/dependencies/portal-tools.properties
@@ -1,3 +1,5 @@
+cluster.link.enabled=false
+
 tck.url=false
 
 resource.actions.read.portlet.resources=false


### PR DESCRIPTION
@brianchandotcom This needs to be backported.

And technically only 6.2 and 6.1 need this, as master's tools already moved on to use ToolDependencies for initialization. But 6.2 and 6.1 are still initializing a spring context for tools, which reads the cluster.link.enabled property. And by default ehcache will use rmi replicator which creates a non-daemon thread, stopping the tools' jvm from exiting.

But to keep things consistent, let's disable cluster link for all tools on all branches, as it is totally harmless thing.
