### PR TITLE
LPS-53857 Make sure module framework starts with a clean state for tests

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1300,6 +1300,13 @@ rerun your task.
 			<if>
 				<available file="test/${current.test.dir}" type="dir" />
 				<then>
+					<if>
+						<equals arg1="@{test.type}" arg2="integration" />
+						<then>
+							<delete dir="${liferay.home}/osgi/state" />
+						</then>
+					</if>
+
 					<junit-cmd
 						forkmode="@{junit.forkmode}"
 						test.type="@{test.type}"

--- a/build-test.xml
+++ b/build-test.xml
@@ -1197,6 +1197,8 @@
 						</then>
 					</if>
 
+					<delete dir="${liferay.home}/osgi/state" />
+
 					<if>
 						<equals arg1="${test.ant.launched.by.selenium}" arg2="true" />
 						<then>

--- a/portal-impl/test/unit/com/liferay/portal/util/InitUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/InitUtilTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.util;
 
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.SystemProperties;
@@ -41,6 +42,10 @@ public class InitUtilTest {
 
 		SystemProperties.set(
 			_RESOURCE_ACTIONS_READ_PORTLET_RESOURCES, StringPool.FALSE);
+
+		File file = new FileImpl();
+
+		file.deltree(PropsValues.MODULE_FRAMEWORK_STATE_DIR);
 
 		try {
 			InitUtil.initWithSpring(


### PR DESCRIPTION
If I am guessing right, this could fix most random osgi unresolvable errors on startup for integration and arquillian tests.

I know this is kind of hacky, the real fix should be always making sure we never left the state inconsistent in the first place, but that should be fixed by OSGi folks.

For now let's simply wipe out any previous inconsistent state before starting new module framework instance, at least this could help us stabilizing the random failing tests.
