### PR TITLE
LPS-52679 Add ExtensionManager to SoapExtender

### DIFF
--- a/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/SoapExtender.java
+++ b/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/SoapExtender.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.soap.extender;
 
+import com.liferay.portal.soap.extender.configuration.ExtensionManager;
+
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -54,16 +56,20 @@ import org.slf4j.LoggerFactory;
  */
 public class SoapExtender {
 
-	public SoapExtender(BundleContext bundleContext, String contextPath) {
+	public SoapExtender(
+		BundleContext bundleContext, String contextPath,
+		ExtensionManager extensionManager) {
+
 		_bundleContext = bundleContext;
 		_contextPath = contextPath;
+		_extensionManager = extensionManager;
 	}
 
 	protected Bus createBus() {
 		CXFBusFactory cxfBusFactory = (CXFBusFactory)CXFBusFactory.newInstance(
 			CXFBusFactory.class.getName());
 
-		return cxfBusFactory.createBus(_extensions);
+		return cxfBusFactory.createBus(_extensionManager.getExtensions());
 	}
 
 	protected void registerCXFServlet(Bus bus, String contextPath) {
@@ -163,7 +169,7 @@ public class SoapExtender {
 
 	private final BundleContext _bundleContext;
 	private final String _contextPath;
-	private final Map<Class<?>, Object> _extensions = new HashMap<>();
+	private final ExtensionManager _extensionManager;
 	private ServiceTracker<Object, ServerTrackingInformation>
 		_serverServiceTracker;
 	private ServiceRegistration<ServletContextHelper>

--- a/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/configuration/ExtensionManager.java
+++ b/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/configuration/ExtensionManager.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.soap.extender.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class ExtensionManager {
+
+	public Map<Class<?>, Object> getExtensions() {
+		return _extensions;
+	}
+
+	protected void addExtension(
+		Map<String, Object> properties, Object extension) {
+
+		Class<?> extensionClass = (Class<?>)properties.get(
+			"soap.extension.class");
+
+		_extensions.put(extensionClass, extension);
+	}
+
+	protected void removeExtension(Object extension) {}
+
+	private final Map<Class<?>, Object> _extensions = new HashMap<>();
+
+}

--- a/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/configuration/SoapExtenderConfigurationAdmin.java
+++ b/modules/portal/portal-soap-extender/src/com/liferay/portal/soap/extender/configuration/SoapExtenderConfigurationAdmin.java
@@ -47,9 +47,11 @@ public class SoapExtenderConfigurationAdmin {
 
 		_component = dependencyManager.createComponent();
 
+		ExtensionManager extensionManager = new ExtensionManager();
+
 		SoapExtender soapExtender = new SoapExtender(
 			componentContext.getBundleContext(),
-			_soapExtenderConfiguration.contextPath());
+			_soapExtenderConfiguration.contextPath(), extensionManager);
 
 		_component.setImplementation(soapExtender);
 
@@ -60,6 +62,8 @@ public class SoapExtenderConfigurationAdmin {
 				ServiceDependency serviceDependency =
 					dependencyManager.createServiceDependency();
 
+				serviceDependency.setCallbacks(
+					extensionManager, "addExtension", "removeExtension");
 				serviceDependency.setService(
 					Object.class, _createExtensionFilter(extension));
 				serviceDependency.setRequired(true);


### PR DESCRIPTION
@brianchandotcom changes in extensions are only reloaded when the CXF itself servlet is reloaded, since for CXF it makes not sense to "hot swap" extensions. So, basically, if extensions are added or removed while the tracker is active it does not respond by design. Only when the administrator reloads the component the changes in extensions will take place. Alas, any state that the servlet could have would be lost, that is why we wanted this to be an admin conscious decision to make. 
