### PR TITLE
LPS-53994 Make arquillian-extension-junit-bridge depends on arquillian-c...

### DIFF
--- a/modules/test/arquillian-extension-junit-bridge/ivy.xml
+++ b/modules/test/arquillian-extension-junit-bridge/ivy.xml
@@ -18,6 +18,8 @@
 
 	<dependencies defaultconf="default">
 		<dependency name="aQute.bnd" org="com.liferay" rev="2.3.0" />
+		<dependency name="arquillian-container-liferay" org="org.arquillian.liferay" rev="1.0.0.Final-SNAPSHOT" />
+		<dependency name="arquillian-deployment-generator-bnd" org="org.arquillian.liferay" rev="1.0.0.Final-SNAPSHOT" />
 		<dependency name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.7.Final" />
 		<dependency name="jbosgi-metadata" org="org.jboss.osgi.metadata" rev="4.0.0.CR1" />
 		<dependency name="junit" org="junit" rev="4.12" />


### PR DESCRIPTION
...ontainer-liferay and arquillian-deployment-generator-bnd, so that the modules need arquillian test only needs to depend on arquillian-extension-junit-bridge

@brianchandotcom please publish this module first, then I will send the usage apply pull.
