### PR TITLE
LPS-53995 Allow ivy home to be outside of version control

### DIFF
--- a/build-common-ivy.xml
+++ b/build-common-ivy.xml
@@ -2,8 +2,6 @@
 <!DOCTYPE project>
 
 <project name="build-common-ivy" xmlns:antelope="antlib:ise.antelope.tasks" xmlns:ivy="antlib:org.apache.ivy.ant">
-	<property name="ivy.home" value="${project.dir}/.ivy" />
-
 	<macrodef name="mirrors-get">
 		<attribute name="dest" />
 		<attribute default="false" name="ignoreerrors" />

--- a/build.properties
+++ b/build.properties
@@ -138,6 +138,7 @@
 
     ivy.cache.ttl.default=eternal
     ivy.custom.settings.file=${project.dir}/ivy-settings.xml
+    ivy.home=${project.dir}/.ivy
     ivy.jar.url=http://cdn.repository.liferay.com/nexus/content/repositories/liferay-snapshots-ce/com/liferay/org.apache.ivy/${ivy.version}/org.apache.ivy-${ivy.version}.jar
     ivy.version=2.3.0.LIFERAY-PATCHED-1-SNAPSHOT
 

--- a/build.xml
+++ b/build.xml
@@ -1027,7 +1027,7 @@
 			auto.deploy.dir=${liferay.home}/osgi/apps
 			clean.delete.ivy.md5=true
 			clean.delete.lib=true
-			ivy.home=${project.dir}/.ivy
+			ivy.home=${ivy.home}
 			junit.test.excludes=${junit.test.excludes}
 			liferay.home=${liferay.home}
 			lp.portal.project.dir=${project.dir}


### PR DESCRIPTION
@david-truong See this nice thing @shinnlok made.

Now all the ivy haters have a workaround to keep their repo clean after ant all. Just point the ivy.home somewhere outside your repo in your build.${user.name}.properties
