### PR TITLE
LPS-53965 Only pass property key when checking for renamed property keys

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -1043,8 +1043,8 @@ public class VerifyProperties extends VerifyProcess {
 			"passwords.passwordpolicytoolkit.validator.charset.uppercase"
 		},
 		new String[] {
-			"permissions.inline.sql.resource.block.query.threshhold=100",
-			"permissions.inline.sql.resource.block.query.threshold=100"
+			"permissions.inline.sql.resource.block.query.threshhold",
+			"permissions.inline.sql.resource.block.query.threshold"
 		},
 		new String[] {
 			"portal.instance.http.port", "portal.instance.http.socket.address"


### PR DESCRIPTION
@hhuijser caught my mistake in VerifyProperties.
