### PR TITLE
LPS-53994 Runtime dependency

### DIFF
--- a/modules/test/arquillian-extension-junit-bridge/ivy.xml
+++ b/modules/test/arquillian-extension-junit-bridge/ivy.xml
@@ -17,9 +17,9 @@
 	</publications>
 
 	<dependencies defaultconf="default">
+		<dependency conf="runtime->default" name="arquillian-container-liferay" org="org.arquillian.liferay" rev="1.0.0.Final-SNAPSHOT" />
+		<dependency conf="runtime->default" name="arquillian-deployment-generator-bnd" org="org.arquillian.liferay" rev="1.0.0.Final-SNAPSHOT" />
 		<dependency name="aQute.bnd" org="com.liferay" rev="2.3.0" />
-		<dependency name="arquillian-container-liferay" org="org.arquillian.liferay" rev="1.0.0.Final-SNAPSHOT" />
-		<dependency name="arquillian-deployment-generator-bnd" org="org.arquillian.liferay" rev="1.0.0.Final-SNAPSHOT" />
 		<dependency name="arquillian-junit-container" org="org.jboss.arquillian.junit" rev="1.1.7.Final" />
 		<dependency name="jbosgi-metadata" org="org.jboss.osgi.metadata" rev="4.0.0.CR1" />
 		<dependency name="junit" org="junit" rev="4.12" />


### PR DESCRIPTION
Those dependencies have to be runtime, so that other arquillian test modules can transparently get the dependencies.

Please publish this module, then I will resend apply usage pull.
