### PR TITLE
Lps 54091

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/auth/JAASTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/auth/JAASTest.java
@@ -333,7 +333,16 @@ public class JAASTest {
 			}
 		);
 
-		MainServlet mainServlet = new MainServlet();
+		MainServlet mainServlet = new MainServlet() {
+
+			@Override
+			protected void processStartupEvents() {
+
+				// Don't run StartupAction again, it will create race condition.
+
+			}
+
+		};
 
 		MockServletContext mockServletContext =
 			new AutoDeployMockServletContext(new FileSystemResourceLoader());

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -129,6 +129,7 @@ public class PACLAggregateTest {
 		URL url = PACLAggregateTest.class.getResource("security.policy");
 
 		arguments.add("-Djava.security.policy=" + url.getFile());
+		arguments.add("-Dliferay.mode=test");
 
 		boolean junitDebug = Boolean.getBoolean("junit.debug");
 

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -134,6 +134,8 @@ public class PACLAggregateTest {
 		arguments.add(
 			"-D" + PropsKeys.LIFERAY_LIB_PORTAL_DIR + "=" +
 				PropsValues.LIFERAY_LIB_PORTAL_DIR);
+		arguments.add(
+			"-D" + PropsKeys.MODULE_FRAMEWORK_PROPERTIES + _OSGI_CONSOLE);
 
 		builder.setArguments(arguments);
 		builder.setBootstrapClassPath(System.getProperty("java.class.path"));
@@ -195,6 +197,8 @@ public class PACLAggregateTest {
 	private static final String _JVM_MAX_PERM_SIZE = "-XX:MaxPermSize=256m";
 
 	private static final String _JVM_XMX = "-Xmx1024m";
+
+	private static final String _OSGI_CONSOLE = "osgi.console=localhost:11312";
 
 	private static class DummySocksProxySelector extends ProxySelector {
 

--- a/portal-test-internal/src/com/liferay/portal/service/test/ServiceTestUtil.java
+++ b/portal-test-internal/src/com/liferay/portal/service/test/ServiceTestUtil.java
@@ -179,16 +179,7 @@ public class ServiceTestUtil {
 		}
 	}
 
-	public static void initServices() {
-
-		// JCR
-
-		try {
-			JCRFactoryUtil.prepare();
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-		}
+	public static void initStaticServices() {
 
 		// Indexers
 
@@ -234,10 +225,6 @@ public class ServiceTestUtil {
 
 		PortalRegisterTestUtil.registerAssetRendererFactories();
 
-		// Thread locals
-
-		_setThreadLocals();
-
 		// Company
 
 		try {
@@ -247,6 +234,22 @@ public class ServiceTestUtil {
 		catch (Exception e) {
 			_log.error(e, e);
 		}
+	}
+
+	public static void initServices() {
+
+		// JCR
+
+		try {
+			JCRFactoryUtil.prepare();
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+		}
+
+		// Thread locals
+
+		_setThreadLocals();
 
 		// Directories
 

--- a/portal-test-internal/src/com/liferay/portal/service/test/ServiceTestUtil.java
+++ b/portal-test-internal/src/com/liferay/portal/service/test/ServiceTestUtil.java
@@ -133,20 +133,7 @@ public class ServiceTestUtil {
 		}
 	}
 
-	public static void initServices() {
-
-		// JCR
-
-		try {
-			JCRFactoryUtil.prepare();
-		}
-		catch (Exception e) {
-			_log.error(e.getMessage(), e);
-		}
-
-		// Indexers
-
-		PortalRegisterTestUtil.registerIndexers();
+	public static void initMainServletServices() {
 
 		// Upgrade
 
@@ -176,19 +163,6 @@ public class ServiceTestUtil {
 			DoPrivilegedUtil.wrap(messageSender),
 			DoPrivilegedUtil.wrap(synchronousMessageSender));
 
-		if (TestPropsValues.DL_FILE_ENTRY_PROCESSORS_TRIGGER_SYNCHRONOUSLY) {
-			_replaceWithSynchronousDestination(
-				DestinationNames.DOCUMENT_LIBRARY_AUDIO_PROCESSOR);
-			_replaceWithSynchronousDestination(
-				DestinationNames.DOCUMENT_LIBRARY_IMAGE_PROCESSOR);
-			_replaceWithSynchronousDestination(
-				DestinationNames.DOCUMENT_LIBRARY_PDF_PROCESSOR);
-			_replaceWithSynchronousDestination(
-				DestinationNames.DOCUMENT_LIBRARY_RAW_METADATA_PROCESSOR);
-			_replaceWithSynchronousDestination(
-				DestinationNames.DOCUMENT_LIBRARY_VIDEO_PROCESSOR);
-		}
-
 		// Scheduler
 
 		try {
@@ -205,6 +179,37 @@ public class ServiceTestUtil {
 		}
 		catch (Exception e) {
 			_log.error(e.getMessage(), e);
+		}
+	}
+
+	public static void initServices() {
+
+		// JCR
+
+		try {
+			JCRFactoryUtil.prepare();
+		}
+		catch (Exception e) {
+			_log.error(e.getMessage(), e);
+		}
+
+		// Indexers
+
+		PortalRegisterTestUtil.registerIndexers();
+
+		// Messaging
+
+		if (TestPropsValues.DL_FILE_ENTRY_PROCESSORS_TRIGGER_SYNCHRONOUSLY) {
+			_replaceWithSynchronousDestination(
+				DestinationNames.DOCUMENT_LIBRARY_AUDIO_PROCESSOR);
+			_replaceWithSynchronousDestination(
+				DestinationNames.DOCUMENT_LIBRARY_IMAGE_PROCESSOR);
+			_replaceWithSynchronousDestination(
+				DestinationNames.DOCUMENT_LIBRARY_PDF_PROCESSOR);
+			_replaceWithSynchronousDestination(
+				DestinationNames.DOCUMENT_LIBRARY_RAW_METADATA_PROCESSOR);
+			_replaceWithSynchronousDestination(
+				DestinationNames.DOCUMENT_LIBRARY_VIDEO_PROCESSOR);
 		}
 
 		// Class names

--- a/portal-test-internal/src/com/liferay/portal/service/test/ServiceTestUtil.java
+++ b/portal-test-internal/src/com/liferay/portal/service/test/ServiceTestUtil.java
@@ -129,7 +129,7 @@ public class ServiceTestUtil {
 			setUser(TestPropsValues.getUser());
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 	}
 
@@ -140,11 +140,8 @@ public class ServiceTestUtil {
 		try {
 			DBUpgrader.upgrade();
 		}
-		catch (AssertionError ae) {
-			_log.error(ae.getMessage(), ae);
-		}
-		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+		catch (Throwable t) {
+			_log.error(t, t);
 		}
 
 		// Messaging
@@ -169,7 +166,7 @@ public class ServiceTestUtil {
 			SchedulerEngineHelperUtil.start();
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 
 		// Verify
@@ -178,7 +175,7 @@ public class ServiceTestUtil {
 			DBUpgrader.verify();
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 	}
 
@@ -190,7 +187,7 @@ public class ServiceTestUtil {
 			JCRFactoryUtil.prepare();
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 
 		// Indexers
@@ -222,7 +219,7 @@ public class ServiceTestUtil {
 			_checkResourceActions();
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 
 		// Trash
@@ -248,7 +245,7 @@ public class ServiceTestUtil {
 				TestPropsValues.COMPANY_WEB_ID);
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 
 		// Directories
@@ -264,7 +261,7 @@ public class ServiceTestUtil {
 			SearchEngineUtil.initialize(TestPropsValues.getCompanyId());
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 	}
 
@@ -338,7 +335,7 @@ public class ServiceTestUtil {
 				PropsValues.LUCENE_DIR + TestPropsValues.getCompanyId());
 		}
 		catch (Exception e) {
-			_log.error(e.getMessage(), e);
+			_log.error(e, e);
 		}
 	}
 

--- a/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
@@ -251,6 +251,7 @@ public class PACLTestRule implements TestRule {
 
 		InitUtil.initWithSpring(configLocations, true);
 
+		ServiceTestUtil.initMainServletServices();
 		ServiceTestUtil.initServices();
 		ServiceTestUtil.initPermissions();
 

--- a/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
@@ -252,6 +252,7 @@ public class PACLTestRule implements TestRule {
 		InitUtil.initWithSpring(configLocations, true);
 
 		ServiceTestUtil.initMainServletServices();
+		ServiceTestUtil.initStaticServices();
 		ServiceTestUtil.initServices();
 		ServiceTestUtil.initPermissions();
 

--- a/portal-test-internal/src/com/liferay/portal/test/rule/callback/MainServletTestCallback.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/callback/MainServletTestCallback.java
@@ -58,10 +58,6 @@ public class MainServletTestCallback extends BaseTestCallback<Object, Object> {
 
 	@Override
 	public Object doBeforeClass(Description description) {
-		ServiceTestUtil.initServices();
-
-		ServiceTestUtil.initPermissions();
-
 		if (_mainServlet == null) {
 			final MockServletContext mockServletContext =
 				new AutoDeployMockServletContext(
@@ -97,6 +93,10 @@ public class MainServletTestCallback extends BaseTestCallback<Object, Object> {
 					"The main servlet could not be initialized");
 			}
 		}
+
+		ServiceTestUtil.initServices();
+
+		ServiceTestUtil.initPermissions();
 
 		return null;
 	}

--- a/portal-test-internal/src/com/liferay/portal/test/rule/callback/MainServletTestCallback.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/callback/MainServletTestCallback.java
@@ -92,6 +92,8 @@ public class MainServletTestCallback extends BaseTestCallback<Object, Object> {
 				throw new RuntimeException(
 					"The main servlet could not be initialized");
 			}
+
+			ServiceTestUtil.initStaticServices();
 		}
 
 		ServiceTestUtil.initServices();


### PR DESCRIPTION
@brianchandotcom This pull contains https://github.com/brianchandotcom/liferay-portal/pull/24607 and https://github.com/brianchandotcom/liferay-portal/pull/24613 to show the result as a whole.

LPS-54091 is not a real fix, it is just a way to dodge the bullet. The real problems are still about the async bundles initialization race conditions, they are a lot more complex and harder to deal with. Hope LPS-54091 can ease the issues enough so that it can buy me some time to dig deeper to the root problems.

By far there are still 2 known random failing reasons.
1) ExportImportLifecycleEventTest's backgroup task randomly triggers MVCC error (because of some messy updating ordering and timing)
2) JSONWebServiceActionsManagerImpl's non-threadsafe collection usage causing NPE. As we put down the other top random errors, this one is poping up to become more frequent, if Igor won't solve this soon, I will take it over.
