### PR TITLE
LPS-54041 Portal Service Access Control Profile

### DIFF
--- a/modules/portal/portal-ac-profile/build.xml
+++ b/modules/portal/portal-ac-profile/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../tools/sdk/build-common-plugins.xml" />
+</project>

--- a/modules/portal/portal-ac-profile/portal-ac-profile-service/build.xml
+++ b/modules/portal/portal-ac-profile/portal-ac-profile-service/build.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project name="portal-ac-profile">
+	<property name="import.shared" value="portal-ac-profile-api" />
+	<property name="osgi.ide.dependencies" value="spring-context.jar" />
+	<property name="service.input.file" value="service.xml" />
+
+	<import file="../../../../tools/sdk/build-common-osgi-plugin.xml" />
+
+	<property name="auto.deploy.dir" value="${liferay.home}/osgi/portal" />
+
+	<target name="build-service">
+		<build-service
+			service.api.dir="../portal-ac-profile-api/src"
+			service.auto.namespace.tables="false"
+			service.hbm.file.name="module-hbm.xml"
+			service.spring.file.name="module-spring.xml"
+			service.sql.dir="src/META-INF/sql"
+			service.test.dir="../portal-ac-profile-test/test/integration"
+		/>
+	</target>
+</project>

--- a/modules/portal/portal-ac-profile/portal-ac-profile-service/service.xml
+++ b/modules/portal/portal-ac-profile/portal-ac-profile-service/service.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!DOCTYPE service-builder PUBLIC "-//Liferay//DTD Service Builder 7.0.0//EN" "http://www.liferay.com/dtd/liferay-service-builder_7_0_0.dtd">
+
+<service-builder package-path="com.liferay.portal.ac.profile">
+	<namespace>ACP</namespace>
+	<entity name="ServiceACProfile" uuid="true" local-service="true" remote-service="false" trash-enabled="false">
+
+		<!-- PK fields -->
+
+		<column name="serviceACProfileId" type="long" primary="true" />
+
+		<!-- Audit fields -->
+
+		<column name="companyId" type="long" />
+		<column name="userId" type="long" />
+		<column name="userName" type="String" />
+		<column name="createDate" type="Date" />
+		<column name="modifiedDate" type="Date" />
+
+		<!-- Other fields -->
+
+		<column name="allowedServices" type="String" />
+		<column name="name" type="String" />
+		<column name="title" type="String" localized="true" />
+
+		<!-- Finder methods -->
+		<finder name="CompanyId" return-type="Collection">
+			<finder-column name="companyId" />
+		</finder>
+		<finder name="C_N" return-type="ServiceACProfile">
+			<finder-column name="companyId" />
+			<finder-column name="name" />
+		</finder>
+	</entity>
+</service-builder>


### PR DESCRIPTION
Hi Brian, 

I'm sending this in small pieces for you to review as I progress. You can either merge it into master or just send me a pull request with your changes so I can include them in the next piece. I think this way it's easiest for you to review as we go. 

First little background on what we are doing. We are creating a way for portal administrator to create predefined service access control profiles that declare what services or service methods can be called. Basically this is creating a more fine grained control than what we already have in OAuth where you can only define either READ or WRITE. This will also be completely separate from OAuth and can be attached to any Remote API authorisation method. These profiles can the be granted to different applications. Enforcing the profiles will be done by a new AccessControlPolicy.

This module will provide the backend implementation for the public API we'll be creating in portal-service com.liferay.portal.security.ac where two new interfaces will be added: ServiceAccessControlProfile and ServiceAccessControlProfileService. Each profile is tied to a portal instance. We decided to put this part under modules/portal because it is a portal wide service.
