### PR TITLE
Revert "LPS-53920 make servicebuilder imports a little smarter"

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/persistence_impl.ftl
@@ -94,7 +94,7 @@ import java.util.Map;
 import java.util.Set;
 
 <#list referenceList as tempEntity>
-	<#if tempEntity.hasColumns() && (entity.name == "Counter" || tempEntity.name != "Counter") && (tempEntity.packagePath != packagePath)>
+	<#if tempEntity.hasColumns() && (entity.name == "Counter" || tempEntity.name != "Counter")>
 		import ${tempEntity.packagePath}.service.persistence.${tempEntity.name}Persistence;
 	</#if>
 </#list>


### PR DESCRIPTION
This reverts commit 9b0e5283c711d089027e1f913a91a47c7e5d12f3.

Compilations were failing after building services with that commit. See https://issues.liferay.com/browse/LPS-54117.

@codyhoag discovered this issue
