### PR TITLE
Lps 54138

### DIFF
--- a/modules/portal/portal-spring-extender/src/META-INF/spring/extender/config.xml
+++ b/modules/portal/portal-spring-extender/src/META-INF/spring/extender/config.xml
@@ -9,4 +9,5 @@
 >
 	<bean id="applicationContextCreator" class="com.liferay.portal.spring.extender.internal.context.ModuleApplicationContextCreator" />
 	<bean id="osgiApplicationContextListener" class="com.liferay.portal.spring.extender.internal.context.event.BeanLocatorLifecycleManager" />
+	<bean id="taskExecutor" class="org.springframework.core.task.SyncTaskExecutor" />
 </beans>

--- a/modules/portal/portal-wab-extender/src/com/liferay/portal/wab/extender/internal/WabFactory.java
+++ b/modules/portal/portal-wab-extender/src/com/liferay/portal/wab/extender/internal/WabFactory.java
@@ -62,6 +62,8 @@ public class WabFactory extends AbstractExtender {
 		_wabExtenderConfiguration = Configurable.createConfigurable(
 			WabExtenderConfiguration.class, properties);
 
+		setSynchronous(true);
+
 		try {
 			_webBundleDeployer = new WebBundleDeployer(
 				_bundleContext, _extendedHttpService, _saxParserFactory,

--- a/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionsManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionsManagerImpl.java
@@ -535,6 +535,11 @@ public class JSONWebServiceActionsManagerImpl
 						contextName);
 		}
 
+		jsonWebServiceActionConfigs = new ArrayList<>(
+			jsonWebServiceActionConfigs);
+
+		Collections.sort(jsonWebServiceActionConfigs);
+
 		int max = -1;
 
 		JSONWebServiceActionConfig matchedJSONWebServiceActionConfig = null;


### PR DESCRIPTION
@brianchandotcom This includes https://github.com/brianchandotcom/liferay-portal/pull/24656 to show the result as a whole.

After more than half days' debugging, I finally fixed it, now we do all bundles deployments in serial, so no more bundle deployments race conditions.

You will be surprised about how simple the fix is, I have to admit, if I know better about the OSGi integration infrastructure, this would not take so long.
But I am getting familiar with it, so for any further issues, it will get easier.

What really happened is, the racing between XYZ-service bundle and XYZ-web bundle deployment.

In XYZ-service bundle, we all have ServiceConfigurator, like WikiServiceConfigurator. Which eventually calls ServiceComponentLocalServiceUtil.initServiceComponent() -> ModelHintsUtil.read() -> ClassNameLocalServiceUtil.getClassName(name) to populate ClassName, in Felix DS threads.
In XYZ-web bundle, we call WabBundleProcessor.init(), which eventually trying to use ClassNames in a lot of HotDeployListeners. As you know we have the lazy creation logic support in ClassNameLocalServiceImpl, so on getting ClassNames, if they don't realy exist, it goes ahead to create them. And all of them happen in WAB extender threads.

Therefore we end up having 2 groups of threads racing to populate the same set of ClassNames, causing all sort of unique index failures. Similar case for ResourceAction table.

The fixes in this pull, force DS and WAB to work in a sync way, exactly how things worked before, so no more race condition.

This fix should cover a lot random failures. But we still have a lot others, most of them are especial one for individual tests, no global ones. I have a long list of them, and I want to use this chance as training process to improve my team's debugging and analyzing skills. So I might have most of them worked by Will and Matt. In the mean time, I want to spend a couple more days, to get to know the OSGi infrastructure, I can foresee, things will never end like this. I need to be ready to deal with the future issues.
