### PR TITLE
Lps 54210

### DIFF
--- a/classes/Test.java
+++ b/classes/Test.java
@@ -18,8 +18,14 @@
 public class Test {
 
 	public static void main(String[] args) throws Exception {
-		//com.liferay.portal.util.InitUtil.initWithSpring();
+		//com.liferay.portal.util.InitUtil.initWithSpring(true);
 
+		run();
+
+		//com.liferay.portal.util.InitUtil.stopModuleFramework();
+	}
+
+	protected static void run() {
 		System.out.println("Test");
 	}
 

--- a/classes/build.xml
+++ b/classes/build.xml
@@ -24,6 +24,8 @@
 	</target>
 
 	<target name="Test" depends="compile">
+		<echo file="portal-ext.properties">liferay.home=${liferay.home}</echo>
+
 		<java
 			classname="Test"
 			classpathref="project.classpath"
@@ -36,5 +38,7 @@
 			<jvmarg value="-Duser.timezone=GMT" />
 			-->
 		</java>
+
+		<delete file="portal-ext.properties" quiet="true" />
 	</target>
 </project>

--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/connection/EmbeddedElasticsearchConnection.java
@@ -73,11 +73,6 @@ public class EmbeddedElasticsearchConnection
 		initialize();
 	}
 
-	@Deactivate
-	protected void deactivate(Map<String, Object> properties) {
-		close();
-	}
-
 	@Override
 	protected Client createClient(ImmutableSettings.Builder builder) {
 		NodeBuilder nodeBuilder = NodeBuilder.nodeBuilder();
@@ -116,6 +111,11 @@ public class EmbeddedElasticsearchConnection
 		}
 
 		return client;
+	}
+
+	@Deactivate
+	protected void deactivate(Map<String, Object> properties) {
+		close();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/connection/EmbeddedElasticsearchConnection.java
@@ -30,6 +30,7 @@ import org.elasticsearch.node.NodeBuilder;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -70,6 +71,11 @@ public class EmbeddedElasticsearchConnection
 			MapUtil.getString(properties, "testConfigFileName"));
 
 		initialize();
+	}
+
+	@Deactivate
+	protected void deactivate(Map<String, Object> properties) {
+		close();
 	}
 
 	@Override

--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/connection/RemoteElasticsearchConnection.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/connection/RemoteElasticsearchConnection.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -126,6 +127,11 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 		}
 
 		return transportClient;
+	}
+
+	@Deactivate
+	protected void deactivate(Map<String, Object> properties) {
+		close();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
@shinnlok, I finally figured out the randomness behaviors you saw.

First, without your change, if you remove state folder before running the test, it guarantees never hangs. But sometimes it gets 0 output.

The reason for that is, without the cache state folder, all bundles are installed by felix file install thread, which is a daemon thread starts by ModuleFrameworkImpl.startFramework() -> line 328 _setupInitialBundles(); One of the initial bundle is felix file install. Eventually it reaches to MappingUpdateAction.start() which starts a new thread without setting anything about daemon, so the new thread copy the daemon flag from parent thread (the felix file install thread, which is daemon thread). Therefore the MasterMappingUpdater is also a daemon thread. As long as in your test, you shutdown the module frame work, the jvm will exit peacefully.

As you can see the file install thread in charge of installing all the bundles, in an async way, there is a chance that you shutdown the module framework before it loads any bundles, therefore you might see 0 output.

Second, without your change, if the state folder is there with all the bundles cache in, it guarantees hanging there.

The reason for that is, all cached bundles are restarted by ModuleFrameworkImpl.startFramework() -> line 320 _framework.start(); by main thread which is a non-daemon thread. Therefore this time the MasterMappingUpdater's parent thread is main thread, making it also a non-daemon thread. Without your fix, shutdown module framework does not really shutdown elasticsearch. Leaving a non-daemon thread alive keeping jvm from exiting.

This inconsistence between clean startup and cached startup is really an OSGi infrastructure issue, which needs a deeper review. It's better leaving it to @rotty3000 to look into it. Let's simply using your solution for now, at least it can prevent elasticsearch from leaking out non-daemon thread hanging the jvm.

CC @mhan810
