### PR TITLE
LPS-53897 When web.xml is absent, jasper assume the version number is 2....

### DIFF
--- a/modules/util/jasper-jspc/src/com/liferay/jasper/jspc/JspC.java
+++ b/modules/util/jasper-jspc/src/com/liferay/jasper/jspc/JspC.java
@@ -15,10 +15,14 @@
 package com.liferay.jasper.jspc;
 
 import java.io.File;
+import java.io.IOException;
 
 import java.util.Iterator;
 
 import org.apache.jasper.JasperException;
+import org.apache.jasper.compiler.JspConfig;
+import org.apache.jasper.compiler.WebXml;
+import org.apache.tomcat.util.scan.Constants;
 
 /**
  * @author Shuyang Zhou
@@ -55,6 +59,27 @@ public class JspC extends org.apache.jasper.JspC {
 				iterator.remove();
 			}
 		}
+	}
+
+	@Override
+	protected void initServletContext() {
+		super.initServletContext();
+
+		try {
+			WebXml webXml = new WebXml(context);
+
+			if (webXml.getInputSource() != null) {
+				return;
+			}
+		}
+		catch (IOException ioe) {
+			throw new RuntimeException(ioe);
+		}
+
+		context.setAttribute(
+			Constants.MERGED_WEB_XML, "<web-app version=\"2.4\" />");
+
+		jspConfig = new JspConfig(context);
 	}
 
 }


### PR DESCRIPTION
...3 which does not support EL, causing a lot portlet jsp compilation failure. This change feeds jasper a dummy web.xml with version 2.4 on seeing target plugin missing the web.xml to ensure EL is turned on.

@brianchandotcom please publish the module once after you merge it in, we need this to continue the plugins compile-jsp fixing.
