### PR TITLE
LPS-54329 Make node local configurable, and by default to be true.

### DIFF
--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/configuration/ElasticsearchConfiguration.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/configuration/ElasticsearchConfiguration.java
@@ -42,6 +42,9 @@ public interface ElasticsearchConfiguration {
 	@Meta.AD(deflt = "true", required = false)
 	public boolean httpEnabled();
 
+	@Meta.AD(deflt = "true", required = false)
+	public String nodeLocal();
+
 	@Meta.AD(deflt = "EMBEDDED", required = false)
 	public String operationMode();
 

--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
@@ -127,6 +127,7 @@ public class EmbeddedElasticsearchConnection
 		builder.put("index.number_of_shards", 1);
 		builder.put("node.client", false);
 		builder.put("node.data", true);
+		builder.put("node.local", elasticsearchConfiguration.nodeLocal());
 		builder.put(
 			"path.data",
 			PropsUtil.get(PropsKeys.LIFERAY_HOME) + "/data/elasticsearch");
@@ -140,11 +141,6 @@ public class EmbeddedElasticsearchConnection
 			builder.put("index.store.type", "memory");
 			builder.put("index.translog.flush_threshold_ops", "1");
 			builder.put("index.translog.interval", "1ms");
-
-			builder.put("node.local", true);
-		}
-		else {
-			builder.put("node.local", false);
 		}
 	}
 

--- a/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/internal/connection/RemoteElasticsearchConnection.java
+++ b/modules/portal/portal-search-elasticsearch/src/com/liferay/portal/search/elasticsearch/internal/connection/RemoteElasticsearchConnection.java
@@ -144,7 +144,7 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 		builder.put("http.enabled", false);
 		builder.put("node.client", true);
 		builder.put("node.data", false);
-		builder.put("node.local", false);
+		builder.put("node.local", elasticsearchConfiguration.nodeLocal());
 		builder.put(
 			"path.logs", PropsUtil.get(PropsKeys.LIFERAY_HOME) + "/logs");
 		builder.put(


### PR DESCRIPTION
@mhan810

https://github.com/liferay/liferay-portal/commit/2e795b789e18b19c36b8fe1527439991362a2f56 made "node.local" defaults to false for production mode. This is causing all arquillian portals join each other to form a cluster, leads to tons of test failures.

See sample failures at https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-backend%28master%29/group=0,label_exp=!test-1-6/201/consoleFull, search for "start-app-server:", you will see arquillian portal starts failed with elasticsearch.

Not really sure whether this is the best way to fix it(We might need to sync this setting with cluster.link.enabled eventually). But we do need to make sure by default elasticsearch cluster is off, otherwise starting 2 portals in the same network (without real cluster settings) will always cause some problems.
