### PR TITLE
LPS-53578 Broken reference (caused by 675f5e08fc2a9d7810eb5400e52ac9cd43cf4eef)

### DIFF
--- a/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/portlet.properties
+++ b/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/portlet.properties
@@ -9,7 +9,7 @@ ddm.template.key.default=breadcrumb-horizontal-ftl
 # Set the location of the XML file containing the configuration of the default
 # display templates for the Breadcrumb portlet.
 #
-display.templates.config=com/liferay/breadcrumb/web/portlet/template/dependencies/portlet-display-templates.xml
+display.templates.config=com/liferay/site/navigation/breadcrumb/web/portlet/template/dependencies/portlet-display-templates.xml
 
 #
 # Input a list of comma delimited resource action configurations that will be

--- a/modules/apps/site-navigation/site-navigation-language-web/src/portlet.properties
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/portlet.properties
@@ -4,7 +4,7 @@ include-and-override=portlet-ext.properties
 # Set the location of the XML file containing the configuration of the default
 # display templates for the Language portlet.
 #
-display.templates.config=com/liferay/language/web/portlet/template/dependencies/portlet-display-templates.xml
+display.templates.config=com/liferay/site/navigation/language/web/portlet/template/dependencies/portlet-display-templates.xml
 
 #
 # Input a list of comma delimited resource action configurations that will be


### PR DESCRIPTION
@juliocamarero
This is caused by 675f5e08fc2a9d7810eb5400e52ac9cd43cf4eef, making tons of test failures.

See sample failure : https://test-1-5.liferay.com/job/test-portal-acceptance-pullrequest-backend%28master%29/group=0,label_exp=!test-1-5/181/consoleFull, search for "com.liferay.portal.kernel.events.ActionException: java.io.IOException: Unable to open resource in class loader com/liferay/breadcrumb/web/portlet/template/dependencies/portlet-display-templates.xml"
