### PR TITLE
LPS-54411 InvokerFilterChain intercepts Exception chain breaks TCK tests...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
@@ -101,6 +101,9 @@ public class InvokerFilterChain implements FilterChain {
 					catch (ServletException se) {
 						throw se;
 					}
+					catch (RuntimeException re) {
+						throw re;
+					}
 					catch (Exception e) {
 						throw new ServletException(e);
 					}


### PR DESCRIPTION
... (This bug is caused by LPS-14894, but until LPS-52574 it got exposed.)
