### PR TITLE
LPS-54374 Rename from "renderedNestedDDMFormFields" to "renderedChildElements"

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.classpath
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.classpath
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<classpath>
+	<classpathentry excluding="**/.svn/**|.svn/" kind="src" path="src" />
+	<classpathentry kind="src" path="/portal-master" />
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER" />
+	<classpathentry excluding="**/.svn/**|.svn/" kind="src" path="test/unit" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/junit.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/mockito.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-api-mockito.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-api-support.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-core.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-module-junit4.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/powermock-module-junit4-common.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/spring-test.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/activation.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/annotations.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/jsp-api.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/mail.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/development/servlet-api.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/global/portlet.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/bnd.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/commons-io.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/commons-lang.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/commons-logging.jar" />
+	<classpathentry kind="lib" path="/portal-master/lib/portal/log4j.jar" />
+	<classpathentry kind="lib" path="/portal-master/portal-service/portal-service.jar" />
+	<classpathentry kind="lib" path="/portal-master/util-bridges/util-bridges.jar" />
+	<classpathentry kind="lib" path="/portal-master/util-java/util-java.jar" />
+	<classpathentry kind="lib" path="/portal-master/util-taglib/util-taglib.jar" />
+	<classpathentry kind="lib" path="lib/org.osgi.compendium.jar" />
+	<classpathentry kind="output" path="bin" />
+</classpath>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.project
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.project
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<projectDescription>
+	<name>dynamic-data-mapping-form-renderer-master</name>
+	<comment></comment>
+	<projects></projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments></arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/bnd.bnd
@@ -1,0 +1,7 @@
+Bundle-Name: Liferay Dynamic Data Mapping Form Renderer
+Bundle-SymbolicName: com.liferay.dynamic.data.mapping.form.renderer
+Bundle-Version: 1.0.0
+Export-Package: com.liferay.dynamic.data.mapping.form.renderer
+Include-Resource:\
+	classes,\
+	META-INF=src/META-INF

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/build.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/build.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../../tools/sdk/build-common-osgi-plugin.xml" />
+
+	<property name="auto.deploy.dir" value="${liferay.home}/osgi/modules" />
+</project>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/ivy.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/ivy.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<ivy-module
+	version="2.0"
+	xmlns:m2="http://ant.apache.org/ivy/maven"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd"
+>
+	<info module="${plugin.name}" organisation="com.liferay">
+		<extends extendType="configurations,description,info" location="${sdk.dir}/ivy.xml" module="com.liferay.sdk" organisation="com.liferay" revision="latest.integration" />
+	</info>
+
+	<publications>
+		<artifact type="jar" />
+		<artifact type="pom" />
+		<artifact m2:classifier="sources" />
+	</publications>
+
+	<dependencies defaultconf="default">
+		<dependency name="org.osgi.compendium" org="org.osgi" rev="5.0.0" />
+	</dependencies>
+</ivy-module>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/META-INF/resources/form.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/META-INF/resources/form.soy
@@ -1,0 +1,60 @@
+{namespace ddm}
+
+/**
+ * Prints all pages.
+ * @param pages
+ */
+{template .pages}
+	<div class="lfr-form-pages">
+		<ul class="nav nav-tabs">
+			{foreach $page in $pages}
+				<li>
+					<a href="javascript:;">{$page.title}</a>
+				</li>
+			{/foreach}
+		</ul>
+		<div class="tab-content">
+			{foreach $page in $pages}
+				<div class="tab-pane">
+					{call ddm.rows data="all"}
+						{param rows: $page.rows /}
+					{/call}
+				</div>
+			{/foreach}
+		</div>
+	</div>
+{/template}
+
+/**
+ * Prints all rows.
+ * @param rows
+ */
+{template .rows}
+	{foreach $row in $rows}
+		{call ddm.columns data="all"}
+			{param columns: $row.columns /}
+		{/call}
+	{/foreach}
+{/template}
+
+/**
+ * Prints all columns.
+ * @param columns
+ */
+{template .columns}
+	{foreach $column in $columns}
+		{call ddm.column data="all"}
+			{param column: $column /}
+		{/call}
+	{/foreach}
+{/template}
+
+/**
+ * Prints a column.
+ * @param column
+ */
+{template .column}
+	<div class="col-md-{$column.size}">
+		{$column.renderedDDMFormField|noAutoescape}
+	</div>
+{/template}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRenderer.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portlet.dynamicdatamapping.model.DDMForm;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayout;
+
+/**
+ * @author Marcellus Tavares
+ */
+public interface DDMFormRenderer {
+
+	public String render(
+			DDMForm ddmForm, DDMFormLayout ddmFormLayout,
+			DDMFormRenderingContext ddmFormRenderingContext)
+		throws PortalException;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRendererConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRendererConstants.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer;
+
+import com.liferay.portal.kernel.util.StringPool;
+
+/**
+ * @author Marcellus Tavares
+ */
+public class DDMFormRendererConstants {
+
+	public static final String DDM_FORM_FIELD_LANGUAGE_ID_SEPARATOR =
+		StringPool.DOUBLE_UNDERLINE;
+
+	public static final String DDM_FORM_FIELD_NAME_PREFIX = "ddm__";
+
+	public static final String DDM_FORM_FIELD_PARTS_SEPARATOR =
+		StringPool.UNDERLINE;
+
+	public static final String DDM_FORM_FIELDS_SEPARATOR = StringPool.POUND;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRenderingContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/DDMFormRenderingContext.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer;
+
+import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Marcellus Tavares
+ */
+public class DDMFormRenderingContext {
+
+	public DDMFormValues getDDMFormValues() {
+		return _ddmFormValues;
+	}
+
+	public HttpServletRequest getHttpServletRequest() {
+		return _httpServletRequest;
+	}
+
+	public HttpServletResponse getHttpServletResponse() {
+		return _httpServletResponse;
+	}
+
+	public Locale getLocale() {
+		return _locale;
+	}
+
+	public String getPortletNamespace() {
+		return _portletNamespace;
+	}
+
+	public void setDDMFormValues(DDMFormValues ddmFormValues) {
+		_ddmFormValues = ddmFormValues;
+	}
+
+	public void setHttpServletRequest(HttpServletRequest httpServletRequest) {
+		_httpServletRequest = httpServletRequest;
+	}
+
+	public void setHttpServletResponse(
+		HttpServletResponse httpServletResponse) {
+
+		_httpServletResponse = httpServletResponse;
+	}
+
+	public void setLocale(Locale locale) {
+		_locale = locale;
+	}
+
+	public void setPortletNamespace(String portletNamespace) {
+		_portletNamespace = portletNamespace;
+	}
+
+	private DDMFormValues _ddmFormValues;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
+	private Locale _locale;
+	private String _portletNamespace;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormLayoutTransformer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormLayoutTransformer.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer.impl;
+
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayout;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayoutColumn;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayoutPage;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayoutRow;
+import com.liferay.portlet.dynamicdatamapping.model.LocalizedValue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Marcellus Tavares
+ */
+public class DDMFormLayoutTransformer {
+
+	public DDMFormLayoutTransformer(
+		DDMFormLayout ddmFormLayout,
+		Map<String, String> renderedDDMFormFieldsMap, Locale locale) {
+
+		_ddmFormLayout = ddmFormLayout;
+		_renderedDDMFormFieldsMap = renderedDDMFormFieldsMap;
+		_locale = locale;
+	}
+
+	public List<Object> getPages() {
+		return getPages(_ddmFormLayout.getDDMFormLayoutPages());
+	}
+
+	protected Map<String, Object> getColumn(
+		DDMFormLayoutColumn ddmFormLayoutColumn) {
+
+		Map<String, Object> column = new HashMap<>();
+
+		column.put(
+			"renderedDDMFormField",
+			_renderedDDMFormFieldsMap.get(
+				ddmFormLayoutColumn.getDDMFormFieldName()));
+
+		column.put("size", ddmFormLayoutColumn.getSize());
+
+		return column;
+	}
+
+	protected List<Object> getColumns(
+		List<DDMFormLayoutColumn> ddmFormLayoutColumns) {
+
+		List<Object> columns = new ArrayList<>();
+
+		for (DDMFormLayoutColumn ddmFormLayoutColumn : ddmFormLayoutColumns) {
+			columns.add(getColumn(ddmFormLayoutColumn));
+		}
+
+		return columns;
+	}
+
+	protected Map<String, Object> getPage(DDMFormLayoutPage ddmFormLayoutPage) {
+		Map<String, Object> page = new HashMap<>();
+
+		LocalizedValue title = ddmFormLayoutPage.getTitle();
+
+		page.put("title", title.getString(_locale));
+		page.put("rows", getRows(ddmFormLayoutPage.getDDMFormLayoutRows()));
+
+		return page;
+	}
+
+	protected List<Object> getPages(
+		List<DDMFormLayoutPage> ddmFormLayoutPages) {
+
+		List<Object> pages = new ArrayList<>();
+
+		for (DDMFormLayoutPage ddmFormLayoutPage : ddmFormLayoutPages) {
+			pages.add(getPage(ddmFormLayoutPage));
+		}
+
+		return pages;
+	}
+
+	protected Map<String, Object> getRow(DDMFormLayoutRow ddFormLayoutRow) {
+		Map<String, Object> row = new HashMap<>();
+
+		row.put(
+			"columns", getColumns(ddFormLayoutRow.getDDMFormLayoutColumns()));
+
+		return row;
+	}
+
+	protected List<Object> getRows(List<DDMFormLayoutRow> ddmFormLayoutRows) {
+		List<Object> rows = new ArrayList<>();
+
+		for (DDMFormLayoutRow ddmFormLayoutRow : ddmFormLayoutRows) {
+			rows.add(getRow(ddmFormLayoutRow));
+		}
+
+		return rows;
+	}
+
+	private final DDMFormLayout _ddmFormLayout;
+	private final Locale _locale;
+	private final Map<String, String> _renderedDDMFormFieldsMap;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelper.java
@@ -1,0 +1,325 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer.impl;
+
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRendererConstants;
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingContext;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portlet.dynamicdatamapping.model.DDMForm;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormField;
+import com.liferay.portlet.dynamicdatamapping.model.LocalizedValue;
+import com.liferay.portlet.dynamicdatamapping.model.Value;
+import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldRenderer;
+import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldType;
+import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldTypeRegistryUtil;
+import com.liferay.portlet.dynamicdatamapping.render.DDMFormFieldRenderingContext;
+import com.liferay.portlet.dynamicdatamapping.storage.DDMFormFieldValue;
+import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * @author Marcellus Tavares
+ */
+public class DDMFormRendererHelper {
+
+	public DDMFormRendererHelper(
+		DDMForm ddmForm, DDMFormRenderingContext ddmFormRenderingContext) {
+
+		_ddmForm = ddmForm;
+		_ddmFormFieldsMap = ddmForm.getDDMFormFieldsMap(true);
+		_ddmFormRenderingContext = ddmFormRenderingContext;
+		_ddmFormValues = ddmFormRenderingContext.getDDMFormValues();
+	}
+
+	public Map<String, String> getRenderedDDMFormFieldsMap()
+		throws PortalException {
+
+		if (_ddmFormValues != null) {
+			return getRenderedDDMFormFieldValues();
+		}
+		else {
+			return getRenderedDDMFormFields();
+		}
+	}
+
+	protected DDMFormFieldRenderingContext
+		createDDMFormFieldRenderingContext() {
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			new DDMFormFieldRenderingContext();
+
+		ddmFormFieldRenderingContext.setHttpServletRequest(
+			_ddmFormRenderingContext.getHttpServletRequest());
+		ddmFormFieldRenderingContext.setHttpServletResponse(
+			_ddmFormRenderingContext.getHttpServletResponse());
+		ddmFormFieldRenderingContext.setLabel(StringPool.BLANK);
+		ddmFormFieldRenderingContext.setLocale(
+			_ddmFormRenderingContext.getLocale());
+		ddmFormFieldRenderingContext.setName(StringPool.BLANK);
+		ddmFormFieldRenderingContext.setPortletNamespace(
+			_ddmFormRenderingContext.getPortletNamespace());
+		ddmFormFieldRenderingContext.setRenderedNestedDDMFormFields(
+			StringPool.BLANK);
+		ddmFormFieldRenderingContext.setValue(StringPool.BLANK);
+
+		return ddmFormFieldRenderingContext;
+	}
+
+	protected String getAffixedDDMFormFieldParameterName(
+		String ddmFormFieldParameterName) {
+
+		StringBundler sb = new StringBundler(5);
+
+		sb.append(_ddmFormRenderingContext.getPortletNamespace());
+		sb.append(DDMFormRendererConstants.DDM_FORM_FIELD_NAME_PREFIX);
+		sb.append(ddmFormFieldParameterName);
+		sb.append(
+			DDMFormRendererConstants.DDM_FORM_FIELD_LANGUAGE_ID_SEPARATOR);
+		sb.append(
+			LocaleUtil.toLanguageId(_ddmFormRenderingContext.getLocale()));
+
+		return sb.toString();
+	}
+
+	protected String getDDMFormFieldParameterName(
+		String ddmFormFieldName, String instanceId, int index,
+		String parentDDMFormFieldParameterName) {
+
+		StringBundler sb = new StringBundler(7);
+
+		if (Validator.isNotNull(parentDDMFormFieldParameterName)) {
+			sb.append(parentDDMFormFieldParameterName);
+			sb.append(DDMFormRendererConstants.DDM_FORM_FIELDS_SEPARATOR);
+		}
+
+		sb.append(ddmFormFieldName);
+		sb.append(DDMFormRendererConstants.DDM_FORM_FIELD_PARTS_SEPARATOR);
+		sb.append(instanceId);
+		sb.append(DDMFormRendererConstants.DDM_FORM_FIELD_PARTS_SEPARATOR);
+		sb.append(index);
+
+		return sb.toString();
+	}
+
+	protected Map<String, String> getRenderedDDMFormFields()
+		throws PortalException {
+
+		Map<String, String> renderedDDMFormFieldsMap = new HashMap<>();
+
+		for (DDMFormField ddmFormField : _ddmForm.getDDMFormFields()) {
+			renderedDDMFormFieldsMap.put(
+				ddmFormField.getName(),
+				renderDDMFormField(ddmFormField, StringPool.BLANK));
+		}
+
+		return renderedDDMFormFieldsMap;
+	}
+
+	protected Map<String, String> getRenderedDDMFormFieldValues()
+		throws PortalException {
+
+		Map<String, String> renderedDDMFormFieldValuesMap = new HashMap<>();
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			_ddmFormValues.getDDMFormFieldValuesMap();
+
+		for (Map.Entry<String, List<DDMFormFieldValue>> entry :
+				ddmFormFieldValuesMap.entrySet()) {
+
+			renderedDDMFormFieldValuesMap.put(
+				entry.getKey(),
+				renderDDMFormFieldValues(entry.getValue(), StringPool.BLANK));
+		}
+
+		return renderedDDMFormFieldValuesMap;
+	}
+
+	protected String renderDDMFormField(
+			DDMFormField ddmFormField,
+			DDMFormFieldRenderingContext ddmFormFieldRenderingContext)
+		throws PortalException {
+
+		DDMFormFieldType ddmFormFieldType =
+			DDMFormFieldTypeRegistryUtil.getDDMFormFieldType(
+				ddmFormField.getType());
+
+		DDMFormFieldRenderer ddmFormFieldRenderer =
+			ddmFormFieldType.getDDMFormFieldRenderer();
+
+		return ddmFormFieldRenderer.render(
+			ddmFormField, ddmFormFieldRenderingContext);
+	}
+
+	protected String renderDDMFormField(
+			DDMFormField ddmFormField, String parentDDMFormFieldParameterName)
+		throws PortalException {
+
+		String ddmFormFieldParameterName = getDDMFormFieldParameterName(
+			ddmFormField.getName(), StringUtil.randomString(), 0,
+			parentDDMFormFieldParameterName);
+
+		List<DDMFormField> nestedDDMFormFields =
+			ddmFormField.getNestedDDMFormFields();
+
+		StringBundler sb = new StringBundler(nestedDDMFormFields.size());
+
+		for (DDMFormField nestedDDMFormField : nestedDDMFormFields) {
+			sb.append(
+				renderDDMFormField(
+					nestedDDMFormField, ddmFormFieldParameterName));
+		}
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			createDDMFormFieldRenderingContext();
+
+		setDDMFormFieldRenderingContextLabel(
+			ddmFormField.getLabel(), ddmFormFieldRenderingContext);
+		setDDMFormFieldRenderingContextName(
+			ddmFormFieldParameterName, ddmFormFieldRenderingContext);
+		setDDMFormFieldRenderingContextRenderedNestedDDMFormFields(
+			sb.toString(), ddmFormFieldRenderingContext);
+
+		return renderDDMFormField(ddmFormField, ddmFormFieldRenderingContext);
+	}
+
+	protected String renderDDMFormFieldValue(
+			DDMFormFieldValue ddmFormFieldValue,
+			DDMFormFieldRenderingContext ddmFormFieldRenderingContext)
+		throws PortalException {
+
+		DDMFormField ddmFormField = _ddmFormFieldsMap.get(
+			ddmFormFieldValue.getName());
+
+		setDDMFormFieldRenderingContextLabel(
+			ddmFormField.getLabel(), ddmFormFieldRenderingContext);
+		setDDMFormFieldRenderingContextValue(
+			ddmFormFieldValue.getValue(), ddmFormFieldRenderingContext);
+
+		return renderDDMFormField(ddmFormField, ddmFormFieldRenderingContext);
+	}
+
+	protected String renderDDMFormFieldValue(
+			DDMFormFieldValue ddmFormFieldValue, int index,
+			String parentDDMFormFieldParameterName)
+		throws PortalException {
+
+		String ddmFormFieldParameterName = getDDMFormFieldParameterName(
+			ddmFormFieldValue.getName(), ddmFormFieldValue.getInstanceId(),
+			index, parentDDMFormFieldParameterName);
+
+		Map<String, List<DDMFormFieldValue>> nestedDDMFormFieldValuesMap =
+			ddmFormFieldValue.getNestedDDMFormFieldValuesMap();
+
+		StringBundler sb = new StringBundler(
+			nestedDDMFormFieldValuesMap.size());
+
+		for (List<DDMFormFieldValue> nestedDDMFormFieldValues :
+				nestedDDMFormFieldValuesMap.values()) {
+
+			sb.append(
+				renderDDMFormFieldValues(
+					nestedDDMFormFieldValues, ddmFormFieldParameterName));
+		}
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			createDDMFormFieldRenderingContext();
+
+		setDDMFormFieldRenderingContextName(
+			ddmFormFieldParameterName, ddmFormFieldRenderingContext);
+		setDDMFormFieldRenderingContextRenderedNestedDDMFormFields(
+			sb.toString(), ddmFormFieldRenderingContext);
+
+		return renderDDMFormFieldValue(
+			ddmFormFieldValue, ddmFormFieldRenderingContext);
+	}
+
+	protected String renderDDMFormFieldValues(
+			List<DDMFormFieldValue> ddmFormFieldValues,
+			String parentDDMFormFieldParameterName)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(ddmFormFieldValues.size());
+
+		int index = 0;
+
+		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
+			sb.append(
+				renderDDMFormFieldValue(
+					ddmFormFieldValue, index++,
+					parentDDMFormFieldParameterName));
+		}
+
+		return sb.toString();
+	}
+
+	protected void setDDMFormFieldRenderingContextLabel(
+		LocalizedValue label,
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		Map<Locale, String> values = label.getValues();
+
+		if (values.isEmpty()) {
+			return;
+		}
+
+		ddmFormFieldRenderingContext.setLabel(
+			label.getString(ddmFormFieldRenderingContext.getLocale()));
+	}
+
+	protected void setDDMFormFieldRenderingContextName(
+		String ddmFormFieldParameterName,
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		String name = getAffixedDDMFormFieldParameterName(
+			ddmFormFieldParameterName);
+
+		ddmFormFieldRenderingContext.setName(name);
+	}
+
+	protected void setDDMFormFieldRenderingContextRenderedNestedDDMFormFields(
+		String renderedNestedDDMFormFields,
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		ddmFormFieldRenderingContext.setRenderedNestedDDMFormFields(
+			renderedNestedDDMFormFields);
+	}
+
+	protected void setDDMFormFieldRenderingContextValue(
+		Value value,
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		if (value == null) {
+			return;
+		}
+
+		ddmFormFieldRenderingContext.setValue(
+			value.getString(ddmFormFieldRenderingContext.getLocale()));
+	}
+
+	private final DDMForm _ddmForm;
+	private final Map<String, DDMFormField> _ddmFormFieldsMap;
+	private final DDMFormRenderingContext _ddmFormRenderingContext;
+	private final DDMFormValues _ddmFormValues;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelper.java
@@ -79,8 +79,7 @@ public class DDMFormRendererHelper {
 		ddmFormFieldRenderingContext.setName(StringPool.BLANK);
 		ddmFormFieldRenderingContext.setPortletNamespace(
 			_ddmFormRenderingContext.getPortletNamespace());
-		ddmFormFieldRenderingContext.setRenderedNestedDDMFormFields(
-			StringPool.BLANK);
+		ddmFormFieldRenderingContext.setRenderedChildElements(StringPool.BLANK);
 		ddmFormFieldRenderingContext.setValue(StringPool.BLANK);
 
 		return ddmFormFieldRenderingContext;
@@ -197,7 +196,7 @@ public class DDMFormRendererHelper {
 			ddmFormField.getLabel(), ddmFormFieldRenderingContext);
 		setDDMFormFieldRenderingContextName(
 			ddmFormFieldParameterName, ddmFormFieldRenderingContext);
-		setDDMFormFieldRenderingContextRenderedNestedDDMFormFields(
+		setDDMFormFieldRenderingContextRenderedChildElements(
 			sb.toString(), ddmFormFieldRenderingContext);
 
 		return renderDDMFormField(ddmFormField, ddmFormFieldRenderingContext);
@@ -247,7 +246,7 @@ public class DDMFormRendererHelper {
 
 		setDDMFormFieldRenderingContextName(
 			ddmFormFieldParameterName, ddmFormFieldRenderingContext);
-		setDDMFormFieldRenderingContextRenderedNestedDDMFormFields(
+		setDDMFormFieldRenderingContextRenderedChildElements(
 			sb.toString(), ddmFormFieldRenderingContext);
 
 		return renderDDMFormFieldValue(
@@ -297,12 +296,12 @@ public class DDMFormRendererHelper {
 		ddmFormFieldRenderingContext.setName(name);
 	}
 
-	protected void setDDMFormFieldRenderingContextRenderedNestedDDMFormFields(
-		String renderedNestedDDMFormFields,
+	protected void setDDMFormFieldRenderingContextRenderedChildElements(
+		String renderedChildElements,
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
 
-		ddmFormFieldRenderingContext.setRenderedNestedDDMFormFields(
-			renderedNestedDDMFormFields);
+		ddmFormFieldRenderingContext.setRenderedChildElements(
+			renderedChildElements);
 	}
 
 	protected void setDDMFormFieldRenderingContextValue(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererImpl.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer.impl;
+
+import aQute.bnd.annotation.component.Deactivate;
+
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingContext;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
+import com.liferay.portal.kernel.template.Template;
+import com.liferay.portal.kernel.template.TemplateConstants;
+import com.liferay.portal.kernel.template.TemplateManagerUtil;
+import com.liferay.portal.kernel.template.TemplateResource;
+import com.liferay.portal.kernel.template.URLTemplateResource;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portlet.dynamicdatamapping.model.DDMForm;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayout;
+
+import java.io.Writer;
+
+import java.net.URL;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Marcellus Tavares
+ */
+@Component(
+	immediate = true, property = {"templatePath=/META-INF/resources/form.soy"},
+	service = {DDMFormRenderer.class}
+)
+public class DDMFormRendererImpl implements DDMFormRenderer {
+
+	@Override
+	public String render(
+			DDMForm ddmForm, DDMFormLayout ddmFormLayout,
+			DDMFormRenderingContext ddmFormRenderingContext)
+		throws PortalException {
+
+		Template template = TemplateManagerUtil.getTemplate(
+			TemplateConstants.LANG_TYPE_SOY, _templateResource, false);
+
+		template.put(TemplateConstants.NAMESPACE, "ddm.pages");
+
+		Map<String, String> renderedDDMFormFieldsMap =
+			getRenderedDDMFormFieldsMap(ddmForm, ddmFormRenderingContext);
+
+		List<Object> pages = getPages(
+			ddmFormLayout, renderedDDMFormFieldsMap,
+			ddmFormRenderingContext.getLocale());
+
+		template.put("pages", pages);
+
+		return render(template);
+	}
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		String templatePath = MapUtil.getString(properties, "templatePath");
+
+		_templateResource = getTemplateResource(templatePath);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_templateResource = null;
+	}
+
+	protected List<Object> getPages(
+		DDMFormLayout ddmFormLayout,
+		Map<String, String> renderedDDMFormFieldsMap, Locale locale) {
+
+		DDMFormLayoutTransformer ddmFormLayoutTransformer =
+			new DDMFormLayoutTransformer(
+				ddmFormLayout, renderedDDMFormFieldsMap, locale);
+
+		return ddmFormLayoutTransformer.getPages();
+	}
+
+	protected Map<String, String> getRenderedDDMFormFieldsMap(
+			DDMForm ddmForm, DDMFormRenderingContext ddmFormRenderingContext)
+		throws PortalException {
+
+		DDMFormRendererHelper ddmFormRendererHelper = new DDMFormRendererHelper(
+			ddmForm, ddmFormRenderingContext);
+
+		return ddmFormRendererHelper.getRenderedDDMFormFieldsMap();
+	}
+
+	protected TemplateResource getTemplateResource(String templatePath) {
+		Class<?> clazz = getClass();
+
+		ClassLoader classLoader = clazz.getClassLoader();
+
+		URL templateURL = classLoader.getResource(templatePath);
+
+		return new URLTemplateResource(templateURL.getPath(), templateURL);
+	}
+
+	protected String render(Template template) throws PortalException {
+		Writer writer = new UnsyncStringWriter();
+
+		template.processTemplate(writer);
+
+		return writer.toString();
+	}
+
+	private TemplateResource _templateResource;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/unit/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormLayoutTransformerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/unit/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormLayoutTransformerTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer.impl;
+
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayout;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayoutColumn;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayoutPage;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormLayoutRow;
+import com.liferay.portlet.dynamicdatamapping.model.LocalizedValue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Marcellus Tavares
+ */
+public class DDMFormLayoutTransformerTest {
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetPages() {
+		DDMFormLayout ddmFormLayout = new DDMFormLayout();
+
+		DDMFormLayoutPage ddmFormLayoutPage = new DDMFormLayoutPage();
+
+		LocalizedValue title = new LocalizedValue(_LOCALE);
+
+		title.addString(_LOCALE, "Page 1");
+
+		ddmFormLayoutPage.setTitle(title);
+
+		DDMFormLayoutRow ddmFormLayoutRow1 = new DDMFormLayoutRow();
+
+		ddmFormLayoutRow1.setDDMFormLayoutColumns(
+			createDDMFormLayoutColumns("Field_1", "Field_2"));
+
+		ddmFormLayoutPage.addDDMFormLayoutRow(ddmFormLayoutRow1);
+
+		DDMFormLayoutRow ddmFormLayoutRow2 = new DDMFormLayoutRow();
+
+		ddmFormLayoutRow2.setDDMFormLayoutColumns(
+			createDDMFormLayoutColumns("Field_3", "Field_4", "Field_5"));
+
+		ddmFormLayoutPage.addDDMFormLayoutRow(ddmFormLayoutRow2);
+
+		ddmFormLayout.addDDMFormLayoutPage(ddmFormLayoutPage);
+
+		Map<String, String> renderedDDMFormFieldsMap = new HashMap<>();
+
+		renderedDDMFormFieldsMap.put("Field_1", "Rendered Field 1");
+		renderedDDMFormFieldsMap.put("Field_2", "Rendered Field 2");
+		renderedDDMFormFieldsMap.put("Field_3", "Rendered Field 3");
+		renderedDDMFormFieldsMap.put("Field_4", "Rendered Field 4");
+		renderedDDMFormFieldsMap.put("Field_5", "Rendered Field 5");
+
+		DDMFormLayoutTransformer ddmFormLayoutTransformer =
+			new DDMFormLayoutTransformer(
+				ddmFormLayout, renderedDDMFormFieldsMap, _LOCALE);
+
+		List<Object> pages = ddmFormLayoutTransformer.getPages();
+
+		Assert.assertEquals(1, pages.size());
+
+		Map<String, Object> page1 = (Map<String, Object>)pages.get(0);
+
+		Assert.assertEquals("Page 1", page1.get("title"));
+
+		List<Object> rows = (List<Object>)page1.get("rows");
+
+		Assert.assertEquals(2, rows.size());
+
+		Map<String, Object> row1 = (Map<String, Object>)rows.get(0);
+
+		List<Object> columnsRow1 = (List<Object>)row1.get("columns");
+
+		Assert.assertEquals(2, columnsRow1.size());
+
+		assertColumnEquals(
+			"Rendered Field 1", 6, (Map<String, Object>)columnsRow1.get(0));
+		assertColumnEquals(
+			"Rendered Field 2", 6, (Map<String, Object>)columnsRow1.get(1));
+
+		Map<String, Object> row2 = (Map<String, Object>)rows.get(1);
+
+		List<Object> columnsRow2 = (List<Object>)row2.get("columns");
+
+		Assert.assertEquals(3, columnsRow2.size());
+
+		assertColumnEquals(
+			"Rendered Field 3", 4, (Map<String, Object>)columnsRow2.get(0));
+		assertColumnEquals(
+			"Rendered Field 4", 4, (Map<String, Object>)columnsRow2.get(1));
+		assertColumnEquals(
+			"Rendered Field 5", 4, (Map<String, Object>)columnsRow2.get(2));
+	}
+
+	protected void assertColumnEquals(
+		String expectedRenderedDDMFormField, int expectedSize,
+		Map<String, Object> actualColumn) {
+
+		Assert.assertEquals(
+			expectedRenderedDDMFormField,
+			actualColumn.get("renderedDDMFormField"));
+		Assert.assertEquals(expectedSize, actualColumn.get("size"));
+	}
+
+	protected DDMFormLayoutColumn createDDMFormLayoutColumn(
+		String ddmFormFieldName, int size) {
+
+		return new DDMFormLayoutColumn(ddmFormFieldName, size);
+	}
+
+	protected List<DDMFormLayoutColumn> createDDMFormLayoutColumns(
+		String... ddmFormFieldNames) {
+
+		List<DDMFormLayoutColumn> ddmFormLayoutColumns = new ArrayList<>();
+
+		int ddmFormLayoutColumnSize =
+			(DDMFormLayoutColumn.FULL / ddmFormFieldNames.length);
+
+		for (String ddmFormFieldName : ddmFormFieldNames) {
+			ddmFormLayoutColumns.add(
+				createDDMFormLayoutColumn(
+					ddmFormFieldName, ddmFormLayoutColumnSize));
+		}
+
+		return ddmFormLayoutColumns;
+	}
+
+	private static final Locale _LOCALE = LocaleUtil.US;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/unit/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/unit/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelperTest.java
@@ -1,0 +1,453 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.renderer.impl;
+
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRendererConstants;
+import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderingContext;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portlet.dynamicdatamapping.model.DDMForm;
+import com.liferay.portlet.dynamicdatamapping.model.DDMFormField;
+import com.liferay.portlet.dynamicdatamapping.model.UnlocalizedValue;
+import com.liferay.portlet.dynamicdatamapping.model.Value;
+import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldRenderer;
+import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldType;
+import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldTypeRegistry;
+import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldTypeRegistryUtil;
+import com.liferay.portlet.dynamicdatamapping.render.DDMFormFieldRenderingContext;
+import com.liferay.portlet.dynamicdatamapping.storage.DDMFormFieldValue;
+import com.liferay.portlet.dynamicdatamapping.storage.DDMFormValues;
+import com.liferay.portlet.dynamicdatamapping.util.test.DDMFormValuesTestUtil;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author Marcellus Tavares
+ */
+@PrepareForTest({LocaleUtil.class, StringUtil.class})
+@RunWith(PowerMockRunner.class)
+public class DDMFormRendererHelperTest extends PowerMockito {
+
+	@Before
+	public void setUp() throws Exception {
+		setUpDDMFormFieldTypeRegistryUtil();
+		setUpLocaleUtil();
+		setUpStringUtil();
+	}
+
+	@Test
+	public void testGetRenderedDDMFormFieldsMapByDDMFormValues()
+		throws Exception {
+
+		DDMForm ddmForm = new DDMForm();
+
+		DDMFormField contactDDMFormField = new DDMFormField("Contact", "text");
+
+		contactDDMFormField.addNestedDDMFormField(
+			new DDMFormField("FirstName", "text"));
+
+		contactDDMFormField.addNestedDDMFormField(
+			new DDMFormField("LastName", "text"));
+
+		ddmForm.addDDMFormField(contactDDMFormField);
+
+		DDMFormValues ddmFormValues = new DDMFormValues(ddmForm);
+
+		DDMFormFieldValue contact1DDMFormFieldValue = createDDMFormFieldValue(
+			"asxd", "Contact", "Contact 1");
+
+		contact1DDMFormFieldValue.addNestedDDMFormFieldValue(
+			createDDMFormFieldValue("hegt", "FirstName", "Joe"));
+
+		contact1DDMFormFieldValue.addNestedDDMFormFieldValue(
+			createDDMFormFieldValue("nahy", "LastName", "Bloggs"));
+
+		ddmFormValues.addDDMFormFieldValue(contact1DDMFormFieldValue);
+
+		DDMFormFieldValue contact2DDMFormFieldValue = createDDMFormFieldValue(
+			"uahy", "Contact", "Contact 2");
+
+		contact2DDMFormFieldValue.addNestedDDMFormFieldValue(
+			createDDMFormFieldValue("wbuy", "FirstName", "Elza"));
+
+		contact2DDMFormFieldValue.addNestedDDMFormFieldValue(
+			createDDMFormFieldValue("aaho", "LastName", "Fitzgerald"));
+
+		ddmFormValues.addDDMFormFieldValue(contact2DDMFormFieldValue);
+
+		String renderedContact1DDMFormFieldValue =
+			renderContactDDMFormFieldValue(contact1DDMFormFieldValue, 0);
+
+		String renderedContact2DDMFormFieldValue =
+			renderContactDDMFormFieldValue(contact2DDMFormFieldValue, 1);
+
+		String renderedContactDDMFormFieldValues =
+			renderedContact1DDMFormFieldValue.concat(
+				renderedContact2DDMFormFieldValue);
+
+		DDMFormRenderingContext ddmFormRenderingContext =
+			createDDMFormRenderingContext();
+
+		ddmFormRenderingContext.setDDMFormValues(ddmFormValues);
+
+		DDMFormRendererHelper ddmFormRendererHelper = new DDMFormRendererHelper(
+			ddmForm, ddmFormRenderingContext);
+
+		Map<String, String> renderedDDMFormFieldsMap =
+			ddmFormRendererHelper.getRenderedDDMFormFieldsMap();
+
+		Assert.assertEquals(
+			renderedContactDDMFormFieldValues,
+			renderedDDMFormFieldsMap.get("Contact"));
+	}
+
+	@Test
+	public void testGetRenderedDDMFormFieldsMapByDDMFormWithNestedFields()
+		throws Exception {
+
+		DDMForm ddmForm = new DDMForm();
+
+		DDMFormField nameDDMFormField = new DDMFormField("Name", "text");
+		DDMFormField phoneDDMFormField = new DDMFormField("Phone", "text");
+		DDMFormField extDDMFormField = new DDMFormField("Ext", "text");
+
+		phoneDDMFormField.addNestedDDMFormField(extDDMFormField);
+
+		nameDDMFormField.addNestedDDMFormField(phoneDDMFormField);
+
+		ddmForm.addDDMFormField(nameDDMFormField);
+
+		String nameDDMFormFieldParameterName = getDDMFormFieldParameterName(
+			"Name", StringPool.BLANK);
+
+		String phoneDDMFormFieldParameterName = getDDMFormFieldParameterName(
+			"Phone", nameDDMFormFieldParameterName);
+
+		String extDDMFormFieldFieldParameterName = getDDMFormFieldParameterName(
+			"Ext", phoneDDMFormFieldParameterName);
+
+		String renderedExtDDMFormField = renderTextField(
+			extDDMFormFieldFieldParameterName, StringPool.BLANK,
+			StringPool.BLANK);
+
+		String renderedPhoneDDMFormField = renderTextField(
+			phoneDDMFormFieldParameterName, StringPool.BLANK,
+			renderedExtDDMFormField);
+
+		String renderedNameDDMFormField = renderTextField(
+			nameDDMFormFieldParameterName, StringPool.BLANK,
+			renderedPhoneDDMFormField);
+
+		DDMFormRendererHelper ddmFormFieldRendererHelper =
+			new DDMFormRendererHelper(ddmForm, createDDMFormRenderingContext());
+
+		Map<String, String> renderedDDMFormFieldsMap =
+			ddmFormFieldRendererHelper.getRenderedDDMFormFieldsMap();
+
+		Assert.assertEquals(
+			renderedNameDDMFormField, renderedDDMFormFieldsMap.get("Name"));
+	}
+
+	@Test
+	public void testGetRenderedDDMFormFieldsMapByDDMFormWithoutNestedFields()
+		throws Exception {
+
+		DDMForm ddmForm = new DDMForm();
+
+		ddmForm.addDDMFormField(new DDMFormField("Name", "text"));
+		ddmForm.addDDMFormField(new DDMFormField("Age", "text"));
+
+		String nameDDMFormFieldParameterName = getDDMFormFieldParameterName(
+			"Name", StringPool.BLANK);
+
+		String renderedNameDDMFormField = renderTextField(
+			nameDDMFormFieldParameterName, StringPool.BLANK, StringPool.BLANK);
+
+		String ageDDMFormFieldParameterName = getDDMFormFieldParameterName(
+			"Age", StringPool.BLANK);
+
+		String renderedAgeDDMFormField = renderTextField(
+			ageDDMFormFieldParameterName, StringPool.BLANK, StringPool.BLANK);
+
+		DDMFormRendererHelper ddmFormFieldRendererHelper =
+			new DDMFormRendererHelper(ddmForm, createDDMFormRenderingContext());
+
+		Map<String, String> renderedDDMFormFieldsMap =
+			ddmFormFieldRendererHelper.getRenderedDDMFormFieldsMap();
+
+		Assert.assertEquals(
+			renderedNameDDMFormField, renderedDDMFormFieldsMap.get("Name"));
+		Assert.assertEquals(
+			renderedAgeDDMFormField, renderedDDMFormFieldsMap.get("Age"));
+	}
+
+	protected DDMFormFieldValue createDDMFormFieldValue(
+		String instanceId, String name, String value) {
+
+		return DDMFormValuesTestUtil.createDDMFormFieldValue(
+			instanceId, name, new UnlocalizedValue(value));
+	}
+
+	protected DDMFormRenderingContext createDDMFormRenderingContext() {
+		DDMFormRenderingContext ddmFormRenderingContext =
+			new DDMFormRenderingContext();
+
+		ddmFormRenderingContext.setLocale(_LOCALE);
+		ddmFormRenderingContext.setPortletNamespace(_PORTLET_NAMESPACE);
+
+		return ddmFormRenderingContext;
+	}
+
+	protected String getAffixedDDMFormFieldParameterName(
+		String ddmFormFieldParameterName) {
+
+		StringBundler sb = new StringBundler(5);
+
+		sb.append(_PORTLET_NAMESPACE);
+		sb.append(DDMFormRendererConstants.DDM_FORM_FIELD_NAME_PREFIX);
+		sb.append(ddmFormFieldParameterName);
+		sb.append(
+			DDMFormRendererConstants.DDM_FORM_FIELD_LANGUAGE_ID_SEPARATOR);
+		sb.append(LocaleUtil.toLanguageId(_LOCALE));
+
+		return sb.toString();
+	}
+
+	protected String getDDMFormFieldParameterName(
+		String ddmFormFieldName, String parentDDMFormFieldParameterName) {
+
+		return getDDMFormFieldParameterName(
+			ddmFormFieldName, _RANDOM_STRING, 0,
+			parentDDMFormFieldParameterName);
+	}
+
+	protected String getDDMFormFieldParameterName(
+		String ddmFormFieldName, String instanceId, int index) {
+
+		return getDDMFormFieldParameterName(
+			ddmFormFieldName, instanceId, index, StringPool.BLANK);
+	}
+
+	protected String getDDMFormFieldParameterName(
+		String ddmFormFieldName, String instanceId, int index,
+		String parentDDMFormFieldParameterName) {
+
+		StringBundler sb = new StringBundler(7);
+
+		if (Validator.isNotNull(parentDDMFormFieldParameterName)) {
+			sb.append(parentDDMFormFieldParameterName);
+			sb.append(DDMFormRendererConstants.DDM_FORM_FIELDS_SEPARATOR);
+		}
+
+		sb.append(ddmFormFieldName);
+		sb.append(DDMFormRendererConstants.DDM_FORM_FIELD_PARTS_SEPARATOR);
+		sb.append(instanceId);
+		sb.append(DDMFormRendererConstants.DDM_FORM_FIELD_PARTS_SEPARATOR);
+		sb.append(index);
+
+		return sb.toString();
+	}
+
+	protected String renderContactDDMFormFieldValue(
+		DDMFormFieldValue contactDDMFormFieldValue, int index) {
+
+		String contactDDMFormFieldParameterName = getDDMFormFieldParameterName(
+			contactDDMFormFieldValue.getName(),
+			contactDDMFormFieldValue.getInstanceId(), index);
+
+		List<DDMFormFieldValue> contactNestedDDMFormFieldValues =
+			contactDDMFormFieldValue.getNestedDDMFormFieldValues();
+
+		String renderedContactFirstName = renderContactNestedDDMFormFieldValue(
+			contactDDMFormFieldParameterName,
+			contactNestedDDMFormFieldValues.get(0));
+
+		String renderedContactLastName = renderContactNestedDDMFormFieldValue(
+			contactDDMFormFieldParameterName,
+			contactNestedDDMFormFieldValues.get(1));
+
+		String contactRenderedNestedDDMFormFieldValues =
+			renderedContactFirstName.concat(renderedContactLastName);
+
+		Value value = contactDDMFormFieldValue.getValue();
+
+		return renderTextField(
+			contactDDMFormFieldParameterName, value.getString(_LOCALE),
+			contactRenderedNestedDDMFormFieldValues);
+	}
+
+	protected String renderContactNestedDDMFormFieldValue(
+		String contactDDMFormFieldParameterName,
+		DDMFormFieldValue ddmFormFieldValue) {
+
+		String ddmFormFieldParameterName = getDDMFormFieldParameterName(
+			ddmFormFieldValue.getName(), ddmFormFieldValue.getInstanceId(), 0,
+			contactDDMFormFieldParameterName);
+
+		Value value = ddmFormFieldValue.getValue();
+
+		return renderTextField(
+			ddmFormFieldParameterName, value.getString(_LOCALE),
+			StringPool.BLANK);
+	}
+
+	protected String renderTextField(
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
+
+		return StringUtil.replace(
+			_INPUT_FIELD_TEMPLATE,
+			new String[] {
+				"$name", "$value", "$nestedDDMFormFields"
+			},
+			new String[] {
+				ddmFormFieldRenderingContext.getName(),
+				ddmFormFieldRenderingContext.getValue(),
+				ddmFormFieldRenderingContext.getRenderedNestedDDMFormFields()
+			}
+		);
+	}
+
+	protected String renderTextField(
+		String ddmFormFieldParameterName, String value,
+		String renderedNestedDDMFormFields) {
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			new DDMFormFieldRenderingContext();
+
+		String name = getAffixedDDMFormFieldParameterName(
+			ddmFormFieldParameterName);
+
+		ddmFormFieldRenderingContext.setName(name);
+		ddmFormFieldRenderingContext.setRenderedNestedDDMFormFields(
+			renderedNestedDDMFormFields);
+		ddmFormFieldRenderingContext.setValue(value);
+
+		return renderTextField(ddmFormFieldRenderingContext);
+	}
+
+	protected void setUpDDMFormFieldRenderer() throws Exception {
+		when(
+			_ddmFormFieldRenderer.render(
+				Matchers.any(DDMFormField.class),
+				Matchers.any(DDMFormFieldRenderingContext.class))
+		).then(
+			new Answer<String>() {
+
+				@Override
+				public String answer(InvocationOnMock invocationOnMock)
+					throws Throwable {
+
+					Object[] args = invocationOnMock.getArguments();
+
+					DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+						(DDMFormFieldRenderingContext)args[1];
+
+					return renderTextField(ddmFormFieldRenderingContext);
+				}
+
+			}
+		);
+	}
+
+	protected void setUpDDMFormFieldType() {
+		when(
+			_ddmFormFieldType.getDDMFormFieldRenderer()
+		).thenReturn(
+			_ddmFormFieldRenderer
+		);
+	}
+
+	protected void setUpDDMFormFieldTypeRegistryUtil() throws Exception {
+		setUpDDMFormFieldRenderer();
+		setUpDDMFormFieldType();
+
+		when(
+			_ddmFormFieldTypeRegistry.getDDMFormFieldType(Matchers.anyString())
+		).thenReturn(
+			_ddmFormFieldType
+		);
+
+		DDMFormFieldTypeRegistryUtil ddmFormFieldTypeRegistryUtil =
+			new DDMFormFieldTypeRegistryUtil();
+
+		ddmFormFieldTypeRegistryUtil.setDDMFormFieldTypeRegistry(
+			_ddmFormFieldTypeRegistry);
+	}
+
+	protected void setUpLocaleUtil() {
+		mockStatic(LocaleUtil.class);
+
+		when(
+			LocaleUtil.fromLanguageId("en_US")
+		).thenReturn(
+			LocaleUtil.US
+		);
+
+		when(
+			LocaleUtil.toLanguageId(LocaleUtil.US)
+		).thenReturn(
+			"en_US"
+		);
+	}
+
+	protected void setUpStringUtil() {
+		spy(StringUtil.class);
+
+		when(
+			StringUtil.randomString()
+		).thenReturn(
+			_RANDOM_STRING
+		);
+	}
+
+	private static final String _INPUT_FIELD_TEMPLATE =
+		"<div><input name=\"$name\" value=\"$value\">$nestedDDMFormFields" +
+			"</div>";
+
+	private static final Locale _LOCALE = LocaleUtil.US;
+
+	private static final String _PORTLET_NAMESPACE = "_NAMESPACE_";
+
+	private static final String _RANDOM_STRING = "_RANDOM_";
+
+	@Mock
+	private DDMFormFieldRenderer _ddmFormFieldRenderer;
+
+	@Mock
+	private DDMFormFieldType _ddmFormFieldType;
+
+	@Mock
+	private DDMFormFieldTypeRegistry _ddmFormFieldTypeRegistry;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/unit/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/test/unit/com/liferay/dynamic/data/mapping/form/renderer/impl/DDMFormRendererHelperTest.java
@@ -333,14 +333,14 @@ public class DDMFormRendererHelperTest extends PowerMockito {
 			new String[] {
 				ddmFormFieldRenderingContext.getName(),
 				ddmFormFieldRenderingContext.getValue(),
-				ddmFormFieldRenderingContext.getRenderedNestedDDMFormFields()
+				ddmFormFieldRenderingContext.getRenderedChildElements()
 			}
 		);
 	}
 
 	protected String renderTextField(
 		String ddmFormFieldParameterName, String value,
-		String renderedNestedDDMFormFields) {
+		String renderedChildElements) {
 
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
 			new DDMFormFieldRenderingContext();
@@ -349,8 +349,8 @@ public class DDMFormRendererHelperTest extends PowerMockito {
 			ddmFormFieldParameterName);
 
 		ddmFormFieldRenderingContext.setName(name);
-		ddmFormFieldRenderingContext.setRenderedNestedDDMFormFields(
-			renderedNestedDDMFormFields);
+		ddmFormFieldRenderingContext.setRenderedChildElements(
+			renderedChildElements);
 		ddmFormFieldRenderingContext.setValue(value);
 
 		return renderTextField(ddmFormFieldRenderingContext);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-text/src/META-INF/resources/text.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-text/src/META-INF/resources/text.soy
@@ -4,18 +4,19 @@
  * Prints the DDM form text field.
  *
  * @param dir
- * @param fieldLabel
- * @param fieldName
- * @param fieldNameSuffix
- * @param fieldValue
- * @param fieldQualifiedName
+ * @param label
+ * @param name
+ * @param renderedNestedDDMFormFields
+ * @param value
  */
 {template .text}
-	<div class="form-group field-wrapper" data-fieldname="{$fieldName}" data-fieldnamespace="{$fieldNameSuffix}">
-		<label class="control-fieldLabel" for="{$fieldQualifiedName}">
-			{$fieldLabel}
+	<div class="form-group field-wrapper">
+		<label class="control-fieldLabel" for="{$name}">
+			{$label}
 		</label>
 
-		 <input class="field form-control" dir="{$dir}" id="{$fieldQualifiedName}" name="{$fieldQualifiedName}" type="text" value="{$fieldValue}"> 
+		 <input class="field form-control" dir="{$dir}" id="{$name}" name="{$name}" type="text" value="{$value}">
+
+		{$renderedNestedDDMFormFields}
 	</div>
 {/template}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-text/src/META-INF/resources/text.soy
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-text/src/META-INF/resources/text.soy
@@ -6,7 +6,7 @@
  * @param dir
  * @param label
  * @param name
- * @param renderedNestedDDMFormFields
+ * @param renderedChildElements
  * @param value
  */
 {template .text}
@@ -17,6 +17,6 @@
 
 		 <input class="field form-control" dir="{$dir}" id="{$name}" name="{$name}" type="text" value="{$value}">
 
-		{$renderedNestedDDMFormFields}
+		{$renderedChildElements}
 	</div>
 {/template}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-text/src/com/liferay/dynamic/data/mapping/type/TextDDMFormFieldRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-type-text/src/com/liferay/dynamic/data/mapping/type/TextDDMFormFieldRenderer.java
@@ -14,18 +14,17 @@
 
 package com.liferay.dynamic.data.mapping.type;
 
+import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateResource;
-import com.liferay.portal.kernel.template.URLTemplateResource;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portlet.dynamicdatamapping.registry.BaseDDMFormFieldRenderer;
 import com.liferay.portlet.dynamicdatamapping.registry.DDMFormFieldRenderer;
-
-import java.net.URL;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 
 /**
  * @author Marcellus Tavares
@@ -38,24 +37,33 @@ import org.osgi.service.component.annotations.Component;
 )
 public class TextDDMFormFieldRenderer extends BaseDDMFormFieldRenderer {
 
+	@Override
+	public String getTemplateLanguage() {
+		return TemplateConstants.LANG_TYPE_SOY;
+	}
+
+	@Override
+	public String getTemplateNamespace() {
+		return "ddm.text";
+	}
+
+	@Override
+	public TemplateResource getTemplateResource() {
+		return _templateResource;
+	}
+
 	@Activate
 	protected void activate(Map<String, Object> properties) {
 		String templatePath = MapUtil.getString(properties, "templatePath");
 
-		TemplateResource templateResource = getTemplateResource(templatePath);
-
-		this.templateNamespace = "ddm.text";
-		this.templateResource = templateResource;
+		_templateResource = getTemplateResource(templatePath);
 	}
 
-	protected TemplateResource getTemplateResource(String templatePath) {
-		Class<?> clazz = getClass();
-
-		ClassLoader classLoader = clazz.getClassLoader();
-
-		URL templateURL = classLoader.getResource(templatePath);
-
-		return new URLTemplateResource(templateURL.getPath(), templateURL);
+	@Deactivate
+	protected void deactivate() {
+		_templateResource = null;
 	}
+
+	private TemplateResource _templateResource;
 
 }

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/registry/BaseDDMFormFieldRenderer.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/registry/BaseDDMFormFieldRenderer.java
@@ -81,8 +81,8 @@ public abstract class BaseDDMFormFieldRenderer implements DDMFormFieldRenderer {
 		template.put("label", ddmFormFieldRenderingContext.getLabel());
 		template.put("name", ddmFormFieldRenderingContext.getName());
 		template.put(
-			"renderedNestedDDMFormFields",
-			ddmFormFieldRenderingContext.getRenderedNestedDDMFormFields());
+			"renderedChildElements",
+			ddmFormFieldRenderingContext.getRenderedChildElements());
 		template.put("value", ddmFormFieldRenderingContext.getValue());
 	}
 

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/registry/DDMFormFieldRenderer.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/registry/DDMFormFieldRenderer.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.dynamicdatamapping.registry;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portlet.dynamicdatamapping.model.DDMFormField;
 import com.liferay.portlet.dynamicdatamapping.render.DDMFormFieldRenderingContext;
 
@@ -22,6 +23,12 @@ import com.liferay.portlet.dynamicdatamapping.render.DDMFormFieldRenderingContex
  * @author Pablo Carvalho
  */
 public interface DDMFormFieldRenderer {
+
+	public String getTemplateLanguage();
+
+	public String getTemplateNamespace();
+
+	public TemplateResource getTemplateResource();
 
 	public String render(
 			DDMFormField ddmFormField,

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/render/DDMFormFieldRenderingContext.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/render/DDMFormFieldRenderingContext.java
@@ -39,6 +39,10 @@ public class DDMFormFieldRenderingContext {
 		return _httpServletResponse;
 	}
 
+	public String getLabel() {
+		return _label;
+	}
+
 	public Locale getLocale() {
 		return _locale;
 	}
@@ -47,12 +51,24 @@ public class DDMFormFieldRenderingContext {
 		return _mode;
 	}
 
+	public String getName() {
+		return _name;
+	}
+
 	public String getNamespace() {
 		return _namespace;
 	}
 
 	public String getPortletNamespace() {
 		return _portletNamespace;
+	}
+
+	public String getRenderedNestedDDMFormFields() {
+		return _renderedNestedDDMFormFields;
+	}
+
+	public String getValue() {
+		return _value;
 	}
 
 	public boolean isReadOnly() {
@@ -85,12 +101,20 @@ public class DDMFormFieldRenderingContext {
 		_httpServletResponse = httpServletResponse;
 	}
 
+	public void setLabel(String label) {
+		_label = label;
+	}
+
 	public void setLocale(Locale locale) {
 		_locale = locale;
 	}
 
 	public void setMode(String mode) {
 		_mode = mode;
+	}
+
+	public void setName(String name) {
+		_name = name;
 	}
 
 	public void setNamespace(String namespace) {
@@ -105,18 +129,32 @@ public class DDMFormFieldRenderingContext {
 		_readOnly = readOnly;
 	}
 
+	public void setRenderedNestedDDMFormFields(
+		String renderedNestedDDMFormFields) {
+
+		_renderedNestedDDMFormFields = renderedNestedDDMFormFields;
+	}
+
 	public void setShowEmptyFieldLabel(boolean showEmptyFieldLabel) {
 		_showEmptyFieldLabel = showEmptyFieldLabel;
+	}
+
+	public void setValue(String value) {
+		_value = value;
 	}
 
 	private Fields _fields;
 	private HttpServletRequest _httpServletRequest;
 	private HttpServletResponse _httpServletResponse;
+	private String _label;
 	private Locale _locale;
 	private String _mode;
+	private String _name;
 	private String _namespace;
 	private String _portletNamespace;
 	private boolean _readOnly;
+	private String _renderedNestedDDMFormFields;
 	private boolean _showEmptyFieldLabel;
+	private String _value;
 
 }

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/render/DDMFormFieldRenderingContext.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/render/DDMFormFieldRenderingContext.java
@@ -63,8 +63,8 @@ public class DDMFormFieldRenderingContext {
 		return _portletNamespace;
 	}
 
-	public String getRenderedNestedDDMFormFields() {
-		return _renderedNestedDDMFormFields;
+	public String getRenderedChildElements() {
+		return _renderedChildElements;
 	}
 
 	public String getValue() {
@@ -129,10 +129,8 @@ public class DDMFormFieldRenderingContext {
 		_readOnly = readOnly;
 	}
 
-	public void setRenderedNestedDDMFormFields(
-		String renderedNestedDDMFormFields) {
-
-		_renderedNestedDDMFormFields = renderedNestedDDMFormFields;
+	public void setRenderedChildElements(String renderedChildElements) {
+		_renderedChildElements = renderedChildElements;
 	}
 
 	public void setShowEmptyFieldLabel(boolean showEmptyFieldLabel) {
@@ -153,7 +151,7 @@ public class DDMFormFieldRenderingContext {
 	private String _namespace;
 	private String _portletNamespace;
 	private boolean _readOnly;
-	private String _renderedNestedDDMFormFields;
+	private String _renderedChildElements;
 	private boolean _showEmptyFieldLabel;
 	private String _value;
 

--- a/util-taglib/src/com/liferay/taglib/ui/AssetDisplayTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/AssetDisplayTag.java
@@ -170,8 +170,7 @@ public class AssetDisplayTag extends IncludeTag {
 			}
 		}
 
-		request.setAttribute(
-			"liferay-ui:asset-display:assetEntry", _assetEntry);
+		request.setAttribute("liferay-ui:asset-display:assetEntry", assetEntry);
 
 		Renderer renderer = _renderer;
 


### PR DESCRIPTION
Hi Brian, I've renamed from "rendereNestedDDMFormFields" to "renderedChildElements" but I'm not sure if it's the better name though. Or could use "renderedChildHTMLElements" (maybe too verbose)?

I'd like to be closer to HTML because this variable represents all the rendered nested form elements that could be placed inside another element.

Let me know what you think.

Thanks for the help! :)
