### PR TITLE
master-qa-14579

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
+++ b/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
@@ -1032,6 +1032,14 @@ public class LiferaySeleniumHelper {
 			}
 		}
 
+		// LRQA-14442, temporary workaround until Kiyoshi Lee fixes it
+
+		if (line.contains("Framework Event Dispatcher: Equinox Container:")) {
+			if (line.contains("[org_eclipse_equinox_http_servlet")) {
+				return true;
+			}
+		}
+
 		// WCM-202
 
 		if (line.contains("No score point assigners available")) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-14579

@brianchandotcom This is to ignore a framework event error that is only happening in our Jenkins servers.

Kiyoshi is currently looking into it (https://issues.liferay.com/browse/LRQA-14442). As far as we can tell it could have something to do with the torrent we use, but it is currently affecting all of our tests.

cc @michaelhashimoto
cc @lawrence-lee
cc @kiyoshilee
cc @alee8888
