### PR TITLE
LPS-54491

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.image.SpriteProcessor;
 import com.liferay.portal.kernel.image.SpriteProcessorUtil;
-import com.liferay.portal.kernel.lar.DefaultConfigurationPortletDataHandler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.plugin.PluginPackage;
@@ -1374,11 +1373,6 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		String portletDataHandlerClass = GetterUtil.getString(
 			portletElement.elementText("portlet-data-handler-class"),
 			portletModel.getPortletDataHandlerClass());
-
-		if (Validator.isNull(portletDataHandlerClass)) {
-			portletDataHandlerClass =
-				DefaultConfigurationPortletDataHandler.class.getName();
-		}
 
 		portletModel.setPortletDataHandlerClass(portletDataHandlerClass);
 

--- a/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
+++ b/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
@@ -579,7 +579,11 @@ public class PortletBagFactory {
 			(PortletDataHandler)newInstance(
 				PortletDataHandler.class, portletDataHandlerClass);
 
-		portletDataHandlerInstances.add(portletDataHandlerInstance);
+		Map<String, Object> properties = new HashMap<>();
+
+		properties.put("service.ranking", Integer.MIN_VALUE);
+
+		portletDataHandlerInstances.add(portletDataHandlerInstance, properties);
 
 		return portletDataHandlerInstances;
 	}

--- a/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
+++ b/portal-impl/src/com/liferay/portlet/PortletBagFactory.java
@@ -17,6 +17,7 @@ package com.liferay.portlet;
 import com.liferay.portal.kernel.atom.AtomCollectionAdapter;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
+import com.liferay.portal.kernel.lar.DefaultConfigurationPortletDataHandler;
 import com.liferay.portal.kernel.lar.PortletDataHandler;
 import com.liferay.portal.kernel.lar.StagedModelDataHandler;
 import com.liferay.portal.kernel.log.Log;
@@ -567,16 +568,18 @@ public class PortletBagFactory {
 		ServiceTrackerList<PortletDataHandler> portletDataHandlerInstances =
 			getServiceTrackerList(PortletDataHandler.class, portlet);
 
-		if (Validator.isNotNull(portlet.getPortletDataHandlerClass())) {
-			PortletDataHandler portletDataHandlerInstance =
-				(PortletDataHandler)newInstance(
-					PortletDataHandler.class,
-					portlet.getPortletDataHandlerClass());
+		String portletDataHandlerClass = portlet.getPortletDataHandlerClass();
 
-			portletDataHandlerInstance.setPortletId(portlet.getPortletId());
-
-			portletDataHandlerInstances.add(portletDataHandlerInstance);
+		if (Validator.isNull(portletDataHandlerClass)) {
+			portletDataHandlerClass =
+				DefaultConfigurationPortletDataHandler.class.getName();
 		}
+
+		PortletDataHandler portletDataHandlerInstance =
+			(PortletDataHandler)newInstance(
+				PortletDataHandler.class, portletDataHandlerClass);
+
+		portletDataHandlerInstances.add(portletDataHandlerInstance);
 
 		return portletDataHandlerInstances;
 	}


### PR DESCRIPTION
Hi Brian,

I have talked with @migue about this change and about how I could move this logic to PLSI.

The PortletTracker calls PortletBagFactory directly and the old portlet deploy mechanism calls PLSI which calls PortletBagfactory again, so I think it makes sense to put this generic logic to PortletBagFactory. It is always called when deploying any type of portlets so we can handle this situation in a generic way. I think it is important because the bug itself happens in case of OSGi portlets, but works well for the traditional ones.

thanks,
Daniel
