### PR TITLE
LPS-54573 Wrong and unnecessary server log available checking

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1199,10 +1199,7 @@
 				</elseif>
 				<else>
 					<waitfor maxwait="1" maxwaitunit="second" timeoutproperty="portal.not.started">
-						<and>
-							<available file="${test.app.server.parent.dir}/logs" />
-							<socket server="localhost" port="${test.app.server.leading.port.number}080" />
-						</and>
+						<socket server="localhost" port="${test.app.server.leading.port.number}080" />
 					</waitfor>
 				</else>
 			</if>
@@ -1264,10 +1261,7 @@
 						</elseif>
 						<else>
 							<waitfor maxwait="5" maxwaitunit="minute">
-								<and>
-									<available file="${test.app.server.parent.dir}/logs" />
-									<http url="http://localhost:${test.app.server.leading.port.number}080/web/guest" />
-								</and>
+								<http url="http://localhost:${test.app.server.leading.port.number}080/web/guest" />
 							</waitfor>
 						</else>
 					</if>


### PR DESCRIPTION
@brianchandotcom This should cut down the CI build time for about 3~4 mins. Consider this as a pre-optimization for TCK tests, ideally TCK tests should only add in about 1+min to the build time, we might end up having a shorter build time comparing to right now :)

The logs folder is pointed to a wrong location. And it is not necessary at all. It cause the waitfor always timeout after 5mins waiting, while the server is actually only taking about 1.5min to startup.

@mtambara, backport please, thanks!

CC @michaelhashimoto, I think QA checked in this piece of code long long time ago, I did not trace back to the source, but just FYI about this. In case it was for a real purpose, you might want to readd the logs folder watching, but to the correct location "${test.app.server.dir}/logs".
