### PR TITLE
LPS-54672 When using CallerRunsPolicy or any other customized RejectedEx...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/messaging/ParallelDestination.java
+++ b/portal-service/src/com/liferay/portal/kernel/messaging/ParallelDestination.java
@@ -58,6 +58,8 @@ public class ParallelDestination extends BaseAsyncDestination {
 	protected void dispatch(
 		Set<MessageListener> messageListeners, final Message message) {
 
+		final Thread dispatchThread = Thread.currentThread();
+
 		ThreadPoolExecutor threadPoolExecutor = getThreadPoolExecutor();
 
 		for (final MessageListener messageListener : messageListeners) {
@@ -74,9 +76,12 @@ public class ParallelDestination extends BaseAsyncDestination {
 						_log.error("Unable to process message " + message, mle);
 					}
 					finally {
-						ThreadLocalCacheManager.clearAll(Lifecycle.REQUEST);
+						if (Thread.currentThread() != dispatchThread) {
+							ThreadLocalCacheManager.clearAll(Lifecycle.REQUEST);
 
-						CentralizedThreadLocal.clearShortLivedThreadLocals();
+							CentralizedThreadLocal.
+								clearShortLivedThreadLocals();
+						}
 					}
 				}
 


### PR DESCRIPTION
...ecutionHandler that runs the job on the dispatcher thread, we should not interfere with ThreadLocals.

@laszlocsontos I have not really tested it, but I think it should fix the problem. Please retest to confirm, and if it does, please proceed with the backports.
