### PR TITLE
LPS-54662

### DIFF
--- a/portal-impl/src/com/liferay/portal/minifier/GoogleJavaScriptMinifier.java
+++ b/portal-impl/src/com/liferay/portal/minifier/GoogleJavaScriptMinifier.java
@@ -47,6 +47,8 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 
 		setCompileOptions(compilerOptions);
 
+		compiler.disableThreads();
+
 		compiler.compile(
 			SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,
 			compilerOptions);

--- a/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
+++ b/portal-web/test/functional/com/liferay/portalweb/portal/util/liferayselenium/LiferaySeleniumHelper.java
@@ -1051,15 +1051,6 @@ public class LiferaySeleniumHelper {
 			}
 		}
 
-		// LPS-54662, temporary workaround while Kenji Heigel investigates it
-
-		if (line.contains(
-				"The web application [] appears to have started a thread " +
-					"named [jscompiler]")) {
-
-			return true;
-		}
-
 		// LPS-54680
 
 		if (line.contains(


### PR DESCRIPTION
This fix was sent from @csierra and fixes a jscompiler memory leak error that occurs upon shutdown
