### PR TITLE
Lps 55038

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -1092,10 +1092,11 @@ public class VerifyProperties extends VerifyProcess {
 		"sites.form.add.miscellaneous", "sites.form.add.seo",
 		"sites.form.update.advanced", "sites.form.update.main",
 		"sites.form.update.miscellaneous", "sites.form.update.seo",
-		"staging.lock.enabled", "tck.url", "webdav.storage.class",
-		"webdav.storage.show.edit.url", "webdav.storage.show.view.url",
-		"webdav.storage.tokens", "wiki.email.page.added.signature",
-		"wiki.email.page.updated.signature", "xss.allow"
+		"staging.lock.enabled", "table.mapper.cacheless.mapping.table.names",
+		"tck.url", "webdav.storage.class", "webdav.storage.show.edit.url",
+		"webdav.storage.show.view.url", "webdav.storage.tokens",
+		"wiki.email.page.added.signature", "wiki.email.page.updated.signature",
+		"xss.allow"
 	};
 
 	private static final String[] _OBSOLETE_SYSTEM_KEYS = new String[] {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5959,10 +5959,10 @@
 ##
 
     #
-    # Set a list of comma delimited mapping table names that will not be using
-    # cache in their table mappers.
+    # Set a list of comma delimited mapping table names that will be using cache
+    # in their table mappers.
     #
-    table.mapper.cacheless.mapping.table.names=
+    table.mapper.cache.mapping.table.names=
 
 ##
 ## Audit Message

--- a/portal-impl/test/unit/com/liferay/portal/service/persistence/impl/TableMapperTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/service/persistence/impl/TableMapperTest.java
@@ -1317,12 +1317,12 @@ public class TableMapperTest {
 	}
 
 	@Test
-	public void testTableMapperFactoryCacheless() {
-		Set<String> cachelessMappingTableNames =
-			TableMapperFactory.cachelessMappingTableNames;
+	public void testTableMapperFactoryCache() {
+		Set<String> cacheMappingTableNames =
+			TableMapperFactory.cacheMappingTableNames;
 
 		ReflectionTestUtil.setFieldValue(
-			TableMapperFactory.class, "cachelessMappingTableNames",
+			TableMapperFactory.class, "cacheMappingTableNames",
 			new HashSet<String>() {
 
 				@Override
@@ -1337,8 +1337,8 @@ public class TableMapperTest {
 		}
 		finally {
 			ReflectionTestUtil.setFieldValue(
-				TableMapperFactory.class, "cachelessMappingTableNames",
-				cachelessMappingTableNames);
+				TableMapperFactory.class, "cacheMappingTableNames",
+				cacheMappingTableNames);
 		}
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2481,7 +2481,7 @@ public interface PropsKeys {
 
 	public static final String SYSTEM_SITE_ROLES = "system.site.roles";
 
-	public static final String TABLE_MAPPER_CACHELESS_MAPPING_TABLE_NAMES = "table.mapper.cacheless.mapping.table.names";
+	public static final String TABLE_MAPPER_CACHE_MAPPING_TABLE_NAMES = "table.mapper.cache.mapping.table.names";
 
 	public static final String TERMS_OF_USE_JOURNAL_ARTICLE_GROUP_ID = "terms.of.use.journal.article.group.id";
 

--- a/portal-service/src/com/liferay/portal/service/persistence/impl/TableMapperFactory.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/impl/TableMapperFactory.java
@@ -41,13 +41,13 @@ public class TableMapperFactory {
 		if (tableMapper == null) {
 			TableMapperImpl<L, R> tableMapperImpl = null;
 
-			if (cachelessMappingTableNames.contains(tableName)) {
-				tableMapperImpl = new CachelessTableMapperImpl<>(
+			if (cacheMappingTableNames.contains(tableName)) {
+				tableMapperImpl = new TableMapperImpl<>(
 					tableName, leftColumnName, rightColumnName, leftPersistence,
 					rightPersistence);
 			}
 			else {
-				tableMapperImpl = new TableMapperImpl<>(
+				tableMapperImpl = new CachelessTableMapperImpl<>(
 					tableName, leftColumnName, rightColumnName, leftPersistence,
 					rightPersistence);
 			}
@@ -74,10 +74,10 @@ public class TableMapperFactory {
 		}
 	}
 
-	protected static final Set<String> cachelessMappingTableNames =
+	protected static final Set<String> cacheMappingTableNames =
 		SetUtil.fromArray(
 			PropsUtil.getArray(
-				PropsKeys.TABLE_MAPPER_CACHELESS_MAPPING_TABLE_NAMES));
+				PropsKeys.TABLE_MAPPER_CACHE_MAPPING_TABLE_NAMES));
 	protected static final Map<String, TableMapper<?, ?>> tableMappers =
 		new ConcurrentHashMap<>();
 


### PR DESCRIPTION
CC @mhan810

@dantewang @slnn this is a temporarily mapping table cache removal by default. (I will re-enable it when starting the tuning process for 7 release), but it will hurt your tests. To avoid the test results decline, add table.mapper.cache.mapping.table.names= in portal-ext.properties for benchmark, list out all the mapping table's names we are using during the tests. They can case sensitive, so for example, it should be something like:

table.mapper.cache.mapping.table.names=Users_Groups,Users_Orgs,Users_Roles, ......

As long as you cover all the tables the tests are using, this should not affect any performance number.
