### PR TITLE
LPS-54974 we support creating pages with friendlyURL ending in /c but then they can not be visited

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8179,7 +8179,6 @@
     # Set the extensions that will be ignored for virtual hosts.
     #
     virtual.hosts.ignore.extensions=\
-        /c,\
         .css,\
         .gif,\
         .image/company_logo,\


### PR DESCRIPTION
Hi Brian, I'm resending this PR, I've checked that changing the portal context-path and having a VirtualHost, all the redirects after login-logout and the navigation through pages are working fine with this fix. Thx. cc/ @juliocamarero
