### PR TITLE
[See description] LPS-55162

### DIFF
--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -139,6 +139,12 @@ public class WebServerServlet extends HttpServlet {
 
 			User user = _getUser(request);
 
+			if (!user.isDefaultUser()) {
+				PrincipalThreadLocal.setName(user.getUserId());
+				PrincipalThreadLocal.setPassword(
+					PortalUtil.getUserPassword(request));
+			}
+
 			String path = HttpUtil.fixPath(request.getPathInfo());
 
 			String[] pathArray = StringUtil.split(path, CharPool.SLASH);


### PR DESCRIPTION
Hey Brian,

This pull comes for support and they try to fix and issue when downloading documents from Alfresco because the user is not properly set in the thread local so it cannot be connected to Alfresco.

This fix was actually implemented by Alex in LPS-13311 but it was reverted by you, and I don't have the knowledge about why this was done, so I guess that you're the person who may know that.

I include the comment from Jonathan:

---

Hey Sergio,

The issue here is that in CMISRepositoryHandler.getLogin, the PrincipalThreadLocal isn't set so the name returns null and the document cannot be downloaded. The fix I made was to set the name (just like in the service method below it) and if it's the default user, leave it as null to make sure "dl.repository.guest.*" still functions properly.

My only concern is LPS-13311 where Brian reverted a fix doing a similar thing. He added in a comment saying "Do not use permission checking" so I left out setting the permission checker in the thread local. Let me know what you think about this fix and if you have any insight into why Brian did the revert in LPS-13311.

Thanks!
