### PR TITLE
master-qa-14721

### DIFF
--- a/modules/test/poshi-runner/src/com/liferay/poshi/runner/selenium/MobileDriverToSeleniumBridge.java
+++ b/modules/test/poshi-runner/src/com/liferay/poshi/runner/selenium/MobileDriverToSeleniumBridge.java
@@ -1023,8 +1023,6 @@ public class MobileDriverToSeleniumBridge
 			}
 		}
 		else if (PropsValues.MOBILE_DEVICE_TYPE.equals("ios")) {
-			context("NATIVE_APP");
-
 			TouchAction touchAction = new TouchAction(this);
 
 			int screenPositionX = WebDriverHelper.getElementPositionCenterX(
@@ -1035,6 +1033,8 @@ public class MobileDriverToSeleniumBridge
 			int screenPositionY =
 				WebDriverHelper.getElementPositionCenterY(this, locator) +
 					navigationBarHeight;
+
+			context("NATIVE_APP");
 
 			touchAction.tap(screenPositionX, screenPositionY);
 


### PR DESCRIPTION
http://issues.liferay.com/browse/LRQA-14721

> Basically, to use the TouchAction class methods, you have to switch the context to NATIVE_APP right
>  before it's used. All the other normal webdriver commands are supposed to be run in the webview
> context. Switching the context in the beginning of the method makes the webdriver methods unusable
> because it's trying to use them in the NATIVE_APP context. Let me know if you have any questions. 
> 
> Reference:
> https://github.com/appium/appium/issues/4529
