### PR TITLE
LPS-55417 Should never set ready to false on undeployment, that will …

### DIFF
--- a/modules/portal/portal-portlet-tracker/src/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
+++ b/modules/portal/portal-portlet-tracker/src/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
@@ -178,7 +178,7 @@ public class PortletTracker
 		ServiceReference<Portlet> serviceReference,
 		com.liferay.portal.model.Portlet portletModel) {
 
-		portletModel.setReady(false);
+		portletModel.unsetReady();
 
 		ServiceRegistrations serviceRegistrations = _serviceRegistrations.get(
 			serviceReference.getBundle());

--- a/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/PortletImpl.java
@@ -3968,6 +3968,11 @@ public class PortletImpl extends PortletBaseImpl {
 		_xmlRpcMethodClass = xmlRpcMethodClass;
 	}
 
+	@Override
+	public void unsetReady() {
+		_readyMap.remove(getRootPortletId());
+	}
+
 	/**
 	 * Log instance for this class.
 	 */

--- a/portal-service/src/com/liferay/portal/model/Portlet.java
+++ b/portal-service/src/com/liferay/portal/model/Portlet.java
@@ -2352,4 +2352,7 @@ public interface Portlet extends PortletModel, PersistedModel {
 	portlet
 	*/
 	public void setXmlRpcMethodClass(java.lang.String xmlRpcMethodClass);
+
+	public void unsetReady();
+
 }

--- a/portal-service/src/com/liferay/portal/model/PortletWrapper.java
+++ b/portal-service/src/com/liferay/portal/model/PortletWrapper.java
@@ -3509,6 +3509,11 @@ public class PortletWrapper implements Portlet, ModelWrapper<Portlet> {
 	}
 
 	@Override
+	public void unsetReady() {
+		_portlet.unsetReady();
+	}
+
+	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
 			return true;


### PR DESCRIPTION
…leave a mark in the cache causing following renderring process fails to recreate PortletBag for undeploy placeholder portlet, as it is considered as not ready.

CC @gamerson @willnewbury
