### PR TITLE
LPS-55484 commit 51bfbab did a partial rollback of LPS-44746 but it d…

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/LayoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LayoutAction.java
@@ -275,8 +275,10 @@ public class LayoutAction extends Action {
 
 			String portletId = ParamUtil.getString(request, "p_p_id");
 
-			if (resetLayout && (previousLayout != null) &&
-				(layout.getPlid() != previousLayout.getPlid())) {
+			if (resetLayout &&
+				(Validator.isNull(portletId) ||
+				 ((previousLayout != null) &&
+				  (layout.getPlid() != previousLayout.getPlid())))) {
 
 				// Always clear render parameters on a layout url, but do not
 				// clear on portlet urls invoked on the same layout


### PR DESCRIPTION
…idn't keep the original behaviour of cleaning the render parameters when the portlet id is blank. This includes that logic back.
