### PR TITLE
LPS-55512 Refine MailboxUtilTest's reaper join back error assert

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/mailbox/MailboxUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/mailbox/MailboxUtilTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.test.rule.NewEnv;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtilAdvice;
 import com.liferay.portal.kernel.util.ThreadUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.AdviseWith;
 import com.liferay.portal.test.rule.AspectJNewEnvTestRule;
 
@@ -151,8 +152,12 @@ public class MailboxUtilTest {
 
 		overdueMailQueue.offer(createReceiptStub());
 
-		reaperThread.join(1000);
+		reaperThread.join(10 * Time.MINUTE);
 
+		Assert.assertFalse(
+			"Reaper thread " + reaperThread +
+				" failed to join back after waiting for 10 mins",
+			reaperThread.isAlive());
 		Assert.assertSame(
 			reaperThread, RecorderUncaughtExceptionHandler._thread);
 


### PR DESCRIPTION
Fix for https://github.com/brianchandotcom/liferay-portal/pull/26360 , 1 sec waiting seem too short when the server is under load. Bump up wait time to 10 mins with proper join back assert
