### PR TITLE
master-qa-15475

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3479,15 +3479,6 @@ module.framework.properties.osgi.console=11312</echo>
 		</if>
 
 		<if>
-			<isset property="ignore.errors.delimiter" />
-			<then>
-				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
-					ignore.errors.delimiter=${ignore.errors.delimiter}
-				</echo>
-			</then>
-		</if>
-
-		<if>
 			<isset property="liferay.portal.branch" />
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
@@ -4082,6 +4073,17 @@ module.framework.properties.osgi.console=11312</echo>
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
 					ignore.errors=${ignore.errors}
+				</echo>
+			</then>
+		</if>
+
+		<get-testcase-property property.name="ignore.errors.delimiter" />
+
+		<if>
+			<isset property="ignore.errors.delimiter" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					ignore.errors.delimiter=${ignore.errors.delimiter}
 				</echo>
 			</then>
 		</if>

--- a/test.properties
+++ b/test.properties
@@ -743,6 +743,7 @@
         default.layout.template.id,\
         hook.plugins.includes,\
         ignore.errors,\
+        ignore.errors.delimiter,\
         layouttpl.plugins.includes,\
         legacy.plugin.includes,\
         legacy.plugins.social.office.version,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-15475

The ignore.errors.delimiter property currently isn't being used outside of our tests, but we need it for our tests, so we're just turning it into a testcase property.
