### PR TITLE
LPS-55209 - Create an ant task in modules that will deploy without running all dependent tasks

### DIFF
--- a/modules/frontend/frontend-js-web/build.xml
+++ b/modules/frontend/frontend-js-web/build.xml
@@ -124,6 +124,16 @@
 		</if>
 	</target>
 
+	<target name="deploy-static-files">
+		<delete file="${liferay.home}/osgi/portal/${plugin.name}.${plugin.packaging}" />
+		<delete file="${liferay.home}/osgi/portal/${plugin.name}-wsdd.jar" />
+		<delete dir="classes" />
+
+		<deploy
+			module.dir="${basedir}"
+		/>
+	</target>
+
 	<target name="jar" depends="build-common.compile,build-alloy">
 		<jar-macro
 			module.dir="${basedir}"


### PR DESCRIPTION
Hi Brian,

These changes have been rebased and conflicts resolved.

It doesn't duplicate work done in deploy, but it does duplicate a few lines in the "clean" task in tools/sdk/build-common.xml.

But this task more of a 'nice to have' feature for frontend-devs to make changes in alloy easier to test, so it's not entirely necessary.  I'm not sure it would be worth the trouble to have build-common call this task.

Please let me know if there are any issues.

Thanks!
