### PR TITLE
LPS-55209 - Create an ant task in frontend-js-web that will deploy without running all dependent tasks

### DIFF
--- a/modules/frontend/frontend-js-web/build.xml
+++ b/modules/frontend/frontend-js-web/build.xml
@@ -188,6 +188,14 @@
 		</if>
 	</target>
 
+	<target name="deploy-fast">
+		<delete dir="classes" />
+
+		<deploy
+			module.dir="${basedir}"
+		/>
+	</target>
+
 	<target name="jar" depends="build-common.compile,build-alloy-bootstrap,build-alloy">
 		<jar-macro
 			module.dir="${basedir}"


### PR DESCRIPTION
Hey Brian,

So in order to fast deploy, we only need to delete the classes directory.  I removed the lines deleting the jars as they aren't necessary.

The classes directory needs to be deleted so the bnd task will run in build-common.xml.  The check is happening here: https://github.com/liferay/liferay-plugins/blob/master/build-common.xml#L1804

Please let me know if there are any issues.

Thanks!
