### PR TITLE
master-qa-14249

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3111,6 +3111,18 @@ ${custom.properties}</echo>
 			</then>
 		</if>
 
+		<get-testcase-property property.name="delete.jdbc.portal.ext.properties" />
+
+		<if>
+			<equals arg1="${delete.jdbc.portal.ext.properties}" arg2="true" />
+			<then>
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.driverClassName=${database.driver}" value="" />
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.password=${database.password}" value="" />
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.url=${database.url}" value="" />
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.username=${database.username}" value="" />
+			</then>
+		</if>
+
 		<if>
 			<equals arg1="${java.security}" arg2="true" />
 			<then>

--- a/build-test.xml
+++ b/build-test.xml
@@ -5281,8 +5281,13 @@ if (ppstate.equals("normal")) {
 
 		<ant dir="portal-impl" target="compile-test" inheritAll="false" />
 
+		<get-testcase-property property.name="setup.wizard.enabled" />
+
 		<if>
-			<equals arg1="${database.type}" arg2="hsql" />
+			<or>
+				<equals arg1="${database.type}" arg2="hsql" />
+				<equals arg1="${setup.wizard.enabled}" arg2="true" />
+			</or>
 			<then>
 				<antcall target="rebuild-database" inheritAll="false">
 					<param name="database.type" value="mysql" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -5286,6 +5286,7 @@ if (ppstate.equals("normal")) {
 			<then>
 				<antcall target="rebuild-database" inheritAll="false">
 					<param name="database.type" value="mysql" />
+					<param name="delete.liferay.home" value="false" />
 				</antcall>
 
 				<echo file="portal-impl/classes/portal-ext.properties">liferay.home=${liferay.home}

--- a/build-test.xml
+++ b/build-test.xml
@@ -3693,6 +3693,42 @@ module.framework.properties.osgi.console=11312</echo>
 		</if>
 
 		<if>
+			<isset property="database.hsql.driver" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.driver=${database.hsql.driver}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="database.hsql.password" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.password=${database.hsql.password}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="database.hsql.url" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.url=${database.hsql.url}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="database.hsql.username" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.username=${database.hsql.username}
+				</echo>
+			</then>
+		</if>
+
+		<if>
 			<isset property="database.mysql.driver" />
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">

--- a/portal-web/test/functional/com/liferay/portalweb/util/TestPropsValues.java
+++ b/portal-web/test/functional/com/liferay/portalweb/util/TestPropsValues.java
@@ -49,6 +49,18 @@ public class TestPropsValues
 	public static final String DATABASE_DB2_USERNAME = TestPropsUtil.get(
 		"database.db2.username");
 
+	public static final String DATABASE_HSQL_DRIVER = TestPropsUtil.get(
+		"database.hsql.driver");
+
+	public static final String DATABASE_HSQL_PASSWORD = TestPropsUtil.get(
+		"database.hsql.password");
+
+	public static final String DATABASE_HSQL_URL = TestPropsUtil.get(
+		"database.hsql.url");
+
+	public static final String DATABASE_HSQL_USERNAME = TestPropsUtil.get(
+		"database.hsql.username");
+
 	public static final String DATABASE_MYSQL_DRIVER = TestPropsUtil.get(
 		"database.mysql.driver");
 

--- a/test.properties
+++ b/test.properties
@@ -735,6 +735,7 @@
         database.sharding,\
         databases.size,\
         default.layout.template.id,\
+        delete.jdbc.portal.ext.properties,\
         hook.plugins.includes,\
         ignore.errors,\
         ignore.errors.delimiter,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-14249

These commits allow us to test setup wizard with HSQL as the starting point. Currently, if we wanted to test going from HSQL to MySQL, there isn't a way because if we set database.type=hsql the mysql database that we want to connect to wouldn't get created.

With these commits, we can set database.type=mysql. Albert's changes make it so that we'd remove the mysql jdbc properties that automatically get echoed into the portal-ext.properties upon creation of the mysql database. That way we can still connect to HSQL on startup and also have a MySQL database for setup wizard to connect to.
