### PR TITLE
Lps 55690

### DIFF
--- a/modules/portal/portal-scripting-javascript/bnd.bnd
+++ b/modules/portal/portal-scripting-javascript/bnd.bnd
@@ -3,7 +3,8 @@ Bundle-SymbolicName: com.liferay.portal.scripting.javascript
 Bundle-Version: 1.0.0
 Import-Package:\
 	!javax.swing.*,\
+	!org.apache.xmlbeans.*,\
 	*
-Include-Resource: \
+Include-Resource:\
 	classes,\
 	@lib/rhino.jar

--- a/portal-impl/test/integration/com/liferay/portal/portletfilerepository/PortletFileRepositoryTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/portletfilerepository/PortletFileRepositoryTest.java
@@ -35,12 +35,11 @@ import com.liferay.portlet.documentlibrary.model.DLFileEntry;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-
-import org.testng.Assert;
 
 /**
  * @author Adolfo Pérez
@@ -93,7 +92,7 @@ public class PortletFileRepositoryTest {
 			RandomTestUtil.randomString());
 
 		Assert.assertEquals(
-			fileEntry.getVersion(), DLFileEntryConstants.VERSION_DEFAULT);
+			DLFileEntryConstants.VERSION_DEFAULT, fileEntry.getVersion());
 	}
 
 	@Test
@@ -104,7 +103,7 @@ public class PortletFileRepositoryTest {
 		int count = PortletFileRepositoryUtil.getPortletFileEntriesCount(
 			_group.getGroupId(), _folder.getFolderId());
 
-		Assert.assertEquals(count, 2);
+		Assert.assertEquals(2, count);
 	}
 
 	@Test
@@ -114,7 +113,7 @@ public class PortletFileRepositoryTest {
 		int count = PortletFileRepositoryUtil.getPortletFileEntriesCount(
 			_group.getGroupId(), _folder.getFolderId());
 
-		Assert.assertEquals(count, 1);
+		Assert.assertEquals(1, count);
 	}
 
 	@Test

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetTestIndexer.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/AssetTestIndexer.java
@@ -16,7 +16,7 @@ package com.liferay.portlet.asset.service;
 
 import com.liferay.portlet.blogs.util.BlogsIndexer;
 
-import org.testng.Assert;
+import org.junit.Assert;
 
 /**
  * @author Michael C. Han

--- a/portal-impl/test/unit/com/liferay/counter/service/persistence/impl/MultiDataCenterCounterFinderImplTest.java
+++ b/portal-impl/test/unit/com/liferay/counter/service/persistence/impl/MultiDataCenterCounterFinderImplTest.java
@@ -14,9 +14,8 @@
 
 package com.liferay.counter.service.persistence.impl;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import org.testng.Assert;
 
 /**
  * @author Michael C. Han

--- a/portal-impl/test/unit/com/liferay/portal/dao/jdbc/aop/DynamicDataSourceAdviceTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/dao/jdbc/aop/DynamicDataSourceAdviceTest.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 /**
  * @author Shuyang Zhou
  */
-public class DefaultDynamicDataSourceAdviceTest {
+public class DynamicDataSourceAdviceTest {
 
 	@ClassRule
 	public static final CodeCoverageAssertor codeCoverageAssertor =
@@ -61,7 +61,7 @@ public class DefaultDynamicDataSourceAdviceTest {
 			new DefaultDynamicDataSourceTargetSource();
 
 		ClassLoader classLoader =
-			DefaultDynamicDataSourceAdviceTest.class.getClassLoader();
+			DynamicDataSourceAdviceTest.class.getClassLoader();
 
 		InvocationHandler invocationHandler = new InvocationHandler() {
 

--- a/portal-impl/test/unit/com/liferay/portal/security/xml/StripDoctypeXMLReaderTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/xml/StripDoctypeXMLReaderTest.java
@@ -19,9 +19,8 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import org.testng.Assert;
 
 /**
  * @author Tomas Polesovsky
@@ -43,7 +42,7 @@ public class StripDoctypeXMLReaderTest {
 
 			String result = new String(buff, 0, length);
 
-			Assert.assertEquals(result, _SANITIZED_XML[i]);
+			Assert.assertEquals(_SANITIZED_XML[i], result);
 		}
 	}
 
@@ -63,7 +62,7 @@ public class StripDoctypeXMLReaderTest {
 
 			String result = new String(chars, 0, length);
 
-			Assert.assertEquals(result, _SANITIZED_XML[i]);
+			Assert.assertEquals(_SANITIZED_XML[i], result);
 		}
 	}
 

--- a/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/storage/DDMFormFieldValueTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/storage/DDMFormFieldValueTest.java
@@ -18,9 +18,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portlet.dynamicdatamapping.BaseDDMTestCase;
 import com.liferay.portlet.dynamicdatamapping.model.UnlocalizedValue;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import org.testng.Assert;
 
 /**
  * @author Marcellus Tavares
@@ -35,7 +34,7 @@ public class DDMFormFieldValueTest extends BaseDDMTestCase {
 		DDMFormFieldValue ddmFormFieldValue2 = createDDMFormFieldValue(
 			StringUtil.randomString(), "Test", new UnlocalizedValue("Value"));
 
-		Assert.assertFalse(ddmFormFieldValue1.equals(ddmFormFieldValue2));
+		Assert.assertNotEquals(ddmFormFieldValue1, ddmFormFieldValue2);
 	}
 
 	@Test
@@ -46,7 +45,7 @@ public class DDMFormFieldValueTest extends BaseDDMTestCase {
 		DDMFormFieldValue ddmFormFieldValue2 = createDDMFormFieldValue(
 			"xhsy", StringUtil.randomString(), new UnlocalizedValue("Value"));
 
-		Assert.assertFalse(ddmFormFieldValue1.equals(ddmFormFieldValue2));
+		Assert.assertNotEquals(ddmFormFieldValue1, ddmFormFieldValue2);
 	}
 
 	@Test
@@ -66,7 +65,7 @@ public class DDMFormFieldValueTest extends BaseDDMTestCase {
 				"jamy", "Nested",
 				new UnlocalizedValue("Different Nested Value")));
 
-		Assert.assertFalse(ddmFormFieldValue1.equals(ddmFormFieldValue2));
+		Assert.assertNotEquals(ddmFormFieldValue1, ddmFormFieldValue2);
 	}
 
 	@Test
@@ -77,7 +76,7 @@ public class DDMFormFieldValueTest extends BaseDDMTestCase {
 		DDMFormFieldValue ddmFormFieldValue2 = createDDMFormFieldValue(
 			"xhsy", "Test", new UnlocalizedValue("Different Value"));
 
-		Assert.assertFalse(ddmFormFieldValue1.equals(ddmFormFieldValue2));
+		Assert.assertNotEquals(ddmFormFieldValue1, ddmFormFieldValue2);
 	}
 
 	@Test
@@ -96,7 +95,7 @@ public class DDMFormFieldValueTest extends BaseDDMTestCase {
 			createDDMFormFieldValue(
 				"jamy", "Nested", new UnlocalizedValue("Nested Value")));
 
-		Assert.assertTrue(ddmFormFieldValue1.equals(ddmFormFieldValue2));
+		Assert.assertEquals(ddmFormFieldValue1, ddmFormFieldValue2);
 	}
 
 }

--- a/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/storage/LocalizedValueTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/storage/LocalizedValueTest.java
@@ -18,9 +18,8 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portlet.dynamicdatamapping.model.LocalizedValue;
 import com.liferay.portlet.dynamicdatamapping.model.Value;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import org.testng.Assert;
 
 /**
  * @author Marcellus Tavares
@@ -32,7 +31,7 @@ public class LocalizedValueTest {
 		Value value1 = new LocalizedValue(LocaleUtil.US);
 		Value value2 = new LocalizedValue(LocaleUtil.BRAZIL);
 
-		Assert.assertFalse(value1.equals(value2));
+		Assert.assertNotEquals(value1, value2);
 	}
 
 	@Test
@@ -47,7 +46,7 @@ public class LocalizedValueTest {
 		value2.addString(LocaleUtil.US, "Different Test");
 		value2.addString(LocaleUtil.BRAZIL, "Teste");
 
-		Assert.assertFalse(value1.equals(value2));
+		Assert.assertNotEquals(value1, value2);
 	}
 
 	@Test
@@ -62,7 +61,7 @@ public class LocalizedValueTest {
 		value2.addString(LocaleUtil.US, "Test");
 		value2.addString(LocaleUtil.BRAZIL, "Teste");
 
-		Assert.assertTrue(value1.equals(value2));
+		Assert.assertEquals(value1, value2);
 	}
 
 }

--- a/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/storage/UnlocalizedValueTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/dynamicdatamapping/storage/UnlocalizedValueTest.java
@@ -18,9 +18,8 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portlet.dynamicdatamapping.model.UnlocalizedValue;
 import com.liferay.portlet.dynamicdatamapping.model.Value;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import org.testng.Assert;
 
 /**
  * @author Marcellus Tavares
@@ -32,7 +31,7 @@ public class UnlocalizedValueTest {
 		Value value1 = new UnlocalizedValue(StringUtil.randomString());
 		Value value2 = new UnlocalizedValue(StringUtil.randomString());
 
-		Assert.assertFalse(value1.equals(value2));
+		Assert.assertNotEquals(value1, value2);
 	}
 
 	@Test
@@ -42,7 +41,7 @@ public class UnlocalizedValueTest {
 		Value value1 = new UnlocalizedValue(valueString);
 		Value value2 = new UnlocalizedValue(valueString);
 
-		Assert.assertTrue(value1.equals(value2));
+		Assert.assertEquals(value1, value2);
 	}
 
 }

--- a/portal-service/test/unit/com/liferay/portal/kernel/settings/LocalizedValuesMapTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/settings/LocalizedValuesMapTest.java
@@ -16,9 +16,8 @@ package com.liferay.portal.kernel.settings;
 
 import com.liferay.portal.kernel.util.LocaleUtil;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import org.testng.Assert;
 
 /**
  * @author Iván Zaera


### PR DESCRIPTION
@hhuijser, please see https://github.com/brianchandotcom/liferay-portal/commit/14f0090a93ad168b54156a07b54207f38554a7d7, we should SF this. Basically preventing people from using org.testng.Assert completely, we should always use org.junit.Assert

@mhan810, I had to exclude org.apache.xmlbeans.\* for portal-scripting-javascript, as it is failing to be resolved. See https://github.com/brianchandotcom/liferay-portal/commit/6c36a8f6f6d4423f345f7d47801457128623bcd8

@brianchandotcom, about https://github.com/brianchandotcom/liferay-portal/commit/63e756b2cadecfa520be71a301e957b4a6a19b81, test class name has to match the test being tested. That's how CodeCoverageAssertor automatically looking up which class to assert coverage. The DefaultDynamicDataSourceAdviceTest was failing because of can not find "DefaultDynamicDataSourceAdvice"

And also, I am not sure what has changed in SDK build script recently, you might (a good chance) to see the CI ant build process run OOM on perm space. Since I will eventually get to the sdk build script optimization (after finishing the portal side, hopefully some time next week), can we simply bump up the CI ANT_OPTS for now to do 512MB for perm, 2048MB for Xmx, currently it is "-Xmx1024m -XX:MaxPermSize=384m". Otherwise, CI will get tons of random OOM errors when people start to send pulls.
