### PR TITLE
LPS-55730 When missing osgi/core folder, throw IllegalStateException …

### DIFF
--- a/portal-impl/src/com/liferay/portal/module/framework/RuntimeClasspathResolver.java
+++ b/portal-impl/src/com/liferay/portal/module/framework/RuntimeClasspathResolver.java
@@ -31,6 +31,11 @@ public class RuntimeClasspathResolver implements ClasspathResolver {
 
 		File[] files = coreDir.listFiles();
 
+		if (files == null) {
+			throw new IllegalStateException(
+				"Missing " + coreDir.getCanonicalPath());
+		}
+
 		URL[] urls = new URL[files.length];
 
 		for (int i = 0; i < urls.length; i++) {


### PR DESCRIPTION
…with explicit message, rather than triggering the confusing NPE
