### PR TITLE
master-qa-14249

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3367,6 +3367,18 @@ include-and-override=${liferay.home}/portal-setup-wizard.properties</echo>
 			</then>
 		</if>
 
+		<get-testcase-property property.name="setup.wizard.initial.database.type" />
+
+		<if>
+			<equals arg1="${setup.wizard.initial.database.type}" arg2="hsql" />
+			<then>
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.driverClassName=${database.driver}" value="" />
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.password=${database.password}" value="" />
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.url=${database.url}" value="" />
+				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.username=${database.username}" value="" />
+			</then>
+		</if>
+
 		<echo file="portal-impl/src/portal-ext.properties" append="true">
 
 hot.deploy.dependency.management.enabled=false</echo>

--- a/build-test.xml
+++ b/build-test.xml
@@ -2931,6 +2931,8 @@ osb.lcs.portlet.oauth.consumer.secret=${osb.lcs.portlet.oauth.consumer.secret}</
 
 		<echo file="portal-impl/src/portal-ext.properties">liferay.home=${liferay.home}
 
+hot.deploy.dependency.management.enabled=false
+
 plugin.notifications.enabled=false
 
 jdbc.default.jndi.name=
@@ -3378,10 +3380,6 @@ include-and-override=${liferay.home}/portal-setup-wizard.properties</echo>
 				<replace file="portal-impl/src/portal-ext.properties" token="jdbc.default.username=${database.username}" value="" />
 			</then>
 		</if>
-
-		<echo file="portal-impl/src/portal-ext.properties" append="true">
-
-hot.deploy.dependency.management.enabled=false</echo>
 
 		<if>
 			<isset property="test.set.default.portal.properties" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -5281,8 +5281,13 @@ if (ppstate.equals("normal")) {
 
 		<ant dir="portal-impl" target="compile-test" inheritAll="false" />
 
+		<get-testcase-property property.name="setup.wizard.enabled" />
+
 		<if>
-			<equals arg1="${database.type}" arg2="hsql" />
+			<or>
+				<equals arg1="${database.type}" arg2="hsql" />
+				<equals arg1="${setup.wizard.enabled}" arg2="true" />
+			</or>
 			<then>
 				<antcall target="rebuild-database" inheritAll="false">
 					<param name="database.type" value="mysql" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -5286,6 +5286,7 @@ if (ppstate.equals("normal")) {
 			<then>
 				<antcall target="rebuild-database" inheritAll="false">
 					<param name="database.type" value="mysql" />
+					<param name="delete.liferay.home" value="false" />
 				</antcall>
 
 				<echo file="portal-impl/classes/portal-ext.properties">liferay.home=${liferay.home}

--- a/build-test.xml
+++ b/build-test.xml
@@ -3693,6 +3693,42 @@ module.framework.properties.osgi.console=11312</echo>
 		</if>
 
 		<if>
+			<isset property="database.hsql.driver" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.driver=${database.hsql.driver}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="database.hsql.password" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.password=${database.hsql.password}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="database.hsql.url" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.url=${database.hsql.url}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="database.hsql.username" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					database.hsql.username=${database.hsql.username}
+				</echo>
+			</then>
+		</if>
+
+		<if>
 			<isset property="database.mysql.driver" />
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">

--- a/build-test.xml
+++ b/build-test.xml
@@ -5279,12 +5279,12 @@ if (ppstate.equals("normal")) {
 
 		<ant dir="portal-impl" target="compile-test" inheritAll="false" />
 
-		<get-testcase-property property.name="setup.wizard.enabled" />
+		<get-testcase-property property.name="setup.wizard.initial.database.type" />
 
 		<if>
 			<or>
 				<equals arg1="${database.type}" arg2="hsql" />
-				<equals arg1="${setup.wizard.enabled}" arg2="true" />
+				<equals arg1="${setup.wizard.initial.database.type}" arg2="hsql" />
 			</or>
 			<then>
 				<antcall target="rebuild-database" inheritAll="false">

--- a/portal-web/test/functional/com/liferay/portalweb/util/TestPropsValues.java
+++ b/portal-web/test/functional/com/liferay/portalweb/util/TestPropsValues.java
@@ -49,6 +49,18 @@ public class TestPropsValues
 	public static final String DATABASE_DB2_USERNAME = TestPropsUtil.get(
 		"database.db2.username");
 
+	public static final String DATABASE_HSQL_DRIVER = TestPropsUtil.get(
+		"database.hsql.driver");
+
+	public static final String DATABASE_HSQL_PASSWORD = TestPropsUtil.get(
+		"database.hsql.password");
+
+	public static final String DATABASE_HSQL_URL = TestPropsUtil.get(
+		"database.hsql.url");
+
+	public static final String DATABASE_HSQL_USERNAME = TestPropsUtil.get(
+		"database.hsql.username");
+
 	public static final String DATABASE_MYSQL_DRIVER = TestPropsUtil.get(
 		"database.mysql.driver");
 

--- a/test.properties
+++ b/test.properties
@@ -752,6 +752,7 @@
         portlet.properties.marketplace-portlet,\
         portlet.properties.private-messaging-portlet,\
         setup.wizard.enabled,\
+        setup.wizard.initial.database.type,\
         sharepoint.enabled,\
         solr.enabled,\
         test.assert.javascript.errors,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-14249

We added a property called "setup.wizard.initial.database.type" because setup wizard starts out in one database and configures to another database.

These commits make it so that we can have database.type=mysql and still build a mysql database, but have setup wizard start using hsql instead.
