### PR TITLE
Lps 55780

### DIFF
--- a/modules/core/required-depedencies/build.xml
+++ b/modules/core/required-depedencies/build.xml
@@ -7,4 +7,28 @@
 	<import file="../../../tools/sdk/build-common-osgi-plugin.xml" />
 
 	<property name="auto.deploy.dir" value="${liferay.home}/osgi/static" />
+
+	<target name="deploy">
+		<process-ivy
+			module.dir="${basedir}"
+		/>
+
+		<unjar src="lib/org.apache.felix.configadmin.jar" dest="lib">
+			<patternset>
+				<include name="META-INF/MANIFEST.MF" />
+			</patternset>
+		</unjar>
+
+		<jar destfile="lib/temp.jar" manifest="lib/META-INF/MANIFEST.MF">
+			<zipfileset src="lib/org.apache.felix.configadmin.jar" excludes="OSGI-INF/permissions.perm" />
+		</jar>
+
+		<move file="lib/temp.jar" tofile="lib/org.apache.felix.configadmin.jar" />
+
+		<delete dir="lib/META-INF" />
+
+		<deploy
+			module.dir="${basedir}"
+		/>
+	</target>
 </project>

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -235,7 +235,7 @@ public class InitUtil {
 			ModuleFrameworkUtilAdapter.stopFramework();
 		}
 		catch (Exception e) {
-			new RuntimeException(e);
+			throw new RuntimeException(e);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -239,6 +239,15 @@ public class InitUtil {
 		}
 	}
 
+	public synchronized static void stopRuntime() {
+		try {
+			ModuleFrameworkUtilAdapter.stopRuntime();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	private static final boolean _PRINT_TIME = false;
 
 	private static boolean _initialized;

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -388,6 +388,8 @@ public class PACLAggregateTest {
 				throw new ProcessException(ioe);
 			}
 			finally {
+				InitUtil.stopRuntime();
+
 				InitUtil.stopModuleFramework();
 
 				MPIHelperUtil.shutdown();

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -139,6 +139,9 @@ public class PACLAggregateTest {
 		}
 
 		arguments.add(
+			"-Dportal:" + PropsKeys.CLUSTER_LINK_AUTODETECT_ADDRESS +
+				StringPool.EQUAL);
+		arguments.add(
 			"-D" + PropsKeys.LIFERAY_LIB_PORTAL_DIR + "=" +
 				PropsValues.LIFERAY_LIB_PORTAL_DIR);
 		arguments.add(

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.PACLTestRule;
 import com.liferay.portal.util.InitUtil;
 import com.liferay.portal.util.PropsValues;
 
@@ -57,6 +58,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Future;
+
+import javax.naming.Context;
 
 import org.junit.Test;
 import org.junit.runner.Description;
@@ -333,6 +336,19 @@ public class PACLAggregateTest {
 		@Override
 		public Result call() throws ProcessException {
 			ProxySelector.setDefault(new DummySocksProxySelector());
+
+			URL resource = PACLTestRule.class.getResource(
+				"pacl-test.properties");
+
+			if (resource != null) {
+				System.setProperty("external-properties", resource.getPath());
+			}
+
+			System.setProperty(
+				Context.INITIAL_CONTEXT_FACTORY,
+				"org.apache.naming.java.javaURLContextFactory");
+
+			System.setProperty("catalina.base", ".");
 
 			Path tempStatePath = null;
 

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -28,9 +28,14 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
+import com.liferay.portal.test.log.CaptureAppender;
 import com.liferay.portal.test.rule.PACLTestRule;
+import com.liferay.portal.test.rule.callback.LogAssertionTestCallback;
 import com.liferay.portal.util.InitUtil;
+import com.liferay.portal.util.PropsImpl;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.util.log4j.Log4JUtil;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -350,6 +355,8 @@ public class PACLAggregateTest {
 
 			System.setProperty("catalina.base", ".");
 
+			CaptureAppender captureAppender = null;
+
 			Path tempStatePath = null;
 
 			try {
@@ -358,6 +365,17 @@ public class PACLAggregateTest {
 				System.setProperty(
 					"portal:" + PropsKeys.MODULE_FRAMEWORK_STATE_DIR,
 					tempStatePath.toString());
+
+				com.liferay.portal.kernel.util.PropsUtil.setProps(
+					new PropsImpl());
+
+				SystemProperties.set(
+					"log4j.configure.on.startup", StringPool.FALSE);
+
+				Log4JUtil.configureLog4J(
+					PACLTestsProcessCallable.class.getClassLoader());
+
+				captureAppender = LogAssertionTestCallback.startAssert(null);
 
 				JUnitCore junitCore = new JUnitCore();
 
@@ -406,6 +424,8 @@ public class PACLAggregateTest {
 					catch (IOException ioe) {
 						throw new ProcessException(ioe);
 					}
+
+					LogAssertionTestCallback.endAssert(null, captureAppender);
 				}
 			}
 		}

--- a/portal-impl/test/unit/com/liferay/portal/util/InitUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/InitUtilTest.java
@@ -67,6 +67,8 @@ public class InitUtilTest {
 					_LOG4J_CONFIGURE_ON_STARTUP, log4jConfigureOnStartup);
 			}
 
+			InitUtil.stopRuntime();
+
 			InitUtil.stopModuleFramework();
 		}
 	}

--- a/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
@@ -49,8 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.naming.Context;
-
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 
@@ -234,18 +232,6 @@ public class PACLTestRule implements TestRule {
 		"com.liferay.portal.security.pacl.test.";
 
 	static {
-		URL resource = PACLTestRule.class.getResource("pacl-test.properties");
-
-		if (resource != null) {
-			System.setProperty("external-properties", resource.getPath());
-		}
-
-		System.setProperty(
-			Context.INITIAL_CONTEXT_FACTORY,
-			"org.apache.naming.java.javaURLContextFactory");
-
-		System.setProperty("catalina.base", ".");
-
 		List<String> configLocations = ListUtil.fromArray(
 			PropsUtil.getArray(PropsKeys.SPRING_CONFIGS));
 

--- a/portal-test-internal/src/com/liferay/portal/test/rule/callback/LogAssertionTestCallback.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/callback/LogAssertionTestCallback.java
@@ -56,40 +56,7 @@ public class LogAssertionTestCallback
 		}
 	}
 
-	@Override
-	public void doAfterClass(
-		Description description, CaptureAppender captureAppender) {
-
-		ExpectedLogs expectedLogs = description.getAnnotation(
-			ExpectedLogs.class);
-
-		endAssert(expectedLogs, captureAppender);
-	}
-
-	@Override
-	public void doAfterMethod(
-		Description description, CaptureAppender captureAppender,
-		Object target) {
-
-		doAfterClass(description, captureAppender);
-	}
-
-	@Override
-	public CaptureAppender doBeforeClass(Description description) {
-		ExpectedLogs expectedLogs = description.getAnnotation(
-			ExpectedLogs.class);
-
-		return startAssert(expectedLogs);
-	}
-
-	@Override
-	public CaptureAppender doBeforeMethod(
-		Description description, Object target) {
-
-		return doBeforeClass(description);
-	}
-
-	protected static void endAssert(
+	public static void endAssert(
 		ExpectedLogs expectedLogs, CaptureAppender captureAppender) {
 
 		if (expectedLogs != null) {
@@ -128,6 +95,57 @@ public class LogAssertionTestCallback
 		finally {
 			_concurrentFailures.clear();
 		}
+	}
+
+	public static CaptureAppender startAssert(ExpectedLogs expectedLogs) {
+		_thread = Thread.currentThread();
+
+		CaptureAppender captureAppender = null;
+
+		if (expectedLogs != null) {
+			Class<?> clazz = expectedLogs.loggerClass();
+
+			captureAppender = Log4JLoggerTestUtil.configureLog4JLogger(
+				clazz.getName(), Level.toLevel(expectedLogs.level()));
+		}
+
+		installJdk14Handler();
+		installLog4jAppender();
+
+		return captureAppender;
+	}
+
+	@Override
+	public void doAfterClass(
+		Description description, CaptureAppender captureAppender) {
+
+		ExpectedLogs expectedLogs = description.getAnnotation(
+			ExpectedLogs.class);
+
+		endAssert(expectedLogs, captureAppender);
+	}
+
+	@Override
+	public void doAfterMethod(
+		Description description, CaptureAppender captureAppender,
+		Object target) {
+
+		doAfterClass(description, captureAppender);
+	}
+
+	@Override
+	public CaptureAppender doBeforeClass(Description description) {
+		ExpectedLogs expectedLogs = description.getAnnotation(
+			ExpectedLogs.class);
+
+		return startAssert(expectedLogs);
+	}
+
+	@Override
+	public CaptureAppender doBeforeMethod(
+		Description description, Object target) {
+
+		return doBeforeClass(description);
 	}
 
 	protected static void installJdk14Handler() {
@@ -171,24 +189,6 @@ public class LogAssertionTestCallback
 		}
 
 		return false;
-	}
-
-	protected static CaptureAppender startAssert(ExpectedLogs expectedLogs) {
-		_thread = Thread.currentThread();
-
-		CaptureAppender captureAppender = null;
-
-		if (expectedLogs != null) {
-			Class<?> clazz = expectedLogs.loggerClass();
-
-			captureAppender = Log4JLoggerTestUtil.configureLog4JLogger(
-				clazz.getName(), Level.toLevel(expectedLogs.level()));
-		}
-
-		installJdk14Handler();
-		installLog4jAppender();
-
-		return captureAppender;
 	}
 
 	private LogAssertionTestCallback() {


### PR DESCRIPTION
@brianchandotcom this is the simplest way that I can get to make it working.

Basically org.apache.felix.configadmin.jar has a static local permissions file defined, which is completely bypassing the PACL security mechanism, therefore it is not possible to intercept and fix this at PACL level.

So the solution is to strip off the OSGI-INF/permissions.perm, to make it a normal bundle which will fail back to PACL mechanism.

With this all PACL tests are passing and stable now. Tomorrow I will try to figure out a way to enable the log asserter during the test initialization phase, so that errors like these can be caught stably in the future.
