### PR TITLE
master-qa-15783

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/platform/deployment/setupwizard/Setupwizard.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/platform/deployment/setupwizard/Setupwizard.testcase
@@ -1,4 +1,4 @@
-<definition component-name="portal-deployment">
+<definition component-name="portal-deployment-mysql">
 	<property name="setup.wizard.enabled" value="true" />
 	<property name="testray.main.component.name" value="Setup Wizard" />
 

--- a/test.properties
+++ b/test.properties
@@ -202,7 +202,8 @@
         portal-collaboration,\
         portal-configuration,\
         portal-core-infrastructure-portal-services,\
-        portal-deployment,\
+        portal-deployment-hsql,\
+        portal-deployment-mysql,\
         portal-document-management,\
         portal-document-management-ee,\
         portal-frameworks,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-15783

Because we want to test setup wizard with multiple different databases as the starting point, but we don't want one database's tests to run in another database's job (e.g. We don't want to run the HSQL tests in the MySQL job), we're splitting up the setup wizard component (portal-deployment) by database.

@kiyoshilee
