### PR TITLE
LPS-52174

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1389,15 +1389,15 @@ public class ServicePreAction extends Action {
 	protected void addDefaultUserPrivateLayouts(User user)
 		throws PortalException {
 
-		Group userGroup = user.getGroup();
+		Group group = user.getGroup();
 
 		if (privateLARFile != null) {
 			addDefaultLayoutsByLAR(
-				user.getUserId(), userGroup.getGroupId(), true, privateLARFile);
+				user.getUserId(), group.getGroupId(), true, privateLARFile);
 		}
 		else {
 			addDefaultUserPrivateLayoutByProperties(
-				user.getUserId(), userGroup.getGroupId());
+				user.getUserId(), group.getGroupId());
 		}
 	}
 
@@ -1501,12 +1501,12 @@ public class ServicePreAction extends Action {
 	protected void deleteDefaultUserPrivateLayouts(User user)
 		throws PortalException {
 
-		Group userGroup = user.getGroup();
+		Group group = user.getGroup();
 
 		ServiceContext serviceContext = new ServiceContext();
 
 		LayoutLocalServiceUtil.deleteLayouts(
-			userGroup.getGroupId(), true, serviceContext);
+			group.getGroupId(), true, serviceContext);
 	}
 
 	protected void deleteDefaultUserPublicLayouts(User user)
@@ -1525,15 +1525,14 @@ public class ServicePreAction extends Action {
 
 		Layout layout = null;
 
-		Group userGroup = user.getGroup();
+		Group group = user.getGroup();
 
 		List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
-			userGroup.getGroupId(), true,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+			group.getGroupId(), true, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
 		if (layouts.isEmpty()) {
 			layouts = LayoutLocalServiceUtil.getLayouts(
-				userGroup.getGroupId(), false,
+				group.getGroupId(), false,
 				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 		}
 

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1520,7 +1520,7 @@ public class ServicePreAction extends Action {
 			userGroup.getGroupId(), false, serviceContext);
 	}
 
-	protected Object[] getDefaultSiteLayout(User user) throws PortalException {
+	protected Object[] getGuestSiteLayout(User user) throws PortalException {
 		Layout layout = null;
 		List<Layout> layouts = null;
 
@@ -1563,7 +1563,7 @@ public class ServicePreAction extends Action {
 		return new Object[] {layout, layouts};
 	}
 
-	protected Object[] getDefaultUserSiteLayout(User user)
+	protected Object[] getDefaultUserSitesLayout(User user)
 		throws PortalException {
 
 		Layout layout = null;
@@ -1604,7 +1604,7 @@ public class ServicePreAction extends Action {
 			String controlPanelCategory, boolean signedIn)
 		throws PortalException {
 
-		Object[] defaultLayout = getDefaultVirtualLayout(request);
+		Object[] defaultLayout = getDefaultVirtualHostLayout(request);
 
 		defaultLayout = getViewableLayouts(
 			request, user, permissionChecker, defaultLayout, doAsGroupId,
@@ -1618,7 +1618,7 @@ public class ServicePreAction extends Action {
 			defaultLayout = getDefaultUserPersonalLayout(user);
 
 			if (defaultLayout[0] == null) {
-				defaultLayout = getDefaultUserSiteLayout(user);
+				defaultLayout = getDefaultUserSitesLayout(user);
 			}
 
 			defaultLayout = getViewableLayouts(
@@ -1630,14 +1630,14 @@ public class ServicePreAction extends Action {
 			}
 		}
 
-		defaultLayout = getDefaultSiteLayout(user);
+		defaultLayout = getGuestSiteLayout(user);
 
 		return getViewableLayouts(
 			request, user, permissionChecker, defaultLayout, doAsGroupId,
 			controlPanelCategory);
 	}
 
-	protected Object[] getDefaultVirtualLayout(HttpServletRequest request)
+	protected Object[] getDefaultVirtualHostLayout(HttpServletRequest request)
 		throws PortalException {
 
 		Layout layout = null;

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1520,24 +1520,6 @@ public class ServicePreAction extends Action {
 			userGroup.getGroupId(), false, serviceContext);
 	}
 
-	protected Object[] getGuestSiteLayout(User user) throws PortalException {
-		Layout layout = null;
-		List<Layout> layouts = null;
-
-		Group guestGroup = GroupLocalServiceUtil.getGroup(
-			user.getCompanyId(), GroupConstants.GUEST);
-
-		layouts = LayoutLocalServiceUtil.getLayouts(
-			guestGroup.getGroupId(), false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-
-		if (!layouts.isEmpty()) {
-			layout = layouts.get(0);
-		}
-
-		return new Object[] {layout, layouts};
-	}
-
 	protected Object[] getDefaultUserPersonalLayout(User user)
 		throws PortalException {
 
@@ -1696,6 +1678,24 @@ public class ServicePreAction extends Action {
 		friendlyURL = GetterUtil.getString(friendlyURL);
 
 		return FriendlyURLNormalizerUtil.normalize(friendlyURL);
+	}
+
+	protected Object[] getGuestSiteLayout(User user) throws PortalException {
+		Layout layout = null;
+		List<Layout> layouts = null;
+
+		Group guestGroup = GroupLocalServiceUtil.getGroup(
+			user.getCompanyId(), GroupConstants.GUEST);
+
+		layouts = LayoutLocalServiceUtil.getLayouts(
+			guestGroup.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+		if (!layouts.isEmpty()) {
+			layout = layouts.get(0);
+		}
+
+		return new Object[] {layout, layouts};
 	}
 
 	protected Object[] getViewableLayouts(

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1522,11 +1522,10 @@ public class ServicePreAction extends Action {
 
 	protected Object[] getDefaultUserPersonalLayout(User user) {
 		Layout layout = null;
-		List<Layout> layouts = null;
 
 		Group userGroup = user.getGroup();
 
-		layouts = LayoutLocalServiceUtil.getLayouts(
+		List<Layout> layouts = LayoutLocalServiceUtil.getLayouts(
 			userGroup.getGroupId(), true,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1606,11 +1606,8 @@ public class ServicePreAction extends Action {
 
 		Object[] defaultLayout = getDefaultVirtualLayout(request);
 
-		Layout layout = (Layout)defaultLayout[0];
-		List<Layout> layouts = (List<Layout>)defaultLayout[1];
-
 		defaultLayout = getViewableLayouts(
-			request, user, permissionChecker, layout, layouts, doAsGroupId,
+			request, user, permissionChecker, defaultLayout, doAsGroupId,
 			controlPanelCategory);
 
 		if (defaultLayout[1] != null) {
@@ -1624,11 +1621,8 @@ public class ServicePreAction extends Action {
 				defaultLayout = getDefaultUserSiteLayout(user);
 			}
 
-			layout = (Layout)defaultLayout[0];
-			layouts = (List<Layout>)defaultLayout[1];
-
 			defaultLayout = getViewableLayouts(
-				request, user, permissionChecker, layout, layouts, doAsGroupId,
+				request, user, permissionChecker, defaultLayout, doAsGroupId,
 				controlPanelCategory);
 
 			if (defaultLayout[1] != null) {
@@ -1638,11 +1632,8 @@ public class ServicePreAction extends Action {
 
 		defaultLayout = getDefaultSiteLayout(user);
 
-		layout = (Layout)defaultLayout[0];
-		layouts = (List<Layout>)defaultLayout[1];
-
 		return getViewableLayouts(
-			request, user, permissionChecker, layout, layouts, doAsGroupId,
+			request, user, permissionChecker, defaultLayout, doAsGroupId,
 			controlPanelCategory);
 	}
 
@@ -1772,6 +1763,20 @@ public class ServicePreAction extends Action {
 		}
 
 		return new Object[] {layout, layouts};
+	}
+
+	protected Object[] getViewableLayouts(
+			HttpServletRequest request, User user,
+			PermissionChecker permissionChecker, Object[] defaultLayout,
+			long doAsGroupId, String controlPanelCategory)
+		throws PortalException {
+
+		Layout layout = (Layout)defaultLayout[0];
+		List<Layout> layouts = (List<Layout>)defaultLayout[1];
+
+		return getViewableLayouts(
+			request, user, permissionChecker, layout, layouts, doAsGroupId,
+			controlPanelCategory);
 	}
 
 	protected boolean hasAccessPermission(

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1520,7 +1520,9 @@ public class ServicePreAction extends Action {
 			userGroup.getGroupId(), false, serviceContext);
 	}
 
-	protected LayoutComposite getDefaultUserPersonalLayoutComposite(User user) {
+	protected LayoutComposite getDefaultUserPersonalSiteLayoutComposite(
+		User user) {
+
 		Layout layout = null;
 
 		Group userGroup = user.getGroup();
@@ -1593,7 +1595,7 @@ public class ServicePreAction extends Action {
 		}
 
 		if (signedIn) {
-			defaultLayoutComposite = getDefaultUserPersonalLayoutComposite(
+			defaultLayoutComposite = getDefaultUserPersonalSiteLayoutComposite(
 				user);
 
 			if (defaultLayoutComposite.getLayout() == null) {

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -482,25 +482,25 @@ public class ServicePreAction extends Action {
 
 		List<Layout> unfilteredLayouts = layouts;
 
-		Object[] viewableLayouts = null;
+		LayoutComposite viewableLayoutComposite = null;
 
 		if (layout == null) {
-			viewableLayouts = getDefaultViewableLayouts(
+			viewableLayoutComposite = getDefaultViewableLayoutComposite(
 				request, user, permissionChecker, doAsGroupId,
 				controlPanelCategory, signedIn);
 
 			request.setAttribute(WebKeys.LAYOUT_DEFAULT, Boolean.TRUE);
 		}
 		else {
-			viewableLayouts = getViewableLayouts(
+			viewableLayoutComposite = getViewableLayoutComposite(
 				request, user, permissionChecker, layout, layouts, doAsGroupId,
 				controlPanelCategory);
 		}
 
 		String layoutSetLogo = null;
 
-		layout = (Layout)viewableLayouts[0];
-		layouts = (List<Layout>)viewableLayouts[1];
+		layout = viewableLayoutComposite.getLayout();
+		layouts = viewableLayoutComposite.getLayouts();
 
 		Group group = null;
 
@@ -1520,7 +1520,7 @@ public class ServicePreAction extends Action {
 			userGroup.getGroupId(), false, serviceContext);
 	}
 
-	protected Object[] getDefaultUserPersonalLayout(User user) {
+	protected LayoutComposite getDefaultUserPersonalLayoutComposite(User user) {
 		Layout layout = null;
 
 		Group userGroup = user.getGroup();
@@ -1539,10 +1539,10 @@ public class ServicePreAction extends Action {
 			layout = layouts.get(0);
 		}
 
-		return new Object[] {layout, layouts};
+		return new LayoutComposite(layout, layouts);
 	}
 
-	protected Object[] getDefaultUserSitesLayout(User user) {
+	protected LayoutComposite getDefaultUserSitesLayoutComposite(User user) {
 		Layout layout = null;
 		List<Layout> layouts = null;
 
@@ -1572,49 +1572,53 @@ public class ServicePreAction extends Action {
 			}
 		}
 
-		return new Object[] {layout, layouts};
+		return new LayoutComposite(layout, layouts);
 	}
 
-	protected Object[] getDefaultViewableLayouts(
+	protected LayoutComposite getDefaultViewableLayoutComposite(
 			HttpServletRequest request, User user,
 			PermissionChecker permissionChecker, long doAsGroupId,
 			String controlPanelCategory, boolean signedIn)
 		throws PortalException {
 
-		Object[] defaultLayout = getDefaultVirtualHostLayout(request);
+		LayoutComposite defaultLayoutComposite =
+			getDefaultVirtualHostLayoutComposite(request);
 
-		defaultLayout = getViewableLayouts(
-			request, user, permissionChecker, defaultLayout, doAsGroupId,
-			controlPanelCategory);
+		defaultLayoutComposite = getViewableLayoutComposite(
+			request, user, permissionChecker, defaultLayoutComposite,
+			doAsGroupId, controlPanelCategory);
 
-		if (defaultLayout[1] != null) {
-			return defaultLayout;
+		if (defaultLayoutComposite.getLayouts() != null) {
+			return defaultLayoutComposite;
 		}
 
 		if (signedIn) {
-			defaultLayout = getDefaultUserPersonalLayout(user);
+			defaultLayoutComposite = getDefaultUserPersonalLayoutComposite(
+				user);
 
-			if (defaultLayout[0] == null) {
-				defaultLayout = getDefaultUserSitesLayout(user);
+			if (defaultLayoutComposite.getLayout() == null) {
+				defaultLayoutComposite = getDefaultUserSitesLayoutComposite(
+					user);
 			}
 
-			defaultLayout = getViewableLayouts(
-				request, user, permissionChecker, defaultLayout, doAsGroupId,
-				controlPanelCategory);
+			defaultLayoutComposite = getViewableLayoutComposite(
+				request, user, permissionChecker, defaultLayoutComposite,
+				doAsGroupId, controlPanelCategory);
 
-			if (defaultLayout[1] != null) {
-				return defaultLayout;
+			if (defaultLayoutComposite.getLayouts() != null) {
+				return defaultLayoutComposite;
 			}
 		}
 
-		defaultLayout = getGuestSiteLayout(user);
+		defaultLayoutComposite = getGuestSiteLayoutComposite(user);
 
-		return getViewableLayouts(
-			request, user, permissionChecker, defaultLayout, doAsGroupId,
-			controlPanelCategory);
+		return getViewableLayoutComposite(
+			request, user, permissionChecker, defaultLayoutComposite,
+			doAsGroupId, controlPanelCategory);
 	}
 
-	protected Object[] getDefaultVirtualHostLayout(HttpServletRequest request)
+	protected LayoutComposite getDefaultVirtualHostLayoutComposite(
+			HttpServletRequest request)
 		throws PortalException {
 
 		Layout layout = null;
@@ -1666,7 +1670,7 @@ public class ServicePreAction extends Action {
 			}
 		}
 
-		return new Object[] {layout, layouts};
+		return new LayoutComposite(layout, layouts);
 	}
 
 	protected String getFriendlyURL(String friendlyURL) {
@@ -1675,7 +1679,9 @@ public class ServicePreAction extends Action {
 		return FriendlyURLNormalizerUtil.normalize(friendlyURL);
 	}
 
-	protected Object[] getGuestSiteLayout(User user) throws PortalException {
+	protected LayoutComposite getGuestSiteLayoutComposite(User user)
+		throws PortalException {
+
 		Layout layout = null;
 		List<Layout> layouts = null;
 
@@ -1690,17 +1696,17 @@ public class ServicePreAction extends Action {
 			layout = layouts.get(0);
 		}
 
-		return new Object[] {layout, layouts};
+		return new LayoutComposite(layout, layouts);
 	}
 
-	protected Object[] getViewableLayouts(
+	protected LayoutComposite getViewableLayoutComposite(
 			HttpServletRequest request, User user,
 			PermissionChecker permissionChecker, Layout layout,
 			List<Layout> layouts, long doAsGroupId, String controlPanelCategory)
 		throws PortalException {
 
 		if ((layouts == null) || layouts.isEmpty()) {
-			return new Object[] {layout, layouts};
+			return new LayoutComposite(layout, layouts);
 		}
 
 		Group group = layout.getGroup();
@@ -1757,19 +1763,20 @@ public class ServicePreAction extends Action {
 			layouts = accessibleLayouts;
 		}
 
-		return new Object[] {layout, layouts};
+		return new LayoutComposite(layout, layouts);
 	}
 
-	protected Object[] getViewableLayouts(
+	protected LayoutComposite getViewableLayoutComposite(
 			HttpServletRequest request, User user,
-			PermissionChecker permissionChecker, Object[] defaultLayout,
-			long doAsGroupId, String controlPanelCategory)
+			PermissionChecker permissionChecker,
+			LayoutComposite defaultLayoutComposite, long doAsGroupId,
+			String controlPanelCategory)
 		throws PortalException {
 
-		Layout layout = (Layout)defaultLayout[0];
-		List<Layout> layouts = (List<Layout>)defaultLayout[1];
+		Layout layout = defaultLayoutComposite.getLayout();
+		List<Layout> layouts = defaultLayoutComposite.getLayouts();
 
-		return getViewableLayouts(
+		return getViewableLayoutComposite(
 			request, user, permissionChecker, layout, layouts, doAsGroupId,
 			controlPanelCategory);
 	}
@@ -1944,11 +1951,12 @@ public class ServicePreAction extends Action {
 				guestGroup.getGroupId(), false,
 				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-			Object[] viewableLayouts = getViewableLayouts(
-				request, user, permissionChecker, layout, guestLayouts,
+			LayoutComposite viewableLayoutComposite =
+				getViewableLayoutComposite(
+					request, user, permissionChecker, layout, guestLayouts,
 				doAsGroupId, controlPanelCategory);
 
-			guestLayouts = (List<Layout>)viewableLayouts[1];
+			guestLayouts = viewableLayoutComposite.getLayouts();
 
 			if (layouts == null) {
 				return guestLayouts;
@@ -1995,11 +2003,12 @@ public class ServicePreAction extends Action {
 						previousGroupId.longValue(), false,
 						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-				Object[] viewableLayouts = getViewableLayouts(
-					request, user, permissionChecker, layout, previousLayouts,
-					doAsGroupId, controlPanelCategory);
+				LayoutComposite viewableLayoutComposite =
+					getViewableLayoutComposite(
+						request, user, permissionChecker, layout,
+						previousLayouts, doAsGroupId, controlPanelCategory);
 
-				previousLayouts = (List<Layout>)viewableLayouts[1];
+				previousLayouts = viewableLayoutComposite.getLayouts();
 
 				if (previousLayouts != null) {
 					layouts.addAll(previousLayouts);
@@ -2339,6 +2348,26 @@ public class ServicePreAction extends Action {
 
 	protected File privateLARFile;
 	protected File publicLARFile;
+
+	protected class LayoutComposite {
+
+		protected LayoutComposite(Layout layout, List<Layout> layouts) {
+			_layout = layout;
+			_layouts = layouts;
+		}
+
+		protected Layout getLayout() {
+			return _layout;
+		}
+
+		protected List<Layout> getLayouts() {
+			return _layouts;
+		}
+
+		private final Layout _layout;
+		private final List<Layout> _layouts;
+
+	}
 
 	private static final String _PATH_PORTAL_LAYOUT = "/portal/layout";
 

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1520,6 +1520,84 @@ public class ServicePreAction extends Action {
 			userGroup.getGroupId(), false, serviceContext);
 	}
 
+	protected Object[] getDefaultSiteLayout(User user) throws PortalException {
+		Layout layout = null;
+		List<Layout> layouts = null;
+
+		Group guestGroup = GroupLocalServiceUtil.getGroup(
+			user.getCompanyId(), GroupConstants.GUEST);
+
+		layouts = LayoutLocalServiceUtil.getLayouts(
+			guestGroup.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+		if (!layouts.isEmpty()) {
+			layout = layouts.get(0);
+		}
+
+		return new Object[] {layout, layouts};
+	}
+
+	protected Object[] getDefaultUserPersonalLayout(User user)
+		throws PortalException {
+
+		Layout layout = null;
+		List<Layout> layouts = null;
+
+		Group userGroup = user.getGroup();
+
+		layouts = LayoutLocalServiceUtil.getLayouts(
+			userGroup.getGroupId(), true,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+		if (layouts.isEmpty()) {
+			layouts = LayoutLocalServiceUtil.getLayouts(
+				userGroup.getGroupId(), false,
+				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+		}
+
+		if (!layouts.isEmpty()) {
+			layout = layouts.get(0);
+		}
+
+		return new Object[] {layout, layouts};
+	}
+
+	protected Object[] getDefaultUserSiteLayout(User user)
+		throws PortalException {
+
+		Layout layout = null;
+		List<Layout> layouts = null;
+
+		LinkedHashMap<String, Object> groupParams = new LinkedHashMap<>();
+
+		groupParams.put("usersGroups", new Long(user.getUserId()));
+
+		List<Group> groups = GroupLocalServiceUtil.search(
+			user.getCompanyId(), null, null, groupParams, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS);
+
+		for (Group group : groups) {
+			layouts = LayoutLocalServiceUtil.getLayouts(
+				group.getGroupId(), true,
+				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+			if (layouts.isEmpty()) {
+				layouts = LayoutLocalServiceUtil.getLayouts(
+					group.getGroupId(), false,
+					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+			}
+
+			if (!layouts.isEmpty()) {
+				layout = layouts.get(0);
+
+				break;
+			}
+		}
+
+		return new Object[] {layout, layouts};
+	}
+
 	protected Object[] getDefaultViewableLayouts(
 			HttpServletRequest request, User user,
 			PermissionChecker permissionChecker, long doAsGroupId,
@@ -1618,85 +1696,6 @@ public class ServicePreAction extends Action {
 					layout = null;
 				}
 			}
-		}
-
-		return new Object[] {layout, layouts};
-	}
-
-	protected Object[] getDefaultUserPersonalLayout(User user)
-		throws PortalException {
-
-		Layout layout = null;
-		List<Layout> layouts = null;
-
-		Group userGroup = user.getGroup();
-
-		layouts = LayoutLocalServiceUtil.getLayouts(
-			userGroup.getGroupId(), true,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-
-		if (layouts.isEmpty()) {
-			layouts = LayoutLocalServiceUtil.getLayouts(
-				userGroup.getGroupId(), false,
-				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-		}
-
-		if (!layouts.isEmpty()) {
-			layout = layouts.get(0);
-		}
-
-		return new Object[] {layout, layouts};
-	}
-
-	protected Object[] getDefaultUserSiteLayout(User user)
-		throws PortalException {
-
-		Layout layout = null;
-		List<Layout> layouts = null;
-
-		LinkedHashMap<String, Object> groupParams =
-			new LinkedHashMap<>();
-
-		groupParams.put("usersGroups", new Long(user.getUserId()));
-
-		List<Group> groups = GroupLocalServiceUtil.search(
-			user.getCompanyId(), null, null, groupParams,
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		for (Group group : groups) {
-			layouts = LayoutLocalServiceUtil.getLayouts(
-				group.getGroupId(), true,
-				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-
-			if (layouts.isEmpty()) {
-				layouts = LayoutLocalServiceUtil.getLayouts(
-					group.getGroupId(), false,
-					LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-			}
-
-			if (!layouts.isEmpty()) {
-				layout = layouts.get(0);
-
-				break;
-			}
-		}
-
-		return new Object[] {layout, layouts};
-	}
-
-	protected Object[] getDefaultSiteLayout(User user) throws PortalException {
-		Layout layout = null;
-		List<Layout> layouts = null;
-
-		Group guestGroup = GroupLocalServiceUtil.getGroup(
-			user.getCompanyId(), GroupConstants.GUEST);
-
-		layouts = LayoutLocalServiceUtil.getLayouts(
-			guestGroup.getGroupId(), false,
-			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
-
-		if (!layouts.isEmpty()) {
-			layout = layouts.get(0);
 		}
 
 		return new Object[] {layout, layouts};

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -482,18 +482,20 @@ public class ServicePreAction extends Action {
 
 		List<Layout> unfilteredLayouts = layouts;
 
-		if (layout == null) {
-			Object[] defaultLayout = getDefaultLayout(request, user, signedIn);
+		Object[] viewableLayouts = null;
 
-			layout = (Layout)defaultLayout[0];
-			layouts = (List<Layout>)defaultLayout[1];
+		if (layout == null) {
+			viewableLayouts = getDefaultViewableLayouts(
+				request, user, permissionChecker, doAsGroupId,
+				controlPanelCategory, signedIn);
 
 			request.setAttribute(WebKeys.LAYOUT_DEFAULT, Boolean.TRUE);
 		}
-
-		Object[] viewableLayouts = getViewableLayouts(
-			request, user, permissionChecker, layout, layouts, doAsGroupId,
-			controlPanelCategory);
+		else {
+			viewableLayouts = getViewableLayouts(
+				request, user, permissionChecker, layout, layouts, doAsGroupId,
+				controlPanelCategory);
+		}
 
 		String layoutSetLogo = null;
 
@@ -1518,27 +1520,52 @@ public class ServicePreAction extends Action {
 			userGroup.getGroupId(), false, serviceContext);
 	}
 
-	protected Object[] getDefaultLayout(
-			HttpServletRequest request, User user, boolean signedIn)
+	protected Object[] getDefaultViewableLayouts(
+			HttpServletRequest request, User user,
+			PermissionChecker permissionChecker, long doAsGroupId,
+			String controlPanelCategory, boolean signedIn)
 		throws PortalException {
 
 		Object[] defaultLayout = getDefaultVirtualLayout(request);
 
+		Layout layout = (Layout)defaultLayout[0];
+		List<Layout> layouts = (List<Layout>)defaultLayout[1];
+
+		defaultLayout = getViewableLayouts(
+			request, user, permissionChecker, layout, layouts, doAsGroupId,
+			controlPanelCategory);
+
+		if (defaultLayout[1] != null) {
+			return defaultLayout;
+		}
+
 		if (signedIn) {
-			if (defaultLayout[0] == null) {
-				defaultLayout = getDefaultUserPersonalLayout(user);
-			}
+			defaultLayout = getDefaultUserPersonalLayout(user);
 
 			if (defaultLayout[0] == null) {
 				defaultLayout = getDefaultUserSiteLayout(user);
 			}
+
+			layout = (Layout)defaultLayout[0];
+			layouts = (List<Layout>)defaultLayout[1];
+
+			defaultLayout = getViewableLayouts(
+				request, user, permissionChecker, layout, layouts, doAsGroupId,
+				controlPanelCategory);
+
+			if (defaultLayout[1] != null) {
+				return defaultLayout;
+			}
 		}
 
-		if (defaultLayout[0] == null) {
-			defaultLayout = getDefaultSiteLayout(user);
-		}
+		defaultLayout = getDefaultSiteLayout(user);
 
-		return defaultLayout;
+		layout = (Layout)defaultLayout[0];
+		layouts = (List<Layout>)defaultLayout[1];
+
+		return getViewableLayouts(
+			request, user, permissionChecker, layout, layouts, doAsGroupId,
+			controlPanelCategory);
 	}
 
 	protected Object[] getDefaultVirtualLayout(HttpServletRequest request)

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1520,9 +1520,7 @@ public class ServicePreAction extends Action {
 			userGroup.getGroupId(), false, serviceContext);
 	}
 
-	protected Object[] getDefaultUserPersonalLayout(User user)
-		throws PortalException {
-
+	protected Object[] getDefaultUserPersonalLayout(User user) {
 		Layout layout = null;
 		List<Layout> layouts = null;
 
@@ -1545,9 +1543,7 @@ public class ServicePreAction extends Action {
 		return new Object[] {layout, layouts};
 	}
 
-	protected Object[] getDefaultUserSitesLayout(User user)
-		throws PortalException {
-
+	protected Object[] getDefaultUserSitesLayout(User user) {
 		Layout layout = null;
 		List<Layout> layouts = null;
 

--- a/portal-impl/src/com/liferay/portal/security/membershippolicy/DefaultSiteMembershipPolicy.java
+++ b/portal-impl/src/com/liferay/portal/security/membershippolicy/DefaultSiteMembershipPolicy.java
@@ -215,14 +215,14 @@ public class DefaultSiteMembershipPolicy extends BaseSiteMembershipPolicy {
 
 		int total = UserLocalServiceUtil.getGroupUsersCount(group.getGroupId());
 
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(total);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(total);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end)
+				public Void performIntervalAction(int start, int end)
 					throws PortalException {
 
 					List<User> users = UserLocalServiceUtil.getGroupUsers(
@@ -240,6 +240,8 @@ public class DefaultSiteMembershipPolicy extends BaseSiteMembershipPolicy {
 							intervalActionProcessor.incrementStart();
 						}
 					}
+
+					return null;
 				}
 
 			});

--- a/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryLocalServiceImpl.java
@@ -467,14 +467,14 @@ public class AnnouncementsEntryLocalServiceImpl
 				params);
 		}
 
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(total);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(total);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end)
+				public Void performIntervalAction(int start, int end)
 					throws PortalException {
 
 					List<User> users = null;
@@ -494,6 +494,8 @@ public class AnnouncementsEntryLocalServiceImpl
 						users, entry, company.getLocale(), toAddress, toName);
 
 					intervalActionProcessor.incrementStart(users.size());
+
+					return null;
 				}
 
 			});

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -603,14 +603,14 @@ public class DLFileEntryLocalServiceImpl
 
 		int total = dlFileEntryFinder.countByExtraSettings();
 
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(total);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(total);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end)
+				public Void performIntervalAction(int start, int end)
 					throws PortalException {
 
 					List<DLFileEntry> dlFileEntries =
@@ -622,6 +622,8 @@ public class DLFileEntryLocalServiceImpl
 
 					intervalActionProcessor.incrementStart(
 						dlFileEntries.size());
+
+					return null;
 				}
 
 			});
@@ -962,14 +964,14 @@ public class DLFileEntryLocalServiceImpl
 
 		int total = dlFileEntryPersistence.countByR_F(repositoryId, folderId);
 
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(total);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(total);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end)
+				public Void performIntervalAction(int start, int end)
 					throws PortalException {
 
 					List<DLFileEntry> dlFileEntries =
@@ -987,6 +989,8 @@ public class DLFileEntryLocalServiceImpl
 							intervalActionProcessor.incrementStart();
 						}
 					}
+
+					return null;
 				}
 
 			});

--- a/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
@@ -71,18 +71,6 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidGuestSiteLayout() throws Exception {
-		long plid = getThemeDisplayPlid(false, false);
-
-		Object[] defaultLayout =
-			TestServicePreAction.INSTANCE.getGuestSiteLayout(_user);
-
-		Layout layout = (Layout)defaultLayout[0];
-
-		Assert.assertEquals(layout.getPlid(), plid);
-	}
-
-	@Test
 	public void testInitThemeDisplayPlidDefaultUserPersonalLayout()
 		throws Exception {
 
@@ -124,6 +112,18 @@ public class ServicePreActionTest {
 			PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_AUTO_CREATE =
 				privateLayoutsAutoCreate;
 		}
+	}
+
+	@Test
+	public void testInitThemeDisplayPlidGuestSiteLayout() throws Exception {
+		long plid = getThemeDisplayPlid(false, false);
+
+		Object[] defaultLayout =
+			TestServicePreAction.INSTANCE.getGuestSiteLayout(_user);
+
+		Layout layout = (Layout)defaultLayout[0];
+
+		Assert.assertEquals(layout.getPlid(), plid);
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
@@ -71,11 +71,11 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidSiteLayout() throws Exception {
+	public void testInitThemeDisplayPlidGuestSiteLayout() throws Exception {
 		long plid = getThemeDisplayPlid(false, false);
 
 		Object[] defaultLayout =
-			TestServicePreAction.INSTANCE.getDefaultSiteLayout(_user);
+			TestServicePreAction.INSTANCE.getGuestSiteLayout(_user);
 
 		Layout layout = (Layout)defaultLayout[0];
 
@@ -83,7 +83,9 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidUserPersonalLayout() throws Exception {
+	public void testInitThemeDisplayPlidDefaultUserPersonalLayout()
+		throws Exception {
+
 		long plid = getThemeDisplayPlid(false, true);
 
 		Object[] defaultLayout =
@@ -95,7 +97,9 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidUserSiteLayout() throws Exception {
+	public void testInitThemeDisplayPlidDefaultUserSitesLayout()
+		throws Exception {
+
 		boolean publicLayoutsAutoCreate =
 			PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_AUTO_CREATE;
 		boolean privateLayoutsAutoCreate =
@@ -108,7 +112,7 @@ public class ServicePreActionTest {
 			long plid = getThemeDisplayPlid(false, true);
 
 			Object[] defaultLayout =
-				TestServicePreAction.INSTANCE.getDefaultUserSiteLayout(_user);
+				TestServicePreAction.INSTANCE.getDefaultUserSitesLayout(_user);
 
 			Layout layout = (Layout)defaultLayout[0];
 
@@ -123,11 +127,11 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidVirtualLayout() throws Exception {
+	public void testInitThemeDisplayPlidVirtualHostLayout() throws Exception {
 		long plid = getThemeDisplayPlid(true, false);
 
 		Object[] defaultLayout =
-			TestServicePreAction.INSTANCE.getDefaultVirtualLayout(_request);
+			TestServicePreAction.INSTANCE.getDefaultVirtualHostLayout(_request);
 
 		Layout layout = (Layout)defaultLayout[0];
 

--- a/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.events;
+
+import com.liferay.portal.events.test.TestServicePreAction;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.TransactionalTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.Role;
+import com.liferay.portal.model.RoleConstants;
+import com.liferay.portal.model.User;
+import com.liferay.portal.security.permission.ActionKeys;
+import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.service.RoleLocalServiceUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.MainServletTestRule;
+import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.util.WebKeys;
+import com.liferay.portal.util.test.LayoutTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Preston Crary
+ */
+public class ServicePreActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(), MainServletTestRule.INSTANCE,
+			TransactionalTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		LayoutTestUtil.addLayout(_group);
+
+		_request.setRequestURI(PortalUtil.getPathMain() + "/portal/login");
+
+		_request.setAttribute(
+			WebKeys.VIRTUAL_HOST_LAYOUT_SET, _group.getPublicLayoutSet());
+	}
+
+	@Test
+	public void testInitThemeDisplayPlidSiteLayout() throws Exception {
+		long plid = getThemeDisplayPlid(false, false);
+
+		Object[] defaultLayout =
+			TestServicePreAction.INSTANCE.getDefaultSiteLayout(_user);
+
+		Layout layout = (Layout)defaultLayout[0];
+
+		Assert.assertEquals(layout.getPlid(), plid);
+	}
+
+	@Test
+	public void testInitThemeDisplayPlidUserPersonalLayout() throws Exception {
+		long plid = getThemeDisplayPlid(false, true);
+
+		Object[] defaultLayout =
+			TestServicePreAction.INSTANCE.getDefaultUserPersonalLayout(_user);
+
+		Layout layout = (Layout)defaultLayout[0];
+
+		Assert.assertEquals(layout.getPlid(), plid);
+	}
+
+	@Test
+	public void testInitThemeDisplayPlidUserSiteLayout() throws Exception {
+		boolean publicLayoutsAutoCreate =
+			PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_AUTO_CREATE;
+		boolean privateLayoutsAutoCreate =
+			PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_AUTO_CREATE;
+
+		PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_AUTO_CREATE = false;
+		PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_AUTO_CREATE = false;
+
+		try {
+			long plid = getThemeDisplayPlid(false, true);
+
+			Object[] defaultLayout =
+				TestServicePreAction.INSTANCE.getDefaultUserSiteLayout(_user);
+
+			Layout layout = (Layout)defaultLayout[0];
+
+			Assert.assertEquals(layout.getPlid(), plid);
+		}
+		finally {
+			PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_AUTO_CREATE =
+				publicLayoutsAutoCreate;
+			PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_AUTO_CREATE =
+				privateLayoutsAutoCreate;
+		}
+	}
+
+	@Test
+	public void testInitThemeDisplayPlidVirtualLayout() throws Exception {
+		long plid = getThemeDisplayPlid(true, false);
+
+		Object[] defaultLayout =
+			TestServicePreAction.INSTANCE.getDefaultVirtualLayout(_request);
+
+		Layout layout = (Layout)defaultLayout[0];
+
+		Assert.assertEquals(layout.getPlid(), plid);
+	}
+
+	protected long getThemeDisplayPlid(
+			boolean hasGuestViewPermission, boolean signedIn)
+		throws Exception {
+
+		if (!hasGuestViewPermission) {
+			Role role = RoleLocalServiceUtil.getRole(
+				_group.getCompanyId(), RoleConstants.GUEST);
+
+			ResourcePermissionLocalServiceUtil.removeResourcePermissions(
+				_group.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId(),
+				ActionKeys.VIEW);
+		}
+
+		if (signedIn) {
+			_user = UserTestUtil.addUser();
+		}
+		else {
+			_user = PortalUtil.initUser(_request);
+		}
+
+		_request.setAttribute(WebKeys.USER, _user);
+
+		ThemeDisplay themeDisplay =
+			TestServicePreAction.INSTANCE.initThemeDisplay(_request, _response);
+
+		return themeDisplay.getPlid();
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private final MockHttpServletRequest _request =
+		new MockHttpServletRequest();
+	private final MockHttpServletResponse _response =
+		new MockHttpServletResponse();
+	private User _user;
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
@@ -71,7 +71,7 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidDefaultUserPersonalLayout()
+	public void testInitThemeDisplayPlidDefaultUserPersonalSiteLayoutComposite()
 		throws Exception {
 
 		long plid = getThemeDisplayPlid(false, true);
@@ -86,7 +86,7 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidDefaultUserSitesLayout()
+	public void testInitThemeDisplayPlidDefaultUserSitesLayoutComposite()
 		throws Exception {
 
 		boolean publicLayoutsAutoCreate =
@@ -117,7 +117,9 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidGuestSiteLayout() throws Exception {
+	public void testInitThemeDisplayPlidGuestSiteLayoutComposite()
+		throws Exception {
+
 		long plid = getThemeDisplayPlid(false, false);
 
 		ServicePreAction.LayoutComposite defaultLayoutComposite =
@@ -129,7 +131,9 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testInitThemeDisplayPlidVirtualHostLayout() throws Exception {
+	public void testInitThemeDisplayPlidVirtualHostLayoutComposite()
+		throws Exception {
+
 		long plid = getThemeDisplayPlid(true, false);
 
 		ServicePreAction.LayoutComposite defaultLayoutComposite =

--- a/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
@@ -77,8 +77,8 @@ public class ServicePreActionTest {
 		long plid = getThemeDisplayPlid(false, true);
 
 		ServicePreAction.LayoutComposite defaultLayoutComposite =
-			TestServicePreAction.INSTANCE.getDefaultUserPersonalSiteLayoutComposite(
-				_user);
+			TestServicePreAction.INSTANCE.
+				getDefaultUserPersonalSiteLayoutComposite(_user);
 
 		Layout layout = defaultLayoutComposite.getLayout();
 

--- a/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
@@ -76,10 +76,11 @@ public class ServicePreActionTest {
 
 		long plid = getThemeDisplayPlid(false, true);
 
-		Object[] defaultLayout =
-			TestServicePreAction.INSTANCE.getDefaultUserPersonalLayout(_user);
+		ServicePreAction.LayoutComposite defaultLayoutComposite =
+			TestServicePreAction.INSTANCE.getDefaultUserPersonalLayoutComposite(
+				_user);
 
-		Layout layout = (Layout)defaultLayout[0];
+		Layout layout = defaultLayoutComposite.getLayout();
 
 		Assert.assertEquals(layout.getPlid(), plid);
 	}
@@ -99,10 +100,11 @@ public class ServicePreActionTest {
 		try {
 			long plid = getThemeDisplayPlid(false, true);
 
-			Object[] defaultLayout =
-				TestServicePreAction.INSTANCE.getDefaultUserSitesLayout(_user);
+			ServicePreAction.LayoutComposite defaultLayoutComposite =
+				TestServicePreAction.INSTANCE.
+					getDefaultUserSitesLayoutComposite(_user);
 
-			Layout layout = (Layout)defaultLayout[0];
+			Layout layout = defaultLayoutComposite.getLayout();
 
 			Assert.assertEquals(layout.getPlid(), plid);
 		}
@@ -118,10 +120,10 @@ public class ServicePreActionTest {
 	public void testInitThemeDisplayPlidGuestSiteLayout() throws Exception {
 		long plid = getThemeDisplayPlid(false, false);
 
-		Object[] defaultLayout =
-			TestServicePreAction.INSTANCE.getGuestSiteLayout(_user);
+		ServicePreAction.LayoutComposite defaultLayoutComposite =
+			TestServicePreAction.INSTANCE.getGuestSiteLayoutComposite(_user);
 
-		Layout layout = (Layout)defaultLayout[0];
+		Layout layout = defaultLayoutComposite.getLayout();
 
 		Assert.assertEquals(layout.getPlid(), plid);
 	}
@@ -130,10 +132,11 @@ public class ServicePreActionTest {
 	public void testInitThemeDisplayPlidVirtualHostLayout() throws Exception {
 		long plid = getThemeDisplayPlid(true, false);
 
-		Object[] defaultLayout =
-			TestServicePreAction.INSTANCE.getDefaultVirtualHostLayout(_request);
+		ServicePreAction.LayoutComposite defaultLayoutComposite =
+			TestServicePreAction.INSTANCE.getDefaultVirtualHostLayoutComposite(
+				_request);
 
-		Layout layout = (Layout)defaultLayout[0];
+		Layout layout = defaultLayoutComposite.getLayout();
 
 		Assert.assertEquals(layout.getPlid(), plid);
 	}

--- a/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/events/ServicePreActionTest.java
@@ -77,7 +77,7 @@ public class ServicePreActionTest {
 		long plid = getThemeDisplayPlid(false, true);
 
 		ServicePreAction.LayoutComposite defaultLayoutComposite =
-			TestServicePreAction.INSTANCE.getDefaultUserPersonalLayoutComposite(
+			TestServicePreAction.INSTANCE.getDefaultUserPersonalSiteLayoutComposite(
 				_user);
 
 		Layout layout = defaultLayoutComposite.getLayout();

--- a/portal-service/src/com/liferay/portal/kernel/interval/IntervalActionProcessor.java
+++ b/portal-service/src/com/liferay/portal/kernel/interval/IntervalActionProcessor.java
@@ -65,6 +65,10 @@ public class IntervalActionProcessor<T> {
 	}
 
 	public T performIntervalActions() throws PortalException {
+		if (_total == 0) {
+			return null;
+		}
+
 		int pages = _total / _interval;
 
 		for (int i = 0; i <= pages; i++) {

--- a/portal-service/src/com/liferay/portal/kernel/interval/IntervalActionProcessor.java
+++ b/portal-service/src/com/liferay/portal/kernel/interval/IntervalActionProcessor.java
@@ -19,8 +19,9 @@ import com.liferay.portal.kernel.exception.PortalException;
 /**
  * @author Jonathan McCann
  * @author Sergio González
+ * @author Preston Crary
  */
-public class IntervalActionProcessor {
+public class IntervalActionProcessor<T> {
 
 	public static final int INTERVAL_DEFAULT = 100;
 
@@ -55,7 +56,7 @@ public class IntervalActionProcessor {
 		_start += increment;
 	}
 
-	public void performIntervalActions() throws PortalException {
+	public T performIntervalActions() throws PortalException {
 		int pages = _total / _interval;
 
 		for (int i = 0; i <= pages; i++) {
@@ -65,33 +66,42 @@ public class IntervalActionProcessor {
 				end = _total;
 			}
 
-			performIntervalActions(_start, end);
+			T result = performIntervalActions(_start, end);
+
+			if (result != null) {
+				return result;
+			}
 		}
+
+		return null;
 	}
 
 	public void setPerformIntervalActionMethod(
-		PerformIntervalActionMethod performIntervalActionMethod) {
+		PerformIntervalActionMethod<T> performIntervalActionMethod) {
 
 		_performIntervalActionMethod = performIntervalActionMethod;
 	}
 
-	public interface PerformIntervalActionMethod {
+	public interface PerformIntervalActionMethod<T> {
 
-		public void performIntervalAction(int start, int end)
+		public T performIntervalAction(int start, int end)
 			throws PortalException;
 
 	}
 
-	protected void performIntervalActions(int start, int end)
+	protected T performIntervalActions(int start, int end)
 		throws PortalException {
 
 		if (_performIntervalActionMethod != null) {
-			_performIntervalActionMethod.performIntervalAction(start, end);
+			return _performIntervalActionMethod.performIntervalAction(
+				start, end);
 		}
+
+		return null;
 	}
 
 	private final int _interval;
-	private PerformIntervalActionMethod _performIntervalActionMethod;
+	private PerformIntervalActionMethod<T> _performIntervalActionMethod;
 	private int _start;
 	private final int _total;
 

--- a/portal-service/src/com/liferay/portal/kernel/interval/IntervalActionProcessor.java
+++ b/portal-service/src/com/liferay/portal/kernel/interval/IntervalActionProcessor.java
@@ -27,7 +27,8 @@ public class IntervalActionProcessor<T> {
 
 	public IntervalActionProcessor(int total) {
 		if (total < 0) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(
+				"Total " + total + " is less than zero");
 		}
 
 		_total = total;
@@ -36,8 +37,14 @@ public class IntervalActionProcessor<T> {
 	}
 
 	public IntervalActionProcessor(int total, int interval) {
-		if ((total < 0) || (interval <= 0)) {
-			throw new IllegalArgumentException();
+		if (total < 0) {
+			throw new IllegalArgumentException(
+				"Total " + total + " is less than zero");
+		}
+
+		if (interval <= 0) {
+			throw new IllegalArgumentException(
+				"Interval " + interval + " is less than or equal to zero");
 		}
 
 		_total = total;
@@ -50,7 +57,8 @@ public class IntervalActionProcessor<T> {
 
 	public void incrementStart(int increment) {
 		if (increment < 0) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(
+				"Increment " + increment + " is less than zero");
 		}
 
 		_start += increment;

--- a/portal-service/test/unit/com/liferay/portal/kernel/interval/IntervalActionProcessorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/interval/IntervalActionProcessorTest.java
@@ -27,19 +27,21 @@ public class IntervalActionProcessorTest {
 
 	@Test
 	public void testIntervalActionEndCalculation() throws Exception {
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(125);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(125);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end) {
+				public Void performIntervalAction(int start, int end) {
 					for (int i = start; i < end; i++) {
 						_count.incrementAndGet();
 					}
 
 					intervalActionProcessor.incrementStart(end - start);
+
+					return null;
 				}
 
 			});
@@ -53,19 +55,21 @@ public class IntervalActionProcessorTest {
 	public void testIntervalActionEndCalculationWithInterval()
 		throws Exception {
 
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(125, 200);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(125, 200);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end) {
+				public Void performIntervalAction(int start, int end) {
 					for (int i = start; i < end; i++) {
 						_count.incrementAndGet();
 					}
 
 					intervalActionProcessor.incrementStart(end - start);
+
+					return null;
 				}
 
 			});
@@ -77,17 +81,19 @@ public class IntervalActionProcessorTest {
 
 	@Test
 	public void testIntervalActionPageCalculation() throws Exception {
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(125);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(125);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end) {
+				public Void performIntervalAction(int start, int end) {
 					_count.incrementAndGet();
 
 					intervalActionProcessor.incrementStart(end - start);
+
+					return null;
 				}
 
 			});
@@ -101,17 +107,19 @@ public class IntervalActionProcessorTest {
 	public void testIntervalActionPageCalculationWithInterval()
 		throws Exception {
 
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(125, 200);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(125, 200);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end) {
+				public Void performIntervalAction(int start, int end) {
 					_count.incrementAndGet();
 
 					intervalActionProcessor.incrementStart(end - start);
+
+					return null;
 				}
 
 			});
@@ -125,15 +133,17 @@ public class IntervalActionProcessorTest {
 	public void testIntervalActionWithNegativeIncrementStart()
 		throws Exception {
 
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(125, 200);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(125, 200);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end) {
+				public Void performIntervalAction(int start, int end) {
 					intervalActionProcessor.incrementStart(start - end);
+
+					return null;
 				}
 
 			});
@@ -143,39 +153,41 @@ public class IntervalActionProcessorTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testIntervalActionWithNegativeInterval() throws Exception {
-		new IntervalActionProcessor(125, -10);
+		new IntervalActionProcessor<Void>(125, -10);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testIntervalActionWithNegativeTotal1() throws Exception {
-		new IntervalActionProcessor(-10);
+		new IntervalActionProcessor<Void>(-10);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testIntervalActionWithNegativeTotal2() throws Exception {
-		new IntervalActionProcessor(-10, 200);
+		new IntervalActionProcessor<Void>(-10, 200);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testIntervalActionWithZeroInterval() throws Exception {
-		new IntervalActionProcessor(125, 0);
+		new IntervalActionProcessor<Void>(125, 0);
 	}
 
 	@Test
 	public void testIntervalActionWithZeroTotal() throws Exception {
-		final IntervalActionProcessor intervalActionProcessor =
-			new IntervalActionProcessor(0);
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(0);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod() {
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
 
 				@Override
-				public void performIntervalAction(int start, int end) {
+				public Void performIntervalAction(int start, int end) {
 					for (int i = start; i < end; i++) {
 						_count.incrementAndGet();
 					}
 
 					intervalActionProcessor.incrementStart(end - start);
+
+					return null;
 				}
 
 			});
@@ -183,6 +195,48 @@ public class IntervalActionProcessorTest {
 		intervalActionProcessor.performIntervalActions();
 
 		Assert.assertEquals(0, _count.get());
+	}
+
+	@Test
+	public void testIntervalWithBooleanType() throws Exception {
+		final IntervalActionProcessor<Boolean> intervalActionProcessor =
+			new IntervalActionProcessor<>(3, 1);
+
+		intervalActionProcessor.setPerformIntervalActionMethod(
+			new IntervalActionProcessor.PerformIntervalActionMethod<Boolean>() {
+
+				@Override
+				public Boolean performIntervalAction(int start, int end) {
+					if ((start == 1) && (end == 2)) {
+						return true;
+					}
+
+					intervalActionProcessor.incrementStart();
+
+					return null;
+				}
+
+		});
+
+		Assert.assertTrue(intervalActionProcessor.performIntervalActions());
+	}
+
+	@Test
+	public void testIntervalWithBooleanTypeAndZeroTotal() throws Exception {
+		IntervalActionProcessor<Boolean> intervalSearcher =
+			new IntervalActionProcessor<>(0, 1);
+
+		intervalSearcher.setPerformIntervalActionMethod(
+			new IntervalActionProcessor.PerformIntervalActionMethod<Boolean>() {
+
+				@Override
+				public Boolean performIntervalAction(int start, int end) {
+					return false;
+				}
+
+		});
+
+		Assert.assertNull(intervalSearcher.performIntervalActions());
 	}
 
 	private final AtomicInteger _count = new AtomicInteger();

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -83,11 +83,6 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getGuestSiteLayout(User user) throws PortalException {
-		return super.getGuestSiteLayout(user);
-	}
-
-	@Override
 	public Object[] getDefaultUserPersonalLayout(User user)
 		throws PortalException {
 
@@ -95,7 +90,9 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getDefaultUserSitesLayout(User user) throws PortalException {
+	public Object[] getDefaultUserSitesLayout(User user)
+		throws PortalException {
+
 		return super.getDefaultUserSitesLayout(user);
 	}
 
@@ -116,6 +113,11 @@ public class TestServicePreAction extends ServicePreAction {
 		throws PortalException {
 
 		return super.getDefaultVirtualHostLayout(request);
+	}
+
+	@Override
+	public Object[] getGuestSiteLayout(User user) throws PortalException {
+		return super.getGuestSiteLayout(user);
 	}
 
 	@Override

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -83,11 +83,39 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getDefaultLayout(
-			HttpServletRequest request, User user, boolean signedIn)
+	public Object[] getDefaultSiteLayout(User user) throws PortalException {
+		return super.getDefaultSiteLayout(user);
+	}
+
+	@Override
+	public Object[] getDefaultUserPersonalLayout(User user)
 		throws PortalException {
 
-		return super.getDefaultLayout(request, user, signedIn);
+		return super.getDefaultUserPersonalLayout(user);
+	}
+
+	@Override
+	public Object[] getDefaultUserSiteLayout(User user) throws PortalException {
+		return super.getDefaultUserSiteLayout(user);
+	}
+
+	@Override
+	public Object[] getDefaultViewableLayouts(
+			HttpServletRequest request, User user,
+			PermissionChecker permissionChecker, long doAsGroupId,
+			String controlPanelCategory, boolean signedIn)
+		throws PortalException {
+
+		return super.getDefaultViewableLayouts(
+			request, user, permissionChecker, doAsGroupId, controlPanelCategory,
+			signedIn);
+	}
+
+	@Override
+	public Object[] getDefaultVirtualLayout(HttpServletRequest request)
+		throws PortalException {
+
+		return super.getDefaultVirtualLayout(request);
 	}
 
 	@Override

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -83,8 +83,8 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getDefaultSiteLayout(User user) throws PortalException {
-		return super.getDefaultSiteLayout(user);
+	public Object[] getGuestSiteLayout(User user) throws PortalException {
+		return super.getGuestSiteLayout(user);
 	}
 
 	@Override
@@ -95,8 +95,8 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getDefaultUserSiteLayout(User user) throws PortalException {
-		return super.getDefaultUserSiteLayout(user);
+	public Object[] getDefaultUserSitesLayout(User user) throws PortalException {
+		return super.getDefaultUserSitesLayout(user);
 	}
 
 	@Override
@@ -112,10 +112,10 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getDefaultVirtualLayout(HttpServletRequest request)
+	public Object[] getDefaultVirtualHostLayout(HttpServletRequest request)
 		throws PortalException {
 
-		return super.getDefaultVirtualLayout(request);
+		return super.getDefaultVirtualHostLayout(request);
 	}
 
 	@Override

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -83,16 +83,12 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getDefaultUserPersonalLayout(User user)
-		throws PortalException {
-
+	public Object[] getDefaultUserPersonalLayout(User user) {
 		return super.getDefaultUserPersonalLayout(user);
 	}
 
 	@Override
-	public Object[] getDefaultUserSitesLayout(User user)
-		throws PortalException {
-
+	public Object[] getDefaultUserSitesLayout(User user) {
 		return super.getDefaultUserSitesLayout(user);
 	}
 

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -83,8 +83,8 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public LayoutComposite getDefaultUserPersonalLayoutComposite(User user) {
-		return super.getDefaultUserPersonalLayoutComposite(user);
+	public LayoutComposite getDefaultUserPersonalSiteLayoutComposite(User user) {
+		return super.getDefaultUserPersonalSiteLayoutComposite(user);
 	}
 
 	@Override

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -90,7 +90,9 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public LayoutComposite getDefaultUserSitesLayoutComposite(User user) {
+	public LayoutComposite getDefaultUserSitesLayoutComposite(User user)
+		throws PortalException {
+
 		return super.getDefaultUserSitesLayoutComposite(user);
 	}
 

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -83,47 +83,50 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public Object[] getDefaultUserPersonalLayout(User user) {
-		return super.getDefaultUserPersonalLayout(user);
+	public LayoutComposite getDefaultUserPersonalLayoutComposite(User user) {
+		return super.getDefaultUserPersonalLayoutComposite(user);
 	}
 
 	@Override
-	public Object[] getDefaultUserSitesLayout(User user) {
-		return super.getDefaultUserSitesLayout(user);
+	public LayoutComposite getDefaultUserSitesLayoutComposite(User user) {
+		return super.getDefaultUserSitesLayoutComposite(user);
 	}
 
 	@Override
-	public Object[] getDefaultViewableLayouts(
+	public LayoutComposite getDefaultViewableLayoutComposite(
 			HttpServletRequest request, User user,
 			PermissionChecker permissionChecker, long doAsGroupId,
 			String controlPanelCategory, boolean signedIn)
 		throws PortalException {
 
-		return super.getDefaultViewableLayouts(
+		return super.getDefaultViewableLayoutComposite(
 			request, user, permissionChecker, doAsGroupId, controlPanelCategory,
 			signedIn);
 	}
 
 	@Override
-	public Object[] getDefaultVirtualHostLayout(HttpServletRequest request)
+	public LayoutComposite getDefaultVirtualHostLayoutComposite(
+			HttpServletRequest request)
 		throws PortalException {
 
-		return super.getDefaultVirtualHostLayout(request);
+		return super.getDefaultVirtualHostLayoutComposite(request);
 	}
 
 	@Override
-	public Object[] getGuestSiteLayout(User user) throws PortalException {
-		return super.getGuestSiteLayout(user);
+	public LayoutComposite getGuestSiteLayoutComposite(User user)
+		throws PortalException {
+
+		return super.getGuestSiteLayoutComposite(user);
 	}
 
 	@Override
-	public Object[] getViewableLayouts(
+	public LayoutComposite getViewableLayoutComposite(
 			HttpServletRequest request, User user,
 			PermissionChecker permissionChecker, Layout layout,
 			List<Layout> layouts, long doAsGroupId, String controlPanelCategory)
 		throws PortalException {
 
-		return super.getViewableLayouts(
+		return super.getViewableLayoutComposite(
 			request, user, permissionChecker, layout, layouts, doAsGroupId,
 			controlPanelCategory);
 	}

--- a/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
+++ b/portal-test-internal/src/com/liferay/portal/events/test/TestServicePreAction.java
@@ -83,7 +83,9 @@ public class TestServicePreAction extends ServicePreAction {
 	}
 
 	@Override
-	public LayoutComposite getDefaultUserPersonalSiteLayoutComposite(User user) {
+	public LayoutComposite getDefaultUserPersonalSiteLayoutComposite(
+		User user) {
+
 		return super.getDefaultUserPersonalSiteLayoutComposite(user);
 	}
 


### PR DESCRIPTION
TestServicePreAction only exists to elevate protected methods so that they can be accessed within tests without extending ServicePreAction.  This is necessary in VerifyPermissionTest since we extend BaseVerifyProcessTestCase.

If you want, I can instead add an inner class to VerifyPermissionTest so that it can access the method it needs and extend ServicePreAction in ServicePreActionTest.

I added TestServicePreAction because we may need to run protected methods from ServicePreAction in other tests as well.

@jonathanmccann took a look at the changes to IntervalActionProcessor.
