### PR TITLE
LPS-55630 Possible concurrent delete failure between ${app.server.por…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -171,8 +171,8 @@
 					</and>
 				</not>
 				<then>
-					<delete dir="${app.server.portal.dir}" />
-					<delete file="${app.server.portal.dir}" />
+					<delete dir="${app.server.portal.dir}" failonerror="false" />
+					<delete file="${app.server.portal.dir}" failonerror="false" />
 				</then>
 				<else>
 					<delete failonerror="false">


### PR DESCRIPTION
…tal.dir} and individual deployed jar cleaning from build-common-java.xml clean-cmd (which already have the failonerror="false" protection)

CC @dantewang @slnn
