### PR TITLE
Lps 56021

### DIFF
--- a/modules/core/portal-bootstrap/src/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -746,15 +746,6 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 				return;
 			}
 
-			if (((bundle.getState() & Bundle.UNINSTALLED) == 0) &&
-				(startLevel > 0)) {
-
-				BundleStartLevel bundleStartLevel = bundle.adapt(
-					BundleStartLevel.class);
-
-				bundleStartLevel.setStartLevel(startLevel);
-			}
-
 			if (start) {
 				bundle.start();
 
@@ -781,6 +772,15 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 				bundleTracker.open();
 
 				countDownLatch.await();
+			}
+
+			if (((bundle.getState() & Bundle.UNINSTALLED) == 0) &&
+				(startLevel > 0)) {
+
+				BundleStartLevel bundleStartLevel = bundle.adapt(
+					BundleStartLevel.class);
+
+				bundleStartLevel.setStartLevel(startLevel);
 			}
 		}
 		catch (Exception e) {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7075,6 +7075,8 @@
 
     module.framework.properties.osgi.console=localhost:11311
 
+    module.framework.properties.osgi.module.lock.timeout=3600
+
 ##
 ## Module Framework Web Application Bundles
 ##

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7052,6 +7052,7 @@
     module.framework.properties.felix.fileinstall.bundles.new.start=true
     module.framework.properties.felix.fileinstall.bundles.startActivationPolicy=false
     module.framework.properties.felix.fileinstall.bundles.startTransient=false
+    module.framework.properties.felix.fileinstall.noInitialDelay=true
     module.framework.properties.gosh.args=--noshutdown
 
     module.framework.properties.org.osgi.framework.bootdelegation=\


### PR DESCRIPTION
Finally, we can get rid off the really annoying random startup race condition when starting cleanly (without osgi/state folder), which is the case like first bootup after ant all, or all CI's integration/arquillian tests.

Please notice, this does not really fix anything, but if anything is broken that can cause starting up race condition, it was only showing up randomly when you don't have the state folder. And after the first bootup, without removing the state folder manually, the problems never show up again, which is very very confusing for a lot of people and they blame CI for the failing tests(because CI always removes the state folder to make sure we are testing cleanly).

Now all bundles are loaded in a sequence, no more concurrent loading, no matter you have the state folder or not, so if there is any errors, they will show themselves in a consistent way on both CI and local development env.
