### PR TITLE
LPS-56044 When a client requests a PortletURL for a portlet which is not deployed the target should point to the new UndeployedPortlet

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -54,6 +54,7 @@ import com.liferay.portal.service.PortletLocalServiceUtil;
 import com.liferay.portal.theme.PortletDisplay;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.WebKeys;
 import com.liferay.portlet.admin.util.PortalAdministrationApplicationType;
@@ -196,6 +197,13 @@ public class PortletURLImpl
 			try {
 				_portlet = PortletLocalServiceUtil.getPortletById(
 					PortalUtil.getCompanyId(_request), _portletId);
+
+				if (_portlet.isUndeployedPortlet()) {
+					_portletId = PortletKeys.UNDEPLOYED;
+
+					_portlet = PortletLocalServiceUtil.getPortletById(
+						PortalUtil.getCompanyId(_request), _portletId);
+				}
 			}
 			catch (SystemException se) {
 				_log.error(se.getMessage());

--- a/portal-service/src/com/liferay/portal/util/PortletKeys.java
+++ b/portal-service/src/com/liferay/portal/util/PortletKeys.java
@@ -183,6 +183,8 @@ public class PortletKeys {
 
 	public static final String TRANSLATOR = "26";
 
+	public static final String UNDEPLOYED = "201";
+
 	public static final String UNIT_CONVERTER = "27";
 
 	public static final String USER_GROUPS_ADMIN = "127";

--- a/portal-web/docroot/WEB-INF/liferay-display.xml
+++ b/portal-web/docroot/WEB-INF/liferay-display.xml
@@ -52,6 +52,7 @@
 		<portlet id="197" />
 		<portlet id="199" />
 		<portlet id="200" />
+		<portlet id="201" />
 	</category>
 	<category name="category.news">
 		<portlet id="83" />

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1052,6 +1052,13 @@
 		<add-default-resource>true</add-default-resource>
 		<system>true</system>
 	</portlet>
+	<portlet>
+		<portlet-name>201</portlet-name>
+		<icon>/html/icons/default.png</icon>
+		<struts-path>undeployed</struts-path>
+		<add-default-resource>true</add-default-resource>
+		<system>true</system>
+	</portlet>
 	<role-mapper>
 		<role-name>administrator</role-name>
 		<role-link>Administrator</role-link>

--- a/portal-web/docroot/WEB-INF/portlet-custom.xml
+++ b/portal-web/docroot/WEB-INF/portlet-custom.xml
@@ -1457,6 +1457,25 @@
 			<role-name>administrator</role-name>
 		</security-role-ref>
 	</portlet>
+	<portlet>
+		<portlet-name>201</portlet-name>
+		<display-name>Undeployed</display-name>
+		<portlet-class>com.liferay.portlet.UndeployedPortlet</portlet-class>
+		<expiration-cache>0</expiration-cache>
+		<supports>
+			<mime-type>text/html</mime-type>
+		</supports>
+		<resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
+		<security-role-ref>
+			<role-name>guest</role-name>
+		</security-role-ref>
+		<security-role-ref>
+			<role-name>power-user</role-name>
+		</security-role-ref>
+		<security-role-ref>
+			<role-name>user</role-name>
+		</security-role-ref>
+	</portlet>
 	<custom-portlet-mode>
 		<portlet-mode>edit_guest</portlet-mode>
 		<portal-managed>true</portal-managed>


### PR DESCRIPTION
FYI @topolik. This doesn't break the other UndeployedPortlet concept right? I don't think so but please have a look.
