### PR TITLE
Lps 51464

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -490,26 +490,6 @@ Please set the environment variable ANT_OPTS to the recommended value of
 
 	<property name="whip.agent" value="-javaagent:${project.dir}/${junit.whip.jar}=${junit.whip.includes};${junit.whip.excludes}" />
 
-	<macrodef name="ant-execute">
-		<attribute default="build.xml" name="ant.build.file" />
-		<attribute name="ant.dir" />
-		<attribute name="ant.target" />
-
-		<sequential>
-			<if>
-				<os family="unix" />
-				<then>
-					<ant antfile="@{ant.build.file}" dir="@{ant.dir}" target="@{ant.target}" inheritAll="false" />
-				</then>
-				<else>
-					<exec dir="@{ant.dir}" executable="${ant.home}/bin/ant.bat" failonerror="true">
-						<arg line="-f @{ant.build.file} @{ant.target}" />
-					</exec>
-				</else>
-			</if>
-		</sequential>
-	</macrodef>
-
 	<macrodef name="app-server-properties-reset">
 		<sequential>
 			<delete file="app.server.${user.name}.properties" />

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -424,7 +424,7 @@
 			plugins.war.excludes=**/WEB-INF/service/**,**/WEB-INF/src/**
 		</echo>
 
-		<ant antfile="build.xml" dir="${lp.plugins.dir}" target="all" inheritAll="false" />
+		<ant dir="${lp.plugins.dir}" target="all" inheritAll="false" />
 
 		<copy todir="${app.server.tcat.dir}/admin/tcat_init/webapps/${lp.version.tcat}">
 			<fileset dir="${lp.plugins.dir}/dist" includes="*.war" />

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -424,10 +424,7 @@
 			plugins.war.excludes=**/WEB-INF/service/**,**/WEB-INF/src/**
 		</echo>
 
-		<ant-execute
-			ant.dir="${lp.plugins.dir}"
-			ant.target="all"
-		/>
+		<ant antfile="build.xml" dir="${lp.plugins.dir}" target="all" inheritAll="false" />
 
 		<copy todir="${app.server.tcat.dir}/admin/tcat_init/webapps/${lp.version.tcat}">
 			<fileset dir="${lp.plugins.dir}/dist" includes="*.war" />

--- a/build-test-plugins.xml
+++ b/build-test-plugins.xml
@@ -153,14 +153,14 @@ app.server.tomcat.dir=${app.server.parent.dir}/tomcat-7.0.42</echo>
 				<if>
 					<isset property="plugin.types" />
 					<then>
-						<ant antfile="build.xml" dir="${lp.plugins.dir}/${plugin.types}" target="clean" inheritAll="false" />
+						<ant dir="${lp.plugins.dir}/${plugin.types}" target="clean" inheritAll="false" />
 
-						<ant antfile="build.xml" dir="${lp.plugins.dir}/${plugin.types}" target="deploy" inheritAll="false" />
+						<ant dir="${lp.plugins.dir}/${plugin.types}" target="deploy" inheritAll="false" />
 					</then>
 					<else>
-						<ant antfile="build.xml" dir="${lp.plugins.dir}" target="clean" inheritAll="false" />
+						<ant dir="${lp.plugins.dir}" target="clean" inheritAll="false" />
 
-						<ant antfile="build.xml" dir="${lp.plugins.dir}" target="deploy" inheritAll="false" />
+						<ant dir="${lp.plugins.dir}" target="deploy" inheritAll="false" />
 					</else>
 				</if>
 			</else>
@@ -209,15 +209,15 @@ auto.deploy.dir=${auto.deploy.dir}
 
 plugins.includes=${test.plugin}</echo>
 
-		<ant antfile="build.xml" dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="clean" inheritAll="false" />
+		<ant dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="clean" inheritAll="false" />
 
 		<if>
 			<contains string="${test.plugin}" substring="portlet" />
 			<then>
-				<ant antfile="build.xml" dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="compile-jsp" inheritAll="false" />
+				<ant dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="compile-jsp" inheritAll="false" />
 			</then>
 			<else>
-				<ant antfile="build.xml" dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="compile" inheritAll="false" />
+				<ant dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="compile" inheritAll="false" />
 			</else>
 		</if>
 	</target>

--- a/build-test-plugins.xml
+++ b/build-test-plugins.xml
@@ -153,26 +153,14 @@ app.server.tomcat.dir=${app.server.parent.dir}/tomcat-7.0.42</echo>
 				<if>
 					<isset property="plugin.types" />
 					<then>
-						<ant-execute
-							ant.dir="${lp.plugins.dir}/${plugin.types}"
-							ant.target="clean"
-						/>
+						<ant antfile="build.xml" dir="${lp.plugins.dir}/${plugin.types}" target="clean" inheritAll="false" />
 
-						<ant-execute
-							ant.dir="${lp.plugins.dir}/${plugin.types}"
-							ant.target="deploy"
-						/>
+						<ant antfile="build.xml" dir="${lp.plugins.dir}/${plugin.types}" target="deploy" inheritAll="false" />
 					</then>
 					<else>
-						<ant-execute
-							ant.dir="${lp.plugins.dir}"
-							ant.target="clean"
-						/>
+						<ant antfile="build.xml" dir="${lp.plugins.dir}" target="clean" inheritAll="false" />
 
-						<ant-execute
-							ant.dir="${lp.plugins.dir}"
-							ant.target="deploy"
-						/>
+						<ant antfile="build.xml" dir="${lp.plugins.dir}" target="deploy" inheritAll="false" />
 					</else>
 				</if>
 			</else>
@@ -221,24 +209,15 @@ auto.deploy.dir=${auto.deploy.dir}
 
 plugins.includes=${test.plugin}</echo>
 
-		<ant-execute
-			ant.dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}"
-			ant.target="clean"
-		/>
+		<ant antfile="build.xml" dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="clean" inheritAll="false" />
 
 		<if>
 			<contains string="${test.plugin}" substring="portlet" />
 			<then>
-				<ant-execute
-					ant.dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}"
-					ant.target="compile-jsp"
-				/>
+				<ant antfile="build.xml" dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="compile-jsp" inheritAll="false" />
 			</then>
 			<else>
-				<ant-execute
-					ant.dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}"
-					ant.target="compile"
-				/>
+				<ant antfile="build.xml" dir="${lp.plugins.dir}/${test.plugin.type}/${test.plugin}" target="compile" inheritAll="false" />
 			</else>
 		</if>
 	</target>

--- a/build.xml
+++ b/build.xml
@@ -262,7 +262,7 @@
 
 				<setup-sdk />
 
-				<ant antfile="build.xml" dir="${project.dir}/modules" target="clean" inheritAll="false" />
+				<ant dir="${project.dir}/modules" target="clean" inheritAll="false" />
 			</sequential>
 
 			<delete dir="${doc.dir}" />
@@ -497,9 +497,9 @@
 
 		<stopwatch name="modules.stopwatch" />
 
-		<ant antfile="build.xml" dir="${project.dir}/modules/core/registry-api" target="deploy" inheritAll="false" />
+		<ant dir="${project.dir}/modules/core/registry-api" target="deploy" inheritAll="false" />
 
-		<ant antfile="build.xml" dir="${project.dir}/modules" target="deploy" inheritAll="false" />
+		<ant dir="${project.dir}/modules" target="deploy" inheritAll="false" />
 
 		<stopwatch action="elapsed" name="modules.stopwatch" />
 

--- a/build.xml
+++ b/build.xml
@@ -262,10 +262,7 @@
 
 				<setup-sdk />
 
-				<ant-execute
-					ant.dir="${project.dir}/modules"
-					ant.target="clean"
-				/>
+				<ant antfile="build.xml" dir="${project.dir}/modules" target="clean" inheritAll="false" />
 			</sequential>
 
 			<delete dir="${doc.dir}" />
@@ -500,15 +497,9 @@
 
 		<stopwatch name="modules.stopwatch" />
 
-		<ant-execute
-			ant.dir="${project.dir}/modules/core/registry-api"
-			ant.target="deploy"
-		/>
+		<ant antfile="build.xml" dir="${project.dir}/modules/core/registry-api" target="deploy" inheritAll="false" />
 
-		<ant-execute
-			ant.dir="${project.dir}/modules"
-			ant.target="deploy"
-		/>
+		<ant antfile="build.xml" dir="${project.dir}/modules" target="deploy" inheritAll="false" />
 
 		<stopwatch action="elapsed" name="modules.stopwatch" />
 

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -66,11 +66,7 @@
 				/>
 			</not>
 			<then>
-				<ant-execute
-					ant.build.file="build.xml"
-					ant.dir="../modules/frontend/frontend-css-web"
-					ant.target="build-bourbon"
-				/>
+				<ant antfile="build.xml" dir="../modules/frontend/frontend-css-web" target="build-bourbon" inheritAll="false" />
 			</then>
 		</if>
 	</target>
@@ -634,19 +630,11 @@ Please set the property "jdk.7.home" in build.properties.
 	</target>
 
 	<target name="node-execute">
-		<ant-execute
-			ant.build.file="build-node.xml"
-			ant.dir="${sdk.dir}"
-			ant.target="node-execute"
-		/>
+		<ant antfile="build-node.xml" dir="${sdk.dir}" target="node-execute" inheritAll="false" />
 	</target>
 
 	<target name="npm-execute">
-		<ant-execute
-			ant.build.file="build-node.xml"
-			ant.dir="${sdk.dir}"
-			ant.target="npm-execute"
-		/>
+		<ant antfile="build-node.xml" dir="${sdk.dir}" target="npm-execute" inheritAll="false" />
 	</target>
 
 	<target name="war" depends="build-portal-web-dependencies">

--- a/portal-web/build.xml
+++ b/portal-web/build.xml
@@ -66,7 +66,7 @@
 				/>
 			</not>
 			<then>
-				<ant antfile="build.xml" dir="../modules/frontend/frontend-css-web" target="build-bourbon" inheritAll="false" />
+				<ant dir="../modules/frontend/frontend-css-web" target="build-bourbon" inheritAll="false" />
 			</then>
 		</if>
 	</target>


### PR DESCRIPTION
@michaelhashimoto @kiyoshilee, if this somehow affects QA's build processes (hope not), please let us know

@brianchandotcom for linux/unix users, this changes nothing, but for windows users, they should see some build time saving as it no longer forks new ant process during ant all. But if for any reason they see the previous jar locking issue again (we tried, could not reproduce on current master in windows VMs), please redirect them to us, we will figure out a fix for them.

When this is in, for all platforms, ant all is only one ant process, then we can proceed with the further JGit optimization.
