### PR TITLE
LPS-55440 Add general action form to user panel layout type

### DIFF
--- a/modules/apps/productivity-center/productivity-center-web/src/META-INF/resources/layout/view/user_personal_panel.jsp
+++ b/modules/apps/productivity-center/productivity-center-web/src/META-INF/resources/layout/view/user_personal_panel.jsp
@@ -33,3 +33,7 @@
 		</aui:container>
 	</c:otherwise>
 </c:choose>
+
+<form action="#" id="hrefFm" method="post" name="hrefFm">
+	<span></span>
+</form>


### PR DESCRIPTION
Hi @brianchandotcom,

This is a resend of an old PR (see https://github.com/brianchandotcom/liferay-portal/pull/26516).

This form is required for some portlets to work (e.g. Workflow), and all other layout types include a form with this same ID (See /html/portal/layout/view/common.jspf) So, we need to add this to the personal space layout for everything to work as expected.

As you commented in the previous PR, there could be conflicts if someone defined an element with the same ID. This is not something particular to my PR, but a more general portal issue (as apps require it and, being in the layout type view, it cannot easily be namespaced as if in a portlet).

I'm cc'ing @marcellustavares and @leoadb, as they know more details about why it is required.

Thanks!
