### PR TITLE
LPS-56192 Add more general method and maintain compatibility

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/BaseFindActionHelper.java
+++ b/portal-impl/src/com/liferay/portal/struts/BaseFindActionHelper.java
@@ -99,8 +99,7 @@ public abstract class BaseFindActionHelper implements FindActionHelper {
 			PortletURL portletURL = PortletURLFactoryUtil.create(
 				request, portletId, plid, PortletRequest.RENDER_PHASE);
 
-			portletURL.setParameter(
-				"struts_action", getStrutsAction(request, portletId));
+			addRequiredParameters(request, portletId, portletURL);
 
 			boolean inheritRedirect = ParamUtil.getBoolean(
 				request, "inheritRedirect");
@@ -157,10 +156,6 @@ public abstract class BaseFindActionHelper implements FindActionHelper {
 
 	@Override
 	public abstract String getPrimaryKeyParameterName();
-
-	@Override
-	public abstract String getStrutsAction(
-		HttpServletRequest request, String portletId);
 
 	@Override
 	public abstract String[] initPortletIds();
@@ -323,6 +318,9 @@ public abstract class BaseFindActionHelper implements FindActionHelper {
 			throw new RuntimeException("Portlet IDs cannot be null or empty");
 		}
 	}
+
+	protected abstract void addRequiredParameters(
+		HttpServletRequest request, String portletId, PortletURL portletURL);
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseFindActionHelper.class);

--- a/portal-impl/src/com/liferay/portal/struts/BaseStrutsPortletFindActionHelper.java
+++ b/portal-impl/src/com/liferay/portal/struts/BaseStrutsPortletFindActionHelper.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.struts;
+
+/**
+ * @author Adolfo Pérez
+ */
+public abstract class BaseStrutsPortletFindActionHelper
+	extends BaseFindActionHelper {
+}

--- a/portal-impl/src/com/liferay/portal/struts/BaseStrutsPortletFindActionHelper.java
+++ b/portal-impl/src/com/liferay/portal/struts/BaseStrutsPortletFindActionHelper.java
@@ -14,9 +14,26 @@
 
 package com.liferay.portal.struts;
 
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * @author Adolfo Pérez
  */
 public abstract class BaseStrutsPortletFindActionHelper
-	extends BaseFindActionHelper {
+	extends BaseFindActionHelper implements StrutsPortletFindActionHelper {
+
+	@Override
+	public abstract String getStrutsAction(
+		HttpServletRequest request, String portletId);
+
+	@Override
+	protected void addRequiredParameters(
+		HttpServletRequest request, String portletId, PortletURL portletURL) {
+
+		portletURL.setParameter(
+			"struts_action", getStrutsAction(request, portletId));
+	}
+
 }

--- a/portal-impl/src/com/liferay/portal/struts/FindAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/FindAction.java
@@ -30,7 +30,7 @@ import org.apache.struts.action.ActionMapping;
 public abstract class FindAction extends Action {
 
 	public FindAction() {
-		_findActionHelper = new BaseFindActionHelper() {
+		_findActionHelper = new BaseStrutsPortletFindActionHelper() {
 
 			@Override
 			public long getGroupId(long primaryKey) throws Exception {

--- a/portal-impl/src/com/liferay/portal/struts/FindStrutsAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/FindStrutsAction.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 public abstract class FindStrutsAction extends BaseStrutsAction {
 
 	public FindStrutsAction() {
-		_findActionHelper = new BaseFindActionHelper() {
+		_findActionHelper = new BaseStrutsPortletFindActionHelper() {
 
 			@Override
 			public long getGroupId(long primaryKey) throws Exception {

--- a/portal-impl/src/com/liferay/portal/struts/StrutsPortletFindActionHelper.java
+++ b/portal-impl/src/com/liferay/portal/struts/StrutsPortletFindActionHelper.java
@@ -14,31 +14,13 @@
 
 package com.liferay.portal.struts;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author Adolfo Pérez
  */
-public interface FindActionHelper {
+public interface StrutsPortletFindActionHelper extends FindActionHelper {
 
-	public void execute(
-			HttpServletRequest request, HttpServletResponse response)
-		throws Exception;
-
-	public long getGroupId(long primaryKey) throws Exception;
-
-	public String getPrimaryKeyParameterName();
-
-	public String[] initPortletIds();
-
-	public PortletURL processPortletURL(
-			HttpServletRequest request, PortletURL portletURL)
-		throws Exception;
-
-	public void setPrimaryKeyParameter(PortletURL portletURL, long primaryKey)
-		throws Exception;
+	public String getStrutsAction(HttpServletRequest request, String portletId);
 
 }


### PR DESCRIPTION
Hi @brianchandotcom 

This PR contains a small change to the "find entry" helpers so that the logic can be reused for MVC portlets (or any non-struts portlet for that matter). We're currently extracting Blogs, D&M and Message Boards and we need this to avoid duplicating the logic in the helper.

Thanks!
