### PR TITLE
LPS-56196 "-Xmx2048m -XX:MaxPermSize=512m" is way too high for testin…

### DIFF
--- a/build-test-tck.xml
+++ b/build-test-tck.xml
@@ -306,6 +306,7 @@ ${logfile.content}</echo>
 			<sequential>
 				<exec dir="tools/tck/src/@{test.directory}" executable="${basedir}/tools/tck/bin/tsant${tsant.file.suffix.bat}" newenvironment="true">
 					<arg line="runclient" />
+					<env key="ANT_OPTS" value="-verbose:gc -Xloggc:/tmp/tsant-gc.log -XX:+PrintGCCause -XX:+PrintGCDetails" />
 					<env key="TS_HOME" value="${basedir}/tools/tck" />
 				</exec>
 

--- a/build-test-tck.xml
+++ b/build-test-tck.xml
@@ -304,7 +304,7 @@ ${logfile.content}</echo>
 
 		<for list="${test.directories}" param="test.directory">
 			<sequential>
-				<exec dir="tools/tck/src/@{test.directory}" executable="${basedir}/tools/tck/bin/tsant${tsant.file.suffix.bat}">
+				<exec dir="tools/tck/src/@{test.directory}" executable="${basedir}/tools/tck/bin/tsant${tsant.file.suffix.bat}" failonerror="true">
 					<arg line="runclient" />
 					<env key="ANT_OPTS" value="-verbose:gc -Xloggc:/tmp/tsant-gc.log -XX:+PrintGCCause -XX:+PrintGCDetails" />
 					<env key="TS_HOME" value="${basedir}/tools/tck" />

--- a/build-test-tck.xml
+++ b/build-test-tck.xml
@@ -304,7 +304,7 @@ ${logfile.content}</echo>
 
 		<for list="${test.directories}" param="test.directory">
 			<sequential>
-				<exec dir="tools/tck/src/@{test.directory}" executable="${basedir}/tools/tck/bin/tsant${tsant.file.suffix.bat}" newenvironment="true">
+				<exec dir="tools/tck/src/@{test.directory}" executable="${basedir}/tools/tck/bin/tsant${tsant.file.suffix.bat}">
 					<arg line="runclient" />
 					<env key="ANT_OPTS" value="-verbose:gc -Xloggc:/tmp/tsant-gc.log -XX:+PrintGCCause -XX:+PrintGCDetails" />
 					<env key="TS_HOME" value="${basedir}/tools/tck" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -6044,6 +6044,21 @@ ${tomcat-gc-log}</echo>
 				<echo>Unable to read /tmp/tomcat-gc.log</echo>
 			</else>
 		</if>
+
+		<if>
+			<available file="/tmp/tsant-gc.log" />
+			<then>
+				<loadfile property="tsant-gc-log" srcFile="/tmp/tsant-gc.log" />
+
+				<echo>
+Tsant GC log:
+
+${tsant-gc-log}</echo>
+			</then>
+			<else>
+				<echo>Unable to read /tmp/tsant-gc.log</echo>
+			</else>
+		</if>
 	</target>
 
 	<target name="test-integration">

--- a/build-test.xml
+++ b/build-test.xml
@@ -4429,7 +4429,7 @@ module.framework.properties.osgi.console=11312</echo>
 
 		<replace file="${app.server.tomcat.bin.dir}/setenv${file.suffix.bat}">
 			<replacetoken><![CDATA[-Xmx1024m -XX:MaxPermSize=256m]]></replacetoken>
-			<replacevalue><![CDATA[-verbose:gc -Xloggc:/tmp/tomcat-gc.log -Xmx2048m  -XX:+PrintGCCause -XX:+PrintGCDetails -XX:MaxPermSize=512m]]></replacevalue>
+			<replacevalue><![CDATA[-verbose:gc -Xloggc:/tmp/tomcat-gc.log -Xms512m -Xmx512m -XX:MaxNewSize=32m -XX:MaxPermSize=200m -XX:MaxTenuringThreshold=0 -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:PermSize=200m -XX:+PrintGCCause -XX:+PrintGCDetails -XX:SurvivorRatio=65536 -XX:TargetSurvivorRatio=0 -XX:+UseParNewGC]]></replacevalue>
 		</replace>
 
 		<antcall target="prepare-test-build-tomcat-dependents" inheritAll="false" />


### PR DESCRIPTION
…g purpose, CI is choking on high memory allocation at OS level. Lower the settings to help OS to scale.

@brianchandotcom this is a very aggressive heap size shrinking, if works will save us 1.8GB memory at OS level.

@michaelhashimoto please rerun Spain's test, and send me the link, I need to check whether it can live with this setting (I think it should, but need to actually run it to know for sure).
