### PR TITLE
LPS-56352 Fix transaction lifecycle listener ordering issue

### DIFF
--- a/portal-impl/src/META-INF/base-spring.xml
+++ b/portal-impl/src/META-INF/base-spring.xml
@@ -86,8 +86,8 @@
 		<property name="transactionLifecycleListeners">
 			<list>
 				<util:constant static-field="com.liferay.portal.kernel.cache.ThreadLocalCacheManager.TRANSACTION_LIFECYCLE_LISTENER" />
-				<util:constant static-field="com.liferay.portal.kernel.cache.transactional.TransactionalPortalCacheHelper.TRANSACTION_LIFECYCLE_LISTENER" />
 				<util:constant static-field="com.liferay.portal.spring.hibernate.LastSessionRecorderUtil.TRANSACTION_LIFECYCLE_LISTENER" />
+				<util:constant static-field="com.liferay.portal.kernel.cache.transactional.TransactionalPortalCacheHelper.TRANSACTION_LIFECYCLE_LISTENER" />
 				<util:constant static-field="com.liferay.portal.spring.transaction.TransactionCommitCallbackUtil.TRANSACTION_LIFECYCLE_LISTENER" />
 			</list>
 		</property>


### PR DESCRIPTION
@brianchandotcom In case you will ask test for this, we actually have tests that can cover this, and they are currently generating errors on this. That's how I noticed this issue.

However, due to the modularization + arquillianlizing the integration tests, we lost the ability to assert those errors.

And we actually have quite a few cases like these. Funny thing is after this fix, I got a lot more error outputs, which was hidden by this, due to this fails first, the testing logic do even continue to run the rest, and the rest logic has some even worse failures. But we are not asserting anyone of them.

I am currently working on a solution to add one more assertion layer to protect us from it in the future. And I actually have it done, but there are too many random failures out there, I can not really commit this protection layer without fixing them first, otherwise it will put CI into a very unstable status.

Next week, I am planning to mostly working with my team on the dbs integration, but still have to spare sometime on this. It is already pretty bad now(if you look at the arquillian tomcat log you will see, no one really read it, not even the test developers, if they ever run the test locally, and look at the log, they must see those NPEs, MVCC failures + all other random stuff), I just want to push this in asap before things get even worse.

Over the time on working all these testing things, if I learnt anything at all, that would be if we don't catch the errors on site, then no one would ever care it again. And before we know it, hacky work arounds built on top the real bugs, layers by layers, causing more bugs, by the time we start to fix them, no one will be capable enough to understand them.
