### PR TITLE
LPS-56356 Missing LiferayIntegrationTestRule and not initialize permi…

### DIFF
--- a/modules/apps/asset/asset-publisher-test/test/integration/com/liferay/asset/publisher/portlet/DisplayPageFriendlyURLResolverTest.java
+++ b/modules/apps/asset/asset-publisher-test/test/integration/com/liferay/asset/publisher/portlet/DisplayPageFriendlyURLResolverTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.publisher.web.constants.AssetPublisherPortletKeys;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.NoSuchLayoutException;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -33,6 +34,8 @@ import com.liferay.portal.model.LayoutTypePortlet;
 import com.liferay.portal.model.LayoutTypePortletConstants;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
+import com.liferay.portal.service.test.ServiceTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.Portal;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.journal.model.JournalArticleConstants;
@@ -44,6 +47,8 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,8 +60,15 @@ import org.springframework.mock.web.MockHttpServletRequest;
 @RunWith(Arquillian.class)
 public class DisplayPageFriendlyURLResolverTest {
 
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
 	@Before
 	public void setUp() throws Exception {
+		ServiceTestUtil.initPermissions();
+
 		_group = GroupTestUtil.addGroup();
 	}
 

--- a/modules/apps/asset/asset-publisher-test/test/integration/com/liferay/asset/publisher/service/AssetPublisherServiceTest.java
+++ b/modules/apps/asset/asset-publisher-test/test/integration/com/liferay/asset/publisher/service/AssetPublisherServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.asset.publisher.service;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -44,6 +45,7 @@ import javax.portlet.PortletPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,6 +58,11 @@ import org.springframework.mock.web.portlet.MockPortletRequest;
  */
 @RunWith(Arquillian.class)
 public class AssetPublisherServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
 
 	@Before
 	public void setUp() throws Exception {
@@ -173,10 +180,6 @@ public class AssetPublisherServiceTest {
 
 		Assert.assertEquals(expectedAssetEntries, filteredAssetEntries);
 	}
-
-	@Rule
-	public final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
 
 	protected void addAssetCategories(long vocabularyId) throws Exception {
 		ServiceContext serviceContext =


### PR DESCRIPTION
…ssions cause PermissionChecker NPE (arquillian can not use MainServletTestRule, but if you still depends on faked request context, you need to at least setup necessary ThreadLocals)
