### PR TITLE
Lps 56346

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/CookieUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/CookieUtil.java
@@ -21,6 +21,9 @@ import java.net.HttpCookie;
 
 import java.nio.ByteBuffer;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.servlet.http.Cookie;
 
 /**
@@ -107,6 +110,20 @@ public class CookieUtil {
 		}
 
 		return true;
+	}
+
+	public static Map<String, HttpCookie> parseHttpCookies(
+		String cookieString) {
+
+		Map<String, HttpCookie> httpCookies = new HashMap<>();
+
+		for (HttpCookie httpCookie : HttpCookie.parse(
+			"Set-Cookie2:" + cookieString)) {
+
+			httpCookies.put(httpCookie.getName(), httpCookie);
+		}
+
+		return httpCookies;
 	}
 
 	public static byte[] serialize(Cookie cookie) {

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/CookieUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/CookieUtilTest.java
@@ -14,15 +14,21 @@
 
 package com.liferay.portal.kernel.util;
 
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 
 import java.net.HttpCookie;
 
+import java.util.Map;
+
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Shuyang Zhou
@@ -131,6 +137,22 @@ public class CookieUtilTest {
 		// Equals
 
 		Assert.assertTrue(CookieUtil.equals(cookie1, cookie2));
+	}
+
+	@Test
+	public void testParseHttpCookies() {
+		HttpServletResponse response = new MockHttpServletResponse();
+
+		response.setHeader(HttpHeaders.SET_COOKIE, "name1=value1,name2=value2");
+
+		Map<String, HttpCookie> map = CookieUtil.parseHttpCookies(
+			response.getHeader(HttpHeaders.SET_COOKIE));
+
+		Assert.assertEquals(2, map.size());
+		Assert.assertEquals(
+			new HttpCookie("name1", "value1"), map.get("name1"));
+		Assert.assertEquals(
+			new HttpCookie("name2", "value2"), map.get("name2"));
 	}
 
 	@Test


### PR DESCRIPTION
@lipusz

Ok, this is a bit hacky, but I can not find out any cleaner way to "set" cookies without wipe out the pre-exist server set ones.

What we are really missing here is a fully RFC compatible cookie string parser(and toString() logic), the parsing support from HttpCookie is not very handy to use. 

I will spend some time to read through the RFC on the cookie formatting section, then create those parts later.

This should be good enough for now. Let me know if you see anything else does not work as expected.
