### PR TITLE
LPS-55586 Fix OSGi exporting private references

### DIFF
--- a/modules/portal-security/portal-security-auto-login/src/com/liferay/portal/security/auto/login/basic/auth/header/BasicAuthHeaderAutoLogin.java
+++ b/modules/portal-security/portal-security-auto-login/src/com/liferay/portal/security/auto/login/basic/auth/header/BasicAuthHeaderAutoLogin.java
@@ -147,8 +147,25 @@ public class BasicAuthHeaderAutoLogin extends BaseAutoLogin {
 		return credentials;
 	}
 
-	protected BasicAuthHeaderAutoLoginConfiguration
-		getBasicAuthHeaderAutoLoginConfiguration(long companyId) {
+	protected boolean isEnabled(long companyId) {
+		BasicAuthHeaderAutoLoginConfiguration
+			basicAuthHeaderAutoLoginConfiguration =
+				_getBasicAuthHeaderAutoLoginConfiguration(companyId);
+
+		if (basicAuthHeaderAutoLoginConfiguration == null) {
+			return false;
+		}
+
+		return basicAuthHeaderAutoLoginConfiguration.enabled();
+	}
+
+	@Reference
+	protected void setSettingsFactory(SettingsFactory settingsFactory) {
+		_settingsFactory = settingsFactory;
+	}
+
+	private BasicAuthHeaderAutoLoginConfiguration
+		_getBasicAuthHeaderAutoLoginConfiguration(long companyId) {
 
 		try {
 			BasicAuthHeaderAutoLoginConfiguration
@@ -166,23 +183,6 @@ public class BasicAuthHeaderAutoLogin extends BaseAutoLogin {
 		}
 
 		return null;
-	}
-
-	protected boolean isEnabled(long companyId) {
-		BasicAuthHeaderAutoLoginConfiguration
-			basicAuthHeaderAutoLoginConfiguration =
-				getBasicAuthHeaderAutoLoginConfiguration(companyId);
-
-		if (basicAuthHeaderAutoLoginConfiguration == null) {
-			return false;
-		}
-
-		return basicAuthHeaderAutoLoginConfiguration.enabled();
-	}
-
-	@Reference
-	protected void setSettingsFactory(SettingsFactory settingsFactory) {
-		_settingsFactory = settingsFactory;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/portal-security/portal-security-auto-login/src/com/liferay/portal/security/auto/login/request/header/RequestHeaderAutoLogin.java
+++ b/modules/portal-security/portal-security-auto-login/src/com/liferay/portal/security/auto/login/request/header/RequestHeaderAutoLogin.java
@@ -109,34 +109,12 @@ public class RequestHeaderAutoLogin extends BaseAutoLogin {
 		return credentials;
 	}
 
-	protected RequestHeaderAutoLoginConfiguration
-		getRequestHeaderAutoLoginConfiguration(long companyId) {
-
-		try {
-			RequestHeaderAutoLoginConfiguration
-				requestHeaderAutoLoginConfiguration =
-					_settingsFactory.getSettings(
-						RequestHeaderAutoLoginConfiguration.class,
-						new CompanyServiceSettingsLocator(
-							companyId,
-							RequestHeaderAutoLoginConstants.SERVICE_NAME));
-
-			return requestHeaderAutoLoginConfiguration;
-		}
-		catch (SettingsException se) {
-			_log.error(
-				"Unable to get request header auto login configuration", se);
-		}
-
-		return null;
-	}
-
 	protected boolean isAccessAllowed(
 		long companyId, HttpServletRequest request) {
 
 		RequestHeaderAutoLoginConfiguration
 			requestHeaderAutoLoginConfiguration =
-				getRequestHeaderAutoLoginConfiguration(companyId);
+				_getRequestHeaderAutoLoginConfiguration(companyId);
 
 		if (requestHeaderAutoLoginConfiguration == null) {
 			return false;
@@ -157,7 +135,7 @@ public class RequestHeaderAutoLogin extends BaseAutoLogin {
 	protected boolean isEnabled(long companyId) {
 		RequestHeaderAutoLoginConfiguration
 			requestHeaderAutoLoginConfiguration =
-				getRequestHeaderAutoLoginConfiguration(companyId);
+				_getRequestHeaderAutoLoginConfiguration(companyId);
 
 		if (requestHeaderAutoLoginConfiguration == null) {
 			return false;
@@ -169,7 +147,7 @@ public class RequestHeaderAutoLogin extends BaseAutoLogin {
 	protected boolean isLDAPImportEnabled(long companyId) {
 		RequestHeaderAutoLoginConfiguration
 			requestHeaderAutoLoginConfiguration =
-				getRequestHeaderAutoLoginConfiguration(companyId);
+				_getRequestHeaderAutoLoginConfiguration(companyId);
 
 		if (requestHeaderAutoLoginConfiguration == null) {
 			return false;
@@ -181,6 +159,28 @@ public class RequestHeaderAutoLogin extends BaseAutoLogin {
 	@Reference
 	protected void setSettingsFactory(SettingsFactory settingsFactory) {
 		_settingsFactory = settingsFactory;
+	}
+
+	private RequestHeaderAutoLoginConfiguration
+		_getRequestHeaderAutoLoginConfiguration(long companyId) {
+
+		try {
+			RequestHeaderAutoLoginConfiguration
+				requestHeaderAutoLoginConfiguration =
+					_settingsFactory.getSettings(
+						RequestHeaderAutoLoginConfiguration.class,
+						new CompanyServiceSettingsLocator(
+							companyId,
+							RequestHeaderAutoLoginConstants.SERVICE_NAME));
+
+			return requestHeaderAutoLoginConfiguration;
+		}
+		catch (SettingsException se) {
+			_log.error(
+				"Unable to get request header auto login configuration", se);
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/portal-security/portal-security-auto-login/src/com/liferay/portal/security/auto/login/request/parameter/RequestParameterAutoLogin.java
+++ b/modules/portal-security/portal-security-auto-login/src/com/liferay/portal/security/auto/login/request/parameter/RequestParameterAutoLogin.java
@@ -127,8 +127,25 @@ public class RequestParameterAutoLogin extends BaseAutoLogin {
 		return _PASSWORD_PARAM;
 	}
 
-	protected RequestParameterAutoLoginConfiguration
-		getRequestParameterAutoLoginConfiguration(long companyId) {
+	protected boolean isEnabled(long companyId) {
+		RequestParameterAutoLoginConfiguration
+			requestParameterAutoLoginConfiguration =
+				_getRequestParameterAutoLoginConfiguration(companyId);
+
+		if (requestParameterAutoLoginConfiguration == null) {
+			return false;
+		}
+
+		return requestParameterAutoLoginConfiguration.enabled();
+	}
+
+	@Reference
+	protected void setSettingsFactory(SettingsFactory settingsFactory) {
+		_settingsFactory = settingsFactory;
+	}
+
+	private RequestParameterAutoLoginConfiguration
+		_getRequestParameterAutoLoginConfiguration(long companyId) {
 
 		try {
 			RequestParameterAutoLoginConfiguration
@@ -147,23 +164,6 @@ public class RequestParameterAutoLogin extends BaseAutoLogin {
 		}
 
 		return null;
-	}
-
-	protected boolean isEnabled(long companyId) {
-		RequestParameterAutoLoginConfiguration
-			requestParameterAutoLoginConfiguration =
-				getRequestParameterAutoLoginConfiguration(companyId);
-
-		if (requestParameterAutoLoginConfiguration == null) {
-			return false;
-		}
-
-		return requestParameterAutoLoginConfiguration.enabled();
-	}
-
-	@Reference
-	protected void setSettingsFactory(SettingsFactory settingsFactory) {
-		_settingsFactory = settingsFactory;
 	}
 
 	private static final String _LOGIN_PARAM = "parameterAutoLoginLogin";


### PR DESCRIPTION
Hi Brian,

SF bnd regression (https://github.com/brianchandotcom/liferay-portal/commit/7476ae487f71c2dca388db5e198151157a65bb73)  - export warnings:

```
ant clean deploy
Buildfile: /opt/liferay.git/portal/modules/portal-security/portal-security-auto-login/build.xml
[ivy:resolve] :: Apache Ivy 2.4.0 - 20141213170938 :: http://ant.apache.org/ivy/ ::
[ivy:resolve] :: loading settings :: file = /opt/liferay.git/portal/tools/sdk/ivy-settings.xml

clean:
   [delete] Deleting: /opt/liferay.git/portal/tools/sdk/dist/com.liferay.portal.security.auto.login-1.0.0.jar
   [delete] Deleting: /opt/liferay.git/portal/modules/portal-security/portal-security-auto-login/ivy.xml.MD5
   [delete] Deleting: /opt/liferay.git/bundles/osgi/portal/com.liferay.portal.security.auto.login.jar

deploy:
    [mkdir] Created dir: /opt/liferay.git/portal/modules/portal-security/portal-security-auto-login/classes
     [copy] Copied 23 empty directories to 23 empty directories under /opt/liferay.git/portal/modules/portal-security/portal-security-auto-login/classes
    [javac] Compiling 16 source files to /opt/liferay.git/portal/modules/portal-security/portal-security-auto-login/classes
      [bnd] 3 WARNINGS
      [bnd]  Export com.liferay.portal.security.auto.login.basic.auth.header,  has 1,  private references [com.liferay.portal.security.auto.login.basic.auth.header.configuration], 
      [bnd]  Export com.liferay.portal.security.auto.login.request.parameter,  has 1,  private references [com.liferay.portal.security.auto.login.request.parameter.configuration], 
      [bnd]  Export com.liferay.portal.security.auto.login.request.header,  has 1,  private references [com.liferay.portal.security.auto.login.request.header.configuration], 
      [bnd] # com.liferay.portal.security.auto.login (com.liferay.portal.security.auto.login-1.0.0.jar) 29 
     [copy] Copying 1 file to /opt/liferay.git/bundles/osgi/portal

BUILD SUCCESSFUL
Total time: 4 seconds
```

I discussed it with @rotty3000 last week:

> Ray Auge [4:14 PM]
> FYI, regarding the build warning about the package, you should NOT refer to private classes in the API signatures of exported classes
> you can use the class within the exported class, but not in any public visible part of the class
> 
> Tomas Polesovsky [4:16 PM] 
> I see, there is a protected method returning MyConfiguration object
> would private method help?
> 
> Ray Auge [4:16 PM] 
> probably

And therefore I made the getConfiguration methods private.
