### PR TITLE
LPS-56271 Postgresql only allows Blob accessing within an explicit tr…

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLContentLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/DLContentLocalServiceTest.java
@@ -17,7 +17,9 @@ package com.liferay.portlet.documentlibrary.service;
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.TransactionalTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.MainServletTestRule;
@@ -45,7 +47,8 @@ public class DLContentLocalServiceTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
-			new LiferayIntegrationTestRule(), MainServletTestRule.INSTANCE);
+			new LiferayIntegrationTestRule(), MainServletTestRule.INSTANCE,
+			new TransactionalTestRule(Propagation.REQUIRED));
 
 	@Before
 	public void setUp() throws Exception {


### PR DESCRIPTION
…ansaction, trying to read blob value when connection is on auto-commit will be rejected. This is actually fixed for production long time ago by https://issues.liferay.com/browse/LPS-26839, and later centralized into Store proxy created by StoreFactory for postgresql. So this is a test only blob tx issue. Simply wrap all test methods with an explicit tx will make the errors go away.
