### PR TITLE
Lps 56271 2

### DIFF
--- a/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -950,9 +950,9 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 			for (Serializable primaryKey : uncachedPrimaryKeys) {
 				<#if entity.PKClassName == "String">
-					query.append(StringPool.QUOTE);
+					query.append(StringPool.APOSTROPHE);
 					query.append((String)primaryKey);
-					query.append(StringPool.QUOTE);
+					query.append(StringPool.APOSTROPHE);
 				<#else>
 					query.append(String.valueOf(primaryKey));
 				</#if>

--- a/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterPersistenceImpl.java
@@ -459,9 +459,9 @@ public class CounterPersistenceImpl extends BasePersistenceImpl<Counter>
 		query.append(_SQL_SELECT_COUNTER_WHERE_PKS_IN);
 
 		for (Serializable primaryKey : uncachedPrimaryKeys) {
-			query.append(StringPool.QUOTE);
+			query.append(StringPool.APOSTROPHE);
 			query.append((String)primaryKey);
-			query.append(StringPool.QUOTE);
+			query.append(StringPool.APOSTROPHE);
 
 			query.append(StringPool.COMMA);
 		}


### PR DESCRIPTION
We know for sure, mysql can handle both StringPool.QUOTE and StringPool.APOSTROPHE quoted string constants. But postgresql can only do StringPool.APOSTROPHE, so let's default to StringPool.APOSTROPHE for now. If later other DBMS' requirements conflicts with this, we will have to do runtime DB type detecting for proper quoting char.
