### PR TITLE
LPS-56041

### DIFF
--- a/modules/apps/microblogs/microblogs-api/bnd.bnd
+++ b/modules/apps/microblogs/microblogs-api/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Mircoblogs API
 Bundle-SymbolicName: com.liferay.microblogs.api
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.2
 Export-Package: com.liferay.microblogs.*
 Include-Resource: classes

--- a/modules/apps/microblogs/microblogs-service/bnd.bnd
+++ b/modules/apps/microblogs/microblogs-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Microblogs Service
 Bundle-SymbolicName: com.liferay.microblogs.service
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.2
 Export-Package:\
 	com.liferay.microblogs.service.permission,\
 	com.liferay.microblogs.util,\

--- a/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade.java
+++ b/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade.java
@@ -14,8 +14,6 @@
 
 package com.liferay.microblogs.upgrade;
 
-import com.liferay.microblogs.upgrade.v1_0_1.UpgradeUserNotificationEvent;
-import com.liferay.microblogs.upgrade.v1_0_2.UpgradeSocial;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.service.ReleaseLocalService;
@@ -54,17 +52,14 @@ public class MicroblogsServiceUpgrade {
 
 	@Activate
 	protected void upgrade() throws PortalException {
-		List<UpgradeProcess> upgradeProcesses = new ArrayList<>();
+		List<UpgradeProcess> upgradeProcesses = new ArrayList<>(1);
 
-		upgradeProcesses.add(
-			new com.liferay.microblogs.upgrade.v1_0_0.UpgradeMicroblogsEntry());
-		upgradeProcesses.add(new UpgradeUserNotificationEvent());
-		upgradeProcesses.add(
-			new com.liferay.microblogs.upgrade.v1_0_2.UpgradeMicroblogsEntry());
-		upgradeProcesses.add(new UpgradeSocial());
+		upgradeProcesses.add(new MicroblogsServiceUpgrade_1_0_0());
+		upgradeProcesses.add(new MicroblogsServiceUpgrade_1_0_1());
+		upgradeProcesses.add(new MicroblogsServiceUpgrade_1_0_2());
 
 		_releaseLocalService.updateRelease(
-			"com.liferay.microblogs.service", upgradeProcesses, 1, 1, false);
+			"com.liferay.microblogs.service", upgradeProcesses, 102, 1, false);
 	}
 
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade_1_0_0.java
+++ b/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade_1_0_0.java
@@ -1,0 +1,31 @@
+
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.microblogs.upgrade;
+
+import com.liferay.microblogs.upgrade.v1_0_0.UpgradeMicroblogsEntry;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Ryan Park
+ */
+public class MicroblogsServiceUpgrade_1_0_0 extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgrade(new UpgradeMicroblogsEntry());
+	}
+
+}

--- a/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade_1_0_1.java
+++ b/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade_1_0_1.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.microblogs.upgrade;
+
+import com.liferay.microblogs.upgrade.v1_0_1.UpgradeUserNotificationEvent;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Ryan Park
+ */
+public class MicroblogsServiceUpgrade_1_0_1 extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgrade(new UpgradeUserNotificationEvent());
+	}
+
+}

--- a/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade_1_0_2.java
+++ b/modules/apps/microblogs/microblogs-service/src/com/liferay/microblogs/upgrade/MicroblogsServiceUpgrade_1_0_2.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.microblogs.upgrade;
+
+import com.liferay.microblogs.upgrade.v1_0_2.UpgradeMicroblogsEntry;
+import com.liferay.microblogs.upgrade.v1_0_2.UpgradeSocial;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Ryan Park
+ */
+public class MicroblogsServiceUpgrade_1_0_2 extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgrade(new UpgradeMicroblogsEntry());
+		upgrade(new UpgradeSocial());
+	}
+
+}

--- a/modules/apps/microblogs/microblogs-test/bnd.bnd
+++ b/modules/apps/microblogs/microblogs-test/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Microblogs Test
 Bundle-SymbolicName: com.liferay.microblogs.test
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.2
 Include-Resource: classes

--- a/modules/apps/microblogs/microblogs-web/bnd.bnd
+++ b/modules/apps/microblogs/microblogs-web/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Microblogs Web
 Bundle-SymbolicName: com.liferay.microblogs.web
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.2
 Import-Package: \
 	com.liferay.microblogs.exception,\
 	com.liferay.microblogs.model,\


### PR DESCRIPTION
This is my take on how upgrades should be done. Duplicating `MicroblogsServiceUpgrade` for each version requires you to create a method in `MicroblogsServiceConfigurator` for each new class. This seemed simplest and would guarantee order.
