### PR TITLE
LPS-55518 Specify clearly in which context the code is injected

### DIFF
--- a/modules/apps/microblogs/microblogs-service/ivy.xml
+++ b/modules/apps/microblogs/microblogs-service/ivy.xml
@@ -18,5 +18,6 @@
 
 	<dependencies defaultconf="default">
 		<dependency name="com.liferay.portal.spring.extender" org="com.liferay" rev="1.0.0-SNAPSHOT" />
+		<dependency name="org.osgi.core" org="org.osgi" rev="5.0.0" />
 	</dependencies>
 </ivy-module>

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/alloyeditor.jsp
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/alloyeditor.jsp
@@ -212,7 +212,7 @@ if (showSource) {
 			}
 		).render();
 
-		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#onEditorCreate" %>' />
+		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#js#onEditorCreate" %>' />
 	};
 
 	window['<%= name %>'] = {

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/bbcode.jsp
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/bbcode.jsp
@@ -34,7 +34,7 @@ String name = namespace + GetterUtil.getString((String)request.getAttribute("lif
 		}
 	);
 
-	<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#onEditorCreate" %>' />
+	<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#js#onEditorCreate" %>' />
 
 	window['<%= name %>'] = bbCodeEditor;
 

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor.jsp
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor.jsp
@@ -476,7 +476,7 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 
 		var ckEditor = CKEDITOR.instances['<%= name %>'];
 
-		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#onEditorCreate" %>' />
+		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#js#onEditorCreate" %>' />
 
 		<c:if test="<%= inlineEdit && (Validator.isNotNull(inlineEditSaveURL)) %>">
 			inlineEditor = new Liferay.CKEditorInline(

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor.jsp
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor.jsp
@@ -218,7 +218,7 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 			else {
 				data = CKEDITOR.instances['<%= name %>'].getData();
 
-				if (CKEDITOR.env.gecko && (CKEDITOR.tools.trim(data) == '<br />')) {
+				if (CKEDITOR.env.gecko && CKEDITOR.tools.trim(data) == '<br />') {
 					data = '';
 				}
 			}

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor_diffs/extension/creole_dialog_definition.js
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/ckeditor_diffs/extension/creole_dialog_definition.js
@@ -29,7 +29,6 @@ CKEDITOR.on(
 				dialogDefinition.minWidth = 210;
 			}
 			else if (dialogName === 'table' || dialogName === 'tableProperties') {
-				debugger;
 				infoTab = dialogDefinition.getContents('info');
 
 				infoTab.remove('cmbAlign');

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/tinymce.jsp
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/tinymce.jsp
@@ -205,7 +205,7 @@ String toolbarSet = (String)request.getAttribute("liferay-ui:input-editor:toolba
 
 			var tinyMCEEditor = tinyMCE.editors['<%= name %>'];
 
-			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#onEditorCreate" %>' />
+			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#js#onEditorCreate" %>' />
 		},
 
 		initInstanceCallback: function() {

--- a/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/tinymce_simple.jsp
+++ b/modules/frontend/frontend-editors-web/src/META-INF/resources/html/editors/tinymce_simple.jsp
@@ -204,7 +204,7 @@ boolean skipEditorLoading = GetterUtil.getBoolean((String)request.getAttribute("
 
 			var tinyMCEEditor = tinyMCE.editors['<%= name %>'];
 
-			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#onEditorCreate" %>' />
+			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editors.web#" + editorName + "#js#onEditorCreate" %>' />
 		},
 
 		initInstanceCallback: function() {

--- a/modules/frontend/frontend-editors-web/src/com/liferay/frontend/editors/web/servlet/taglib/CKEditorCreoleOnEditorCreateDynamicInclude.java
+++ b/modules/frontend/frontend-editors-web/src/com/liferay/frontend/editors/web/servlet/taglib/CKEditorCreoleOnEditorCreateDynamicInclude.java
@@ -68,7 +68,8 @@ public class CKEditorCreoleOnEditorCreateDynamicInclude
 		DynamicInclude.DynamicIncludeRegistry dynamicIncludeRegistry) {
 
 		dynamicIncludeRegistry.register(
-			"com.liferay.frontend.editors.web#ckeditor_creole#onEditorCreate");
+			"com.liferay.frontend.editors.web#ckeditor_creole#js#" +
+				"onEditorCreate");
 	}
 
 	@Activate

--- a/modules/frontend/frontend-editors-web/src/com/liferay/frontend/editors/web/servlet/taglib/CKEditorOnEditorCreateDynamicInclude.java
+++ b/modules/frontend/frontend-editors-web/src/com/liferay/frontend/editors/web/servlet/taglib/CKEditorOnEditorCreateDynamicInclude.java
@@ -55,7 +55,7 @@ public class CKEditorOnEditorCreateDynamicInclude implements DynamicInclude {
 		DynamicInclude.DynamicIncludeRegistry dynamicIncludeRegistry) {
 
 		dynamicIncludeRegistry.register(
-			"com.liferay.frontend.editors.web#ckeditor#onEditorCreate");
+			"com.liferay.frontend.editors.web#ckeditor#js#onEditorCreate");
 	}
 
 	@Activate


### PR DESCRIPTION
Hey Brian,

We think it's very important to make the context where the code will be injected as explicit as possible. This will help avoid people injecting html where js is exepected, for example.

I've renamed the keys so `com.liferay.frontend.editors.web#editorName#onEditorCreate` becomes `com.liferay.frontend.editors.web#editorName#js#onEditorCreate`.

Thanks!
