### PR TITLE
LPS-55310 removeDestination should also remove mbeanServiceRegistrati…

### DIFF
--- a/modules/portal/portal-messaging/src/com/liferay/portal/messaging/internal/jmx/MessageBusManager.java
+++ b/modules/portal/portal-messaging/src/com/liferay/portal/messaging/internal/jmx/MessageBusManager.java
@@ -147,7 +147,7 @@ public class MessageBusManager
 
 	protected synchronized void removeDestination(Destination destination) {
 		ServiceRegistration<DynamicMBean> mbeanServiceRegistration =
-			_mbeanServiceRegistrations.get(destination.getName());
+			_mbeanServiceRegistrations.remove(destination.getName());
 
 		if (mbeanServiceRegistration != null) {
 			mbeanServiceRegistration.unregister();


### PR DESCRIPTION
…on, otherwise on deactivate, we will try to unregister an already unregistered ServiceRegistration, causing "java.lang.IllegalStateException: The service has been unregistered"

@mhan810 

This it the fix for the errors we got in PACL tests:

```
    [junit] [PACLTestSuite]17:15:15,423 ERROR [Framework stop][com_liferay_portal_messaging:96] [com.liferay.portal.messaging.internal.jmx.MessageBusManager(108)] The deactivate method has thrown an exception 
    [junit] java.lang.IllegalStateException: The service has been unregistered
    [junit]     at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.unregister(ServiceRegistrationImpl.java:206)
    [junit]     at com.liferay.portal.messaging.internal.jmx.MessageBusManager.deactivate(MessageBusManager.java:142)
    [junit]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    [junit]     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    [junit]     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    [junit]     at java.lang.reflect.Method.invoke(Method.java:606)
    [junit]     at org.apache.felix.scr.impl.helper.BaseMethod.invokeMethod(BaseMethod.java:231)
    [junit]     at org.apache.felix.scr.impl.helper.BaseMethod.access$500(BaseMethod.java:39)
    [junit]     at org.apache.felix.scr.impl.helper.BaseMethod$Resolved.invoke(BaseMethod.java:624)
    [junit]     at org.apache.felix.scr.impl.helper.BaseMethod.invoke(BaseMethod.java:508)
    [junit]     at org.apache.felix.scr.impl.helper.ActivateMethod.invoke(ActivateMethod.java:149)
    [junit]     at org.apache.felix.scr.impl.manager.SingleComponentManager.disposeImplementationObject(SingleComponentManager.java:355)
    [junit]     at org.apache.felix.scr.impl.manager.SingleComponentManager.deleteComponent(SingleComponentManager.java:170)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager.doDeactivate(AbstractComponentManager.java:908)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager.deactivateInternal(AbstractComponentManager.java:883)
    [junit]     at org.apache.felix.scr.impl.manager.DependencyManager$SingleStaticCustomizer.removedService(DependencyManager.java:974)
    [junit]     at org.apache.felix.scr.impl.manager.DependencyManager$SingleStaticCustomizer.removedService(DependencyManager.java:895)
    [junit]     at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:1506)
    [junit]     at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:1401)
    [junit]     at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.untrack(ServiceTracker.java:1261)
    [junit]     at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:1440)
    [junit]     at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:109)
    [junit]     at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:914)
    [junit]     at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
    [junit]     at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)
    [junit]     at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:862)
    [junit]     at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry$1.run(ServiceRegistry.java:805)
    [junit]     at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry$1.run(ServiceRegistry.java:1)
    [junit]     at java.security.AccessController.doPrivileged(Native Method)
    [junit]     at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:803)
    [junit]     at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.unregister(ServiceRegistrationImpl.java:222)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.unregister(AbstractComponentManager.java:1011)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.unregister(AbstractComponentManager.java:992)
    [junit]     at org.apache.felix.scr.impl.manager.RegistrationManager.changeRegistration(RegistrationManager.java:141)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager.unregisterService(AbstractComponentManager.java:1054)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager.doDeactivate(AbstractComponentManager.java:900)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager.deactivateInternal(AbstractComponentManager.java:883)
    [junit]     at org.apache.felix.scr.impl.manager.AbstractComponentManager.dispose(AbstractComponentManager.java:580)
    [junit]     at org.apache.felix.scr.impl.config.ConfigurableComponentHolder.disposeComponents(ConfigurableComponentHolder.java:406)
    [junit]     at org.apache.felix.scr.impl.BundleComponentActivator.dispose(BundleComponentActivator.java:335)
    [junit]     at org.apache.felix.scr.impl.Activator.disposeComponents(Activator.java:313)
    [junit]     at org.apache.felix.scr.impl.Activator.access$300(Activator.java:45)
    [junit]     at org.apache.felix.scr.impl.Activator$ScrExtension.destroy(Activator.java:198)
    [junit]     at org.apache.felix.utils.extender.AbstractExtender$2.run(AbstractExtender.java:290)
    [junit]     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    [junit]     at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    [junit]     at org.apache.felix.utils.extender.AbstractExtender.destroyExtension(AbstractExtender.java:312)
    [junit]     at org.apache.felix.utils.extender.AbstractExtender.bundleChanged(AbstractExtender.java:186)
    [junit]     at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:902)
    [junit]     at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
    [junit]     at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEventPrivileged(EquinoxEventPublisher.java:165)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxEventPublisher$1.run(EquinoxEventPublisher.java:79)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxEventPublisher$1.run(EquinoxEventPublisher.java:1)
    [junit]     at java.security.AccessController.doPrivileged(Native Method)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:77)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:67)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor.publishModuleEvent(EquinoxContainerAdaptor.java:102)
    [junit]     at org.eclipse.osgi.container.Module.publishEvent(Module.java:466)
    [junit]     at org.eclipse.osgi.container.Module.doStop(Module.java:624)
    [junit]     at org.eclipse.osgi.container.Module.stop(Module.java:488)
    [junit]     at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.decStartLevel(ModuleContainer.java:1623)
    [junit]     at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1542)
    [junit]     at org.eclipse.osgi.container.SystemModule.stopWorker(SystemModule.java:248)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule.stopWorker(EquinoxBundle.java:144)
    [junit]     at org.eclipse.osgi.container.Module.doStop(Module.java:626)
    [junit]     at org.eclipse.osgi.container.Module.stop(Module.java:488)
    [junit]     at org.eclipse.osgi.container.SystemModule.stop(SystemModule.java:186)
    [junit]     at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule$1.run(EquinoxBundle.java:159)
    [junit]     at java.lang.Thread.run(Thread.java:745)
```
