### PR TITLE
LPS-56500 Ensure TemplateManagers are initialized out side PACL polic…

### DIFF
--- a/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/PACLTestRule.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.deploy.hot.HotDeployUtil;
 import com.liferay.portal.kernel.portlet.PortletClassLoaderUtil;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterHelper;
+import com.liferay.portal.kernel.template.TemplateManagerUtil;
 import com.liferay.portal.kernel.util.ClassLoaderPool;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalLifecycleUtil;
@@ -243,6 +244,15 @@ public class PACLTestRule implements TestRule {
 
 		new IndexerPostProcessorRegistry();
 		new ServiceWrapperRegistry();
+
+		try {
+			Class.forName(
+				TemplateManagerUtil.class.getName(), true,
+				PACLTestRule.class.getClassLoader());
+		}
+		catch (ClassNotFoundException cnfe) {
+			throw new ExceptionInInitializerError(cnfe);
+		}
 	}
 
 	private Object _instance;


### PR DESCRIPTION
…y scope

This is the fixing the mysterious random 270 PACL test failures

```
Could not initialize class com.liferay.portal.kernel.template.TemplateManagerUtil

java.lang.NoClassDefFoundError: Could not initialize class com.liferay.portal.kernel.template.TemplateManagerUtil
    at com.liferay.portal.deploy.hot.HotDeployImpl.fireUndeployEvent(HotDeployImpl.java:125)
    at com.liferay.portal.security.lang.DoPrivilegedHandler$InvokePrivilegedExceptionAction.run(DoPrivilegedHandler.java:168)
    at java.security.AccessController.doPrivileged(Native Method)
    at com.liferay.portal.security.lang.DoPrivilegedHandler.doInvoke(DoPrivilegedHandler.java:101)
    at com.liferay.portal.security.lang.DoPrivilegedHandler.invoke(DoPrivilegedHandler.java:57)
    at com.sun.proxy.$Proxy87.fireUndeployEvent(Unknown Source)
    at com.liferay.portal.kernel.deploy.hot.HotDeployUtil.fireUndeployEvent(HotDeployUtil.java:32)
    at com.liferay.portal.test.rule.PACLTestRule.afterClass(PACLTestRule.java:103)
    at com.liferay.portal.test.rule.PACLTestRule$1.evaluate(PACLTestRule.java:92)
    at com.liferay.portal.test.rule.PACLTestRule.invokeStatement(PACLTestRule.java:207)
    at com.liferay.portal.test.rule.PACLTestRule$1.evaluate(PACLTestRule.java:88)
    at com.liferay.portal.security.pacl.PACLAggregateTest$PACLTestsProcessCallable.call(PACLAggregateTest.java:384)
    at com.liferay.portal.security.pacl.PACLAggregateTest$PACLTestsProcessCallable.call(PACLAggregateTest.java:338)
    at com.liferay.portal.kernel.process.local.LocalProcessLauncher.main(LocalProcessLauncher.java:122)
```
