### PR TITLE
LPS-56383 Temporarily disabled

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -189,7 +189,9 @@ public class DBUpgrader {
 			_log.debug("Delete temporary images");
 		}
 
-		_deleteTempImages();
+		// Temporarily disabled due to LPS-56383
+
+		// _deleteTempImages();
 
 		// Clear the caches only if the upgrade process was run
 


### PR DESCRIPTION
@epgarcia Journal has moved out as a module, so should its upgrade logic be moved out together with it.

Currently due to the missing tables, we have a boot up failure. I am just simply comment out the upgrade logic for it, please move it out to its module properly, thanks!
