### PR TITLE
LPS-56383 PropsUtil.get() can not take null as input, caused by 77cbf…

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java
@@ -368,9 +368,15 @@ public class LocalizationImpl implements Localization {
 		PortletPreferences preferences, String preferenceName,
 		String propertyName) {
 
+		String defaultPropertyValue = null;
+
+		if (propertyName != null) {
+			defaultPropertyValue = PropsUtil.get(propertyName);
+		}
+
 		return getLocalizationMap(
-			preferences, preferenceName, propertyName,
-			PropsUtil.get(propertyName), getClass().getClassLoader());
+			preferences, preferenceName, propertyName, defaultPropertyValue,
+			getClass().getClassLoader());
 	}
 
 	@Override


### PR DESCRIPTION
…161d1f01ee722649168ba86adae631da932.

Fix LocalizationImplTest:

```
    [junit] Testcase: testGetModifiedLocales(com.liferay.portal.util.LocalizationImplTest): Caused an ERROR
    [junit] null
    [junit] java.lang.NullPointerException
    [junit]     at java.util.concurrent.ConcurrentHashMap.hash(ConcurrentHashMap.java:333)
    [junit]     at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:988)
    [junit]     at com.liferay.portal.configuration.ConfigurationImpl.get(ConfigurationImpl.java:156)
    [junit]     at com.liferay.portal.util.PropsUtil._get(PropsUtil.java:217)
    [junit]     at com.liferay.portal.util.PropsUtil.get(PropsUtil.java:60)
    [junit]     at com.liferay.portal.util.LocalizationImpl.getLocalizationMap(LocalizationImpl.java:371)
    [junit]     at com.liferay.portal.util.LocalizationImpl.getLocalizationMap(LocalizationImpl.java:363)
    [junit]     at com.liferay.portal.kernel.util.LocalizationUtil.getLocalizationMap(LocalizationUtil.java:139)
    [junit]     at com.liferay.portal.util.LocalizationImplTest.testGetModifiedLocales(LocalizationImplTest.java:219)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
    [junit]     at com.liferay.portal.kernel.test.rule.BaseTestRule$1.evaluate(BaseTestRule.java:62)
```

CC @epgarcia
