### PR TITLE
LPS-56383 Sort

### DIFF
--- a/modules/apps/journal/journal-service/service.xml
+++ b/modules/apps/journal/journal-service/service.xml
@@ -122,6 +122,10 @@
 			<finder-column name="groupId" />
 			<finder-column name="status" />
 		</finder>
+		<finder name="C_DDMTK" return-type="Collection">
+			<finder-column name="classNameId" />
+			<finder-column name="DDMTemplateKey" />
+		</finder>
 		<finder name="C_V" return-type="Collection">
 			<finder-column name="companyId" />
 			<finder-column name="version" />
@@ -133,10 +137,6 @@
 		<finder name="C_NotST" return-type="Collection">
 			<finder-column name="companyId" />
 			<finder-column name="status" comparator="!=" />
-		</finder>
-		<finder name="C_DDMTK" return-type="Collection">
-			<finder-column name="classNameId" />
-			<finder-column name="DDMTemplateKey" />
 		</finder>
 		<finder name="LtD_S" return-type="Collection">
 			<finder-column name="displayDate" comparator="&lt;" />


### PR DESCRIPTION
@hhuijser SF is acting funny for service.xml

I had to make this change to stop it from complaining:
     [java] order: modules/apps/journal/journal-service/service.xml JournalArticle C_DDMTK

But as you can see the ordering does not really make sense here, even after the change.
