### PR TITLE
master-qa-16388

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3904,6 +3904,15 @@ module.framework.properties.osgi.console=11312</echo>
 		</if>
 
 		<if>
+			<isset property="osb.lcs.portlet.host.name" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					osb.lcs.portlet.host.name=${osb.lcs.portlet.host.name}
+				</echo>
+			</then>
+		</if>
+
+		<if>
 			<isset property="liferay.portal.branch" />
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">

--- a/build-test.xml
+++ b/build-test.xml
@@ -3895,19 +3895,10 @@ module.framework.properties.osgi.console=11312</echo>
 		<antcall target="prepare-selenium-testcase-properties" />
 
 		<if>
-			<isset property="mobile.android.home" />
+			<isset property="legacy.theme.ids" />
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
-					mobile.android.home=${mobile.android.home}
-				</echo>
-			</then>
-		</if>
-
-		<if>
-			<isset property="osb.lcs.portlet.host.name" />
-			<then>
-				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
-					osb.lcs.portlet.host.name=${osb.lcs.portlet.host.name}
+					theme.ids=${legacy.theme.ids}
 				</echo>
 			</then>
 		</if>
@@ -3931,10 +3922,19 @@ module.framework.properties.osgi.console=11312</echo>
 		</if>
 
 		<if>
-			<isset property="legacy.theme.ids" />
+			<isset property="mobile.android.home" />
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
-					theme.ids=${legacy.theme.ids}
+					mobile.android.home=${mobile.android.home}
+				</echo>
+			</then>
+		</if>
+
+		<if>
+			<isset property="osb.lcs.portlet.host.name" />
+			<then>
+				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
+					osb.lcs.portlet.host.name=${osb.lcs.portlet.host.name}
 				</echo>
 			</then>
 		</if>

--- a/portal-web/test/functional/com/liferay/portalweb/util/TestPropsValues.java
+++ b/portal-web/test/functional/com/liferay/portalweb/util/TestPropsValues.java
@@ -220,6 +220,9 @@ public class TestPropsValues
 	public static final boolean MOBILE_DEVICE_ENABLED = GetterUtil.getBoolean(
 		TestPropsUtil.get("mobile.device.enabled"));
 
+	public static final String OSB_LCS_PORTLET_HOST_NAME = TestPropsUtil.get(
+		"osb.lcs.portlet.host.name");
+
 	public static final String OUTPUT_DIR_NAME = TestPropsUtil.get(
 		"output.dir");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-16388

This allows LCS testers to use osb.lcs.portlet.host.name in the poshi tests.

The second sort commit is to fix the alphabetizing of the conditional checks in prepare-selenium.
