### PR TITLE
LPS-56383 Move delete temp images logic to module

### DIFF
--- a/modules/apps/journal/journal-service/src/com/liferay/journal/verify/JournalServiceVerifyProcess.java
+++ b/modules/apps/journal/journal-service/src/com/liferay/journal/verify/JournalServiceVerifyProcess.java
@@ -27,6 +27,8 @@ import com.liferay.journal.service.JournalContentSearchLocalService;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.journal.service.configuration.configurator.JournalServiceConfigurator;
 import com.liferay.journal.util.comparator.ArticleVersionComparator;
+import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.cache.MultiVMPoolUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
@@ -91,6 +93,7 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 	protected void doVerify() throws Exception {
 		verifyArticleAssets();
 		verifyArticleContents();
+		verifyArticleImages();
 		verifyArticleLayouts();
 		verifyArticleStructures();
 		verifyContentSearch();
@@ -627,6 +630,21 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 		}
 	}
 
+	protected void verifyArticleImages() throws Exception {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Delete temporary images");
+		}
+
+		DB db = DBFactoryUtil.getDB();
+
+		db.runSQL(_DELETE_TEMP_IMAGES_1);
+		db.runSQL(_DELETE_TEMP_IMAGES_2);
+
+		if (StartupHelperUtil.isUpgraded()) {
+			MultiVMPoolUtil.clear();
+		}
+	}
+
 	protected void verifyArticleLayouts() throws Exception {
 		verifyUuid("JournalArticle");
 	}
@@ -849,6 +867,13 @@ public class JournalServiceVerifyProcess extends VerifyLayout {
 			DataAccess.cleanUp(con, ps, rs);
 		}
 	}
+
+	private static final String _DELETE_TEMP_IMAGES_1 =
+		"delete from Image where imageId IN (SELECT articleImageId FROM " +
+			"JournalArticleImage where tempImage = TRUE)";
+
+	private static final String _DELETE_TEMP_IMAGES_2 =
+		"delete from JournalArticleImage where tempImage = TRUE";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalServiceVerifyProcess.class);

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -183,16 +183,6 @@ public class DBUpgrader {
 
 		ResourceActionLocalServiceUtil.checkResourceActions();
 
-		// Delete temporary images
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Delete temporary images");
-		}
-
-		// Temporarily disabled due to LPS-56383
-
-		// _deleteTempImages();
-
 		// Clear the caches only if the upgrade process was run
 
 		if (_log.isDebugEnabled()) {
@@ -338,13 +328,6 @@ public class DBUpgrader {
 		throw new IllegalStateException(sb.toString());
 	}
 
-	private static void _deleteTempImages() throws Exception {
-		DB db = DBFactoryUtil.getDB();
-
-		db.runSQL(_DELETE_TEMP_IMAGES_1);
-		db.runSQL(_DELETE_TEMP_IMAGES_2);
-	}
-
 	private static void _disableTransactions() throws Exception {
 		if (_log.isDebugEnabled()) {
 			_log.debug("Disable transactions");
@@ -479,13 +462,6 @@ public class DBUpgrader {
 			DataAccess.cleanUp(con, ps);
 		}
 	}
-
-	private static final String _DELETE_TEMP_IMAGES_1 =
-		"delete from Image where imageId IN (SELECT articleImageId FROM " +
-			"JournalArticleImage where tempImage = TRUE)";
-
-	private static final String _DELETE_TEMP_IMAGES_2 =
-		"delete from JournalArticleImage where tempImage = TRUE";
 
 	private static final Log _log = LogFactoryUtil.getLog(DBUpgrader.class);
 


### PR DESCRIPTION
Hi @brianchandotcom,

Currently the upgrade processes in the OSGi modules (JournalServiceUpgrade, DDLServiceUpgrade, etc.) are launched before the module tables are created. Since in most cases they are aimed to update other portal tables (such as Portlet or ClassName) this worked so far. But when I tried to add upgrade logic that affects the own module tables (i.e. move journal 7.0 upgrade stuff to the module) it failed. 

@mhan810 told me they're still working to redefine the upgrade processes. In the meantime, we agreed that the _deleteTempImages logic in the DBUpgrader could be moved to the JournalServiceVerifyProcess, that it's executed once module tables are available.

Regards
