### PR TITLE
LPS-56056 Duplicated attributes cause shutdown failure (caused by 476…

### DIFF
--- a/portal-impl/src/com/liferay/portlet/blogs/action/ViewMVCRenderCommand.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/action/ViewMVCRenderCommand.java
@@ -26,7 +26,7 @@ import javax.portlet.RenderResponse;
  */
 @OSGiBeanProperties(
 	property = {
-		"javax.portlet.name=" + PortletKeys.BLOGS, "mvc.command.name=",
+		"javax.portlet.name=" + PortletKeys.BLOGS,
 		"mvc.command.name=/blogs/view"
 	}
 )

--- a/portal-impl/src/com/liferay/portlet/blogsadmin/action/ViewMVCRenderCommand.java
+++ b/portal-impl/src/com/liferay/portlet/blogsadmin/action/ViewMVCRenderCommand.java
@@ -26,7 +26,7 @@ import javax.portlet.RenderResponse;
  */
 @OSGiBeanProperties(
 	property = {
-		"javax.portlet.name=" + PortletKeys.BLOGS_ADMIN, "mvc.command.name=",
+		"javax.portlet.name=" + PortletKeys.BLOGS_ADMIN,
 		"mvc.command.name=/blogs_admin/view"
 	}
 )

--- a/portal-impl/src/com/liferay/portlet/blogsaggregator/action/ViewMVCRenderCommand.java
+++ b/portal-impl/src/com/liferay/portlet/blogsaggregator/action/ViewMVCRenderCommand.java
@@ -26,7 +26,7 @@ import javax.portlet.RenderResponse;
  */
 @OSGiBeanProperties(
 	property = {
-		"javax.portlet.name=" + PortletKeys.BLOGS_AGGREGATOR, "mvc.command.name=",
+		"javax.portlet.name=" + PortletKeys.BLOGS_AGGREGATOR,
 		"mvc.command.name=/blogs_aggregator/view"
 	}
 )


### PR DESCRIPTION
…7ac3fa7ee3793c4e82fc13e07cccf985d4b08)

Fix for shutdown failure:

```
00:33:36,608 ERROR [localhost-startStop-2][MainServlet:164] java.lang.ClassCastException: [Ljava.lang.String; cannot be cast to java.lang.String
java.lang.ClassCastException: [Ljava.lang.String; cannot be cast to java.lang.String
    at com.liferay.portal.kernel.portlet.bridges.mvc.MVCCommandCache$MVCCommandServiceTrackerCustomizer.removedService(MVCCommandCache.java:194)
    at com.liferay.portal.kernel.portlet.bridges.mvc.MVCCommandCache$MVCCommandServiceTrackerCustomizer.removedService(MVCCommandCache.java:158)
    at com.liferay.registry.internal.ServiceTrackerCustomizerAdapter.removedService(ServiceTrackerCustomizerAdapter.java:51)
    at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:967)
    at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:1)
    at org.osgi.util.tracker.AbstractTracked.untrack(AbstractTracked.java:341)
    at org.osgi.util.tracker.ServiceTracker.close(ServiceTracker.java:377)
    at com.liferay.registry.internal.ServiceTrackerWrapper.close(ServiceTrackerWrapper.java:46)
    at com.liferay.portal.kernel.portlet.bridges.mvc.MVCCommandCache.close(MVCCommandCache.java:70)
    at com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet.destroy(MVCPortlet.java:63)
    at com.liferay.portlet.InvokerPortletImpl.destroy(InvokerPortletImpl.java:211)
    at com.liferay.portlet.MonitoringPortlet.destroy(MonitoringPortlet.java:67)
    at com.liferay.portlet.PortletInstanceFactoryImpl.clear(PortletInstanceFactoryImpl.java:63)
    at com.liferay.portlet.PortletInstanceFactoryImpl.clear(PortletInstanceFactoryImpl.java:48)
    at com.liferay.portlet.PortletInstanceFactoryImpl.destroy(PortletInstanceFactoryImpl.java:208)
    at com.liferay.portlet.PortletInstanceFactoryUtil.destroy(PortletInstanceFactoryUtil.java:49)
    at com.liferay.portal.servlet.MainServlet.destroyPortlets(MainServlet.java:658)
    at com.liferay.portal.servlet.MainServlet.destroy(MainServlet.java:161)
    at org.apache.catalina.core.StandardWrapper.unload(StandardWrapper.java:1486)
    at org.apache.catalina.core.StandardWrapper.stopInternal(StandardWrapper.java:1847)
    at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:232)
    at org.apache.catalina.core.StandardContext.stopInternal(StandardContext.java:5711)
    at org.apache.catalina.util.LifecycleBase.stop(LifecycleBase.java:232)
    at org.apache.catalina.core.ContainerBase$StopChild.call(ContainerBase.java:1591)
    at org.apache.catalina.core.ContainerBase$StopChild.call(ContainerBase.java:1580)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
```

@sergiogonzalez
