### PR TITLE
[Pushed to upstream] LPS-56056 LPS-56689 mvc.command.names can have multiple values and in that case it's an array of String[] not a String

### DIFF
--- a/portal-impl/src/com/liferay/portlet/blogs/action/ViewMVCRenderCommand.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/action/ViewMVCRenderCommand.java
@@ -26,7 +26,7 @@ import javax.portlet.RenderResponse;
  */
 @OSGiBeanProperties(
 	property = {
-		"javax.portlet.name=" + PortletKeys.BLOGS,
+		"javax.portlet.name=" + PortletKeys.BLOGS, "mvc.command.name=",
 		"mvc.command.name=/blogs/view"
 	}
 )

--- a/portal-impl/src/com/liferay/portlet/blogsadmin/action/ViewMVCRenderCommand.java
+++ b/portal-impl/src/com/liferay/portlet/blogsadmin/action/ViewMVCRenderCommand.java
@@ -26,7 +26,7 @@ import javax.portlet.RenderResponse;
  */
 @OSGiBeanProperties(
 	property = {
-		"javax.portlet.name=" + PortletKeys.BLOGS_ADMIN,
+		"javax.portlet.name=" + PortletKeys.BLOGS_ADMIN, "mvc.command.name=",
 		"mvc.command.name=/blogs_admin/view"
 	}
 )

--- a/portal-impl/src/com/liferay/portlet/blogsaggregator/action/ViewMVCRenderCommand.java
+++ b/portal-impl/src/com/liferay/portlet/blogsaggregator/action/ViewMVCRenderCommand.java
@@ -27,7 +27,7 @@ import javax.portlet.RenderResponse;
 @OSGiBeanProperties(
 	property = {
 		"javax.portlet.name=" + PortletKeys.BLOGS_AGGREGATOR,
-		"mvc.command.name=/blogs_aggregator/view"
+		"mvc.command.name=", "mvc.command.name=/blogs_aggregator/view"
 	}
 )
 public class ViewMVCRenderCommand implements MVCRenderCommand {

--- a/portal-service/src/com/liferay/portal/kernel/portlet/bridges/mvc/MVCCommandCache.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/bridges/mvc/MVCCommandCache.java
@@ -191,13 +191,15 @@ public class MVCCommandCache {
 
 			registry.ungetService(serviceReference);
 
-			String mvcCommandName = (String)serviceReference.getProperty(
-				"mvc.command.name");
+			List<String> mvcCommandNames = StringPlus.asList(
+				serviceReference.getProperty("mvc.command.name"));
 
-			_mvcCommandCache.remove(mvcCommandName);
+			for (String mvcCommandName : mvcCommandNames) {
+				_mvcCommandCache.remove(mvcCommandName);
 
-			for (List<MVCCommand> mvcCommands : _mvcCommands.values()) {
-				mvcCommands.remove(mvcCommand);
+				for (List<MVCCommand> mvcCommands : _mvcCommands.values()) {
+					mvcCommands.remove(mvcCommand);
+				}
 			}
 		}
 


### PR DESCRIPTION
Hey guys,

We need the empty string in mvc.command.name to map the first rendering of the page when there's no struts_action of mvcPath or mvcCommandName in the request parameters. 

I have fixed the issue when shutting down the portal by considering the possibility that the mvc.command.name property can have multiple values (and in that case it behaves as an Array). The fix is basically to consider that case, as it's done in the addingService method:

``` java
            List<String> mvcCommandNames = StringPlus.asList(
                serviceReference.getProperty("mvc.command.name"));

```

Thanks guys and sorry for the trouble.
