### PR TITLE
LPS-56624 OSGi modules are registered in wrong context root in jsonws services

### DIFF
--- a/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionsManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionsManagerImpl.java
@@ -291,14 +291,9 @@ public class JSONWebServiceActionsManagerImpl
 
 	@Override
 	public int registerServletContext(ServletContext servletContext) {
-		String contextPath = ContextPathUtil.getContextPath(servletContext);
+		String contextPath = servletContext.getServletContextName();
 
 		int count = registerServletContext(contextPath);
-
-		if (count < 0) {
-			count = registerServletContext(
-				servletContext.getServletContextName());
-		}
 
 		return count;
 	}
@@ -316,8 +311,8 @@ public class JSONWebServiceActionsManagerImpl
 		else {
 			String contextName = contextPath;
 
-			if (contextName.startsWith(StringPool.SLASH)) {
-				contextName = contextName.substring(1);
+			if (!contextPath.startsWith(StringPool.SLASH)) {
+				contextPath = StringPool.SLASH.concat(contextPath);
 			}
 
 			beanLocator = PortletBeanLocatorUtil.getBeanLocator(contextName);


### PR DESCRIPTION
Hi!

I've sent this pull to @igorspasic for reviewing in https://github.com/igorspasic/liferay-portal/pull/81 . He gave me the ok. The problem is this:

I think I've found a bug when registering OSGi modules as jsonws services. The bug manifests as OSGi json services deployed without a slash in their context root and you can't call them by url/curl/mobile generated services... but they are available through invokews.

I think the code thinks that all services are going to start with a slash and OSGi ones start with /o/audiencetargeting (for example).

I've changed the way of calculating the context path based on this commit: https://github.com/liferay/liferay-portal/commit/054af01
