### PR TITLE
LPS-56475 Same as BookmarksFolderLocalServiceTreeTest

### DIFF
--- a/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/service/permission/test/BookmarksFolderPermissionCheckerTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/service/permission/test/BookmarksFolderPermissionCheckerTest.java
@@ -19,6 +19,9 @@ import com.liferay.bookmarks.model.BookmarksFolder;
 import com.liferay.bookmarks.service.permission.BookmarksFolderPermissionChecker;
 import com.liferay.bookmarks.service.permission.BookmarksResourcePermissionChecker;
 import com.liferay.bookmarks.util.test.BookmarksTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.security.permission.ActionKeys;
@@ -38,13 +41,16 @@ import org.junit.runner.RunWith;
  * @author Shinn Lok
  */
 @RunWith(Arquillian.class)
+@Sync
 public class BookmarksFolderPermissionCheckerTest
 	extends BasePermissionTestCase {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	@Override


### PR DESCRIPTION
@mhan810 One more BookmarksFolder creation indexing error, once the search engine side fix is finished, you can revert all the commits under LPS-56475, do a couple ci runs to confirm the problem is gone, thanks!
