### PR TITLE
LPS-25776 Regen documents when version is pending

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
@@ -390,7 +390,8 @@ public class PDFProcessorImpl
 					destinationFileVersion.getVersion());
 
 				if (Validator.equals(
-						"PWC", destinationFileVersion.getVersion())) {
+						"PWC", destinationFileVersion.getVersion()) ||
+					destinationFileVersion.isPending()) {
 
 					File file = new File(
 						DocumentConversionUtil.getFilePath(tempFileId, "pdf"));


### PR DESCRIPTION
@daviddotzhang @hhuijser The generated file cannot be deleted unconditionally, as that breaks the OpenOffice cache. This PR implements a less aggresive strategy: remove the generated file only when the version is the PWC (private working copy) or it is on review.

@daviddotzhang I've tested it, but to be sure everything works as expected, could you please recheck that this fixes your case for real?

Thanks!
