### PR TITLE
Lps 56834

### DIFF
--- a/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -5321,11 +5321,13 @@ public class ServiceBuilder {
 
 		context.put("classDeprecated", false);
 
-		DocletTag tag = javaClass.getTagByName("deprecated");
+		if (javaClass != null) {
+			DocletTag tag = javaClass.getTagByName("deprecated");
 
-		if (tag != null) {
-			context.put("classDeprecated", true);
-			context.put("classDeprecatedComment", tag.getValue());
+			if (tag != null) {
+				context.put("classDeprecated", true);
+				context.put("classDeprecatedComment", tag.getValue());
+			}
 		}
 
 		return context;

--- a/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -905,6 +905,12 @@ public class ServiceBuilder {
 								entity, modelImplJavaClass);
 							_createExtendedModelImpl(entity);
 
+							if (modelImplJavaClass == null) {
+								modelImplJavaClass = _getJavaClass(
+									_outputPath + "/model/impl/" +
+										entity.getName() + "Impl.java");
+							}
+
 							entity.setTransients(_getTransients(entity, false));
 							entity.setParentTransients(
 								_getTransients(entity, true));


### PR DESCRIPTION
@hhuijser this is fixing bug caused by https://github.com/liferay/liferay-portal/commit/7c1a2801075b4321e1cca662f30dca48eb854993

I think we should keep it in the old way, to always reload the JavaClass when needed. But it is up to you, this fix is a bit hacky, but it works, if you prefer to only trying to create the JavaClass once, we can just use this fix.

You can test it by running "ant build-service" under "modules/util/portal-tools-service-builder/samples"

@brianchandotcom we might just spawn a batch job on CI to call "ant build-servers" under portal-impl to catch future errors like this?
