### PR TITLE
LPS-57004 Fix test, the async indexing is fighting with @DeleteAfterT…

### DIFF
--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/util/test/JournalConverterUtilTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/util/test/JournalConverterUtilTest.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -85,12 +87,15 @@ import org.junit.runner.RunWith;
  * @author Marcellus Tavares
  */
 @RunWith(Arquillian.class)
+@Sync
 public class JournalConverterUtilTest {
 
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {


### PR DESCRIPTION
…estRun, causing randomly seeing non-exist indexing object from DB.

Fix for https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch%28master%29/AXIS_VARIABLE=4,label_exp=!master/38/testReport/com.liferay.portal.log.assertor/PortalLogAssertorTest/testScanXmlLog/
