### PR TITLE
LPS-57153 Create method to populate ModelPermissions from the request and use it from ServiceContextFactory in a backwards compatible way

### DIFF
--- a/portal-service/src/com/liferay/portal/service/ModelPermissions.java
+++ b/portal-service/src/com/liferay/portal/service/ModelPermissions.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service;
+
+import com.liferay.portal.model.Role;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Jorge Ferrer
+ */
+public class ModelPermissions implements Serializable {
+
+    public void addRolePermissions(Role role, String[] actionIds) {
+        for (String actionId : actionIds) {
+            addRolePermissions(role, actionId);
+        }
+    }
+    
+    public void addRolePermissions(Role role, String actionId) {
+        getRoles(actionId).add(role);
+        getActionIds(role).add(actionId);
+
+        _roles.add(role);
+    }
+
+    public List<String> getActionIds(Role role) {
+        List<String> actionIds = _rolesMap.get(role.getName());
+
+        if (actionIds == null) {
+            actionIds = new ArrayList<>();
+
+            _rolesMap.put(role.getName(), actionIds);
+        }
+
+        return actionIds;
+    }
+
+    public List<Role> getRoles() {
+        return _roles;
+    }
+
+    public List<Role> getRoles(String actionId) {
+        List<Role> roles = _actionsMap.get(actionId);
+
+        if (roles == null) {
+            roles = new ArrayList<>();
+
+            _actionsMap.put(actionId, roles);
+        }
+
+        return roles;
+    }
+
+    public boolean isEmpty() {
+        return _roles.isEmpty();
+    }
+
+    private Map<String, List<Role>> _actionsMap = new HashMap<>();
+    private Map<String, List<String>> _rolesMap = new HashMap<>();
+    private List<Role> _roles = new ArrayList<>();
+
+}

--- a/portal-service/src/com/liferay/portal/service/ModelPermissionsFactory.java
+++ b/portal-service/src/com/liferay/portal/service/ModelPermissionsFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.model.Role;
+import com.liferay.portal.model.RoleConstants;
+import com.liferay.portal.security.auth.CompanyThreadLocal;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+/**
+ * @author Jorge Ferrer
+ */
+public class ModelPermissionsFactory {
+
+    public static ModelPermissions create(
+            long companyId, long groupId, String[] groupPermissions,
+            String[] guestPermissions)
+        throws PortalException {
+
+        ModelPermissions modelPermissions = new ModelPermissions();
+
+        // Group permissions
+
+        if ((groupId > 0) && (groupPermissions != null) &&
+            (groupPermissions.length > 0)){
+
+            Role defaultGroupRole =
+                RoleLocalServiceUtil.getDefaultGroupRole(groupId);
+
+            modelPermissions.addRolePermissions(
+                defaultGroupRole, groupPermissions);
+        }
+
+        // Guest permissions
+
+        if ((guestPermissions != null) && (guestPermissions.length > 0)) {
+            Role guestRole = RoleLocalServiceUtil.getRole(
+                companyId, RoleConstants.GUEST);
+
+            if (guestPermissions == null) {
+                guestPermissions = new String[0];
+            }
+
+            modelPermissions.addRolePermissions(guestRole, guestPermissions);
+        }
+
+        return modelPermissions;
+    }
+
+}

--- a/portal-service/src/com/liferay/portal/service/ResourceLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/ResourceLocalService.java
@@ -137,6 +137,16 @@ public interface ResourceLocalService extends BaseLocalService {
 		java.lang.String[] groupPermissions, java.lang.String[] guestPermissions)
 		throws PortalException;
 
+	public void addModelResources(long companyId, long groupId, long userId,
+		java.lang.String name, long primKey,
+		com.liferay.portal.service.ModelPermissions modelPermissions)
+		throws PortalException;
+
+	public void addModelResources(long companyId, long groupId, long userId,
+		java.lang.String name, java.lang.String primKey,
+		com.liferay.portal.service.ModelPermissions modelPermissions)
+		throws PortalException;
+
 	/**
 	* Adds resources for the entity with the name. Use this method if the user
 	* is unknown or irrelevant and there is no current entity instance.

--- a/portal-service/src/com/liferay/portal/service/ResourceLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/ResourceLocalServiceUtil.java
@@ -144,6 +144,24 @@ public class ResourceLocalServiceUtil {
 			groupPermissions, guestPermissions);
 	}
 
+	public static void addModelResources(long companyId, long groupId,
+		long userId, java.lang.String name, long primKey,
+		com.liferay.portal.service.ModelPermissions modelPermissions)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.addModelResources(companyId, groupId, userId, name, primKey,
+			modelPermissions);
+	}
+
+	public static void addModelResources(long companyId, long groupId,
+		long userId, java.lang.String name, java.lang.String primKey,
+		com.liferay.portal.service.ModelPermissions modelPermissions)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.addModelResources(companyId, groupId, userId, name, primKey,
+			modelPermissions);
+	}
+
 	/**
 	* Adds resources for the entity with the name. Use this method if the user
 	* is unknown or irrelevant and there is no current entity instance.

--- a/portal-service/src/com/liferay/portal/service/ResourceLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/ResourceLocalServiceWrapper.java
@@ -135,6 +135,24 @@ public class ResourceLocalServiceWrapper implements ResourceLocalService,
 			name, primKey, groupPermissions, guestPermissions);
 	}
 
+	@Override
+	public void addModelResources(long companyId, long groupId, long userId,
+		java.lang.String name, long primKey,
+		com.liferay.portal.service.ModelPermissions modelPermissions)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_resourceLocalService.addModelResources(companyId, groupId, userId,
+			name, primKey, modelPermissions);
+	}
+
+	@Override
+	public void addModelResources(long companyId, long groupId, long userId,
+		java.lang.String name, java.lang.String primKey,
+		com.liferay.portal.service.ModelPermissions modelPermissions)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_resourceLocalService.addModelResources(companyId, groupId, userId,
+			name, primKey, modelPermissions);
+	}
+
 	/**
 	* Adds resources for the entity with the name. Use this method if the user
 	* is unknown or irrelevant and there is no current entity instance.

--- a/portal-service/src/com/liferay/portal/service/ServiceContext.java
+++ b/portal-service/src/com/liferay/portal/service/ServiceContext.java
@@ -491,6 +491,10 @@ public class ServiceContext implements Cloneable, Serializable {
 		return LocaleUtil.fromLanguageId(_languageId);
 	}
 
+	public ModelPermissions getModelPermissions() {
+		return _modelPermissions;
+	}
+
 	/**
 	 * Returns the date when an entity was modified if this service context is
 	 * being passed as a parameter to a method which updates an entity.
@@ -1332,6 +1336,10 @@ public class ServiceContext implements Cloneable, Serializable {
 		_layoutURL = layoutURL;
 	}
 
+	public void setModelPermissions(ModelPermissions modelPermissions) {
+		_modelPermissions = modelPermissions;
+	}
+
 	/**
 	 * Sets the date when an entity was modified in this service context.
 	 *
@@ -1555,6 +1563,7 @@ public class ServiceContext implements Cloneable, Serializable {
 	private String _languageId;
 	private String _layoutFullURL;
 	private String _layoutURL;
+	private ModelPermissions _modelPermissions;
 	private Date _modifiedDate;
 	private String _pathFriendlyURLPrivateGroup;
 	private String _pathFriendlyURLPrivateUser;

--- a/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
+++ b/portal-service/src/com/liferay/portal/service/ServiceContextFactory.java
@@ -173,17 +173,25 @@ public class ServiceContextFactory {
 
 		// Permissions
 
-		boolean addGroupPermissions = ParamUtil.getBoolean(
-			request, "addGroupPermissions");
-		boolean addGuestPermissions = ParamUtil.getBoolean(
-			request, "addGuestPermissions");
-		String[] groupPermissions = PortalUtil.getGroupPermissions(request);
-		String[] guestPermissions = PortalUtil.getGuestPermissions(request);
+		ModelPermissions modelPermissions = ModelPermissionsFactory.create(
+			request);
 
-		serviceContext.setAddGroupPermissions(addGroupPermissions);
-		serviceContext.setAddGuestPermissions(addGuestPermissions);
-		serviceContext.setGroupPermissions(groupPermissions);
-		serviceContext.setGuestPermissions(guestPermissions);
+		if (!modelPermissions.isEmpty()) {
+			serviceContext.setModelPermissions(modelPermissions);
+		}
+		else {
+			boolean addGroupPermissions = ParamUtil.getBoolean(
+				request, "addGroupPermissions");
+			boolean addGuestPermissions = ParamUtil.getBoolean(
+				request, "addGuestPermissions");
+			String[] groupPermissions = PortalUtil.getGroupPermissions(request);
+			String[] guestPermissions = PortalUtil.getGuestPermissions(request);
+
+			serviceContext.setAddGroupPermissions(addGroupPermissions);
+			serviceContext.setAddGuestPermissions(addGuestPermissions);
+			serviceContext.setGroupPermissions(groupPermissions);
+			serviceContext.setGuestPermissions(guestPermissions);
+		}
 
 		// Portlet preferences ids
 

--- a/portal-service/test/unit/com/liferay/portal/service/ModelPermissionsFactoryTest.java
+++ b/portal-service/test/unit/com/liferay/portal/service/ModelPermissionsFactoryTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.service;
 
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.model.Role;
 import com.liferay.portal.model.RoleConstants;
 import org.junit.Assert;
@@ -28,7 +29,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Jorge Ferrer
@@ -51,6 +54,13 @@ public class ModelPermissionsFactoryTest extends PowerMockito {
 
         when(
             RoleLocalServiceUtil.getDefaultGroupRole(Mockito.anyLong())
+        ).thenReturn(
+            siteMemberRole
+        );
+
+        when(
+            RoleLocalServiceUtil.getRole(
+                Mockito.anyLong(), Mockito.eq(RoleConstants.SITE_MEMBER))
         ).thenReturn(
             siteMemberRole
         );
@@ -160,6 +170,73 @@ public class ModelPermissionsFactoryTest extends PowerMockito {
             _COMPANY_ID, 0, groupPermissions, guestPermissions);
 
         Assert.assertTrue(modelPermissions.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testCreateWithoutParameters() throws Exception {
+        Map<String, String[]> parameterMap = new HashMap<>();
+
+        ModelPermissions modelPermissions =
+            ModelPermissionsFactory.create(parameterMap);
+
+        List<Role> roles = modelPermissions.getRoles();
+
+        Assert.assertEquals(0, roles.size());
+    }
+
+    @Test
+    public void testCreateWithParameterForOneRole() throws Exception {
+        Map<String, String[]> parameterMap = new HashMap<>();
+
+        String[] permissions = {"VIEW"};
+
+        parameterMap.put(
+            ModelPermissionsFactory.MODEL_PERMISSIONS_PREFIX +
+                RoleConstants.GUEST,
+            permissions);
+
+        ModelPermissions modelPermissions =
+            ModelPermissionsFactory.create(parameterMap);
+
+        List<Role> roles = modelPermissions.getRoles();
+
+        Assert.assertEquals(1, roles.size());
+
+        Role role = roles.get(0);
+
+        Assert.assertEquals(RoleConstants.GUEST, role.getName());
+        Assert.assertEquals(
+            ListUtil.fromArray(permissions),
+            modelPermissions.getActionIds(role));
+    }
+
+    @Test
+    public void testCreateWithParameterForTwoRoles() throws Exception {
+        Map<String, String[]> parameterMap = new HashMap<>();
+
+        String[] permissions = {"VIEW"};
+
+        parameterMap.put(
+            ModelPermissionsFactory.MODEL_PERMISSIONS_PREFIX +
+                RoleConstants.GUEST,
+            permissions);
+        parameterMap.put(
+            ModelPermissionsFactory.MODEL_PERMISSIONS_PREFIX +
+                RoleConstants.SITE_MEMBER,
+            permissions);
+
+        ModelPermissions modelPermissions =
+            ModelPermissionsFactory.create(parameterMap);
+
+        List<Role> roles = modelPermissions.getRoles();
+
+        Assert.assertEquals(2, roles.size());
+
+        Role role = roles.get(0);
+
+        Assert.assertEquals(
+            ListUtil.fromArray(permissions),
+            modelPermissions.getActionIds(role));
     }
 
     private static final long _COMPANY_ID = 1;


### PR DESCRIPTION
Hey Brian, this is the improvement to ServiceContext that I told you about. This is the first step to validate with you the pattern. As you can see it's not applied anywhere but there are quite a few unit tests. As a next step I would like to apply this to all core services, since it should be pretty simple
