### PR TITLE
master-qa-16681

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2656,6 +2656,12 @@ go]]></replacevalue>
 		</if>
 	</target>
 
+	<target name="deploy-lcs-environment-token">
+		<copy todir="${liferay.home}/data">
+			<fileset dir="${selenium.output.dir}" includes="lcs-cluster-entry-token-*.txt" />
+		</copy>
+	</target>
+
 	<target name="deploy-license-xml">
 		<if>
 			<matches pattern="http" string="${test.build.license.xml.zip.url}" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-16681

This target is for LCS tests. They need it because one of their tests downloads a token which then needs to be copied into the Liferay home data folder.

CC @mandyzia
CC @christianstokes 
