### PR TITLE
LPS-56993 ant format-source

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/taglib/aui/ScriptData.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/taglib/aui/ScriptData.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.kernel.servlet.taglib.aui;
 
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.util.Mergeable;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -27,11 +26,16 @@ import java.io.Serializable;
 import java.io.Writer;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -41,21 +45,27 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class ScriptData implements Mergeable<ScriptData>, Serializable {
 
-	public void append(String portletId, String content, String use) {
+	public void append(
+		String portletId, String content, String modules, ModuleTypes type) {
+
 		PortletData portletData = _getPortletData(portletId);
 
-		portletData.append(content, use);
+		portletData.append(content, modules, type);
 	}
 
-	public void append(String portletId, StringBundler contentSB, String use) {
+	public void append(
+		String portletId, StringBundler contentSB, String modules,
+		ModuleTypes type) {
+
 		PortletData portletData = _getPortletData(portletId);
 
-		portletData.append(contentSB, use);
+		portletData.append(contentSB, modules, type);
 	}
 
 	public void mark() {
 		for (PortletData portletData : _portletDataMap.values()) {
-			_addToSBIndexList(portletData._callbackSB);
+			_addToSBIndexList(portletData._auiCallbackSB);
+			_addToSBIndexList(portletData._es6CallbackSB);
 			_addToSBIndexList(portletData._rawSB);
 		}
 	}
@@ -82,52 +92,94 @@ public class ScriptData implements Mergeable<ScriptData>, Serializable {
 
 		writer.write("<script type=\"text/javascript\">\n// <![CDATA[\n");
 
-		StringBundler callbackSB = new StringBundler(_portletDataMap.size());
+		StringBundler auiModulesSB = new StringBundler(_portletDataMap.size());
+		StringBundler es6ModulesSB = new StringBundler(_portletDataMap.size());
+
+		Set<String> auiModulesSet = new HashSet<>();
+		Set<String> es6ModulesSet = new HashSet<>();
 
 		for (PortletData portletData : _portletDataMap.values()) {
 			portletData._rawSB.writeTo(writer);
 
-			callbackSB.append(portletData._callbackSB);
+			if (!portletData._auiModulesSet.isEmpty()) {
+				auiModulesSB.append(portletData._auiCallbackSB);
+			}
+
+			if (!portletData._es6ModulesSet.isEmpty()) {
+				es6ModulesSB.append(portletData._es6CallbackSB);
+			}
+
+			auiModulesSet.addAll(portletData._auiModulesSet);
+			es6ModulesSet.addAll(portletData._es6ModulesSet);
 		}
 
-		if (callbackSB.index() == 0) {
+		if ((auiModulesSB.index() == 0) && (es6ModulesSB.index() == 0)) {
 			writer.write("\n// ]]>\n</script>");
 
 			return;
 		}
 
-		String loadMethod = "use";
+		if (!es6ModulesSet.isEmpty()) {
+			writer.write("require(");
 
-		if (BrowserSnifferUtil.isIe(request) &&
-			(BrowserSnifferUtil.getMajorVersion(request) < 8)) {
+			Map<String, String> generatedVariables = _generateVariables(
+				es6ModulesSet);
 
-			loadMethod = "ready";
-		}
+			for (Iterator<String> iterator = es6ModulesSet.iterator();
+				 iterator.hasNext();) {
+					writer.write(StringPool.APOSTROPHE);
+					writer.write(iterator.next());
+					writer.write(StringPool.APOSTROPHE);
 
-		writer.write("AUI().");
-		writer.write(loadMethod);
-		writer.write("(");
+					if (iterator.hasNext()) {
+						writer.write(StringPool.COMMA_AND_SPACE);
+					}
+			}
 
-		Set<String> useSet = new TreeSet<>();
-
-		for (PortletData portletData : _portletDataMap.values()) {
-			useSet.addAll(portletData._useSet);
-		}
-
-		for (String use : useSet) {
-			writer.write(StringPool.APOSTROPHE);
-			writer.write(use);
-			writer.write(StringPool.APOSTROPHE);
 			writer.write(StringPool.COMMA_AND_SPACE);
+			writer.write("function(");
+
+			for (Iterator<String> iterator = es6ModulesSet.iterator();
+				 iterator.hasNext();) {
+					writer.write(generatedVariables.get(iterator.next()));
+
+					if (iterator.hasNext()) {
+						writer.write(StringPool.COMMA_AND_SPACE);
+					}
+			}
+
+			writer.write(") {\n");
+
+			es6ModulesSB.writeTo(writer);
+
+			writer.write("},\nfunction(error) {\nconsole.error(error);\n});");
+
+			writer.write("\n// ]]>\n</script>");
 		}
+		else if (!auiModulesSet.isEmpty()) {
+			writer.write("AUI().use(");
 
-		writer.write("function(A) {");
+			for (String use : auiModulesSet) {
+				writer.write(StringPool.APOSTROPHE);
+				writer.write(use);
+				writer.write(StringPool.APOSTROPHE);
+				writer.write(StringPool.COMMA_AND_SPACE);
+			}
 
-		callbackSB.writeTo(writer);
+			writer.write("function(A) {");
 
-		writer.write("});");
+			auiModulesSB.writeTo(writer);
 
-		writer.write("\n// ]]>\n</script>");
+			writer.write("});");
+
+			writer.write("\n// ]]>\n</script>");
+		}
+	}
+
+	public static enum ModuleTypes {
+
+		MODULE_AUI, MODULE_ES6
+
 	}
 
 	private void _addToSBIndexList(StringBundler sb) {
@@ -144,6 +196,70 @@ public class ScriptData implements Mergeable<ScriptData>, Serializable {
 
 			ovp.setValue(sb.index());
 		}
+	}
+
+	private Map<String, String> _generateVariables(Set<String> requiredFiles) {
+		Map<String, String> generatedVariablesMap = new HashMap<>();
+		Map<String, Integer> variablesIndex = new HashMap<>();
+		Set<String> generatedVariables = new HashSet<>();
+
+		for (String requiredFile : requiredFiles) {
+			StringBundler sb = new StringBundler();
+			CharSequence firstCharacter = requiredFile.subSequence(0, 1);
+			Matcher matcher = patternValidFirstCharacter.matcher(
+				firstCharacter);
+
+			if (!matcher.matches()) {
+				sb.append(StringPool.UNDERLINE);
+			}
+			else {
+				sb.append(firstCharacter);
+			}
+
+			for (int i = 1; i < requiredFile.length(); i++) {
+				CharSequence curCharacter = requiredFile.subSequence(i, i + 1);
+
+				matcher = patternValidCharacters.matcher(curCharacter);
+
+				if (!matcher.matches()) {
+					while (++i < requiredFile.length()) {
+						CharSequence nextCharacter = requiredFile.subSequence(
+							i, i + 1);
+
+						matcher = patternValidCharacters.matcher(nextCharacter);
+
+						if (matcher.matches()) {
+							sb.append(StringUtil.toUpperCase(
+								nextCharacter.toString()));
+
+							break;
+						}
+					}
+				}
+				else {
+					sb.append(curCharacter);
+				}
+			}
+
+			String generatedVariable = sb.toString();
+
+			if (generatedVariables.contains(generatedVariable)) {
+				int index = 1;
+
+				if (variablesIndex.containsKey(generatedVariable)) {
+					index = variablesIndex.get(generatedVariable) + 1;
+				}
+
+				variablesIndex.put(generatedVariable, index);
+
+				generatedVariable += index;
+			}
+
+			generatedVariables.add(generatedVariable);
+			generatedVariablesMap.put(requiredFile, generatedVariable);
+		}
+
+		return generatedVariablesMap;
 	}
 
 	private PortletData _getPortletData(String portletId) {
@@ -173,48 +289,78 @@ public class ScriptData implements Mergeable<ScriptData>, Serializable {
 		new ConcurrentHashMap<>();
 	private final List<ObjectValuePair<StringBundler, Integer>> _sbIndexList =
 		new ArrayList<>();
+	private final Pattern patternValidCharacters = Pattern.compile(
+		"[0-9a-z_$]", Pattern.CASE_INSENSITIVE);
+	private final Pattern patternValidFirstCharacter = Pattern.compile(
+		"[a-z_$]", Pattern.CASE_INSENSITIVE);
 
 	private class PortletData implements Serializable {
 
-		public void append(String content, String use) {
-			if (Validator.isNull(use)) {
+		public void append(String content, String modules, ModuleTypes type) {
+			if (Validator.isNull(modules)) {
 				_rawSB.append(content);
 			}
 			else {
-				_callbackSB.append("(function() {");
-				_callbackSB.append(content);
-				_callbackSB.append("})();");
+				String[] modulesArray = StringUtil.split(modules);
 
-				String[] useArray = StringUtil.split(use);
+				if (type == ModuleTypes.MODULE_AUI) {
+					_auiCallbackSB.append("(function() {");
+					_auiCallbackSB.append(content);
+					_auiCallbackSB.append("})();");
 
-				for (int i = 0; i < useArray.length; i++) {
-					_useSet.add(StringUtil.trim(useArray[i]));
+					for (String module : modulesArray) {
+						_auiModulesSet.add(StringUtil.trim(module));
+					}
+				}
+				else {
+					_es6CallbackSB.append("(function() {");
+					_es6CallbackSB.append(content);
+					_es6CallbackSB.append("})();");
+
+					for (String module : modulesArray) {
+						_es6ModulesSet.add(StringUtil.trim(module));
+					}
 				}
 			}
 		}
 
-		public void append(StringBundler contentSB, String use) {
-			if (Validator.isNull(use)) {
+		public void append(
+			StringBundler contentSB, String modules, ModuleTypes type) {
+
+			if (Validator.isNull(modules)) {
 				_rawSB.append(contentSB);
 			}
 			else {
-				_callbackSB.append("(function() {");
-				_callbackSB.append(contentSB);
-				_callbackSB.append("})();");
+				String[] modulesArray = StringUtil.split(modules);
 
-				String[] useArray = StringUtil.split(use);
+				if (type == ModuleTypes.MODULE_AUI) {
+					_auiCallbackSB.append("(function() {");
+					_auiCallbackSB.append(contentSB);
+					_auiCallbackSB.append("})();");
 
-				for (int i = 0; i < useArray.length; i++) {
-					_useSet.add(StringUtil.trim(useArray[i]));
+					for (String module : modulesArray) {
+						_auiModulesSet.add(StringUtil.trim(module));
+					}
+				}
+				else {
+					_es6CallbackSB.append("(function() {");
+					_es6CallbackSB.append(contentSB);
+					_es6CallbackSB.append("})();");
+
+					for (String module : modulesArray) {
+						_es6ModulesSet.add(StringUtil.trim(module));
+					}
 				}
 			}
 		}
 
 		private static final long serialVersionUID = 1L;
 
-		private final StringBundler _callbackSB = new StringBundler();
+		private final StringBundler _auiCallbackSB = new StringBundler();
+		private final Set<String> _auiModulesSet = new HashSet<>();
+		private final StringBundler _es6CallbackSB = new StringBundler();
+		private final Set<String> _es6ModulesSet = new HashSet<>();
 		private final StringBundler _rawSB = new StringBundler();
-		private final Set<String> _useSet = new TreeSet<>();
 
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/servlet/taglib/aui/ScriptData.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/taglib/aui/ScriptData.java
@@ -229,8 +229,9 @@ public class ScriptData implements Mergeable<ScriptData>, Serializable {
 						matcher = patternValidCharacters.matcher(nextCharacter);
 
 						if (matcher.matches()) {
-							sb.append(StringUtil.toUpperCase(
-								nextCharacter.toString()));
+							sb.append(
+								StringUtil.toUpperCase(
+									nextCharacter.toString()));
 
 							break;
 						}

--- a/util-taglib/src/META-INF/aui.tld
+++ b/util-taglib/src/META-INF/aui.tld
@@ -2426,6 +2426,13 @@
 			<type>boolean</type>
 		</attribute>
 		<attribute>
+			<description><![CDATA[AMD modules to be used in the script. Names of multiple modules must be separated by commas.]]></description>
+			<name>require</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>java.lang.String</type>
+		</attribute>
+		<attribute>
 			<description><![CDATA[AlloyUI modules to be used in the script. Names of multiple modules must be separated by commas.]]></description>
 			<name>use</name>
 			<required>false</required>

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseScriptTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseScriptTag.java
@@ -34,12 +34,20 @@ public abstract class BaseScriptTag extends com.liferay.taglib.util.PositionTagS
 		return _sandbox;
 	}
 
+	public java.lang.String getRequire() {
+		return _require;
+	}
+
 	public java.lang.String getUse() {
 		return _use;
 	}
 
 	public void setSandbox(boolean sandbox) {
 		_sandbox = sandbox;
+	}
+
+	public void setRequire(java.lang.String require) {
+		_require = require;
 	}
 
 	public void setUse(java.lang.String use) {
@@ -51,6 +59,7 @@ public abstract class BaseScriptTag extends com.liferay.taglib.util.PositionTagS
 		super.cleanUp();
 
 		_sandbox = false;
+		_require = null;
 		_use = null;
 	}
 
@@ -62,6 +71,7 @@ public abstract class BaseScriptTag extends com.liferay.taglib.util.PositionTagS
 		"/html/taglib/aui/script/page.jsp";
 
 	private boolean _sandbox = false;
+	private java.lang.String _require = null;
 	private java.lang.String _use = null;
 
 }

--- a/util-taglib/src/com/liferay/taglib/liferay-aui.xml
+++ b/util-taglib/src/com/liferay/taglib/liferay-aui.xml
@@ -1349,6 +1349,12 @@
 				<defaultValue>false</defaultValue>
 			</attribute>
 			<attribute>
+				<description>AMD modules to be used in the script. Names of multiple modules must be separated by commas.</description>
+				<name>require</name>
+				<inputType>java.lang.String</inputType>
+				<outputType>java.lang.String</outputType>
+			</attribute>
+			<attribute>
 				<description>AlloyUI modules to be used in the script. Names of multiple modules must be separated by commas.</description>
 				<name>use</name>
 				<inputType>java.lang.String</inputType>

--- a/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
@@ -396,7 +396,7 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 					jspWriter.write("</a>");
 
 					ScriptTag.doTag(
-						null, "liferay-menu",
+						null, null, "liferay-menu",
 						"Liferay.Menu.register('" + _id + "');", bodyContent,
 						pageContext);
 
@@ -426,7 +426,7 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 
 				if (_showExpanded) {
 					ScriptTag.doTag(
-						null, "liferay-menu",
+						null, null, "liferay-menu",
 						"Liferay.Menu.handleFocus('#" + _id + "menu');",
 						bodyContent, pageContext);
 				}


### PR DESCRIPTION
@brianchandotcom This PR adds support for both AUI and ES6 modules to the `aui:script` taglib. The two kinds of modules are incompatibe, so it's not possible to use both attributes (`use` and `require`) at the same time.
