### PR TITLE
LPS-56228 ant format-source

### DIFF
--- a/portal-impl/src/com/liferay/portal/comment/action/EditDiscussionStrutsAction.java
+++ b/portal-impl/src/com/liferay/portal/comment/action/EditDiscussionStrutsAction.java
@@ -55,7 +55,8 @@ import javax.servlet.http.HttpServletResponse;
  * @author Adolfo Pérez
  */
 @OSGiBeanProperties(
-	property = "path=/portal/edit_discussion", service = StrutsAction.class
+	property = "path=/portal/comment/edit_discussion",
+	service = StrutsAction.class
 )
 public class EditDiscussionStrutsAction extends BaseStrutsAction {
 

--- a/portal-impl/src/com/liferay/portal/comment/action/GetCommentsStrutsAction.java
+++ b/portal-impl/src/com/liferay/portal/comment/action/GetCommentsStrutsAction.java
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletResponse;
  * @author Adolfo Pérez
  */
 @OSGiBeanProperties(
-	property = "path=/portal/get_comments", service = StrutsAction.class
+	property = "path=/portal/comment/get_comments", service = StrutsAction.class
 )
 public class GetCommentsStrutsAction extends BaseStrutsAction {
 

--- a/portal-impl/src/com/liferay/portal/editor/configuration/EditorConfigurationFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/editor/configuration/EditorConfigurationFactoryImpl.java
@@ -55,8 +55,8 @@ public class EditorConfigurationFactoryImpl
 
 		if (editorConfigTransformer != null) {
 			editorConfigTransformer.transform(
-				editorOptions, inputEditorTaglibAttributes, configJSONObject, themeDisplay,
-				requestBackedPortletURLFactory);
+				editorOptions, inputEditorTaglibAttributes, configJSONObject,
+				themeDisplay, requestBackedPortletURLFactory);
 		}
 
 		return new EditorConfigurationImpl(configJSONObject, editorOptions);

--- a/portal-impl/src/com/liferay/portal/editor/configuration/EditorConfigurationFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/editor/configuration/EditorConfigurationFactoryImpl.java
@@ -55,8 +55,8 @@ public class EditorConfigurationFactoryImpl
 
 		if (editorConfigTransformer != null) {
 			editorConfigTransformer.transform(
-				editorOptions, inputEditorTaglibAttributes, themeDisplay,
-				requestBackedPortletURLFactory, configJSONObject);
+				editorOptions, inputEditorTaglibAttributes, configJSONObject, themeDisplay,
+				requestBackedPortletURLFactory);
 		}
 
 		return new EditorConfigurationImpl(configJSONObject, editorOptions);

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3710,8 +3710,8 @@
         /message_boards/edit_message,\
         /message_boards/rss,\
         \
-        /portal/edit_discussion,\
-        /portal/get_comments
+        /portal/comment/edit_discussion,\
+        /portal/comment/get_comments
 
     #
     # Set a list of comma delimited origins that will not be checked for an

--- a/portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigContributorTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigContributorTest.java
@@ -412,7 +412,7 @@ public class EditorConfigContributorTest {
 	}
 
 	@Test
-	public void 
+	public void
 			testPortletNameAndEditorNameOverridesEditorConfigKeyEditorConfig()
 		throws Exception {
 

--- a/portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigTransformerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigTransformerTest.java
@@ -314,9 +314,8 @@ public class EditorConfigTransformerTest {
 		public void transform(
 			EditorOptions editorOptions,
 			Map<String, Object> inputEditorTaglibAttributes,
-			ThemeDisplay themeDisplay,
-			RequestBackedPortletURLFactory requestBackedPortletURLFactory,
-			JSONObject configJSONObject) {
+			JSONObject configJSONObject, ThemeDisplay themeDisplay,
+			RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
 			String uploadURL = editorOptions.getUploadURL();
 

--- a/portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigTransformerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigTransformerTest.java
@@ -212,7 +212,7 @@ public class EditorConfigTransformerTest {
 	}
 
 	@Test
-	public void 
+	public void
 			testEditorConfigTransformedWithMultipleEditorOptionsContributors()
 		throws Exception {
 

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/subscriptions/BlogsSubscriptionRootContainerModelTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/subscriptions/BlogsSubscriptionRootContainerModelTest.java
@@ -99,7 +99,7 @@ public class BlogsSubscriptionRootContainerModelTest
 	}
 
 	@Override
-	protected void updateBaseModel(long userId, long baseModelId) 
+	protected void updateBaseModel(long userId, long baseModelId)
 		throws Exception {
 
 		ServiceContext serviceContext =

--- a/portal-service/src/com/liferay/portal/kernel/editor/configuration/EditorConfigTransformer.java
+++ b/portal-service/src/com/liferay/portal/kernel/editor/configuration/EditorConfigTransformer.java
@@ -53,20 +53,18 @@ public interface EditorConfigTransformer {
 	/**
 	 * Transforms the editor options in configuration that the editor can
 	 * handle, by populating the configuration JSON object.
-	 *
-	 * @param editorOptions the {@link EditorOptions} object composed of the
+	 *  @param editorOptions the {@link EditorOptions} object composed of the
 	 *        options set by {@link EditorOptionsContributor} modules
 	 * @param inputEditorTaglibAttributes the attributes specified to the input
 	 *        taglib tag that renders the editor
-	 * @param themeDisplay the theme display
 	 * @param configJSONObject the JSON object composed of the entire
 	 *        configuration set by {@link EditorConfigContributor} modules
+	 * @param themeDisplay the theme display
 	 */
 	public void transform(
 		EditorOptions editorOptions,
 		Map<String, Object> inputEditorTaglibAttributes,
-		ThemeDisplay themeDisplay,
-		RequestBackedPortletURLFactory requestBackedPortletURLFactory,
-		JSONObject configJSONObject);
+		JSONObject configJSONObject, ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory);
 
 }

--- a/util-taglib/src/com/liferay/taglib/aui/ScriptTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ScriptTag.java
@@ -149,7 +149,7 @@ public class ScriptTag extends BaseScriptTag {
 						portletId, bodyContentSB, require,
 						ScriptData.ModulesType.ES6);
 				}
-				else if (use != null) {
+				else {
 					scriptData.append(
 						portletId, bodyContentSB, use,
 						ScriptData.ModulesType.AUI);
@@ -181,7 +181,7 @@ public class ScriptTag extends BaseScriptTag {
 						portletId, bodyContentSB, require,
 						ScriptData.ModulesType.ES6);
 				}
-				else if (use != null) {
+				else {
 					scriptData.append(
 						portletId, bodyContentSB, use,
 						ScriptData.ModulesType.AUI);

--- a/util-taglib/src/com/liferay/taglib/ui/DiscussionTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/DiscussionTag.java
@@ -90,7 +90,7 @@ public class DiscussionTag extends IncludeTag {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		return themeDisplay.getPathMain() + "/portal/edit_discussion";
+		return themeDisplay.getPathMain() + "/portal/comment/edit_discussion";
 	}
 
 	@Override
@@ -107,7 +107,8 @@ public class DiscussionTag extends IncludeTag {
 		String portletId = portletDisplay.getId();
 
 		return themeDisplay.getPathMain() +
-			"/portal/get_comments?p_p_isolated=1&portletId=" + portletId;
+			"/portal/comment/get_comments?p_p_isolated=1&portletId=" +
+				portletId;
 	}
 
 	@Override


### PR DESCRIPTION
@brianchandotcom This is a followup to https://github.com/brianchandotcom/liferay-portal/pull/28326

I couldn't push all `RequestBackedPortletURLFactory` parameters to the end consistently because the `ItemSelector.getItemSelectorURL()` has a varargs argument (and those must go at the end). Moving it to the front didn't look right either, so I've tried to follow two rules of thumb:
1. In the ItemSelector API, the factory takes at the rightmost possible position, but before any item selector specific parameters (itemSelectorEventName, itemSelectorCriteria).
2. In the Editor API, it goes at the end (except when rule #1 applies), and always after `ThemeDisplay`.

This way, we avoid breaking related parameters in the middle (see `ItemSelector.getItemSelectorURL`), and we push the factory as far as possible to the right.

I'm not entirely convinced about this, so if you don't like it, I can send you another PR where I break rule #1 (thus pushing the factory to the end no matter what).

Thanks!
