### PR TITLE
LPS-57100 Fix generic compiling error (for JDK7 is warning, for JDK8 …

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/com/liferay/dynamic/data/mapping/internal/DDMStructureManagerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/com/liferay/dynamic/data/mapping/internal/DDMStructureManagerImpl.java
@@ -327,7 +327,7 @@ public class DDMStructureManagerImpl implements DDMStructureManager {
 		_ddmStructureLocalService.updateDDMStructure(ddmStructure);
 	}
 
-	protected OrderByComparator getStructureOrderByComparator(
+	protected OrderByComparator<com.liferay.portlet.dynamicdatamapping.model.DDMStructure> getStructureOrderByComparator(
 		int structureComparator) {
 
 		if (structureComparator ==


### PR DESCRIPTION
…is failure)

@hhuijser I just noticed, when you run ant format-source under modules' folder, it does not pick up the source-formatter.properties.

In this case, if I run it under portal-impl, it does not complain anything as we have modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/com/liferay/dynamic/data/mapping/internal/DDMStructureManagerImpl.java in line.length.excludes.files already.

However, if I run it under modules/apps/dynamic-data-mapping/dynamic-data-mapping-service, it complains:

```
format-source:
     [java] > 80: ./src/com/liferay/dynamic/data/mapping/internal/DDMStructureManagerImpl.java 330
```
