### PR TITLE
LPS-57478 Always refer to interface/super type whenever it is possible to avoid the unnecessary compatibility issue

### DIFF
--- a/modules/apps/item-selector/item-selector-web/src/com/liferay/item/selector/web/util/ItemSelectorCriterionSerializer.java
+++ b/modules/apps/item-selector/item-selector-web/src/com/liferay/item/selector/web/util/ItemSelectorCriterionSerializer.java
@@ -40,6 +40,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.commons.beanutils.PropertyUtils;
@@ -252,7 +253,7 @@ public class ItemSelectorCriterionSerializer<T extends ItemSelectorCriterion> {
 		ItemSelectorCriterionSerializer.class);
 
 	private BundleContext _bundleContext;
-	private final ConcurrentHashMap<String, List<ItemSelectorReturnType>>
+	private final ConcurrentMap<String, List<ItemSelectorReturnType>>
 		_itemSelectorReturnTypes = new ConcurrentHashMap<>();
 	private ServiceTracker<ItemSelectorView, ItemSelectorView> _serviceTracker;
 

--- a/modules/core/osgi-service-tracker-map/src/com/liferay/osgi/service/tracker/map/internal/ServiceTrackerMapImpl.java
+++ b/modules/core/osgi-service-tracker-map/src/com/liferay/osgi/service/tracker/map/internal/ServiceTrackerMapImpl.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
@@ -147,7 +148,7 @@ public class ServiceTrackerMapImpl<K, SR, TS, R>
 	private final ServiceReferenceMapper<K, ? super SR> _serviceReferenceMapper;
 	private final ServiceTracker<SR, ServiceReferenceServiceTuple<SR, TS, K>>
 		_serviceTracker;
-	private final ConcurrentHashMap<K, ServiceTrackerBucket<SR, TS, R>>
+	private final ConcurrentMap<K, ServiceTrackerBucket<SR, TS, R>>
 		_serviceTrackerBuckets = new ConcurrentHashMap<>();
 	private final ServiceTrackerCustomizer<SR, TS> _serviceTrackerCustomizer;
 	private final ServiceTrackerBucketFactory<SR, TS, R>

--- a/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/internal/BundleContextWrapper.java
+++ b/modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/internal/BundleContextWrapper.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.osgi.framework.Bundle;
@@ -228,7 +229,7 @@ public class BundleContextWrapper implements BundleContext {
 	}
 
 	private final BundleContext _bundleContext;
-	private final ConcurrentHashMap<ServiceReference<?>, AtomicInteger>
+	private final ConcurrentMap<ServiceReference<?>, AtomicInteger>
 		_serviceReferenceCountsMap = new ConcurrentHashMap<>();
 
 }

--- a/modules/core/registry-test/src/com/liferay/registry/internal/RegistryWrapper.java
+++ b/modules/core/registry-test/src/com/liferay/registry/internal/RegistryWrapper.java
@@ -25,6 +25,7 @@ import com.liferay.registry.dependency.ServiceDependencyManager;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -257,7 +258,7 @@ public class RegistryWrapper implements Registry {
 	}
 
 	private final Registry _registry;
-	private final ConcurrentHashMap<ServiceReference<?>, AtomicInteger>
+	private final ConcurrentMap<ServiceReference<?>, AtomicInteger>
 		_serviceReferenceCountsMap = new ConcurrentHashMap<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/util/ExternalRepositoryFactoryUtil.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/ExternalRepositoryFactoryUtil.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.repository.RepositoryException;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author Adolfo Pérez
@@ -68,7 +69,7 @@ public class ExternalRepositoryFactoryUtil {
 		externalRepositoryFactories.remove(className);
 	}
 
-	private static final ConcurrentHashMap<String, ExternalRepositoryFactory>
+	private static final ConcurrentMap<String, ExternalRepositoryFactory>
 		externalRepositoryFactories = new ConcurrentHashMap<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/repository/util/RepositoryFactoryUtil.java
+++ b/portal-impl/src/com/liferay/portal/repository/util/RepositoryFactoryUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.util.PropsValues;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author     Mika Koivisto
@@ -66,7 +67,7 @@ public class RepositoryFactoryUtil {
 		_repositoryFactories.remove(className);
 	}
 
-	private static final ConcurrentHashMap<String, RepositoryFactory>
+	private static final ConcurrentMap<String, RepositoryFactory>
 		_repositoryFactories = new ConcurrentHashMap<>();
 
 	static {


### PR DESCRIPTION
@hhuijser we need to SF this, please see the ticket for more info.

Basically, normally people should not directly refer to ConcurrentHashMap as type reference, they should use ConcurrentMap.

For now I am sure, there is no exception case in our codebase, but technically it could happen. In case of that, there are still ways to provide the jdk7 compatibility, for example, they should extends ConcurrentHashMap and override the keySet() method to return plain Set type. Then use the extended type to avoid the broken compile time binding, but as you can see that's some additional work, only for some very very special cases (we don't have any for now), we should do that as last resort.

And this limitation should be removed, once we start requiring JDK8.

CC @dantewang
