### PR TITLE
[See rationale for extension point name inside] LPS-57517 Add extension point for js loader modules configuration

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -364,6 +364,12 @@
 </c:choose>
 
 <script type="text/javascript">
+	(function() {
+		<liferay-util:dynamic-include key="com.liferay.portal.js.loader.modules.config" />
+	}());
+</script>
+
+<script type="text/javascript">
 	// <![CDATA[
 		<c:if test="<%= (layoutTypePortlet != null) %>">
 


### PR DESCRIPTION
Hey Brian,

The purpose of this difference in name is:
- **Show purpose rather than position** helps developers understand what are they meant for without requiring additional documentation and reduces posible abuses.
- Have **many different extension points in a jsp** without conflicting names.
- Be able to **change where we put the extension point (from one jsp to another) without compromising third-party code** since we can keep the name unchanged.

For this one, I thought it would make sense to use the package of the `JSLoaderModulesServlet` class that handles part of the configuration, but changing the `config` part to express that this is meant to allow developers to configure the loading of their modules.

How does it sound?

PS: In this PR I've actually changed the key to match 100% with the beginning of the `JSLoaderModulesServlet` class package.
