### PR TITLE
LPS-57469

### DIFF
--- a/modules/apps/nested-portlets/nested-portlets-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/META-INF/resources/view.jsp
@@ -38,8 +38,10 @@
 
 <%
 try {
-	String templateId = (String)request.getAttribute(NestedPortletsConfiguration.TEMPLATE_ID);
-	String templateContent = (String)request.getAttribute(NestedPortletsConfiguration.TEMPLATE_CONTENT);
+	String portletId = portletDisplay.getId();
+
+	String templateId = (String)request.getAttribute(NestedPortletsConfiguration.TEMPLATE_ID + portletId);
+	String templateContent = (String)request.getAttribute(NestedPortletsConfiguration.TEMPLATE_CONTENT + portletId);
 
 	if (Validator.isNotNull(templateId) && Validator.isNotNull(templateContent)) {
 		RuntimePageUtil.processTemplate(request, response, new StringTemplateResource(templateId, templateContent));

--- a/modules/apps/nested-portlets/nested-portlets-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/META-INF/resources/view.jsp
@@ -40,8 +40,8 @@
 try {
 	String portletId = portletDisplay.getId();
 
-	String templateId = (String)request.getAttribute(NestedPortletsPortletKeys.TEMPLATE_ID + portletId);
-	String templateContent = (String)request.getAttribute(NestedPortletsPortletKeys.TEMPLATE_CONTENT + portletId);
+	String templateId = (String)request.getAttribute(NestedPortletsPortletKeys.getTemplateIdKey(portletId));
+	String templateContent = (String)request.getAttribute(NestedPortletsPortletKeys.getTemplateContentKey(portletId));
 
 	if (Validator.isNotNull(templateId) && Validator.isNotNull(templateContent)) {
 		RuntimePageUtil.processTemplate(request, response, new StringTemplateResource(templateId, templateContent));

--- a/modules/apps/nested-portlets/nested-portlets-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/META-INF/resources/view.jsp
@@ -40,8 +40,8 @@
 try {
 	String portletId = portletDisplay.getId();
 
-	String templateId = (String)request.getAttribute(NestedPortletsConfiguration.TEMPLATE_ID + portletId);
-	String templateContent = (String)request.getAttribute(NestedPortletsConfiguration.TEMPLATE_CONTENT + portletId);
+	String templateId = (String)request.getAttribute(NestedPortletsPortletKeys.TEMPLATE_ID + portletId);
+	String templateContent = (String)request.getAttribute(NestedPortletsPortletKeys.TEMPLATE_CONTENT + portletId);
 
 	if (Validator.isNotNull(templateId) && Validator.isNotNull(templateContent)) {
 		RuntimePageUtil.processTemplate(request, response, new StringTemplateResource(templateId, templateContent));

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/configuration/NestedPortletsConfiguration.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/configuration/NestedPortletsConfiguration.java
@@ -25,10 +25,6 @@ import aQute.bnd.annotation.metatype.Meta;
 )
 public interface NestedPortletsConfiguration {
 
-	public static final String TEMPLATE_CONTENT = "TEMPLATE_CONTENT";
-
-	public static final String TEMPLATE_ID = "TEMPLATE_ID";
-
 	@Meta.AD(
 		deflt = "2_columns_i", id = "layout.template.default", required = false
 	)

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/constants/NestedPortletsPortletKeys.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/constants/NestedPortletsPortletKeys.java
@@ -14,6 +14,8 @@
 
 package com.liferay.nested.portlets.web.constants;
 
+import com.liferay.portal.kernel.util.StringPool;
+
 /**
  * @author Eudaldo Alonso
  */
@@ -25,5 +27,13 @@ public class NestedPortletsPortletKeys {
 	public static final String TEMPLATE_CONTENT = "TEMPLATE_CONTENT";
 
 	public static final String TEMPLATE_ID = "TEMPLATE_ID";
+
+	public static String getTemplateContentKey(String portletId) {
+		return TEMPLATE_CONTENT + StringPool.POUND + portletId;
+	}
+
+	public static String getTemplateIdKey(String portletId) {
+		return TEMPLATE_ID + StringPool.POUND + portletId;
+	}
 
 }

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/constants/NestedPortletsPortletKeys.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/constants/NestedPortletsPortletKeys.java
@@ -22,4 +22,8 @@ public class NestedPortletsPortletKeys {
 	public static final String NESTED_PORTLETS =
 		"com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet";
 
+	public static final String TEMPLATE_CONTENT = "TEMPLATE_CONTENT";
+
+	public static final String TEMPLATE_ID = "TEMPLATE_ID";
+
 }

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
@@ -36,6 +36,7 @@ import com.liferay.portal.model.LayoutTypePortletConstants;
 import com.liferay.portal.model.Theme;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutTemplateLocalServiceUtil;
+import com.liferay.portal.theme.PortletDisplay;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.WebKeys;
@@ -161,20 +162,26 @@ public class NestedPortletsPortlet extends MVCPortlet {
 
 		checkLayout(themeDisplay.getLayout(), columnIds.values());
 
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		String portletId = portletDisplay.getId();
+
 		renderRequest.setAttribute(
-			NestedPortletsConfiguration.TEMPLATE_ID, templateId);
+			NestedPortletsConfiguration.TEMPLATE_ID + portletId, templateId);
 		renderRequest.setAttribute(
-			NestedPortletsConfiguration.TEMPLATE_CONTENT, templateContent);
+			NestedPortletsConfiguration.TEMPLATE_CONTENT + portletId,
+			templateContent);
 
 		Map<String, Object> vmVariables =
 			(Map<String, Object>)renderRequest.getAttribute(
-				WebKeys.VM_VARIABLES);
+				WebKeys.VM_VARIABLES + portletId);
 
 		if (vmVariables != null) {
 			vmVariables.putAll(columnIds);
 		}
 		else {
-			renderRequest.setAttribute(WebKeys.VM_VARIABLES, columnIds);
+			renderRequest.setAttribute(
+				WebKeys.VM_VARIABLES + portletId, columnIds);
 		}
 
 		renderRequest.setAttribute(

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
@@ -175,14 +175,14 @@ public class NestedPortletsPortlet extends MVCPortlet {
 
 		Map<String, Object> vmVariables =
 			(Map<String, Object>)renderRequest.getAttribute(
-				WebKeys.VM_VARIABLES + portletId);
+				WebKeys.getVMVariablesKey(portletId));
 
 		if (vmVariables != null) {
 			vmVariables.putAll(columnIds);
 		}
 		else {
 			renderRequest.setAttribute(
-				WebKeys.VM_VARIABLES + portletId, columnIds);
+				WebKeys.getVMVariablesKey(portletId), columnIds);
 		}
 
 		renderRequest.setAttribute(

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
@@ -17,6 +17,7 @@ package com.liferay.nested.portlets.web.portlet;
 import aQute.bnd.annotation.metatype.Configurable;
 
 import com.liferay.nested.portlets.web.configuration.NestedPortletsConfiguration;
+import com.liferay.nested.portlets.web.constants.NestedPortletsPortletKeys;
 import com.liferay.nested.portlets.web.display.context.NestedPortletsDisplayContext;
 import com.liferay.nested.portlets.web.upgrade.NestedPortletWebUpgrade;
 import com.liferay.portal.kernel.log.Log;
@@ -167,9 +168,9 @@ public class NestedPortletsPortlet extends MVCPortlet {
 		String portletId = portletDisplay.getId();
 
 		renderRequest.setAttribute(
-			NestedPortletsConfiguration.TEMPLATE_ID + portletId, templateId);
+			NestedPortletsPortletKeys.TEMPLATE_ID + portletId, templateId);
 		renderRequest.setAttribute(
-			NestedPortletsConfiguration.TEMPLATE_CONTENT + portletId,
+			NestedPortletsPortletKeys.TEMPLATE_CONTENT + portletId,
 			templateContent);
 
 		Map<String, Object> vmVariables =

--- a/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/com/liferay/nested/portlets/web/portlet/NestedPortletsPortlet.java
@@ -168,9 +168,9 @@ public class NestedPortletsPortlet extends MVCPortlet {
 		String portletId = portletDisplay.getId();
 
 		renderRequest.setAttribute(
-			NestedPortletsPortletKeys.TEMPLATE_ID + portletId, templateId);
+			NestedPortletsPortletKeys.getTemplateIdKey(portletId), templateId);
 		renderRequest.setAttribute(
-			NestedPortletsPortletKeys.TEMPLATE_CONTENT + portletId,
+			NestedPortletsPortletKeys.getTemplateContentKey(portletId),
 			templateContent);
 
 		Map<String, Object> vmVariables =

--- a/modules/portal/portal-template-velocity/src/com/liferay/portal/template/velocity/VelocityTemplateContextHelper.java
+++ b/modules/portal/portal-template-velocity/src/com/liferay/portal/template/velocity/VelocityTemplateContextHelper.java
@@ -27,6 +27,7 @@ import com.liferay.portal.service.permission.RolePermissionUtil;
 import com.liferay.portal.template.TemplateContextHelper;
 import com.liferay.portal.template.TemplatePortletPreferences;
 import com.liferay.portal.template.velocity.configuration.VelocityEngineConfiguration;
+import com.liferay.portal.theme.PortletDisplay;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.WebKeys;
 
@@ -116,8 +117,11 @@ public class VelocityTemplateContextHelper extends TemplateContextHelper {
 
 		// Insert custom vm variables
 
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
 		Map<String, Object> vmVariables =
-			(Map<String, Object>)request.getAttribute(WebKeys.VM_VARIABLES);
+			(Map<String, Object>)request.getAttribute(
+				WebKeys.VM_VARIABLES + portletDisplay.getId());
 
 		if (vmVariables != null) {
 			for (Map.Entry<String, Object> entry : vmVariables.entrySet()) {

--- a/modules/portal/portal-template-velocity/src/com/liferay/portal/template/velocity/VelocityTemplateContextHelper.java
+++ b/modules/portal/portal-template-velocity/src/com/liferay/portal/template/velocity/VelocityTemplateContextHelper.java
@@ -121,7 +121,7 @@ public class VelocityTemplateContextHelper extends TemplateContextHelper {
 
 		Map<String, Object> vmVariables =
 			(Map<String, Object>)request.getAttribute(
-				WebKeys.VM_VARIABLES + portletDisplay.getId());
+				WebKeys.getVMVariablesKey(portletDisplay.getId()));
 
 		if (vmVariables != null) {
 			for (Map.Entry<String, Object> entry : vmVariables.entrySet()) {

--- a/portal-impl/src/com/liferay/portal/util/WebKeys.java
+++ b/portal-impl/src/com/liferay/portal/util/WebKeys.java
@@ -17,6 +17,7 @@ package com.liferay.portal.util;
 import com.liferay.portal.kernel.resiliency.spi.agent.annotation.Direction;
 import com.liferay.portal.kernel.resiliency.spi.agent.annotation.Distributed;
 import com.liferay.portal.kernel.resiliency.spi.agent.annotation.MatchType;
+import com.liferay.portal.kernel.util.StringPool;
 
 /**
  * @author Brian Wing Shun Chan
@@ -415,5 +416,9 @@ public class WebKeys implements com.liferay.portal.kernel.util.WebKeys {
 	public static final String WSRP_NEW_SESSION = "WSRP_NEW_SESSION";
 
 	public static final String WSRP_PRODUCER = "WSRP_PRODUCER";
+
+	public static final String getVMVariablesKey(String portletId) {
+		return VM_VARIABLES + StringPool.POUND + portletId;
+	}
 
 }


### PR DESCRIPTION
Heya Brian,
This pull is from László, and here's what he said about this pull:

> What the fix does is that we include the actual nested portlet's ID and
>     content in the request attribute in order not to being reused from multiple
>     rendering threads. This way these request attributes become unique and they
>     don't interfere with each other during the parallel rendering phrase.

The part I'm not sure about is whether you're okay with WebKeys having a method in it (since this would be the first one), but you would have a stronger opinion on that one.

Let me or László know if you need any more info.

Thanks Brian,
