### PR TITLE
Lps 57478

### DIFF
--- a/modules/core/registry-api/src/com/liferay/registry/collections/ServiceRegistrationMapImpl.java
+++ b/modules/core/registry-api/src/com/liferay/registry/collections/ServiceRegistrationMapImpl.java
@@ -16,11 +16,12 @@ package com.liferay.registry.collections;
 
 import com.liferay.registry.ServiceRegistration;
 
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * @author Shuyang Zhou
+ * @author Brian Wing Shun Chan
  */
-public interface ServiceRegistrationMap<T>
-	extends ConcurrentMap<T, ServiceRegistration<T>> {
+public class ServiceRegistrationMapImpl<T>
+	extends ConcurrentHashMap<T, ServiceRegistration<T>>
+	implements ServiceRegistrationMap<T> {
 }

--- a/modules/core/registry-api/src/com/liferay/registry/collections/StringServiceRegistrationMapImpl.java
+++ b/modules/core/registry-api/src/com/liferay/registry/collections/StringServiceRegistrationMapImpl.java
@@ -16,11 +16,12 @@ package com.liferay.registry.collections;
 
 import com.liferay.registry.ServiceRegistration;
 
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * @author Shuyang Zhou
+ * @author Brian Wing Shun Chan
  */
-public interface StringServiceRegistrationMap<T>
-	extends ConcurrentMap<String, ServiceRegistration<T>> {
+public class StringServiceRegistrationMapImpl<T>
+	extends ConcurrentHashMap<String, ServiceRegistration<T>>
+	implements StringServiceRegistrationMap<T> {
 }

--- a/modules/core/registry-api/src/com/liferay/registry/collections/internal/ServiceTrackerCollectionImpl.java
+++ b/modules/core/registry-api/src/com/liferay/registry/collections/internal/ServiceTrackerCollectionImpl.java
@@ -22,6 +22,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 import com.liferay.registry.collections.ServiceTrackerList;
 
 import java.lang.reflect.Array;
@@ -317,7 +318,7 @@ public class ServiceTrackerCollectionImpl<S> implements ServiceTrackerList<S> {
 	private final Filter _filter;
 	private final Map<String, Object> _properties;
 	private final ServiceRegistrationMap<S> _serviceRegistrations =
-		new ServiceRegistrationMap<>();
+		new ServiceRegistrationMapImpl<>();
 	private final List<EntryWrapper> _services = new CopyOnWriteArrayList<>();
 	private final ServiceTracker<S, S> _serviceTracker;
 

--- a/portal-impl/src/com/liferay/portal/deploy/hot/PortletHotDeployListener.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/PortletHotDeployListener.java
@@ -64,6 +64,7 @@ import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 import com.liferay.util.bridges.php.PHPPortlet;
 
 import java.util.HashMap;
@@ -637,6 +638,6 @@ public class PortletHotDeployListener extends BaseHotDeployListener {
 	private static final Map<String, List<Portlet>> _portlets = new HashMap<>();
 
 	private final ServiceRegistrationMap<ResourceBundle>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/nio/intraband/proxy/StubMapImpl.java
+++ b/portal-impl/src/com/liferay/portal/nio/intraband/proxy/StubMapImpl.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.nio.intraband.proxy;
+
+import com.liferay.portal.kernel.nio.intraband.RegistrationReference;
+import com.liferay.portal.kernel.resiliency.spi.SPI;
+import com.liferay.portal.kernel.resiliency.spi.SPIRegistryUtil;
+import com.liferay.portal.nio.intraband.proxy.StubHolder.StubCreator;
+
+import java.rmi.RemoteException;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class StubMapImpl<T>
+	extends ConcurrentHashMap<String, T> implements StubMap<T> {
+
+	public StubMapImpl(StubCreator<T> stubCreator) {
+		_stubCreator = stubCreator;
+	}
+
+	@Override
+	public T get(Object key) {
+		String portletId = String.valueOf(key);
+
+		StubHolder<T> stubHolder = _stubHolders.get(portletId);
+
+		if (stubHolder != null) {
+			return stubHolder.getStub();
+		}
+
+		T originalValue = super.get(key);
+
+		if (originalValue == null) {
+			return null;
+		}
+
+		RegistrationReference registrationReference = _getRegistrationReference(
+			portletId);
+
+		if (registrationReference == null) {
+			return originalValue;
+		}
+
+		stubHolder = new StubHolder<>(
+			originalValue, portletId, registrationReference, _stubCreator);
+
+		StubHolder<T> previousStubHolder = _stubHolders.putIfAbsent(
+			portletId, stubHolder);
+
+		if (previousStubHolder != null) {
+			stubHolder = previousStubHolder;
+		}
+
+		return stubHolder.getStub();
+	}
+
+	@Override
+	public boolean removeStubHolder(String portletId, T stub) {
+		return _stubHolders.remove(portletId, stub);
+	}
+
+	private RegistrationReference _getRegistrationReference(String portletId) {
+		SPI spi = SPIRegistryUtil.getPortletSPI(portletId);
+
+		if (spi == null) {
+			return null;
+		}
+
+		try {
+			return spi.getRegistrationReference();
+		}
+		catch (RemoteException re) {
+			throw new RuntimeException(re);
+		}
+	}
+
+	private final StubCreator<T> _stubCreator;
+	private final ConcurrentMap<String, StubHolder<T>> _stubHolders =
+		new ConcurrentHashMap<>();
+
+}

--- a/portal-impl/src/com/liferay/portal/poller/PollerProcessorUtil.java
+++ b/portal-impl/src/com/liferay/portal/poller/PollerProcessorUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.nio.intraband.proxy.IntrabandProxyInstallationUtil;
 import com.liferay.portal.nio.intraband.proxy.IntrabandProxyUtil;
 import com.liferay.portal.nio.intraband.proxy.StubHolder.StubCreator;
 import com.liferay.portal.nio.intraband.proxy.StubMap;
+import com.liferay.portal.nio.intraband.proxy.StubMapImpl;
 import com.liferay.portal.nio.intraband.proxy.WarnLogExceptionHandler;
 import com.liferay.registry.Filter;
 import com.liferay.registry.Registry;
@@ -101,7 +102,7 @@ public class PollerProcessorUtil {
 		new PollerProcessorUtil();
 
 	private final StubMap<PollerProcessor> _pollerPorcessors =
-		new StubMap<PollerProcessor>(
+		new StubMapImpl<>(
 			new StubCreator<PollerProcessor>() {
 
 				@Override

--- a/portal-impl/src/com/liferay/portal/poller/PollerProcessorUtil.java
+++ b/portal-impl/src/com/liferay/portal/poller/PollerProcessorUtil.java
@@ -30,6 +30,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -156,7 +157,7 @@ public class PollerProcessorUtil {
 			});
 
 	private final StringServiceRegistrationMap<PollerProcessor>
-		_serviceRegistrations = new StringServiceRegistrationMap<>();
+		_serviceRegistrations = new StringServiceRegistrationMapImpl<>();
 	private final ServiceTracker<PollerProcessor, PollerProcessor>
 		_serviceTracker;
 

--- a/portal-impl/src/com/liferay/portal/pop/POPServerUtil.java
+++ b/portal-impl/src/com/liferay/portal/pop/POPServerUtil.java
@@ -33,6 +33,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -142,7 +143,7 @@ public class POPServerUtil {
 
 	private final List<MessageListener> _listeners = new ArrayList<>();
 	private final ServiceRegistrationMap<MessageListener>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<MessageListener, MessageListenerWrapper>
 		_serviceTracker;
 

--- a/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinitionCatalogImpl.java
+++ b/portal-impl/src/com/liferay/portal/repository/registry/RepositoryClassDefinitionCatalogImpl.java
@@ -29,6 +29,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 
 import java.util.Collection;
 import java.util.List;
@@ -149,7 +150,7 @@ public class RepositoryClassDefinitionCatalogImpl
 		_repositoryClassDefinitions = new ConcurrentHashMap<>();
 	private List<RepositoryDefiner> _repositoryDefiners;
 	private final StringServiceRegistrationMap<RepositoryDefiner>
-		_serviceRegistrations = new StringServiceRegistrationMap<>();
+		_serviceRegistrations = new StringServiceRegistrationMapImpl<>();
 	private ServiceTracker<RepositoryDefiner, RepositoryDefiner>
 		_serviceTracker;
 

--- a/portal-impl/src/com/liferay/portal/security/auth/AuthTokenWhitelistImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthTokenWhitelistImpl.java
@@ -31,6 +31,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 import com.liferay.registry.util.StringPlus;
 import com.liferay.util.Encryptor;
 
@@ -271,7 +272,7 @@ public class AuthTokenWhitelistImpl implements AuthTokenWhitelist {
 	private Set<String> _portletInvocationWhitelist;
 	private Set<String> _portletInvocationWhitelistActions;
 	private final StringServiceRegistrationMap<Object> _serviceRegistrations =
-		new StringServiceRegistrationMap<>();
+		new StringServiceRegistrationMapImpl<>();
 	private final ServiceTracker<Object, Object> _serviceTracker;
 
 	private class AuthTokenIgnoreActionsServiceTrackerCustomizer

--- a/portal-impl/src/com/liferay/portal/struts/AuthPublicPathRegistry.java
+++ b/portal-impl/src/com/liferay/portal/struts/AuthPublicPathRegistry.java
@@ -22,6 +22,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 import com.liferay.registry.util.StringPlus;
 
 import java.util.HashMap;
@@ -95,7 +96,7 @@ public class AuthPublicPathRegistry {
 
 	private final Set<String> _paths = new ConcurrentHashSet<>();
 	private final StringServiceRegistrationMap<Object>
-		_serviceRegistrations = new StringServiceRegistrationMap<>();
+		_serviceRegistrations = new StringServiceRegistrationMapImpl<>();
 	private final ServiceTracker<Object, Object> _serviceTracker;
 
 	private class AuthPublicTrackerCustomizer

--- a/portal-impl/src/com/liferay/portal/struts/StrutsActionRegistryUtil.java
+++ b/portal-impl/src/com/liferay/portal/struts/StrutsActionRegistryUtil.java
@@ -24,6 +24,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -146,10 +147,10 @@ public class StrutsActionRegistryUtil {
 	private final ServiceTracker<?, Action> _serviceTracker;
 	private final StringServiceRegistrationMap<StrutsAction>
 		_strutsActionServiceRegistrations =
-			new StringServiceRegistrationMap<>();
+			new StringServiceRegistrationMapImpl<>();
 	private final StringServiceRegistrationMap<StrutsPortletAction>
 		_strutsPortletActionServiceRegistrations =
-			new StringServiceRegistrationMap<>();
+			new StringServiceRegistrationMapImpl<>();
 
 	private class ActionServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer<Object, Action> {

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLProcessorRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLProcessorRegistryImpl.java
@@ -35,6 +35,7 @@ import com.liferay.registry.collections.ServiceReferenceMapper;
 import com.liferay.registry.collections.ServiceTrackerCollections;
 import com.liferay.registry.collections.ServiceTrackerMap;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 
 /**
  * @author Mika Koivisto
@@ -295,6 +296,6 @@ public class DLProcessorRegistryImpl implements DLProcessorRegistry {
 			});
 
 	private final StringServiceRegistrationMap<DLProcessor>
-		_serviceRegistrations = new StringServiceRegistrationMap<>();
+		_serviceRegistrations = new StringServiceRegistrationMapImpl<>();
 
 }

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/render/DDMFormFieldRendererRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/render/DDMFormFieldRendererRegistryImpl.java
@@ -22,6 +22,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -78,7 +79,7 @@ public class DDMFormFieldRendererRegistryImpl
 	private final Map<String, List<DDMFormFieldRenderer>>
 		_ddmFormFieldRenderersMap = new HashMap<>();
 	private final ServiceRegistrationMap<DDMFormFieldRenderer>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<DDMFormFieldRenderer, DDMFormFieldRenderer>
 		_serviceTracker;
 

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityInterpreterLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialActivityInterpreterLocalServiceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -336,7 +337,7 @@ public class SocialActivityInterpreterLocalServiceImpl
 	private final Map<String, List<SocialActivityInterpreter>>
 		_activityInterpreters = new HashMap<>();
 	private final ServiceRegistrationMap<SocialActivityInterpreter>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private ServiceTracker<SocialActivityInterpreter, SocialActivityInterpreter>
 		_serviceTracker;
 

--- a/portal-impl/src/com/liferay/portlet/social/service/impl/SocialRequestInterpreterLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/social/service/impl/SocialRequestInterpreterLocalServiceImpl.java
@@ -36,6 +36,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.HashMap;
 import java.util.List;
@@ -275,7 +276,7 @@ public class SocialRequestInterpreterLocalServiceImpl
 	private final List<SocialRequestInterpreter> _requestInterpreters =
 		new CopyOnWriteArrayList<>();
 	private final ServiceRegistrationMap<SocialRequestInterpreter>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private ServiceTracker<SocialRequestInterpreter, SocialRequestInterpreter>
 		_serviceTracker;
 

--- a/portal-service/src/com/liferay/portal/kernel/notifications/UserNotificationManagerUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/notifications/UserNotificationManagerUtil.java
@@ -28,6 +28,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 import com.liferay.registry.collections.ServiceTrackerCollections;
 import com.liferay.registry.collections.ServiceTrackerMap;
 
@@ -313,7 +314,7 @@ public class UserNotificationManagerUtil {
 		_userNotificationHandlers = new ConcurrentHashMap<>();
 	private final ServiceRegistrationMap<UserNotificationHandler>
 		_userNotificationHandlerServiceRegistrations =
-			new ServiceRegistrationMap<>();
+			new ServiceRegistrationMapImpl<>();
 	private final
 		ServiceTracker<UserNotificationHandler, UserNotificationHandler>
 			_userNotificationHandlerServiceTracker;

--- a/portal-service/src/com/liferay/portal/kernel/portlet/FriendlyURLResolverRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/FriendlyURLResolverRegistryUtil.java
@@ -24,6 +24,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.List;
 import java.util.Map;
@@ -107,7 +108,7 @@ public class FriendlyURLResolverRegistryUtil {
 	private final Map<String, FriendlyURLResolver> _friendlyURLResolvers =
 		new ConcurrentHashMap<>();
 	private final ServiceRegistrationMap<FriendlyURLResolver>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<FriendlyURLResolver, FriendlyURLResolver>
 		_serviceTracker;
 

--- a/portal-service/src/com/liferay/portal/kernel/portlet/ResourceBundleTracker.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/ResourceBundleTracker.java
@@ -26,6 +26,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 
 import java.io.Closeable;
 
@@ -106,7 +107,7 @@ public class ResourceBundleTracker implements Closeable {
 	private final Map<String, ResourceBundle> _resourceBundles =
 		new ConcurrentHashMap<>();
 	private final StringServiceRegistrationMap<ResourceBundle>
-		_serviceRegistrations = new StringServiceRegistrationMap<>();
+		_serviceRegistrations = new StringServiceRegistrationMapImpl<>();
 	private final ServiceTracker<ResourceBundle, ResourceBundle>
 		_serviceTracker;
 

--- a/portal-service/src/com/liferay/portal/kernel/trash/TrashHandlerRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/trash/TrashHandlerRegistryUtil.java
@@ -22,6 +22,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.List;
 import java.util.Map;
@@ -99,7 +100,7 @@ public class TrashHandlerRegistryUtil {
 		new TrashHandlerRegistryUtil();
 
 	private final ServiceRegistrationMap<TrashHandler> _serviceRegistrations =
-		new ServiceRegistrationMap<>();
+		new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<TrashHandler, TrashHandler> _serviceTracker;
 	private final Map<String, TrashHandler> _trashHandlers =
 		new ConcurrentSkipListMap<>();

--- a/portal-service/src/com/liferay/portal/kernel/webdav/WebDAVUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/webdav/WebDAVUtil.java
@@ -43,6 +43,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -402,7 +403,7 @@ public class WebDAVUtil {
 	private static final WebDAVUtil _instance = new WebDAVUtil();
 
 	private final ServiceRegistrationMap<WebDAVStorage> _serviceRegistrations =
-		new ServiceRegistrationMap<>();
+		new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<WebDAVStorage, WebDAVStorage> _serviceTracker;
 	private final Map<String, WebDAVStorage> _storageMap =
 		new ConcurrentSkipListMap<>();

--- a/portal-service/src/com/liferay/portal/kernel/workflow/WorkflowHandlerRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/workflow/WorkflowHandlerRegistryUtil.java
@@ -34,6 +34,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.io.Serializable;
 
@@ -321,7 +322,7 @@ public class WorkflowHandlerRegistryUtil {
 	private final Map<String, WorkflowHandler<?>> _scopeableWorkflowHandlerMap =
 		new ConcurrentSkipListMap<>();
 	private final ServiceRegistrationMap<WorkflowHandler<?>>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<WorkflowHandler<?>, WorkflowHandler<?>>
 		_serviceTracker;
 	private final Map<String, WorkflowHandler<?>> _workflowHandlerMap =

--- a/portal-service/src/com/liferay/portal/util/TermsOfUseContentProviderRegistryUtil.java
+++ b/portal-service/src/com/liferay/portal/util/TermsOfUseContentProviderRegistryUtil.java
@@ -24,6 +24,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.List;
 import java.util.Map;
@@ -133,7 +134,7 @@ public class TermsOfUseContentProviderRegistryUtil {
 		new TermsOfUseContentProviderRegistryUtil();
 
 	private final ServiceRegistrationMap<TermsOfUseContentProvider>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<TermsOfUseContentProvider,
 		TermsOfUseContentProvider> _serviceTracker;
 	private final Map<String, TermsOfUseContentProvider>

--- a/portal-service/src/com/liferay/portlet/asset/AssetRendererFactoryRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/AssetRendererFactoryRegistryUtil.java
@@ -28,6 +28,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.List;
 import java.util.Map;
@@ -236,7 +237,7 @@ public class AssetRendererFactoryRegistryUtil {
 	private final Map<String, AssetRendererFactory>
 		_assetRenderFactoriesMapByClassType = new ConcurrentHashMap<>();
 	private final ServiceRegistrationMap<AssetRendererFactory>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<AssetRendererFactory, AssetRendererFactory>
 		_serviceTracker;
 

--- a/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMDisplayRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/dynamicdatamapping/util/DDMDisplayRegistryUtil.java
@@ -24,6 +24,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,7 @@ public class DDMDisplayRegistryUtil {
 	private final Map<String, DDMDisplay> _ddmDisplays =
 		new ConcurrentHashMap<>();
 	private final ServiceRegistrationMap<DDMDisplay> _serviceRegistrations =
-		new ServiceRegistrationMap<>();
+		new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<DDMDisplay, DDMDisplay> _serviceTracker;
 
 	private class DDMDisplayServiceTrackerCustomizer

--- a/portal-service/src/com/liferay/portlet/exportimport/controller/ExportImportControllerRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/controller/ExportImportControllerRegistryUtil.java
@@ -24,6 +24,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 import com.liferay.registry.util.StringPlus;
 
 import java.util.Collection;
@@ -113,7 +114,7 @@ public class ExportImportControllerRegistryUtil {
 	private final Map<String, ImportController> _importControllers =
 		new ConcurrentHashMap<>();
 	private final ServiceRegistrationMap<ExportImportController>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<ExportImportController, ExportImportController>
 		_serviceTracker;
 

--- a/portal-service/src/com/liferay/portlet/exportimport/lar/StagedModelDataHandlerRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/lar/StagedModelDataHandlerRegistryUtil.java
@@ -24,6 +24,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.Collection;
 import java.util.List;
@@ -149,7 +150,7 @@ public class StagedModelDataHandlerRegistryUtil {
 		new StagedModelDataHandlerRegistryUtil();
 
 	private final ServiceRegistrationMap<StagedModelDataHandler<?>>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final
 		ServiceTracker<StagedModelDataHandler<?>, StagedModelDataHandler<?>>
 			_serviceTracker;

--- a/portal-service/src/com/liferay/portlet/exportimport/lifecycle/ExportImportLifecycleEventListenerRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/lifecycle/ExportImportLifecycleEventListenerRegistryUtil.java
@@ -21,6 +21,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.HashSet;
 import java.util.List;
@@ -118,7 +119,7 @@ public class ExportImportLifecycleEventListenerRegistryUtil {
 	private final Set<ExportImportLifecycleListener>
 		_asyncExportImportLifecycleListeners = new HashSet<>();
 	private final ServiceRegistrationMap<ExportImportLifecycleListener>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker
 		<ExportImportLifecycleListener, ExportImportLifecycleListener>
 			_serviceTracker;

--- a/portal-service/src/com/liferay/portlet/exportimport/xstream/XStreamAliasRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/xstream/XStreamAliasRegistryUtil.java
@@ -22,6 +22,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -100,7 +101,7 @@ public class XStreamAliasRegistryUtil {
 		new XStreamAliasRegistryUtil();
 
 	private final ServiceRegistrationMap<XStreamAlias> _serviceRegistrations =
-		new ServiceRegistrationMap<>();
+		new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker<XStreamAlias, XStreamAlias> _serviceTracker;
 	private final Map<Class<?>, String> _xstreamAliases =
 		new ConcurrentHashMap<>();

--- a/portal-service/src/com/liferay/portlet/exportimport/xstream/XStreamConverterRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/xstream/XStreamConverterRegistryUtil.java
@@ -21,6 +21,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -78,7 +79,7 @@ public class XStreamConverterRegistryUtil {
 		new XStreamConverterRegistryUtil();
 
 	private final ServiceRegistrationMap<XStreamConverter>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final ServiceTracker <XStreamConverter, XStreamConverter>
 		_serviceTracker;
 	private final Set<XStreamConverter> _xStreamConverters = new HashSet<>();

--- a/portal-service/src/com/liferay/portlet/layoutsadmin/util/SitemapURLProviderRegistryUtil.java
+++ b/portal-service/src/com/liferay/portlet/layoutsadmin/util/SitemapURLProviderRegistryUtil.java
@@ -24,6 +24,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.ServiceRegistrationMap;
+import com.liferay.registry.collections.ServiceRegistrationMapImpl;
 
 import java.util.Collection;
 import java.util.List;
@@ -103,7 +104,7 @@ public class SitemapURLProviderRegistryUtil {
 		new SitemapURLProviderRegistryUtil();
 
 	private final ServiceRegistrationMap<SitemapURLProvider>
-		_serviceRegistrations = new ServiceRegistrationMap<>();
+		_serviceRegistrations = new ServiceRegistrationMapImpl<>();
 	private final
 		ServiceTracker<SitemapURLProvider, SitemapURLProvider> _serviceTracker;
 	private final Map<String, SitemapURLProvider>

--- a/portal-test-internal/src/com/liferay/portal/search/test/TestIndexerRegistry.java
+++ b/portal-test-internal/src/com/liferay/portal/search/test/TestIndexerRegistry.java
@@ -26,6 +26,7 @@ import com.liferay.registry.ServiceRegistration;
 import com.liferay.registry.ServiceTracker;
 import com.liferay.registry.ServiceTrackerCustomizer;
 import com.liferay.registry.collections.StringServiceRegistrationMap;
+import com.liferay.registry.collections.StringServiceRegistrationMapImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -126,7 +127,7 @@ public class TestIndexerRegistry implements IndexerRegistry {
 	private final Map<String, Indexer<? extends Object>> _indexers =
 		new ConcurrentHashMap<>();
 	private final StringServiceRegistrationMap<Indexer<?>>
-		_serviceRegistrations = new StringServiceRegistrationMap<>();
+		_serviceRegistrations = new StringServiceRegistrationMapImpl<>();
 	private ServiceTracker<Indexer<?>, Indexer<?>> _serviceTracker;
 
 	private class IndexerServiceTrackerCustomizer


### PR DESCRIPTION
@hhuijser

To ensure JDK8 compile time/ JDK7 runtime compatibility, we need a special treatment for all classes extends ConcurrentHashMap and making sure no one is directly refering the ConcurrentHashMap or its subclasses.

So we need to SF this, sorry, Hugo :(

Here is how the logic supposed to look like. (I am just making up the properties name, please rename them to more proper ones)
1) concurrenthashmap.subclass.whitelist=ServiceRegistrationMapImpl,StringServiceRegistrationMapImpl,StubMapImpl
    Any class in codebase that extends ConcurrentHashMap, needs a special treatment, and declare themselves in this list, so that SF can just let them go.

2) No class outside the concurrenthashmap.subclass.whitelist is allowed to extend ConcurrentHashMap.

3) Any class in concurrenthashmap.subclass.whitelist must extend ConcurrentHashMap and also implements an interface whose name is XYZMap, while the matching class name is XYZMapImpl. The XYZMap inteface should extend ConcurrentMap.

4) No one should directly refer to ConcurrentHashMap or any class in concurrenthashmap.subclass.whitelist, they should always refer to ConcurrentMap or the XYZMap interfaces.

Sorry, I know it is a bit complex, let me know if you need more input.

Thanks

CC @dantewang
