### PR TITLE
LRQA-17076

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2614,7 +2614,7 @@ go]]></replacevalue>
 					<sequential>
 						<mirrors-get
 							dest="${todir}"
-							src="${test.jdbc.drivers.url}/db2/8.1.18/@{jdbc.driver}"
+							src="${test.jdbc.drivers.url}/db2/10.5.1/@{jdbc.driver}"
 						/>
 					</sequential>
 				</for>

--- a/build.properties
+++ b/build.properties
@@ -106,7 +106,7 @@
 ## JDBC Drivers
 ##
 
-    jdbc.db2.driver=db2jcc.jar,db2jcc_license_cu.jar
+    jdbc.db2.driver=db2jcc4.jar,db2jcc_license_cu.jar
     jdbc.firebird.driver=firebird.jar
     jdbc.hsql.driver=hsql.jar
     jdbc.interbase.driver=interbase.jar

--- a/portal-impl/test/integration/com/liferay/portal/service/ResourceBlockLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/ResourceBlockLocalServiceTest.java
@@ -80,9 +80,7 @@ public class ResourceBlockLocalServiceTest {
 		expectedLogs = {
 			@ExpectedLog(
 				dbType = DB.TYPE_DB2,
-				expectedLog =
-					"Error for batch element #0: DB2 SQL error: SQLCODE: " +
-						"-803, SQLSTATE: 23505",
+				expectedLog = "Error for batch element #0:",
 				expectedType = ExpectedType.PREFIX
 			),
 			@ExpectedLog(
@@ -198,9 +196,7 @@ public class ResourceBlockLocalServiceTest {
 		expectedLogs = {
 			@ExpectedLog(
 				dbType = DB.TYPE_DB2,
-				expectedLog =
-					"Error for batch element #0: DB2 SQL error: SQLCODE: " +
-						"-803, SQLSTATE: 23505",
+				expectedLog = "Error for batch element #0:",
 				expectedType = ExpectedType.PREFIX
 			),
 			@ExpectedLog(

--- a/portal-impl/test/integration/com/liferay/portal/verify/VerifyUUIDTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/verify/VerifyUUIDTest.java
@@ -52,9 +52,7 @@ public class VerifyUUIDTest extends BaseVerifyProcessTestCase {
 		expectedLogs = {
 			@ExpectedLog(
 				dbType = DB.TYPE_DB2,
-				expectedLog =
-					"Unable to process runnable: DB2 SQL error: SQLCODE: " +
-						"-206, SQLSTATE: 42703",
+				expectedLog = "Unable to process runnable:",
 				expectedType = ExpectedType.PREFIX
 			),
 			@ExpectedLog(
@@ -103,9 +101,7 @@ public class VerifyUUIDTest extends BaseVerifyProcessTestCase {
 		expectedLogs = {
 			@ExpectedLog(
 				dbType = DB.TYPE_DB2,
-				expectedLog =
-					"Unable to process runnable: DB2 SQL error: SQLCODE: " +
-						"-204, SQLSTATE: 42704",
+				expectedLog = "Unable to process runnable:",
 				expectedType = ExpectedType.PREFIX
 			),
 			@ExpectedLog(
@@ -164,14 +160,12 @@ public class VerifyUUIDTest extends BaseVerifyProcessTestCase {
 			@ExpectedLog(
 				dbType = DB.TYPE_DB2,
 				expectedLog =
-					"Unable to process runnable: DB2 SQL error: SQLCODE: " +
-						"-204, SQLSTATE: 42704",
+					"Unable to process runnable:",
 				expectedType = ExpectedType.PREFIX
 			),
 			@ExpectedLog(
 				dbType = DB.TYPE_MYSQL,
-				expectedLog =
-					"Unable to process runnable: Table ",
+				expectedLog = "Unable to process runnable: Table ",
 				expectedType = ExpectedType.PREFIX
 			),
 			@ExpectedLog(


### PR DESCRIPTION
In the new driver version they slightly changed error messages - all of the information is the same, they just structured things a bit different. For instance, before and after: 

Unable to process runnable: DB2 SQL error: SQLCODE: -204, SQLSTATE: 42704
Unable to process runnable: DB2 SQL error: SQLCODE=-204, SQLSTATE=42704

Its all the same information is there, just not the exact same string. My fix to this was to shorten what we are checking to just look at "Unable to process runnable:" - we lose some information about the error, but further upgrades to the driver should not run into this same type of error again. We are creating the error and thus already know what it is for the most part, but if we want to keep that information I cut out in our check, we can just update the entire string.
