### PR TITLE
LPS-57549 CounterLocalServiceTest is loading DataSources twice, cause…

### DIFF
--- a/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
@@ -161,9 +161,7 @@ public class CounterLocalServiceTest {
 
 			InitUtil.initWithSpring(
 				Arrays.asList(
-					"META-INF/base-spring.xml", "META-INF/hibernate-spring.xml",
-					"META-INF/infrastructure-spring.xml",
-					"META-INF/counter-spring.xml"),
+					"META-INF/base-spring.xml", "META-INF/counter-spring.xml"),
 				false);
 
 			List<Long> ids = new ArrayList<>();


### PR DESCRIPTION
…d by LPS-54649 70fec699e0ac7ba24a19dcd93c906bf26abe340f

@brianchandotcom this is fixing the random CounterLocalServiceTest failure on Oracle, it turns out LPS-54649 made it loads every DataSource twice, because it is unconditionally loading some spring files which is already loaded explicitly inside CounterLocalServiceTest. So that we end up creating 4 DataSource per testing jvm. Just oracle is not scaling well on these many connections. This fix gets it back to 2 DataSource per testing jvm, we should be fine from now on.
