### PR TITLE
LPS-57637 Automatic build of jQuery Form Plugin

### DIFF
--- a/modules/frontend/frontend-js-web/build.xml
+++ b/modules/frontend/frontend-js-web/build.xml
@@ -4,6 +4,7 @@
 <project>
 	<property name="alloy.bootstrap.version" value="3.2.0-2" />
 	<property name="alloy.version" value="3.0.1" />
+	<property name="jquery.plugins.form.version" value="3.51" />
 	<property name="lexicon.version" value="0.1.9" />
 	<property name="third.party.dir" value="../../../portal-web/third-party" />
 
@@ -265,12 +266,41 @@
 		</sequential>
 	</macrodef>
 
+	<macrodef name="build-jquery-plugins-form">
+		<sequential>
+			<if>
+				<not>
+					<available file="src/META-INF/resources/html/js/jquery/form.js" />
+				</not>
+				<then>
+					<mirrors-get
+						dest="src/META-INF/resources/html/js/jquery/form.js"
+						src="https://raw.githubusercontent.com/malsup/form/${jquery.plugins.form.version}/jquery.form.js"
+					/>
+
+					<replace file="src/META-INF/resources/html/js/jquery/form.js">
+						<replacetoken><![CDATA[typeof define === 'function']]></replacetoken>
+						<replacevalue><![CDATA[false && typeof define === 'function']]></replacevalue>
+					</replace>
+
+					<loadfile property="form.js.content" srcFile="src/META-INF/resources/html/js/jquery/form.js" />
+
+					<echo file="src/META-INF/resources/html/js/jquery/form.js"><![CDATA[;(function(jQuery){]]>${line.separator}${form.js.content}<![CDATA[})(AUI.$);]]></echo>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<target name="build-alloy">
 		<build-alloy />
 	</target>
 
 	<target name="build-alloy-bootstrap">
 		<build-alloy-bootstrap />
+	</target>
+
+	<target name="build-jquery-plugins-form">
+		<build-jquery-plugins-form />
 	</target>
 
 	<target name="build-lexicon">
@@ -285,6 +315,8 @@
 		<build-alloy-bootstrap />
 
 		<build-alloy />
+
+		<build-jquery-plugins-form />
 
 		<build-lexicon />
 

--- a/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/jquery/form.js
+++ b/modules/frontend/frontend-js-web/src/META-INF/resources/html/js/jquery/form.js
@@ -13,7 +13,14 @@
 
 // AMD support
 (function (factory) {
-    factory( (typeof(jQuery) != 'undefined') ? jQuery : window.Zepto );
+    "use strict";
+    if (false && typeof define === 'function' && define.amd) {
+        // using AMD; register as anon module
+        define(['jquery'], factory);
+    } else {
+        // no AMD; invoke directly
+        factory( (typeof(jQuery) != 'undefined') ? jQuery : window.Zepto );
+    }
 }
 
 (function($) {
@@ -66,7 +73,7 @@ feature.formdata = window.FormData !== undefined;
 var hasProp = !!$.fn.prop;
 
 // attr2 uses prop when it can but checks the return type for
-// an expected string.  this accounts for the case where a form
+// an expected string.  this accounts for the case where a form 
 // contains inputs with names like "action" or "method"; in those
 // cases "prop" returns the element
 $.fn.attr2 = function() {
@@ -455,7 +462,7 @@ $.fn.ajaxSubmit = function(options) {
 
         var CLIENT_TIMEOUT_ABORT = 1;
         var SERVER_ABORT = 2;
-
+                
         function getDoc(frame) {
             /* it looks like contentWindow or contentDocument do not
              * carry the protocol property in ie8, when running under ssl
@@ -463,9 +470,9 @@ $.fn.ajaxSubmit = function(options) {
              * the protocol is know but not on the other two objects. strange?
              * "Same origin policy" http://en.wikipedia.org/wiki/Same_origin_policy
              */
-
+            
             var doc = null;
-
+            
             // IE8 cascading access check
             try {
                 if (frame.contentWindow) {
@@ -501,8 +508,8 @@ $.fn.ajaxSubmit = function(options) {
         // take a breath so that pending repaints get some cpu time before the upload starts
         function doSubmit() {
             // make sure form attrs are set
-            var t = $form.attr2('target'),
-                a = $form.attr2('action'),
+            var t = $form.attr2('target'), 
+                a = $form.attr2('action'), 
                 mp = 'multipart/form-data',
                 et = $form.attr('enctype') || $form.attr('encoding') || mp;
 
@@ -613,7 +620,7 @@ $.fn.ajaxSubmit = function(options) {
             if (xhr.aborted || callbackProcessed) {
                 return;
             }
-
+            
             doc = getDoc(io);
             if(!doc) {
                 log('cannot access response document');


### PR DESCRIPTION
Hey Brian,

We've updated the build of the `frontend-js-web` module so we don't manually patch the `form.js` plugin anymore. We found there were already manual changes so we reapplied them on top of the downloaded file.

Our patch turns

``` javascript
if (typeof define === 'function' && define.amd)
```

into

``` javascript
if (false && typeof define === 'function' && define.amd)
```

In this way, the changes are minimal and the js-minifier will remove this dead code in production. 

/cc @ipeychev @natecavanaugh 
