### PR TITLE
LPS-57653 Add dynamic data mapping jars to SampleSQLBuilder classpath

### DIFF
--- a/benchmarks/build.xml
+++ b/benchmarks/build.xml
@@ -5,7 +5,7 @@
 
 	<target name="build-sample-sql">
 		<path id="sample.sql.builder.classpath">
-			<fileset dir="${sdk.dir}/dist" includes="com.liferay.dynamic.data.lists.*.jar" />
+			<fileset dir="${sdk.dir}/dist" includes="com.liferay.dynamic.data.*.jar" />
 			<fileset dir="${sdk.dir}/dist" includes="com.liferay.journal.*.jar" />
 			<fileset dir="${sdk.dir}/dist" includes="com.liferay.portal.tools.sample.sql.builder*.jar" />
 			<fileset dir="${sdk.dir}/dist" includes="com.liferay.wiki.*.jar" />


### PR DESCRIPTION
@tomwang2011 is going to make a change so that benchmarks/build.xml is going to pick up the classpath info from modules/util/portal-tools-sample-sql-builder/build.xml, so that in the future we won't have to remember update classpath in 2 different locations.
