### PR TITLE
LPS-57662 ProxyModeThreadLocal.isForceSync() should be transalted to …

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/search/SearchEngineUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/SearchEngineUtil.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.search;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.search.queue.QueuingSearchEngine;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 import com.liferay.portal.kernel.util.ClassUtil;
@@ -891,7 +892,8 @@ public class SearchEngineUtil {
 
 		SearchContext searchContext = new SearchContext();
 
-		searchContext.setCommitImmediately(commitImmediately);
+		searchContext.setCommitImmediately(
+			commitImmediately || ProxyModeThreadLocal.isForceSync());
 		searchContext.setCompanyId(companyId);
 		searchContext.setSearchEngineId(searchEngineId);
 


### PR DESCRIPTION
Fix for the random com.liferay.document.library.search.test.DLFileEntrySearchTest.testSearchTikaRawMetadata failure like this https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch%28master%29/AXIS_VARIABLE=3,label_exp=!master/3629/testReport/com.liferay.document.library.search.test/DLFileEntrySearchTest/testSearchTikaRawMetadata/, and it actually should fix all the arquillian tests' random failures caused by async indexing.

CC @mhan810
