### PR TITLE
LPS-51081 Patched "gradle-resources-http" with forced cache logic

### DIFF
--- a/modules/sdk/gradle-plugins/src/com/liferay/gradle/plugins/LiferayJavaPlugin.java
+++ b/modules/sdk/gradle-plugins/src/com/liferay/gradle/plugins/LiferayJavaPlugin.java
@@ -1505,7 +1505,13 @@ public class LiferayJavaPlugin implements Plugin<Project> {
 	protected void configureTaskDeploy(
 		Project project, LiferayExtension liferayExtension) {
 
-		Copy copy = (Copy)GradleUtil.getTask(project, DEPLOY_TASK_NAME);
+		Task task = GradleUtil.getTask(project, DEPLOY_TASK_NAME);
+
+		if (!(task instanceof Copy)) {
+			return;
+		}
+
+		Copy copy = (Copy)task;
 
 		configureTaskDeployInto(copy, liferayExtension);
 

--- a/modules/sdk/gradle-plugins/src/com/liferay/gradle/plugins/LiferayOSGiPlugin.java
+++ b/modules/sdk/gradle-plugins/src/com/liferay/gradle/plugins/LiferayOSGiPlugin.java
@@ -659,9 +659,13 @@ public class LiferayOSGiPlugin extends LiferayJavaPlugin {
 
 		super.configureTaskDeploy(project, liferayExtension);
 
-		Copy copy = (Copy)GradleUtil.getTask(project, DEPLOY_TASK_NAME);
+		Task task = GradleUtil.getTask(project, DEPLOY_TASK_NAME);
 
-		configureTaskDeployRename(copy);
+		if (!(task instanceof Copy)) {
+			return;
+		}
+
+		configureTaskDeployRename((Copy)task);
 	}
 
 	@Override

--- a/modules/third-party/org-gradle-resources-http/bnd.bnd
+++ b/modules/third-party/org-gradle-resources-http/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-SymbolicName: gradle-resources-http
+Bundle-Version: 2.5.LIFERAY-PATCHED-1
+Include-Resource: classes

--- a/modules/third-party/org-gradle-resources-http/build.gradle
+++ b/modules/third-party/org-gradle-resources-http/build.gradle
@@ -1,0 +1,46 @@
+import com.liferay.gradle.util.FileUtil
+
+dependencies {
+	compile gradleApi()
+}
+
+String gradleVersion = version.substring(0, version.lastIndexOf('.'))
+
+if (gradleVersion != gradle.gradleVersion) {
+	throw new GradleException("Unable to use Gradle " + gradle.gradleVersion + ", " + gradleVersion + " is required")
+}
+
+task deploy(type: Zip, overwrite: true)
+task jar(type: Jar, overwrite: true)
+
+deploy {
+	baseName = "gradle"
+	classifier = "bin"
+	destinationDir = rootProject.file("../tools")
+	exclude "gradle-${gradleVersion}/lib/plugins/gradle-resources-http-${gradleVersion}.jar"
+
+	ext {
+		autoClean = false
+	}
+
+	from zipTree(
+		{
+			FileUtil.get(project, "https://services.gradle.org/distributions/gradle-${gradleVersion}-bin.zip")
+		})
+
+	into("gradle-${gradleVersion}/lib/plugins") {
+		from jar
+	}
+}
+
+jar {
+	duplicatesStrategy = "exclude"
+	from sourceSets.main.output
+
+	from zipTree(
+		{
+			configurations.compile.find {
+				it.name.startsWith "gradle-resources-http-"
+			}
+		})
+}

--- a/modules/third-party/org-gradle-resources-http/build.xml
+++ b/modules/third-party/org-gradle-resources-http/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../tools/sdk/build-common-osgi-plugin.xml" />
+</project>

--- a/modules/third-party/org-gradle-resources-http/ivy.xml
+++ b/modules/third-party/org-gradle-resources-http/ivy.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<ivy-module
+	version="2.0"
+	xmlns:m2="http://ant.apache.org/ivy/maven"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd"
+>
+	<info module="${plugin.name}" organisation="com.liferay">
+		<extends extendType="configurations,description,info" location="${sdk.dir}/ivy.xml" module="com.liferay.sdk" organisation="com.liferay" revision="latest.integration" />
+	</info>
+
+	<publications>
+		<artifact type="jar" />
+		<artifact type="pom" />
+		<artifact m2:classifier="sources" />
+	</publications>
+
+	<dependencies defaultconf="default" />
+</ivy-module>

--- a/modules/third-party/org-gradle-resources-http/src/META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry
+++ b/modules/third-party/org-gradle-resources-http/src/META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry
@@ -1,0 +1,1 @@
+org.gradle.internal.resource.transport.http.LiferayHttpResourcesPluginServiceRegistry

--- a/modules/third-party/org-gradle-resources-http/src/org/gradle/internal/resource/transport/http/LiferayHttpConnectorFactory.java
+++ b/modules/third-party/org-gradle-resources-http/src/org/gradle/internal/resource/transport/http/LiferayHttpConnectorFactory.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import org.gradle.internal.resource.PasswordCredentials;
+import org.gradle.internal.resource.connector.ResourceConnectorSpecification;
+import org.gradle.internal.resource.transfer.DefaultExternalResourceConnector;
+import org.gradle.internal.resource.transfer.ExternalResourceConnector;
+
+/**
+ * @author Andrea Di Giorgi
+ */
+public class LiferayHttpConnectorFactory extends HttpConnectorFactory {
+
+	@Override
+	public ExternalResourceConnector createResourceConnector(
+		ResourceConnectorSpecification resourceConnectorSpecification) {
+
+		HttpClientHelper httpClientHelper = new HttpClientHelper(
+			new DefaultHttpSettings(
+				resourceConnectorSpecification.getCredentials(
+					PasswordCredentials.class)));
+
+		HttpResourceAccessor httpResourceAccessor =
+			new LiferayHttpResourceAccessor(httpClientHelper);
+		HttpResourceLister httpResourceLister = new HttpResourceLister(
+			httpResourceAccessor);
+		HttpResourceUploader httpResourceUploader = new HttpResourceUploader(
+			httpClientHelper);
+
+		return new DefaultExternalResourceConnector(
+			httpResourceAccessor, httpResourceLister, httpResourceUploader);
+	}
+
+}

--- a/modules/third-party/org-gradle-resources-http/src/org/gradle/internal/resource/transport/http/LiferayHttpResourceAccessor.java
+++ b/modules/third-party/org-gradle-resources-http/src/org/gradle/internal/resource/transport/http/LiferayHttpResourceAccessor.java
@@ -1,0 +1,363 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+import java.net.URI;
+
+import java.util.Iterator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+
+import org.gradle.internal.hash.HashUtil;
+import org.gradle.internal.hash.HashValue;
+import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
+import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Andrea Di Giorgi
+ */
+public class LiferayHttpResourceAccessor extends HttpResourceAccessor {
+
+	public LiferayHttpResourceAccessor(HttpClientHelper httpClientHelper) {
+		super(httpClientHelper);
+	}
+
+	@Override
+	public ExternalResourceMetaData getMetaData(URI uri) {
+		if (!_FORCED_CACHE_ENABLED) {
+			return super.getMetaData(uri);
+		}
+
+		String location = _getLocation(uri);
+
+		if (StringUtils.isBlank(location)) {
+			return super.getMetaData(uri);
+		}
+
+		File cachedArtifactFile = _getCachedArtifactFile(location);
+
+		if (cachedArtifactFile == null) {
+			return super.getMetaData(uri);
+		}
+
+		HashValue hashValue = HashUtil.sha1(cachedArtifactFile);
+
+		return new DefaultExternalResourceMetaData(
+			uri, cachedArtifactFile.lastModified(), cachedArtifactFile.length(),
+			null, hashValue.asHexString(), hashValue);
+	}
+
+	@Override
+	public HttpResponseResource openResource(URI uri) {
+		if (!_FORCED_CACHE_ENABLED) {
+			return super.openResource(uri);
+		}
+
+		String location = _getLocation(uri);
+
+		if (StringUtils.isBlank(location)) {
+			return super.openResource(uri);
+		}
+
+		HttpResponseResource httpResponseResource = null;
+
+		try {
+			if (StringUtils.endsWithIgnoreCase(
+					location, "/maven-metadata.xml")) {
+
+				httpResponseResource = _getMavenMetadataResponseResource(
+					uri, location);
+			}
+			else if (StringUtils.endsWithIgnoreCase(location, ".sha1")) {
+				httpResponseResource = _getSHA1ResponseResource(uri, location);
+			}
+		}
+		catch (Exception e) {
+			_logger.error(e.getMessage(), e);
+		}
+
+		if (httpResponseResource == null) {
+			httpResponseResource = super.openResource(uri);
+		}
+
+		return httpResponseResource;
+	}
+
+	private File _fetchCachedFile(File dir, String fileName) {
+		File cachedFile = null;
+
+		Iterator<File> iterator = FileUtils.iterateFiles(
+			dir, new NameFileFilter(fileName), TrueFileFilter.TRUE);
+
+		while (iterator.hasNext()) {
+			File file = iterator.next();
+
+			if ((cachedFile == null) ||
+				(cachedFile.lastModified() < file.lastModified())) {
+
+				cachedFile = file;
+			}
+		}
+
+		return cachedFile;
+	}
+
+	private File _getCachedArtifactFile(String location) {
+		String[] tokens = StringUtils.split(location, '/');
+
+		String fileName = tokens[tokens.length - 1];
+		String group = StringUtils.join(tokens, '.', 0, tokens.length - 3);
+		String module = tokens[tokens.length - 3];
+		String version = tokens[tokens.length - 2];
+
+		File artifactDir = new File(
+			_getGradleUserHome(),
+			_FILES_CACHE_DIR_NAME + "/" + group + "/" + module + "/" + version);
+
+		if (!artifactDir.exists()) {
+			return null;
+		}
+
+		File cachedFile = _fetchCachedFile(artifactDir, fileName);
+
+		if (cachedFile == null) {
+			cachedFile = _fetchCachedFile(
+				artifactDir,
+				module + "-" + version + "." +
+					FilenameUtils.getExtension(fileName));
+		}
+
+		return cachedFile;
+	}
+
+	private File _getGradleUserHome() {
+		String gradleUserHome = System.getProperty("gradle.user.home");
+
+		if (StringUtils.isBlank(gradleUserHome)) {
+			gradleUserHome = System.getenv("GRADLE_USER_HOME");
+		}
+
+		if (StringUtils.isBlank(gradleUserHome)) {
+			gradleUserHome = System.getProperty("user.home") + "/.gradle";
+		}
+
+		return new File(gradleUserHome);
+	}
+
+	private String _getLocation(URI uri) {
+		String location = uri.toString();
+
+		for (String repositoryUrl : _REPOSITORY_URLS) {
+			if (location.startsWith(repositoryUrl)) {
+				return location.substring(repositoryUrl.length());
+			}
+		}
+
+		return null;
+	}
+
+	private HttpResponseResource _getMavenMetadataResponseResource(
+			URI uri, String location)
+		throws Exception {
+
+		String[] tokens = StringUtils.split(location, '/');
+
+		String group = null;
+		String module = null;
+		String version = tokens[tokens.length - 2];
+
+		if (StringUtils.endsWithIgnoreCase(version, "-SNAPSHOT")) {
+			group = StringUtils.join(tokens, '.', 0, tokens.length - 3);
+			module = tokens[tokens.length - 3];
+		}
+		else {
+			group = StringUtils.join(tokens, '.', 0, tokens.length - 2);
+			module = version;
+			version = null;
+		}
+
+		File moduleDir = new File(
+			_getGradleUserHome(),
+			_FILES_CACHE_DIR_NAME + "/" + group + "/" + module);
+
+		if (!moduleDir.exists()) {
+			return null;
+		}
+
+		if (StringUtils.isNotBlank(version)) {
+			File artifactDir = new File(moduleDir, version);
+
+			if (!artifactDir.exists()) {
+				return null;
+			}
+		}
+
+		Metadata metadata = new Metadata();
+
+		metadata.setArtifactId(module);
+		metadata.setGroupId(group);
+
+		Versioning versioning = new Versioning();
+
+		if (StringUtils.isNotBlank(version)) {
+			metadata.setVersion(version);
+		}
+		else {
+			SortedSet<ComparableVersion> moduleVersions = _getModuleVersions(
+				moduleDir, false);
+
+			for (ComparableVersion moduleVersion : moduleVersions) {
+				versioning.addVersion(moduleVersion.toString());
+			}
+		}
+
+		versioning.setLatest(_getModuleLatestVersion(moduleDir, false));
+		versioning.setRelease(_getModuleLatestVersion(moduleDir, true));
+
+		metadata.setVersioning(versioning);
+
+		MetadataXpp3Writer metadataXpp3Writer = new MetadataXpp3Writer();
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		metadataXpp3Writer.write(byteArrayOutputStream, metadata);
+
+		HttpResponse httpResponse = new BasicHttpResponse(
+			new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, null));
+
+		httpResponse.setEntity(
+			new ByteArrayEntity(
+				byteArrayOutputStream.toByteArray(),
+				ContentType.APPLICATION_XML));
+		httpResponse.setHeader(
+			HttpHeaders.CONTENT_LENGTH,
+			String.valueOf(byteArrayOutputStream.size()));
+
+		return new HttpResponseResource(HttpGet.METHOD_NAME, uri, httpResponse);
+	}
+
+	private String _getModuleLatestVersion(
+		File moduleDir, boolean excludeSnapshots) {
+
+		SortedSet<ComparableVersion> moduleVersions = _getModuleVersions(
+			moduleDir, excludeSnapshots);
+
+		if (moduleVersions.isEmpty()) {
+			return null;
+		}
+
+		ComparableVersion moduleVersion = moduleVersions.last();
+
+		return moduleVersion.toString();
+	}
+
+	private SortedSet<ComparableVersion> _getModuleVersions(
+		File moduleDir, boolean excludeSnapshots) {
+
+		SortedSet<ComparableVersion> moduleVersions = new TreeSet<>();
+
+		String[] versions = moduleDir.list(DirectoryFileFilter.DIRECTORY);
+
+		for (String version : versions) {
+			if (excludeSnapshots &&
+				StringUtils.endsWithIgnoreCase(version, "-SNAPSHOT")) {
+
+				continue;
+			}
+
+			moduleVersions.add(new ComparableVersion(version));
+		}
+
+		return moduleVersions;
+	}
+
+	private HttpResponseResource _getSHA1ResponseResource(
+			URI uri, String location)
+		throws Exception {
+
+		location = location.substring(0, location.length() - 5);
+
+		File cachedArtifactFile = _getCachedArtifactFile(location);
+
+		if (cachedArtifactFile == null) {
+			return null;
+		}
+
+		HashValue hashValue = HashUtil.sha1(cachedArtifactFile);
+
+		String sha1 = hashValue.asHexString();
+
+		HttpResponse httpResponse = new BasicHttpResponse(
+			new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, null));
+
+		httpResponse.setEntity(new StringEntity(sha1));
+		httpResponse.setHeader(
+			HttpHeaders.CONTENT_LENGTH, String.valueOf(sha1.length()));
+		httpResponse.setHeader(
+			HttpHeaders.LAST_MODIFIED,
+			String.valueOf(cachedArtifactFile.lastModified()));
+
+		return new HttpResponseResource(HttpGet.METHOD_NAME, uri, httpResponse);
+	}
+
+	private static final String _FILES_CACHE_DIR_NAME =
+		"caches/modules-2/files-2.1";
+
+	private static final boolean _FORCED_CACHE_ENABLED = Boolean.getBoolean(
+		"forced.cache.enabled");
+
+	private static final String[] _REPOSITORY_URLS = {
+		"http://cdn.repository.liferay.com/nexus/content/groups/public/",
+		"http://repository.liferay.com/nexus/content/groups/public/"
+	};
+
+	private static final Logger _logger = LoggerFactory.getLogger(
+		LiferayHttpResourceAccessor.class);
+
+	static {
+		if (_FORCED_CACHE_ENABLED) {
+			System.out.println("Forced cache is enabled.");
+		}
+	}
+
+}

--- a/modules/third-party/org-gradle-resources-http/src/org/gradle/internal/resource/transport/http/LiferayHttpResourcesPluginServiceRegistry.java
+++ b/modules/third-party/org-gradle-resources-http/src/org/gradle/internal/resource/transport/http/LiferayHttpResourcesPluginServiceRegistry.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import org.gradle.internal.resource.connector.ResourceConnectorFactory;
+import org.gradle.internal.service.ServiceRegistration;
+import org.gradle.internal.service.scopes.PluginServiceRegistry;
+
+/**
+ * @author Andrea Di Giorgi
+ */
+public class LiferayHttpResourcesPluginServiceRegistry
+	implements PluginServiceRegistry {
+
+	@Override
+	public void registerBuildServices(ServiceRegistration serviceRegistration) {
+	}
+
+	@Override
+	public void registerGlobalServices(
+		ServiceRegistration serviceRegistration) {
+
+		serviceRegistration.addProvider(new GlobalScopeServices());
+	}
+
+	@Override
+	public void registerGradleServices(
+		ServiceRegistration serviceRegistration) {
+	}
+
+	@Override
+	public void registerProjectServices(
+		ServiceRegistration serviceRegistration) {
+	}
+
+	private static class GlobalScopeServices {
+
+		@SuppressWarnings("unused")
+		public ResourceConnectorFactory createHttpConnectorFactory() {
+			return new LiferayHttpConnectorFactory();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Hi @brianchandotcom!

This is the same as https://github.com/brianchandotcom/liferay-portal/pull/29003, I just renamed `gradle-resources-http` to `org-gradle-resources-http`.

In the `bnd.bnd` file, I kept `Bundle-SymbolicName: gradle-resources-http` because the Gradle plugin uses it as the base name for the jars. This way, the jar will be called `gradle-resources-http-2.5.LIFERAY-PATCHED-1.jar` (which is consistent to the name of the jar we're replacing) and not `org-gradle-resources-http-2.5.LIFERAY-PATCHED-1.jar`.
