### PR TITLE
7.0.x-qa-17257

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -593,7 +593,7 @@
 ## Liferay Portal
 ##
 
-    liferay.portal.branch=master
+    liferay.portal.branch=7.0.x
 
     liferay.portal.master.bundle=latest
 


### PR DESCRIPTION
http://issues.liferay.com/browse/LRQA-16935

@brianchandotcom - We need this for 'testray' results so that these are separate from the 'master' results, otherwise they will blend together.
