### PR TITLE
[TECHNICAL-SUPPORT] LPS-57164 Improve search memory usage when searching several pages into the results (ie. page 10+)

### DIFF
--- a/modules/apps/bookmarks/bookmarks-api/src/com/liferay/bookmarks/service/BookmarksFolderLocalService.java
+++ b/modules/apps/bookmarks/bookmarks-api/src/com/liferay/bookmarks/service/BookmarksFolderLocalService.java
@@ -370,8 +370,8 @@ public interface BookmarksFolderLocalService extends BaseLocalService,
 		throws PortalException;
 
 	@com.liferay.portal.kernel.search.Indexable(type = IndexableType.REINDEX)
-	public void restoreFolderFromTrash(long userId, long folderId)
-		throws PortalException;
+	public com.liferay.bookmarks.model.BookmarksFolder restoreFolderFromTrash(
+		long userId, long folderId) throws PortalException;
 
 	/**
 	* Sets the Spring bean ID for this bean.

--- a/modules/apps/bookmarks/bookmarks-api/src/com/liferay/bookmarks/service/BookmarksFolderLocalServiceUtil.java
+++ b/modules/apps/bookmarks/bookmarks-api/src/com/liferay/bookmarks/service/BookmarksFolderLocalServiceUtil.java
@@ -445,9 +445,10 @@ public class BookmarksFolderLocalServiceUtil {
 			.rebuildTree(companyId, parentFolderId, parentTreePath, reindex);
 	}
 
-	public static void restoreFolderFromTrash(long userId, long folderId)
+	public static com.liferay.bookmarks.model.BookmarksFolder restoreFolderFromTrash(
+		long userId, long folderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		getService().restoreFolderFromTrash(userId, folderId);
+		return getService().restoreFolderFromTrash(userId, folderId);
 	}
 
 	/**

--- a/modules/apps/bookmarks/bookmarks-api/src/com/liferay/bookmarks/service/BookmarksFolderLocalServiceWrapper.java
+++ b/modules/apps/bookmarks/bookmarks-api/src/com/liferay/bookmarks/service/BookmarksFolderLocalServiceWrapper.java
@@ -496,9 +496,11 @@ public class BookmarksFolderLocalServiceWrapper
 	}
 
 	@Override
-	public void restoreFolderFromTrash(long userId, long folderId)
+	public com.liferay.bookmarks.model.BookmarksFolder restoreFolderFromTrash(
+		long userId, long folderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_bookmarksFolderLocalService.restoreFolderFromTrash(userId, folderId);
+		return _bookmarksFolderLocalService.restoreFolderFromTrash(userId,
+			folderId);
 	}
 
 	/**

--- a/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/search/BookmarksFolderIndexer.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/search/BookmarksFolderIndexer.java
@@ -89,9 +89,7 @@ public class BookmarksFolderIndexer extends BaseIndexer<BookmarksFolder> {
 	protected void doDelete(BookmarksFolder bookmarksFolder) throws Exception {
 		Document document = new DocumentImpl();
 
-		document.addUID(
-			CLASS_NAME, bookmarksFolder.getFolderId(),
-			bookmarksFolder.getName());
+		document.addUID(CLASS_NAME, bookmarksFolder.getFolderId());
 
 		SearchEngineUtil.deleteDocument(
 			getSearchEngineId(), bookmarksFolder.getCompanyId(),

--- a/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/service/impl/BookmarksFolderLocalServiceImpl.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/com/liferay/bookmarks/service/impl/BookmarksFolderLocalServiceImpl.java
@@ -500,7 +500,7 @@ public class BookmarksFolderLocalServiceImpl
 
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
-	public void restoreFolderFromTrash(long userId, long folderId)
+	public BookmarksFolder restoreFolderFromTrash(long userId, long folderId)
 		throws PortalException {
 
 		// Folder
@@ -537,6 +537,8 @@ public class BookmarksFolderLocalServiceImpl
 			folder.getFolderId(),
 			SocialActivityConstants.TYPE_RESTORE_FROM_TRASH,
 			extraDataJSONObject.toString(), 0);
+
+		return folder;
 	}
 
 	@Override

--- a/modules/apps/journal/journal-service/src/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -3609,6 +3609,15 @@ public class JournalArticleLocalServiceImpl
 			JournalArticle.class.getName(), article.getResourcePrimKey(),
 			false);
 
+		// Comment
+
+		if (JournalServiceConfigurationValues.
+				JOURNAL_ARTICLE_COMMENTS_ENABLED) {
+
+			CommentManagerUtil.moveDiscussionToTrash(
+				JournalArticle.class.getName(), article.getResourcePrimKey());
+		}
+
 		// Social
 
 		JSONObject extraDataJSONObject = JSONFactoryUtil.createJSONObject();
@@ -3805,6 +3814,15 @@ public class JournalArticleLocalServiceImpl
 
 		trashEntryLocalService.deleteEntry(
 			JournalArticle.class.getName(), article.getResourcePrimKey());
+
+		// Comment
+
+		if (JournalServiceConfigurationValues.
+				JOURNAL_ARTICLE_COMMENTS_ENABLED) {
+
+			CommentManagerUtil.restoreDiscussionFromTrash(
+				JournalArticle.class.getName(), article.getResourcePrimKey());
+		}
 
 		// Social
 

--- a/modules/apps/message-boards/message-boards-comment/src/com/liferay/message/boards/comment/MBCommentManagerImpl.java
+++ b/modules/apps/message-boards/message-boards-comment/src/com/liferay/message/boards/comment/MBCommentManagerImpl.java
@@ -252,6 +252,30 @@ public class MBCommentManagerImpl implements CommentManager {
 		return true;
 	}
 
+	@Override
+	public void moveDiscussionToTrash(String className, long classPK) {
+		List<MBMessage> messages = _mbMessageLocalService.getMessages(
+			className, classPK, WorkflowConstants.STATUS_APPROVED);
+
+		for (MBMessage message : messages) {
+			message.setStatus(WorkflowConstants.STATUS_IN_TRASH);
+
+			_mbMessageLocalService.updateMBMessage(message);
+		}
+	}
+
+	@Override
+	public void restoreDiscussionFromTrash(String className, long classPK) {
+		List<MBMessage> messages = _mbMessageLocalService.getMessages(
+			className, classPK, WorkflowConstants.STATUS_IN_TRASH);
+
+		for (MBMessage message : messages) {
+			message.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+			_mbMessageLocalService.updateMBMessage(message);
+		}
+	}
+
 	@Reference(unbind = "-")
 	public void setMBDiscussionLocalService(
 		MBDiscussionLocalService mbDiscussionLocalService) {

--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/search/WikiNodeIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/search/WikiNodeIndexer.java
@@ -80,7 +80,7 @@ public class WikiNodeIndexer extends BaseIndexer<WikiNode> {
 	protected void doDelete(WikiNode wikiNode) throws Exception {
 		Document document = new DocumentImpl();
 
-		document.addUID(CLASS_NAME, wikiNode.getNodeId(), wikiNode.getName());
+		document.addUID(CLASS_NAME, wikiNode.getNodeId());
 
 		SearchEngineUtil.deleteDocument(
 			getSearchEngineId(), wikiNode.getCompanyId(),
@@ -91,7 +91,7 @@ public class WikiNodeIndexer extends BaseIndexer<WikiNode> {
 	protected Document doGetDocument(WikiNode wikiNode) throws Exception {
 		Document document = getBaseModelDocument(CLASS_NAME, wikiNode);
 
-		document.addUID(CLASS_NAME, wikiNode.getNodeId(), wikiNode.getName());
+		document.addUID(CLASS_NAME, wikiNode.getNodeId());
 
 		document.addText(Field.DESCRIPTION, wikiNode.getDescription());
 		document.addText(Field.TITLE, wikiNode.getName());

--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/search/WikiPageIndexer.java
@@ -183,14 +183,14 @@ public class WikiPageIndexer
 
 	@Override
 	protected void doDelete(WikiPage wikiPage) throws Exception {
-		deleteDocument(wikiPage.getCompanyId(), wikiPage.getPageId());
+		deleteDocument(wikiPage.getCompanyId(), wikiPage.getResourcePrimKey());
 	}
 
 	@Override
 	protected Document doGetDocument(WikiPage wikiPage) throws Exception {
 		Document document = getBaseModelDocument(CLASS_NAME, wikiPage);
 
-		document.addUID(CLASS_NAME, wikiPage.getNodeId(), wikiPage.getTitle());
+		document.addUID(CLASS_NAME, wikiPage.getResourcePrimKey());
 
 		String content = HtmlUtil.extractText(
 			WikiUtil.convert(wikiPage, null, null, null));

--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/search/WikiPageIndexer.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/search/WikiPageIndexer.java
@@ -217,8 +217,11 @@ public class WikiPageIndexer
 
 	@Override
 	protected void doReindex(String className, long classPK) throws Exception {
-		WikiPage page = WikiPageLocalServiceUtil.getPage(
-			classPK, (Boolean)null);
+		WikiPage page = WikiPageLocalServiceUtil.fetchWikiPage(classPK);
+
+		if (page == null) {
+			page = WikiPageLocalServiceUtil.getPage(classPK, (Boolean)null);
+		}
 
 		doReindex(page);
 	}

--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -1723,6 +1723,11 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		assetEntryLocalService.updateVisible(
 			WikiPage.class.getName(), page.getResourcePrimKey(), false);
 
+		// Comment
+
+		CommentManagerUtil.moveDiscussionToTrash(
+			WikiPage.class.getName(), page.getResourcePrimKey());
+
 		// Social
 
 		JSONObject extraDataJSONObject = JSONFactoryUtil.createJSONObject();
@@ -3006,6 +3011,11 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		}
 
 		trashEntryLocalService.deleteEntry(
+			WikiPage.class.getName(), page.getResourcePrimKey());
+
+		// Comment
+
+		CommentManagerUtil.restoreDiscussionFromTrash(
 			WikiPage.class.getName(), page.getResourcePrimKey());
 
 		// Social

--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -1723,6 +1723,13 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		assetEntryLocalService.updateVisible(
 			WikiPage.class.getName(), page.getResourcePrimKey(), false);
 
+		// Attachments
+
+		for (FileEntry fileEntry : page.getAttachmentsFileEntries()) {
+			PortletFileRepositoryUtil.movePortletFileEntryToTrash(
+				userId, fileEntry.getFileEntryId());
+		}
+
 		// Comment
 
 		CommentManagerUtil.moveDiscussionToTrash(
@@ -2743,6 +2750,15 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 				WikiPage.class.getName(), page.getResourcePrimKey(), true);
 		}
 
+		// Attachments
+
+		WikiNode node = page.getNode();
+
+		for (FileEntry fileEntry : page.getAttachmentsFileEntries()) {
+			PortletFileRepositoryUtil.restorePortletFileEntryFromTrash(
+				node.getStatusByUserId(), fileEntry.getFileEntryId());
+		}
+
 		// Index
 
 		Indexer<WikiPage> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
@@ -2886,6 +2902,15 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 				WikiPage.class.getName(), page.getResourcePrimKey(), false);
 		}
 
+		// Attachments
+
+		WikiNode node = page.getNode();
+
+		for (FileEntry fileEntry : page.getAttachmentsFileEntries()) {
+			PortletFileRepositoryUtil.movePortletFileEntryToTrash(
+				node.getStatusByUserId(), fileEntry.getFileEntryId());
+		}
+
 		// Indexer
 
 		Indexer<WikiPage> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
@@ -2987,6 +3012,13 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		updateStatus(
 			userId, page, trashEntry.getStatus(), new ServiceContext(),
 			new HashMap<String, Serializable>());
+
+		// Attachments
+
+		for (FileEntry fileEntry : page.getAttachmentsFileEntries()) {
+			PortletFileRepositoryUtil.restorePortletFileEntryFromTrash(
+				userId, fileEntry.getFileEntryId());
+		}
 
 		// Child pages
 

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaClass.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaClass.java
@@ -108,6 +108,16 @@ public class JavaClass {
 
 			checkUnusedParameters(javaTerm);
 
+			if (_fileName.endsWith("LocalServiceImpl.java") &&
+				javaTerm.hasAnnotation("Indexable") &&
+				!javaTerm.hasReturnType()) {
+
+				_javaSourceProcessor.processErrorMessage(
+					_fileName,
+					"Missing return type for method with @Indexable: " +
+						_fileName + " " + javaTerm.getLineCount());
+			}
+
 			if (!BaseSourceProcessor.isExcludedFile(
 					checkJavaFieldTypesExclusionFiles, _absolutePath)) {
 

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaClass.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaClass.java
@@ -881,7 +881,7 @@ public class JavaClass {
 		}
 
 		JavaTerm javaTerm = new JavaTerm(
-			name, type, javaTermContent, lineCount);
+			name, type, javaTermContent, lineCount, _indent);
 
 		if (javaTerm.isConstructor()) {
 			_constructorCount++;

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaClass.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaClass.java
@@ -210,19 +210,13 @@ public class JavaClass {
 		JavaTerm javaTerm, String annotation, String requiredMethodNameRegex,
 		int requiredMethodType, String fileName) {
 
-		String methodContent = javaTerm.getContent();
 		String methodName = javaTerm.getName();
 
 		Pattern pattern = Pattern.compile(requiredMethodNameRegex);
 
 		Matcher matcher = pattern.matcher(methodName);
 
-		if (methodContent.contains(
-				_indent + StringPool.AT + annotation + "\n") ||
-			methodContent.contains(
-				_indent + StringPool.AT + annotation +
-					StringPool.OPEN_PARENTHESIS)) {
-
+		if (javaTerm.hasAnnotation(annotation)) {
 			if (!matcher.find()) {
 				_javaSourceProcessor.processErrorMessage(
 					fileName,
@@ -236,9 +230,7 @@ public class JavaClass {
 						fileName);
 			}
 		}
-		else if (matcher.find() &&
-				 !methodContent.contains(_indent + "@Override")) {
-
+		else if (matcher.find() && !javaTerm.hasAnnotation("Override")) {
 			_javaSourceProcessor.processErrorMessage(
 				fileName,
 				"Annotation @" + annotation + " required for " + methodName +
@@ -351,12 +343,8 @@ public class JavaClass {
 			String modifierDefinition)
 		throws Exception {
 
-		String javaTermContent = javaTerm.getContent();
-
 		for (String annotation : annotationsExclusions) {
-			if (javaTermContent.contains(
-					_indent + StringPool.AT + annotation)) {
-
+			if (javaTerm.hasAnnotation(annotation)) {
 				return;
 			}
 		}
@@ -377,6 +365,8 @@ public class JavaClass {
 		if (!isFinalableField(javaTerm, _name, pattern, true)) {
 			return;
 		}
+
+		String javaTermContent = javaTerm.getContent();
 
 		String newJavaTermContent = StringUtil.replaceFirst(
 			javaTermContent, modifierDefinition, modifierDefinition + " final");

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaSourceProcessor.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaSourceProcessor.java
@@ -303,6 +303,36 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 		}
 	}
 
+	protected void checkIndexableAnnotations(
+		String newContent, String fileName) {
+
+		if (!fileName.endsWith("LocalServiceImpl.java")) {
+			return;
+		}
+
+		int i = newContent.indexOf("@Indexable");
+
+		while (i > 0) {
+			int j = newContent.indexOf(StringPool.OPEN_CURLY_BRACE, i);
+
+			String methodSignature = newContent.substring(i, j);
+
+			if (methodSignature.contains(" void ")) {
+				int k = newContent.indexOf(" void ", i);
+
+				int lineCount = StringUtil.count(
+					newContent.substring(0, k), "\n");
+
+				processErrorMessage(
+					fileName,
+					"Missing return value for Indexable annotation: " +
+						fileName + " " + lineCount);
+			}
+
+			i = newContent.indexOf("@Indexable", j);
+		}
+	}
+
 	protected void checkSystemEventAnnotations(String content, String fileName)
 		throws Exception {
 
@@ -778,6 +808,8 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 		// LPS-41315
 
 		checkLogLevel(newContent, fileName);
+
+		checkIndexableAnnotations(newContent, fileName);
 
 		// LPS-46632
 

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaSourceProcessor.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaSourceProcessor.java
@@ -303,36 +303,6 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 		}
 	}
 
-	protected void checkIndexableAnnotations(
-		String newContent, String fileName) {
-
-		if (!fileName.endsWith("LocalServiceImpl.java")) {
-			return;
-		}
-
-		int i = newContent.indexOf("@Indexable");
-
-		while (i > 0) {
-			int j = newContent.indexOf(StringPool.OPEN_CURLY_BRACE, i);
-
-			String methodSignature = newContent.substring(i, j);
-
-			if (methodSignature.contains(" void ")) {
-				int k = newContent.indexOf(" void ", i);
-
-				int lineCount = StringUtil.count(
-					newContent.substring(0, k), "\n");
-
-				processErrorMessage(
-					fileName,
-					"Missing return value for Indexable annotation: " +
-						fileName + " " + lineCount);
-			}
-
-			i = newContent.indexOf("@Indexable", j);
-		}
-	}
-
 	protected void checkSystemEventAnnotations(String content, String fileName)
 		throws Exception {
 
@@ -808,8 +778,6 @@ public class JavaSourceProcessor extends BaseSourceProcessor {
 		// LPS-41315
 
 		checkLogLevel(newContent, fileName);
-
-		checkIndexableAnnotations(newContent, fileName);
 
 		// LPS-46632
 

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
@@ -112,6 +112,18 @@ public class JavaTerm {
 		return _type;
 	}
 
+	public boolean hasAnnotation(String annotation) {
+		if (_content.contains(_indent + StringPool.AT + annotation + "\n") ||
+			_content.contains(
+				_indent + StringPool.AT + annotation + 
+					StringPool.OPEN_PARENTHESIS)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isClass() {
 		if ((_type == TYPE_CLASS_PRIVATE) ||
 			(_type == TYPE_CLASS_PRIVATE_STATIC) ||

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
@@ -70,11 +70,14 @@ public class JavaTerm {
 
 	public static final int TYPE_VARIABLE_PUBLIC_STATIC = 1;
 
-	public JavaTerm(String name, int type, String content, int lineCount) {
+	public JavaTerm(
+		String name, int type, String content, int lineCount, String indent) {
+
 		_name = name;
 		_type = type;
 		_content = content;
 		_lineCount = lineCount;
+		_indent = indent;
 	}
 
 	public String getContent() {
@@ -381,6 +384,7 @@ public class JavaTerm {
 	}
 
 	private String _content;
+	private String _indent;
 	private int _lineCount;
 	private String _name;
 	private List<String> _parameterNames;

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
@@ -124,6 +124,18 @@ public class JavaTerm {
 		return false;
 	}
 
+	public boolean hasReturnType() {
+		if (!isMethod()) {
+			return false;
+		}
+
+		int i = _content.indexOf(_name);
+
+		String methodSignature = StringUtil.trim(_content.substring(0, i));
+
+		return !methodSignature.endsWith(" void");
+	}
+
 	public boolean isClass() {
 		if ((_type == TYPE_CLASS_PRIVATE) ||
 			(_type == TYPE_CLASS_PRIVATE_STATIC) ||

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/JavaTerm.java
@@ -235,22 +235,6 @@ public class JavaTerm {
 		}
 	}
 
-	public void setContent(String content) {
-		_content = content;
-	}
-
-	public void setLineCount(int lineCount) {
-		_lineCount = lineCount;
-	}
-
-	public void setName(String name) {
-		_name = name;
-	}
-
-	public void setParameterTypes(List<String> parameterTypes) {
-		_parameterTypes = parameterTypes;
-	}
-
 	public void setType(int type) {
 		_type = type;
 	}

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -279,7 +279,7 @@ public class AssetCategoryLocalServiceImpl
 				category.getCategoryId());
 
 		for (AssetCategory curCategory : categories) {
-			deleteCategory(curCategory, true);
+			assetCategoryLocalService.deleteCategory(curCategory, true);
 		}
 
 		if (!categories.isEmpty() && !skipRebuildTree) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -204,7 +204,7 @@ public class AssetVocabularyLocalServiceImpl
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteVocabulary(AssetVocabulary vocabulary)
+	public AssetVocabulary deleteVocabulary(AssetVocabulary vocabulary)
 		throws PortalException {
 
 		// Vocabulary
@@ -221,6 +221,8 @@ public class AssetVocabularyLocalServiceImpl
 
 		assetCategoryLocalService.deleteVocabularyCategories(
 			vocabulary.getVocabularyId());
+
+		return vocabulary;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -1548,6 +1548,11 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			// Trash
 
 			if (oldStatus == WorkflowConstants.STATUS_IN_TRASH) {
+				if (PropsValues.BLOGS_ENTRY_COMMENTS_ENABLED) {
+					commentManager.restoreDiscussionFromTrash(
+						BlogsEntry.class.getName(), entryId);
+				}
+
 				trashEntryLocalService.deleteEntry(
 					BlogsEntry.class.getName(), entryId);
 			}
@@ -1599,12 +1604,22 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			// Trash
 
 			if (status == WorkflowConstants.STATUS_IN_TRASH) {
+				if (PropsValues.BLOGS_ENTRY_COMMENTS_ENABLED) {
+					commentManager.moveDiscussionToTrash(
+						BlogsEntry.class.getName(), entryId);
+				}
+
 				trashEntryLocalService.addTrashEntry(
 					userId, entry.getGroupId(), BlogsEntry.class.getName(),
 					entry.getEntryId(), entry.getUuid(), null, oldStatus, null,
 					null);
 			}
 			else if (oldStatus == WorkflowConstants.STATUS_IN_TRASH) {
+				if (PropsValues.BLOGS_ENTRY_COMMENTS_ENABLED) {
+					commentManager.restoreDiscussionFromTrash(
+						BlogsEntry.class.getName(), entryId);
+				}
+
 				trashEntryLocalService.deleteEntry(
 					BlogsEntry.class.getName(), entryId);
 			}

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileEntryLocalServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.documentlibrary.service.impl;
 
+import com.liferay.portal.kernel.comment.CommentManagerUtil;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -2007,6 +2008,17 @@ public class DLFileEntryLocalServiceImpl
 			userId, new LiferayFileEntry(dlFileEntry),
 			new LiferayFileVersion(dlFileVersion), oldStatus, status,
 			serviceContext, workflowContext);
+
+		if (PropsValues.DL_FILE_ENTRY_COMMENTS_ENABLED) {
+			if (status == WorkflowConstants.STATUS_IN_TRASH) {
+				CommentManagerUtil.moveDiscussionToTrash(
+					DLFileEntry.class.getName(), dlFileEntry.getFileEntryId());
+			}
+			else if (oldStatus == WorkflowConstants.STATUS_IN_TRASH) {
+				CommentManagerUtil.restoreDiscussionFromTrash(
+					DLFileEntry.class.getName(), dlFileEntry.getFileEntryId());
+			}
+		}
 
 		// Indexer
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBThreadLocalServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.increment.BufferedIncrement;
 import com.liferay.portal.kernel.increment.NumberIncrement;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
@@ -660,6 +661,8 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 		Set<Long> userIds = new HashSet<>();
 
+		MBThread thread = mbThreadLocalService.getThread(threadId);
+
 		List<MBMessage> messages = mbMessageLocalService.getThreadMessages(
 			threadId, WorkflowConstants.STATUS_ANY);
 
@@ -698,6 +701,13 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 			if (oldStatus == WorkflowConstants.STATUS_APPROVED) {
 				assetEntryLocalService.updateVisible(
 					MBMessage.class.getName(), message.getMessageId(), false);
+			}
+
+			// Attachments
+
+			for (FileEntry fileEntry : message.getAttachmentsFileEntries()) {
+				PortletFileRepositoryUtil.movePortletFileEntryToTrash(
+					thread.getStatusByUserId(), fileEntry.getFileEntryId());
 			}
 
 			// Indexer
@@ -907,6 +917,8 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 
 		Set<Long> userIds = new HashSet<>();
 
+		MBThread thread = mbThreadLocalService.getThread(threadId);
+
 		List<MBMessage> messages = mbMessageLocalService.getThreadMessages(
 			threadId, WorkflowConstants.STATUS_ANY);
 
@@ -944,6 +956,13 @@ public class MBThreadLocalServiceImpl extends MBThreadLocalServiceBaseImpl {
 			if (oldStatus == WorkflowConstants.STATUS_APPROVED) {
 				assetEntryLocalService.updateVisible(
 					MBMessage.class.getName(), message.getMessageId(), true);
+			}
+
+			// Attachments
+
+			for (FileEntry fileEntry : message.getAttachmentsFileEntries()) {
+				PortletFileRepositoryUtil.restorePortletFileEntryFromTrash(
+					thread.getStatusByUserId(), fileEntry.getFileEntryId());
 			}
 
 			// Indexer

--- a/portal-service/src/com/liferay/portal/kernel/comment/CommentManager.java
+++ b/portal-service/src/com/liferay/portal/kernel/comment/CommentManager.java
@@ -71,6 +71,10 @@ public interface CommentManager {
 	public boolean hasDiscussion(String className, long classPK)
 		throws PortalException;
 
+	public void moveDiscussionToTrash(String className, long classPK);
+
+	public void restoreDiscussionFromTrash(String className, long classPK);
+
 	public void subscribeDiscussion(
 			long userId, long groupId, String className, long classPK)
 		throws PortalException;

--- a/portal-service/src/com/liferay/portal/kernel/comment/CommentManagerUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/comment/CommentManagerUtil.java
@@ -122,6 +122,16 @@ public class CommentManagerUtil {
 		return getCommentManager().hasDiscussion(className, classPK);
 	}
 
+	public static void moveDiscussionToTrash(String className, long classPK) {
+		getCommentManager().moveDiscussionToTrash(className, classPK);
+	}
+
+	public static void restoreDiscussionFromTrash(
+		String className, long classPK) {
+
+		getCommentManager().restoreDiscussionFromTrash(className, classPK);
+	}
+
 	public static void subscribeDiscussion(
 			long userId, long groupId, String className, long classPK)
 		throws PortalException {

--- a/portal-service/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Time;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -41,9 +42,8 @@ public abstract class BaseSearchResultPermissionFilter
 			Set<String> selectedFieldNameSet = SetUtil.fromArray(
 				queryConfig.getSelectedFieldNames());
 
-			for (String selectedFieldName : _PERMISSION_SELECTED_FIELD_NAMES) {
-				selectedFieldNameSet.add(selectedFieldName);
-			}
+			Collections.addAll(
+				selectedFieldNameSet, _PERMISSION_SELECTED_FIELD_NAMES);
 
 			queryConfig.setSelectedFieldNames(
 				selectedFieldNameSet.toArray(

--- a/portal-service/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
@@ -71,6 +71,7 @@ public abstract class BaseSearchResultPermissionFilter
 			return getHits(searchContext);
 		}
 
+		double amplificationFactor = 1.0;
 		int excludedDocsSize = 0;
 		int hitsSize = 0;
 		int offset = 0;
@@ -82,8 +83,7 @@ public abstract class BaseSearchResultPermissionFilter
 		while (true) {
 			int count = end - documents.size();
 
-			int amplifiedCount = (int)(
-				count * _INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR);
+			int amplifiedCount = (int)Math.ceil(count * amplificationFactor);
 
 			int amplifiedEnd = offset + amplifiedCount;
 
@@ -119,6 +119,9 @@ public abstract class BaseSearchResultPermissionFilter
 			}
 
 			offset = amplifiedEnd;
+
+			amplificationFactor = _getAmplificationFactor(
+				documents.size(), offset);
 		}
 	}
 
@@ -163,6 +166,16 @@ public abstract class BaseSearchResultPermissionFilter
 		hits.setLength(size);
 		hits.setSearchTime(
 			(float)(System.currentTimeMillis() - startTime) / Time.SECOND);
+	}
+
+	private double _getAmplificationFactor(double totalViewable, double total) {
+		if (totalViewable == 0) {
+			return _INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR;
+		}
+
+		return Math.min(
+			1.0 / (totalViewable / total),
+			_INDEX_PERMISSION_FILTER_SEARCH_AMPLIFICATION_FACTOR);
 	}
 
 	private static final double

--- a/portal-service/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/BaseSearchResultPermissionFilter.java
@@ -56,13 +56,19 @@ public abstract class BaseSearchResultPermissionFilter
 		if ((end == QueryUtil.ALL_POS) && (start == QueryUtil.ALL_POS)) {
 			Hits hits = getHits(searchContext);
 
-			filterHits(hits, searchContext);
+			if (!isGroupAdmin(searchContext)) {
+				filterHits(hits, searchContext);
+			}
 
 			return hits;
 		}
 
 		if ((start < 0) || (start > end)) {
 			return new HitsImpl();
+		}
+
+		if (isGroupAdmin(searchContext)) {
+			return getHits(searchContext);
 		}
 
 		int excludedDocsSize = 0;
@@ -136,6 +142,8 @@ public abstract class BaseSearchResultPermissionFilter
 
 	protected abstract Hits getHits(SearchContext searchContext)
 		throws SearchException;
+
+	protected abstract boolean isGroupAdmin(SearchContext searchContext);
 
 	protected void updateHits(
 		Hits hits, List<Document> documents, List<Float> scores, int start,

--- a/portal-service/src/com/liferay/portal/kernel/search/DefaultSearchResultPermissionFilter.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/DefaultSearchResultPermissionFilter.java
@@ -94,6 +94,27 @@ public class DefaultSearchResultPermissionFilter
 		return _baseIndexer.doSearch(searchContext);
 	}
 
+	@Override
+	protected boolean isGroupAdmin(SearchContext searchContext) {
+		if (_permissionChecker.isCompanyAdmin(searchContext.getCompanyId())) {
+			return true;
+		}
+
+		long[] groupIds = searchContext.getGroupIds();
+
+		if (groupIds == null) {
+			return false;
+		}
+
+		for (long groupId : groupIds) {
+			if (!_permissionChecker.isGroupAdmin(groupId)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private final BaseIndexer<?> _baseIndexer;
 	private final PermissionChecker _permissionChecker;
 

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalService.java
@@ -128,7 +128,7 @@ public interface AssetVocabularyLocalService extends BaseLocalService,
 
 	@com.liferay.portal.kernel.search.Indexable(type = IndexableType.DELETE)
 	@com.liferay.portal.kernel.systemevent.SystemEvent(action = SystemEventConstants.ACTION_SKIP, type = SystemEventConstants.TYPE_DELETE)
-	public void deleteVocabulary(
+	public com.liferay.portlet.asset.model.AssetVocabulary deleteVocabulary(
 		com.liferay.portlet.asset.model.AssetVocabulary vocabulary)
 		throws PortalException;
 

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceUtil.java
@@ -142,10 +142,10 @@ public class AssetVocabularyLocalServiceUtil {
 		getService().deleteVocabularies(groupId);
 	}
 
-	public static void deleteVocabulary(
+	public static com.liferay.portlet.asset.model.AssetVocabulary deleteVocabulary(
 		com.liferay.portlet.asset.model.AssetVocabulary vocabulary)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		getService().deleteVocabulary(vocabulary);
+		return getService().deleteVocabulary(vocabulary);
 	}
 
 	public static void deleteVocabulary(long vocabularyId)

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyLocalServiceWrapper.java
@@ -147,10 +147,10 @@ public class AssetVocabularyLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteVocabulary(
+	public com.liferay.portlet.asset.model.AssetVocabulary deleteVocabulary(
 		com.liferay.portlet.asset.model.AssetVocabulary vocabulary)
 		throws com.liferay.portal.kernel.exception.PortalException {
-		_assetVocabularyLocalService.deleteVocabulary(vocabulary);
+		return _assetVocabularyLocalService.deleteVocabulary(vocabulary);
 	}
 
 	@Override


### PR DESCRIPTION
Only change is 4f20ad35f0dc15b1d2eb2c445f01b234b5010486.  Instead of using the thread local I'm using getStatusByUserId of the node / thread when moving all the the node's / thread's children to the trash - we always set the statusByUserId before we call this.

I first considered adding a userId parameter to these methods but that lead to a collision with an already deprecated method MBThreadLocalServiceImpl#restoreDependentsFromTrash(long, long, long).  I could instead either rename the methods or pass a user instead of a userId to avoid the conflicting method.

Let me know if you want me to go with one of the other options.

Thanks!
