### PR TITLE
master-qa-15734

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6242,51 +6242,6 @@ jdbc.default.password=${database.mysql.password}</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="solr.enabled" />
-
-		<if>
-			<equals arg1="${solr.enabled}" arg2="true" />
-			<then>
-				<ant antfile="build-test-solr.xml" target="start-solr" />
-			</then>
-		</if>
-
-		<antcall target="deploy-specified-plugins" />
-
-		<antcall target="deploy-extra-apps" />
-
-		<get-testcase-property property.name="app.server.bundles.size" />
-
-		<if>
-			<isset property="app.server.bundles.size" />
-			<then>
-				<prepare-additional-bundles />
-			</then>
-		</if>
-
-		<get-testcase-property property.name="cluster.enabled" />
-
-		<if>
-			<equals arg1="${cluster.enabled}" arg2="true" />
-			<then>
-				<prepare-test-cluster-properties />
-			</then>
-		</if>
-
-		<get-testcase-property property.name="hook.plugins.includes" />
-
-		<if>
-			<and>
-				<contains string="${hook.plugins.includes}" substring="so-hook" />
-				<equals arg1="${app.server.type}" arg2="jboss" />
-			</and>
-			<then>
-				<start-app-server />
-
-				<stop-app-server />
-			</then>
-		</if>
-
 		<get-testcase-property property.name="cmis.repository.type" />
 
 		<if>
@@ -6329,6 +6284,51 @@ jdbc.default.password=${database.mysql.password}</echo>
 						/>
 					</then>
 				</if>
+			</then>
+		</if>
+
+		<get-testcase-property property.name="solr.enabled" />
+
+		<if>
+			<equals arg1="${solr.enabled}" arg2="true" />
+			<then>
+				<ant antfile="build-test-solr.xml" target="start-solr" />
+			</then>
+		</if>
+
+		<antcall target="deploy-specified-plugins" />
+
+		<antcall target="deploy-extra-apps" />
+
+		<get-testcase-property property.name="app.server.bundles.size" />
+
+		<if>
+			<isset property="app.server.bundles.size" />
+			<then>
+				<prepare-additional-bundles />
+			</then>
+		</if>
+
+		<get-testcase-property property.name="cluster.enabled" />
+
+		<if>
+			<equals arg1="${cluster.enabled}" arg2="true" />
+			<then>
+				<prepare-test-cluster-properties />
+			</then>
+		</if>
+
+		<get-testcase-property property.name="hook.plugins.includes" />
+
+		<if>
+			<and>
+				<contains string="${hook.plugins.includes}" substring="so-hook" />
+				<equals arg1="${app.server.type}" arg2="jboss" />
+			</and>
+			<then>
+				<start-app-server />
+
+				<stop-app-server />
 			</then>
 		</if>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -5187,13 +5187,16 @@ module.framework.properties.osgi.console=11312</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="sharepoint.enabled" />
+		<get-testcase-property property.name="cmis.repository.type" />
 
 		<if>
-			<equals arg1="${sharepoint.enabled}" arg2="true" />
+			<or>
+				<equals arg1="${cmis.repository.type}" arg2="documentum6" />
+				<equals arg1="${cmis.repository.type}" arg2="sharepoint2010" />
+			</or>
 			<then>
 				<echo file="portal-web/test/test-portal-web-ext.properties" append="true">
-					sharepoint.vm.host.name=${sharepoint.vm.host.name}
+					cmis.repository.vm.host.name=${cmis.repository.vm.host.name}
 				</echo>
 			</then>
 		</if>
@@ -6284,31 +6287,34 @@ jdbc.default.password=${database.mysql.password}</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="sharepoint.enabled" />
+		<get-testcase-property property.name="cmis.repository.type" />
 
 		<if>
-			<equals arg1="${sharepoint.enabled}" arg2="true" />
+			<or>
+				<equals arg1="${cmis.repository.type}" arg2="documentum6" />
+				<equals arg1="${cmis.repository.type}" arg2="sharepoint2010" />
+			</or>
 			<then>
 				<if>
 					<os family="unix" />
 					<then>
-						<exec executable="/bin/bash" os="${os.unix}" outputproperty="sharepoint.vm.host.name">
+						<exec executable="/bin/bash" os="${os.unix}" outputproperty="cmis.repository.vm.host.name">
 							<arg value="-c" />
-							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2Esharepoint2010&quot;" />
+							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2E${cmis.repository.type}&quot;" />
 						</exec>
 					</then>
 					<else>
-						<exec executable="cmd" outputproperty="sharepoint.vm.host.name">
+						<exec executable="cmd" outputproperty="cmis.repository.vm.host.name">
 							<arg value="/c" />
-							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2Esharepoint2010&quot;" />
+							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/borrow?leaseTime=30000&amp;resourceType=qa%2E${cmis.repository.type}&quot;" />
 						</exec>
 					</else>
 				</if>
 
 				<propertyregex
-					input="${sharepoint.vm.host.name}"
+					input="${cmis.repository.vm.host.name}"
 					override="true"
-					property="sharepoint.vm.host.name"
+					property="cmis.repository.vm.host.name"
 					regexp="&quot;(cloud.*?)&quot;"
 					select="\1"
 				/>
@@ -6391,10 +6397,13 @@ jdbc.default.password=${database.mysql.password}</echo>
 
 		<antcall target="run-selenium-test" />
 
-		<get-testcase-property property.name="sharepoint.enabled" />
+		<get-testcase-property property.name="cmis.repository.type" />
 
 		<if>
-			<equals arg1="${sharepoint.enabled}" arg2="true" />
+			<or>
+				<equals arg1="${cmis.repository.type}" arg2="documentum6" />
+				<equals arg1="${cmis.repository.type}" arg2="sharepoint2010" />
+			</or>
 			<then>
 				<property file="${project.dir}/portal-web/test/test-portal-web-ext.properties" />
 
@@ -6403,13 +6412,13 @@ jdbc.default.password=${database.mysql.password}</echo>
 					<then>
 						<exec executable="/bin/bash" os="${os.unix}">
 							<arg value="-c" />
-							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/release?hostname=${sharepoint.vm.host.name}&amp;resourceType=qa%2Esharepoint2010&quot;" />
+							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/release?hostname=${cmis.repository.vm.host.name}&amp;resourceType=qa%2E${cmis.repository.type}&quot;" />
 						</exec>
 					</then>
 					<else>
 						<exec executable="cmd">
 							<arg value="/c" />
-							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/release?hostname=${sharepoint.vm.host.name}&amp;resourceType=qa%2Esharepoint2010&quot;" />
+							<arg value="curl &quot;http://it.liferay.com/osb-ici-controller-web/vm/allocation/release?hostname=${cmis.repository.vm.host.name}&amp;resourceType=qa%2E${cmis.repository.type}&quot;" />
 						</exec>
 					</else>
 				</if>

--- a/build-test.xml
+++ b/build-test.xml
@@ -6318,6 +6318,17 @@ jdbc.default.password=${database.mysql.password}</echo>
 					regexp="&quot;(cloud.*?)&quot;"
 					select="\1"
 				/>
+
+				<if>
+					<equals arg1="${cmis.repository.type}" arg2="documentum6" />
+					<then>
+						<replace
+							file="${lp.plugins.dir}/hooks/documentum-hook/docroot/WEB-INF/src/dfc.properties"
+							token="dfc.docbroker.host[0]=localhost"
+							value="dfc.docbroker.host[0]=${cmis.repository.vm.host.name}"
+						/>
+					</then>
+				</if>
 			</then>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/CPSharepoint.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/CPSharepoint.testcase
@@ -1,7 +1,7 @@
 <definition component-name="portal-document-management-ee">
 	<property name="custom.properties" value="session.store.password=true${line.separator}company.security.auth.type=screenName" />
 	<property name="hook.plugins.includes" value="sharepoint-hook" />
-	<property name="sharepoint.enabled" value="true" />
+	<property name="cmis.repository.type" value="sharepoint2010" />
 	<property name="testray.main.component.name" value="Documents Management" />
 
 	<set-up>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/CPSharepoint.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/CPSharepoint.testcase
@@ -1,7 +1,7 @@
 <definition component-name="portal-document-management-ee">
+	<property name="cmis.repository.type" value="sharepoint2010" />
 	<property name="custom.properties" value="session.store.password=true${line.separator}company.security.auth.type=screenName" />
 	<property name="hook.plugins.includes" value="sharepoint-hook" />
-	<property name="cmis.repository.type" value="sharepoint2010" />
 	<property name="testray.main.component.name" value="Documents Management" />
 
 	<set-up>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/PGSharepoint.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/PGSharepoint.testcase
@@ -1,7 +1,7 @@
 <definition component-name="portal-document-management-ee">
 	<property name="custom.properties" value="session.store.password=true${line.separator}company.security.auth.type=screenName" />
 	<property name="hook.plugins.includes" value="sharepoint-hook" />
-	<property name="sharepoint.enabled" value="true" />
+	<property name="cmis.repository.type" value="sharepoint2010" />
 	<property name="testray.main.component.name" value="Documents Management" />
 
 	<set-up>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/PGSharepoint.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/collaborationanddocmanagement/documentmanagement/connectors/sharepoint/PGSharepoint.testcase
@@ -1,7 +1,7 @@
 <definition component-name="portal-document-management-ee">
+	<property name="cmis.repository.type" value="sharepoint2010" />
 	<property name="custom.properties" value="session.store.password=true${line.separator}company.security.auth.type=screenName" />
 	<property name="hook.plugins.includes" value="sharepoint-hook" />
-	<property name="cmis.repository.type" value="sharepoint2010" />
 	<property name="testray.main.component.name" value="Documents Management" />
 
 	<set-up>

--- a/test.properties
+++ b/test.properties
@@ -775,6 +775,7 @@
         app.server.bundles.size,\
         captcha.max.challenges,\
         cluster.enabled,\
+        cmis.repository.type,\
         custom.properties,\
         data.archive.type,\
         database.jndi.enabled,\
@@ -797,7 +798,6 @@
         portlet.properties.marketplace-portlet,\
         portlet.properties.private-messaging-portlet,\
         setup.wizard.enabled,\
-        sharepoint.enabled,\
         solr.enabled,\
         test.assert.javascript.errors,\
         testcase.url,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-15734

We want to add documentum tests, and the logic needed in build-test.xml is the same as the logic for sharepoint, so this changes the sharepoint.enabled property to cmis.repository.type and checks for the value passed in. There is an extra setup that is needed for documentum that was also added.
