### PR TITLE
LPS-56696 Caused by LPS-55977 2c7dd0d8f88bcbede67319cad8b156e633d47b28

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/edit_template_display.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/META-INF/resources/edit_template_display.jspf
@@ -453,9 +453,9 @@ if (Validator.isNotNull(scriptContent)) {
 		function(event) {
 			var form = A.one('#<portlet:namespace />fm');
 
-			<portlet:actionURL name="refreshTemplate" var="refreshTemplateURL">
+			<portlet:renderURL var="refreshTemplateURL">
 				<portlet:param name="mvcPath" value="/edit_template.jsp" />
-			</portlet:actionURL>
+			</portlet:renderURL>
 
 			form.attr('action', '<%= refreshTemplateURL %>');
 


### PR DESCRIPTION
@leoadb this is a regression cause by your change at https://github.com/liferay/liferay-portal/commit/2c7dd0d8f88bcbede67319cad8b156e633d47b28
The refresh URL has to be render url, it can not be action url, otherwise the target portlet request is going to lose "focus", causing it not to carry on the paramters, see PortletRequestImpl.init() for more detail. And it is logically the right thing to do, as refresh does not save anything on the server side, it should be simply reloading the page with some different parameters, as the current page is loaded via render url, there is no reason the refresh is doing anything different.

CC @rotty3000 @marcellustavares
