### PR TITLE
LPS-57845 Disable ES cluster test temporarily André fixes them.

### DIFF
--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster1InstanceTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster1InstanceTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.search.elasticsearch.internal.connection.Elasticsearch
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -26,6 +27,9 @@ import org.junit.rules.TestName;
 /**
  * @author André de Oliveira
  */
+@Ignore(
+	"This test is ignored, because it is very unstable, André please fix it."
+)
 public class Cluster1InstanceTest {
 
 	@Before

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster2InstancesTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster2InstancesTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.search.elasticsearch.internal.connection.Elasticsearch
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -26,6 +27,9 @@ import org.junit.rules.TestName;
 /**
  * @author André de Oliveira
  */
+@Ignore(
+	"This test is ignored, because it is very unstable, André please fix it."
+)
 public class Cluster2InstancesTest {
 
 	@Before

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterUnicastTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterUnicastTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.search.elasticsearch.internal.connection.Elasticsearch
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -26,6 +27,9 @@ import org.junit.rules.TestName;
 /**
  * @author André de Oliveira
  */
+@Ignore(
+	"This test is ignored, because it is very unstable, André please fix it."
+)
 public class ClusterUnicastTest {
 
 	@Before

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ReplicasClusterListenerTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ReplicasClusterListenerTest.java
@@ -25,6 +25,7 @@ import java.util.logging.LogRecord;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.mockito.Mock;
@@ -34,6 +35,9 @@ import org.mockito.MockitoAnnotations;
 /**
  * @author André de Oliveira
  */
+@Ignore(
+	"This test is ignored, because it is very unstable, André please fix it."
+)
 public class ReplicasClusterListenerTest {
 
 	@Before


### PR DESCRIPTION
@arboliveira I am disabling your ES cluster tests as they are very unstable, fails frequently.

You can see examples like:
https://github.com/brianchandotcom/liferay-portal/pull/29226
https://github.com/brianchandotcom/liferay-portal/pull/29237
https://github.com/brianchandotcom/liferay-portal/pull/29236

Please re-enable them after you get them fixed, thanks!
