### PR TITLE
LPS-57777 Add back all removed @sync, it is too aggressive to remove …

### DIFF
--- a/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/search/test/BookmarksEntrySearchTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/search/test/BookmarksEntrySearchTest.java
@@ -24,6 +24,7 @@ import com.liferay.bookmarks.util.test.BookmarksTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -46,6 +47,7 @@ import org.junit.runner.RunWith;
  * @author Manuel de la Peña
  */
 @RunWith(Arquillian.class)
+@Sync
 public class BookmarksEntrySearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/search/test/BookmarksFolderSearchTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/search/test/BookmarksFolderSearchTest.java
@@ -21,6 +21,7 @@ import com.liferay.bookmarks.service.BookmarksFolderLocalServiceUtil;
 import com.liferay.bookmarks.service.BookmarksFolderServiceUtil;
 import com.liferay.bookmarks.util.test.BookmarksTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -42,6 +43,7 @@ import org.junit.runner.RunWith;
  * @author Eudaldo Alonso
  */
 @RunWith(Arquillian.class)
+@Sync
 public class BookmarksFolderSearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/modules/apps/document-library/document-library-test/test/integration/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/test/integration/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
@@ -81,6 +82,7 @@ import org.junit.runner.RunWith;
  * @author Eudaldo Alonso
  */
 @RunWith(Arquillian.class)
+@Sync
 public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.search.SearchEngineUtil;
 import com.liferay.portal.kernel.test.IdempotentRetryAssert;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -60,6 +61,7 @@ import org.junit.runner.RunWith;
  * @author André de Oliveira
  */
 @RunWith(Arquillian.class)
+@Sync
 public class DDLRecordSearchTest {
 
 	@ClassRule

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/asset/test/JournalArticleAssetSearchTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/asset/test/JournalArticleAssetSearchTest.java
@@ -24,6 +24,7 @@ import com.liferay.journal.model.JournalArticleConstants;
 import com.liferay.journal.model.JournalFolderConstants;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -47,6 +48,7 @@ import org.junit.runner.RunWith;
  * @author Eudaldo Alonso
  */
 @RunWith(Arquillian.class)
+@Sync
 public class JournalArticleAssetSearchTest extends BaseAssetSearchTestCase {
 
 	@ClassRule

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/search/test/JournalArticleSearchTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/search/test/JournalArticleSearchTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.search.SearchEngineUtil;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.test.IdempotentRetryAssert;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
@@ -77,6 +78,7 @@ import org.junit.runner.RunWith;
  * @author Tibor Lipusz
  */
 @RunWith(Arquillian.class)
+@Sync
 public class JournalArticleSearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/search/test/JournalFolderSearchTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/search/test/JournalFolderSearchTest.java
@@ -20,6 +20,7 @@ import com.liferay.journal.model.JournalFolderConstants;
 import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -41,6 +42,7 @@ import org.junit.runner.RunWith;
  * @author Eudaldo Alonso
  */
 @RunWith(Arquillian.class)
+@Sync
 public class JournalFolderSearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/search/test/WikiPageSearchTest.java
+++ b/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/search/test/WikiPageSearchTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchEngine;
 import com.liferay.portal.kernel.search.SearchEngineUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
@@ -55,6 +56,7 @@ import org.junit.runner.RunWith;
  * @author Eudaldo Alonso
  */
 @RunWith(Arquillian.class)
+@Sync
 public class WikiPageSearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/portal-impl/test/integration/com/liferay/portlet/asset/search/AssetCategorySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/search/AssetCategorySearchTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.asset.search;
 
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.model.BaseModel;
@@ -42,6 +43,7 @@ import org.junit.Test;
  * @author Istvan Andras Dezsi
  * @author Tibor Lipusz
  */
+@Sync
 public class AssetCategorySearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/portal-impl/test/integration/com/liferay/portlet/asset/search/AssetVocabularySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/search/AssetVocabularySearchTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.asset.search;
 
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.model.BaseModel;
 import com.liferay.portal.search.test.BaseSearchTestCase;
@@ -37,6 +38,7 @@ import org.junit.Test;
  * @author Istvan Andras Dezsi
  * @author Tibor Lipusz
  */
+@Sync
 public class AssetVocabularySearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/asset/BlogsEntryAssetSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/asset/BlogsEntryAssetSearchTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.blogs.asset;
 
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -38,6 +39,7 @@ import org.junit.Test;
 /**
  * @author Eudaldo Alonso
  */
+@Sync
 public class BlogsEntryAssetSearchTest extends BaseAssetSearchTestCase {
 
 	@ClassRule

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/search/BlogsEntrySearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/search/BlogsEntrySearchTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.blogs.search;
 
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.model.BaseModel;
@@ -34,6 +35,7 @@ import org.junit.Test;
 /**
  * @author Eudaldo Alonso
  */
+@Sync
 public class BlogsEntrySearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFolderSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/search/DLFolderSearchTest.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.search;
 
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.model.BaseModel;
@@ -38,6 +39,7 @@ import org.junit.Test;
 /**
  * @author Eudaldo Alonso
  */
+@Sync
 public class DLFolderSearchTest extends BaseSearchTestCase {
 
 	@ClassRule

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/search/MBMessageSearchTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/search/MBMessageSearchTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -54,6 +55,7 @@ import org.junit.Test;
 /**
  * @author Eudaldo Alonso
  */
+@Sync
 public class MBMessageSearchTest extends BaseSearchTestCase {
 
 	@ClassRule


### PR DESCRIPTION
…them, tests start to randomly fail again. @sync is not just used for search, it is used generally for MessageBus. And if we really should remove it, its test rule should be remove all together. We need to manually check the test one by one to be sure whether it is removable per test based.  @arboliveira please check those tests carefully, if some of them are really removeable, please redo them one by one.

@arboliveira see https://test-1-2.liferay.com/job/test-portal-acceptance-pullrequest-batch%28master%29/AXIS_VARIABLE=4,label_exp=!master/5216/testReport/com.liferay.portal.log.assertor/PortalLogAssertorTest/testScanXmlLog/ this is an example of random failures caused by the @sync removal.
