### PR TITLE
LPS-56798 - Simplify resource paths in frontend modules

### DIFF
--- a/definitions/liferay-look-and-feel_7_0_0.dtd
+++ b/definitions/liferay-look-and-feel_7_0_0.dtd
@@ -128,9 +128,9 @@ the user.
 
 <!--
 The root-path value sets the location of the root path for the theme. For
-example, the root path for the Classic theme is "/html/themes/classic". This
+example, the root path for the Classic theme is "/classic". This
 means you can find the files for the Classic theme in
-/docroot/html/themes/classic.
+/modules/frontend/frontend-themes-web/src/META-INF/resources/classic.
 
 For convenience, the root-path attribute can be referenced in the rest of the
 theme element as ${root-path}.
@@ -142,8 +142,8 @@ The default value is "/".
 <!--
 The templates-path value sets the location of the templates path for the theme.
 For example, the templates path for the Classic theme is
-"/html/themes/classic/templates". This means you can find the JSP or VM
-templates for the Classic theme in /docroot/html/themes/classic/templates.
+"/classic/templates". This means you can find the JSP or VM
+templates for the Classic theme in /modules/frontend/frontend-themes-web/src/META-INF/resources/classic/templates.
 
 For convenience, the templates-path attribute can be referenced in the rest of
 the theme element as ${templates-path}.
@@ -154,8 +154,8 @@ The default value is "${root-path}/templates".
 
 <!--
 The css-path value sets the location of the css path for the theme. For example,
-the css path for the Classic theme is "/html/themes/classic/css". This means you
-can find css for the Classic theme in /docroot/html/themes/classic/css.
+the css path for the Classic theme is "/classic/css". This means you
+can find css for the Classic theme in /modules/frontend/frontend-themes-web/src/META-INF/resources/classic/css.
 
 For convenience, the css-path attribute can be referenced in the rest of the
 theme element as ${css-path}.
@@ -166,9 +166,9 @@ The default value is "${root-path}/css".
 
 <!--
 The images-path value sets the location of the images path for the theme. For
-example, the images path for the Classic theme is "/html/themes/classic/images".
+example, the images path for the Classic theme is "/classic/images".
 This means you can find images for the Classic theme in
-/docroot/html/themes/classic/images.
+/modules/frontend/frontend-themes-web/src/META-INF/resources/classic/images.
 
 For convenience, the images-path attribute can be referenced in the rest of the
 theme element as ${images-path}.
@@ -180,8 +180,8 @@ The default value is "${root-path}/images".
 <!--
 The javascript-path value sets the location of the JavaScript path for the
 theme. For example, the JavaScript path for the Classic theme is
-"/html/themes/classic/js". This means you can find JavaScript for the
-Classic theme in /docroot/html/themes/classic/js.
+"/classic/js". This means you can find JavaScript for the
+Classic theme in /modules/frontend/frontend-themes-web/src/META-INF/resources/classic/js.
 
 For convenience, the javascript-path attribute can be referenced in the rest of
 the theme element as ${javascript-path}.

--- a/modules/frontend/frontend-common-css/src/META-INF/resources/.npmignore
+++ b/modules/frontend/frontend-common-css/src/META-INF/resources/.npmignore
@@ -1,0 +1,2 @@
+/bourbon
+_bourbon.scss

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/CSSSourceProcessor.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/CSSSourceProcessor.java
@@ -53,8 +53,8 @@ public class CSSSourceProcessor extends BaseSourceProcessor {
 			"**/.ivy/**", "**/.sass-cache/**", "**/__MACOSX/**",
 			"**/aui_deprecated.css", "**/_partial.scss",
 			"**/bourbon/**", "**/expected/**", "**/aui/**",
-			"**/frontend-editors-web/**", "**/misc/**", "**/_unstyled/css/**",
-			"**/admin/css/**", "**/atlas/css/**",
+			"**/frontend-editors-web/**", "**/_unstyled/css/**",
+			"**/admin/css/**",
 			"**/classic/css/**", "**/control_panel/css/**",
 			"**/tools/node**"
 		};

--- a/modules/util/source-formatter/src/com/liferay/source/formatter/CSSSourceProcessor.java
+++ b/modules/util/source-formatter/src/com/liferay/source/formatter/CSSSourceProcessor.java
@@ -51,12 +51,10 @@ public class CSSSourceProcessor extends BaseSourceProcessor {
 	protected List<String> doGetFileNames() throws Exception {
 		String[] excludes = {
 			"**/.ivy/**", "**/.sass-cache/**", "**/__MACOSX/**",
-			"**/aui_deprecated.css", "**/_partial.scss",
-			"**/bourbon/**", "**/expected/**", "**/aui/**",
-			"**/frontend-editors-web/**", "**/_unstyled/css/**",
-			"**/admin/css/**",
-			"**/classic/css/**", "**/control_panel/css/**",
-			"**/tools/node**"
+			"**/aui_deprecated.css", "**/_partial.scss", "**/bourbon/**",
+			"**/expected/**", "**/aui/**", "**/frontend-editors-web/**",
+			"**/_unstyled/css/**", "**/admin/css/**", "**/classic/css/**",
+			"**/control_panel/css/**", "**/tools/node**"
 		};
 
 		return getFileNames(excludes, getIncludes());


### PR DESCRIPTION
Hey Brian,

Attached is an update for https://issues.liferay.com/browse/LPS-56798.

These changes are from your suggestions in my last pull https://github.com/brianchandotcom/liferay-portal/pull/29249#issuecomment-130872327.

1) I was able to remove the `/atlas/` exclude, and the `/misc/` exclude from the CSSSourceProcessor.  But all the excludes in the JSSourceProcessor are still needed.

2) The .npmignore was added back to frontend-common-css.  This is needed so that NPM won't track our extracted bourbon files.

3) I update only the 7.0.0 liferay-look-and-feel.dtd to reference the correct theme paths, i.e. `/modules/frontend/frontend-themes-web/src/META-INF/resources/classic`

Please let me know if there are any issues.

Thanks!
