### PR TITLE
LPS-57906 Uncaught exception in non-main threads should be treated as…

### DIFF
--- a/portal-test-internal/src/com/liferay/portal/test/rule/LogAssertionUncaughtExceptionHandler.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/LogAssertionUncaughtExceptionHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule;
+
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.test.rule.callback.LogAssertionTestCallback;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class LogAssertionUncaughtExceptionHandler
+	implements UncaughtExceptionHandler {
+
+	public LogAssertionUncaughtExceptionHandler(
+		UncaughtExceptionHandler uncaughtExceptionHandler) {
+
+		_uncaughtExceptionHandler = uncaughtExceptionHandler;
+	}
+
+	@Override
+	public void uncaughtException(Thread thread, Throwable throwable) {
+		if (_uncaughtExceptionHandler != null) {
+			_uncaughtExceptionHandler.uncaughtException(thread, throwable);
+		}
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("Uncaught exception in ");
+		sb.append(thread);
+		sb.append(StringPool.COMMA_AND_SPACE);
+		sb.append(throwable);
+
+		LogAssertionTestCallback.caughtFailure(
+			new AssertionError(sb.toString(), throwable));
+	}
+
+	private final UncaughtExceptionHandler _uncaughtExceptionHandler;
+
+}

--- a/portal-test-internal/src/com/liferay/portal/test/rule/callback/LogAssertionTestCallback.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/callback/LogAssertionTestCallback.java
@@ -26,6 +26,9 @@ import com.liferay.portal.test.rule.ExpectedLogs;
 import com.liferay.portal.test.rule.ExpectedType;
 import com.liferay.portal.test.rule.LogAssertionAppender;
 import com.liferay.portal.test.rule.LogAssertionHandler;
+import com.liferay.portal.test.rule.LogAssertionUncaughtExceptionHandler;
+
+import java.lang.Thread.UncaughtExceptionHandler;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,6 +82,8 @@ public class LogAssertionTestCallback
 			}
 		}
 
+		Thread.setDefaultUncaughtExceptionHandler(_uncaughtExceptionHandler);
+
 		_thread = null;
 
 		try {
@@ -102,6 +107,11 @@ public class LogAssertionTestCallback
 
 	public static CaptureAppender startAssert(ExpectedLogs expectedLogs) {
 		_thread = Thread.currentThread();
+		_uncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+
+		Thread.setDefaultUncaughtExceptionHandler(
+			new LogAssertionUncaughtExceptionHandler(
+				_uncaughtExceptionHandler));
 
 		CaptureAppender captureAppender = null;
 
@@ -210,5 +220,6 @@ public class LogAssertionTestCallback
 	private static final Map<Thread, Error> _concurrentFailures =
 		new ConcurrentHashMap<>();
 	private static volatile Thread _thread;
+	private static volatile UncaughtExceptionHandler _uncaughtExceptionHandler;
 
 }


### PR DESCRIPTION
… test failure.

@brianchandotcom One more addition protection layer for CI, we found this during Sybase integration, as some of the modules' logic runs in non-main thread during portal bootup/integration test initialization. And junit only treat uncaught exception in main as test failure, we end up with a lot of error dumped into System.err (JVM's default behavior for Thread without an explicitly installed UncaughtExceptionHandler) and the tests are still considered passed.
The solution is we install a default UncaughtExceptionHandler by ourselves during test runs, treat uncaught exception in the same way as error logs.
