### PR TITLE
LPS-57811

### DIFF
--- a/modules/apps/export-import/export-import-service/src/com/liferay/exportimport/messaging/LayoutsRemotePublisherMessageListener.java
+++ b/modules/apps/export-import/export-import-service/src/com/liferay/exportimport/messaging/LayoutsRemotePublisherMessageListener.java
@@ -77,7 +77,7 @@ public class LayoutsRemotePublisherMessageListener
 			settingsMap, "remotePathContext");
 		boolean secureConnection = MapUtil.getBoolean(
 			settingsMap, "secureConnection");
-		long remoteGroupId = MapUtil.getLong(settingsMap, "remoteGroupId");
+		long targetGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
 		boolean remotePrivateLayout = MapUtil.getBoolean(
 			settingsMap, "remotePrivateLayout");
 
@@ -91,7 +91,7 @@ public class LayoutsRemotePublisherMessageListener
 			StagingUtil.copyRemoteLayouts(
 				sourceGroupId, privateLayout, layoutIdMap, parameterMap,
 				remoteAddress, remotePort, remotePathContext, secureConnection,
-				remoteGroupId, remotePrivateLayout);
+				targetGroupId, remotePrivateLayout);
 		}
 		finally {
 			resetThreadLocals();

--- a/modules/apps/export-import/export-import-service/src/com/liferay/exportimport/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/com/liferay/exportimport/staging/StagingImpl.java
@@ -297,7 +297,7 @@ public class StagingImpl implements Staging {
 		Map<String, Serializable> settingsMap =
 			exportImportConfiguration.getSettingsMap();
 
-		long remoteGroupId = MapUtil.getLong(settingsMap, "remoteGroupId");
+		long targetGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
 		String remoteAddress = MapUtil.getString(settingsMap, "remoteAddress");
 		int remotePort = MapUtil.getInteger(settingsMap, "remotePort");
 		String remotePathContext = MapUtil.getString(
@@ -306,7 +306,7 @@ public class StagingImpl implements Staging {
 			settingsMap, "secureConnection");
 
 		validateRemoteGroup(
-			exportImportConfiguration.getGroupId(), remoteGroupId,
+			exportImportConfiguration.getGroupId(), targetGroupId,
 			remoteAddress, remotePort, remotePathContext, secureConnection);
 
 		boolean remotePrivateLayout = MapUtil.getBoolean(

--- a/portal-impl/src/com/liferay/portlet/exportimport/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/backgroundtask/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -93,7 +93,7 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 
 			Map<Long, Boolean> layoutIdMap =
 				(Map<Long, Boolean>)settingsMap.get("layoutIdMap");
-			long remoteGroupId = MapUtil.getLong(settingsMap, "remoteGroupId");
+			long targetGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
 
 			Map<String, Serializable> taskContextMap =
 				backgroundTask.getTaskContextMap();
@@ -101,13 +101,13 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 			httpPrincipal = (HttpPrincipal)taskContextMap.get("httpPrincipal");
 
 			file = exportLayoutsAsFile(
-				exportImportConfiguration, layoutIdMap, remoteGroupId,
+				exportImportConfiguration, layoutIdMap, targetGroupId,
 				httpPrincipal);
 
 			String checksum = FileUtil.getMD5Checksum(file);
 
 			stagingRequestId = StagingServiceHttp.createStagingRequest(
-				httpPrincipal, remoteGroupId, checksum);
+				httpPrincipal, targetGroupId, checksum);
 
 			transferFileToRemoteLive(file, stagingRequestId, httpPrincipal);
 

--- a/portal-service/src/com/liferay/portlet/exportimport/configuration/ExportImportConfigurationSettingsMapFactory.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/configuration/ExportImportConfigurationSettingsMapFactory.java
@@ -75,7 +75,7 @@ public class ExportImportConfigurationSettingsMapFactory {
 
 		return buildSettingsMap(
 			userId, sourceGroupId, sourcePlid, 0, 0, portletId, null, null,
-			null, parameterMap, StringPool.BLANK, 0, StringPool.BLANK, null, 0,
+			null, parameterMap, StringPool.BLANK, 0, StringPool.BLANK, null,
 			null, locale, timeZone, fileName);
 	}
 
@@ -96,8 +96,7 @@ public class ExportImportConfigurationSettingsMapFactory {
 		return buildSettingsMap(
 			userId, 0, 0, targetGroupId, 0, StringPool.BLANK, privateLayout,
 			null, layoutIds, parameterMap, StringPool.BLANK, 0,
-			StringPool.BLANK, null, 0, null, locale, timeZone,
-			StringPool.BLANK);
+			StringPool.BLANK, null, null, locale, timeZone, StringPool.BLANK);
 	}
 
 	public static Map<String, Serializable> buildImportLayoutSettingsMap(
@@ -115,7 +114,7 @@ public class ExportImportConfigurationSettingsMapFactory {
 
 		return buildSettingsMap(
 			userId, 0, 0, targetGroupId, targetPlid, portletId, null, null,
-			null, parameterMap, StringPool.BLANK, 0, StringPool.BLANK, null, 0,
+			null, parameterMap, StringPool.BLANK, 0, StringPool.BLANK, null,
 			null, locale, timeZone, StringPool.BLANK);
 	}
 
@@ -136,8 +135,7 @@ public class ExportImportConfigurationSettingsMapFactory {
 		return buildSettingsMap(
 			userId, sourceGroupId, 0, targetGroupId, 0, StringPool.BLANK,
 			privateLayout, null, layoutIds, parameterMap, StringPool.BLANK, 0,
-			StringPool.BLANK, null, 0, null, locale, timeZone,
-			StringPool.BLANK);
+			StringPool.BLANK, null, null, locale, timeZone, StringPool.BLANK);
 	}
 
 	public static Map<String, Serializable> buildPublishLayoutLocalSettingsMap(
@@ -158,9 +156,9 @@ public class ExportImportConfigurationSettingsMapFactory {
 		boolean remotePrivateLayout, Locale locale, TimeZone timeZone) {
 
 		return buildSettingsMap(
-			userId, sourceGroupId, 0, 0, 0, StringPool.BLANK, privateLayout,
-			layoutIdMap, null, parameterMap, remoteAddress, remotePort,
-			remotePathContext, secureConnection, remoteGroupId,
+			userId, sourceGroupId, 0, remoteGroupId, 0, StringPool.BLANK,
+			privateLayout, layoutIdMap, null, parameterMap, remoteAddress,
+			remotePort, remotePathContext, secureConnection,
 			remotePrivateLayout, locale, timeZone, StringPool.BLANK);
 	}
 
@@ -186,7 +184,7 @@ public class ExportImportConfigurationSettingsMapFactory {
 		return buildSettingsMap(
 			userId, sourceGroupId, sourcePlid, targetGroupId, targetPlid,
 			portletId, null, null, null, parameterMap, StringPool.BLANK, 0,
-			StringPool.BLANK, null, 0, null, locale, timeZone, null);
+			StringPool.BLANK, null, null, locale, timeZone, null);
 	}
 
 	public static Map<String, Serializable> buildPublishPortletSettingsMap(
@@ -298,8 +296,8 @@ public class ExportImportConfigurationSettingsMapFactory {
 		Map<Long, Boolean> layoutIdMap, long[] layoutIds,
 		Map<String, String[]> parameterMap, String remoteAddress,
 		int remotePort, String remotePathContext, Boolean secureConnection,
-		long remoteGroupId, Boolean remotePrivateLayout, Locale locale,
-		TimeZone timeZone, String fileName) {
+		Boolean remotePrivateLayout, Locale locale, TimeZone timeZone,
+		String fileName) {
 
 		Map<String, Serializable> settingsMap = new HashMap<>();
 
@@ -339,10 +337,6 @@ public class ExportImportConfigurationSettingsMapFactory {
 
 		if (Validator.isNotNull(remoteAddress)) {
 			settingsMap.put("remoteAddress", remoteAddress);
-		}
-
-		if (remoteGroupId > 0) {
-			settingsMap.put("remoteGroupId", remoteGroupId);
 		}
 
 		if (Validator.isNotNull(remotePathContext)) {


### PR DESCRIPTION
Hi Brian,

I'm resending this pull as per your comment here: https://github.com/brianchandotcom/liferay-portal/pull/29355#issuecomment-131859362

remoteGroupId is a property of a Group that has Remote Staging turned on. This hasn't been changed and it is still stored as a remoteGroupId along with the remoteAddress, remotePort, etc.. The only thing that has been changed is the settingsMap because we use ExportImportConfigurations now and on the import side there has to be a standard naming (sourceGroupId and targetGroupId) instead of a mixed usage of targetGroupId or remoteGroupId.

I think StagingImpl#copyRemoteLayouts as an API should hide the internal logic of how we handle remote or local groupIds, that's why I haven't renamed it.

I have rechecked the ordering because of the renamings but they seem correct to me (as used).

Based on these I just rebased the code to the latest master but haven't changed anything.

Thanks,
Ákos
