### PR TITLE
LPS-57476 Catch all throwables

### DIFF
--- a/portal-test-internal/src/com/liferay/portal/test/randomizerbumpers/TikaSafeRandomizerBumper.java
+++ b/portal-test-internal/src/com/liferay/portal/test/randomizerbumpers/TikaSafeRandomizerBumper.java
@@ -58,7 +58,7 @@ public class TikaSafeRandomizerBumper implements RandomizerBumper<byte[]> {
 
 			return contentType.contains(_contentType);
 		}
-		catch (Exception e) {
+		catch (Throwable t) {
 			return false;
 		}
 	}


### PR DESCRIPTION
@brianchandotcom This is fix for random error like this https://github.com/shuyangzhou/liferay-portal/pull/1657#issuecomment-132120525

Sometime the random bytes we generate are way too off that Tika throws an Error instead of Exception. And we need to recover from any Throwable.
