### PR TITLE
LPS-57845 Re-enable Elasticsearch cluster tests

### DIFF
--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster1InstanceTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster1InstanceTest.java
@@ -19,7 +19,6 @@ import com.liferay.portal.search.elasticsearch.internal.connection.Elasticsearch
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -27,7 +26,6 @@ import org.junit.rules.TestName;
 /**
  * @author André de Oliveira
  */
-@Ignore("This test will ignored due to instability until André fixes it.")
 public class Cluster1InstanceTest {
 
 	@Before

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster2InstancesTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/Cluster2InstancesTest.java
@@ -19,7 +19,6 @@ import com.liferay.portal.search.elasticsearch.internal.connection.Elasticsearch
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -27,7 +26,6 @@ import org.junit.rules.TestName;
 /**
  * @author André de Oliveira
  */
-@Ignore("This test will ignored due to instability until André fixes it.")
 public class Cluster2InstancesTest {
 
 	@Before

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterAssert.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterAssert.java
@@ -147,13 +147,14 @@ public class ClusterAssert {
 		throws Exception {
 
 		IdempotentRetryAssert.retryAssert(
-			3, TimeUnit.SECONDS,
+			10, TimeUnit.MINUTES,
 			new Callable<Void>() {
 
 				@Override
 				public Void call() throws Exception {
 					ClusterHealthResponse clusterHealthResponse =
-						elasticsearchFixture.getClusterHealthResponse();
+						elasticsearchFixture.getClusterHealthResponse(
+							healthExpectations);
 
 					_assertHealth(clusterHealthResponse, healthExpectations);
 

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterAssert.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterAssert.java
@@ -19,12 +19,12 @@ import static org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus.
 
 import com.liferay.portal.kernel.test.IdempotentRetryAssert;
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch.internal.connection.HealthExpectations;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
 
 import org.junit.Assert;
 
@@ -39,7 +39,7 @@ public class ClusterAssert {
 
 		ClusterAssert.assertHealth(
 			elasticsearchFixture,
-			new ClusterAssert.HealthExpectations() {
+			new HealthExpectations() {
 				{
 					activePrimaryShards = 1;
 					activeShards = 1;
@@ -57,7 +57,7 @@ public class ClusterAssert {
 
 		ClusterAssert.assertHealth(
 			elasticsearchFixture,
-			new ClusterAssert.HealthExpectations() {
+			new HealthExpectations() {
 				{
 					activePrimaryShards = 1;
 					activeShards = 1;
@@ -75,7 +75,7 @@ public class ClusterAssert {
 
 		ClusterAssert.assertHealth(
 			elasticsearchFixture,
-			new ClusterAssert.HealthExpectations() {
+			new HealthExpectations() {
 				{
 					activePrimaryShards = 1;
 					activeShards = 1;
@@ -93,7 +93,7 @@ public class ClusterAssert {
 
 		ClusterAssert.assertHealth(
 			elasticsearchFixture,
-			new ClusterAssert.HealthExpectations() {
+			new HealthExpectations() {
 				{
 					activePrimaryShards = 1;
 					activeShards = 2;
@@ -111,7 +111,7 @@ public class ClusterAssert {
 
 		ClusterAssert.assertHealth(
 			elasticsearchFixture,
-			new ClusterAssert.HealthExpectations() {
+			new HealthExpectations() {
 				{
 					activePrimaryShards = 1;
 					activeShards = 2;
@@ -129,7 +129,7 @@ public class ClusterAssert {
 
 		ClusterAssert.assertHealth(
 			elasticsearchFixture,
-			new ClusterAssert.HealthExpectations() {
+			new HealthExpectations() {
 				{
 					activePrimaryShards = 1;
 					activeShards = 3;
@@ -163,39 +163,15 @@ public class ClusterAssert {
 			});
 	}
 
-	public static class HealthExpectations {
-
-		public int activePrimaryShards;
-		public int activeShards;
-		public int numberOfDataNodes;
-		public int numberOfNodes;
-		public ClusterHealthStatus status;
-		public int unassignedShards;
-
-	}
-
 	private static void _assertHealth(
 		ClusterHealthResponse clusterHealthResponse,
 		HealthExpectations healthExpectations) {
 
+		HealthExpectations actualHealthExpectations = new HealthExpectations(
+			clusterHealthResponse);
+
 		Assert.assertEquals(
-			"activePrimaryShards", healthExpectations.activePrimaryShards,
-			clusterHealthResponse.getActivePrimaryShards());
-		Assert.assertEquals(
-			"activeShards", healthExpectations.activeShards,
-			clusterHealthResponse.getActiveShards());
-		Assert.assertEquals(
-			"numberOfDataNodes", healthExpectations.numberOfDataNodes,
-			clusterHealthResponse.getNumberOfDataNodes());
-		Assert.assertEquals(
-			"numberOfNodes", healthExpectations.numberOfNodes,
-			clusterHealthResponse.getNumberOfNodes());
-		Assert.assertEquals(
-			"status", healthExpectations.status,
-			clusterHealthResponse.getStatus());
-		Assert.assertEquals(
-			"unassignedShards", healthExpectations.unassignedShards,
-			clusterHealthResponse.getUnassignedShards());
+			healthExpectations.toString(), actualHealthExpectations.toString());
 	}
 
 }

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterUnicastTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ClusterUnicastTest.java
@@ -19,7 +19,6 @@ import com.liferay.portal.search.elasticsearch.internal.connection.Elasticsearch
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -27,7 +26,6 @@ import org.junit.rules.TestName;
 /**
  * @author André de Oliveira
  */
-@Ignore("This test will ignored due to instability until André fixes it.")
 public class ClusterUnicastTest {
 
 	@Before

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ReplicasClusterListenerTest.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/cluster/ReplicasClusterListenerTest.java
@@ -25,7 +25,6 @@ import java.util.logging.LogRecord;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.mockito.Mock;
@@ -35,7 +34,6 @@ import org.mockito.MockitoAnnotations;
 /**
  * @author André de Oliveira
  */
-@Ignore("This test will ignored due to instability until André fixes it.")
 public class ReplicasClusterListenerTest {
 
 	@Before

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/connection/ElasticsearchFixture.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/connection/ElasticsearchFixture.java
@@ -21,6 +21,7 @@ import com.liferay.portal.search.elasticsearch.configuration.ElasticsearchConfig
 import com.liferay.portal.search.elasticsearch.connection.ElasticsearchConnection;
 import com.liferay.portal.search.elasticsearch.internal.cluster.ClusterSettingsContext;
 import com.liferay.portal.search.elasticsearch.internal.cluster.UnicastSettingsContributor;
+import com.liferay.portal.search.elasticsearch.settings.BaseSettingsContributor;
 
 import java.io.File;
 
@@ -41,6 +42,7 @@ import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.ClusterAdminClient;
 import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.settings.ImmutableSettings.Builder;
 import org.elasticsearch.indices.IndexMissingException;
 
 import org.mockito.Mockito;
@@ -182,6 +184,8 @@ public class ElasticsearchFixture {
 
 		addUnicastSettingsContributor(embeddedElasticsearchConnection);
 
+		preventUnassignedReplicasWithLowSpace(embeddedElasticsearchConnection);
+
 		Props props = Mockito.mock(Props.class);
 
 		Mockito.when(
@@ -220,6 +224,22 @@ public class ElasticsearchFixture {
 		catch (Exception e) {
 			throw new IllegalStateException(e);
 		}
+	}
+
+	protected void preventUnassignedReplicasWithLowSpace(
+		EmbeddedElasticsearchConnection embeddedElasticsearchConnection) {
+
+		embeddedElasticsearchConnection.addSettingsContributor(
+			new BaseSettingsContributor(0) {
+
+				@Override
+				public void populate(Builder builder) {
+					builder.put(
+						"cluster.routing.allocation.disk.threshold_enabled",
+						"false");
+				}
+
+			});
 	}
 
 	private ClusterSettingsContext _clusterSettingsContext;

--- a/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/connection/HealthExpectations.java
+++ b/modules/portal/portal-search-elasticsearch/test/unit/com/liferay/portal/search/elasticsearch/internal/connection/HealthExpectations.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import com.liferay.portal.kernel.util.StringBundler;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
+
+/**
+ * @author André de Oliveira
+ */
+public class HealthExpectations {
+
+	public HealthExpectations() {
+	}
+
+	public HealthExpectations(ClusterHealthResponse clusterHealthResponse) {
+		activePrimaryShards = clusterHealthResponse.getActivePrimaryShards();
+		activeShards = clusterHealthResponse.getActiveShards();
+		numberOfDataNodes = clusterHealthResponse.getNumberOfDataNodes();
+		numberOfNodes = clusterHealthResponse.getNumberOfNodes();
+		status = clusterHealthResponse.getStatus();
+		timedOut = clusterHealthResponse.isTimedOut();
+		unassignedShards = clusterHealthResponse.getUnassignedShards();
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(20);
+
+		sb.append("activePrimaryShards=");
+		sb.append(activePrimaryShards);
+		sb.append('\n');
+		sb.append("activeShards=");
+		sb.append(activeShards);
+		sb.append('\n');
+		sb.append("numberOfDataNodes=");
+		sb.append(numberOfDataNodes);
+		sb.append('\n');
+		sb.append("numberOfNodes=");
+		sb.append(numberOfNodes);
+		sb.append('\n');
+		sb.append("status=");
+		sb.append(status);
+		sb.append('\n');
+		sb.append("timedOut=");
+		sb.append(timedOut);
+		sb.append('\n');
+		sb.append("unassignedShards=");
+		sb.append(unassignedShards);
+
+		return sb.toString();
+	}
+
+	public int activePrimaryShards;
+	public int activeShards;
+	public int numberOfDataNodes;
+	public int numberOfNodes;
+	public ClusterHealthStatus status;
+	public boolean timedOut;
+	public int unassignedShards;
+
+}


### PR DESCRIPTION
(cc @shuyangzhou)

Fixed random failures in Elasticsearch cluster tests. https://github.com/arboliveira/liferay-portal/commit/94d537b3cc68945d8e22ed8fb430d228df3a67bb

Narrowed it down to disk space on CI servers fluctuating around Elasticsearch's default threshold - when too low, replicas aren't assigned and numbers checked by replica tests won't match.

Exact same failure reproduced on developer's machine under right conditions.

Fix adapted from Shuyang's solution to clean CI logs: disable Elasticsearch's threshold entirely. https://github.com/liferay/liferay-portal/commit/462bfc561c557454234034f5f517448f0f94e761#diff-0

Tested on CI by running ci retest 8 times in a row.

Without fix, random failure observed: https://github.com/mhan810/liferay-portal/pull/725 

With fix applied, not observed anymore: https://github.com/mhan810/liferay-portal/pull/728  

(Failed test in the latter is yet another random failure, unrelated to search.)

Author: @arboliveira
Reviewer: @mhan810
