### PR TITLE
LPS-57942

### DIFF
--- a/modules/portal/portal-authenticator-ldap/src/com/liferay/portal/authenticator/ldap/LDAPAuth.java
+++ b/modules/portal/portal-authenticator-ldap/src/com/liferay/portal/authenticator/ldap/LDAPAuth.java
@@ -305,6 +305,11 @@ public class LDAPAuth implements Authenticator {
 				Attributes attributes = PortalLDAPUtil.getUserAttributes(
 					ldapServerId, companyId, ldapContext, fullUserDN);
 
+				// Get user or create from LDAP
+
+				User user = LDAPUserImporterUtil.importUser(
+					ldapServerId, companyId, ldapContext, attributes, password);
+
 				LDAPAuthResult ldapAuthResult = authenticate(
 					ldapContext, companyId, attributes, fullUserDN, password);
 
@@ -334,11 +339,6 @@ public class LDAPAuth implements Authenticator {
 				if (!ldapAuthResult.isAuthenticated()) {
 					return FAILURE;
 				}
-
-				// Get user or create from LDAP
-
-				User user = LDAPUserImporterUtil.importUser(
-					ldapServerId, companyId, ldapContext, attributes, password);
 
 				// Process LDAP success codes
 


### PR DESCRIPTION
We have a bug where if we turn on sync'ing of the "status" field, if the user is rejected by LDAP due to being deactivated, the data doesn't sync if "requires" is not set for LDAP. This pull request addresses that issue.
