### PR TITLE
LPS-51081 Broken buildService settings

### DIFF
--- a/modules/portal/portal-background-task-service/build.gradle
+++ b/modules/portal/portal-background-task-service/build.gradle
@@ -1,3 +1,8 @@
+buildService {
+	apiDirName = "../portal-background-task-api/src"
+	testDirName = "../portal-background-task-test/test/integration"
+}
+
 dependencies {
 	compile group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "1.0.2"
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"


### PR DESCRIPTION
@Ithildir One more case. We need to catch this automatically by failing the build on service regenerating.
