### PR TITLE
master-qa-17667

### DIFF
--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -64,7 +64,7 @@
 			<contains>Table 'lportal.lock_' doesn't exist</contains>
 			<matches></matches>
 		</ignore-error>
-		<ignore-error description="LPS-17667">
+		<ignore-error description="LPS-17639">
 			<contains>Table 'lportal.Lock_' doesn't exist</contains>
 			<matches></matches>
 		</ignore-error>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-17667

This is a permanent ignore for LPS-17639 where if the Lock table doesn't already exist, there will be a console error message. The lowercase version was already ignored, but this ignores the uppercase version (to account for different casing in windows and linux).
