### PR TITLE
LPS-57308 Fix for "lfr-module-config-generator"

### DIFF
--- a/modules/sdk/gradle-plugins-js-module-config-generator/src/com/liferay/gradle/plugins/js/module/config/generator/ConfigJSModulesTask.java
+++ b/modules/sdk/gradle-plugins-js-module-config-generator/src/com/liferay/gradle/plugins/js/module/config/generator/ConfigJSModulesTask.java
@@ -18,7 +18,6 @@ import com.liferay.gradle.plugins.node.tasks.ExecuteNodeTask;
 import com.liferay.gradle.util.FileUtil;
 import com.liferay.gradle.util.GradleUtil;
 import com.liferay.gradle.util.StringUtil;
-import com.liferay.gradle.util.Validator;
 
 import groovy.lang.Closure;
 
@@ -295,21 +294,21 @@ public class ConfigJSModulesTask extends ExecuteNodeTask {
 
 		String configVariable = getConfigVariable();
 
-		if (Validator.isNotNull(configVariable)) {
+		if (configVariable != null) {
 			completeArgs.add("--config");
 			completeArgs.add(configVariable);
 		}
 
 		String moduleExtension = getModuleExtension();
 
-		if (Validator.isNotNull(moduleExtension)) {
+		if (moduleExtension != null) {
 			completeArgs.add("--extension");
 			completeArgs.add(moduleExtension);
 		}
 
 		String moduleFormat = getModuleFormat();
 
-		if (Validator.isNotNull(moduleFormat)) {
+		if (moduleFormat != null) {
 			completeArgs.add("--format");
 			completeArgs.add(moduleFormat);
 		}

--- a/modules/sdk/gradle-plugins/build.gradle
+++ b/modules/sdk/gradle-plugins/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.css.builder", version: "1.0.6"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.jasper.jspc", version: "1.0.3"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.javadoc.formatter", version: "1.0.2"
-	compile group: "com.liferay", name: "com.liferay.gradle.plugins.js.module.config.generator", version: "1.0.5"
+	compile group: "com.liferay", name: "com.liferay.gradle.plugins.js.module.config.generator", version: "1.0.6"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.js.transpiler", version: "1.0.7"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.lang.builder", version: "1.0.0"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.patcher", version: "1.0.4"

--- a/modules/sdk/gradle-plugins/src/com/liferay/gradle/plugins/LiferayJavaPlugin.java
+++ b/modules/sdk/gradle-plugins/src/com/liferay/gradle/plugins/LiferayJavaPlugin.java
@@ -1509,12 +1509,20 @@ public class LiferayJavaPlugin implements Plugin<Project> {
 				project,
 				JSModuleConfigGeneratorPlugin.CONFIG_JS_MODULES_TASK_NAME);
 
+		configureTaskConfigJSModulesConfigVariable(configJSModulesTask);
 		configureTaskConfigJSModulesDependsOn(configJSModulesTask);
 		configureTaskConfigJSModulesIgnorePath(configJSModulesTask);
 		configureTaskConfigJSModulesIncludes(configJSModulesTask);
+		configureTaskConfigJSModulesModuleExtension(configJSModulesTask);
 		configureTaskConfigJSModulesModuleFormat(configJSModulesTask);
 		configureTaskConfigJSModulesMustRunAfter(configJSModulesTask);
 		configureTaskConfigJSModulesSourceDir(configJSModulesTask);
+	}
+
+	protected void configureTaskConfigJSModulesConfigVariable(
+		ConfigJSModulesTask configJSModulesTask) {
+
+		configJSModulesTask.setConfigVariable("");
 	}
 
 	protected void configureTaskConfigJSModulesDependsOn(
@@ -1533,6 +1541,12 @@ public class LiferayJavaPlugin implements Plugin<Project> {
 		ConfigJSModulesTask configJSModulesTask) {
 
 		configJSModulesTask.setIncludes(Collections.singleton("**/*.es.js"));
+	}
+
+	protected void configureTaskConfigJSModulesModuleExtension(
+		ConfigJSModulesTask configJSModulesTask) {
+
+		configJSModulesTask.setModuleExtension("");
 	}
 
 	protected void configureTaskConfigJSModulesModuleFormat(


### PR DESCRIPTION
Because of this problem, the build of `frontend-js-metal-web` was broken. There is still an issue when the module in built on Windows, but it will be solved with a new version of [lfr-module-config-generator](https://github.com/ipeychev/lfr-module-config-generator).

When both `gradle-plugins-js-module-config-generator` and `gradle-plugins` are published, I can send you a new PR that re-enables the build of `frontend-js-metal-web` :blush:

Thank you!

cc @jbalsas
