### PR TITLE
NoSuchResourceActionException for com_liferay_blogs_web_portlet_BlogsAdminPortlet#ADD_TO_PAGE when adding a page on a different portal instance

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -906,7 +906,17 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			long groupId, String name, String primKey, String actionId)
 		throws Exception {
 
-		ResourceActionsUtil.checkAction(name, actionId);
+		try {
+			ResourceActionsUtil.checkAction(name, actionId);
+		}
+		catch (Exception e) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					name + " does not have guest permission to resource:" +
+					actionId);
+
+			return false;
+		}
 
 		if (name.indexOf(CharPool.PERIOD) != -1) {
 


### PR DESCRIPTION
When initCompany initializes all portlets from categories, admin portlets will appear on list. As the method iterates through portlets, the check for hasAddPermission throws exception from unhandled check. Simple fix, 
