### PR TITLE
master-qa-17695

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4498,7 +4498,7 @@ module.framework.properties.osgi.console=11312</echo>
 			test.case.available.property.names=${test.case.available.property.names}
 			test.console.log.file.name=${liferay.home}/logs/liferay.${current.date}.xml
 			test.console.shut.down.file.name=${project.dir}/console-shut-down
-			test.dependencies.dir.name=com/liferay/portalweb/dependencies
+			test.dependencies.dir.name=dependencies
 			test.poshi.warnings.file.name=${project.dir}/poshi-warnings.xml
 		</echo>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-17695

CC @michaelhashimoto

This fixes an issue we have in our tests with regards to uploading files or referencing images for Sikuli.

Error: "Image file can not be loaded from /opt/dev/projects/github/liferay-portal-ee-6.2.x/portal-web/test/functional/com/liferay/portalweb/com/liferay/portalweb/dependencies/sikuli/linux/portal/screenshots/calendar/scheduler_event_day_view.png "
