### PR TITLE
    LPS-57946  NoSuchResourceActionException for com_liferay_blogs_web_portlet_BlogsAdminPortlet#ADD_TO_PAGE when adding a page on a different portal instance

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -906,7 +906,18 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			long groupId, String name, String primKey, String actionId)
 		throws Exception {
 
-		ResourceActionsUtil.checkAction(name, actionId);
+		try {
+			ResourceActionsUtil.checkAction(name, actionId);
+		}
+		catch (Exception e) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					name + " does not have guest permission to resource:" +
+					actionId);
+			}
+
+			return false;
+		}
 
 		if (name.indexOf(CharPool.PERIOD) != -1) {
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -56,6 +56,24 @@ public class PermissionCheckerTest {
 	}
 
 	@Test
+	public void testHasPermission() throws Exception {
+		_user = UserTestUtil.addUser();
+
+		PermissionChecker permissionChecker = _getPermissionChecker(_user);
+
+		try {
+			Assert.assertFalse(
+				permissionChecker.hasPermission(
+					_group.getGroupId(),
+					"com_liferay_blogs_web_portlet_BlogsAdminPortlet",
+					_group.getGroupId(), "ADD_TO_PAGE"));
+		}
+		catch (Exception e) {
+			Assert.fail();
+		}
+	}
+
+	@Test
 	public void testIsCompanyAdminWithCompanyAdmin() throws Exception {
 		PermissionChecker permissionChecker = _getPermissionChecker(
 			TestPropsValues.getUser());


### PR DESCRIPTION
The fix keeps the exception from being thrown and uncaught upstream. The test will fail if the the hasPermission throws an exception, in theory a boolean method should not be throwing exceptions.
