### PR TITLE
master-qa-17835

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/auditing/cpauditreports/usecase/CPAuditreportsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/auditing/cpauditreports/usecase/CPAuditreportsUsecase.testcase
@@ -1,7 +1,7 @@
 <definition component-name="portal-core-infrastructure-portal-services">
 	<property name="hook.plugins.includes" value="audit-hook" />
 	<property name="portlet.plugins.includes" value="audit-portlet" />
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Auditing" />
 	<property name="testray.testcase.product.edition" value="EE" />
 
 	<set-up>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/customfields/cpcustomfields/CPCustomfields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/customfields/cpcustomfields/CPCustomfields.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Custom Fields" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/portalconfiguration/cpportalsettings/CPPortalSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/portalconfiguration/cpportalsettings/CPPortalSettings.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Portal Settings" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/portalconfiguration/usecase/PortalconfigurationUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/portalconfiguration/usecase/PortalconfigurationUsecase.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Portal Instances" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/rolesandpermissions/cproles/CPRoles.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/rolesandpermissions/cproles/CPRoles.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Roles" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/rolesandpermissions/usecase/RolesandpermissionsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/rolesandpermissions/usecase/RolesandpermissionsUsecase.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Roles" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/serveradministration/usecase/ServeradministrationUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/serveradministration/usecase/ServeradministrationUsecase.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Server Administration" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/cpusergroups/CPUsergroups.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/cpusergroups/CPUsergroups.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="User Groups" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/cpusergroups/UsergroupsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/cpusergroups/UsergroupsUsecase.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="User Groups" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/cpusersandorganizations/CPUsersandorganizations.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/cpusersandorganizations/CPUsersandorganizations.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Users and Organizations" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/myaccount/Myaccount.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/myaccount/Myaccount.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="My Account" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/usecase/PasswordpoliciesUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/usecase/PasswordpoliciesUsecase.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Password Policies" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/usecase/UsersandorganizationsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/administration/users/usecase/UsersandorganizationsUsecase.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-management-and-portal-configuration">
-	<property name="testray.main.component.name" value="Administration" />
+	<property name="testray.main.component.name" value="Users and Organizations" />
 
 	<set-up>
 		<execute macro="User#firstLoginPG" />

--- a/test.properties
+++ b/test.properties
@@ -936,21 +936,31 @@
         Antisamy Hook,\
         APIs,\
         Application Standards,\
+        Auditing,\
         Authentication,\
         Clustering,\
+        Custom Fields,\
         Databases,\
         Development Tools,\
         Login,\
+        My Account,\
+        Password Policies,\
         Permissions,\
+        Portal Instances,\
+        Portal Settings,\
+        Roles,\
         SAML,\
         Sample Portlet Plugins,\
         Search,\
         Security,\
+        Server Administration,\
         Setup Wizard,\
         Solr,\
         Test Plugins,\
         Upgrades,\
+        User Groups,\
         Users,\
+        Users and Organizations,\
         Util,\
         WSRP,\
         XSS

--- a/test.properties
+++ b/test.properties
@@ -932,7 +932,6 @@
         Plugin Installer
 
     testray.team.platform.component.names=\
-        Administration,\
         Antisamy Hook,\
         APIs,\
         Application Standards,\
@@ -959,7 +958,6 @@
         Test Plugins,\
         Upgrades,\
         User Groups,\
-        Users,\
         Users and Organizations,\
         Util,\
         WSRP,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-17835

CC @alee8888 @jhendley

Joel - after this, the test failures in 'Administration', which is an old component name, should get distributed and categorized into the updated component names, so you'll be able to match up tests with jira components.
