### PR TITLE
LPS-53828 Wrong column name, caused by f80ed3fc3498026974c6aa3607d897…

### DIFF
--- a/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -3892,6 +3892,7 @@ public class ServiceBuilder {
 			for (int i = 0; i < pkList.size(); i++) {
 				EntityColumn col = pkList.get(i);
 
+				String colName = col.getName();
 				String colType = col.getType();
 
 				sb.append("\t");
@@ -3919,8 +3920,7 @@ public class ServiceBuilder {
 				}
 				else if (colType.equals("String")) {
 					int maxLength = getMaxLength(
-						_packagePath + ".model." + entity.getName(),
-						entity.getName());
+						_packagePath + ".model." + entity.getName(), colName);
 
 					if (col.isLocalized()) {
 						maxLength = 4000;


### PR DESCRIPTION
…41dc499ddb

@hhuijser you made this typo mistake at https://github.com/liferay/liferay-portal/commit/f80ed3fc3498026974c6aa3607d89741dc499ddb

And it actually got caught by PMDTest, but here is the funny part.

@marcellustavares you fixed the PMDTest at https://github.com/liferay/liferay-portal/commit/1a658541ab77821c511a1e6cb2674e2330de0046 which did not fix the real problem, but just stopped PMDTest from complaining.

We need to be careful with PMDTest failures, they are normally signs of logical problems, not just formatting problems.
