### PR TITLE
LPS-58587

### DIFF
--- a/modules/build-module.gradle
+++ b/modules/build-module.gradle
@@ -292,6 +292,12 @@ if (System.getenv("JENKINS_HOME")) {
 		nodeUrl = "https://nodejs.org/dist/v${nodeVersion}/node-v${nodeVersion}-linux-x64.tar.gz"
 	}
 
+	pluginManager.withPlugin("com.liferay.cache") {
+		cache {
+			forcedCache = true
+		}
+	}
+
 	startTestableTomcat {
 		ext {
 			deleteLiferayHome = false

--- a/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/CacheExtension.java
+++ b/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/CacheExtension.java
@@ -37,6 +37,14 @@ public class CacheExtension {
 		return _taskCaches;
 	}
 
+	public boolean isForcedCache() {
+		return _forcedCache;
+	}
+
+	public void setForcedCache(boolean forcedCache) {
+		_forcedCache = forcedCache;
+	}
+
 	public TaskCache task(String name, Closure<Void> closure) {
 		return _taskCaches.create(name, closure);
 	}
@@ -45,6 +53,7 @@ public class CacheExtension {
 		return task(task.getName(), closure);
 	}
 
+	private boolean _forcedCache;
 	private final NamedDomainObjectContainer<TaskCache> _taskCaches;
 
 }

--- a/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/CachePlugin.java
+++ b/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/CachePlugin.java
@@ -39,15 +39,15 @@ public class CachePlugin implements Plugin<Project> {
 
 				@Override
 				public void execute(Project project) {
-					applyTaskCaches(cacheExtension.getTasks());
+					applyTaskCaches(cacheExtension);
 				}
 
 			});
 	}
 
-	protected void applyTaskCaches(Iterable<TaskCache> taskCaches) {
-		for (TaskCache taskCache : taskCaches) {
-			_taskCacheApplicator.apply(taskCache);
+	protected void applyTaskCaches(CacheExtension cacheExtension) {
+		for (TaskCache taskCache : cacheExtension.getTasks()) {
+			_taskCacheApplicator.apply(cacheExtension, taskCache);
 		}
 	}
 

--- a/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/task/TaskCache.java
+++ b/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/task/TaskCache.java
@@ -45,7 +45,7 @@ public class TaskCache implements PatternFilterable {
 
 	public TaskCache(String name, Project project) {
 		_baseDir = project.getProjectDir();
-		_cacheFile = project.file(name + ".zip");
+		_cacheDir = project.file(".cache/" + name);
 		_name = name;
 		_project = project;
 	}
@@ -82,8 +82,8 @@ public class TaskCache implements PatternFilterable {
 		return GradleUtil.toFile(_project, _baseDir);
 	}
 
-	public File getCacheFile() {
-		return GradleUtil.toFile(_project, _cacheFile);
+	public File getCacheDir() {
+		return GradleUtil.toFile(_project, _cacheDir);
 	}
 
 	@Override
@@ -178,10 +178,10 @@ public class TaskCache implements PatternFilterable {
 			throw new GradleException("At least one test file is required");
 		}
 
-		File cacheFile = getCacheFile();
+		File cacheDir = getCacheDir();
 
 		for (File testFile : testFiles) {
-			if (!FileUtil.isUpToDate(_project, testFile, cacheFile)) {
+			if (!FileUtil.isUpToDate(_project, testFile, cacheDir)) {
 				return false;
 			}
 		}
@@ -193,8 +193,8 @@ public class TaskCache implements PatternFilterable {
 		_baseDir = baseDir;
 	}
 
-	public void setCacheFile(Object cacheFile) {
-		_cacheFile = cacheFile;
+	public void setCacheDir(Object cacheDir) {
+		_cacheDir = cacheDir;
 	}
 
 	@Override
@@ -261,7 +261,7 @@ public class TaskCache implements PatternFilterable {
 	}
 
 	private Object _baseDir;
-	private Object _cacheFile;
+	private Object _cacheDir;
 	private boolean _failIfOutOfDate;
 	private final String _name;
 	private final PatternFilterable _patternFilterable = new PatternSet();

--- a/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/task/TaskCacheApplicator.java
+++ b/modules/sdk/gradle-plugins-cache/src/com/liferay/gradle/plugins/cache/task/TaskCacheApplicator.java
@@ -14,8 +14,11 @@
 
 package com.liferay.gradle.plugins.cache.task;
 
+import com.liferay.gradle.plugins.cache.CacheExtension;
 import com.liferay.gradle.util.GradleUtil;
 import com.liferay.gradle.util.StringUtil;
+
+import java.io.File;
 
 import java.util.Set;
 
@@ -32,10 +35,25 @@ import org.gradle.api.tasks.Copy;
  */
 public class TaskCacheApplicator {
 
-	public void apply(final TaskCache taskCache) {
+	public void apply(CacheExtension cacheExtension, TaskCache taskCache) {
 		Task task = taskCache.getTask();
 
-		if (taskCache.isUpToDate()) {
+		boolean upToDate = false;
+
+		if (cacheExtension.isForcedCache()) {
+			File cacheDir = taskCache.getCacheDir();
+
+			if (!cacheDir.exists()) {
+				throw new GradleException("Unable to find " + cacheDir);
+			}
+
+			upToDate = true;
+		}
+		else {
+			upToDate = taskCache.isUpToDate();
+		}
+
+		if (upToDate) {
 			applyUpToDate(taskCache, task);
 		}
 		else {


### PR DESCRIPTION
Hi @brianchandotcom!

Before publishing the new `gradle-plugins-cache`, could you please publish the new `gradle-util` and update the version in `gradle-plugins-cache`? Thank you! :blush:

I closed the previous pull and added https://github.com/brianchandotcom/liferay-portal/commit/8a09452b4b09202c39d9b73b78a1b80215606e84 in this one. This is a workaround to the following scenario:
- the plugin checks the last modified date between the cache dir and one or more files called _test files_ (usually the `build.gradle`, `package.json`, etc.), and regenerates the cache only if these _test files_ are more recent than the cache dir
- sometimes, the _test files_ may change (for example, because a new task has been added to `build.gradle`, a SF, etc.), but these changes still produce the same exact files in the cache dir, which will not be committed
- therefore, the cache dir will be considered out-of-date, even if it's not, and this will trigger a regeneration in CI

With that switch, CI will always use the cache dir, and it won't even try to build those files. The downside is that developers will always have to commit the cache dir, otherwise CI will use the old version and it won't output any message.

I don't particularly like this approach, but for now it's the quickest to implement (they are pressing me to push `frontend-js-metal-web`, they really need it! :cold_sweat: ). Having a hash-based check is definitely more complicated, because the line ending of text files can change between Windows and Unix, and so the hash.

What do you think? I'll try to come up with something better, maybe there's an easy solution that I can't see yet :confused:
