### PR TITLE
[See description] LPS-58693 Dot not propagate search parameters if they don't exist

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
@@ -143,26 +143,9 @@ public class SearchContainer<R> {
 		_iteratorURL.setParameter(_curParam, String.valueOf(_cur));
 		_iteratorURL.setParameter(_deltaParam, String.valueOf(_delta));
 
-		String keywords = portletRequest.getParameter(DisplayTerms.KEYWORDS);
-
-		if (keywords != null) {
-			_iteratorURL.setParameter(DisplayTerms.KEYWORDS, keywords);
-		}
-
-		String advancedSearch =
-			portletRequest.getParameter(DisplayTerms.ADVANCED_SEARCH);
-
-		if (advancedSearch != null) {
-			_iteratorURL.setParameter(
-				DisplayTerms.ADVANCED_SEARCH, advancedSearch);
-		}
-
-		String andOperator = portletRequest.getParameter(
-			DisplayTerms.AND_OPERATOR);
-
-		if (andOperator != null) {
-			_iteratorURL.setParameter(DisplayTerms.AND_OPERATOR, andOperator);
-		}
+		setNotNullParameter(DisplayTerms.KEYWORDS);
+		setNotNullParameter(DisplayTerms.ADVANCED_SEARCH);
+		setNotNullParameter(DisplayTerms.AND_OPERATOR);
 
 		if (headerNames != null) {
 			_headerNames = new ArrayList<>(headerNames.size());
@@ -512,6 +495,15 @@ public class SearchContainer<R> {
 
 	public void setTotalVar(String totalVar) {
 		_totalVar = totalVar;
+	}
+
+	protected void setNotNullParameter(String paramName) {
+
+		String paramValue = _portletRequest.getParameter(paramName);
+
+		if (paramValue != null) {
+			_iteratorURL.setParameter(paramName, paramValue);
+		}
 	}
 
 	private void _buildNormalizedHeaderNames(List<String> headerNames) {

--- a/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
@@ -143,9 +143,9 @@ public class SearchContainer<R> {
 		_iteratorURL.setParameter(_curParam, String.valueOf(_cur));
 		_iteratorURL.setParameter(_deltaParam, String.valueOf(_delta));
 
-		setNotNullParameter(DisplayTerms.KEYWORDS);
-		setNotNullParameter(DisplayTerms.ADVANCED_SEARCH);
-		setNotNullParameter(DisplayTerms.AND_OPERATOR);
+		_setNotNullParameter(DisplayTerms.KEYWORDS);
+		_setNotNullParameter(DisplayTerms.ADVANCED_SEARCH);
+		_setNotNullParameter(DisplayTerms.AND_OPERATOR);
 
 		if (headerNames != null) {
 			_headerNames = new ArrayList<>(headerNames.size());
@@ -497,15 +497,6 @@ public class SearchContainer<R> {
 		_totalVar = totalVar;
 	}
 
-	protected void setNotNullParameter(String paramName) {
-
-		String paramValue = _portletRequest.getParameter(paramName);
-
-		if (paramValue != null) {
-			_iteratorURL.setParameter(paramName, paramValue);
-		}
-	}
-
 	private void _buildNormalizedHeaderNames(List<String> headerNames) {
 		if (headerNames == null) {
 			return;
@@ -547,6 +538,14 @@ public class SearchContainer<R> {
 
 		if (_resultEnd > _total) {
 			_resultEnd = _total;
+		}
+	}
+
+	private void _setNotNullParameter(String paramName) {
+		String paramValue = _portletRequest.getParameter(paramName);
+
+		if (paramValue != null) {
+			_iteratorURL.setParameter(paramName, paramValue);
 		}
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/search/SearchContainer.java
@@ -142,19 +142,27 @@ public class SearchContainer<R> {
 
 		_iteratorURL.setParameter(_curParam, String.valueOf(_cur));
 		_iteratorURL.setParameter(_deltaParam, String.valueOf(_delta));
-		_iteratorURL.setParameter(
-			DisplayTerms.KEYWORDS,
-			ParamUtil.getString(portletRequest, DisplayTerms.KEYWORDS));
-		_iteratorURL.setParameter(
-			DisplayTerms.ADVANCED_SEARCH,
-			String.valueOf(
-				ParamUtil.getBoolean(
-					portletRequest, DisplayTerms.ADVANCED_SEARCH)));
-		_iteratorURL.setParameter(
-			DisplayTerms.AND_OPERATOR,
-			String.valueOf(
-				ParamUtil.getBoolean(
-					portletRequest, DisplayTerms.AND_OPERATOR, true)));
+
+		String keywords = portletRequest.getParameter(DisplayTerms.KEYWORDS);
+
+		if (keywords != null) {
+			_iteratorURL.setParameter(DisplayTerms.KEYWORDS, keywords);
+		}
+
+		String advancedSearch =
+			portletRequest.getParameter(DisplayTerms.ADVANCED_SEARCH);
+
+		if (advancedSearch != null) {
+			_iteratorURL.setParameter(
+				DisplayTerms.ADVANCED_SEARCH, advancedSearch);
+		}
+
+		String andOperator = portletRequest.getParameter(
+			DisplayTerms.AND_OPERATOR);
+
+		if (andOperator != null) {
+			_iteratorURL.setParameter(DisplayTerms.AND_OPERATOR, andOperator);
+		}
 
 		if (headerNames != null) {
 			_headerNames = new ArrayList<>(headerNames.size());


### PR DESCRIPTION
Hey Brian,

SearchContainer is always propagating the parameters in the portletURL, so when the user paginates, those parameters are set in the request even though they are blank (like keywords).
We should only propagate those parameters if they exists and don't leave them blank in the request.
