### PR TITLE
LPS-58746

### DIFF
--- a/modules/util/lang-builder/src/com/liferay/lang/builder/LangBuilder.java
+++ b/modules/util/lang-builder/src/com/liferay/lang/builder/LangBuilder.java
@@ -39,6 +39,9 @@ import java.io.InputStream;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -143,8 +146,10 @@ public class LangBuilder {
 			_renameKeys = null;
 		}
 
-		String content = _orderProperties(
-			new File(_langDirName + "/" + _langFileName + ".properties"));
+		File propertiesFile = new File(
+			_langDirName + "/" + _langFileName + ".properties");
+
+		String content = _orderProperties(propertiesFile);
 
 		// Locales that are not invoked by _createProperties should still be
 		// rewritten to use the right line separator
@@ -155,6 +160,8 @@ public class LangBuilder {
 			new File(_langDirName + "/" + _langFileName + "_en_GB.properties"));
 		_orderProperties(
 			new File(_langDirName + "/" + _langFileName + "_fr_CA.properties"));
+
+		_copyProperties(propertiesFile, "en");
 
 		_createProperties(content, "ar"); // Arabic
 		_createProperties(content, "eu"); // Basque
@@ -198,6 +205,15 @@ public class LangBuilder {
 		_createProperties(content, "tr"); // Turkish
 		_createProperties(content, "uk"); // Ukrainian
 		_createProperties(content, "vi"); // Vietnamese
+	}
+
+	private void _copyProperties(File file, String languageId)
+		throws IOException {
+
+		Path path = Paths.get(
+			_langDirName, _langFileName + "_" + languageId + ".properties");
+
+		Files.copy(file.toPath(), path, StandardCopyOption.REPLACE_EXISTING);
 	}
 
 	private void _createProperties(String content, String languageId)

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -118,8 +118,8 @@
         modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/trash/test/WikiPageTrashHandlerTest.java@185,\
         modules/core/osgi-service-tracker-map/test/integration/com/liferay/osgi/service/tracker/map/test/ObjectServiceTrackerMapTest.java@432,\
         modules/portal/portal-template-freemarker/src/com/liferay/portal/template/freemarker/configuration/FreeMarkerEngineConfiguration.java@52,\
-        modules/util/lang-builder/src/com/liferay/lang/builder/LangBuilder.java@491,\
-        modules/util/lang-builder/src/com/liferay/lang/builder/LangBuilder.java@499,\
+        modules/util/lang-builder/src/com/liferay/lang/builder/LangBuilder.java@507,\
+        modules/util/lang-builder/src/com/liferay/lang/builder/LangBuilder.java@515,\
         modules/util/osgi-util/test/integration/com/liferay/osgi/util/test/ReflectionServiceTrackerTest.java@166,\
         modules/util/pmd/src/com/liferay/pmd/rules/java/OverrideBothEqualsAndHashcodeRule.java@28,\
         modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/ServiceBuilder.java,\


### PR DESCRIPTION
Hi @brianchandotcom!

In order to use the new version of `lang-builder`, you have to update the version in `modules/gradle.properties` and run `ant setup-sdk` again.

Thank you! :blush:
