### PR TITLE
Lps 58662

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
@@ -138,6 +139,10 @@ public class MySQLDB extends BaseDB {
 
 	@Override
 	protected String[] getTemplate() {
+		if (GetterUtil.getFloat(getVersionString()) >= 5.6F) {
+			_MYSQL[8] = " datetime(6)";
+		}
+
 		return _MYSQL;
 	}
 

--- a/portal-impl/src/com/liferay/portal/events/StartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupAction.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManagerUtil;
 import com.liferay.portal.kernel.cluster.ClusterExecutor;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
 import com.liferay.portal.kernel.events.ActionException;
 import com.liferay.portal.kernel.events.SimpleAction;
 import com.liferay.portal.kernel.executor.PortalExecutorManager;
@@ -41,6 +43,7 @@ import com.liferay.portal.kernel.scheduler.SchedulerEngineHelper;
 import com.liferay.portal.kernel.scheduler.SchedulerLifecycle;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalLifecycle;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringPool;
@@ -147,6 +150,22 @@ public class StartupAction extends SimpleAction {
 				}
 
 			});
+
+		// MySQL version checking
+
+		DB db = DBFactoryUtil.getDB();
+
+		String dbType = db.getType();
+
+		if (dbType.equals(DB.TYPE_MYSQL) &&
+			GetterUtil.getFloat(db.getVersionString()) < 5.6F) {
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Please upgrade to MySQL 5.6.4+. Portal will drop off " +
+						"support to all MySQL releases before 5.6.4 soon!");
+			}
+		}
 
 		// Upgrade
 

--- a/test.properties
+++ b/test.properties
@@ -760,11 +760,13 @@
         functional-tomcat-mysql,\
         integration-db2,\
         integration-hypersonic,\
+        integration-mysql,\
         integration-oracle,\
         integration-postgresql,\
         integration-sybase,\
         modules-integration-db2,\
         modules-integration-hypersonic,\
+        modules-integration-mysql,\
         modules-integration-oracle,\
         modules-integration-postgresql,\
         modules-integration-sybase,\


### PR DESCRIPTION
@brianchandotcom with this change, we can turn back on MySQL tests.

But the date milliseconds issue is still far away from finishing.

We need to completely remove the DateUtil.compareTo(Date date1, Date date2, boolean ignoreMilliseconds), DB.isSupportsDateMilliseconds() and their usage to be accurate on all time stamps processing and we will eventually eliminate all those annoying randomly failing time based tests.

And we just found out other dbs like sybase, db2 also have some sort of special rules for milliseconds processing, the rest of the clean up process might take a longer time. So I thought I would do them separately, to let MySQL tests back up running first.
