### PR TITLE
Lps 59148

### DIFF
--- a/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/service/persistence/test/BookmarksEntryPersistenceTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/service/persistence/test/BookmarksEntryPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class BookmarksEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/service/persistence/test/BookmarksFolderPersistenceTest.java
+++ b/modules/apps/bookmarks/bookmarks-test/test/integration/com/liferay/bookmarks/service/persistence/test/BookmarksFolderPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class BookmarksFolderPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarBookingPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class CalendarBookingPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarNotificationTemplatePersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarNotificationTemplatePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class CalendarNotificationTemplatePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarPersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class CalendarPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarResourcePersistenceTest.java
+++ b/modules/apps/calendar/calendar-test/test/integration/com/liferay/calendar/service/persistence/test/CalendarResourcePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class CalendarResourcePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDLRecordPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordSetPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDLRecordSetPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/test/integration/com/liferay/dynamic/data/lists/service/persistence/test/DDLRecordVersionPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDLRecordVersionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMContentPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMContentPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMContentPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStorageLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStorageLinkPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,8 +63,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMStorageLinkPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLayoutPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLayoutPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMStructureLayoutPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureLinkPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMStructureLinkPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructurePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructurePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMStructurePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMStructureVersionPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMStructureVersionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateLinkPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateLinkPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMTemplateLinkPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplatePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMTemplatePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateVersionPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/test/integration/com/liferay/dynamic/data/mapping/service/persistence/test/DDMTemplateVersionPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class DDMTemplateVersionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalArticleImagePersistenceTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalArticleImagePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class JournalArticleImagePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
@@ -46,6 +46,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,8 +66,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class JournalArticlePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalArticleResourcePersistenceTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalArticleResourcePersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class JournalArticleResourcePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalContentSearchPersistenceTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalContentSearchPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class JournalContentSearchPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalFeedPersistenceTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalFeedPersistenceTest.java
@@ -46,6 +46,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,8 +66,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class JournalFeedPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
+++ b/modules/apps/journal/journal-test/test/integration/com/liferay/journal/service/persistence/test/JournalFolderPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class JournalFolderPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/marketplace/marketplace-test/test/integration/com/liferay/marketplace/service/persistence/test/AppPersistenceTest.java
+++ b/modules/apps/marketplace/marketplace-test/test/integration/com/liferay/marketplace/service/persistence/test/AppPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class AppPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/marketplace/marketplace-test/test/integration/com/liferay/marketplace/service/persistence/test/ModulePersistenceTest.java
+++ b/modules/apps/marketplace/marketplace-test/test/integration/com/liferay/marketplace/service/persistence/test/ModulePersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ModulePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/microblogs/microblogs-test/test/integration/com/liferay/microblogs/service/persistence/test/MicroblogsEntryPersistenceTest.java
+++ b/modules/apps/microblogs/microblogs-test/test/integration/com/liferay/microblogs/service/persistence/test/MicroblogsEntryPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class MicroblogsEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRActionPersistenceTest.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRActionPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class MDRActionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRRuleGroupInstancePersistenceTest.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRRuleGroupInstancePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class MDRRuleGroupInstancePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRRuleGroupPersistenceTest.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRRuleGroupPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class MDRRuleGroupPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRRulePersistenceTest.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-test/test/integration/com/liferay/mobile/device/rules/service/persistence/test/MDRRulePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class MDRRulePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/polls/polls-test/test/integration/com/liferay/polls/service/persistence/test/PollsChoicePersistenceTest.java
+++ b/modules/apps/polls/polls-test/test/integration/com/liferay/polls/service/persistence/test/PollsChoicePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class PollsChoicePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/polls/polls-test/test/integration/com/liferay/polls/service/persistence/test/PollsQuestionPersistenceTest.java
+++ b/modules/apps/polls/polls-test/test/integration/com/liferay/polls/service/persistence/test/PollsQuestionPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class PollsQuestionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/polls/polls-test/test/integration/com/liferay/polls/service/persistence/test/PollsVotePersistenceTest.java
+++ b/modules/apps/polls/polls-test/test/integration/com/liferay/polls/service/persistence/test/PollsVotePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class PollsVotePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/service-access-policy/service-access-policy-test/test/integration/com/liferay/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
+++ b/modules/apps/service-access-policy/service-access-policy-test/test/integration/com/liferay/service/access/policy/service/persistence/test/SAPEntryPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.service.access.policy.service.persistence.SAPEntryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class SAPEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingCartPersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingCartPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.shopping.service.persistence.ShoppingCartUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,8 +63,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingCartPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingCategoryPersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingCategoryPersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.shopping.service.persistence.ShoppingCategoryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingCategoryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingCouponPersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingCouponPersistenceTest.java
@@ -46,6 +46,7 @@ import com.liferay.shopping.service.persistence.ShoppingCouponUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,8 +66,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingCouponPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingItemFieldPersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingItemFieldPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.shopping.service.persistence.ShoppingItemFieldUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,8 +61,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingItemFieldPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingItemPersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingItemPersistenceTest.java
@@ -46,6 +46,7 @@ import com.liferay.shopping.service.persistence.ShoppingItemUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,8 +66,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingItemPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingItemPricePersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingItemPricePersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.shopping.service.persistence.ShoppingItemPriceUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingItemPricePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingOrderItemPersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingOrderItemPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.shopping.service.persistence.ShoppingOrderItemUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,8 +63,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingOrderItemPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingOrderPersistenceTest.java
+++ b/modules/apps/shopping/shopping-test/test/integration/com/liferay/shopping/service/persistence/test/ShoppingOrderPersistenceTest.java
@@ -46,6 +46,7 @@ import com.liferay.shopping.service.persistence.ShoppingOrderUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,8 +66,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class ShoppingOrderPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/service/persistence/test/WikiNodePersistenceTest.java
@@ -45,6 +45,7 @@ import com.liferay.wiki.service.persistence.WikiNodeUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -64,8 +65,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class WikiNodePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/service/persistence/test/WikiPagePersistenceTest.java
@@ -46,6 +46,7 @@ import com.liferay.wiki.service.persistence.WikiPageUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -65,8 +66,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class WikiPagePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/service/persistence/test/WikiPageResourcePersistenceTest.java
+++ b/modules/apps/wiki/wiki-test/test/integration/com/liferay/wiki/service/persistence/test/WikiPageResourcePersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.wiki.service.persistence.WikiPageResourceUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class WikiPageResourcePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-background-task-test/test/integration/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
+++ b/modules/portal/portal-background-task-test/test/integration/com/liferay/portal/background/task/service/persistence/test/BackgroundTaskPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,8 +63,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class BackgroundTaskPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-lock-test/test/integration/com/liferay/portal/lock/service/persistence/test/LockPersistenceTest.java
+++ b/modules/portal/portal-lock-test/test/integration/com/liferay/portal/lock/service/persistence/test/LockPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class LockPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoActionPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoActionPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoActionUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoActionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoConditionPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoConditionPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoConditionUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoConditionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoDefinitionPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoDefinitionUtil
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoDefinitionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstancePersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstancePersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoInstanceUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoInstancePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstanceTokenPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoInstanceTokenPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoInstanceTokenU
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,8 +61,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoInstanceTokenPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoLogPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoLogPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoLogUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoLogPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodePersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNodePersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoNodeUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,8 +61,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoNodePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoNotificationUt
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoNotificationPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationRecipientPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoNotificationRecipientPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoNotificationRe
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,8 +61,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoNotificationRecipientPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentInstancePersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentInstancePersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoTaskAssignment
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoTaskAssignmentInstancePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskAssignmentPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoTaskAssignment
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoTaskAssignmentPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskInstanceTokenPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskInstanceTokenPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoTaskInstanceTo
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,8 +63,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoTaskInstanceTokenPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTaskPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoTaskUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoTaskPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerInstanceTokenPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerInstanceTokenPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoTimerInstanceT
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoTimerInstanceTokenPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTimerPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoTimerUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -62,8 +63,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoTimerPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTransitionPersistenceTest.java
+++ b/modules/portal/portal-workflow-kaleo-test/test/integration/com/liferay/portal/workflow/kaleo/service/persistence/test/KaleoTransitionPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.workflow.kaleo.service.persistence.KaleoTransitionUtil
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  */
 @RunWith(Arquillian.class)
 public class KaleoTransitionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
+++ b/modules/util/portal-tools-service-builder/src/com/liferay/portal/tools/service/builder/dependencies/persistence_test.ftl
@@ -74,6 +74,7 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,8 +95,9 @@ import org.junit.runner.RunWith;
 </#if>
 public class ${entity.name}PersistenceTest {
 
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(
 		new LiferayIntegrationTestRule(), PersistenceTestRule.INSTANCE, new TransactionalTestRule(Propagation.REQUIRED));
 
 	@Before

--- a/portal-impl/test/integration/com/liferay/counter/service/persistence/test/CounterPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/counter/service/persistence/test/CounterPersistenceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -52,8 +53,9 @@ import java.util.Set;
  * @generated
  */
 public class CounterPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/AccountPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/AccountPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class AccountPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/AddressPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class AddressPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/BrowserTrackerPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/BrowserTrackerPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class BrowserTrackerPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ClassNamePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ClassNamePersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ClassNamePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ClusterGroupPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ClusterGroupPersistenceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,8 +55,9 @@ import java.util.Set;
  * @generated
  */
 public class ClusterGroupPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/CompanyPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/CompanyPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class CompanyPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ContactPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ContactPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class ContactPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/CountryPersistenceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,8 +55,9 @@ import java.util.Set;
  * @generated
  */
 public class CountryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/EmailAddressPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class EmailAddressPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/GroupPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class GroupPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ImagePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ImagePersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class ImagePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutBranchPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutBranchPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutBranchPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutFriendlyURLPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutFriendlyURLPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutFriendlyURLPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutPrototypePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutPrototypePersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutPrototypePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutRevisionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutRevisionPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutRevisionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutSetBranchPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutSetBranchPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutSetBranchPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutSetPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutSetPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutSetPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutSetPrototypePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/LayoutSetPrototypePersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class LayoutSetPrototypePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ListTypePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ListTypePersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ListTypePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/MembershipRequestPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/MembershipRequestPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class MembershipRequestPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/OrgGroupRolePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/OrgGroupRolePersistenceTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -49,8 +50,9 @@ import java.util.Set;
  * @generated
  */
 public class OrgGroupRolePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/OrgLaborPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/OrgLaborPersistenceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,8 +55,9 @@ import java.util.Set;
  * @generated
  */
 public class OrgLaborPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/OrganizationPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class OrganizationPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PasswordPolicyPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PasswordPolicyPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class PasswordPolicyPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PasswordPolicyRelPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PasswordPolicyRelPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class PasswordPolicyRelPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PasswordTrackerPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PasswordTrackerPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class PasswordTrackerPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PhonePersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class PhonePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PluginSettingPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PluginSettingPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class PluginSettingPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortalPreferencesPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortalPreferencesPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class PortalPreferencesPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortletItemPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortletItemPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class PortletItemPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortletPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortletPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class PortletPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortletPreferencesPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/PortletPreferencesPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class PortletPreferencesPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RegionPersistenceTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,8 +55,9 @@ import java.util.Set;
  * @generated
  */
 public class RegionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ReleasePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ReleasePersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class ReleasePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RepositoryEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RepositoryEntryPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class RepositoryEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RepositoryPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class RepositoryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceActionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceActionPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ResourceActionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceBlockPermissionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceBlockPermissionPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class ResourceBlockPermissionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceBlockPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceBlockPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ResourceBlockPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourcePermissionPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ResourcePermissionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceTypePermissionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ResourceTypePermissionPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ResourceTypePermissionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/RolePersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class RolePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ServiceComponentPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/ServiceComponentPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ServiceComponentPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/SubscriptionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/SubscriptionPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class SubscriptionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/SystemEventPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/SystemEventPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class SystemEventPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/TeamPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/TeamPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class TeamPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/TicketPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class TicketPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserGroupGroupRolePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserGroupGroupRolePersistenceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -52,8 +53,9 @@ import java.util.Set;
  * @generated
  */
 public class UserGroupGroupRolePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserGroupPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class UserGroupPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserGroupRolePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserGroupRolePersistenceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -52,8 +53,9 @@ import java.util.Set;
  * @generated
  */
 public class UserGroupRolePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserIdMapperPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserIdMapperPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class UserIdMapperPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserNotificationDeliveryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserNotificationDeliveryPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class UserNotificationDeliveryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserNotificationEventPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class UserNotificationEventPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class UserPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserTrackerPathPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserTrackerPathPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class UserTrackerPathPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserTrackerPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/UserTrackerPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class UserTrackerPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/VirtualHostPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/VirtualHostPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class VirtualHostPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WebDAVPropsPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WebDAVPropsPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class WebDAVPropsPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WebsitePersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class WebsitePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WorkflowDefinitionLinkPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class WorkflowDefinitionLinkPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WorkflowInstanceLinkPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/test/WorkflowInstanceLinkPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.test.rule.PersistenceTestRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class WorkflowInstanceLinkPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsDeliveryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsDeliveryPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.announcements.service.persistence.AnnouncementsDelive
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class AnnouncementsDeliveryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsEntryPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.announcements.service.persistence.AnnouncementsEntryU
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class AnnouncementsEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsFlagPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/announcements/service/persistence/test/AnnouncementsFlagPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.announcements.service.persistence.AnnouncementsFlagUt
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class AnnouncementsFlagPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.asset.service.persistence.AssetCategoryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class AssetCategoryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetCategoryPropertyPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.asset.service.persistence.AssetCategoryPropertyUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class AssetCategoryPropertyPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetEntryPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portlet.asset.service.persistence.AssetEntryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,8 +61,9 @@ import java.util.Set;
  * @generated
  */
 public class AssetEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetLinkPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetLinkPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.asset.service.persistence.AssetLinkUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class AssetLinkPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetTagPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.asset.service.persistence.AssetTagUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class AssetTagPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetTagStatsPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetTagStatsPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portlet.asset.service.persistence.AssetTagStatsUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class AssetTagStatsPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/asset/service/persistence/test/AssetVocabularyPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.asset.service.persistence.AssetVocabularyUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class AssetVocabularyPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/service/persistence/test/BlogsEntryPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.blogs.service.persistence.BlogsEntryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class BlogsEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/blogs/service/persistence/test/BlogsStatsUserPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/blogs/service/persistence/test/BlogsStatsUserPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.blogs.service.persistence.BlogsStatsUserUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class BlogsStatsUserPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/calendar/service/persistence/test/CalEventPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/calendar/service/persistence/test/CalEventPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.calendar.service.persistence.CalEventUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -61,8 +62,9 @@ import java.util.Set;
  */
 @Deprecated
 public class CalEventPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLContentPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLContentPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLContentUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,8 +64,9 @@ import java.util.Set;
  * @generated
  */
 public class DLContentPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryMetadataPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLFileEntryMetada
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class DLFileEntryMetadataPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLFileEntryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class DLFileEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryTypePersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLFileEntryTypeUt
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class DLFileEntryTypePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileRankPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileRankPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLFileRankUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class DLFileRankPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileShortcutPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLFileShortcutUti
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class DLFileShortcutPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileVersionPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLFileVersionUtil
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class DLFileVersionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFolderPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLFolderUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class DLFolderPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLSyncEventPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLSyncEventPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portlet.documentlibrary.service.persistence.DLSyncEventUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class DLSyncEventPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoColumnPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoColumnPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.expando.service.persistence.ExpandoColumnUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class ExpandoColumnPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoRowPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoRowPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.expando.service.persistence.ExpandoRowUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ExpandoRowPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoTablePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoTablePersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.expando.service.persistence.ExpandoTableUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class ExpandoTablePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoValuePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/expando/service/persistence/test/ExpandoValuePersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.expando.service.persistence.ExpandoValueUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class ExpandoValuePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/exportimport/service/persistence/test/ExportImportConfigurationPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/exportimport/service/persistence/test/ExportImportConfigurationPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portlet.exportimport.service.persistence.ExportImportConfigur
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class ExportImportConfigurationPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBBanPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBBanPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBBanUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class MBBanPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBCategoryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBCategoryPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBCategoryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class MBCategoryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBDiscussionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBDiscussionPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBDiscussionUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class MBDiscussionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBMailingListPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBMailingListPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBMailingListUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class MBMailingListPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBMessagePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBMessagePersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBMessageUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,8 +61,9 @@ import java.util.Set;
  * @generated
  */
 public class MBMessagePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBStatsUserPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBStatsUserPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBStatsUserUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class MBStatsUserPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBThreadFlagPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBThreadFlagPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBThreadFlagUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class MBThreadFlagPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBThreadPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/persistence/test/MBThreadPersistenceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portlet.messageboards.service.persistence.MBThreadUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,8 +61,9 @@ import java.util.Set;
  * @generated
  */
 public class MBThreadPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/ratings/service/persistence/test/RatingsEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/ratings/service/persistence/test/RatingsEntryPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.ratings.service.persistence.RatingsEntryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class RatingsEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/ratings/service/persistence/test/RatingsStatsPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/ratings/service/persistence/test/RatingsStatsPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.ratings.service.persistence.RatingsStatsUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class RatingsStatsPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityAchievementPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityAchievementPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.social.service.persistence.SocialActivityAchievementU
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialActivityAchievementPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityCounterPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityCounterPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.social.service.persistence.SocialActivityCounterUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialActivityCounterPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityLimitPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityLimitPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.social.service.persistence.SocialActivityLimitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialActivityLimitPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivityPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portlet.social.service.persistence.SocialActivityUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialActivityPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivitySetPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivitySetPersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portlet.social.service.persistence.SocialActivitySetUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialActivitySetPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivitySettingPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialActivitySettingPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.social.service.persistence.SocialActivitySettingUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialActivitySettingPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialRelationPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialRelationPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.social.service.persistence.SocialRelationUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialRelationPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialRequestPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/social/service/persistence/test/SocialRequestPersistenceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portlet.social.service.persistence.SocialRequestUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -58,8 +59,9 @@ import java.util.Set;
  * @generated
  */
 public class SocialRequestPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCFrameworkVersionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCFrameworkVersionPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portlet.softwarecatalog.service.persistence.SCFrameworkVersio
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class SCFrameworkVersionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCLicensePersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCLicensePersistenceTest.java
@@ -39,6 +39,7 @@ import com.liferay.portlet.softwarecatalog.service.persistence.SCLicenseUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -55,8 +56,9 @@ import java.util.Set;
  * @generated
  */
 public class SCLicensePersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCProductEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCProductEntryPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.softwarecatalog.service.persistence.SCProductEntryUti
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class SCProductEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCProductScreenshotPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCProductScreenshotPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portlet.softwarecatalog.service.persistence.SCProductScreensh
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class SCProductScreenshotPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCProductVersionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/softwarecatalog/service/persistence/test/SCProductVersionPersistenceTest.java
@@ -43,6 +43,7 @@ import com.liferay.portlet.softwarecatalog.service.persistence.SCProductVersionU
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -59,8 +60,9 @@ import java.util.Set;
  * @generated
  */
 public class SCProductVersionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/trash/service/persistence/test/TrashEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/service/persistence/test/TrashEntryPersistenceTest.java
@@ -41,6 +41,7 @@ import com.liferay.portlet.trash.service.persistence.TrashEntryUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -57,8 +58,9 @@ import java.util.Set;
  * @generated
  */
 public class TrashEntryPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/integration/com/liferay/portlet/trash/service/persistence/test/TrashVersionPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/service/persistence/test/TrashVersionPersistenceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portlet.trash.service.persistence.TrashVersionUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -56,8 +57,9 @@ import java.util.Set;
  * @generated
  */
 public class TrashVersionPersistenceTest {
+	@ClassRule
 	@Rule
-	public final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
+	public static final AggregateTestRule aggregateTestRule = new AggregateTestRule(new LiferayIntegrationTestRule(),
 			PersistenceTestRule.INSTANCE,
 			new TransactionalTestRule(Propagation.REQUIRED));
 

--- a/portal-impl/test/test-portal-impl.properties
+++ b/portal-impl/test/test-portal-impl.properties
@@ -2,6 +2,8 @@ include-and-override=test-portal-impl-ext.properties
 
 assert.logs=true
 
+ci.test.timeout.time=1200000
+
 company.web.id=liferay.com
 
 dl.file.entry.processors.trigger.synchronously=true

--- a/portal-test-internal/src/com/liferay/portal/test/rule/CITimeoutTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/CITimeoutTestRule.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule;
+
+import com.liferay.portal.kernel.test.rule.BaseTestRule;
+import com.liferay.portal.kernel.test.rule.callback.BaseTestCallback;
+import com.liferay.portal.test.rule.callback.CITimeoutTestCallback;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class CITimeoutTestRule extends BaseTestRule<Long, Object> {
+
+	public static final CITimeoutTestRule INSTANCE = new CITimeoutTestRule();
+
+	public CITimeoutTestRule() {
+		super(_getTestCallback());
+	}
+
+	private static BaseTestCallback<Long, Object> _getTestCallback() {
+		if (System.getenv("JENKINS_HOME") != null) {
+			return CITimeoutTestCallback.INSTANCE;
+		}
+
+		return new BaseTestCallback<>();
+	}
+
+}

--- a/portal-test-internal/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
@@ -38,8 +38,8 @@ public class LiferayIntegrationTestRule extends AggregateTestRule {
 
 	public LiferayIntegrationTestRule() {
 		super(
-			false, LogAssertionTestRule.INSTANCE, _clearThreadLocalTestRule,
-			_uniqueStringRandomizerBumperTestRule,
+			false, CITimeoutTestRule.INSTANCE, LogAssertionTestRule.INSTANCE,
+			_clearThreadLocalTestRule, _uniqueStringRandomizerBumperTestRule,
 			new DeleteAfterTestRunTestRule());
 	}
 

--- a/portal-test-internal/src/com/liferay/portal/test/rule/callback/CITimeoutTestCallback.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/callback/CITimeoutTestCallback.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule.callback;
+
+import com.liferay.portal.kernel.test.rule.callback.BaseTestCallback;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import org.junit.Assert;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.Runner;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class CITimeoutTestCallback extends BaseTestCallback<Long, Object> {
+
+	public static final CITimeoutTestCallback INSTANCE =
+		new CITimeoutTestCallback();
+
+	@Override
+	public void doAfterClass(Description description, Long startTime) {
+		long testTime = System.currentTimeMillis() - startTime;
+
+		if (testTime <= TestPropsValues.CI_TEST_TIMEOUT_TIME) {
+			return;
+		}
+
+		String message =
+			description.getClassName() + " spent " + testTime +
+				"ms, passed the timeout threshold " +
+					TestPropsValues.CI_TEST_TIMEOUT_TIME + "ms.";
+
+		System.setProperty(_TIMEOUT_TEST_CLASS_MESSAGE, message);
+
+		Assert.fail(
+			message + " Marked it as failed and aborting " +
+				"all following tests");
+	}
+
+	@Override
+	public Long doBeforeClass(Description description) {
+		String message = System.getProperty(_TIMEOUT_TEST_CLASS_MESSAGE);
+
+		if (message != null) {
+			Assert.fail(
+				"Abort running " + description.getClassName() + " due to : " +
+					message);
+		}
+
+		if (!_isArquillianTest(description)) {
+			return System.currentTimeMillis();
+		}
+
+		String startTimeKey = _ARQUILLIAN_TEST_START_TIME_KEY_PREFIX.concat(
+			description.getClassName());
+
+		String startTimeValue = System.getProperty(startTimeKey);
+
+		if (startTimeValue == null) {
+			long startTime = System.currentTimeMillis();
+
+			System.setProperty(startTimeKey, String.valueOf(startTime));
+
+			return startTime;
+		}
+
+		return GetterUtil.getLongStrict(startTimeValue);
+	}
+
+	private CITimeoutTestCallback() {
+	}
+
+	private boolean _isArquillianTest(Description description) {
+		RunWith runWith = description.getAnnotation(RunWith.class);
+
+		if (runWith == null) {
+			return false;
+		}
+
+		Class<? extends Runner> runnerClass = runWith.value();
+
+		String runnerClassName = runnerClass.getName();
+
+		if (runnerClassName.equals(
+				"com.liferay.arquillian.extension.junit.bridge.junit." +
+					"Arquillian")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String _ARQUILLIAN_TEST_START_TIME_KEY_PREFIX =
+		"ARQUILLIAN_TEST_START_TIME_KEY_PREFIX_";
+
+	private static final String _TIMEOUT_TEST_CLASS_MESSAGE =
+		"TIMEOUT_TEST_CLASS_MESSAGE";
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsUtil.java
@@ -53,6 +53,10 @@ public class TestPropsUtil {
 			InputStream is = classLoader.getResourceAsStream(
 				"test-portal-impl.properties");
 
+			if (is == null) {
+				return;
+			}
+
 			_props.load(is);
 
 			is = classLoader.getResourceAsStream(

--- a/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
@@ -39,6 +40,9 @@ public class TestPropsValues {
 
 	public static final boolean ASSERT_LOGS = GetterUtil.getBoolean(
 		TestPropsUtil.get("assert.logs"));
+
+	public static final long CI_TEST_TIMEOUT_TIME = GetterUtil.getLong(
+		TestPropsUtil.get("ci.test.timeout.time"), 20 * Time.MINUTE);
 
 	public static final String COMPANY_WEB_ID;
 


### PR DESCRIPTION
Sorry for sending this late, found quite a few bugs while making this change, especially the last commit one. I think some of those bnd.bnd that missed the portal-impl/test/test-portal-impl.properties are even broken. Need to take a closer look, for now just using the NPE check to let tests pass. It will basically ignore the properties timeout settings, but I added the GetterUtil fallback to 20mins anyway, it should be fine for now.
