### PR TITLE
LPS-58680 Annotate WikiGroupServiceConfiguration

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-annotations/bnd.bnd
+++ b/modules/apps/configuration-admin/configuration-admin-annotations/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Configuration Admin Annotations
+Bundle-SymbolicName: com.liferay.configuration.admin.annotations
+Bundle-Version: 1.0.0
+Include-Resource: classes

--- a/modules/apps/configuration-admin/configuration-admin-annotations/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-annotations/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+	compile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.0.0"
+	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compile project(":apps:configuration-admin:configuration-admin-api")
+}
+
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/modules")
+}

--- a/modules/apps/configuration-admin/configuration-admin-annotations/build.xml
+++ b/modules/apps/configuration-admin/configuration-admin-annotations/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../build-module.xml" />
+</project>

--- a/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedAttributeDefinition.java
+++ b/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedAttributeDefinition.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.annotations;
+
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.service.metatype.AttributeDefinition;
+
+/**
+ * @author Iván Zaera
+ */
+public class AnnotationsExtendedAttributeDefinition
+	implements ExtendedAttributeDefinition {
+
+	public AnnotationsExtendedAttributeDefinition(
+		Class<?> configurationBeanClass,
+		AttributeDefinition attributeDefinition) {
+
+		_attributeDefinition = attributeDefinition;
+	}
+
+	@Override
+	public int getCardinality() {
+		return _attributeDefinition.getCardinality();
+	}
+
+	@Override
+	public String[] getDefaultValue() {
+		return _attributeDefinition.getDefaultValue();
+	}
+
+	@Override
+	public String getDescription() {
+		return _attributeDefinition.getDescription();
+	}
+
+	@Override
+	public Map<String, String> getExtensionAttributes(String uri) {
+		Map<String, String> extensionAttributes = _extensionAttributes.get(uri);
+
+		if (extensionAttributes == null) {
+			extensionAttributes = Collections.emptyMap();
+		}
+
+		return extensionAttributes;
+	}
+
+	@Override
+	public Set<String> getExtensionUris() {
+		return _extensionAttributes.keySet();
+	}
+
+	@Override
+	public String getID() {
+		return _attributeDefinition.getID();
+	}
+
+	@Override
+	public String getName() {
+		return _attributeDefinition.getName();
+	}
+
+	@Override
+	public String[] getOptionLabels() {
+		return _attributeDefinition.getOptionLabels();
+	}
+
+	@Override
+	public String[] getOptionValues() {
+		return _attributeDefinition.getOptionValues();
+	}
+
+	@Override
+	public int getType() {
+		return _attributeDefinition.getType();
+	}
+
+	@Override
+	public String validate(String value) {
+		return _attributeDefinition.validate(value);
+	}
+
+	private final AttributeDefinition _attributeDefinition;
+	private final Map<String, Map<String, String>> _extensionAttributes =
+		new HashMap<>();
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedMetaTypeInformation.java
+++ b/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedMetaTypeInformation.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.annotations;
+
+import com.liferay.configuration.admin.api.ExtendedMetaTypeInformation;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
+
+import org.osgi.framework.Bundle;
+import org.osgi.service.metatype.MetaTypeInformation;
+
+/**
+ * @author Iván Zaera
+ */
+public class AnnotationsExtendedMetaTypeInformation
+	implements ExtendedMetaTypeInformation {
+
+	public AnnotationsExtendedMetaTypeInformation(
+		Bundle bundle, MetaTypeInformation metaTypeInformation) {
+
+		_bundle = bundle;
+		_metaTypeInformation = metaTypeInformation;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return _metaTypeInformation.getBundle();
+	}
+
+	@Override
+	public String[] getFactoryPids() {
+		return _metaTypeInformation.getFactoryPids();
+	}
+
+	@Override
+	public String[] getLocales() {
+		return _metaTypeInformation.getLocales();
+	}
+
+	@Override
+	public ExtendedObjectClassDefinition getObjectClassDefinition(
+		String id, String locale) {
+
+		return new AnnotationsExtendedObjectClassDefinition(
+			_bundle, _metaTypeInformation.getObjectClassDefinition(id, locale));
+	}
+
+	@Override
+	public String[] getPids() {
+		return _metaTypeInformation.getPids();
+	}
+
+	private final Bundle _bundle;
+	private final MetaTypeInformation _metaTypeInformation;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedMetaTypeService.java
+++ b/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedMetaTypeService.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.annotations;
+
+import com.liferay.configuration.admin.api.ExtendedMetaTypeInformation;
+import com.liferay.configuration.admin.api.ExtendedMetaTypeService;
+
+import org.osgi.framework.Bundle;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.MetaTypeService;
+
+/**
+ * @author Iván Zaera
+ */
+@Component(service = ExtendedMetaTypeService.class)
+public class AnnotationsExtendedMetaTypeService
+	implements ExtendedMetaTypeService {
+
+	@Override
+	public ExtendedMetaTypeInformation getMetaTypeInformation(Bundle bundle) {
+		return new AnnotationsExtendedMetaTypeInformation(
+			bundle, _metaTypeService.getMetaTypeInformation(bundle));
+	}
+
+	@Reference
+	protected void setMetaTypeService(MetaTypeService metaTypeService) {
+		_metaTypeService = metaTypeService;
+	}
+
+	private MetaTypeService _metaTypeService;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedObjectClassDefinition.java
+++ b/modules/apps/configuration-admin/configuration-admin-annotations/src/com/liferay/configuration/admin/annotations/AnnotationsExtendedObjectClassDefinition.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.annotations;
+
+import com.liferay.configuration.admin.api.ConfigurationAdmin;
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.service.metatype.AttributeDefinition;
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+/**
+ * @author Iván Zaera
+ */
+public class AnnotationsExtendedObjectClassDefinition
+	implements ExtendedObjectClassDefinition {
+
+	public AnnotationsExtendedObjectClassDefinition(
+		Bundle bundle, ObjectClassDefinition objectClassDefinition) {
+
+		_objectClassDefinition = objectClassDefinition;
+
+		_loadConfigurationBeanClass(bundle);
+
+		if (_configurationBeanClass != null) {
+			_processCategoryAnnotation();
+		}
+	}
+
+	@Override
+	public ExtendedAttributeDefinition[] getAttributeDefinitions(int filter) {
+		ExtendedAttributeDefinition[] extendedAttributeDefinitions =
+			_extendedAttributeDefinitions.get(filter);
+
+		if (extendedAttributeDefinitions == null) {
+			AttributeDefinition[] attributeDefinitions =
+				_objectClassDefinition.getAttributeDefinitions(filter);
+
+			extendedAttributeDefinitions =
+				new ExtendedAttributeDefinition[attributeDefinitions.length];
+
+			for (int i = 0; i < attributeDefinitions.length; i++) {
+				extendedAttributeDefinitions[i] =
+					new AnnotationsExtendedAttributeDefinition(
+						_configurationBeanClass, attributeDefinitions[i]);
+			}
+
+			_extendedAttributeDefinitions.put(
+				filter, extendedAttributeDefinitions);
+		}
+
+		return extendedAttributeDefinitions;
+	}
+
+	@Override
+	public String getDescription() {
+		return _objectClassDefinition.getDescription();
+	}
+
+	@Override
+	public Map<String, String> getExtensionAttributes(String uri) {
+		Map<String, String> extensionAttributes = _extensionAttributes.get(uri);
+
+		if (extensionAttributes == null) {
+			extensionAttributes = Collections.emptyMap();
+		}
+
+		return extensionAttributes;
+	}
+
+	@Override
+	public Set<String> getExtensionUris() {
+		return _extensionAttributes.keySet();
+	}
+
+	@Override
+	public InputStream getIcon(int size) throws IOException {
+		return _objectClassDefinition.getIcon(size);
+	}
+
+	@Override
+	public String getID() {
+		return _objectClassDefinition.getID();
+	}
+
+	@Override
+	public String getName() {
+		return _objectClassDefinition.getName();
+	}
+
+	private void _loadConfigurationBeanClass(Bundle bundle) {
+		try {
+			BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+			ClassLoader classLoader = bundleWiring.getClassLoader();
+
+			_configurationBeanClass = classLoader.loadClass(
+				_objectClassDefinition.getID());
+		}
+		catch (ClassNotFoundException cnfe) {
+		}
+	}
+
+	private void _processCategoryAnnotation() {
+		ConfigurationAdmin configurationAdmin =
+			_configurationBeanClass.getAnnotation(ConfigurationAdmin.class);
+
+		if (configurationAdmin != null) {
+			Map<String, String> map = new HashMap<>();
+
+			map.put("category", configurationAdmin.category());
+
+			_extensionAttributes.put(ConfigurationAdmin.NS, map);
+		}
+	}
+
+	private Class<?> _configurationBeanClass;
+	private final Map<Integer, ExtendedAttributeDefinition[]>
+		_extendedAttributeDefinitions = new HashMap<>();
+	private final Map<String, Map<String, String>> _extensionAttributes =
+		new HashMap<>();
+	private final ObjectClassDefinition _objectClassDefinition;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-api/bnd.bnd
+++ b/modules/apps/configuration-admin/configuration-admin-api/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Liferay Configuration Admin API
+Bundle-SymbolicName: com.liferay.configuration.admin.api
+Bundle-Version: 1.0.0
+Export-Package: com.liferay.configuration.admin.*
+Include-Resource: classes

--- a/modules/apps/configuration-admin/configuration-admin-api/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-api/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+}
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/modules")
+}

--- a/modules/apps/configuration-admin/configuration-admin-api/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.0.0"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/apps/configuration-admin/configuration-admin-api/build.xml
+++ b/modules/apps/configuration-admin/configuration-admin-api/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../build-module.xml" />
+</project>

--- a/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ConfigurationAdmin.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ConfigurationAdmin.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.api;
+
+import aQute.bnd.annotation.xml.XMLAttribute;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Iván Zaera
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@XMLAttribute(
+	embedIn = ConfigurationAdmin.EMBED_IN, namespace = ConfigurationAdmin.NS,
+	prefix = ConfigurationAdmin.PREFIX
+)
+public @interface ConfigurationAdmin {
+
+	public static final String EMBED_IN = "*";
+
+	public static final String NS =
+		"http://www.liferay.com/xsd/meta-type-hints_7_0_0";
+
+	public static final String PREFIX = "mh";
+
+	public String category() default "";
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedAttributeDefinition.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedAttributeDefinition.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.api;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.service.metatype.AttributeDefinition;
+
+/**
+ * @author Iván Zaera
+ */
+public interface ExtendedAttributeDefinition extends AttributeDefinition {
+
+	public Map<String, String> getExtensionAttributes(String uri);
+
+	public Set<String> getExtensionUris();
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedMetaTypeInformation.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedMetaTypeInformation.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.api;
+
+import org.osgi.service.metatype.MetaTypeInformation;
+
+/**
+ * @author Iván Zaera
+ */
+public interface ExtendedMetaTypeInformation extends MetaTypeInformation {
+
+	@Override
+	public ExtendedObjectClassDefinition getObjectClassDefinition(
+		String id, String locale);
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedMetaTypeService.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedMetaTypeService.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.api;
+
+import org.osgi.framework.Bundle;
+import org.osgi.service.metatype.MetaTypeService;
+
+/**
+ * @author Iván Zaera
+ */
+public interface ExtendedMetaTypeService extends MetaTypeService {
+
+	@Override
+	public ExtendedMetaTypeInformation getMetaTypeInformation(Bundle bundle);
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedObjectClassDefinition.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/com/liferay/configuration/admin/api/ExtendedObjectClassDefinition.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.api;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+/**
+ * @author Iván Zaera
+ */
+public interface ExtendedObjectClassDefinition extends ObjectClassDefinition {
+
+	@Override
+	public ExtendedAttributeDefinition[] getAttributeDefinitions(int filter);
+
+	public Map<String, String> getExtensionAttributes(String uri);
+
+	public Set<String> getExtensionUris();
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-equinox/bnd.bnd
+++ b/modules/apps/configuration-admin/configuration-admin-equinox/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Configuration Admin Equinox
+Bundle-SymbolicName: com.liferay.configuration.admin.equinox
+Bundle-Version: 1.0.0
+Include-Resource: classes

--- a/modules/apps/configuration-admin/configuration-admin-equinox/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-equinox/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+	compile group: "org.eclipse.equinox", name: "org.eclipse.equinox.metatype", version: "1.4.200-SNAPSHOT"
+	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compile project(":apps:configuration-admin:configuration-admin-api")
+}
+
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/modules")
+}

--- a/modules/apps/configuration-admin/configuration-admin-equinox/build.xml
+++ b/modules/apps/configuration-admin/configuration-admin-equinox/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../build-module.xml" />
+</project>

--- a/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedAttributeDefinition.java
+++ b/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedAttributeDefinition.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.equinox;
+
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.equinox.metatype.Extendable;
+
+import org.osgi.service.metatype.AttributeDefinition;
+
+/**
+ * @author Iván Zaera
+ */
+public class EquinoxExtendedAttributeDefinition
+	implements ExtendedAttributeDefinition {
+
+	public EquinoxExtendedAttributeDefinition(
+		AttributeDefinition attributeDefinition) {
+
+		_attributeDefinition = attributeDefinition;
+
+		if (!(attributeDefinition instanceof Extendable)) {
+			Class<?> clazz = attributeDefinition.getClass();
+
+			throw new IllegalArgumentException(
+				"AttributeDefinition implementation " +
+					clazz.getName() + " does not implement " +
+					Extendable.class.getName());
+		}
+
+		_extendable = (Extendable)attributeDefinition;
+	}
+
+	@Override
+	public int getCardinality() {
+		return _attributeDefinition.getCardinality();
+	}
+
+	@Override
+	public String[] getDefaultValue() {
+		return _attributeDefinition.getDefaultValue();
+	}
+
+	@Override
+	public String getDescription() {
+		return _attributeDefinition.getDescription();
+	}
+
+	@Override
+	public Map<String, String> getExtensionAttributes(String uri) {
+		return _extendable.getExtensionAttributes(uri);
+	}
+
+	@Override
+	public Set<String> getExtensionUris() {
+		return _extendable.getExtensionUris();
+	}
+
+	@Override
+	public String getID() {
+		return _attributeDefinition.getID();
+	}
+
+	@Override
+	public String getName() {
+		return _attributeDefinition.getName();
+	}
+
+	@Override
+	public String[] getOptionLabels() {
+		return _attributeDefinition.getOptionLabels();
+	}
+
+	@Override
+	public String[] getOptionValues() {
+		return _attributeDefinition.getOptionValues();
+	}
+
+	@Override
+	public int getType() {
+		return _attributeDefinition.getType();
+	}
+
+	@Override
+	public String validate(String value) {
+		return _attributeDefinition.validate(value);
+	}
+
+	private final AttributeDefinition _attributeDefinition;
+	private final Extendable _extendable;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedMetaTypeInformation.java
+++ b/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedMetaTypeInformation.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.equinox;
+
+import com.liferay.configuration.admin.api.ExtendedMetaTypeInformation;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
+
+import org.osgi.framework.Bundle;
+import org.osgi.service.metatype.MetaTypeInformation;
+
+/**
+ * @author Iván Zaera
+ */
+public class EquinoxExtendedMetaTypeInformation
+	implements ExtendedMetaTypeInformation {
+
+	public EquinoxExtendedMetaTypeInformation(
+		MetaTypeInformation metaTypeInformation) {
+
+		_metaTypeInformation = metaTypeInformation;
+	}
+
+	@Override
+	public Bundle getBundle() {
+		return _metaTypeInformation.getBundle();
+	}
+
+	@Override
+	public String[] getFactoryPids() {
+		return _metaTypeInformation.getFactoryPids();
+	}
+
+	@Override
+	public String[] getLocales() {
+		return _metaTypeInformation.getLocales();
+	}
+
+	@Override
+	public ExtendedObjectClassDefinition getObjectClassDefinition(
+		String id, String locale) {
+
+		return new EquinoxExtendedObjectClassDefinition(
+			_metaTypeInformation.getObjectClassDefinition(id, locale));
+	}
+
+	@Override
+	public String[] getPids() {
+		return _metaTypeInformation.getPids();
+	}
+
+	private final MetaTypeInformation _metaTypeInformation;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedMetaTypeService.java
+++ b/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedMetaTypeService.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.equinox;
+
+import com.liferay.configuration.admin.api.ExtendedMetaTypeInformation;
+import com.liferay.configuration.admin.api.ExtendedMetaTypeService;
+
+import org.osgi.framework.Bundle;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.MetaTypeService;
+
+/**
+ * @author Iván Zaera
+ */
+//@Component(service = ExtendedMetaTypeService.class)
+public class EquinoxExtendedMetaTypeService implements ExtendedMetaTypeService {
+
+	@Override
+	public ExtendedMetaTypeInformation getMetaTypeInformation(Bundle bundle) {
+		return new EquinoxExtendedMetaTypeInformation(
+			_metaTypeService.getMetaTypeInformation(bundle));
+	}
+
+	@Reference
+	protected void setMetaTypeService(MetaTypeService metaTypeService) {
+		_metaTypeService = metaTypeService;
+	}
+
+	private MetaTypeService _metaTypeService;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedObjectClassDefinition.java
+++ b/modules/apps/configuration-admin/configuration-admin-equinox/src/com/liferay/configuration/admin/equinox/EquinoxExtendedObjectClassDefinition.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.configuration.admin.equinox;
+
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.equinox.metatype.Extendable;
+
+import org.osgi.service.metatype.AttributeDefinition;
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+/**
+ * @author Iván Zaera
+ */
+public class EquinoxExtendedObjectClassDefinition
+	implements ExtendedObjectClassDefinition {
+
+	public EquinoxExtendedObjectClassDefinition(
+		ObjectClassDefinition objectClassDefinition) {
+
+		_objectClassDefinition = objectClassDefinition;
+
+		if (!(objectClassDefinition instanceof Extendable)) {
+			Class<?> clazz = objectClassDefinition.getClass();
+
+			throw new IllegalArgumentException(
+				"ObjectClassDefinition implementation " +
+					clazz.getName() + " does not implement " +
+					Extendable.class.getName());
+		}
+
+		_extendable = (Extendable)objectClassDefinition;
+	}
+
+	@Override
+	public ExtendedAttributeDefinition[] getAttributeDefinitions(int filter) {
+		if (_extendedAttributeDefinitions == null) {
+			AttributeDefinition[] attributeDefinitions =
+				_objectClassDefinition.getAttributeDefinitions(filter);
+
+			_extendedAttributeDefinitions =
+				new ExtendedAttributeDefinition[attributeDefinitions.length];
+
+			for (int i = 0; i < attributeDefinitions.length; i++) {
+				_extendedAttributeDefinitions[i] =
+					new EquinoxExtendedAttributeDefinition(
+						attributeDefinitions[i]);
+			}
+		}
+
+		return _extendedAttributeDefinitions;
+	}
+
+	@Override
+	public String getDescription() {
+		return _objectClassDefinition.getDescription();
+	}
+
+	@Override
+	public Map<String, String> getExtensionAttributes(String uri) {
+		if (_extendable.getExtensionUris().contains(uri)) {
+			return _extendable.getExtensionAttributes(uri);
+		}
+
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public Set<String> getExtensionUris() {
+		return _extendable.getExtensionUris();
+	}
+
+	@Override
+	public InputStream getIcon(int size) throws IOException {
+		return _objectClassDefinition.getIcon(size);
+	}
+
+	@Override
+	public String getID() {
+		return _objectClassDefinition.getID();
+	}
+
+	@Override
+	public String getName() {
+		return _objectClassDefinition.getName();
+	}
+
+	private final Extendable _extendable;
+	private ExtendedAttributeDefinition[] _extendedAttributeDefinitions;
+	private final ObjectClassDefinition _objectClassDefinition;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-web/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-web/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compile project(":apps:application-list:application-list-api")
+	compile project(":apps:configuration-admin:configuration-admin-api")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-renderer")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-values-factory")

--- a/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/model/ConfigurationModel.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/model/ConfigurationModel.java
@@ -14,31 +14,35 @@
 
 package com.liferay.configuration.admin.web.model;
 
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
+
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.util.Map;
+import java.util.Set;
+
 import org.osgi.service.cm.Configuration;
-import org.osgi.service.metatype.AttributeDefinition;
-import org.osgi.service.metatype.ObjectClassDefinition;
 
 /**
  * @author Raymond Augé
  */
-public class ConfigurationModel implements ObjectClassDefinition {
+public class ConfigurationModel implements ExtendedObjectClassDefinition {
 
 	public ConfigurationModel(
-		ObjectClassDefinition objectClassDefinition,
+		ExtendedObjectClassDefinition extendedObjectClassDefinition,
 		Configuration configuration, String bundleLocation, boolean factory) {
 
-		_objectClassDefinition = objectClassDefinition;
+		_extendedObjectClassDefinition = extendedObjectClassDefinition;
 		_configuration = configuration;
 		_bundleLocation = bundleLocation;
 		_factory = factory;
 	}
 
 	@Override
-	public AttributeDefinition[] getAttributeDefinitions(int filter) {
-		return _objectClassDefinition.getAttributeDefinitions(filter);
+	public ExtendedAttributeDefinition[] getAttributeDefinitions(int filter) {
+		return _extendedObjectClassDefinition.getAttributeDefinitions(filter);
 	}
 
 	public String getBundleLocation() {
@@ -51,16 +55,35 @@ public class ConfigurationModel implements ObjectClassDefinition {
 
 	@Override
 	public String getDescription() {
-		return _objectClassDefinition.getDescription();
+		return _extendedObjectClassDefinition.getDescription();
+	}
+
+	public ExtendedObjectClassDefinition getExtendedObjectClassDefinition() {
+		return _extendedObjectClassDefinition;
+	}
+
+	@Override
+	public Map<String, String> getExtensionAttributes(String uri) {
+		return _extendedObjectClassDefinition.getExtensionAttributes(uri);
+	}
+
+	@Override
+	public Set<String> getExtensionUris() {
+		return _extendedObjectClassDefinition.getExtensionUris();
 	}
 
 	public String getFactoryPid() {
-		return _objectClassDefinition.getID();
+		return _extendedObjectClassDefinition.getID();
+	}
+
+	public Map<String, String> getHintAttributes() {
+		return _extendedObjectClassDefinition.getExtensionAttributes(
+			"http://www.liferay.com/xsd/meta-type-hints_7_0_0");
 	}
 
 	@Override
 	public InputStream getIcon(int size) throws IOException {
-		return _objectClassDefinition.getIcon(size);
+		return _extendedObjectClassDefinition.getIcon(size);
 	}
 
 	@Override
@@ -69,16 +92,12 @@ public class ConfigurationModel implements ObjectClassDefinition {
 			return _configuration.getPid();
 		}
 
-		return _objectClassDefinition.getID();
+		return _extendedObjectClassDefinition.getID();
 	}
 
 	@Override
 	public String getName() {
-		return _objectClassDefinition.getName();
-	}
-
-	public ObjectClassDefinition getObjectClassDefinition() {
-		return _objectClassDefinition;
+		return _extendedObjectClassDefinition.getName();
 	}
 
 	public boolean isFactory() {
@@ -87,7 +106,7 @@ public class ConfigurationModel implements ObjectClassDefinition {
 
 	private final String _bundleLocation;
 	private final Configuration _configuration;
+	private final ExtendedObjectClassDefinition _extendedObjectClassDefinition;
 	private final boolean _factory;
-	private final ObjectClassDefinition _objectClassDefinition;
 
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/portlet/ConfigurationAdminPortlet.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/portlet/ConfigurationAdminPortlet.java
@@ -14,6 +14,7 @@
 
 package com.liferay.configuration.admin.web.portlet;
 
+import com.liferay.configuration.admin.api.ExtendedMetaTypeService;
 import com.liferay.configuration.admin.web.constants.ConfigurationAdminPortletKeys;
 import com.liferay.configuration.admin.web.model.ConfigurationModel;
 import com.liferay.configuration.admin.web.util.ConfigurationHelper;
@@ -48,7 +49,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.metatype.MetaTypeService;
 
 /**
  * @author Kamesh Sampath
@@ -119,7 +119,7 @@ public class ConfigurationAdminPortlet extends FreeMarkerPortlet {
 		String factoryPid = ParamUtil.getString(renderRequest, "factoryPid");
 
 		ConfigurationHelper configurationHelper = new ConfigurationHelper(
-			_bundleContext, _configurationAdmin, _metaTypeService,
+			_bundleContext, _configurationAdmin, _extendedMetaTypeService,
 			themeDisplay.getLanguageId());
 
 		if (path.equals("/edit_configuration.ftl")) {
@@ -137,7 +137,7 @@ public class ConfigurationAdminPortlet extends FreeMarkerPortlet {
 
 			if (configurationModel != null) {
 				configurationModel = new ConfigurationModel(
-					configurationModel.getObjectClassDefinition(),
+					configurationModel.getExtendedObjectClassDefinition(),
 					configurationHelper.getConfiguration(pid),
 					configurationModel.getBundleLocation(),
 					configurationModel.isFactory());
@@ -202,13 +202,15 @@ public class ConfigurationAdminPortlet extends FreeMarkerPortlet {
 	}
 
 	@Reference(unbind = "-")
-	protected void setMetaTypeService(MetaTypeService metaTypeService) {
-		_metaTypeService = metaTypeService;
+	protected void setExtendedMetaTypeService(
+		ExtendedMetaTypeService extendedMetaTypeService) {
+
+		_extendedMetaTypeService = extendedMetaTypeService;
 	}
 
 	private BundleContext _bundleContext;
 	private ConfigurationAdmin _configurationAdmin;
 	private DDMFormRenderer _ddmFormRenderer;
-	private MetaTypeService _metaTypeService;
+	private ExtendedMetaTypeService _extendedMetaTypeService;
 
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/portlet/action/BindConfigurationMVCActionCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/portlet/action/BindConfigurationMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.configuration.admin.web.portlet.action;
 
+import com.liferay.configuration.admin.api.ExtendedMetaTypeService;
 import com.liferay.configuration.admin.web.constants.ConfigurationAdminPortletKeys;
 import com.liferay.configuration.admin.web.model.ConfigurationModel;
 import com.liferay.configuration.admin.web.util.ConfigurationHelper;
@@ -48,7 +49,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.metatype.MetaTypeService;
 
 /**
  * @author Kamesh Sampath
@@ -81,7 +81,7 @@ public class BindConfigurationMVCActionCommand implements MVCActionCommand {
 		}
 
 		ConfigurationHelper configurationHelper = new ConfigurationHelper(
-			_bundleContext, _configurationAdmin, _metaTypeService,
+			_bundleContext, _configurationAdmin, _extendedMetaTypeService,
 			themeDisplay.getLanguageId());
 
 		ConfigurationModel configurationModel =
@@ -204,13 +204,15 @@ public class BindConfigurationMVCActionCommand implements MVCActionCommand {
 	}
 
 	@Reference(unbind = "-")
-	protected void setJSONFactory(JSONFactory jsonFactory) {
-		_jsonFactory = jsonFactory;
+	protected void setExtendedMetaTypeService(
+		ExtendedMetaTypeService extendedMetaTypeService) {
+
+		_extendedMetaTypeService = extendedMetaTypeService;
 	}
 
 	@Reference(unbind = "-")
-	protected void setMetaTypeService(MetaTypeService metaTypeService) {
-		_metaTypeService = metaTypeService;
+	protected void setJSONFactory(JSONFactory jsonFactory) {
+		_jsonFactory = jsonFactory;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -219,7 +221,7 @@ public class BindConfigurationMVCActionCommand implements MVCActionCommand {
 	private BundleContext _bundleContext;
 	private ConfigurationAdmin _configurationAdmin;
 	private DDMFormValuesFactory _ddmFormValuesFactory;
+	private ExtendedMetaTypeService _extendedMetaTypeService;
 	private JSONFactory _jsonFactory;
-	private MetaTypeService _metaTypeService;
 
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/portlet/action/DeleteConfigurationMVCActionCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/portlet/action/DeleteConfigurationMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.configuration.admin.web.portlet.action;
 
+import com.liferay.configuration.admin.api.ExtendedMetaTypeService;
 import com.liferay.configuration.admin.web.constants.ConfigurationAdminPortletKeys;
 import com.liferay.configuration.admin.web.util.ConfigurationHelper;
 import com.liferay.portal.kernel.log.Log;
@@ -33,7 +34,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.metatype.MetaTypeService;
 
 /**
  * @author Kamesh Sampath
@@ -62,7 +62,8 @@ public class DeleteConfigurationMVCActionCommand implements MVCActionCommand {
 
 		try {
 			ConfigurationHelper configurationHelper = new ConfigurationHelper(
-				bundleContext, configurationAdmin, metaTypeService, pid);
+				bundleContext, configurationAdmin, extendedMetaTypeService,
+				pid);
 
 			Configuration configuration = configurationHelper.getConfiguration(
 				pid);
@@ -89,13 +90,15 @@ public class DeleteConfigurationMVCActionCommand implements MVCActionCommand {
 	}
 
 	@Reference(unbind = "-")
-	protected void setMetaTypeService(MetaTypeService metaTypeService) {
-		this.metaTypeService = metaTypeService;
+	protected void setExtendedMetaTypeService(
+		ExtendedMetaTypeService extendedMetaTypeService) {
+
+		this.extendedMetaTypeService = extendedMetaTypeService;
 	}
 
 	protected BundleContext bundleContext;
 	protected ConfigurationAdmin configurationAdmin;
-	protected MetaTypeService metaTypeService;
+	protected ExtendedMetaTypeService extendedMetaTypeService;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DeleteConfigurationMVCActionCommand.class);

--- a/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/util/ConfigurationHelper.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/com/liferay/configuration/admin/web/util/ConfigurationHelper.java
@@ -14,6 +14,8 @@
 
 package com.liferay.configuration.admin.web.util;
 
+import com.liferay.configuration.admin.api.ExtendedMetaTypeInformation;
+import com.liferay.configuration.admin.api.ExtendedMetaTypeService;
 import com.liferay.configuration.admin.web.model.ConfigurationModel;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -32,8 +34,6 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.metatype.MetaTypeInformation;
-import org.osgi.service.metatype.MetaTypeService;
 
 /**
  * @author Kamesh Sampath
@@ -43,11 +43,11 @@ public class ConfigurationHelper {
 
 	public ConfigurationHelper(
 		BundleContext bundleContext, ConfigurationAdmin configurationAdmin,
-		MetaTypeService metaTypeService, String languageId) {
+		ExtendedMetaTypeService extendedMetaTypeService, String languageId) {
 
 		_bundleContext = bundleContext;
 		_configurationAdmin = configurationAdmin;
-		_metaTypeService = metaTypeService;
+		_extendedMetaTypeService = extendedMetaTypeService;
 
 		_configurationModels = _getConfigurationModels(languageId);
 	}
@@ -124,20 +124,20 @@ public class ConfigurationHelper {
 		Bundle bundle, Map<String, ConfigurationModel> modelMap, String locale,
 		boolean factory) {
 
-		MetaTypeInformation metaTypeInformation =
-			_metaTypeService.getMetaTypeInformation(bundle);
+		ExtendedMetaTypeInformation extendedMetaTypeInformation =
+			_extendedMetaTypeService.getMetaTypeInformation(bundle);
 
-		if (metaTypeInformation == null) {
+		if (extendedMetaTypeInformation == null) {
 			return;
 		}
 
 		String[] pids = null;
 
 		if (factory) {
-			pids = metaTypeInformation.getFactoryPids();
+			pids = extendedMetaTypeInformation.getFactoryPids();
 		}
 		else {
-			pids = metaTypeInformation.getPids();
+			pids = extendedMetaTypeInformation.getPids();
 		}
 
 		for (String pid : pids) {
@@ -155,8 +155,8 @@ public class ConfigurationHelper {
 	private ConfigurationModel _getConfigurationModel(
 		Bundle bundle, String pid, boolean factory, String locale) {
 
-		MetaTypeInformation metaTypeInformation =
-			_metaTypeService.getMetaTypeInformation(bundle);
+		ExtendedMetaTypeInformation metaTypeInformation =
+			_extendedMetaTypeService.getMetaTypeInformation(bundle);
 
 		if (metaTypeInformation == null) {
 			return null;
@@ -206,6 +206,6 @@ public class ConfigurationHelper {
 	private final BundleContext _bundleContext;
 	private final ConfigurationAdmin _configurationAdmin;
 	private final Map<String, ConfigurationModel> _configurationModels;
-	private final MetaTypeService _metaTypeService;
+	private final ExtendedMetaTypeService _extendedMetaTypeService;
 
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/test/unit/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormConverterTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/test/unit/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormConverterTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.configuration.admin.web.util;
 
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
 import com.liferay.configuration.admin.web.model.ConfigurationModel;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
@@ -35,9 +37,6 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import org.osgi.service.metatype.AttributeDefinition;
-import org.osgi.service.metatype.ObjectClassDefinition;
-
 /**
  * @author Marcellus Tavares
  */
@@ -50,24 +49,24 @@ public class ConfigurationModelToDDMFormConverterTest extends Mockito {
 
 	@Test
 	public void testGetWithCheckboxField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition},
-			ObjectClassDefinition.REQUIRED);
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition},
+			ExtendedObjectClassDefinition.REQUIRED);
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Boolean");
-		whenAttributeDefinitionGetType(
-			attributeDefinition, AttributeDefinition.BOOLEAN);
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Boolean");
+		whenGetType(
+			extendedAttributeDefinition, ExtendedAttributeDefinition.BOOLEAN);
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		ConfigurationModelToDDMFormConverter
 			configurationModelToDDMFormConverter =
@@ -94,24 +93,24 @@ public class ConfigurationModelToDDMFormConverterTest extends Mockito {
 
 	@Test
 	public void testGetWithIntegerField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition},
-			ObjectClassDefinition.REQUIRED);
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition},
+			ExtendedObjectClassDefinition.REQUIRED);
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Integer");
-		whenAttributeDefinitionGetType(
-			attributeDefinition, AttributeDefinition.INTEGER);
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Integer");
+		whenGetType(
+			extendedAttributeDefinition, ExtendedAttributeDefinition.INTEGER);
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		ConfigurationModelToDDMFormConverter
 			configurationModelToDDMFormConverter =
@@ -139,28 +138,28 @@ public class ConfigurationModelToDDMFormConverterTest extends Mockito {
 
 	@Test
 	public void testGetWithSelectField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition},
-			ObjectClassDefinition.REQUIRED);
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition},
+			ExtendedObjectClassDefinition.REQUIRED);
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Select");
-		whenAttributeDefinitionGetType(
-			attributeDefinition, AttributeDefinition.STRING);
-		whenAttributeDefinitionGetOptionLabels(
-			attributeDefinition, new String[] {"Label 1", "Label 2"});
-		whenAttributeDefinitionGetOptionValues(
-			attributeDefinition, new String[] {"Value 1", "Value 2"});
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Select");
+		whenGetType(
+			extendedAttributeDefinition, ExtendedAttributeDefinition.STRING);
+		whenGetOptionLabels(
+			extendedAttributeDefinition, new String[] {"Label 1", "Label 2"});
+		whenGetOptionValues(
+			extendedAttributeDefinition, new String[] {"Value 1", "Value 2"});
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		ConfigurationModelToDDMFormConverter
 			configurationModelToDDMFormConverter =
@@ -205,24 +204,24 @@ public class ConfigurationModelToDDMFormConverterTest extends Mockito {
 
 	@Test
 	public void testGetWithTextField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition},
-			ObjectClassDefinition.OPTIONAL);
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition},
+			ExtendedObjectClassDefinition.OPTIONAL);
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Text");
-		whenAttributeDefinitionGetType(
-			attributeDefinition, AttributeDefinition.STRING);
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Text");
+		whenGetType(
+			extendedAttributeDefinition, ExtendedAttributeDefinition.STRING);
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		ConfigurationModelToDDMFormConverter
 			configurationModelToDDMFormConverter =
@@ -243,64 +242,70 @@ public class ConfigurationModelToDDMFormConverterTest extends Mockito {
 		Assert.assertFalse(ddmFormField.isRequired());
 	}
 
-	protected void whenAttributeDefinitionGetCardinality(
-		AttributeDefinition attributeDefinition, int returnCardinality) {
+	protected void whenGetAttributeDefinitions(
+		ExtendedObjectClassDefinition extendedObjectClassDefinition,
+		ExtendedAttributeDefinition[] returnAttributeDefinitions, int filter) {
 
 		when(
-			attributeDefinition.getCardinality()
+			extendedObjectClassDefinition.getAttributeDefinitions(
+				Matchers.eq(filter))
+		).thenReturn(
+			returnAttributeDefinitions
+		);
+	}
+
+	protected void whenGetCardinality(
+		ExtendedAttributeDefinition extendedAttributeDefinition,
+		int returnCardinality) {
+
+		when(
+			extendedAttributeDefinition.getCardinality()
 		).thenReturn(
 			returnCardinality
 		);
 	}
 
-	protected void whenAttributeDefinitionGetID(
-		AttributeDefinition attributeDefinition, String returnID) {
+	protected void whenGetID(
+		ExtendedAttributeDefinition extendedAttributeDefinition,
+		String returnID) {
 
 		when(
-			attributeDefinition.getID()
+			extendedAttributeDefinition.getID()
 		).thenReturn(
 			returnID
 		);
 	}
 
-	protected void whenAttributeDefinitionGetOptionLabels(
-		AttributeDefinition attributeDefinition, String[] returnOptionLabels) {
+	protected void whenGetOptionLabels(
+		ExtendedAttributeDefinition extendedAttributeDefinition,
+		String[] returnOptionLabels) {
 
 		when(
-			attributeDefinition.getOptionLabels()
+			extendedAttributeDefinition.getOptionLabels()
 		).thenReturn(
 			returnOptionLabels
 		);
 	}
 
-	protected void whenAttributeDefinitionGetOptionValues(
-		AttributeDefinition attributeDefinition, String[] returnOptionValues) {
+	protected void whenGetOptionValues(
+		ExtendedAttributeDefinition extendedAttributeDefinition,
+		String[] returnOptionValues) {
 
 		when(
-			attributeDefinition.getOptionValues()
+			extendedAttributeDefinition.getOptionValues()
 		).thenReturn(
 			returnOptionValues
 		);
 	}
 
-	protected void whenAttributeDefinitionGetType(
-		AttributeDefinition attributeDefinition, int returnType) {
+	protected void whenGetType(
+		ExtendedAttributeDefinition extendedAttributeDefinition,
+		int returnType) {
 
 		when(
-			attributeDefinition.getType()
+			extendedAttributeDefinition.getType()
 		).thenReturn(
 			returnType
-		);
-	}
-
-	protected void whenObjectClassDefinitionGetAttributeDefinitions(
-		ObjectClassDefinition objectClassDefinition,
-		AttributeDefinition[] returnAttributeDefinitions, int filter) {
-
-		when(
-			objectClassDefinition.getAttributeDefinitions(Matchers.eq(filter))
-		).thenReturn(
-			returnAttributeDefinitions
 		);
 	}
 

--- a/modules/apps/configuration-admin/configuration-admin-web/test/unit/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormValuesConverterTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/test/unit/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormValuesConverterTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.configuration.admin.web.util;
 
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
 import com.liferay.configuration.admin.web.model.ConfigurationModel;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.Value;
@@ -37,8 +39,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import org.osgi.service.cm.Configuration;
-import org.osgi.service.metatype.AttributeDefinition;
-import org.osgi.service.metatype.ObjectClassDefinition;
 
 /**
  * @author Marcellus Tavares
@@ -54,19 +54,19 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 	public void
 		testGetValuesByConfigurationAndNegativeCardinalityWithTextField() {
 
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition attributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {attributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, -2);
-		whenAttributeDefinitionGetDefaultValue(attributeDefinition, null);
-		whenAttributeDefinitionGetID(attributeDefinition, "Text");
+		whenGetCardinality(attributeDefinition, -2);
+		whenGetDefaultValue(attributeDefinition, null);
+		whenGetID(attributeDefinition, "Text");
 
 		Configuration configuration = mock(Configuration.class);
 
@@ -79,10 +79,10 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 		properties.put("Text", vector);
 
-		whenConfigurationGetProperties(configuration, properties);
+		whenGetProperties(configuration, properties);
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValues ddmFormValues = getDDMFormValues(
 			configurationModel, getDDMForm(configurationModel));
@@ -101,19 +101,19 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 	public void
 		testGetValuesByConfigurationAndPositiveCardinalityWithTextField() {
 
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 2);
-		whenAttributeDefinitionGetDefaultValue(attributeDefinition, null);
-		whenAttributeDefinitionGetID(attributeDefinition, "Text");
+		whenGetCardinality(extendedAttributeDefinition, 2);
+		whenGetDefaultValue(extendedAttributeDefinition, null);
+		whenGetID(extendedAttributeDefinition, "Text");
 
 		Configuration configuration = mock(Configuration.class);
 
@@ -121,10 +121,10 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 		properties.put("Text", new String[] {"Joe Bloggs", "Ella Fitzgerald"});
 
-		whenConfigurationGetProperties(configuration, properties);
+		whenGetProperties(configuration, properties);
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValues ddmFormValues = getDDMFormValues(
 			configurationModel, getDDMForm(configurationModel));
@@ -141,18 +141,18 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 	@Test
 	public void testGetValuesByConfigurationWithCheckboxField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Boolean");
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Boolean");
 
 		Configuration configuration = mock(Configuration.class);
 
@@ -160,10 +160,10 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 		properties.put("Boolean", Boolean.TRUE);
 
-		whenConfigurationGetProperties(configuration, properties);
+		whenGetProperties(configuration, properties);
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValues ddmFormValues = getDDMFormValues(
 			configurationModel, getDDMForm(configurationModel));
@@ -177,24 +177,23 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 	@Test
 	public void testGetValuesByDefaultValueWithCheckboxField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition attributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {attributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Boolean");
+		whenGetCardinality(attributeDefinition, 0);
+		whenGetID(attributeDefinition, "Boolean");
 
-		whenAttributeDefinitionGetDefaultValue(
-			attributeDefinition, new String[] {"false"});
+		whenGetDefaultValue(attributeDefinition, new String[] {"false"});
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		DDMFormValues ddmFormValues = getDDMFormValues(
 			configurationModel, getDDMForm(configurationModel));
@@ -208,27 +207,27 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 	@Test
 	public void testGetValuesByDefaultValueWithSelectField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition attributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {attributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetDefaultValue(
+		whenGetCardinality(attributeDefinition, 0);
+		whenGetDefaultValue(
 			attributeDefinition, new String[] {"REQUEST_HEADER"});
-		whenAttributeDefinitionGetID(attributeDefinition, "Select");
-		whenAttributeDefinitionGetOptionLabels(
+		whenGetID(attributeDefinition, "Select");
+		whenGetOptionLabels(
 			attributeDefinition, new String[] {"COOKIE", "REQUEST_HEADER"});
-		whenAttributeDefinitionGetOptionValues(
+		whenGetOptionValues(
 			attributeDefinition, new String[] {"COOKIE", "REQUEST_HEADER"});
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		DDMFormValues ddmFormValues = getDDMFormValues(
 			configurationModel, getDDMForm(configurationModel));
@@ -243,23 +242,23 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 	@Test
 	public void testGetValuesByDefaultValueWithTextField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition attributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {attributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 2);
-		whenAttributeDefinitionGetDefaultValue(
+		whenGetCardinality(attributeDefinition, 2);
+		whenGetDefaultValue(
 			attributeDefinition, new String[] {"Joe Bloggs|Ella Fitzgerald"});
-		whenAttributeDefinitionGetID(attributeDefinition, "Text");
+		whenGetID(attributeDefinition, "Text");
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		DDMFormValues ddmFormValues = getDDMFormValues(
 			configurationModel, getDDMForm(configurationModel));
@@ -276,22 +275,22 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 
 	@Test
 	public void testGetValuesByEmptyDefaultValueWithTextField() {
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition attributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {attributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetDefaultValue(attributeDefinition, null);
-		whenAttributeDefinitionGetID(attributeDefinition, "Text");
+		whenGetCardinality(attributeDefinition, 0);
+		whenGetDefaultValue(attributeDefinition, null);
+		whenGetID(attributeDefinition, "Text");
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, null, null, false);
+			extendedObjectClassDefinition, null, null, false);
 
 		DDMFormValues ddmFormValues = getDDMFormValues(
 			configurationModel, getDDMForm(configurationModel));
@@ -330,8 +329,20 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 		return value.getString(_enLocale);
 	}
 
-	protected void whenAttributeDefinitionGetCardinality(
-		AttributeDefinition attributeDefinition, int returnCardinality) {
+	protected void whenGetAttributeDefinitions(
+		ExtendedObjectClassDefinition objectClassDefinition,
+		ExtendedAttributeDefinition[] returnAttributeDefinitions) {
+
+		when(
+			objectClassDefinition.getAttributeDefinitions(Matchers.anyInt())
+		).thenReturn(
+			returnAttributeDefinitions
+		);
+	}
+
+	protected void whenGetCardinality(
+		ExtendedAttributeDefinition attributeDefinition,
+		int returnCardinality) {
 
 		when(
 			attributeDefinition.getCardinality()
@@ -340,8 +351,9 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 		);
 	}
 
-	protected void whenAttributeDefinitionGetDefaultValue(
-		AttributeDefinition attributeDefinition, String[] returnDefaultValue) {
+	protected void whenGetDefaultValue(
+		ExtendedAttributeDefinition attributeDefinition,
+		String[] returnDefaultValue) {
 
 		when(
 			attributeDefinition.getDefaultValue()
@@ -350,8 +362,8 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 		);
 	}
 
-	protected void whenAttributeDefinitionGetID(
-		AttributeDefinition attributeDefinition, String returnID) {
+	protected void whenGetID(
+		ExtendedAttributeDefinition attributeDefinition, String returnID) {
 
 		when(
 			attributeDefinition.getID()
@@ -360,8 +372,9 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 		);
 	}
 
-	protected void whenAttributeDefinitionGetOptionLabels(
-		AttributeDefinition attributeDefinition, String[] returnOptionLabels) {
+	protected void whenGetOptionLabels(
+		ExtendedAttributeDefinition attributeDefinition,
+		String[] returnOptionLabels) {
 
 		when(
 			attributeDefinition.getOptionLabels()
@@ -370,8 +383,9 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 		);
 	}
 
-	protected void whenAttributeDefinitionGetOptionValues(
-		AttributeDefinition attributeDefinition, String[] returnOptionValues) {
+	protected void whenGetOptionValues(
+		ExtendedAttributeDefinition attributeDefinition,
+		String[] returnOptionValues) {
 
 		when(
 			attributeDefinition.getOptionValues()
@@ -380,7 +394,7 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 		);
 	}
 
-	protected void whenConfigurationGetProperties(
+	protected void whenGetProperties(
 		Configuration configuration,
 		Dictionary<String, Object> returnProperties) {
 
@@ -388,17 +402,6 @@ public class ConfigurationModelToDDMFormValuesConverterTest extends Mockito {
 			configuration.getProperties()
 		).thenReturn(
 			returnProperties
-		);
-	}
-
-	protected void whenObjectClassDefinitionGetAttributeDefinitions(
-		ObjectClassDefinition objectClassDefinition,
-		AttributeDefinition[] returnAttributeDefinitions) {
-
-		when(
-			objectClassDefinition.getAttributeDefinitions(Matchers.anyInt())
-		).thenReturn(
-			returnAttributeDefinitions
 		);
 	}
 

--- a/modules/apps/configuration-admin/configuration-admin-web/test/unit/com/liferay/configuration/admin/web/util/DDMFormValuesToPropertiesConverterTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/test/unit/com/liferay/configuration/admin/web/util/DDMFormValuesToPropertiesConverterTest.java
@@ -14,6 +14,8 @@
 
 package com.liferay.configuration.admin.web.util;
 
+import com.liferay.configuration.admin.api.ExtendedAttributeDefinition;
+import com.liferay.configuration.admin.api.ExtendedObjectClassDefinition;
 import com.liferay.configuration.admin.web.model.ConfigurationModel;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
@@ -41,8 +43,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import org.osgi.service.cm.Configuration;
-import org.osgi.service.metatype.AttributeDefinition;
-import org.osgi.service.metatype.ObjectClassDefinition;
 
 /**
  * @author Marcellus Tavares
@@ -81,23 +81,23 @@ public class DDMFormValuesToPropertiesConverterTest extends Mockito {
 		ddmFormValues.addDDMFormFieldValue(
 			createDDMFormFieldValue("Boolean", "true", _enLocale));
 
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
 		Configuration configuration = mock(Configuration.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 3);
-		whenAttributeDefinitionGetID(attributeDefinition, "Boolean");
+		whenGetCardinality(extendedAttributeDefinition, 3);
+		whenGetID(extendedAttributeDefinition, "Boolean");
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValuesToPropertiesConverter ddmFormValuesToPropertiesConverter =
 			new DDMFormValuesToPropertiesConverter(
@@ -136,23 +136,23 @@ public class DDMFormValuesToPropertiesConverterTest extends Mockito {
 		ddmFormValues.addDDMFormFieldValue(
 			createDDMFormFieldValue("Boolean", "true", _enLocale));
 
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
 		Configuration configuration = mock(Configuration.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Boolean");
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Boolean");
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValuesToPropertiesConverter ddmFormValuesToPropertiesConverter =
 			new DDMFormValuesToPropertiesConverter(
@@ -185,23 +185,23 @@ public class DDMFormValuesToPropertiesConverterTest extends Mockito {
 		ddmFormValues.addDDMFormFieldValue(
 			createDDMFormFieldValue("Integer", "42", _enLocale));
 
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
 		Configuration configuration = mock(Configuration.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Integer");
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Integer");
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValuesToPropertiesConverter ddmFormValuesToPropertiesConverter =
 			new DDMFormValuesToPropertiesConverter(
@@ -234,23 +234,23 @@ public class DDMFormValuesToPropertiesConverterTest extends Mockito {
 		ddmFormValues.addDDMFormFieldValue(
 			createDDMFormFieldValue("Select", "[\"42\"]", _enLocale));
 
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
 		Configuration configuration = mock(Configuration.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, 0);
-		whenAttributeDefinitionGetID(attributeDefinition, "Select");
+		whenGetCardinality(extendedAttributeDefinition, 0);
+		whenGetID(extendedAttributeDefinition, "Select");
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValuesToPropertiesConverter ddmFormValuesToPropertiesConverter =
 			new DDMFormValuesToPropertiesConverter(
@@ -288,23 +288,23 @@ public class DDMFormValuesToPropertiesConverterTest extends Mockito {
 		ddmFormValues.addDDMFormFieldValue(
 			createDDMFormFieldValue("Boolean", "true", _enLocale));
 
-		ObjectClassDefinition objectClassDefinition = mock(
-			ObjectClassDefinition.class);
+		ExtendedObjectClassDefinition extendedObjectClassDefinition = mock(
+			ExtendedObjectClassDefinition.class);
 
-		AttributeDefinition attributeDefinition = mock(
-			AttributeDefinition.class);
+		ExtendedAttributeDefinition extendedAttributeDefinition = mock(
+			ExtendedAttributeDefinition.class);
 
 		Configuration configuration = mock(Configuration.class);
 
-		whenObjectClassDefinitionGetAttributeDefinitions(
-			objectClassDefinition,
-			new AttributeDefinition[] {attributeDefinition});
+		whenGetAttributeDefinitions(
+			extendedObjectClassDefinition,
+			new ExtendedAttributeDefinition[] {extendedAttributeDefinition});
 
-		whenAttributeDefinitionGetCardinality(attributeDefinition, -3);
-		whenAttributeDefinitionGetID(attributeDefinition, "Boolean");
+		whenGetCardinality(extendedAttributeDefinition, -3);
+		whenGetID(extendedAttributeDefinition, "Boolean");
 
 		ConfigurationModel configurationModel = new ConfigurationModel(
-			objectClassDefinition, configuration, null, false);
+			extendedObjectClassDefinition, configuration, null, false);
 
 		DDMFormValuesToPropertiesConverter ddmFormValuesToPropertiesConverter =
 			new DDMFormValuesToPropertiesConverter(
@@ -339,34 +339,37 @@ public class DDMFormValuesToPropertiesConverterTest extends Mockito {
 		return ddmFormFieldValue;
 	}
 
-	protected void whenAttributeDefinitionGetCardinality(
-		AttributeDefinition attributeDefinition, int returnCardinality) {
+	protected void whenGetAttributeDefinitions(
+		ExtendedObjectClassDefinition extendedObjectClassDefinition,
+		ExtendedAttributeDefinition[] returnAttributeDefinitions) {
 
 		when(
-			attributeDefinition.getCardinality()
+			extendedObjectClassDefinition.getAttributeDefinitions(
+				Matchers.anyInt())
+		).thenReturn(
+			returnAttributeDefinitions
+		);
+	}
+
+	protected void whenGetCardinality(
+		ExtendedAttributeDefinition extendedAttributeDefinition,
+		int returnCardinality) {
+
+		when(
+			extendedAttributeDefinition.getCardinality()
 		).thenReturn(
 			returnCardinality
 		);
 	}
 
-	protected void whenAttributeDefinitionGetID(
-		AttributeDefinition attributeDefinition, String returnID) {
+	protected void whenGetID(
+		ExtendedAttributeDefinition extendedAttributeDefinition,
+		String returnID) {
 
 		when(
-			attributeDefinition.getID()
+			extendedAttributeDefinition.getID()
 		).thenReturn(
 			returnID
-		);
-	}
-
-	protected void whenObjectClassDefinitionGetAttributeDefinitions(
-		ObjectClassDefinition objectClassDefinition,
-		AttributeDefinition[] returnAttributeDefinitions) {
-
-		when(
-			objectClassDefinition.getAttributeDefinitions(Matchers.anyInt())
-		).thenReturn(
-			returnAttributeDefinitions
 		);
 	}
 

--- a/modules/apps/wiki/wiki-api/build.gradle
+++ b/modules/apps/wiki/wiki-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compile project(":apps:configuration-admin:configuration-admin-api")
 	compile project(":apps:item-selector:item-selector-api")
 	compile project(":apps:item-selector:item-selector-criteria-api")
 	compile project(":portal:portal-settings")

--- a/modules/apps/wiki/wiki-api/src/com/liferay/wiki/configuration/WikiGroupServiceConfiguration.java
+++ b/modules/apps/wiki/wiki-api/src/com/liferay/wiki/configuration/WikiGroupServiceConfiguration.java
@@ -16,11 +16,13 @@ package com.liferay.wiki.configuration;
 
 import aQute.bnd.annotation.metatype.Meta;
 
+import com.liferay.configuration.admin.api.ConfigurationAdmin;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 
 /**
  * @author Iván Zaera
  */
+@ConfigurationAdmin(category = "collaboration")
 @Meta.OCD(id = "com.liferay.wiki.configuration.WikiGroupServiceConfiguration")
 public interface WikiGroupServiceConfiguration {
 


### PR DESCRIPTION
/CC: @JorgeFerrer @rotty3000

Hi Brian:

This is a PR to define an ExtendedMetaTypeService that wraps OSGi's standard MetaTypeService. Its future use is to rely on it to be able to tweak our Configuration Admin to fit our needs (for example: intelligent fields that are automagically populated, typed fields like localized values or dates, and so on).

This PR defines and implements the service based on Equinox and on runtime annotations. In the end we will use Equinox, but with the annotations implementation we are able to continue development based on this, until we finally integrate BND 3 into the build (which is not so easy right now).

The last commit is an example of how it would be used to group configurations by category. It may be not pushed if you don't want to, but it won't do any harm if it is.

Please tell me what do you think or if you find something you don't like.

Cheers,
Ivan
