### PR TITLE
LPS-57577 Elasticsearch changed processing of properties to automatic…

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1079,7 +1079,7 @@ counter.jdbc.prefix=jdbc.counter.]]></echo>
 			<echo file="${liferay.home}/osgi/portal/com.liferay.portal.search.elasticsearch.configuration.ElasticsearchConfiguration.cfg">
 				additionalConfigurations=\
 					cluster.routing.allocation.disk.threshold_enabled: false,\
-					cluster.service.slow_task_logging_threshold: 600s, \
+					cluster.service.cluster.service.slow_task_logging_threshold: 600s, \
 					index.indexing.slowlog.threshold.index.warn: 600s,\
 					index.search.slowlog.threshold.fetch.warn: 600s,\
 					index.search.slowlog.threshold.query.warn: 600s,\


### PR DESCRIPTION
…ally trim prefix from the property. They still check for the prefix when reading the properties...

@brianchandotcom I know this must look weird for you. But we have to do this hacky change to make this ES configuration be loaded, it is a bug in ES.

@mhan810 @arboliveira

To make this long story short, if we can make a change to ES, we should change https://github.com/elastic/elasticsearch/blob/master/core/src/main/java/org/elasticsearch/cluster/service/InternalClusterService.java#L86 to just "slow_task_logging_threshold", then the problem will go away.

To get a full context for this, please see @willnewbury 's comment at https://github.com/shuyangzhou/liferay-portal/pull/1880#issuecomment-146724920

If you decide to make the change and contribute it back to ES, please let us know so we could take out this hacky change.

Thanks
