### PR TITLE
LPS-57476 Add commons-compress to portal-test-internal

### DIFF
--- a/portal-test-internal/bnd.bnd
+++ b/portal-test-internal/bnd.bnd
@@ -24,6 +24,7 @@ Import-Package: *;resolution:=optional
 Include-Resource:\
 	classes,\
 	@${project.dir}/../lib/development/dumbster.jar,\
+	@${project.dir}/../lib/portal/commons-compress.jar,\
 	@${project.dir}/../lib/portal/juniversalchardet.jar,\
 	@${project.dir}/../lib/portal/poi.jar,\
 	@${project.dir}/../lib/portal/tika-core.jar,\


### PR DESCRIPTION
This is required due to the recently Tika upgrade introduced a new required dependency, without it TikaSafeRandomizerBumper will fail to filter out all unacceptable byte arrays which leads to random runtime parsing failures in the arquillian tests.
