### PR TITLE
LPS-58850

### DIFF
--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -1,9 +1,7 @@
 import org.gradle.internal.hash.HashUtil
 import org.gradle.internal.hash.HashValue
 
-if (System.getenv("JENKINS_HOME")) {
-	System.setProperty "http.proxyHost", "squid.lax.liferay.com"
-	System.setProperty "http.proxyPort", "3128"
+if (System.properties["http.proxyHost"] == "squid.lax.liferay.com") {
 	System.setProperty "repository.url", "http://repository.liferay.com/nexus/content/groups/public"
 }
 

--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -2,6 +2,8 @@ import org.gradle.internal.hash.HashUtil
 import org.gradle.internal.hash.HashValue
 
 if (System.properties["http.proxyHost"] == "squid.lax.liferay.com") {
+	println "Using proxy ${System.properties['http.proxyHost']}:${System.properties['http.proxyPort']}."
+
 	System.setProperty "repository.url", "http://repository.liferay.com/nexus/content/groups/public"
 }
 


### PR DESCRIPTION
@mdelapenya told me about the problem they have with their CI: it runs Jenkins, and so the build tries to use our proxy, but of course it fails because it can't reach Squid.

We already set `http.proxyHost` and `http.proxyPort` via `ANT_OPTS` (which is then copied to `GRADLE_OPTS`), so these lines are not necessary anymore.
