### PR TITLE
LPS-59216 When a exception is thrown inside a NoSuchMethodException handler, the latter exception is used as the cause

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -185,7 +185,7 @@ public class LiferayPortlet extends GenericPortlet {
 				return true;
 			}
 			catch (Exception e) {
-				throw new PortletException(nsme);
+				throw new PortletException(e);
 			}
 		}
 		catch (InvocationTargetException ite) {
@@ -231,7 +231,7 @@ public class LiferayPortlet extends GenericPortlet {
 				return true;
 			}
 			catch (Exception e) {
-				throw new PortletException(nsme);
+				throw new PortletException(e);
 			}
 		}
 		catch (InvocationTargetException ite) {


### PR DESCRIPTION
@topero Nice catch!
