### PR TITLE
LPS-59501

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/view.jsp
@@ -42,8 +42,8 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "vocabul
 >
 	<liferay-frontend:management-bar-buttons>
 		<liferay-frontend:management-bar-display-buttons
-			displayStyleURL="<%= portletURL %>"
 			displayViews='<%= new String[] {"list"} %>'
+			portletURL="<%= portletURL %>"
 			selectedDisplayStyle="<%= displayStyle %>"
 		/>
 	</liferay-frontend:management-bar-buttons>

--- a/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/view_categories.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/META-INF/resources/view_categories.jsp
@@ -91,8 +91,8 @@ AssetCategoryUtil.addPortletBreadcrumbEntry(vocabulary, category, request, rende
 		</liferay-portlet:renderURL>
 
 		<liferay-frontend:management-bar-display-buttons
-			displayStyleURL="<%= displayStyleURL %>"
 			displayViews='<%= new String[] {"list"} %>'
+			portletURL="<%= displayStyleURL %>"
 			selectedDisplayStyle="<%= displayStyle %>"
 		/>
 	</liferay-frontend:management-bar-buttons>

--- a/modules/apps/asset/asset-tags-admin-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/META-INF/resources/view.jsp
@@ -40,8 +40,8 @@ String displayStyle = ParamUtil.getString(request, "displayStyle", "list");
 >
 	<liferay-frontend:management-bar-buttons>
 		<liferay-frontend:management-bar-display-buttons
-			displayStyleURL="<%= portletURL %>"
 			displayViews='<%= new String[] {"list"} %>'
+			portletURL="<%= portletURL %>"
 			selectedDisplayStyle="<%= displayStyle %>"
 		/>
 	</liferay-frontend:management-bar-buttons>

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/entry_search_results.jspf
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/entry_search_results.jspf
@@ -27,7 +27,7 @@ if ((assetCategoryId != 0) || Validator.isNotNull(assetTagName)) {
 	}
 }
 else if (Validator.isNull(searchTerms.getKeywords())) {
-	if (navigationFilter.equals("mine")) {
+	if (entriesNavigation.equals("mine")) {
 		total = BlogsEntryServiceUtil.getGroupUserEntriesCount(scopeGroupId, themeDisplay.getUserId(), WorkflowConstants.STATUS_ANY);
 	}
 	else {
@@ -36,7 +36,7 @@ else if (Validator.isNull(searchTerms.getKeywords())) {
 
 	searchContainer.setTotal(total);
 
-	if (navigationFilter.equals("mine")) {
+	if (entriesNavigation.equals("mine")) {
 		results = BlogsEntryServiceUtil.getGroupUserEntries(scopeGroupId, themeDisplay.getUserId(), WorkflowConstants.STATUS_ANY, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
 	}
 	else {

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/entry_search_results.jspf
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/entry_search_results.jspf
@@ -27,11 +27,21 @@ if ((assetCategoryId != 0) || Validator.isNotNull(assetTagName)) {
 	}
 }
 else if (Validator.isNull(searchTerms.getKeywords())) {
-	total = BlogsEntryServiceUtil.getGroupEntriesCount(scopeGroupId, WorkflowConstants.STATUS_ANY);
+	if (navigationFilter.equals("mine")) {
+		total = BlogsEntryServiceUtil.getGroupUserEntriesCount(scopeGroupId, themeDisplay.getUserId(), WorkflowConstants.STATUS_ANY);
+	}
+	else {
+		total = BlogsEntryServiceUtil.getGroupEntriesCount(scopeGroupId, WorkflowConstants.STATUS_ANY);
+	}
 
 	searchContainer.setTotal(total);
 
-	results = BlogsEntryServiceUtil.getGroupEntries(scopeGroupId, WorkflowConstants.STATUS_ANY, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+	if (navigationFilter.equals("mine")) {
+		results = BlogsEntryServiceUtil.getGroupUserEntries(scopeGroupId, themeDisplay.getUserId(), WorkflowConstants.STATUS_ANY, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+	}
+	else {
+		results = BlogsEntryServiceUtil.getGroupEntries(scopeGroupId, WorkflowConstants.STATUS_ANY, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator());
+	}
 }
 else {
 	Indexer indexer = IndexerRegistryUtil.getIndexer(BlogsEntry.class);

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/blogs_admin/init.jsp" %>
 
 <%
-String navigationFilter = ParamUtil.getString(request, "navigationFilter");
+String entriesNavigation = ParamUtil.getString(request, "entriesNavigation");
 
 long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 String assetTagName = ParamUtil.getString(request, "tag");
@@ -43,7 +43,7 @@ navigationPortletURL.setParameter("mvcRenderCommandName", "/blogs_admin/view");
 PortletURL portletURL = renderResponse.createRenderURL();
 
 portletURL.setParameter("mvcRenderCommandName", "/blogs_admin/view");
-portletURL.setParameter("navigationFilter", navigationFilter);
+portletURL.setParameter("entriesNavigation", entriesNavigation);
 
 String keywords = ParamUtil.getString(request, "keywords");
 %>
@@ -64,7 +64,7 @@ String keywords = ParamUtil.getString(request, "keywords");
 		<liferay-frontend:management-bar-filters>
 			<liferay-frontend:management-bar-navigation
 				navigationKeys='<%= new String[] {"all", "mine"} %>'
-				navigationParam="navigationFilter"
+				navigationParam="entriesNavigation"
 				portletURL="<%= navigationPortletURL %>"
 			/>
 

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
@@ -20,6 +20,8 @@
 long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 String assetTagName = ParamUtil.getString(request, "tag");
 
+String navigationFilter = ParamUtil.getString(request, "navigationFilter");
+
 String displayStyle = ParamUtil.getString(request, "displayStyle");
 
 if (Validator.isNull(displayStyle)) {
@@ -34,9 +36,14 @@ else {
 String orderByCol = ParamUtil.getString(request, "orderByCol", "title");
 String orderByType = ParamUtil.getString(request, "orderByType", "asc");
 
+PortletURL navigationPortletURL = renderResponse.createRenderURL();
+
+navigationPortletURL.setParameter("mvcRenderCommandName", "/blogs_admin/view");
+
 PortletURL portletURL = renderResponse.createRenderURL();
 
 portletURL.setParameter("mvcRenderCommandName", "/blogs_admin/view");
+portletURL.setParameter("navigationFilter", navigationFilter);
 %>
 
 <liferay-frontend:management-bar
@@ -52,6 +59,12 @@ portletURL.setParameter("mvcRenderCommandName", "/blogs_admin/view");
 	</liferay-frontend:management-bar-buttons>
 
 	<liferay-frontend:management-bar-filters>
+		<liferay-frontend:management-bar-navigation
+			navigationKeys='<%= new String[] {"all", "mine"} %>'
+			navigationParam="navigationFilter"
+			portletURL="<%= navigationPortletURL %>"
+		/>
+
 		<liferay-frontend:management-bar-sort
 			orderByCol="<%= orderByCol %>"
 			orderByType="<%= orderByType %>"

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
@@ -45,8 +45,8 @@ portletURL.setParameter("mvcRenderCommandName", "/blogs_admin/view");
 >
 	<liferay-frontend:management-bar-buttons>
 		<liferay-frontend:management-bar-display-buttons
-			displayStyleURL="<%= renderResponse.createRenderURL() %>"
 			displayViews='<%= new String[] {"icon", "descriptive", "list"} %>'
+			portletURL="<%= portletURL %>"
 			selectedDisplayStyle="<%= displayStyle %>"
 		/>
 	</liferay-frontend:management-bar-buttons>

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
@@ -44,16 +44,14 @@ PortletURL portletURL = renderResponse.createRenderURL();
 
 portletURL.setParameter("mvcRenderCommandName", "/blogs_admin/view");
 portletURL.setParameter("navigationFilter", navigationFilter);
+
+String keywords = ParamUtil.getString(request, "keywords");
 %>
 
 <liferay-frontend:management-bar
 	checkBoxContainerId="blogEntriesSearchContainer"
 	includeCheckBox="<%= true %>"
 >
-	<%
-	String keywords = ParamUtil.getString(request, "keywords");
-	%>
-
 	<c:if test="<%= Validator.isNull(keywords) %>">
 		<liferay-frontend:management-bar-buttons>
 			<liferay-frontend:management-bar-display-buttons

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
@@ -50,28 +50,34 @@ portletURL.setParameter("navigationFilter", navigationFilter);
 	checkBoxContainerId="blogEntriesSearchContainer"
 	includeCheckBox="<%= true %>"
 >
-	<liferay-frontend:management-bar-buttons>
-		<liferay-frontend:management-bar-display-buttons
-			displayViews='<%= new String[] {"icon", "descriptive", "list"} %>'
-			portletURL="<%= portletURL %>"
-			selectedDisplayStyle="<%= displayStyle %>"
-		/>
-	</liferay-frontend:management-bar-buttons>
+	<%
+	String keywords = ParamUtil.getString(request, "keywords");
+	%>
 
-	<liferay-frontend:management-bar-filters>
-		<liferay-frontend:management-bar-navigation
-			navigationKeys='<%= new String[] {"all", "mine"} %>'
-			navigationParam="navigationFilter"
-			portletURL="<%= navigationPortletURL %>"
-		/>
+	<c:if test="<%= Validator.isNull(keywords) %>">
+		<liferay-frontend:management-bar-buttons>
+			<liferay-frontend:management-bar-display-buttons
+				displayViews='<%= new String[] {"icon", "descriptive", "list"} %>'
+				portletURL="<%= portletURL %>"
+				selectedDisplayStyle="<%= displayStyle %>"
+			/>
+		</liferay-frontend:management-bar-buttons>
 
-		<liferay-frontend:management-bar-sort
-			orderByCol="<%= orderByCol %>"
-			orderByType="<%= orderByType %>"
-			orderColumns='<%= new String[] {"title", "display-date"} %>'
-			portletURL="<%= portletURL %>"
-		/>
-	</liferay-frontend:management-bar-filters>
+		<liferay-frontend:management-bar-filters>
+			<liferay-frontend:management-bar-navigation
+				navigationKeys='<%= new String[] {"all", "mine"} %>'
+				navigationParam="navigationFilter"
+				portletURL="<%= navigationPortletURL %>"
+			/>
+
+			<liferay-frontend:management-bar-sort
+				orderByCol="<%= orderByCol %>"
+				orderByType="<%= orderByType %>"
+				orderColumns='<%= new String[] {"title", "display-date"} %>'
+				portletURL="<%= portletURL %>"
+			/>
+		</liferay-frontend:management-bar-filters>
+	</c:if>
 
 	<liferay-frontend:management-bar-action-buttons>
 

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_entries.jsp
@@ -17,10 +17,10 @@
 <%@ include file="/blogs_admin/init.jsp" %>
 
 <%
+String navigationFilter = ParamUtil.getString(request, "navigationFilter");
+
 long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 String assetTagName = ParamUtil.getString(request, "tag");
-
-String navigationFilter = ParamUtil.getString(request, "navigationFilter");
 
 String displayStyle = ParamUtil.getString(request, "displayStyle");
 

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_images.jsp
@@ -43,22 +43,24 @@ String keywords = ParamUtil.getString(request, "keywords");
 	checkBoxContainerId="imagesSearchContainer"
 	includeCheckBox="<%= true %>"
 >
-	<liferay-frontend:management-bar-buttons>
-		<liferay-frontend:management-bar-display-buttons
-			displayViews='<%= new String[] {"icon", "descriptive", "list"} %>'
-			portletURL="<%= portletURL %>"
-			selectedDisplayStyle="<%= displayStyle %>"
-		/>
-	</liferay-frontend:management-bar-buttons>
+	<c:if test="<%= Validator.isNull(keywords) %>">
+		<liferay-frontend:management-bar-buttons>
+			<liferay-frontend:management-bar-display-buttons
+				displayViews='<%= new String[] {"icon", "descriptive", "list"} %>'
+				portletURL="<%= portletURL %>"
+				selectedDisplayStyle="<%= displayStyle %>"
+			/>
+		</liferay-frontend:management-bar-buttons>
 
-	<liferay-frontend:management-bar-filters>
-		<liferay-frontend:management-bar-sort
-			orderByCol="<%= orderByCol %>"
-			orderByType="<%= orderByType %>"
-			orderColumns='<%= new String[] {"title", "size"} %>'
-			portletURL="<%= PortletURLUtil.clone(portletURL, liferayPortletResponse) %>"
-		/>
-	</liferay-frontend:management-bar-filters>
+		<liferay-frontend:management-bar-filters>
+			<liferay-frontend:management-bar-sort
+				orderByCol="<%= orderByCol %>"
+				orderByType="<%= orderByType %>"
+				orderColumns='<%= new String[] {"title", "size"} %>'
+				portletURL="<%= PortletURLUtil.clone(portletURL, liferayPortletResponse) %>"
+			/>
+		</liferay-frontend:management-bar-filters>
+	</c:if>
 
 	<liferay-frontend:management-bar-action-buttons>
 

--- a/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_images.jsp
+++ b/modules/apps/blogs/blogs-web/src/META-INF/resources/blogs_admin/view_images.jsp
@@ -45,8 +45,8 @@ String keywords = ParamUtil.getString(request, "keywords");
 >
 	<liferay-frontend:management-bar-buttons>
 		<liferay-frontend:management-bar-display-buttons
-			displayStyleURL="<%= PortletURLUtil.clone(portletURL, liferayPortletResponse) %>"
 			displayViews='<%= new String[] {"icon", "descriptive", "list"} %>'
+			portletURL="<%= portletURL %>"
 			selectedDisplayStyle="<%= displayStyle %>"
 		/>
 	</liferay-frontend:management-bar-buttons>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/META-INF/resources/admin/display_style_buttons.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/META-INF/resources/admin/display_style_buttons.jsp
@@ -21,7 +21,7 @@ PortletURL displayStyleURL = renderResponse.createRenderURL();
 %>
 
 <liferay-frontend:management-bar-display-buttons
-	displayStyleURL="<%= displayStyleURL %>"
 	displayViews="<%= ddlFormAdminDisplayContext.getDisplayViews() %>"
+	portletURL="<%= displayStyleURL %>"
 	selectedDisplayStyle="<%= ddlFormAdminDisplayContext.getDisplayStyle() %>"
 />

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/META-INF/resources/display_style_buttons.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/META-INF/resources/display_style_buttons.jsp
@@ -21,7 +21,7 @@ PortletURL displayStyleURL = renderResponse.createRenderURL();
 %>
 
 <liferay-frontend:management-bar-display-buttons
-	displayStyleURL="<%= displayStyleURL %>"
 	displayViews="<%= ddlDisplayContext.getDDLRecordSetDisplayViews() %>"
+	portletURL="<%= displayStyleURL %>"
 	selectedDisplayStyle="<%= ddlDisplayContext.getDDLRecordSetDisplayStyle() %>"
 />

--- a/modules/apps/item-selector/item-selector-taglib/src/META-INF/resources/browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/META-INF/resources/browser/page.jsp
@@ -47,8 +47,8 @@ if (Validator.isNotNull(keywords)) {
 	<liferay-frontend:management-bar>
 		<liferay-frontend:management-bar-buttons>
 			<liferay-frontend:management-bar-display-buttons
-				displayStyleURL="<%= PortletURLUtil.clone(portletURL, liferayPortletResponse) %>"
 				displayViews="<%= BrowserTag.DISPLAY_STYLES %>"
+				portletURL="<%= PortletURLUtil.clone(portletURL, liferayPortletResponse) %>"
 				selectedDisplayStyle="<%= displayStyle %>"
 			/>
 		</liferay-frontend:management-bar-buttons>

--- a/modules/apps/journal/journal-web/src/META-INF/resources/display_style_buttons.jsp
+++ b/modules/apps/journal/journal-web/src/META-INF/resources/display_style_buttons.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <liferay-frontend:management-bar-display-buttons
-	displayStyleURL="<%= journalDisplayContext.getPortletURL() %>"
 	displayViews="<%= journalDisplayContext.getDisplayViews() %>"
+	portletURL="<%= journalDisplayContext.getPortletURL() %>"
 	selectedDisplayStyle="<%= journalDisplayContext.getDisplayStyle() %>"
 />

--- a/modules/apps/journal/journal-web/src/META-INF/resources/view_article_history.jsp
+++ b/modules/apps/journal/journal-web/src/META-INF/resources/view_article_history.jsp
@@ -73,8 +73,8 @@ JournalArticle article = ActionUtil.getArticle(request);
 				%>
 
 				<liferay-frontend:management-bar-display-buttons
-					displayStyleURL="<%= displayStyleURL %>"
 					displayViews='<%= new String[] {"list"} %>'
+					portletURL="<%= displayStyleURL %>"
 					selectedDisplayStyle="<%= displayStyle %>"
 				/>
 			</liferay-frontend:management-bar-buttons>

--- a/modules/apps/site/site-admin-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-admin-web/src/META-INF/resources/view.jsp
@@ -72,8 +72,8 @@ if (group != null) {
 		</c:if>
 
 		<liferay-frontend:management-bar-display-buttons
-			displayStyleURL="<%= portletURL %>"
 			displayViews='<%= new String[] {"list"} %>'
+			portletURL="<%= portletURL %>"
 			selectedDisplayStyle="<%= displayStyle %>"
 		/>
 	</liferay-frontend:management-bar-buttons>

--- a/modules/apps/site/site-teams-web/src/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-teams-web/src/META-INF/resources/view.jsp
@@ -57,8 +57,8 @@ TeamDisplayTerms searchTerms = (TeamDisplayTerms)teamSearchContainer.getSearchTe
 
 	<liferay-frontend:management-bar-buttons>
 		<liferay-frontend:management-bar-display-buttons
-			displayStyleURL="<%= displayStyleURL %>"
 			displayViews='<%= new String[] {"descriptive", "list"} %>'
+			portletURL="<%= displayStyleURL %>"
 			selectedDisplayStyle="<%= displayStyle %>"
 		/>
 	</liferay-frontend:management-bar-buttons>

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/init.jsp
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/init.jsp
@@ -27,9 +27,11 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 page import="com.liferay.portal.kernel.dao.search.ResultRow" %><%@
 page import="com.liferay.portal.kernel.dao.search.RowChecker" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.ArrayUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.util.PortalUtil" %><%@

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/liferay-frontend.tld
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/liferay-frontend.tld
@@ -257,6 +257,26 @@
 		<body-content>JSP</body-content>
 	</tag>
 	<tag>
+		<name>management-bar-navigation</name>
+		<tag-class>com.liferay.frontend.taglib.servlet.taglib.ManagementBarNavigationTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>navigationKeys</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>navigationParam</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>portletURL</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	<tag>
 		<name>management-bar-sort</name>
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.ManagementBarSortTag</tag-class>
 		<body-content>JSP</body-content>

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/liferay-frontend.tld
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/liferay-frontend.tld
@@ -236,12 +236,12 @@
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.ManagementBarDisplayButtonsTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
-			<name>displayStyleURL</name>
+			<name>displayViews</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<name>displayViews</name>
+			<name>portletURL</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_display_buttons/page.jsp
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_display_buttons/page.jsp
@@ -17,9 +17,11 @@
 <%@ include file="/management_bar_display_buttons/init.jsp" %>
 
 <%
-PortletURL displayStyleURL = (PortletURL)request.getAttribute("liferay-frontend:management-bar-display-buttons:displayStyleURL");
 String[] displayViews = (String[])request.getAttribute("liferay-frontend:management-bar-display-buttons:displayViews");
+PortletURL portletURL = (PortletURL)request.getAttribute("liferay-frontend:management-bar-display-buttons:portletURL");
 String selectedDisplayStyle = (String)request.getAttribute("liferay-frontend:management-bar-display-buttons:selectedDisplayStyle");
+
+PortletURL displayStyleURL = PortletURLUtil.clone(portletURL, liferayPortletResponse);
 %>
 
 <%

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_navigation/init.jsp
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_navigation/init.jsp
@@ -1,0 +1,17 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_navigation/page.jsp
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_navigation/page.jsp
@@ -1,0 +1,63 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/management_bar_navigation/init.jsp" %>
+
+<%
+String[] navigationKeys = (String[])request.getAttribute("liferay-frontend:management-bar-navigation:navigationKeys");
+String navigationParam = (String)request.getAttribute("liferay-frontend:management-bar-navigation:navigationParam");
+PortletURL portletURL = (PortletURL)request.getAttribute("liferay-frontend:management-bar-navigation:portletURL");
+
+String curNavigationKey = ParamUtil.getString(request, navigationParam);
+%>
+
+<c:if test="<%= ArrayUtil.isNotEmpty(navigationKeys) %>">
+	<li>
+		<aui:select inlineField="<%= true %>" inlineLabel="left" label="" name="<%= navigationParam %>">
+
+			<%
+			for (String navigationKey : navigationKeys) {
+			%>
+
+				<aui:option label="<%= navigationKey %>" selected="<%= navigationKey.equals(curNavigationKey) %>" value="<%= navigationKey %>" />
+
+			<%
+			}
+			%>
+
+		</aui:select>
+	</li>
+</c:if>
+
+<aui:script>
+
+	<%
+	PortletURL navigationURL = PortletURLUtil.clone(portletURL, liferayPortletResponse);
+	%>
+
+	var navigation = $('#<%= namespace + navigationParam %>');
+
+	navigation.on(
+		'change',
+		function(event) {
+			var uri = '<%= navigationURL %>';
+
+			uri = Liferay.Util.addParams('<%= namespace + navigationParam %>=' + navigation.val(), uri);
+
+			window.location.href = uri;
+		}
+	);
+</aui:script>

--- a/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_navigation/page.jsp
+++ b/modules/frontend/frontend-taglib/src/META-INF/resources/management_bar_navigation/page.jsp
@@ -21,7 +21,7 @@ String[] navigationKeys = (String[])request.getAttribute("liferay-frontend:manag
 String navigationParam = (String)request.getAttribute("liferay-frontend:management-bar-navigation:navigationParam");
 PortletURL portletURL = (PortletURL)request.getAttribute("liferay-frontend:management-bar-navigation:portletURL");
 
-String curNavigationKey = ParamUtil.getString(request, navigationParam);
+String navigationKey = ParamUtil.getString(request, navigationParam);
 %>
 
 <c:if test="<%= ArrayUtil.isNotEmpty(navigationKeys) %>">
@@ -29,10 +29,10 @@ String curNavigationKey = ParamUtil.getString(request, navigationParam);
 		<aui:select inlineField="<%= true %>" inlineLabel="left" label="" name="<%= navigationParam %>">
 
 			<%
-			for (String navigationKey : navigationKeys) {
+			for (String curNavigationKey : navigationKeys) {
 			%>
 
-				<aui:option label="<%= navigationKey %>" selected="<%= navigationKey.equals(curNavigationKey) %>" value="<%= navigationKey %>" />
+				<aui:option label="<%= curNavigationKey %>" selected="<%= curNavigationKey.equals(navigationKey) %>" value="<%= curNavigationKey %>" />
 
 			<%
 			}

--- a/modules/frontend/frontend-taglib/src/com/liferay/frontend/taglib/servlet/taglib/ManagementBarDisplayButtonsTag.java
+++ b/modules/frontend/frontend-taglib/src/com/liferay/frontend/taglib/servlet/taglib/ManagementBarDisplayButtonsTag.java
@@ -38,10 +38,6 @@ public class ManagementBarDisplayButtonsTag
 		return super.doStartTag();
 	}
 
-	public void setDisplayStyleURL(PortletURL displayStyleURL) {
-		_displayStyleURL = displayStyleURL;
-	}
-
 	public void setDisplayViews(String[] displayViews) {
 		_displayViews = displayViews;
 	}
@@ -53,14 +49,18 @@ public class ManagementBarDisplayButtonsTag
 		servletContext = ServletContextUtil.getServletContext();
 	}
 
+	public void setPortletURL(PortletURL portletURL) {
+		_portletURL = portletURL;
+	}
+
 	public void setSelectedDisplayStyle(String selectedDisplayStyle) {
 		_selectedDisplayStyle = selectedDisplayStyle;
 	}
 
 	@Override
 	protected void cleanUp() {
-		_displayStyleURL = null;
 		_displayViews = null;
+		_portletURL = null;
 		_selectedDisplayStyle = StringPool.BLANK;
 	}
 
@@ -82,11 +82,11 @@ public class ManagementBarDisplayButtonsTag
 	@Override
 	protected void setAttributes(HttpServletRequest request) {
 		request.setAttribute(
-			"liferay-frontend:management-bar-display-buttons:displayStyleURL",
-			_displayStyleURL);
-		request.setAttribute(
 			"liferay-frontend:management-bar-display-buttons:displayViews",
 			_displayViews);
+		request.setAttribute(
+			"liferay-frontend:management-bar-display-buttons:portletURL",
+			_portletURL);
 		request.setAttribute(
 			"liferay-frontend:management-bar-display-buttons:" +
 				"selectedDisplayStyle",
@@ -101,8 +101,8 @@ public class ManagementBarDisplayButtonsTag
 	private static final String _PAGE =
 		"/management_bar_display_buttons/page.jsp";
 
-	private PortletURL _displayStyleURL;
 	private String[] _displayViews;
+	private PortletURL _portletURL;
 	private String _selectedDisplayStyle;
 
 }

--- a/modules/frontend/frontend-taglib/src/com/liferay/frontend/taglib/servlet/taglib/ManagementBarNavigationTag.java
+++ b/modules/frontend/frontend-taglib/src/com/liferay/frontend/taglib/servlet/taglib/ManagementBarNavigationTag.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.servlet.ServletContextUtil;
+import com.liferay.taglib.util.IncludeTag;
+
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.BodyTag;
+
+/**
+ * @author Sergio González
+ */
+public class ManagementBarNavigationTag extends IncludeTag implements BodyTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	public void setNavigationKeys(String[] navigationKeys) {
+		_navigationKeys = navigationKeys;
+	}
+
+	public void setNavigationParam(String navigationParam) {
+		_navigationParam = navigationParam;
+	}
+
+	@Override
+	public void setPageContext(PageContext pageContext) {
+		super.setPageContext(pageContext);
+
+		servletContext = ServletContextUtil.getServletContext();
+	}
+
+	public void setPortletURL(PortletURL portletURL) {
+		_portletURL = portletURL;
+	}
+
+	@Override
+	protected void cleanUp() {
+		_navigationKeys = null;
+		_navigationParam = null;
+		_portletURL = null;
+	}
+
+	@Override
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	@Override
+	protected boolean isCleanUpSetAttributes() {
+		return _CLEAN_UP_SET_ATTRIBUTES;
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		return EVAL_BODY_BUFFERED;
+	}
+
+	@Override
+	protected void setAttributes(HttpServletRequest request) {
+		request.setAttribute(
+			"liferay-frontend:management-bar-navigation:navigationKeys",
+			_navigationKeys);
+		request.setAttribute(
+			"liferay-frontend:management-bar-navigation:navigationParam",
+			_navigationParam);
+		request.setAttribute(
+			"liferay-frontend:management-bar-navigation:portletURL",
+			_portletURL);
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE =
+		"liferay-frontend:management-bar-navigation:";
+
+	private static final boolean _CLEAN_UP_SET_ATTRIBUTES = true;
+
+	private static final String _PAGE = "/management_bar_navigation/page.jsp";
+
+	private String[] _navigationKeys;
+	private String _navigationParam = "navigation";
+	private PortletURL _portletURL;
+
+}

--- a/portal-impl/src/com/liferay/portlet/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/http/BlogsEntryServiceHttp.java
@@ -568,6 +568,63 @@ public class BlogsEntryServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getGroupUserEntries(
+		HttpPrincipal httpPrincipal, long groupId, long userId, int status,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portlet.blogs.model.BlogsEntry> obc) {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"getGroupUserEntries", _getGroupUserEntriesParameterTypes16);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					userId, status, start, end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portlet.blogs.model.BlogsEntry>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static int getGroupUserEntriesCount(HttpPrincipal httpPrincipal,
+		long groupId, long userId, int status) {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"getGroupUserEntriesCount",
+					_getGroupUserEntriesCountParameterTypes17);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					userId, status);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getOrganizationEntries(
 		HttpPrincipal httpPrincipal, long organizationId,
 		java.util.Date displayDate, int status, int max)
@@ -575,7 +632,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntries",
-					_getOrganizationEntriesParameterTypes16);
+					_getOrganizationEntriesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max);
@@ -612,7 +669,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntriesRSS",
-					_getOrganizationEntriesRSSParameterTypes17);
+					_getOrganizationEntriesRSSParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max, type, version,
@@ -645,7 +702,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"moveEntryToTrash", _moveEntryToTrashParameterTypes18);
+					"moveEntryToTrash", _moveEntryToTrashParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -677,7 +734,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"restoreEntryFromTrash",
-					_restoreEntryFromTrashParameterTypes19);
+					_restoreEntryFromTrashParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -703,7 +760,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"subscribe", _subscribeParameterTypes20);
+					"subscribe", _subscribeParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -729,7 +786,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"unsubscribe", _unsubscribeParameterTypes21);
+					"unsubscribe", _unsubscribeParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -764,7 +821,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes22);
+					"updateEntry", _updateEntryParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, description, content, displayDateMonth,
@@ -808,7 +865,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes23);
+					"updateEntry", _updateEntryParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, description, content, displayDateMonth,
@@ -906,28 +963,35 @@ public class BlogsEntryServiceHttp {
 	private static final Class<?>[] _getGroupsEntriesParameterTypes15 = new Class[] {
 			long.class, long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getOrganizationEntriesParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes16 = new Class[] {
+			long.class, long.class, int.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes17 = new Class[] {
+			long.class, long.class, int.class
+		};
+	private static final Class<?>[] _getOrganizationEntriesParameterTypes18 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes19 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			java.lang.String.class, double.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class,
 			com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _moveEntryToTrashParameterTypes18 = new Class[] {
+	private static final Class<?>[] _moveEntryToTrashParameterTypes20 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _restoreEntryFromTrashParameterTypes19 = new Class[] {
+	private static final Class<?>[] _restoreEntryFromTrashParameterTypes21 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _subscribeParameterTypes20 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes22 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _unsubscribeParameterTypes21 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes23 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes22 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes24 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, int.class, int.class, int.class, int.class,
 			int.class, boolean.class, boolean.class, java.lang.String[].class,
@@ -935,7 +999,7 @@ public class BlogsEntryServiceHttp {
 			java.io.InputStream.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes23 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes25 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class, int.class, int.class,
 			int.class, int.class, int.class, boolean.class, boolean.class,

--- a/portal-impl/src/com/liferay/portlet/blogs/service/http/BlogsEntryServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/http/BlogsEntryServiceSoap.java
@@ -280,6 +280,39 @@ public class BlogsEntryServiceSoap {
 		}
 	}
 
+	public static com.liferay.portlet.blogs.model.BlogsEntrySoap[] getGroupUserEntries(
+		long groupId, long userId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portlet.blogs.model.BlogsEntry> obc)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> returnValue =
+				BlogsEntryServiceUtil.getGroupUserEntries(groupId, userId,
+					status, start, end, obc);
+
+			return com.liferay.portlet.blogs.model.BlogsEntrySoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static int getGroupUserEntriesCount(long groupId, long userId,
+		int status) throws RemoteException {
+		try {
+			int returnValue = BlogsEntryServiceUtil.getGroupUserEntriesCount(groupId,
+					userId, status);
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.portlet.blogs.model.BlogsEntrySoap[] getOrganizationEntries(
 		long organizationId, java.util.Date displayDate, int status, int max)
 		throws RemoteException {

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -387,7 +387,7 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	public int getGroupUserEntriesCount(long groupId, long userId, int status) {
 		if (status == WorkflowConstants.STATUS_ANY) {
 			return blogsEntryPersistence.filterCountByG_U_NotS(
-				groupId, userId, status);
+				groupId, userId, WorkflowConstants.STATUS_IN_TRASH);
 		}
 		else {
 			return blogsEntryPersistence.filterCountByG_U_S(

--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -368,6 +368,34 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	}
 
 	@Override
+	public List<BlogsEntry> getGroupUserEntries(
+		long groupId, long userId, int status, int start, int end,
+		OrderByComparator<BlogsEntry> obc) {
+
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return blogsEntryPersistence.filterFindByG_U_NotS(
+				groupId, userId, WorkflowConstants.STATUS_IN_TRASH, start, end,
+				obc);
+		}
+		else {
+			return blogsEntryPersistence.filterFindByG_U_S(
+				groupId, userId, status, start, end, obc);
+		}
+	}
+
+	@Override
+	public int getGroupUserEntriesCount(long groupId, long userId, int status) {
+		if (status == WorkflowConstants.STATUS_ANY) {
+			return blogsEntryPersistence.filterCountByG_U_NotS(
+				groupId, userId, status);
+		}
+		else {
+			return blogsEntryPersistence.filterCountByG_U_S(
+				groupId, userId, status);
+		}
+	}
+
+	@Override
 	public List<BlogsEntry> getOrganizationEntries(
 			long organizationId, Date displayDate, int status, int max)
 		throws PortalException {

--- a/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryService.java
+++ b/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryService.java
@@ -145,6 +145,14 @@ public interface BlogsEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getGroupUserEntries(
+		long groupId, long userId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portlet.blogs.model.BlogsEntry> obc);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getGroupUserEntriesCount(long groupId, long userId, int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getGroupsEntries(
 		long companyId, long groupId, java.util.Date displayDate, int status,
 		int max) throws PortalException;

--- a/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryServiceUtil.java
@@ -176,6 +176,18 @@ public class BlogsEntryServiceUtil {
 			version, displayStyle, feedURL, entryURL, themeDisplay);
 	}
 
+	public static java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getGroupUserEntries(
+		long groupId, long userId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portlet.blogs.model.BlogsEntry> obc) {
+		return getService()
+				   .getGroupUserEntries(groupId, userId, status, start, end, obc);
+	}
+
+	public static int getGroupUserEntriesCount(long groupId, long userId,
+		int status) {
+		return getService().getGroupUserEntriesCount(groupId, userId, status);
+	}
+
 	public static java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getGroupsEntries(
 		long companyId, long groupId, java.util.Date displayDate, int status,
 		int max) throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/blogs/service/BlogsEntryServiceWrapper.java
@@ -184,6 +184,20 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 	}
 
 	@Override
+	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getGroupUserEntries(
+		long groupId, long userId, int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portlet.blogs.model.BlogsEntry> obc) {
+		return _blogsEntryService.getGroupUserEntries(groupId, userId, status,
+			start, end, obc);
+	}
+
+	@Override
+	public int getGroupUserEntriesCount(long groupId, long userId, int status) {
+		return _blogsEntryService.getGroupUserEntriesCount(groupId, userId,
+			status);
+	}
+
+	@Override
 	public java.util.List<com.liferay.portlet.blogs.model.BlogsEntry> getGroupsEntries(
 		long companyId, long groupId, java.util.Date displayDate, int status,
 		int max) throws com.liferay.portal.kernel.exception.PortalException {


### PR DESCRIPTION
Hey Brian,

This is a resent of https://github.com/ealonso/liferay-portal/pull/513

We need both `navigation` and `navigationEntries` (in previous pull was `navigationFilter`) because we have 2 navigations in Blogs Portlet:
1. `navigation` is used to navigate between Entries and Images (first level navigation)
2. `entriesNavigation` is used to navigate in the entries (not images) to display all blog entries or only my blog entries. 

I have renamed the parameter to `entriesNavigation` to make it more clear.

Thanks Brian
Sergio
