### PR TITLE
LPS-59148 Bump up ci.test.timeout.time to 40mins for now, to allow th…

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/TestPropsValues.java
@@ -42,7 +42,7 @@ public class TestPropsValues {
 		TestPropsUtil.get("assert.logs"));
 
 	public static final long CI_TEST_TIMEOUT_TIME = GetterUtil.getLong(
-		TestPropsUtil.get("ci.test.timeout.time"), 20 * Time.MINUTE);
+		TestPropsUtil.get("ci.test.timeout.time"), 40 * Time.MINUTE);
 
 	public static final String COMPANY_WEB_ID;
 

--- a/portal-test/src/test-portal-impl.properties
+++ b/portal-test/src/test-portal-impl.properties
@@ -2,7 +2,7 @@ include-and-override=test-portal-impl-ext.properties
 
 assert.logs=true
 
-ci.test.timeout.time=1200000
+ci.test.timeout.time=2400000
 
 company.web.id=liferay.com
 


### PR DESCRIPTION
…e super slow JournalArticleAssetSearchTest to finish. We will come back to optimize the test later and drop back the timeout after it.
