### PR TITLE
Lps 59567

### DIFF
--- a/modules/portal-store/portal-store-cmis-test/src/com/liferay/portal/store/cmis/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-cmis-test/src/com/liferay/portal/store/cmis/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portlet.documentlibrary.store.Store;
 
+import java.io.IOException;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -95,12 +97,8 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 	}
 
 	@Override
-	public void stop(BundleContext bundleContext) {
-		try {
-			_cmisStoreConfiguration.delete();
-		}
-		catch (Exception e) {
-		}
+	public void stop(BundleContext bundleContext) throws IOException {
+		_cmisStoreConfiguration.delete();
 	}
 
 	private Configuration _cmisStoreConfiguration;

--- a/modules/portal-store/portal-store-cmis-test/src/com/liferay/portal/store/cmis/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-cmis-test/src/com/liferay/portal/store/cmis/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -55,10 +55,11 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			ConfigurationAdmin configurationAdmin = bundleContext.getService(
 				serviceReference);
 
-			_cmisStoreConfiguration = configurationAdmin.getConfiguration(
-				"com.liferay.portal.store.cmis.configuration." +
-					"CMISStoreConfiguration",
-				null);
+			Configuration cmisStoreConfiguration =
+				configurationAdmin.getConfiguration(
+					"com.liferay.portal.store.cmis.configuration." +
+						"CMISStoreConfiguration",
+					null);
 
 			Dictionary<String, Object> properties = new Hashtable<>();
 
@@ -69,7 +70,7 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 				"http://alfresco.liferay.org.es/alfresco/service/api/cmis");
 			properties.put("systemRootDir", "testStore");
 
-			_cmisStoreConfiguration.update(properties);
+			cmisStoreConfiguration.update(properties);
 
 			Filter filter = bundleContext.createFilter(
 				"(&(objectClass=" + Store.class.getName() +
@@ -85,7 +86,7 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			serviceTracker.close();
 
 			if (cmisStore == null) {
-				_cmisStoreConfiguration.delete();
+				cmisStoreConfiguration.delete();
 
 				throw new IllegalStateException(
 					"CMIS store was not registered within 10 seconds");
@@ -98,9 +99,24 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 
 	@Override
 	public void stop(BundleContext bundleContext) throws IOException {
-		_cmisStoreConfiguration.delete();
-	}
+		ServiceReference<ConfigurationAdmin> serviceReference =
+			bundleContext.getServiceReference(ConfigurationAdmin.class);
 
-	private Configuration _cmisStoreConfiguration;
+		try {
+			ConfigurationAdmin configurationAdmin = bundleContext.getService(
+				serviceReference);
+
+			Configuration cmisStoreConfiguration =
+				configurationAdmin.getConfiguration(
+					"com.liferay.portal.store.cmis.configuration." +
+						"CMISStoreConfiguration",
+					null);
+
+			cmisStoreConfiguration.delete();
+		}
+		finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
 
 }

--- a/modules/portal-store/portal-store-file-system-test/src/com/liferay/portal/store/file/system/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-file-system-test/src/com/liferay/portal/store/file/system/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portlet.documentlibrary.store.Store;
 
+import java.io.IOException;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -77,18 +79,14 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 	}
 
 	@Override
-	public void stop(BundleContext bundleContext) {
-		try {
-			_advancedFileSystemStoreConfiguration.delete();
+	public void stop(BundleContext bundleContext) throws IOException {
+		_advancedFileSystemStoreConfiguration.delete();
 
-			FileUtil.deltree(_ADVANCED_ROOT_DIR);
+		FileUtil.deltree(_ADVANCED_ROOT_DIR);
 
-			_fileSystemStoreConfiguration.delete();
+		_fileSystemStoreConfiguration.delete();
 
-			FileUtil.deltree(_ROOT_DIR);
-		}
-		catch (Exception e) {
-		}
+		FileUtil.deltree(_ROOT_DIR);
 	}
 
 	protected Configuration getConfiguration(

--- a/modules/portal-store/portal-store-file-system/src/com/liferay/portal/store/file/system/FileSystemStore.java
+++ b/modules/portal-store/portal-store-file-system/src/com/liferay/portal/store/file/system/FileSystemStore.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.store.file.system.configuration.AdvancedFileSystemStoreConfiguration;
 import com.liferay.portal.store.file.system.configuration.FileSystemStoreConfiguration;
 import com.liferay.portlet.documentlibrary.DuplicateFileException;
 import com.liferay.portlet.documentlibrary.NoSuchFileException;
@@ -634,16 +635,14 @@ public class FileSystemStore extends BaseStore {
 		try {
 			Configuration fileSystemStoreConfiguration =
 				configurationAdmin.getConfiguration(
-					"com.liferay.portal.store.file.system.configuration." +
-						"FileSystemStoreConfiguration");
+					FileSystemStoreConfiguration.class.getName());
 
 			Dictionary<String, Object> fileSystemDictionary =
 				fileSystemStoreConfiguration.getProperties();
 
 			Configuration advancedFileSystemStoreConfiguration =
 				configurationAdmin.getConfiguration(
-					"com.liferay.portal.store.file.system.configuration." +
-						"AdvancedFileSystemStoreConfiguration");
+					AdvancedFileSystemStoreConfiguration.class.getName());
 
 			Dictionary<String, Object> advancedFileSystemDictionary =
 				advancedFileSystemStoreConfiguration.getProperties();

--- a/modules/portal-store/portal-store-file-system/src/com/liferay/portal/store/file/system/FileSystemStore.java
+++ b/modules/portal-store/portal-store-file-system/src/com/liferay/portal/store/file/system/FileSystemStore.java
@@ -502,6 +502,40 @@ public class FileSystemStore extends BaseStore {
 		return companyDir;
 	}
 
+	protected Dictionary<String, Object> getConfigurationDictionary(
+			Class<?> configurationClass)
+		throws IOException {
+
+		Configuration configuration = configurationAdmin.getConfiguration(
+			configurationClass.getName());
+
+		boolean allowDeleted = false;
+
+		if ((getClass() == FileSystemStore.class) &&
+			(configurationClass != FileSystemStoreConfiguration.class)) {
+
+			allowDeleted = true;
+		}
+
+		if ((getClass() == AdvancedFileSystemStore.class) &&
+			(configurationClass !=
+				AdvancedFileSystemStoreConfiguration.class)) {
+
+			allowDeleted = true;
+		}
+
+		try {
+			return configuration.getProperties();
+		}
+		catch (IllegalStateException ise) {
+			if (allowDeleted) {
+				return null;
+			}
+
+			throw ise;
+		}
+	}
+
 	protected File getDirNameDir(
 		long companyId, long repositoryId, String dirName) {
 
@@ -633,19 +667,12 @@ public class FileSystemStore extends BaseStore {
 
 	protected void validate() {
 		try {
-			Configuration fileSystemStoreConfiguration =
-				configurationAdmin.getConfiguration(
-					FileSystemStoreConfiguration.class.getName());
-
 			Dictionary<String, Object> fileSystemDictionary =
-				fileSystemStoreConfiguration.getProperties();
-
-			Configuration advancedFileSystemStoreConfiguration =
-				configurationAdmin.getConfiguration(
-					AdvancedFileSystemStoreConfiguration.class.getName());
+				getConfigurationDictionary(FileSystemStoreConfiguration.class);
 
 			Dictionary<String, Object> advancedFileSystemDictionary =
-				advancedFileSystemStoreConfiguration.getProperties();
+				getConfigurationDictionary(
+					AdvancedFileSystemStoreConfiguration.class);
 
 			if ((fileSystemDictionary != null) &&
 				(advancedFileSystemDictionary != null)) {

--- a/modules/portal-store/portal-store-jcr-test/src/com/liferay/portal/store/jcr/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-jcr-test/src/com/liferay/portal/store/jcr/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -43,10 +43,11 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			ConfigurationAdmin configurationAdmin = bundleContext.getService(
 				serviceReference);
 
-			_jcrConfiguration = configurationAdmin.getConfiguration(
-				"com.liferay.portal.store.jcr.configuration." +
-					"JCRStoreConfiguration",
-				null);
+			Configuration jcrConfiguration =
+				configurationAdmin.getConfiguration(
+					"com.liferay.portal.store.jcr.configuration." +
+						"JCRStoreConfiguration",
+					null);
 
 			Dictionary<String, Object> properties = new Hashtable<>();
 
@@ -61,7 +62,7 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			properties.put("workspaceName", "liferay");
 			properties.put("wrapSession", Boolean.TRUE);
 
-			_jcrConfiguration.update(properties);
+			jcrConfiguration.update(properties);
 
 			Filter filter = bundleContext.createFilter(
 				"(&(objectClass=" + Store.class.getName() +
@@ -77,7 +78,7 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			serviceTracker.close();
 
 			if (jcrStore == null) {
-				_jcrConfiguration.delete();
+				jcrConfiguration.delete();
 
 				throw new IllegalStateException(
 					"JCR store was not registered within 10 seconds");
@@ -90,9 +91,24 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 
 	@Override
 	public void stop(BundleContext bundleContext) throws IOException {
-		_jcrConfiguration.delete();
-	}
+		ServiceReference<ConfigurationAdmin> serviceReference =
+			bundleContext.getServiceReference(ConfigurationAdmin.class);
 
-	private Configuration _jcrConfiguration;
+		try {
+			ConfigurationAdmin configurationAdmin = bundleContext.getService(
+				serviceReference);
+
+			Configuration jcrConfiguration =
+				configurationAdmin.getConfiguration(
+					"com.liferay.portal.store.jcr.configuration." +
+						"JCRStoreConfiguration",
+					null);
+
+			jcrConfiguration.delete();
+		}
+		finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
 
 }

--- a/modules/portal-store/portal-store-jcr-test/src/com/liferay/portal/store/jcr/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-jcr-test/src/com/liferay/portal/store/jcr/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.store.jcr.test.activator.configuration;
 
 import com.liferay.portlet.documentlibrary.store.Store;
 
+import java.io.IOException;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -87,12 +89,8 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 	}
 
 	@Override
-	public void stop(BundleContext bundleContext) {
-		try {
-			_jcrConfiguration.delete();
-		}
-		catch (Exception e) {
-		}
+	public void stop(BundleContext bundleContext) throws IOException {
+		_jcrConfiguration.delete();
 	}
 
 	private Configuration _jcrConfiguration;

--- a/modules/portal-store/portal-store-s3-test/src/com/liferay/portal/store/s3/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-s3-test/src/com/liferay/portal/store/s3/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -51,10 +51,11 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			ConfigurationAdmin configurationAdmin = bundleContext.getService(
 				serviceReference);
 
-			_s3StoreConfiguration = configurationAdmin.getConfiguration(
-				"com.liferay.portal.store.s3.configuration." +
-					"S3StoreConfiguration",
-				null);
+			Configuration s3StoreConfiguration =
+				configurationAdmin.getConfiguration(
+					"com.liferay.portal.store.s3.configuration." +
+						"S3StoreConfiguration",
+					null);
 
 			Dictionary<String, Object> properties = new Hashtable<>();
 
@@ -67,7 +68,7 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			properties.put("tempDirCleanUpExpunge", "7");
 			properties.put("tempDirCleanUpFrequency", "100");
 
-			_s3StoreConfiguration.update(properties);
+			s3StoreConfiguration.update(properties);
 
 			Filter filter = bundleContext.createFilter(
 				"(&(objectClass=" + Store.class.getName() +
@@ -83,7 +84,7 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			serviceTracker.close();
 
 			if (s3Store == null) {
-				_s3StoreConfiguration.delete();
+				s3StoreConfiguration.delete();
 
 				throw new IllegalStateException(
 					"S3 store was not registered within 10 seconds");
@@ -96,9 +97,24 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 
 	@Override
 	public void stop(BundleContext bundleContext) throws IOException {
-		_s3StoreConfiguration.delete();
-	}
+		ServiceReference<ConfigurationAdmin> serviceReference =
+			bundleContext.getServiceReference(ConfigurationAdmin.class);
 
-	private Configuration _s3StoreConfiguration;
+		try {
+			ConfigurationAdmin configurationAdmin = bundleContext.getService(
+				serviceReference);
+
+			Configuration s3StoreConfiguration =
+				configurationAdmin.getConfiguration(
+					"com.liferay.portal.store.s3.configuration." +
+						"S3StoreConfiguration",
+					null);
+
+			s3StoreConfiguration.delete();
+		}
+		finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
 
 }

--- a/modules/portal-store/portal-store-s3-test/src/com/liferay/portal/store/s3/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-s3-test/src/com/liferay/portal/store/s3/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portlet.documentlibrary.store.Store;
 
+import java.io.IOException;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -93,12 +95,8 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 	}
 
 	@Override
-	public void stop(BundleContext bundleContext) {
-		try {
-			_s3StoreConfiguration.delete();
-		}
-		catch (Exception e) {
-		}
+	public void stop(BundleContext bundleContext) throws IOException {
+		_s3StoreConfiguration.delete();
 	}
 
 	private Configuration _s3StoreConfiguration;


### PR DESCRIPTION
Hey Guys,

I am going to explain a bit about this pull and changes in https://github.com/liferay/liferay-portal/compare/9f71716190ca8bdddd3771613db1381f976cc84f...10e698e67c3956443a11f01a5da2ce497a4932b2 to all people that is involved.

For @cgoncas and @csierra, actions are required(see details in below), @Ithildir please provide help to make sure we do the dependency right in gradle.

For @mdelapenya, I am fixing issues in your tests, so I think it should bring up your attention so that we can avoid the same type of problems in the future.

For @rotty3000, just going to explain why I reverted your gradle cache changes for arquillian, no action is required.

For @JorgeFerrer, just FYI :)

This is actually a quite messy issue, as it is interweaved with several different indirectly related things. I will try to describe it as clear as I can, but if you get lost or bored with the details, feel free to just jump into the code changes.

Things started getting into our attention by Ray committed gradle cache with newer version of arquillian jars. Then CI was completely borken with portal-store tests. However by the time Ray did the commit, CI was suffering another build problem which was fixed later by @Ithildir at https://github.com/liferay/liferay-portal/commit/5cbbc74e8499959cfb6aa532822d48e352a3fa34 (@rotty3000 this is the fix for those randomly not deployed wiki-web, bookmarks-web, or any wab web issue, just in case you want to know about it). Because CI was flooded with whose wab bundles failures, Brian did not see the portal-store failures caused by this gradle cache commit and merged it in.

The reason why Ray got these gradle cache changes is modules/test/arquillian-extension-junit-bridge had a dependency to https://github.com/arquillian/arquillian-extension-liferay on a snapshot version. And lately @cgoncas and @csierra have updated the dependency to arquillian 1.1.9 https://github.com/arquillian/arquillian-extension-liferay/commit/d4d8e589c63af48cb960fdfeaf3c5362bb27239a and also with some bugs fix inside arquillian-extension-junit-bridge. This snapshot change actually completely changed the modules/test/arquillian-extension-junit-bridge's dependency tree without our notice at all. And that's the reason why CI started to break with portal-store test.

So for this part, @cgoncas and @csierra, please start to release your project, from now on @Ithildir will make sure we no longer depend on "moving target" snapshot version. We don't want to see this quite upgrade surprise again. And after your release, please try to upgrade the dependency in modules/test/arquillian-extension-junit-bridge. Hope nothing else will break with your upgrade after this pull. And after the upgrade, please go ahead to revert my temporarily fix in this pull https://github.com/brianchandotcom/liferay-portal/commit/f9df25414b235e118277df5e350fdb7e87281f14

But the funny part is, the real reason of the failures are not caused by the upgrade, but exposed by the upgrade, those failures are long existed ones. We were just muting them.

@mdelapenya please see https://github.com/brianchandotcom/liferay-portal/commit/b1ddaa795ee63f2c06a6cdf9457d04aee85b8ff5 in this pull, the Exceptions that got swallowed are actually NPEs, those BundleActivator were created in this way since you moved those tests into bundles, I am not sure what was the reason you were swallowing them, but we should always try to avoid swallowing exception at any cost. And the reason those Configurations are null in stop(), is because our https://github.com/arquillian/arquillian-extension-liferay had this bug that creates new BundleActivator instances for both start() and stop(), so start() and stop() end up on different BundleActivator instances, therefore those Configuration fields are all nulls in stop(). This basically means we never really delete any Configuration in those tests.

And in https://github.com/arquillian/arquillian-extension-liferay/commit/373b061b5f27446cd4a483ff33cb803cd6061939 @cgoncas fixed it, good job on that one:) Which is included in @rotty3000 gradle cache changes. So all the sudden we started to actually delete Configruations. And that brings up the real problem here.

@mdelapenya please see https://github.com/brianchandotcom/liferay-portal/commit/3f1f661adc3c44e103d47e99c6b464951751f5df, I put in a very long commit message to explain how your FileSystemStore.validate() implementation created this tricky race condition. I am not going to repeat it here, as I can see this comment is already very very long and you must all already tired with my boring explanation and bad english. But please do read the commit message.

Thank you very much guys for reading this.

Shuyang
