### PR TITLE
LPS-59880 Web Content article's Display Page tooltip is too close to the header

### DIFF
--- a/modules/apps/journal/journal-web/src/META-INF/resources/article/display_page.jsp
+++ b/modules/apps/journal/journal-web/src/META-INF/resources/article/display_page.jsp
@@ -65,7 +65,7 @@ boolean changeStructure = GetterUtil.getBoolean(request.getAttribute("edit_artic
 
 		<liferay-ui:error-marker key="errorSection" value="display-page" />
 
-		<h3><liferay-ui:message key="display-page" /><liferay-ui:icon-help message="default-display-page-help" /></h3>
+		<h3><liferay-ui:message key="display-page" /> <liferay-ui:icon-help message="default-display-page-help" /></h3>
 
 		<div id="<portlet:namespace />pagesContainer">
 			<aui:input id="pagesContainerInput" ignoreRequestValue="<%= true %>" name="layoutUuid" type="hidden" value="<%= layoutUuid %>" />


### PR DESCRIPTION
@brianchandotcom, I saw that his is how it's used in other places. Still, will ask if we can add a css class that can handle this. 
