### PR TITLE
LPS-59954 Disable SocketTest so timeout to prevent random java.net.So…

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/test/SocketTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/test/SocketTest.java
@@ -42,7 +42,7 @@ public class SocketTest {
 	public void testAccept1() throws Exception {
 		try (ServerSocket serverSocket = new ServerSocket(4316)) {
 			serverSocket.setReuseAddress(true);
-			serverSocket.setSoTimeout(50);
+			serverSocket.setSoTimeout(0);
 
 			Runnable runnable = new Runnable() {
 
@@ -78,7 +78,7 @@ public class SocketTest {
 	public void testAccept2() throws Exception {
 		try (ServerSocket serverSocket = new ServerSocket(4316)) {
 			serverSocket.setReuseAddress(true);
-			serverSocket.setSoTimeout(50);
+			serverSocket.setSoTimeout(0);
 
 			Runnable runnable = new Runnable() {
 


### PR DESCRIPTION
…cketTimeoutException due slow test running.

@rotty3000, this 50ms so timeout was too short, we randomly ran into socket timeout. For example, https://github.com/brianchandotcom/liferay-portal/pull/31545

Don't worry about the potential infinitely waiting, as right now the test logic is correct, it won't happen for sure. And I am going to plant in a deadlock/hanging detection logic into CI to protect us from future modification caused hanging.
