### PR TITLE
LPS-60053 UncaughtExceptionHandler is called before thread death, do …

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/mailbox/MailboxUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/nio/intraband/mailbox/MailboxUtilTest.java
@@ -156,6 +156,8 @@ public class MailboxUtilTest {
 
 		recorderUncaughtExceptionHandler.await(10 * Time.MINUTE);
 
+		reaperThread.join();
+
 		Assert.assertFalse(
 			"Reaper thread " + reaperThread +
 				" failed to join back after waiting for 10 mins",


### PR DESCRIPTION
…a post thread join to avoid asserting in the window time before the thread death.
