### PR TITLE
LRQA-19035 - Upgrading version of json.jar. Changed getString() calls to getInt() calls where appropriate.

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
 	compile group: "org.apache.ant", name: "ant", version: "1.9.4"
-	compile group: "org.json", name: "json", version: "20090211"
+	compile group: "org.json", name: "json", version: "20140107"
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
@@ -71,7 +71,7 @@ public class UnstableMessageUtil {
 				String runBuildURL = runJSONObject.getString("url");
 
 				if (!runBuildURL.endsWith(
-						"/" + jsonObject.getString("number") + "/")) {
+						"/" + jsonObject.getInt("number") + "/")) {
 
 					continue;
 				}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UnstableMessageUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/UnstableMessageUtilTest.java
@@ -79,14 +79,14 @@ public class UnstableMessageUtilTest extends BaseJenkinsResultsParserTestCase {
 		JSONObject jobJSONObject = JenkinsResultsParserUtil.toJSONObject(
 			JenkinsResultsParserUtil.getLocalURL(toURLString(jobJSONFile)));
 
-		String number = jobJSONObject.getString("number");
+		int number = jobJSONObject.getInt("number");
 
 		JSONArray runsJSONArray = jobJSONObject.getJSONArray("runs");
 
 		for (int i = 0; i < runsJSONArray.length(); i++) {
 			JSONObject runJSONObject = runsJSONArray.getJSONObject(i);
 
-			if (!number.equals(runJSONObject.getString("number"))) {
+			if (number != runJSONObject.getInt("number")) {
 				continue;
 			}
 


### PR DESCRIPTION
json.jar upgraded to version 20140107 (latest version before Java 8 is required)
