### PR TITLE
LRQA-18829 - Caching bypass 

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -166,20 +166,28 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static JSONObject toJSONObject(String url) throws Exception {
-		return new JSONObject(toString(url));
+		return toJSONObject(url, true);
+	}
+	
+	public static JSONObject toJSONObject(String url, boolean cacheFlag) throws Exception {
+		return new JSONObject(toString(url, cacheFlag));		
+	}
+	
+	public static String toString(String url) throws IOException {
+		return toString(url, true);
 	}
 
-	public static String toString(String url) throws IOException {
+	public static String toString(String url, boolean cacheFlag) throws IOException {
 		url = fixURL(url);
 
 		String key = url.replace("//", "/");
 
-		if (_toStringCache.containsKey(key)) {
+		if (cacheFlag && _toStringCache.containsKey(key)) {
 			System.out.println("Loading " + url);
 
 			return _toStringCache.get(key);
 		}
-
+		
 		System.out.println("Downloading " + url);
 
 		StringBuilder sb = new StringBuilder();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -168,16 +168,20 @@ public class JenkinsResultsParserUtil {
 	public static JSONObject toJSONObject(String url) throws Exception {
 		return toJSONObject(url, true);
 	}
-	
-	public static JSONObject toJSONObject(String url, boolean cacheFlag) throws Exception {
-		return new JSONObject(toString(url, cacheFlag));		
+
+	public static JSONObject toJSONObject(String url, boolean cacheFlag)
+		throws Exception {
+
+		return new JSONObject(toString(url, cacheFlag));
 	}
-	
+
 	public static String toString(String url) throws IOException {
 		return toString(url, true);
 	}
 
-	public static String toString(String url, boolean cacheFlag) throws IOException {
+	public static String toString(String url, boolean cacheFlag)
+		throws IOException {
+
 		url = fixURL(url);
 
 		String key = url.replace("//", "/");
@@ -187,7 +191,7 @@ public class JenkinsResultsParserUtil {
 
 			return _toStringCache.get(key);
 		}
-		
+
 		System.out.println("Downloading " + url);
 
 		StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Added alternative implementations with cacheFlag parameter of toJSONObject() and toString(). If cacheFlag is true, then these methods may return a cached value.
