### PR TITLE
LPS-60008 Add Javadoc to clarify API usage

### DIFF
--- a/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
+++ b/portal-impl/src/com/liferay/portal/repository/capabilities/CapabilityRepository.java
@@ -187,9 +187,11 @@ public class CapabilityRepository
 
 		FileVersion fileVersion = repository.cancelCheckOut(fileEntryId);
 
-		_repositoryEventTrigger.trigger(
-			RepositoryEventType.Update.class, FileEntry.class,
-			fileVersion.getFileEntry());
+		if (fileVersion != null) {
+			_repositoryEventTrigger.trigger(
+				RepositoryEventType.Update.class, FileEntry.class,
+				fileVersion.getFileEntry());
+		}
 
 		return fileVersion;
 	}

--- a/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
+++ b/portal-service/src/com/liferay/portal/kernel/repository/Repository.java
@@ -70,6 +70,17 @@ public interface Repository extends DocumentRepository {
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	 * Cancels the check out of the file entry. If a user has not checked out
+	 * the specified file entry, invoking this method will result in no changes.
+	 *
+	 * @param  fileEntryId the primary key of the file entry to cancel the
+	 *         checkout
+	 * @return the file entry if the cancel checkout operation was successful;
+	 *         <code>null</code> if the file entry was not checked out
+	 * @see    #checkInFileEntry(long, long, boolean, String, ServiceContext)
+	 * @see    #checkOutFileEntry(long, ServiceContext)
+	 */
 	public FileVersion cancelCheckOut(long fileEntryId) throws PortalException;
 
 	/**


### PR DESCRIPTION
@jhinkey I've added a Javadoc to clarify that the `cancelCheckout()` method may return `null` (and that that case needs to be handled).
