### PR TITLE
Lps 60226

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/security/SecureRandomUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/security/SecureRandomUtil.java
@@ -46,7 +46,7 @@ public class SecureRandomUtil {
 			return _bytes[index];
 		}
 
-		return (byte)_reload();
+		return (byte)_reload(index);
 	}
 
 	public static double nextDouble() {
@@ -56,7 +56,7 @@ public class SecureRandomUtil {
 			return BigEndianCodec.getDouble(_bytes, index);
 		}
 
-		return Double.longBitsToDouble(_reload());
+		return Double.longBitsToDouble(_reload(index));
 	}
 
 	public static float nextFloat() {
@@ -66,7 +66,7 @@ public class SecureRandomUtil {
 			return BigEndianCodec.getFloat(_bytes, index);
 		}
 
-		return Float.intBitsToFloat((int)_reload());
+		return Float.intBitsToFloat((int)_reload(index));
 	}
 
 	public static int nextInt() {
@@ -76,7 +76,7 @@ public class SecureRandomUtil {
 			return BigEndianCodec.getInt(_bytes, index);
 		}
 
-		return (int)_reload();
+		return (int)_reload(index);
 	}
 
 	public static long nextLong() {
@@ -86,25 +86,22 @@ public class SecureRandomUtil {
 			return BigEndianCodec.getLong(_bytes, index);
 		}
 
-		return _reload();
+		return _reload(index);
 	}
 
-	private static long _reload() {
+	private static long _reload(int index) {
 		if (_reloadingFlag.compareAndSet(false, true)) {
 			_random.nextBytes(_bytes);
+
+			_gapRandom.setSeed(_random.nextLong());
 
 			_index.set(0);
 
 			_reloadingFlag.set(false);
 		}
 
-		int offset = _index.get() % (_BUFFER_SIZE - 7);
-
-		long l = BigEndianCodec.getLong(_bytes, offset) ^ _gapSeed;
-
-		_gapSeed = l;
-
-		return l;
+		return _gapRandom.nextLong() ^ BigEndianCodec.getLong(
+			_bytes, Math.abs(index % (_BUFFER_SIZE - 7)));
 	}
 
 	private static final int _BUFFER_SIZE;
@@ -112,7 +109,7 @@ public class SecureRandomUtil {
 	private static final int _MIN_BUFFER_SIZE = 1024;
 
 	private static final byte[] _bytes;
-	private static long _gapSeed;
+	private static final Random _gapRandom = new Random();
 	private static final AtomicInteger _index = new AtomicInteger();
 	private static final Random _random = new SecureRandom();
 	private static final AtomicBoolean _reloadingFlag = new AtomicBoolean();
@@ -132,7 +129,7 @@ public class SecureRandomUtil {
 
 		_random.nextBytes(_bytes);
 
-		_gapSeed = _random.nextLong();
+		_gapRandom.setSeed(_random.nextLong());
 	}
 
 }

--- a/portal-service/test/unit/com/liferay/portal/kernel/security/SecureRandomUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/security/SecureRandomUtilTest.java
@@ -62,7 +62,7 @@ public class SecureRandomUtilTest {
 	public void testConcurrentReload() throws Exception {
 		SecureRandom secureRandom = installPredictableRandom();
 
-		FutureTask<Long> futureTask = new FutureTask<Long>(
+		FutureTask<Long> futureTask = new FutureTask<>(
 			new Callable<Long>() {
 
 				@Override
@@ -302,12 +302,12 @@ public class SecureRandomUtilTest {
 			}
 
 			Assert.assertEquals(
-				BigEndianCodec.getInt(bytes, 0), SecureRandomUtil.nextInt(), 0);
+				BigEndianCodec.getInt(bytes, 0), SecureRandomUtil.nextInt());
 		}
 
 		// Gap number
 
-		Assert.assertEquals((int)getLong(7), SecureRandomUtil.nextInt(), 0);
+		Assert.assertEquals((int)getLong(7), SecureRandomUtil.nextInt());
 
 		// Second load
 
@@ -321,13 +321,12 @@ public class SecureRandomUtilTest {
 			}
 
 			Assert.assertEquals(
-				BigEndianCodec.getInt(bytes, 0), SecureRandomUtil.nextInt(), 0);
+				BigEndianCodec.getInt(bytes, 0), SecureRandomUtil.nextInt());
 		}
 
 		// Gap number
 
-		Assert.assertEquals(
-			(int)(getLong(7) ^ 1), SecureRandomUtil.nextInt(), 0);
+		Assert.assertEquals((int)(getLong(7) ^ 1L), SecureRandomUtil.nextInt());
 	}
 
 	@Test
@@ -347,13 +346,12 @@ public class SecureRandomUtilTest {
 			}
 
 			Assert.assertEquals(
-				BigEndianCodec.getLong(bytes, 0), SecureRandomUtil.nextLong(),
-				0);
+				BigEndianCodec.getLong(bytes, 0), SecureRandomUtil.nextLong());
 		}
 
 		// Gap number
 
-		Assert.assertEquals(getLong(7), SecureRandomUtil.nextLong(), 0);
+		Assert.assertEquals(getLong(7), SecureRandomUtil.nextLong());
 
 		// Second load
 
@@ -367,13 +365,12 @@ public class SecureRandomUtilTest {
 			}
 
 			Assert.assertEquals(
-				BigEndianCodec.getLong(bytes, 0), SecureRandomUtil.nextLong(),
-				0);
+				BigEndianCodec.getLong(bytes, 0), SecureRandomUtil.nextLong());
 		}
 
 		// Gap number
 
-		Assert.assertEquals(getLong(7) ^ 1, SecureRandomUtil.nextLong(), 0);
+		Assert.assertEquals(getLong(7) ^ 1, SecureRandomUtil.nextLong());
 	}
 
 	protected long getLong(int offset) {


### PR DESCRIPTION
@brianchandotcom This is the fix for the DLAppServiceTest failues, for example, https://github.com/brianchandotcom/liferay-portal/pull/31798
Basically we had an UUID collision, UUID does not really guarantee uniqueness, but the issue we had in SecureRandomUtil concurrent reload magnified it. With the new logic, the chance of collision should be much lower.
