### PR TITLE
LPS-60146 Do not need to extend the content portlet data handlers since the Portlet Preferences Processor properly handles the export/import logic for display portlets

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/lar/DLDisplayPortletDataHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/lar/DLDisplayPortletDataHandler.java
@@ -17,6 +17,7 @@ package com.liferay.document.library.web.lar;
 import com.liferay.document.library.web.constants.DLPortletKeys;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portlet.exportimport.lar.BasePortletDataHandler;
 import com.liferay.portlet.exportimport.lar.DataLevel;
 import com.liferay.portlet.exportimport.lar.PortletDataContext;
 import com.liferay.portlet.exportimport.lar.PortletDataHandler;
@@ -36,7 +37,7 @@ import org.osgi.service.component.annotations.Component;
 	},
 	service = PortletDataHandler.class
 )
-public class DLDisplayPortletDataHandler extends DLPortletDataHandler {
+public class DLDisplayPortletDataHandler extends BasePortletDataHandler {
 
 	public DLDisplayPortletDataHandler() {
 		setDataLevel(DataLevel.PORTLET_INSTANCE);

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/lar/DDLDisplayPortletDataHandler.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/lar/DDLDisplayPortletDataHandler.java
@@ -17,6 +17,7 @@ package com.liferay.dynamic.data.lists.web.lar;
 import com.liferay.dynamic.data.lists.constants.DDLPortletKeys;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portlet.exportimport.lar.BasePortletDataHandler;
 import com.liferay.portlet.exportimport.lar.DataLevel;
 import com.liferay.portlet.exportimport.lar.PortletDataContext;
 import com.liferay.portlet.exportimport.lar.PortletDataHandler;
@@ -38,7 +39,7 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = PortletDataHandler.class
 )
-public class DDLDisplayPortletDataHandler extends DDLPortletDataHandler {
+public class DDLDisplayPortletDataHandler extends BasePortletDataHandler {
 
 	@Activate
 	protected void activate() {

--- a/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/lar/PollsDisplayPortletDataHandler.java
+++ b/modules/apps/polls/polls-service/src/main/java/com/liferay/polls/lar/PollsDisplayPortletDataHandler.java
@@ -16,10 +16,9 @@ package com.liferay.polls.lar;
 
 import com.liferay.polls.configuration.PollsServiceConfigurationValues;
 import com.liferay.polls.constants.PollsPortletKeys;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portlet.exportimport.lar.BasePortletDataHandler;
 import com.liferay.portlet.exportimport.lar.DataLevel;
 import com.liferay.portlet.exportimport.lar.PortletDataContext;
 import com.liferay.portlet.exportimport.lar.PortletDataHandler;
@@ -39,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {"javax.portlet.name=" + PollsPortletKeys.POLLS_DISPLAY},
 	service = PortletDataHandler.class
 )
-public class PollsDisplayPortletDataHandler extends PollsPortletDataHandler {
+public class PollsDisplayPortletDataHandler extends BasePortletDataHandler {
 
 	@Activate
 	protected void activate() {
@@ -69,8 +68,5 @@ public class PollsDisplayPortletDataHandler extends PollsPortletDataHandler {
 	protected void setModuleServiceLifecycle(
 		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		PollsDisplayPortletDataHandler.class);
 
 }


### PR DESCRIPTION
cc @sergiogonzalez, @marcellustavares
