### PR TITLE
LPS-59815

### DIFF
--- a/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/build.gradle
+++ b/modules/frontend/frontend-editor/frontend-editor-alloyeditor-web/build.gradle
@@ -35,7 +35,9 @@ buildAlloyEditor {
 
 	duplicatesStrategy = "exclude"
 
-	from { zipTree(configurations.alloyEditor.singleFile) } {
+	from {
+		zipTree(configurations.alloyEditor.singleFile)
+	} {
 		eachFile new StripPathSegmentsAction(7)
 		include "META-INF/resources/webjars/alloyeditor/${alloyEditorVersion}/dist/alloy-editor/**"
 	}

--- a/modules/frontend/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/frontend/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -12,12 +12,12 @@ String ckEditorVersion = "4.5.3"
 String ckEditorScaytUrl = "http://download.ckeditor.com/scayt/releases/scayt_${ckEditorVersion}.zip"
 String ckEditorWscUrl = "http://download.ckeditor.com/wsc/releases/wsc_${ckEditorVersion}.zip"
 
-File editorsDestinationDir = file("tmp/META-INF/resources")
-File editorsSrcDir = file("src/main/resources/META-INF/resources")
+File editorDestinationDir = file("tmp/META-INF/resources")
+File editorSrcDir = file("src/main/resources/META-INF/resources")
 File thirdPartyDir = file("../../../../portal-web/third-party")
 
 buildCKEditor {
-	File ckEditorDestinationDir = new File(editorsDestinationDir, "ckeditor")
+	File ckEditorDestinationDir = new File(editorDestinationDir, "ckeditor")
 	File ckEditorZipFile = new File(thirdPartyDir, "ckeditor_${ckEditorVersion}_liferay.zip")
 
 	doFirst {
@@ -31,7 +31,7 @@ buildCKEditor {
 		include "ckeditor/**"
 	}
 
-	from new File(editorsSrcDir, "_diffs")
+	from new File(editorSrcDir, "_diffs")
 	includeEmptyDirs = false
 	into ckEditorDestinationDir
 
@@ -41,7 +41,7 @@ buildCKEditor {
 }
 
 buildCKEditorBBCode {
-	File bbCodeDir = new File(editorsSrcDir, "_diffs/plugins/bbcode")
+	File bbCodeDir = new File(editorSrcDir, "_diffs/plugins/bbcode")
 
 	destinationFile = new File(bbCodeDir, "bbcode_parser.js")
 
@@ -68,7 +68,7 @@ buildCKEditorScayt {
 		zipTree ckEditorScaytFile
 	}
 
-	into new File(editorsDestinationDir, "ckeditor/plugins")
+	into new File(editorDestinationDir, "ckeditor/plugins")
 }
 
 buildCKEditorWsc {
@@ -84,7 +84,7 @@ buildCKEditorWsc {
 		zipTree ckEditorWscFile
 	}
 
-	into new File(editorsDestinationDir, "ckeditor/plugins")
+	into new File(editorDestinationDir, "ckeditor/plugins")
 }
 
 classes {

--- a/modules/frontend/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/frontend/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -65,7 +65,7 @@ buildCKEditorScayt {
 			FileUtil.get(project, ckEditorScaytUrl, ckEditorScaytFile)
 		}
 
-		zipTree ckEditorScaytFile
+		zipTree(ckEditorScaytFile)
 	}
 
 	into new File(editorDestinationDir, "ckeditor/plugins")
@@ -81,7 +81,7 @@ buildCKEditorWsc {
 			FileUtil.get(project, ckEditorWscUrl, ckEditorWscFile)
 		}
 
-		zipTree ckEditorWscFile
+		zipTree(ckEditorWscFile)
 	}
 
 	into new File(editorDestinationDir, "ckeditor/plugins")

--- a/modules/frontend/frontend-editor/frontend-editor-tinymce-web/build.gradle
+++ b/modules/frontend/frontend-editor/frontend-editor-tinymce-web/build.gradle
@@ -5,12 +5,12 @@ task buildTinyMCE(type: Copy)
 
 String tinyMCEVersion = "4.1.7"
 
-File editorsDestinationDir = file("tmp/META-INF/resources")
-File editorsSrcDir = file("src/main/resources/META-INF/resources")
+File editorDestinationDir = file("tmp/META-INF/resources")
+File editorSrcDir = file("src/main/resources/META-INF/resources")
 File thirdPartyDir = file("../../../../portal-web/third-party")
 
 buildTinyMCE {
-	File tinyMCEDestinationDir = new File(editorsDestinationDir, "tiny_mce")
+	File tinyMCEDestinationDir = new File(editorDestinationDir, "tiny_mce")
 	File tinyMCEZipFile = new File(thirdPartyDir, "tinymce_${tinyMCEVersion}.zip")
 
 	doFirst {
@@ -19,7 +19,7 @@ buildTinyMCE {
 
 	duplicatesStrategy = "exclude"
 
-	from new File(editorsSrcDir, "_diffs")
+	from new File(editorSrcDir, "_diffs")
 
 	from(zipTree(tinyMCEZipFile)) {
 		eachFile new StripPathSegmentsAction(3)

--- a/modules/third-party/com-google-gdata-sample-appsforyourdomain/build.gradle
+++ b/modules/third-party/com-google-gdata-sample-appsforyourdomain/build.gradle
@@ -46,7 +46,7 @@ downloadSrc {
 	}
 
 	from {
-		zipTree FileUtil.get(project, "https://gdata-java-client.googlecode.com/files/gdata-samples.java-1.47.1.zip")
+		zipTree(FileUtil.get(project, "https://gdata-java-client.googlecode.com/files/gdata-samples.java-1.47.1.zip"))
 	}
 
 	include "gdata/java/lib/gdata-appsforyourdomain-1.0.jar"

--- a/modules/third-party/com-mockmock/build.gradle
+++ b/modules/third-party/com-mockmock/build.gradle
@@ -26,7 +26,7 @@ configurations {
 
 downloadSrc {
 	from {
-		zipTree FileUtil.get(project, mockMockSrcUrl)
+		zipTree(FileUtil.get(project, mockMockSrcUrl))
 	}
 
 	into buildDir

--- a/modules/third-party/jenkins-core/build.gradle
+++ b/modules/third-party/jenkins-core/build.gradle
@@ -46,7 +46,7 @@ war {
 	extension = "war"
 
 	from {
-		zipTree FileUtil.get(project, "http://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${jenkinsCoreVersion}/jenkins-war-${jenkinsCoreVersion}.war")
+		zipTree(FileUtil.get(project, "http://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${jenkinsCoreVersion}/jenkins-war-${jenkinsCoreVersion}.war"))
 	}
 
 	into("WEB-INF/lib") {

--- a/modules/third-party/org-gradle-resources-http/build.gradle
+++ b/modules/third-party/org-gradle-resources-http/build.gradle
@@ -24,7 +24,7 @@ deploy {
 	}
 
 	from {
-		zipTree FileUtil.get(project, "https://services.gradle.org/distributions/gradle-${gradleVersion}-bin.zip")
+		zipTree(FileUtil.get(project, "https://services.gradle.org/distributions/gradle-${gradleVersion}-bin.zip"))
 	}
 
 	into("gradle-${gradleVersion}/lib/plugins") {

--- a/modules/util/sass-compiler-jni/build.gradle
+++ b/modules/util/sass-compiler-jni/build.gradle
@@ -93,7 +93,7 @@ downloadSassSpec {
 	}
 
 	from {
-		zipTree FileUtil.get(project, sassSpecUrl)
+		zipTree(FileUtil.get(project, sassSpecUrl))
 	}
 
 	include "**/spec/basic/**"


### PR DESCRIPTION
Hi @brianchandotcom!

I think SF in @jbalsas's https://github.com/brianchandotcom/liferay-portal/pull/31872/ pull was correct:
- `configurations { ... }` has to stay at the top, because it defines a configuration which is used in the `buildAlloyEditor { ... }` block.
- I admit that `from { zipTree(configurations.alloyEditor.singleFile) } {` doesn't look very nice, even if I was the one suggesting that SF :sweat_smile: It's because that method requires two closures, and, unless we introduce variables, it's the most straightforward way of calling the method. I tried to make it look a bit better in https://github.com/brianchandotcom/liferay-portal/commit/c382cc8c5560f7eac76e9009b87debd797832cc5.
