### PR TITLE
LPS-60272

### DIFF
--- a/modules/sdk/gradle-plugins-alloy-taglib/build.gradle
+++ b/modules/sdk/gradle-plugins-alloy-taglib/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
 	compile gradleApi()
-	compile group: "com.liferay", name: "com.liferay.gradle.util", version: "1.0.19"
+	compile group: "com.liferay", name: "com.liferay.gradle.util", version: "1.0.23"
 }

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
@@ -32,15 +32,27 @@ import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.TaskContainer;
 
 /**
  * @author Andrea Di Giorgi
  */
 public class AlloyTaglibPlugin implements Plugin<Project> {
 
+	public static final String BUILD_TAGLIBS_TASK_NAME = "buildTaglibs";
+
 	@Override
-	public void apply(final Project project) {
+	public void apply(Project project) {
+		addTaskBuildTaglibs(project);
+	}
+
+	protected BuildTaglibsTask addTaskBuildTaglibs(Project project) {
+		final BuildTaglibsTask buildTaglibsTask = GradleUtil.addTask(
+			project, BUILD_TAGLIBS_TASK_NAME, BuildTaglibsTask.class);
+
+		buildTaglibsTask.setDescription(
+			"Builds the AlloyUI JSP Taglibs for this project.");
+		buildTaglibsTask.setGroup(BasePlugin.BUILD_GROUP);
+
 		PluginContainer pluginContainer = project.getPlugins();
 
 		pluginContainer.withType(
@@ -49,7 +61,8 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 
 				@Override
 				public void execute(BasePlugin basePlugin) {
-					configureTasksBuildTaglibsWithBase(project);
+					configureTaskBuildTaglibsOsgiModuleSymbolicName(
+						buildTaglibsTask);
 				}
 
 			});
@@ -60,10 +73,14 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 
 				@Override
 				public void execute(JavaPlugin javaPlugin) {
-					configureTasksBuildTaglibsWithJava(project);
+					configureTaskBuildTaglibsJavaDir(buildTaglibsTask);
+					configureTaskBuildTaglibsJspParentDir(buildTaglibsTask);
+					configureTaskBuildTaglibsTldDir(buildTaglibsTask);
 				}
 
 			});
+
+		return buildTaglibsTask;
 	}
 
 	protected void configureTaskBuildTaglibsJavaDir(
@@ -132,39 +149,6 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 						buildTaglibsTask.getProject());
 
 					return new File(resourcesDir, "META-INF/resources");
-				}
-
-			});
-	}
-
-	protected void configureTasksBuildTaglibsWithBase(Project project) {
-		TaskContainer taskContainer = project.getTasks();
-
-		taskContainer.withType(
-			BuildTaglibsTask.class,
-			new Action<BuildTaglibsTask>() {
-
-				@Override
-				public void execute(BuildTaglibsTask buildTaglibs) {
-					configureTaskBuildTaglibsOsgiModuleSymbolicName(
-						buildTaglibs);
-				}
-
-			});
-	}
-
-	protected void configureTasksBuildTaglibsWithJava(Project project) {
-		TaskContainer taskContainer = project.getTasks();
-
-		taskContainer.withType(
-			BuildTaglibsTask.class,
-			new Action<BuildTaglibsTask>() {
-
-				@Override
-				public void execute(BuildTaglibsTask buildTaglibsTask) {
-					configureTaskBuildTaglibsJavaDir(buildTaglibsTask);
-					configureTaskBuildTaglibsJspParentDir(buildTaglibsTask);
-					configureTaskBuildTaglibsTldDir(buildTaglibsTask);
 				}
 
 			});

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
@@ -15,6 +15,7 @@
 package com.liferay.gradle.plugins.alloy.taglib;
 
 import com.liferay.gradle.util.GradleUtil;
+import com.liferay.gradle.util.Validator;
 
 import java.io.File;
 
@@ -47,6 +48,28 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 				@Override
 				public void execute(JavaPlugin javaPlugin) {
 					configureTasksBuildTaglibsWithJava(project);
+				}
+
+			});
+	}
+
+	protected void configureTaskBuildTaglibsJavaDir(
+		final BuildTaglibsTask buildTaglibsTask) {
+
+		buildTaglibsTask.setJavaDir(
+			new Callable<File>() {
+
+				@Override
+				public File call() throws Exception {
+					String javaPackage = buildTaglibsTask.getJavaPackage();
+
+					if (Validator.isNull(javaPackage)) {
+						return null;
+					}
+
+					return new File(
+						getJavaDir(buildTaglibsTask.getProject()),
+						javaPackage.replace('.', '/'));
 				}
 
 			});
@@ -89,11 +112,19 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 
 				@Override
 				public void execute(BuildTaglibsTask buildTaglibsTask) {
+					configureTaskBuildTaglibsJavaDir(buildTaglibsTask);
 					configureTaskBuildTaglibsJspParentDir(buildTaglibsTask);
 					configureTaskBuildTaglibsTldDir(buildTaglibsTask);
 				}
 
 			});
+	}
+
+	protected File getJavaDir(Project project) {
+		SourceSet sourceSet = GradleUtil.getSourceSet(
+			project, SourceSet.MAIN_SOURCE_SET_NAME);
+
+		return getSrcDir(sourceSet.getJava());
 	}
 
 	protected File getResourcesDir(Project project) {

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
@@ -83,7 +83,10 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 
 				@Override
 				public File call() throws Exception {
-					return getResourcesDir(buildTaglibsTask.getProject());
+					File resourcesDir = getResourcesDir(
+						buildTaglibsTask.getProject());
+
+					return new File(resourcesDir, "META-INF/resources");
 				}
 
 			});
@@ -97,7 +100,10 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 
 				@Override
 				public File call() throws Exception {
-					return getResourcesDir(buildTaglibsTask.getProject());
+					File resourcesDir = getResourcesDir(
+						buildTaglibsTask.getProject());
+
+					return new File(resourcesDir, "META-INF/resources");
 				}
 
 			});

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
@@ -20,11 +20,14 @@ import java.io.File;
 
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 
@@ -34,43 +37,50 @@ import org.gradle.api.tasks.TaskContainer;
 public class AlloyTaglibPlugin implements Plugin<Project> {
 
 	@Override
-	public void apply(Project project) {
-		project.afterEvaluate(
-			new Action<Project>() {
+	public void apply(final Project project) {
+		PluginContainer pluginContainer = project.getPlugins();
+
+		pluginContainer.withType(
+			JavaPlugin.class,
+			new Action<JavaPlugin>() {
 
 				@Override
-				public void execute(Project project) {
-					configureTasksBuildTaglibs(project);
+				public void execute(JavaPlugin javaPlugin) {
+					configureTasksBuildTaglibsWithJava(project);
 				}
 
 			});
 	}
 
 	protected void configureTaskBuildTaglibsJspParentDir(
-		BuildTaglibsTask buildTaglibsTask) {
+		final BuildTaglibsTask buildTaglibsTask) {
 
-		if (buildTaglibsTask.getJspParentDir() != null) {
-			return;
-		}
+		buildTaglibsTask.setJspParentDir(
+			new Callable<File>() {
 
-		File jspParentDir = getResourcesDir(buildTaglibsTask.getProject());
+				@Override
+				public File call() throws Exception {
+					return getResourcesDir(buildTaglibsTask.getProject());
+				}
 
-		buildTaglibsTask.setJspParentDir(jspParentDir);
+			});
 	}
 
 	protected void configureTaskBuildTaglibsTldDir(
-		BuildTaglibsTask buildTaglibsTask) {
+		final BuildTaglibsTask buildTaglibsTask) {
 
-		if (buildTaglibsTask.getTldDir() != null) {
-			return;
-		}
+		buildTaglibsTask.setTldDir(
+			new Callable<File>() {
 
-		File tldDir = getResourcesDir(buildTaglibsTask.getProject());
+				@Override
+				public File call() throws Exception {
+					return getResourcesDir(buildTaglibsTask.getProject());
+				}
 
-		buildTaglibsTask.setTldDir(tldDir);
+			});
 	}
 
-	protected void configureTasksBuildTaglibs(Project project) {
+	protected void configureTasksBuildTaglibsWithJava(Project project) {
 		TaskContainer taskContainer = project.getTasks();
 
 		taskContainer.withType(

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/AlloyTaglibPlugin.java
@@ -23,14 +23,12 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.plugins.osgi.OsgiHelper;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.SourceSet;
 
 /**
@@ -42,6 +40,8 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 
 	@Override
 	public void apply(Project project) {
+		GradleUtil.applyPlugin(project, JavaPlugin.class);
+
 		addTaskBuildTaglibs(project);
 	}
 
@@ -52,39 +52,6 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 		buildTaglibsTask.setDescription(
 			"Builds the AlloyUI JSP Taglibs for this project.");
 		buildTaglibsTask.setGroup(BasePlugin.BUILD_GROUP);
-
-		PluginContainer pluginContainer = project.getPlugins();
-
-		pluginContainer.withType(
-			BasePlugin.class,
-			new Action<BasePlugin>() {
-
-				@Override
-				public void execute(BasePlugin basePlugin) {
-					configureTaskBuildTaglibsOsgiModuleSymbolicName(
-						buildTaglibsTask);
-				}
-
-			});
-
-		pluginContainer.withType(
-			JavaPlugin.class,
-			new Action<JavaPlugin>() {
-
-				@Override
-				public void execute(JavaPlugin javaPlugin) {
-					configureTaskBuildTaglibsJavaDir(buildTaglibsTask);
-					configureTaskBuildTaglibsJspParentDir(buildTaglibsTask);
-					configureTaskBuildTaglibsTldDir(buildTaglibsTask);
-				}
-
-			});
-
-		return buildTaglibsTask;
-	}
-
-	protected void configureTaskBuildTaglibsJavaDir(
-		final BuildTaglibsTask buildTaglibsTask) {
 
 		buildTaglibsTask.setJavaDir(
 			new Callable<File>() {
@@ -103,10 +70,6 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 				}
 
 			});
-	}
-
-	protected void configureTaskBuildTaglibsJspParentDir(
-		final BuildTaglibsTask buildTaglibsTask) {
 
 		buildTaglibsTask.setJspParentDir(
 			new Callable<File>() {
@@ -120,25 +83,17 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 				}
 
 			});
-	}
 
-	protected void configureTaskBuildTaglibsOsgiModuleSymbolicName(
-		final BuildTaglibsTask buildTaglibs) {
-
-		buildTaglibs.setOsgiModuleSymbolicName(
+		buildTaglibsTask.setOsgiModuleSymbolicName(
 			new Callable<String>() {
 
 				@Override
 				public String call() throws Exception {
 					return _osgiHelper.getBundleSymbolicName(
-						buildTaglibs.getProject());
+						buildTaglibsTask.getProject());
 				}
 
 			});
-	}
-
-	protected void configureTaskBuildTaglibsTldDir(
-		final BuildTaglibsTask buildTaglibsTask) {
 
 		buildTaglibsTask.setTldDir(
 			new Callable<File>() {
@@ -152,6 +107,8 @@ public class AlloyTaglibPlugin implements Plugin<Project> {
 				}
 
 			});
+
+		return buildTaglibsTask;
 	}
 
 	protected File getJavaDir(Project project) {

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
@@ -52,7 +52,7 @@ public class BuildTaglibsTask extends JavaExec {
 
 	@Override
 	public void exec() {
-		super.setSystemProperties(getSystemProperties());
+		setSystemProperties(getCompleteSystemProperties());
 
 		super.exec();
 	}
@@ -89,46 +89,6 @@ public class BuildTaglibsTask extends JavaExec {
 
 	public String getOsgiModuleSymbolicName() {
 		return GradleUtil.toString(_osgiModuleSymbolicName);
-	}
-
-	@Override
-	public Map<String, Object> getSystemProperties() {
-		Map<String, Object> systemProperties = new HashMap<>();
-
-		systemProperties.put(
-			"tagbuilder.components.xml",
-			getRelativePaths(getComponentsXmlFiles()));
-		systemProperties.put("tagbuilder.copyright.year", getCopyrightYear());
-		systemProperties.put(
-			"tagbuilder.java.dir", getRelativePath(getJavaDir()) + "/");
-		systemProperties.put("tagbuilder.java.package", getJavaPackage());
-		systemProperties.put(
-			"tagbuilder.jsp.common.init.path", getJspCommonInitPath());
-
-		String jspDirName = getJspDirName();
-
-		if (!jspDirName.endsWith("/")) {
-			jspDirName = jspDirName + "/";
-		}
-
-		systemProperties.put("tagbuilder.jsp.dir", jspDirName);
-
-		systemProperties.put(
-			"tagbuilder.jsp.parent.dir",
-			getRelativePath(getJspParentDir()) + "/");
-
-		String osgiModuleSymbolicName = getOsgiModuleSymbolicName();
-
-		if (Validator.isNotNull(osgiModuleSymbolicName)) {
-			systemProperties.put(
-				"tagbuilder.osgi.module.symbolic.name", osgiModuleSymbolicName);
-		}
-
-		systemProperties.put("tagbuilder.templates.dir", getTemplatesDirName());
-		systemProperties.put(
-			"tagbuilder.tld.dir", getRelativePath(getTldDir()) + "/");
-
-		return systemProperties;
 	}
 
 	public String getTemplatesDirName() {
@@ -177,11 +137,6 @@ public class BuildTaglibsTask extends JavaExec {
 		_osgiModuleSymbolicName = osgiModuleSymbolicName;
 	}
 
-	@Override
-	public void setSystemProperties(Map<String, ?> properties) {
-		throw new UnsupportedOperationException();
-	}
-
 	public void setTemplatesDirName(Object templatesDirName) {
 		_templatesDirName = templatesDirName;
 	}
@@ -190,14 +145,44 @@ public class BuildTaglibsTask extends JavaExec {
 		_tldDir = tldDir;
 	}
 
-	@Override
-	public JavaExec systemProperties(Map<String, ?> properties) {
-		throw new UnsupportedOperationException();
-	}
+	protected Map<String, Object> getCompleteSystemProperties() {
+		Map<String, Object> systemProperties = new HashMap<>(
+			getSystemProperties());
 
-	@Override
-	public JavaExec systemProperty(String name, Object value) {
-		throw new UnsupportedOperationException();
+		systemProperties.put(
+			"tagbuilder.components.xml",
+			getRelativePaths(getComponentsXmlFiles()));
+		systemProperties.put("tagbuilder.copyright.year", getCopyrightYear());
+		systemProperties.put(
+			"tagbuilder.java.dir", getRelativePath(getJavaDir()) + "/");
+		systemProperties.put("tagbuilder.java.package", getJavaPackage());
+		systemProperties.put(
+			"tagbuilder.jsp.common.init.path", getJspCommonInitPath());
+
+		String jspDirName = getJspDirName();
+
+		if (!jspDirName.endsWith("/")) {
+			jspDirName = jspDirName + "/";
+		}
+
+		systemProperties.put("tagbuilder.jsp.dir", jspDirName);
+
+		systemProperties.put(
+			"tagbuilder.jsp.parent.dir",
+			getRelativePath(getJspParentDir()) + "/");
+
+		String osgiModuleSymbolicName = getOsgiModuleSymbolicName();
+
+		if (Validator.isNotNull(osgiModuleSymbolicName)) {
+			systemProperties.put(
+				"tagbuilder.osgi.module.symbolic.name", osgiModuleSymbolicName);
+		}
+
+		systemProperties.put("tagbuilder.templates.dir", getTemplatesDirName());
+		systemProperties.put(
+			"tagbuilder.tld.dir", getRelativePath(getTldDir()) + "/");
+
+		return systemProperties;
 	}
 
 	protected String getComponentsXml() {

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
@@ -53,7 +53,6 @@ public class BuildTaglibsTask extends JavaExec {
 	@Override
 	public void exec() {
 		super.setSystemProperties(getSystemProperties());
-		super.setWorkingDir(getWorkingDir());
 
 		super.exec();
 	}
@@ -140,13 +139,6 @@ public class BuildTaglibsTask extends JavaExec {
 		return GradleUtil.toFile(getProject(), _tldDir);
 	}
 
-	@Override
-	public File getWorkingDir() {
-		Project project = getProject();
-
-		return project.getProjectDir();
-	}
-
 	public void setComponentsXmlFiles(Iterable<?> componentsXmlFiles) {
 		_componentsXmlFiles.clear();
 
@@ -196,11 +188,6 @@ public class BuildTaglibsTask extends JavaExec {
 
 	public void setTldDir(Object tldDir) {
 		_tldDir = tldDir;
-	}
-
-	@Override
-	public void setWorkingDir(Object dir) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
@@ -36,6 +36,10 @@ import org.gradle.util.GUtil;
  */
 public class BuildTaglibsTask extends JavaExec {
 
+	public BuildTaglibsTask() {
+		setMain("com.liferay.alloy.tools.tagbuilder.TagBuilder");
+	}
+
 	public BuildTaglibsTask componentsXmlFiles(Iterable<?> componentsXmlFiles) {
 		GUtil.addToCollection(_componentsXmlFiles, componentsXmlFiles);
 
@@ -82,11 +86,6 @@ public class BuildTaglibsTask extends JavaExec {
 
 	public File getJspParentDir() {
 		return GradleUtil.toFile(getProject(), _jspParentDir);
-	}
-
-	@Override
-	public String getMain() {
-		return "com.liferay.alloy.tools.tagbuilder.TagBuilder";
 	}
 
 	public String getOsgiModuleSymbolicName() {

--- a/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
+++ b/modules/sdk/gradle-plugins-alloy-taglib/src/main/java/com/liferay/gradle/plugins/alloy/taglib/BuildTaglibsTask.java
@@ -28,7 +28,12 @@ import java.util.Map;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.util.GUtil;
 
 /**
@@ -57,44 +62,56 @@ public class BuildTaglibsTask extends JavaExec {
 		super.exec();
 	}
 
+	@InputFiles
+	@SkipWhenEmpty
 	public FileCollection getComponentsXmlFiles() {
 		Project project = getProject();
 
 		return project.files(_componentsXmlFiles.toArray());
 	}
 
+	@Input
 	public String getCopyrightYear() {
 		return GradleUtil.toString(_copyrightYear);
 	}
 
+	@InputDirectory
 	public File getJavaDir() {
 		return GradleUtil.toFile(getProject(), _javaDir);
 	}
 
+	@Input
 	public String getJavaPackage() {
 		return GradleUtil.toString(_javaPackage);
 	}
 
+	@Input
 	public String getJspCommonInitPath() {
 		return GradleUtil.toString(_jspCommonInitPath);
 	}
 
+	@Input
 	public String getJspDirName() {
 		return GradleUtil.toString(_jspDirName);
 	}
 
+	@InputDirectory
 	public File getJspParentDir() {
 		return GradleUtil.toFile(getProject(), _jspParentDir);
 	}
 
+	@Input
+	@Optional
 	public String getOsgiModuleSymbolicName() {
 		return GradleUtil.toString(_osgiModuleSymbolicName);
 	}
 
+	@Input
 	public String getTemplatesDirName() {
 		return GradleUtil.toString(_templatesDirName);
 	}
 
+	@InputDirectory
 	public File getTldDir() {
 		return GradleUtil.toFile(getProject(), _tldDir);
 	}

--- a/modules/sdk/gradle-plugins/build.gradle
+++ b/modules/sdk/gradle-plugins/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
 	compile gradleApi()
 	compile group: "com.liferay", name: "com.liferay.ant.bnd", version: "2.0.3"
-	compile group: "com.liferay", name: "com.liferay.gradle.plugins.alloy.taglib", version: "1.0.0"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.css.builder", version: "1.0.6"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.jasper.jspc", version: "1.0.3"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.javadoc.formatter", version: "1.0.2"

--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayJavaPlugin.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayJavaPlugin.java
@@ -14,7 +14,6 @@
 
 package com.liferay.gradle.plugins;
 
-import com.liferay.gradle.plugins.alloy.taglib.AlloyTaglibPlugin;
 import com.liferay.gradle.plugins.css.builder.BuildCSSTask;
 import com.liferay.gradle.plugins.css.builder.CSSBuilderPlugin;
 import com.liferay.gradle.plugins.extensions.AppServer;
@@ -890,7 +889,6 @@ public class LiferayJavaPlugin implements Plugin<Project> {
 		GradleUtil.applyPlugin(project, OptionalBasePlugin.class);
 		GradleUtil.applyPlugin(project, ProvidedBasePlugin.class);
 
-		GradleUtil.applyPlugin(project, AlloyTaglibPlugin.class);
 		GradleUtil.applyPlugin(project, CSSBuilderPlugin.class);
 		GradleUtil.applyPlugin(project, JavadocFormatterPlugin.class);
 		GradleUtil.applyPlugin(project, JSModuleConfigGeneratorPlugin.class);

--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayOSGiPlugin.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayOSGiPlugin.java
@@ -16,7 +16,6 @@ package com.liferay.gradle.plugins;
 
 import aQute.bnd.osgi.Constants;
 
-import com.liferay.gradle.plugins.alloy.taglib.BuildTaglibsTask;
 import com.liferay.gradle.plugins.css.builder.BuildCSSTask;
 import com.liferay.gradle.plugins.extensions.LiferayExtension;
 import com.liferay.gradle.plugins.extensions.LiferayOSGiExtension;
@@ -66,7 +65,6 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskInputs;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.bundling.Jar;
@@ -95,7 +93,6 @@ public class LiferayOSGiPlugin extends LiferayJavaPlugin {
 		configureJspCExtension(project);
 
 		configureArchivesBaseName(project);
-		configureTasksBuildTaglibs(project);
 		configureVersion(project);
 
 		project.afterEvaluate(
@@ -657,47 +654,6 @@ public class LiferayOSGiPlugin extends LiferayJavaPlugin {
 		buildServiceTask.setSqlDirName(project.relativePath(sqlDir));
 	}
 
-	protected void configureTaskBuildTaglibsJspParentDir(
-		BuildTaglibsTask buildTaglibsTask) {
-
-		if (buildTaglibsTask.getJspParentDir() != null) {
-			return;
-		}
-
-		File jspParentDir = new File(
-			getResourcesDir(buildTaglibsTask.getProject()),
-			"META-INF/resources");
-
-		buildTaglibsTask.setJspParentDir(jspParentDir);
-	}
-
-	protected void configureTaskBuildTaglibsOsgiModuleSymbolicName(
-		BuildTaglibsTask buildTaglibsTask) {
-
-		if (Validator.isNotNull(buildTaglibsTask.getOsgiModuleSymbolicName())) {
-			return;
-		}
-
-		String bundleSymbolicName = getBundleInstruction(
-			buildTaglibsTask.getProject(), Constants.BUNDLE_SYMBOLICNAME);
-
-		buildTaglibsTask.setOsgiModuleSymbolicName(bundleSymbolicName);
-	}
-
-	protected void configureTaskBuildTaglibsTldDir(
-		BuildTaglibsTask buildTaglibsTask) {
-
-		if (buildTaglibsTask.getTldDir() != null) {
-			return;
-		}
-
-		File tldDir = new File(
-			getResourcesDir(buildTaglibsTask.getProject()),
-			"META-INF/resources");
-
-		buildTaglibsTask.setTldDir(tldDir);
-	}
-
 	@Override
 	protected void configureTaskBuildXSD(Project project) {
 		Zip zip = (Zip)GradleUtil.getTask(
@@ -811,24 +767,6 @@ public class LiferayOSGiPlugin extends LiferayJavaPlugin {
 		configureTaskBuildXSD(project);
 
 		configureTaskAutoUpdateXml(project);
-	}
-
-	protected void configureTasksBuildTaglibs(Project project) {
-		TaskContainer taskContainer = project.getTasks();
-
-		taskContainer.withType(
-			BuildTaglibsTask.class,
-			new Action<BuildTaglibsTask>() {
-
-				@Override
-				public void execute(BuildTaglibsTask buildTaglibsTask) {
-					configureTaskBuildTaglibsJspParentDir(buildTaglibsTask);
-					configureTaskBuildTaglibsOsgiModuleSymbolicName(
-						buildTaglibsTask);
-					configureTaskBuildTaglibsTldDir(buildTaglibsTask);
-				}
-
-			});
 	}
 
 	protected void configureTaskUnzipJar(Project project) {


### PR DESCRIPTION
Hi!

I'm starting to go through the various `gradle-plugins-*` in search of:
- better performance: for example, in this pull I removed the dependency to `gradle-plugins-alloy-taglib` from `gradle-plugins`: the plugin is seldom used, and there's no reason to apply it for every module
- better usability of the plugins when used by themselves (without `gradle-plugins`)
- places where I can apply the same patterns Gradle uses in its source code and make the code easier to maintain

This pull changes `gradle-plugins-alloy-taglib` and `gradle-plugins`, so could you please publish them? I'll send you another pull with the Gradle script changes.

Thank you! :blush:
