### PR TITLE
LRQA-19360 Renamed getFailedJobMessage() to getGitHubJobMessage()

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubJobMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubJobMessageUtil.java
@@ -33,7 +33,7 @@ import org.json.JSONObject;
  */
 public class GitHubJobMessageUtil {
 
-	public static void getFailedJobMessage(Project project) throws Exception {
+	public static void getGitHubJobMessage(Project project) throws Exception {
 		StringBuilder sb = new StringBuilder();
 
 		String buildURL = project.getProperty("build.url");


### PR DESCRIPTION
When I renamed the class from FailedJobMessageUtil to GitHubJobMessageUtil, I failed to change the name of the static method within.
