### PR TITLE
Lps 60334

### DIFF
--- a/portal-impl/test/integration/com/liferay/portlet/trash/service/TrashEntryLocalServiceCheckEntriesTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/trash/service/TrashEntryLocalServiceCheckEntriesTest.java
@@ -63,7 +63,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -71,7 +70,6 @@ import org.junit.Test;
  * @author Sampsa Sohlman
  * @author Shuyang Zhou
  */
-@Ignore("Temporarily disable it until fix the sybase hanging")
 @Sync(cleanTransaction = true)
 public class TrashEntryLocalServiceCheckEntriesTest {
 

--- a/portal-test-internal/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
@@ -39,6 +39,7 @@ public class LiferayIntegrationTestRule extends AggregateTestRule {
 	public LiferayIntegrationTestRule() {
 		super(
 			false, CITimeoutTestRule.INSTANCE, LogAssertionTestRule.INSTANCE,
+			SybaseDumpTransactionLogTestRule.INSTANCE,
 			_clearThreadLocalTestRule, _uniqueStringRandomizerBumperTestRule,
 			new DeleteAfterTestRunTestRule());
 	}

--- a/portal-test-internal/src/com/liferay/portal/test/rule/SybaseDumpTransactionLogTestRule.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/SybaseDumpTransactionLogTestRule.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule;
+
+import com.liferay.portal.kernel.test.rule.BaseTestRule;
+import com.liferay.portal.test.rule.callback.SybaseDumpTransactionLogTestCallback;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class SybaseDumpTransactionLogTestRule extends BaseTestRule<Void, Void> {
+
+	public static final SybaseDumpTransactionLogTestRule INSTANCE =
+		new SybaseDumpTransactionLogTestRule();
+
+	private SybaseDumpTransactionLogTestRule() {
+		super(SybaseDumpTransactionLogTestCallback.INSTANCE);
+	}
+
+}

--- a/portal-test-internal/src/com/liferay/portal/test/rule/callback/SybaseDumpTransactionLogTestCallback.java
+++ b/portal-test-internal/src/com/liferay/portal/test/rule/callback/SybaseDumpTransactionLogTestCallback.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.test.rule.callback;
+
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBFactoryUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.test.rule.callback.BaseTestCallback;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.runner.Description;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class SybaseDumpTransactionLogTestCallback
+	extends BaseTestCallback<Void, Void> {
+
+	public static final SybaseDumpTransactionLogTestCallback INSTANCE =
+		new SybaseDumpTransactionLogTestCallback();
+
+	@Override
+	public Void beforeClass(Description description) throws SQLException {
+		DB db = DBFactoryUtil.getDB();
+
+		String type = db.getType();
+
+		if (!type.equals(DB.TYPE_SYBASE)) {
+			return null;
+		}
+
+		try (Connection connection = DataAccess.getConnection();
+			Statement statement = connection.createStatement()) {
+
+			statement.execute(
+				"dump transaction " + connection.getCatalog() + " with no_log");
+		}
+
+		return null;
+	}
+
+	private SybaseDumpTransactionLogTestCallback() {
+	}
+
+}


### PR DESCRIPTION
It turns out to be a sybase issue that we fill up the transaction log segment that causes all further transactions to hang. I created a new test rule that throws away all previous logs before running a new test class.
