### PR TITLE
Lps 60473

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/AutoBatchPreparedStatementUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/AutoBatchPreparedStatementUtil.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade;
+
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.util.PropsValues;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class AutoBatchPreparedStatementUtil {
+
+	public static PreparedStatement autoBath(
+			PreparedStatement preparedStatement)
+		throws SQLException {
+
+		Connection connection = preparedStatement.getConnection();
+
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+		if (databaseMetaData.supportsBatchUpdates()) {
+			return (PreparedStatement)ProxyUtil.newProxyInstance(
+				ClassLoader.getSystemClassLoader(), _interfaces,
+				new BatchInvocationHandler(preparedStatement));
+		}
+
+		return (PreparedStatement)ProxyUtil.newProxyInstance(
+			ClassLoader.getSystemClassLoader(), _interfaces,
+			new NoBatchInvocationHandler(preparedStatement));
+	}
+
+	private AutoBatchPreparedStatementUtil() {
+	}
+
+	private static final Method _addBatchMethod;
+	private static final Method _executeBatch;
+	private static final Class<?>[] _interfaces =
+		new Class<?>[] {PreparedStatement.class};
+
+	static {
+		try {
+			_addBatchMethod = PreparedStatement.class.getMethod("addBatch");
+			_executeBatch = PreparedStatement.class.getMethod("executeBatch");
+		}
+		catch (NoSuchMethodException nsme) {
+			throw new ExceptionInInitializerError(nsme);
+		}
+	}
+
+	private static class BatchInvocationHandler implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws Throwable {
+
+			if (method.equals(_executeBatch)) {
+				if (_count > 0) {
+					_count = 0;
+
+					return _preparedStatement.executeBatch();
+				}
+
+				return new int[0];
+			}
+
+			if (!method.equals(_addBatchMethod)) {
+				return method.invoke(_preparedStatement, args);
+			}
+
+			_preparedStatement.addBatch();
+
+			if (++_count >= PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
+				_preparedStatement.executeBatch();
+
+				_count = 0;
+			}
+
+			return null;
+		}
+
+		private BatchInvocationHandler(PreparedStatement preparedStatement) {
+			_preparedStatement = preparedStatement;
+		}
+
+		private int _count;
+		private final PreparedStatement _preparedStatement;
+
+	}
+
+	private static class NoBatchInvocationHandler implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws Throwable {
+
+			if (method.equals(_addBatchMethod)) {
+				_preparedStatement.executeUpdate();
+
+				return null;
+			}
+
+			if (method.equals(_executeBatch)) {
+				return new int[0];
+			}
+
+			return method.invoke(_preparedStatement, args);
+		}
+
+		private NoBatchInvocationHandler(PreparedStatement preparedStatement) {
+			_preparedStatement = preparedStatement;
+		}
+
+		private final PreparedStatement _preparedStatement;
+
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
@@ -476,14 +476,10 @@ public class Table {
 			return;
 		}
 
-		PreparedStatement ps = con.prepareStatement(getInsertSQL());
+		try (PreparedStatement ps = con.prepareStatement(getInsertSQL());
+			UnsyncBufferedReader unsyncBufferedReader =
+				new UnsyncBufferedReader(new FileReader(_tempFileName))) {
 
-		UnsyncBufferedReader unsyncBufferedReader = new UnsyncBufferedReader(
-			new FileReader(_tempFileName));
-
-		String line = null;
-
-		try {
 			DatabaseMetaData databaseMetaData = con.getMetaData();
 
 			if (!databaseMetaData.supportsBatchUpdates()) {
@@ -493,6 +489,8 @@ public class Table {
 			}
 
 			int count = 0;
+
+			String line = null;
 
 			while ((line = unsyncBufferedReader.readLine()) != null) {
 				String[] values = StringUtil.split(line);
@@ -533,11 +531,6 @@ public class Table {
 			if (count != 0) {
 				ps.executeBatch();
 			}
-		}
-		finally {
-			DataAccess.cleanUp(null, ps);
-
-			unsyncBufferedReader.close();
 		}
 
 		if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
-import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.upgrade.AutoBatchPreparedStatementUtil;
 
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -43,7 +43,6 @@ import java.nio.file.Paths;
 
 import java.sql.Clob;
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -476,19 +475,10 @@ public class Table {
 			return;
 		}
 
-		try (PreparedStatement ps = con.prepareStatement(getInsertSQL());
+		try (PreparedStatement ps = AutoBatchPreparedStatementUtil.autoBath(
+				con.prepareStatement(getInsertSQL()));
 			UnsyncBufferedReader unsyncBufferedReader =
 				new UnsyncBufferedReader(new FileReader(_tempFileName))) {
-
-			DatabaseMetaData databaseMetaData = con.getMetaData();
-
-			if (!databaseMetaData.supportsBatchUpdates()) {
-				if (_log.isDebugEnabled()) {
-					_log.debug("Database does not support batch updates");
-				}
-			}
-
-			int count = 0;
 
 			String line = null;
 
@@ -511,26 +501,10 @@ public class Table {
 					setColumn(ps, i, (Integer)columns[pos][1], values[pos]);
 				}
 
-				if (databaseMetaData.supportsBatchUpdates()) {
-					ps.addBatch();
-
-					if (count == _BATCH_SIZE) {
-						ps.executeBatch();
-
-						count = 0;
-					}
-					else {
-						count++;
-					}
-				}
-				else {
-					ps.executeUpdate();
-				}
+				ps.addBatch();
 			}
 
-			if (count != 0) {
-				ps.executeBatch();
-			}
+			ps.executeBatch();
 		}
 
 		if (_log.isDebugEnabled()) {
@@ -692,9 +666,6 @@ public class Table {
 			DataAccess.cleanUp(con, ps);
 		}
 	}
-
-	private static final int _BATCH_SIZE = GetterUtil.getInteger(
-		PropsUtil.get("hibernate.jdbc.batch_size"));
 
 	private static final String[][] _SAFE_TABLE_CHARS = {
 		{StringPool.COMMA, StringPool.NEW_LINE, StringPool.RETURN},

--- a/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
@@ -476,9 +476,7 @@ public class Table {
 			return;
 		}
 
-		PreparedStatement ps = null;
-
-		String insertSQL = getInsertSQL();
+		PreparedStatement ps = con.prepareStatement(getInsertSQL());
 
 		UnsyncBufferedReader unsyncBufferedReader = new UnsyncBufferedReader(
 			new FileReader(_tempFileName));
@@ -507,10 +505,6 @@ public class Table {
 							"Attempted to insert row " + line + ".");
 				}
 
-				if (count == 0) {
-					ps = con.prepareStatement(insertSQL);
-				}
-
 				int[] order = getOrder();
 
 				for (int i = 0; i < order.length; i++) {
@@ -525,8 +519,6 @@ public class Table {
 					if (count == _BATCH_SIZE) {
 						ps.executeBatch();
 
-						ps.close();
-
 						count = 0;
 					}
 					else {
@@ -535,15 +527,11 @@ public class Table {
 				}
 				else {
 					ps.executeUpdate();
-
-					ps.close();
 				}
 			}
 
 			if (count != 0) {
 				ps.executeBatch();
-
-				ps.close();
 			}
 		}
 		finally {

--- a/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
@@ -540,12 +540,10 @@ public class Table {
 				}
 			}
 
-			if (databaseMetaData.supportsBatchUpdates()) {
-				if (count != 0) {
-					ps.executeBatch();
+			if (count != 0) {
+				ps.executeBatch();
 
-					ps.close();
-				}
+				ps.close();
 			}
 		}
 		finally {

--- a/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/Table.java
@@ -523,7 +523,9 @@ public class Table {
 					ps.addBatch();
 
 					if (count == _BATCH_SIZE) {
-						populateTableRows(ps, true);
+						ps.executeBatch();
+
+						ps.close();
 
 						count = 0;
 					}
@@ -532,13 +534,17 @@ public class Table {
 					}
 				}
 				else {
-					populateTableRows(ps, false);
+					ps.executeUpdate();
+
+					ps.close();
 				}
 			}
 
 			if (databaseMetaData.supportsBatchUpdates()) {
 				if (count != 0) {
-					populateTableRows(ps, true);
+					ps.executeBatch();
+
+					ps.close();
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
@@ -340,23 +340,16 @@ public class UpgradeImageGallery extends UpgradeProcess {
 			"delete from ResourcePermission where name = ? and companyId = ? " +
 				"and scope = ? and primKey = ? and roleId = ?";
 
-		Connection con = null;
-		PreparedStatement ps = null;
-		ResultSet rs = null;
-
-		try {
-			con = DataAccess.getUpgradeOptimizedConnection();
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+			PreparedStatement ps = con.prepareStatement(selectSQL);
+			ResultSet rs = ps.executeQuery()) {
 
 			DatabaseMetaData databaseMetaData = con.getMetaData();
 
 			boolean supportsBatchUpdates =
 				databaseMetaData.supportsBatchUpdates();
 
-			ps = con.prepareStatement(selectSQL);
-
 			ps.setString(1, igResourceName);
-
-			rs = ps.executeQuery();
 
 			try (PreparedStatement ps2 = con.prepareStatement(deleteSQL)) {
 				int count = 0;
@@ -389,9 +382,6 @@ public class UpgradeImageGallery extends UpgradeProcess {
 					ps2.executeBatch();
 				}
 			}
-		}
-		finally {
-			DataAccess.cleanUp(con, ps, rs);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
@@ -333,6 +333,13 @@ public class UpgradeImageGallery extends UpgradeProcess {
 			String igResourceName, String dlResourceName)
 		throws Exception {
 
+		String selectSQL =
+			"select companyId, scope, primKey, roleId from " +
+				"ResourcePermission where name = ?";
+		String deleteSQL =
+			"delete from ResourcePermission where name = ? and companyId = ? " +
+				"and scope = ? and primKey = ? and roleId = ?";
+
 		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
@@ -345,18 +352,13 @@ public class UpgradeImageGallery extends UpgradeProcess {
 			boolean supportsBatchUpdates =
 				databaseMetaData.supportsBatchUpdates();
 
-			ps = con.prepareStatement(
-				"select companyId, scope, primKey, roleId from " +
-					"ResourcePermission where name = ?");
+			ps = con.prepareStatement(selectSQL);
 
 			ps.setString(1, igResourceName);
 
 			rs = ps.executeQuery();
 
-			PreparedStatement ps2 = con.prepareStatement(
-				"delete from ResourcePermission where name = ? and " +
-					"companyId = ? and scope = ? and primKey = ? and " +
-						"roleId = ?");
+			PreparedStatement ps2 = con.prepareStatement(deleteSQL);
 
 			int count = 0;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Image;
 import com.liferay.portal.service.ImageLocalServiceUtil;
+import com.liferay.portal.upgrade.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.documentlibrary.model.DLFileEntry;
@@ -48,7 +49,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -344,15 +344,11 @@ public class UpgradeImageGallery extends UpgradeProcess {
 			PreparedStatement ps = con.prepareStatement(selectSQL);
 			ResultSet rs = ps.executeQuery()) {
 
-			DatabaseMetaData databaseMetaData = con.getMetaData();
-
-			boolean supportsBatchUpdates =
-				databaseMetaData.supportsBatchUpdates();
-
 			ps.setString(1, igResourceName);
 
-			try (PreparedStatement ps2 = con.prepareStatement(deleteSQL)) {
-				int count = 0;
+			try (PreparedStatement ps2 =
+					AutoBatchPreparedStatementUtil.autoBath(
+						con.prepareStatement(deleteSQL))) {
 
 				while (rs.next()) {
 					ps2.setString(1, dlResourceName);
@@ -361,26 +357,10 @@ public class UpgradeImageGallery extends UpgradeProcess {
 					ps2.setString(4, rs.getString("primKey"));
 					ps2.setLong(5, rs.getLong("roleId"));
 
-					if (supportsBatchUpdates) {
-						ps2.addBatch();
-
-						if (count == PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
-							ps2.executeBatch();
-
-							count = 0;
-						}
-						else {
-							count++;
-						}
-					}
-					else {
-						ps2.executeUpdate();
-					}
+					ps2.addBatch();
 				}
 
-				if (supportsBatchUpdates && (count > 0)) {
-					ps2.executeBatch();
-				}
+				ps2.executeBatch();
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_0/UpgradeImageGallery.java
@@ -353,7 +353,7 @@ public class UpgradeImageGallery extends UpgradeProcess {
 
 			rs = ps.executeQuery();
 
-			ps = con.prepareStatement(
+			PreparedStatement ps2 = con.prepareStatement(
 				"delete from ResourcePermission where name = ? and " +
 					"companyId = ? and scope = ? and primKey = ? and " +
 						"roleId = ?");
@@ -361,17 +361,17 @@ public class UpgradeImageGallery extends UpgradeProcess {
 			int count = 0;
 
 			while (rs.next()) {
-				ps.setString(1, dlResourceName);
-				ps.setLong(2, rs.getLong("companyId"));
-				ps.setInt(3, rs.getInt("scope"));
-				ps.setString(4, rs.getString("primKey"));
-				ps.setLong(5, rs.getLong("roleId"));
+				ps2.setString(1, dlResourceName);
+				ps2.setLong(2, rs.getLong("companyId"));
+				ps2.setInt(3, rs.getInt("scope"));
+				ps2.setString(4, rs.getString("primKey"));
+				ps2.setLong(5, rs.getLong("roleId"));
 
 				if (supportsBatchUpdates) {
-					ps.addBatch();
+					ps2.addBatch();
 
 					if (count == PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
-						ps.executeBatch();
+						ps2.executeBatch();
 
 						count = 0;
 					}
@@ -380,12 +380,12 @@ public class UpgradeImageGallery extends UpgradeProcess {
 					}
 				}
 				else {
-					ps.executeUpdate();
+					ps2.executeUpdate();
 				}
 			}
 
 			if (supportsBatchUpdates && (count > 0)) {
-				ps.executeBatch();
+				ps2.executeBatch();
 			}
 		}
 		finally {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeRatings.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeRatings.java
@@ -146,21 +146,14 @@ public class UpgradeRatings extends UpgradeProcess {
 			"update RatingsStats set totalEntries = ?, totalScore = ?, " +
 				"averageScore = ? where classNameId = ? and classPK = ?";
 
-		Connection con = null;
-		PreparedStatement ps = null;
-		ResultSet rs = null;
-
-		try {
-			con = DataAccess.getUpgradeOptimizedConnection();
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+			PreparedStatement ps = con.prepareStatement(selectSQL);
+			ResultSet rs = ps.executeQuery()) {
 
 			DatabaseMetaData databaseMetaData = con.getMetaData();
 
 			boolean supportsBatchUpdates =
 				databaseMetaData.supportsBatchUpdates();
-
-			ps = con.prepareStatement(selectSQL);
-
-			rs = ps.executeQuery();
 
 			try (PreparedStatement ps2 = con.prepareStatement(updateSQL)) {
 				int count = 0;
@@ -193,9 +186,6 @@ public class UpgradeRatings extends UpgradeProcess {
 					ps2.executeBatch();
 				}
 			}
-		}
-		finally {
-			DataAccess.cleanUp(con, ps, rs);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeRatings.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeRatings.java
@@ -161,24 +161,24 @@ public class UpgradeRatings extends UpgradeProcess {
 
 			rs = ps.executeQuery();
 
-			ps = con.prepareStatement(
+			PreparedStatement ps2 = con.prepareStatement(
 				"update RatingsStats set totalEntries = ?, totalScore = ?, " +
 					"averageScore = ? where classNameId = ? and classPK = ?");
 
 			int count = 0;
 
 			while (rs.next()) {
-				ps.setInt(1, rs.getInt("totalEntries"));
-				ps.setDouble(2, rs.getDouble("totalScore"));
-				ps.setDouble(3, rs.getDouble("averageScore"));
-				ps.setLong(4, rs.getLong("classNameId"));
-				ps.setLong(5, rs.getLong("classPK"));
+				ps2.setInt(1, rs.getInt("totalEntries"));
+				ps2.setDouble(2, rs.getDouble("totalScore"));
+				ps2.setDouble(3, rs.getDouble("averageScore"));
+				ps2.setLong(4, rs.getLong("classNameId"));
+				ps2.setLong(5, rs.getLong("classPK"));
 
 				if (supportsBatchUpdates) {
-					ps.addBatch();
+					ps2.addBatch();
 
 					if (count == PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
-						ps.executeBatch();
+						ps2.executeBatch();
 
 						count = 0;
 					}
@@ -187,12 +187,12 @@ public class UpgradeRatings extends UpgradeProcess {
 					}
 				}
 				else {
-					ps.executeUpdate();
+					ps2.executeUpdate();
 				}
 			}
 
 			if (supportsBatchUpdates && (count > 0)) {
-				ps.executeBatch();
+				ps2.executeBatch();
 			}
 		}
 		finally {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeRatings.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeRatings.java
@@ -148,24 +148,21 @@ public class UpgradeRatings extends UpgradeProcess {
 
 		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
 			PreparedStatement ps = con.prepareStatement(selectSQL);
-			ResultSet rs = ps.executeQuery()) {
+			ResultSet rs = ps.executeQuery();
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBath(
+				con.prepareStatement(updateSQL))) {
 
-			try (PreparedStatement ps2 =
-					AutoBatchPreparedStatementUtil.autoBath(
-						con.prepareStatement(updateSQL))) {
+			while (rs.next()) {
+				ps2.setInt(1, rs.getInt("totalEntries"));
+				ps2.setDouble(2, rs.getDouble("totalScore"));
+				ps2.setDouble(3, rs.getDouble("averageScore"));
+				ps2.setLong(4, rs.getLong("classNameId"));
+				ps2.setLong(5, rs.getLong("classPK"));
 
-				while (rs.next()) {
-					ps2.setInt(1, rs.getInt("totalEntries"));
-					ps2.setDouble(2, rs.getDouble("totalScore"));
-					ps2.setDouble(3, rs.getDouble("averageScore"));
-					ps2.setLong(4, rs.getLong("classNameId"));
-					ps2.setLong(5, rs.getLong("classPK"));
-
-					ps2.addBatch();
-				}
-
-				ps2.executeBatch();
+				ps2.addBatch();
 			}
+
+			ps2.executeBatch();
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -38,11 +38,7 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			"update ResourcePermission set primKeyId = ?, viewActionId = ? " +
 				"where resourcePermissionId = ?";
 
-		Connection con = null;
-
-		try {
-			con = DataAccess.getUpgradeOptimizedConnection();
-
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection()) {
 			DatabaseMetaData databaseMetaData = con.getMetaData();
 
 			boolean supportsBatchUpdates =
@@ -103,9 +99,6 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 					ps2.executeBatch();
 				}
 			}
-		}
-		finally {
-			DataAccess.cleanUp(con);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -64,60 +64,49 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 					continue;
 				}
 
-				updateResourcePermission(
-					con, supportsBatchUpdates, resourcePermissionId,
-					newPrimKeyId, newViewActionId);
+				PreparedStatement ps2 = null;
+
+				try {
+					ps2 = con.prepareStatement(
+						"update ResourcePermission set primKeyId = ?," +
+							"viewActionId = ?  where resourcePermissionId = ?");
+
+					ps2.setLong(1, newPrimKeyId);
+
+					if (newViewActionId) {
+						ps2.setBoolean(2, true);
+					}
+					else {
+						ps2.setBoolean(2, false);
+					}
+
+					ps2.setLong(3, resourcePermissionId);
+
+					int count = 0;
+
+					if (supportsBatchUpdates) {
+						ps2.addBatch();
+
+						if (count == PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
+							ps2.executeBatch();
+
+							count = 0;
+						}
+						else {
+							count++;
+						}
+					}
+					else {
+						ps2.executeUpdate();
+					}
+				}
+				finally {
+					DataAccess.cleanUp(ps2);
+				}
 			}
 		}
 		finally {
 			DataAccess.cleanUp(con, ps, rs);
-		}
-	}
-
-	protected void updateResourcePermission(
-			Connection con, boolean supportsBatchUpdates,
-			long resourcePermissionId, long newPrimKeyId,
-			boolean newViewActionId)
-		throws Exception {
-
-		PreparedStatement ps2 = null;
-
-		try {
-			ps2 = con.prepareStatement(
-				"update ResourcePermission set primKeyId = ?," +
-					"viewActionId = ?  where resourcePermissionId = ?");
-
-			ps2.setLong(1, newPrimKeyId);
-
-			if (newViewActionId) {
-				ps2.setBoolean(2, true);
-			}
-			else {
-				ps2.setBoolean(2, false);
-			}
-
-			ps2.setLong(3, resourcePermissionId);
-
-			int count = 0;
-
-			if (supportsBatchUpdates) {
-				ps2.addBatch();
-
-				if (count == PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
-					ps2.executeBatch();
-
-					count = 0;
-				}
-				else {
-					count++;
-				}
-			}
-			else {
-				ps2.executeUpdate();
-			}
-		}
-		finally {
-			DataAccess.cleanUp(ps2);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -37,45 +37,42 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			"update ResourcePermission set primKeyId = ?, viewActionId = ? " +
 				"where resourcePermissionId = ?";
 
-		try (Connection con = DataAccess.getUpgradeOptimizedConnection()) {
-			try (PreparedStatement ps = con.prepareStatement(selectSQL);
-				ResultSet rs = ps.executeQuery();
-				PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBath(
-					con.prepareStatement(updateSQL))) {
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection();
+			PreparedStatement ps = con.prepareStatement(selectSQL);
+			ResultSet rs = ps.executeQuery();
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBath(
+				con.prepareStatement(updateSQL))) {
 
-				while (rs.next()) {
-					long resourcePermissionId = rs.getLong(
-						"resourcePermissionId");
-					long primKeyId = rs.getLong("primKeyId");
-					long actionIds = rs.getLong("actionIds");
-					boolean viewActionId = rs.getBoolean("viewActionId");
+			while (rs.next()) {
+				long resourcePermissionId = rs.getLong("resourcePermissionId");
+				long primKeyId = rs.getLong("primKeyId");
+				long actionIds = rs.getLong("actionIds");
+				boolean viewActionId = rs.getBoolean("viewActionId");
 
-					long newPrimKeyId = GetterUtil.getLong(
-						rs.getString("primKey"));
-					boolean newViewActionId = (actionIds % 2 == 1);
+				long newPrimKeyId = GetterUtil.getLong(rs.getString("primKey"));
+				boolean newViewActionId = (actionIds % 2 == 1);
 
-					if ((primKeyId == newPrimKeyId) &&
-						(newViewActionId == viewActionId)) {
+				if ((primKeyId == newPrimKeyId) &&
+					(newViewActionId == viewActionId)) {
 
-						continue;
-					}
-
-					ps2.setLong(1, newPrimKeyId);
-
-					if (newViewActionId) {
-						ps2.setBoolean(2, true);
-					}
-					else {
-						ps2.setBoolean(2, false);
-					}
-
-					ps2.setLong(3, resourcePermissionId);
-
-					ps2.addBatch();
+					continue;
 				}
 
-				ps2.executeBatch();
+				ps2.setLong(1, newPrimKeyId);
+
+				if (newViewActionId) {
+					ps2.setBoolean(2, true);
+				}
+				else {
+					ps2.setBoolean(2, false);
+				}
+
+				ps2.setLong(3, resourcePermissionId);
+
+				ps2.addBatch();
 			}
+
+			ps2.executeBatch();
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -56,6 +56,8 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 					"update ResourcePermission set primKeyId = ?," +
 						"viewActionId = ?  where resourcePermissionId = ?");
 
+				int count = 0;
+
 				while (rs.next()) {
 					long resourcePermissionId = rs.getLong(
 						"resourcePermissionId");
@@ -84,8 +86,6 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 
 					ps2.setLong(3, resourcePermissionId);
 
-					int count = 0;
-
 					if (supportsBatchUpdates) {
 						ps2.addBatch();
 
@@ -101,6 +101,10 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 					else {
 						ps2.executeUpdate();
 					}
+				}
+
+				if (supportsBatchUpdates && (count > 0)) {
+					ps2.executeBatch();
 				}
 			}
 			finally {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -31,6 +31,13 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		String selectSQL =
+			"select resourcePermissionId, primKey, primKeyId, actionIds, " +
+				"viewActionId from ResourcePermission";
+		String updateSQL =
+			"update ResourcePermission set primKeyId = ?, viewActionId = ? " +
+				"where resourcePermissionId = ?";
+
 		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
@@ -43,18 +50,14 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			boolean supportsBatchUpdates =
 				databaseMetaData.supportsBatchUpdates();
 
-			ps = con.prepareStatement(
-				"select resourcePermissionId, primKey, primKeyId, actionIds, " +
-					"viewActionId from ResourcePermission");
+			ps = con.prepareStatement(selectSQL);
 
 			rs = ps.executeQuery();
 
 			PreparedStatement ps2 = null;
 
 			try {
-				ps2 = con.prepareStatement(
-					"update ResourcePermission set primKeyId = ?," +
-						"viewActionId = ?  where resourcePermissionId = ?");
+				ps2 = con.prepareStatement(updateSQL);
 
 				int count = 0;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -39,8 +39,6 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 				"where resourcePermissionId = ?";
 
 		Connection con = null;
-		PreparedStatement ps = null;
-		ResultSet rs = null;
 
 		try {
 			con = DataAccess.getUpgradeOptimizedConnection();
@@ -50,11 +48,10 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			boolean supportsBatchUpdates =
 				databaseMetaData.supportsBatchUpdates();
 
-			ps = con.prepareStatement(selectSQL);
+			try (PreparedStatement ps = con.prepareStatement(selectSQL);
+				ResultSet rs = ps.executeQuery();
+				PreparedStatement ps2 = con.prepareStatement(updateSQL)) {
 
-			rs = ps.executeQuery();
-
-			try (PreparedStatement ps2 = con.prepareStatement(updateSQL)) {
 				int count = 0;
 
 				while (rs.next()) {
@@ -108,7 +105,7 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			}
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(con);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -80,31 +80,31 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			boolean newViewActionId)
 		throws Exception {
 
-		PreparedStatement ps = null;
+		PreparedStatement ps2 = null;
 
 		try {
-			ps = con.prepareStatement(
+			ps2 = con.prepareStatement(
 				"update ResourcePermission set primKeyId = ?," +
 					"viewActionId = ?  where resourcePermissionId = ?");
 
-			ps.setLong(1, newPrimKeyId);
+			ps2.setLong(1, newPrimKeyId);
 
 			if (newViewActionId) {
-				ps.setBoolean(2, true);
+				ps2.setBoolean(2, true);
 			}
 			else {
-				ps.setBoolean(2, false);
+				ps2.setBoolean(2, false);
 			}
 
-			ps.setLong(3, resourcePermissionId);
+			ps2.setLong(3, resourcePermissionId);
 
 			int count = 0;
 
 			if (supportsBatchUpdates) {
-				ps.addBatch();
+				ps2.addBatch();
 
 				if (count == PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
-					ps.executeBatch();
+					ps2.executeBatch();
 
 					count = 0;
 				}
@@ -113,11 +113,11 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 				}
 			}
 			else {
-				ps.executeUpdate();
+				ps2.executeUpdate();
 			}
 		}
 		finally {
-			DataAccess.cleanUp(ps);
+			DataAccess.cleanUp(ps2);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -54,11 +54,7 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 
 			rs = ps.executeQuery();
 
-			PreparedStatement ps2 = null;
-
-			try {
-				ps2 = con.prepareStatement(updateSQL);
-
+			try (PreparedStatement ps2 = con.prepareStatement(updateSQL)) {
 				int count = 0;
 
 				while (rs.next()) {
@@ -109,9 +105,6 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 				if (supportsBatchUpdates && (count > 0)) {
 					ps2.executeBatch();
 				}
-			}
-			finally {
-				DataAccess.cleanUp(ps2);
 			}
 		}
 		finally {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -115,10 +115,6 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			else {
 				ps.executeUpdate();
 			}
-
-			if (supportsBatchUpdates && (count > 0)) {
-				ps.executeBatch();
-			}
 		}
 		finally {
 			DataAccess.cleanUp(ps);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeResourcePermission.java
@@ -49,27 +49,29 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 
 			rs = ps.executeQuery();
 
-			while (rs.next()) {
-				long resourcePermissionId = rs.getLong("resourcePermissionId");
-				long primKeyId = rs.getLong("primKeyId");
-				long actionIds = rs.getLong("actionIds");
-				boolean viewActionId = rs.getBoolean("viewActionId");
+			PreparedStatement ps2 = null;
 
-				long newPrimKeyId = GetterUtil.getLong(rs.getString("primKey"));
-				boolean newViewActionId = (actionIds % 2 == 1);
+			try {
+				ps2 = con.prepareStatement(
+					"update ResourcePermission set primKeyId = ?," +
+						"viewActionId = ?  where resourcePermissionId = ?");
 
-				if ((primKeyId == newPrimKeyId) &&
-					(newViewActionId == viewActionId)) {
+				while (rs.next()) {
+					long resourcePermissionId = rs.getLong(
+						"resourcePermissionId");
+					long primKeyId = rs.getLong("primKeyId");
+					long actionIds = rs.getLong("actionIds");
+					boolean viewActionId = rs.getBoolean("viewActionId");
 
-					continue;
-				}
+					long newPrimKeyId = GetterUtil.getLong(
+						rs.getString("primKey"));
+					boolean newViewActionId = (actionIds % 2 == 1);
 
-				PreparedStatement ps2 = null;
+					if ((primKeyId == newPrimKeyId) &&
+						(newViewActionId == viewActionId)) {
 
-				try {
-					ps2 = con.prepareStatement(
-						"update ResourcePermission set primKeyId = ?," +
-							"viewActionId = ?  where resourcePermissionId = ?");
+						continue;
+					}
 
 					ps2.setLong(1, newPrimKeyId);
 
@@ -100,9 +102,9 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 						ps2.executeUpdate();
 					}
 				}
-				finally {
-					DataAccess.cleanUp(ps2);
-				}
+			}
+			finally {
+				DataAccess.cleanUp(ps2);
 			}
 		}
 		finally {

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/AutoBatchPreparedStatementUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/AutoBatchPreparedStatementUtilTest.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.SwappableSecurityManager;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.rule.NewEnv;
+import com.liferay.portal.kernel.test.rule.NewEnvTestRule;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.ReflectionUtil;
+import com.liferay.portal.util.PropsValues;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class AutoBatchPreparedStatementUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, NewEnvTestRule.INSTANCE);
+
+	@NewEnv(type = NewEnv.Type.CLASSLOADER)
+	@Test
+	public void testCINITFailure() throws ClassNotFoundException {
+		final NoSuchMethodException nsme = new NoSuchMethodException();
+		final AtomicInteger counter = new AtomicInteger();
+
+		try (SwappableSecurityManager swappableSecurityManager =
+				new SwappableSecurityManager() {
+
+					@Override
+					public void checkPackageAccess(String pkg) {
+						if (pkg.equals("java.sql") &&
+							(counter.getAndIncrement() == 1)) {
+
+							ReflectionUtil.throwException(nsme);
+						}
+					}
+
+				}) {
+
+			swappableSecurityManager.install();
+
+			Class.forName(AutoBatchPreparedStatementUtil.class.getName());
+		}
+		catch (ExceptionInInitializerError eiie) {
+			Assert.assertSame(nsme, eiie.getCause());
+		}
+	}
+
+	@Test
+	public void testConstructor() throws ReflectiveOperationException {
+		Constructor<AutoBatchPreparedStatementUtil> constructor =
+			AutoBatchPreparedStatementUtil.class.getDeclaredConstructor();
+
+		Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+
+		constructor.setAccessible(true);
+
+		constructor.newInstance();
+	}
+
+	@Test
+	public void testNotSupportBatchUpdates() throws Exception {
+		PreparedStatementInvocationHandler preparedStatementInvocationHandler =
+			new PreparedStatementInvocationHandler(false);
+
+		PreparedStatement preparedStatement =
+			AutoBatchPreparedStatementUtil.autoBath(
+				(PreparedStatement)ProxyUtil.newProxyInstance(
+					ClassLoader.getSystemClassLoader(),
+					new Class<?>[] {PreparedStatement.class},
+					preparedStatementInvocationHandler));
+
+		List<Method> methods = preparedStatementInvocationHandler.getMethods();
+
+		Assert.assertTrue(methods.toString(), methods.isEmpty());
+
+		// AddBatch fallbacks to executeUpdate
+
+		preparedStatement.addBatch();
+
+		Assert.assertEquals(methods.toString(), 1, methods.size());
+		Assert.assertEquals(
+			PreparedStatement.class.getMethod("executeUpdate"),
+			methods.remove(0));
+
+		// ExecuteBatch does nothing
+
+		Assert.assertArrayEquals(new int[0], preparedStatement.executeBatch());
+		Assert.assertTrue(methods.toString(), methods.isEmpty());
+
+		// Other methods like execute pass through
+
+		preparedStatement.execute();
+
+		Assert.assertEquals(methods.toString(), 1, methods.size());
+		Assert.assertEquals(
+			PreparedStatement.class.getMethod("execute"), methods.remove(0));
+	}
+
+	@Test
+	public void testSupportBatchUpdates() throws Exception {
+		PreparedStatementInvocationHandler preparedStatementInvocationHandler =
+			new PreparedStatementInvocationHandler(true);
+
+		PreparedStatement preparedStatement =
+			AutoBatchPreparedStatementUtil.autoBath(
+				(PreparedStatement)ProxyUtil.newProxyInstance(
+					ClassLoader.getSystemClassLoader(),
+					new Class<?>[] {PreparedStatement.class},
+					preparedStatementInvocationHandler));
+
+		InvocationHandler invocationHandler = ProxyUtil.getInvocationHandler(
+			preparedStatement);
+
+		Assert.assertEquals(
+			0, ReflectionTestUtil.getFieldValue(invocationHandler, "_count"));
+
+		List<Method> methods = preparedStatementInvocationHandler.getMethods();
+
+		Assert.assertTrue(methods.toString(), methods.isEmpty());
+
+		int hibernateJDBCBatchSize = PropsValues.HIBERNATE_JDBC_BATCH_SIZE;
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "HIBERNATE_JDBC_BATCH_SIZE", 2);
+
+		try {
+
+			// Protection for executing empty batch
+
+			Assert.assertArrayEquals(
+				new int[0], preparedStatement.executeBatch());
+			Assert.assertTrue(methods.toString(), methods.isEmpty());
+			Assert.assertEquals(
+				0,
+				ReflectionTestUtil.getFieldValue(invocationHandler, "_count"));
+
+			// AddBatch passes through, within hibernate jdbc batch size
+
+			preparedStatement.addBatch();
+
+			Assert.assertEquals(methods.toString(), 1, methods.size());
+			Assert.assertEquals(
+				PreparedStatement.class.getMethod("addBatch"),
+				methods.remove(0));
+			Assert.assertEquals(
+				1,
+				ReflectionTestUtil.getFieldValue(invocationHandler, "_count"));
+
+			// AddBatch passes through and triggers executeBatch,
+			// when exceeding hibernate jdbc batch size
+
+			preparedStatement.addBatch();
+
+			Assert.assertEquals(methods.toString(), 2, methods.size());
+			Assert.assertEquals(
+				PreparedStatement.class.getMethod("addBatch"),
+				methods.remove(0));
+			Assert.assertEquals(
+				PreparedStatement.class.getMethod("executeBatch"),
+				methods.remove(0));
+			Assert.assertEquals(
+				0,
+				ReflectionTestUtil.getFieldValue(invocationHandler, "_count"));
+
+			// AddBatch passes through, within hibernate jdbc batch size
+
+			preparedStatement.addBatch();
+
+			Assert.assertEquals(methods.toString(), 1, methods.size());
+			Assert.assertEquals(
+				PreparedStatement.class.getMethod("addBatch"),
+				methods.remove(0));
+			Assert.assertEquals(
+				1,
+				ReflectionTestUtil.getFieldValue(invocationHandler, "_count"));
+
+			// ExecuteBatch passes through when batch is not empty
+
+			preparedStatement.executeBatch();
+
+			Assert.assertEquals(methods.toString(), 1, methods.size());
+			Assert.assertEquals(
+				PreparedStatement.class.getMethod("executeBatch"),
+				methods.remove(0));
+			Assert.assertEquals(
+				0,
+				ReflectionTestUtil.getFieldValue(invocationHandler, "_count"));
+
+			// Other methods like execute pass through
+
+			preparedStatement.execute();
+
+			Assert.assertEquals(methods.toString(), 1, methods.size());
+			Assert.assertEquals(
+				PreparedStatement.class.getMethod("execute"),
+				methods.remove(0));
+			Assert.assertEquals(
+				0,
+				ReflectionTestUtil.getFieldValue(invocationHandler, "_count"));
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				PropsValues.class, "HIBERNATE_JDBC_BATCH_SIZE",
+				hibernateJDBCBatchSize);
+		}
+	}
+
+	private static class ConnectionInvocationHandler
+		implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws NoSuchMethodException {
+
+			if (method.equals(Connection.class.getMethod("getMetaData"))) {
+				return ProxyUtil.newProxyInstance(
+					ClassLoader.getSystemClassLoader(),
+					new Class<?>[] {DatabaseMetaData.class},
+					new DatabaseMetaDataInvocationHandler(
+						_supportBatchUpdates));
+			}
+
+			throw new UnsupportedOperationException();
+		}
+
+		private ConnectionInvocationHandler(boolean supportBatchUpdates) {
+			_supportBatchUpdates = supportBatchUpdates;
+		}
+
+		private final boolean _supportBatchUpdates;
+
+	}
+
+	private static class DatabaseMetaDataInvocationHandler
+		implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws NoSuchMethodException {
+
+			if (method.equals(
+					DatabaseMetaData.class.getMethod("supportsBatchUpdates"))) {
+
+				return _supportBatchUpdates;
+			}
+
+			throw new UnsupportedOperationException();
+		}
+
+		private DatabaseMetaDataInvocationHandler(boolean supportBatchUpdates) {
+			_supportBatchUpdates = supportBatchUpdates;
+		}
+
+		private final boolean _supportBatchUpdates;
+
+	}
+
+	private static class PreparedStatementInvocationHandler
+		implements InvocationHandler {
+
+		public List<Method> getMethods() {
+			return _methods;
+		}
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws NoSuchMethodException {
+
+			if (method.equals(
+					PreparedStatement.class.getMethod("getConnection"))) {
+
+				return ProxyUtil.newProxyInstance(
+					ClassLoader.getSystemClassLoader(),
+					new Class<?>[] {Connection.class},
+					new ConnectionInvocationHandler(_supportBatchUpdates));
+			}
+
+			_methods.add(method);
+
+			if (method.equals(PreparedStatement.class.getMethod("addBatch"))) {
+				return null;
+			}
+
+			if (method.equals(PreparedStatement.class.getMethod("execute"))) {
+				return false;
+			}
+
+			if (method.equals(
+					PreparedStatement.class.getMethod("executeBatch"))) {
+
+				return new int[0];
+			}
+
+			if (method.equals(
+					PreparedStatement.class.getMethod("executeUpdate"))) {
+
+				return 0;
+			}
+
+			throw new UnsupportedOperationException();
+		}
+
+		private PreparedStatementInvocationHandler(
+			boolean supportBatchUpdates) {
+
+			_supportBatchUpdates = supportBatchUpdates;
+		}
+
+		private final List<Method> _methods = new ArrayList<>();
+		private final boolean _supportBatchUpdates;
+
+	}
+
+}


### PR DESCRIPTION
@migue please see https://github.com/brianchandotcom/liferay-portal/commit/540c8a4dbdf1f2bb73922e016b78fdd0893a542d that is a bug you made in https://github.com/brianchandotcom/liferay-portal/commit/8493f09da620280cc5aa62952ae4669286c84450 which could cause unexecuted batch data got thrown away.

@danielkocsis please see https://github.com/brianchandotcom/liferay-portal/commit/5ebae0129651db2b185d940d304c98c26512659d, that is a bug you made in https://github.com/brianchandotcom/liferay-portal/commit/440d5c5e5a9ede001c62d4d44f24fb67646993e2 which leaves unclosed PreparedStatement.

@sergiogonzalez please see https://github.com/brianchandotcom/liferay-portal/commit/fa53d139c2c29539be9b5ee91f9f411c4c81ef2d, that is a bug you made in https://github.com/brianchandotcom/liferay-portal/commit/ee4c1639da840f7118c62906a332eec3a1027b13 which leaves unclosed PreparedStatement.

@hhuijser can you add a new SF rule to stop people from using DatabaseMetaData.supportsBatchUpdates(), except the case in AutoBatchPreparedStatementUtil.

Thanks

Shuyang
