### PR TITLE
LPS-55975 (Priority 4) Deleting two ConfigurationAdmin configurations fails, causing portlet to fail

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/portlet/action/DeleteConfigurationMVCActionCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/portlet/action/DeleteConfigurationMVCActionCommand.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.theme.ThemeDisplay;
 
 import java.io.IOException;
 
@@ -56,6 +58,9 @@ public class DeleteConfigurationMVCActionCommand implements MVCActionCommand {
 
 		String pid = ParamUtil.getString(actionRequest, "pid");
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		if (_log.isDebugEnabled()) {
 			_log.debug("Deleting configuration for service " + pid);
 		}
@@ -63,7 +68,7 @@ public class DeleteConfigurationMVCActionCommand implements MVCActionCommand {
 		try {
 			ConfigurationHelper configurationHelper = new ConfigurationHelper(
 				bundleContext, configurationAdmin, extendedMetaTypeService,
-				pid);
+				themeDisplay.getLanguageId());
 
 			Configuration configuration = configurationHelper.getConfiguration(
 				pid);


### PR DESCRIPTION
The migration to jsp from ftl fixed the portlet error when deleting two configurations back 2 back, this fix actually fixes just the deletion of a configuration, which without you cannot test the deletion of two configurations.
