### PR TITLE
LPS-60484 Initialize the listener first to be available when dependen…

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/StartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupAction.java
@@ -112,11 +112,11 @@ public class StartupAction extends SimpleAction {
 		ServiceDependencyManager portalResiliencyServiceDependencyManager =
 			new ServiceDependencyManager();
 
-		portalResiliencyServiceDependencyManager.registerDependencies(
-			MessageBus.class, PortalExecutorManager.class);
-
 		portalResiliencyServiceDependencyManager.addServiceDependencyListener(
 			new PortalResiliencyServiceDependencyLister());
+
+		portalResiliencyServiceDependencyManager.registerDependencies(
+			MessageBus.class, PortalExecutorManager.class);
 
 		// Shutdown hook
 
@@ -133,9 +133,6 @@ public class StartupAction extends SimpleAction {
 		ServiceDependencyManager indexerRegistryServiceDependencyManager =
 			new ServiceDependencyManager();
 
-		indexerRegistryServiceDependencyManager.registerDependencies(
-			IndexerRegistry.class);
-
 		indexerRegistryServiceDependencyManager.addServiceDependencyListener(
 			new ServiceDependencyListener() {
 
@@ -150,6 +147,9 @@ public class StartupAction extends SimpleAction {
 				}
 
 			});
+
+		indexerRegistryServiceDependencyManager.registerDependencies(
+			IndexerRegistry.class);
 
 		// MySQL version
 


### PR DESCRIPTION
…cies are registered

Thanks @topolik ! This is a good catch!

Basically this is a race condition on this ServiceDependencyManager usage, current ServiceDependencyManager infrastructure requires listeners to be registered before dependencies registration. Otherwise those listeners will be misfired.

I think it is better to refactor ServiceDependencyManager to be more robust, in case of registering a listener to an already fulfilled ServiceDependencyManager, the listener should be notified immediately, currently it does nothing.

I will make some further changes to ServiceDependencyManager later. Right now this is a good enough fix.

CC @mhan810
