### PR TITLE
LPS-60218 S3Store specific test names must be exactly the same as parent class

### DIFF
--- a/modules/portal-store/portal-store-s3-test/src/testIntegration/java/com/liferay/portal/store/s3/test/S3StoreTest.java
+++ b/modules/portal-store/portal-store-s3-test/src/testIntegration/java/com/liferay/portal/store/s3/test/S3StoreTest.java
@@ -58,7 +58,9 @@ public class S3StoreTest extends BaseStoreTestCase {
 
 	@Override
 	@Test
-	public void testUpdateFileWithNewFileName() throws Exception {
+	public void testUpdateFileWithNewFileNameNoSuchFileException()
+		throws Exception {
+
 		String fileName = RandomTestUtil.randomString();
 
 		store.updateFile(
@@ -69,7 +71,9 @@ public class S3StoreTest extends BaseStoreTestCase {
 
 	@Override
 	@Test
-	public void testUpdateFileWithNewRepositoryId() throws Exception {
+	public void testUpdateFileWithNewRepositoryIdNoSuchFileException()
+		throws Exception {
+
 		String fileName = RandomTestUtil.randomString();
 
 		store.updateFile(

--- a/modules/portal-store/portal-store-s3-test/src/testIntegration/java/com/liferay/portal/store/s3/test/S3StoreTest.java
+++ b/modules/portal-store/portal-store-s3-test/src/testIntegration/java/com/liferay/portal/store/s3/test/S3StoreTest.java
@@ -61,17 +61,23 @@ public class S3StoreTest extends BaseStoreTestCase {
 	public void testUpdateFileWithNewFileNameNoSuchFileException()
 		throws Exception {
 
-		String fileName = RandomTestUtil.randomString();
-
-		store.updateFile(
-			companyId, repositoryId, fileName, RandomTestUtil.randomString());
-
-		Assert.assertFalse(store.hasFile(companyId, repositoryId, fileName));
+		testUpdateFileOnS3StoreShouldNotUpdateTheFile();
 	}
 
 	@Override
 	@Test
 	public void testUpdateFileWithNewRepositoryIdNoSuchFileException()
+		throws Exception {
+
+		testUpdateFileOnS3StoreShouldNotUpdateTheFile();
+	}
+
+	@Override
+	protected String getStoreType() {
+		return "com.liferay.portal.store.s3.S3Store";
+	}
+
+	protected void testUpdateFileOnS3StoreShouldNotUpdateTheFile()
 		throws Exception {
 
 		String fileName = RandomTestUtil.randomString();
@@ -80,11 +86,6 @@ public class S3StoreTest extends BaseStoreTestCase {
 			companyId, repositoryId, fileName, RandomTestUtil.randomString());
 
 		Assert.assertFalse(store.hasFile(companyId, repositoryId, fileName));
-	}
-
-	@Override
-	protected String getStoreType() {
-		return "com.liferay.portal.store.s3.S3Store";
 	}
 
 }


### PR DESCRIPTION
Otherwise, base class tests will fail when executed on S3, as S3Store does not throws the NoSuchFileException. cc/ @preston-crary
