### PR TITLE
LPS-57329

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
@@ -68,10 +68,9 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 	Liferay.Widget({ url: '<%= widgetURL %>'});
 	</script></liferay-util:buffer>
 
-				<label class="control-label" for="<portlet:namespace />widgetScript"><liferay-ui:message key="code" /></label>
-				<textarea class="field form-control lfr-textarea" id="<portlet:namespace />widgetScript" onClick="this.select();" readonly="true">
-					<%= HtmlUtil.escape(textAreaContent) %>
-				</textarea>
+				<aui:field-wrapper label="code">
+					<textarea class="field form-control lfr-textarea" id="<portlet:namespace />widgetScript" onClick="this.select();" readonly="true"><%= HtmlUtil.escape(textAreaContent) %></textarea>
+				</aui:field-wrapper>
 
 				<aui:input label='<%= LanguageUtil.format(request, "allow-users-to-add-x-to-any-website", HtmlUtil.escape(portletDisplay.getTitle()), false) %>' name="widgetShowAddAppLink" type="checkbox" value="<%= widgetShowAddAppLink %>" />
 			</aui:fieldset>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
@@ -68,7 +68,10 @@ String widgetURL = PortalUtil.getWidgetURL(portlet, themeDisplay);
 	Liferay.Widget({ url: '<%= widgetURL %>'});
 	</script></liferay-util:buffer>
 
-				<aui:input cssClass="lfr-textarea" label="code" name="widgetScript" onClick="this.select();" type="textarea" value="<%= textAreaContent %>" />
+				<label class="control-label" for="<portlet:namespace />widgetScript"><liferay-ui:message key="code" /></label>
+				<textarea class="field form-control lfr-textarea" id="<portlet:namespace />widgetScript" onClick="this.select();" readonly="true">
+					<%= HtmlUtil.escape(textAreaContent) %>
+				</textarea>
 
 				<aui:input label='<%= LanguageUtil.format(request, "allow-users-to-add-x-to-any-website", HtmlUtil.escape(portletDisplay.getTitle()), false) %>' name="widgetShowAddAppLink" type="checkbox" value="<%= widgetShowAddAppLink %>" />
 			</aui:fieldset>


### PR DESCRIPTION
Root problem is we're sending the widget JS code with the form when we save. Removing the 'name' attribute from `<textarea>` will prevent the form from submitting the field. This is similar to what we did in 6.2.x:

https://github.com/liferay/liferay-portal-ee/blob/ee-6.2.x/portal-web/docroot/html/portlet/portlet_configuration/edit_sharing.jsp#L77

cc @neilking
