### PR TITLE
LPS-60774 Bubble up the permission checking from local service to it …

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -87,7 +87,7 @@ public class LayoutBranchLocalServiceImpl
 			layoutRevision.getLayoutSetBranchId(), layoutRevision.getPlid(),
 			name, description, master, serviceContext);
 
-		layoutRevisionService.addLayoutRevision(
+		layoutRevisionLocalService.addLayoutRevision(
 			layoutBranch.getUserId(), layoutRevision.getLayoutSetBranchId(),
 			layoutBranch.getLayoutBranchId(),
 			LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID, false,

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchServiceImpl.java
@@ -16,7 +16,10 @@ package com.liferay.portal.service.impl;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.model.LayoutBranch;
+import com.liferay.portal.model.LayoutRevision;
+import com.liferay.portal.model.LayoutSetBranch;
 import com.liferay.portal.security.permission.ActionKeys;
+import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.service.base.LayoutBranchServiceBaseImpl;
 import com.liferay.portal.service.permission.GroupPermissionUtil;
@@ -34,10 +37,23 @@ public class LayoutBranchServiceImpl extends LayoutBranchServiceBaseImpl {
 			boolean master, ServiceContext serviceContext)
 		throws PortalException {
 
+		PermissionChecker permissionChecker = getPermissionChecker();
+
 		long groupId = serviceContext.getScopeGroupId();
 
 		GroupPermissionUtil.check(
-			getPermissionChecker(), groupId, ActionKeys.ADD_LAYOUT_BRANCH);
+			permissionChecker, groupId, ActionKeys.ADD_LAYOUT_BRANCH);
+
+		LayoutRevision layoutRevision =
+			layoutRevisionPersistence.findByPrimaryKey(layoutRevisionId);
+
+		LayoutSetBranch layoutSetBranch =
+			layoutSetBranchPersistence.findByPrimaryKey(
+				layoutRevision.getLayoutSetBranchId());
+
+		GroupPermissionUtil.check(
+			permissionChecker, layoutSetBranch.getGroupId(),
+			ActionKeys.ADD_LAYOUT_BRANCH);
 
 		return layoutBranchLocalService.addLayoutBranch(
 			layoutRevisionId, name, description, false, serviceContext);


### PR DESCRIPTION
…remote service invoker. This is guaranteed to be correct, as long as the upper logic is invoking through remote service rather than local service as it is supposed to. But it might not be necessary, as it might be duplicated that "serviceContext.getScopeGroupId()" and "layoutSetBranch.getGroupId()" are actually the same, so that we will end up running the same checking twice, but I don't really know the business logic here. It was originally added by 15a19613f1043d97ff291087834b9c1c904e6464. julio please check, do we really need the "layoutSetBranch.getGroupId()" permission checking here?

@juliocamarero please read the commit message in this pull. I need your help to check on this change, I know it is logically correct, but I feel there is a chance it can be simplified, which I think only you can confirm that. Basically see the change to LayoutBranchServiceImpl.
What's the relationship between the "serviceContext.getScopeGroupId()" and "layoutSetBranch.getGroupId()"? Could they be same? If so we are basically running the same checking twice. If it is really the case, please drop off one, or if you can confirm they are actually different, then this is the correct logic, nothing needs to be changed.

Thanks for checking it @juliocamarero

Shuyang
