### PR TITLE
LPS-60774 DLAppService, DLAppLocalService and DLAppHelperLocalService…

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppHelperLocalServiceImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet.documentlibrary.service.impl;
 
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -69,6 +70,7 @@ import com.liferay.portlet.documentlibrary.model.DLFileVersion;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
 import com.liferay.portlet.documentlibrary.model.DLSyncConstants;
+import com.liferay.portlet.documentlibrary.service.DLAppService;
 import com.liferay.portlet.documentlibrary.service.base.DLAppHelperLocalServiceBaseImpl;
 import com.liferay.portlet.documentlibrary.service.permission.DLPermission;
 import com.liferay.portlet.documentlibrary.social.DLActivityKeys;
@@ -1974,5 +1976,8 @@ public class DLAppHelperLocalServiceImpl
 				repositoryEventType, modelClass, target);
 		}
 	}
+
+	@BeanReference(type = DLAppService.class)
+	protected DLAppService dlAppService;
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLAppLocalServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.documentlibrary.service.impl;
 
 import com.liferay.portal.NoSuchGroupException;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -51,6 +52,7 @@ import com.liferay.portlet.documentlibrary.model.DLFileEntryTypeConstants;
 import com.liferay.portlet.documentlibrary.model.DLFileRank;
 import com.liferay.portlet.documentlibrary.model.DLFolder;
 import com.liferay.portlet.documentlibrary.model.DLFolderConstants;
+import com.liferay.portlet.documentlibrary.service.DLAppService;
 import com.liferay.portlet.documentlibrary.service.base.DLAppLocalServiceBaseImpl;
 import com.liferay.portlet.documentlibrary.util.DLAppUtil;
 
@@ -1544,6 +1546,9 @@ public class DLAppLocalServiceImpl extends DLAppLocalServiceBaseImpl {
 
 		return destinationFolder;
 	}
+
+	@BeanReference(type = DLAppService.class)
+	protected DLAppService dlAppService;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLAppLocalServiceImpl.class);


### PR DESCRIPTION
… create a 3 parties circular dependencies, every one of them is using the other 2. It won't be easy to break this circle without a massive refactor. So for now I will manually introduce the @BeanReference to link up the circle, in order to proceed the ServiceBuilder change to stop generating the circular dependencies supporting code, leaving this particular DL case to DL experts.

@sergiogonzalez and @adolfopa, not sure who I should check with for this, if you think it should go to others, please help me passing along the message, thanks!

We are trying to stop ServiceBuilder from generating circular dependencies code, but before we can start on that, all exist circular dependencies have to be wiped out first.

One road block we have here is the DLAppService, DLAppLocalService and DLAppHelperLocalService 3 parties circular dependencies, please see commit message for more info.

I manually add in the @BeanReference usage to ServiceImpl classes, so later when we refactor SB code, no real logic change will be made to DLApp*Service, but their circular dependencies still need to be fixed. We are planning to enforce SF to guard it later.

Can you do some cleanup refactor to make sure they don't use remote service within local service?

Thanks

Shuyang
