### PR TITLE
LPS-59517 Missed class name here, causing the following failure on st…

### DIFF
--- a/modules/core/portal-app-license-resolver-hook/src/main/resources/hookconfigurators.properties
+++ b/modules/core/portal-app-license-resolver-hook/src/main/resources/hookconfigurators.properties
@@ -1,1 +1,1 @@
-hook.configurators=com.liferay.portal.app.resolver.AppResolverHookConfigurator
+hook.configurators=com.liferay.portal.app.license.resolver.AppResolverHookConfigurator


### PR DESCRIPTION
…artup:

!SESSION 2015-11-30 18:06:22.605 -----------------------------------------------
eclipse.buildId=unknown
java.version=1.7.0_80
java.vendor=Oracle Corporation
BootLoader constants: OS=linux, ARCH=x86, WS=gtk, NL=en_US

!ENTRY org.eclipse.osgi 4 0 2015-11-30 18:06:29.741
!MESSAGE error loading hook: com.liferay.portal.app.resolver.AppResolverHookConfigurator
!STACK 0
java.lang.ClassNotFoundException: com.liferay.portal.app.resolver.AppResolverHookConfigurator
    at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
    at com.liferay.portal.module.framework.ModuleFrameworkClassLoader.loadClass(ModuleFrameworkClassLoader.java:97)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
    at java.lang.Class.forName0(Native Method)
    at java.lang.Class.forName(Class.java:195)
    at org.eclipse.osgi.internal.hookregistry.HookRegistry.loadConfigurators(HookRegistry.java:185)
    at org.eclipse.osgi.internal.hookregistry.HookRegistry.initialize(HookRegistry.java:106)
    at org.eclipse.osgi.internal.framework.EquinoxContainer.<init>(EquinoxContainer.java:65)
    at org.eclipse.osgi.launch.Equinox.<init>(Equinox.java:31)
    at org.eclipse.osgi.launch.EquinoxFactory.newFramework(EquinoxFactory.java:24)
    at com.liferay.portal.bootstrap.ModuleFrameworkImpl.initFramework(ModuleFrameworkImpl.java:243)
    at com.liferay.portal.module.framework.ModuleFrameworkUtilAdapter.initFramework(ModuleFrameworkUtilAdapter.java:57)
    at com.liferay.portal.spring.context.PortalContextLoaderListener.contextInitialized(PortalContextLoaderListener.java:251)
    at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:5016)
    at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5528)
    at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:150)
    at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:901)
    at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:877)
    at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:652)
    at org.apache.catalina.startup.HostConfig.deployDescriptor(HostConfig.java:677)
    at org.apache.catalina.startup.HostConfig$DeployDescriptor.run(HostConfig.java:1912)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)

CC @rotty3000 @amosfong
