### PR TITLE
LPS-60761 Force the use of the latest snapshot

### DIFF
--- a/modules/build-module.gradle
+++ b/modules/build-module.gradle
@@ -106,7 +106,10 @@ configurations {
 			eachDependency {
 				DependencyResolveDetails dependencyResolveDetails ->
 
-				if ((dependencyResolveDetails.requested.version == "default") && project.hasProperty(dependencyResolveDetails.requested.name + ".version")) {
+				if (dependencyResolveDetails.requested.group == "com.liferay.portal") {
+					dependencyResolveDetails.useVersion liferay.portalVersion
+				}
+				else if ((dependencyResolveDetails.requested.version == "default") && project.hasProperty(dependencyResolveDetails.requested.name + ".version")) {
 					dependencyResolveDetails.useVersion project.properties[dependencyResolveDetails.requested.name + ".version"]
 				}
 			}


### PR DESCRIPTION
This should solve the problem in https://github.com/brianchandotcom/liferay-portal/pull/32714#issuecomment-160552612, by replacing the dependency from `com.liferay.portal:portal-service:7.0.0-m7` in `arquillian-portal-liferay-extension` with the latest snapshot.
