### PR TITLE
Lps 60906

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/HypersonicLoader.java
+++ b/portal-impl/src/com/liferay/portal/tools/HypersonicLoader.java
@@ -89,7 +89,7 @@ public class HypersonicLoader {
 
 		try (Connection con = DriverManager.getConnection(
 				"jdbc:hsqldb:" + sqlDir + "/" + databaseName +
-					";shutdown=true",
+					";shutdown=true;hsqldb.write_delay=false",
 				"sa", "")) {
 
 			if (Validator.isNull(fileNames)) {

--- a/portal-impl/src/com/liferay/portal/tools/HypersonicLoader.java
+++ b/portal-impl/src/com/liferay/portal/tools/HypersonicLoader.java
@@ -89,7 +89,7 @@ public class HypersonicLoader {
 
 		try (Connection con = DriverManager.getConnection(
 				"jdbc:hsqldb:" + sqlDir + "/" + databaseName +
-					";shutdown=true;hsqldb.write_delay=false",
+					";hsqldb.write_delay=false;shutdown=true",
 				"sa", "")) {
 
 			if (Validator.isNull(fileNames)) {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1031,7 +1031,7 @@
     # Hypersonic
     #
     jdbc.default.driverClassName=org.hsqldb.jdbc.JDBCDriver
-    jdbc.default.url=jdbc:hsqldb:${liferay.home}/data/hypersonic/lportal
+    jdbc.default.url=jdbc:hsqldb:${liferay.home}/data/hypersonic/lportal;hsqldb.write_delay=false
     jdbc.default.username=sa
     jdbc.default.password=
 


### PR DESCRIPTION
@brianchandotcom This is for the recent random hypersonic failures we saw for tests that use HypersonicServerTestRule.

Basically now we do a db copy on HypersonicServerTestRule at the file system level. And by default HSQL has 0.5 sec delay on file system syncing for performance reasons I guess. The failure happens when HypersonicServerTestRule does the copy while there is still unsynced changes in memory. Then the new copied db is not complete.

HSQL is never supposed to be used for production purpose, the performance is not something we should worry for it. Let's simply disable the write delay, to get the test stable and consistent.
