### PR TITLE
Lps 60880

### DIFF
--- a/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/portlet/action/EditServerMVCActionCommand.java
@@ -349,7 +349,7 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 		XugglerUtil.installNativeLibraries(jarName);
 	}
 
-	protected void reindex(ActionRequest actionRequest) throws Exception {
+	protected void reindex(final ActionRequest actionRequest) throws Exception {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
@@ -376,11 +376,6 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 
 			return;
 		}
-
-		final PortletSession portletSession = actionRequest.getPortletSession();
-
-		final long lastAccessedTime = portletSession.getLastAccessedTime();
-		final int maxInactiveInterval = portletSession.getMaxInactiveInterval();
 
 		final String uuid = PortalUUIDUtil.generate();
 
@@ -417,11 +412,20 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 					(status == BackgroundTaskConstants.STATUS_FAILED) ||
 					(status == BackgroundTaskConstants.STATUS_SUCCESSFUL)) {
 
-					int reindexSessionDuration =
-						(int)(System.currentTimeMillis() - lastAccessedTime);
+					PortletSession portletSession =
+						actionRequest.getPortletSession();
+
+					long lastAccessedTime =
+						portletSession.getLastAccessedTime();
+					int maxInactiveInterval =
+						portletSession.getMaxInactiveInterval();
+
+					int extendedMaxInactiveIntervalTime =
+						(int)(System.currentTimeMillis() - lastAccessedTime +
+							maxInactiveInterval);
 
 					portletSession.setMaxInactiveInterval(
-						reindexSessionDuration + maxInactiveInterval);
+						extendedMaxInactiveIntervalTime);
 
 					countDownLatch.countDown();
 				}

--- a/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server-admin/server-admin-web/src/main/java/com/liferay/server/admin/web/portlet/action/EditServerMVCActionCommand.java
@@ -377,6 +377,11 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 			return;
 		}
 
+		final PortletSession portletSession = actionRequest.getPortletSession();
+
+		final long lastAccessedTime = portletSession.getLastAccessedTime();
+		final int maxInactiveInterval = portletSession.getMaxInactiveInterval();
+
 		final String uuid = PortalUUIDUtil.generate();
 
 		taskContextMap.put("uuid", uuid);
@@ -411,6 +416,12 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 						BackgroundTaskConstants.STATUS_CANCELLED) ||
 					(status == BackgroundTaskConstants.STATUS_FAILED) ||
 					(status == BackgroundTaskConstants.STATUS_SUCCESSFUL)) {
+
+					int reindexSessionDuration =
+						(int)(System.currentTimeMillis() - lastAccessedTime);
+
+					portletSession.setMaxInactiveInterval(
+						reindexSessionDuration + maxInactiveInterval);
 
 					countDownLatch.countDown();
 				}


### PR DESCRIPTION
This is needed to make sure in case of super long background reindexing, by the time the reindex it done, we won't see a session timeout. Without the fix, when that happens, the following redirect will lead you to guess page, rather than showing the reindexing is done. We need the success status page to show up for benchmark tools.
