### PR TITLE
LPS-60852 Include osgi-util in default deployment

### DIFF
--- a/modules/apps/application-list/application-list-api/build.gradle
+++ b/modules/apps/application-list/application-list-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/adapter/PortletPanelAppAdapterRegistry.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/adapter/PortletPanelAppAdapterRegistry.java
@@ -15,6 +15,7 @@
 package com.liferay.application.list.adapter;
 
 import com.liferay.application.list.PanelApp;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
@@ -39,12 +40,10 @@ public class PortletPanelAppAdapterRegistry {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			bundleContext, Portlet.class,
 			new PortletPanelAppAdapterServiceTrackerCustomizer(
 				bundleContext, _serviceRegistrations));
-
-		_serviceTracker.open();
 	}
 
 	@Deactivate

--- a/modules/apps/bookmarks/bookmarks-api/build.gradle
+++ b/modules/apps/bookmarks/bookmarks-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compile project(":apps:configuration-admin:configuration-admin-api")

--- a/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/service/persistence/BookmarksEntryUtil.java
+++ b/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/service/persistence/BookmarksEntryUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.bookmarks.model.BookmarksEntry;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -4038,14 +4037,6 @@ public class BookmarksEntryUtil {
 	public void setPersistence(BookmarksEntryPersistence persistence) {
 	}
 
-	private static ServiceTracker<BookmarksEntryPersistence, BookmarksEntryPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(BookmarksEntryUtil.class);
-
-		_serviceTracker = new ServiceTracker<BookmarksEntryPersistence, BookmarksEntryPersistence>(bundle.getBundleContext(),
-				BookmarksEntryPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<BookmarksEntryPersistence, BookmarksEntryPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(BookmarksEntryPersistence.class);
 }

--- a/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/service/persistence/BookmarksFolderUtil.java
+++ b/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/service/persistence/BookmarksFolderUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.bookmarks.model.BookmarksFolder;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -2444,14 +2443,6 @@ public class BookmarksFolderUtil {
 	public void setPersistence(BookmarksFolderPersistence persistence) {
 	}
 
-	private static ServiceTracker<BookmarksFolderPersistence, BookmarksFolderPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(BookmarksFolderUtil.class);
-
-		_serviceTracker = new ServiceTracker<BookmarksFolderPersistence, BookmarksFolderPersistence>(bundle.getBundleContext(),
-				BookmarksFolderPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<BookmarksFolderPersistence, BookmarksFolderPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(BookmarksFolderPersistence.class);
 }

--- a/modules/apps/calendar/calendar-api/build.gradle
+++ b/modules/apps/calendar/calendar-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarBookingUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarBookingUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.calendar.model.CalendarBooking;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1936,14 +1935,6 @@ public class CalendarBookingUtil {
 	public void setPersistence(CalendarBookingPersistence persistence) {
 	}
 
-	private static ServiceTracker<CalendarBookingPersistence, CalendarBookingPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(CalendarBookingUtil.class);
-
-		_serviceTracker = new ServiceTracker<CalendarBookingPersistence, CalendarBookingPersistence>(bundle.getBundleContext(),
-				CalendarBookingPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<CalendarBookingPersistence, CalendarBookingPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(CalendarBookingPersistence.class);
 }

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarNotificationTemplateUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarNotificationTemplateUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.calendar.model.CalendarNotificationTemplate;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -947,14 +946,6 @@ public class CalendarNotificationTemplateUtil {
 		CalendarNotificationTemplatePersistence persistence) {
 	}
 
-	private static ServiceTracker<CalendarNotificationTemplatePersistence, CalendarNotificationTemplatePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(CalendarNotificationTemplateUtil.class);
-
-		_serviceTracker = new ServiceTracker<CalendarNotificationTemplatePersistence, CalendarNotificationTemplatePersistence>(bundle.getBundleContext(),
-				CalendarNotificationTemplatePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<CalendarNotificationTemplatePersistence, CalendarNotificationTemplatePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(CalendarNotificationTemplatePersistence.class);
 }

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarResourceUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarResourceUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.calendar.model.CalendarResource;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -2157,14 +2156,6 @@ public class CalendarResourceUtil {
 	public void setPersistence(CalendarResourcePersistence persistence) {
 	}
 
-	private static ServiceTracker<CalendarResourcePersistence, CalendarResourcePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(CalendarResourceUtil.class);
-
-		_serviceTracker = new ServiceTracker<CalendarResourcePersistence, CalendarResourcePersistence>(bundle.getBundleContext(),
-				CalendarResourcePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<CalendarResourcePersistence, CalendarResourcePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(CalendarResourcePersistence.class);
 }

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/persistence/CalendarUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.calendar.model.Calendar;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1385,14 +1384,6 @@ public class CalendarUtil {
 	public void setPersistence(CalendarPersistence persistence) {
 	}
 
-	private static ServiceTracker<CalendarPersistence, CalendarPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(CalendarUtil.class);
-
-		_serviceTracker = new ServiceTracker<CalendarPersistence, CalendarPersistence>(bundle.getBundleContext(),
-				CalendarPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<CalendarPersistence, CalendarPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(CalendarPersistence.class);
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/build.gradle
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compile project(":core:osgi-service-tracker-collections")
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/exporter/DDLExporterFactoryUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/exporter/DDLExporterFactoryUtil.java
@@ -14,9 +14,10 @@
 
 package com.liferay.dynamic.data.lists.exporter;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import java.util.Set;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -38,15 +39,8 @@ public class DDLExporterFactoryUtil {
 	}
 
 	private static final ServiceTracker<DDLExporterFactory, DDLExporterFactory>
-		_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDLExporterFactoryUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDLExporterFactory.class, null);
-
-		_serviceTracker.open();
-	}
+		_serviceTracker = ServiceTrackerFactory.open(
+			FrameworkUtil.getBundle(DDLExporterFactoryUtil.class),
+			DDLExporterFactory.class);
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/persistence/DDLRecordSetUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/persistence/DDLRecordSetUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1097,14 +1096,6 @@ public class DDLRecordSetUtil {
 	public void setPersistence(DDLRecordSetPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDLRecordSetPersistence, DDLRecordSetPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDLRecordSetUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDLRecordSetPersistence, DDLRecordSetPersistence>(bundle.getBundleContext(),
-				DDLRecordSetPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDLRecordSetPersistence, DDLRecordSetPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDLRecordSetPersistence.class);
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/persistence/DDLRecordUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/persistence/DDLRecordUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.lists.model.DDLRecord;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1156,14 +1155,6 @@ public class DDLRecordUtil {
 	public void setPersistence(DDLRecordPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDLRecordPersistence, DDLRecordPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDLRecordUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDLRecordPersistence, DDLRecordPersistence>(bundle.getBundleContext(),
-				DDLRecordPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDLRecordPersistence, DDLRecordPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDLRecordPersistence.class);
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/persistence/DDLRecordVersionUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/persistence/DDLRecordVersionUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.lists.model.DDLRecordVersion;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -668,14 +667,6 @@ public class DDLRecordVersionUtil {
 	public void setPersistence(DDLRecordVersionPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDLRecordVersionPersistence, DDLRecordVersionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDLRecordVersionUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDLRecordVersionPersistence, DDLRecordVersionPersistence>(bundle.getBundleContext(),
-				DDLRecordVersionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDLRecordVersionPersistence, DDLRecordVersionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDLRecordVersionPersistence.class);
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/util/DDLUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/util/DDLUtil.java
@@ -18,6 +18,7 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.Hits;
@@ -30,7 +31,6 @@ import javax.portlet.PortletPreferences;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -124,15 +124,8 @@ public class DDLUtil {
 			recordId, recordSetId, mergeFields, serviceContext);
 	}
 
-	private static final ServiceTracker<DDL, DDL> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDLUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDL.class, null);
-
-		_serviceTracker.open();
-	}
+	private static final ServiceTracker<DDL, DDL> _serviceTracker =
+		ServiceTrackerFactory.open(
+			FrameworkUtil.getBundle(DDLUtil.class), DDL.class);
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/build.gradle
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "util-taglib", version: liferay.portalVersion
 	compile group: "javax.mail", name: "mail", version: "1.4"
 	compile group: "javax.servlet.jsp", name: "jsp-api", version: "2.1"

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
@@ -40,6 +40,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -66,7 +67,6 @@ import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -395,17 +395,10 @@ public class DDLFormAdminDisplayContext {
 	}
 
 	private static final ServiceTracker
-		<DDMFormRenderer, DDMFormRenderer> _ddmFormRendererServiceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDLFormAdminDisplayContext.class);
-
-		_ddmFormRendererServiceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormRenderer.class, null);
-
-		_ddmFormRendererServiceTracker.open();
-	}
+		<DDMFormRenderer, DDMFormRenderer> _ddmFormRendererServiceTracker =
+			ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(DDLFormAdminDisplayContext.class),
+				DDMFormRenderer.class);
 
 	private final DDLFormAdminRequestHelper _ddlFormAdminRequestHelper;
 	private DDMStructure _ddmStucture;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMContentUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMContentUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMContent;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -980,14 +979,6 @@ public class DDMContentUtil {
 	public void setPersistence(DDMContentPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMContentPersistence, DDMContentPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMContentUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMContentPersistence, DDMContentPersistence>(bundle.getBundleContext(),
-				DDMContentPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMContentPersistence, DDMContentPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMContentPersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMDataProviderInstanceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMDataProviderInstanceUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMDataProviderInstance;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1231,14 +1230,6 @@ public class DDMDataProviderInstanceUtil {
 	public void setPersistence(DDMDataProviderInstancePersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMDataProviderInstancePersistence, DDMDataProviderInstancePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMDataProviderInstanceUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMDataProviderInstancePersistence, DDMDataProviderInstancePersistence>(bundle.getBundleContext(),
-				DDMDataProviderInstancePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMDataProviderInstancePersistence, DDMDataProviderInstancePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMDataProviderInstancePersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStorageLinkUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStorageLinkUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMStorageLink;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -824,14 +823,6 @@ public class DDMStorageLinkUtil {
 	public void setPersistence(DDMStorageLinkPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMStorageLinkPersistence, DDMStorageLinkPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMStorageLinkUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMStorageLinkPersistence, DDMStorageLinkPersistence>(bundle.getBundleContext(),
-				DDMStorageLinkPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMStorageLinkPersistence, DDMStorageLinkPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMStorageLinkPersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureLayoutUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureLayoutUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructureLayout;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -734,14 +733,6 @@ public class DDMStructureLayoutUtil {
 	public void setPersistence(DDMStructureLayoutPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMStructureLayoutPersistence, DDMStructureLayoutPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMStructureLayoutUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMStructureLayoutPersistence, DDMStructureLayoutPersistence>(bundle.getBundleContext(),
-				DDMStructureLayoutPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMStructureLayoutPersistence, DDMStructureLayoutPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMStructureLayoutPersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureLinkUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureLinkUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructureLink;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -844,14 +843,6 @@ public class DDMStructureLinkUtil {
 	public void setPersistence(DDMStructureLinkPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMStructureLinkPersistence, DDMStructureLinkPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMStructureLinkUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMStructureLinkPersistence, DDMStructureLinkPersistence>(bundle.getBundleContext(),
-				DDMStructureLinkPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMStructureLinkPersistence, DDMStructureLinkPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMStructureLinkPersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -2746,14 +2745,6 @@ public class DDMStructureUtil {
 	public void setPersistence(DDMStructurePersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMStructurePersistence, DDMStructurePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMStructureUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMStructurePersistence, DDMStructurePersistence>(bundle.getBundleContext(),
-				DDMStructurePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMStructurePersistence, DDMStructurePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMStructurePersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureVersionUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMStructureVersionUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -683,14 +682,6 @@ public class DDMStructureVersionUtil {
 	public void setPersistence(DDMStructureVersionPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMStructureVersionPersistence, DDMStructureVersionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMStructureVersionUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMStructureVersionPersistence, DDMStructureVersionPersistence>(bundle.getBundleContext(),
-				DDMStructureVersionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMStructureVersionPersistence, DDMStructureVersionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMStructureVersionPersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMTemplateLinkUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMTemplateLinkUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMTemplateLink;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -656,14 +655,6 @@ public class DDMTemplateLinkUtil {
 	public void setPersistence(DDMTemplateLinkPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMTemplateLinkPersistence, DDMTemplateLinkPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMTemplateLinkUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMTemplateLinkPersistence, DDMTemplateLinkPersistence>(bundle.getBundleContext(),
-				DDMTemplateLinkPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMTemplateLinkPersistence, DDMTemplateLinkPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMTemplateLinkPersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMTemplateUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMTemplateUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -3608,14 +3607,6 @@ public class DDMTemplateUtil {
 	public void setPersistence(DDMTemplatePersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMTemplatePersistence, DDMTemplatePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMTemplateUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMTemplatePersistence, DDMTemplatePersistence>(bundle.getBundleContext(),
-				DDMTemplatePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMTemplatePersistence, DDMTemplatePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMTemplatePersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMTemplateVersionUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMTemplateVersionUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.dynamic.data.mapping.model.DDMTemplateVersion;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -674,14 +673,6 @@ public class DDMTemplateVersionUtil {
 	public void setPersistence(DDMTemplateVersionPersistence persistence) {
 	}
 
-	private static ServiceTracker<DDMTemplateVersionPersistence, DDMTemplateVersionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMTemplateVersionUtil.class);
-
-		_serviceTracker = new ServiceTracker<DDMTemplateVersionPersistence, DDMTemplateVersionPersistence>(bundle.getBundleContext(),
-				DDMTemplateVersionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<DDMTemplateVersionPersistence, DDMTemplateVersionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(DDMTemplateVersionPersistence.class);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMBeanTranslatorUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMBeanTranslatorUtil.java
@@ -17,8 +17,8 @@ package com.liferay.dynamic.data.mapping.util;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -68,15 +68,8 @@ public class DDMBeanTranslatorUtil {
 	}
 
 	private static final ServiceTracker<DDMBeanTranslator, DDMBeanTranslator>
-		_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMBeanTranslatorUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMBeanTranslator.class, null);
-
-		_serviceTracker.open();
-	}
+		_serviceTracker = ServiceTrackerFactory.open(
+			FrameworkUtil.getBundle(DDMBeanTranslatorUtil.class),
+			DDMBeanTranslator.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMDisplayRegistryUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMDisplayRegistryUtil.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.util;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.List;
@@ -62,11 +63,9 @@ public class DDMDisplayRegistryUtil {
 
 		_bundleContext = bundle.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			_bundleContext, DDMDisplay.class,
 			new DDMDisplayServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	private DDMDisplay _getDDMDisplay(String portletId) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMUtil.java
@@ -22,6 +22,7 @@ import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -32,7 +33,6 @@ import java.io.Serializable;
 
 import javax.portlet.PortletRequest;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -154,15 +154,8 @@ public class DDMUtil {
 		return _serviceTracker.getService();
 	}
 
-	private static final ServiceTracker<DDM, DDM> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(DDMUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDM.class, null);
-
-		_serviceTracker.open();
-	}
+	private static final ServiceTracker<DDM, DDM> _serviceTracker =
+		ServiceTrackerFactory.open(
+			FrameworkUtil.getBundle(DDMUtil.class), DDM.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/FieldsToDDMFormValuesConverterUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/FieldsToDDMFormValuesConverterUtil.java
@@ -17,9 +17,9 @@ package com.liferay.dynamic.data.mapping.util;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -43,17 +43,10 @@ public class FieldsToDDMFormValuesConverterUtil {
 	}
 
 	private static final ServiceTracker<FieldsToDDMFormValuesConverter,
-		FieldsToDDMFormValuesConverter> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			FieldsToDDMFormValuesConverterUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), FieldsToDDMFormValuesConverter.class,
-			null);
-
-		_serviceTracker.open();
-	}
+		FieldsToDDMFormValuesConverter> _serviceTracker =
+			ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(
+					FieldsToDDMFormValuesConverterUtil.class),
+				FieldsToDDMFormValuesConverter.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DDMFormFieldTypeServicesTrackerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DDMFormFieldTypeServicesTrackerUtil.java
@@ -14,13 +14,13 @@
 
 package com.liferay.dynamic.data.mapping.form.field.type;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -98,17 +98,9 @@ public class DDMFormFieldTypeServicesTrackerUtil {
 
 	private static final ServiceTracker
 		<DDMFormFieldTypeServicesTracker, DDMFormFieldTypeServicesTracker>
-			_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormFieldTypeServicesTrackerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormFieldTypeServicesTracker.class,
-			null);
-
-		_serviceTracker.open();
-	}
+			_serviceTracker = ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(
+					DDMFormFieldTypeServicesTrackerUtil.class),
+				DDMFormFieldTypeServicesTracker.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormFieldTypesJSONSerializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormFieldTypesJSONSerializerUtil.java
@@ -15,12 +15,12 @@
 package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldType;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
 import java.util.List;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -47,17 +47,9 @@ public class DDMFormFieldTypesJSONSerializerUtil {
 
 	private static final ServiceTracker
 		<DDMFormFieldTypesJSONSerializer, DDMFormFieldTypesJSONSerializer>
-			_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormFieldTypesJSONSerializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormFieldTypesJSONSerializer.class,
-			null);
-
-		_serviceTracker.open();
-	}
+			_serviceTracker = ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(
+					DDMFormFieldTypesJSONSerializerUtil.class),
+				DDMFormFieldTypesJSONSerializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormJSONDeserializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormJSONDeserializerUtil.java
@@ -15,10 +15,10 @@
 package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -41,16 +41,9 @@ public class DDMFormJSONDeserializerUtil {
 	}
 
 	private static final ServiceTracker
-		<DDMFormJSONDeserializer, DDMFormJSONDeserializer> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormJSONDeserializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormJSONDeserializer.class, null);
-
-		_serviceTracker.open();
-	}
+		<DDMFormJSONDeserializer, DDMFormJSONDeserializer> _serviceTracker =
+			ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(DDMFormJSONDeserializerUtil.class),
+				DDMFormJSONDeserializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormJSONSerializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormJSONSerializerUtil.java
@@ -15,9 +15,9 @@
 package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -38,16 +38,9 @@ public class DDMFormJSONSerializerUtil {
 	}
 
 	private static final ServiceTracker
-		<DDMFormJSONSerializer, DDMFormJSONSerializer> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormJSONSerializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormJSONSerializer.class, null);
-
-		_serviceTracker.open();
-	}
+		<DDMFormJSONSerializer, DDMFormJSONSerializer> _serviceTracker =
+			ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(DDMFormJSONSerializerUtil.class),
+				DDMFormJSONSerializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormLayoutJSONDeserializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormLayoutJSONDeserializerUtil.java
@@ -15,10 +15,10 @@
 package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -45,17 +45,9 @@ public class DDMFormLayoutJSONDeserializerUtil {
 
 	private static final ServiceTracker
 		<DDMFormLayoutJSONDeserializer, DDMFormLayoutJSONDeserializer>
-			_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormLayoutJSONDeserializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormLayoutJSONDeserializer.class,
-			null);
-
-		_serviceTracker.open();
-	}
+			_serviceTracker = ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(
+					DDMFormLayoutJSONDeserializerUtil.class),
+				DDMFormLayoutJSONDeserializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormLayoutJSONSerializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormLayoutJSONSerializerUtil.java
@@ -15,9 +15,9 @@
 package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -39,16 +39,8 @@ public class DDMFormLayoutJSONSerializerUtil {
 
 	private static final ServiceTracker
 		<DDMFormLayoutJSONSerializer, DDMFormLayoutJSONSerializer>
-			_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormLayoutJSONSerializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormLayoutJSONSerializer.class, null);
-
-		_serviceTracker.open();
-	}
+			_serviceTracker = ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(DDMFormLayoutJSONSerializerUtil.class),
+				DDMFormLayoutJSONSerializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormValuesJSONDeserializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormValuesJSONDeserializerUtil.java
@@ -16,10 +16,10 @@ package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -50,17 +50,9 @@ public class DDMFormValuesJSONDeserializerUtil {
 
 	private static final ServiceTracker
 		<DDMFormValuesJSONDeserializer, DDMFormValuesJSONDeserializer>
-			_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormValuesJSONDeserializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormValuesJSONDeserializer.class,
-			null);
-
-		_serviceTracker.open();
-	}
+			_serviceTracker = ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(
+					DDMFormValuesJSONDeserializerUtil.class),
+				DDMFormValuesJSONDeserializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormValuesJSONSerializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormValuesJSONSerializerUtil.java
@@ -15,9 +15,9 @@
 package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -42,16 +42,8 @@ public class DDMFormValuesJSONSerializerUtil {
 
 	private static final ServiceTracker
 		<DDMFormValuesJSONSerializer, DDMFormValuesJSONSerializer>
-			_serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormValuesJSONSerializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormValuesJSONSerializer.class, null);
-
-		_serviceTracker.open();
-	}
+			_serviceTracker = ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(DDMFormValuesJSONSerializerUtil.class),
+				DDMFormValuesJSONSerializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormXSDDeserializerUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/DDMFormXSDDeserializerUtil.java
@@ -15,10 +15,10 @@
 package com.liferay.dynamic.data.mapping.io;
 
 import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -41,16 +41,9 @@ public class DDMFormXSDDeserializerUtil {
 	}
 
 	private static final ServiceTracker
-		<DDMFormXSDDeserializer, DDMFormXSDDeserializer> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			DDMFormXSDDeserializerUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), DDMFormXSDDeserializer.class, null);
-
-		_serviceTracker.open();
-	}
+		<DDMFormXSDDeserializer, DDMFormXSDDeserializer> _serviceTracker =
+			ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(DDMFormXSDDeserializerUtil.class),
+				DDMFormXSDDeserializer.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldRendererRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldRendererRegistryImpl.java
@@ -17,7 +17,6 @@ package com.liferay.dynamic.data.mapping.render.impl;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderer;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRendererRegistry;
 import com.liferay.osgi.util.ServiceTrackerFactory;
-import com.liferay.portal.kernel.util.ReflectionUtil;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldRendererRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldRendererRegistryImpl.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.render.impl;
 
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderer;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRendererRegistry;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 
 import java.util.ArrayList;
@@ -25,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -46,22 +46,16 @@ public class DDMFormFieldRendererRegistryImpl
 
 		_bundleContext = bundle.getBundleContext();
 
-		Filter filter = null;
-
 		try {
-			filter = FrameworkUtil.createFilter(
+			_serviceTracker = ServiceTrackerFactory.open(
+				_bundleContext,
 				"(&(objectClass=" + DDMFormFieldRenderer.class.getName() +
-					")(!(objectClass=" + clazz.getName() + ")))");
+					")(!(objectClass=" + clazz.getName() + ")))",
+				new DDMFormFieldRendererServiceTrackerCustomizer());
 		}
 		catch (InvalidSyntaxException ise) {
 			ReflectionUtil.throwException(ise);
 		}
-
-		_serviceTracker = new ServiceTracker<>(
-			_bundleContext, filter,
-			new DDMFormFieldRendererServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldRendererRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldRendererRegistryImpl.java
@@ -39,23 +39,18 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 public class DDMFormFieldRendererRegistryImpl
 	implements DDMFormFieldRendererRegistry {
 
-	public DDMFormFieldRendererRegistryImpl() {
+	public DDMFormFieldRendererRegistryImpl() throws InvalidSyntaxException {
 		Class<?> clazz = getClass();
 
 		Bundle bundle = FrameworkUtil.getBundle(clazz);
 
 		_bundleContext = bundle.getBundleContext();
 
-		try {
-			_serviceTracker = ServiceTrackerFactory.open(
-				_bundleContext,
-				"(&(objectClass=" + DDMFormFieldRenderer.class.getName() +
-					")(!(objectClass=" + clazz.getName() + ")))",
-				new DDMFormFieldRendererServiceTrackerCustomizer());
-		}
-		catch (InvalidSyntaxException ise) {
-			ReflectionUtil.throwException(ise);
-		}
+		_serviceTracker = ServiceTrackerFactory.open(
+			_bundleContext,
+			"(&(objectClass=" + DDMFormFieldRenderer.class.getName() +
+				")(!(objectClass=" + clazz.getName() + ")))",
+			new DDMFormFieldRendererServiceTrackerCustomizer());
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldValueRendererRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldValueRendererRegistryImpl.java
@@ -38,23 +38,20 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 public class DDMFormFieldValueRendererRegistryImpl
 	implements DDMFormFieldValueRendererRegistry {
 
-	public DDMFormFieldValueRendererRegistryImpl() {
+	public DDMFormFieldValueRendererRegistryImpl()
+		throws InvalidSyntaxException {
+
 		Class<?> clazz = getClass();
 
 		Bundle bundle = FrameworkUtil.getBundle(clazz);
 
 		_bundleContext = bundle.getBundleContext();
 
-		try {
-			_serviceTracker = ServiceTrackerFactory.open(
-				_bundleContext,
-				"(&(objectClass=" + DDMFormFieldValueRenderer.class.getName() +
-					")(!(objectClass=" + clazz.getName() + ")))",
-				new DDMFormFieldValueRendererServiceTrackerCustomizer());
-		}
-		catch (InvalidSyntaxException ise) {
-			ReflectionUtil.throwException(ise);
-		}
+		_serviceTracker = ServiceTrackerFactory.open(
+			_bundleContext,
+			"(&(objectClass=" + DDMFormFieldValueRenderer.class.getName() +
+				")(!(objectClass=" + clazz.getName() + ")))",
+			new DDMFormFieldValueRendererServiceTrackerCustomizer());
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldValueRendererRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldValueRendererRegistryImpl.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.render.impl;
 
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldValueRenderer;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldValueRendererRegistry;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 
 import java.util.ArrayList;
@@ -25,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -45,22 +45,16 @@ public class DDMFormFieldValueRendererRegistryImpl
 
 		_bundleContext = bundle.getBundleContext();
 
-		Filter filter = null;
-
 		try {
-			filter = FrameworkUtil.createFilter(
+			_serviceTracker = ServiceTrackerFactory.open(
+				_bundleContext,
 				"(&(objectClass=" + DDMFormFieldValueRenderer.class.getName() +
-					")(!(objectClass=" + clazz.getName() + ")))");
+					")(!(objectClass=" + clazz.getName() + ")))",
+				new DDMFormFieldValueRendererServiceTrackerCustomizer());
 		}
 		catch (InvalidSyntaxException ise) {
 			ReflectionUtil.throwException(ise);
 		}
-
-		_serviceTracker = new ServiceTracker<>(
-			_bundleContext, filter,
-			new DDMFormFieldValueRendererServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldValueRendererRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldValueRendererRegistryImpl.java
@@ -17,7 +17,6 @@ package com.liferay.dynamic.data.mapping.render.impl;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldValueRenderer;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldValueRendererRegistry;
 import com.liferay.osgi.util.ServiceTrackerFactory;
-import com.liferay.portal.kernel.util.ReflectionUtil;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StorageAdapterRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StorageAdapterRegistryImpl.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.storage.impl;
 
 import com.liferay.dynamic.data.mapping.storage.StorageAdapter;
 import com.liferay.dynamic.data.mapping.storage.StorageAdapterRegistry;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 
 import java.util.List;
@@ -25,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -44,22 +44,16 @@ public class StorageAdapterRegistryImpl implements StorageAdapterRegistry {
 
 		_bundleContext = bundle.getBundleContext();
 
-		Filter filter = null;
-
 		try {
-			filter = FrameworkUtil.createFilter(
-				"(&(objectClass=" + StorageAdapter.class.getName() +
-					")(!(objectClass=" + clazz.getName() + ")))");
+			_serviceTracker = ServiceTrackerFactory.open(
+					_bundleContext,
+					"(&(objectClass=" + StorageAdapter.class.getName() +
+							")(!(objectClass=" + clazz.getName() + ")))",
+					new StorageAdapterServiceTrackerCustomizer());
 		}
 		catch (InvalidSyntaxException ise) {
 			ReflectionUtil.throwException(ise);
 		}
-
-		_serviceTracker = new ServiceTracker<>(
-			_bundleContext, filter,
-			new StorageAdapterServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StorageAdapterRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StorageAdapterRegistryImpl.java
@@ -17,7 +17,6 @@ package com.liferay.dynamic.data.mapping.storage.impl;
 import com.liferay.dynamic.data.mapping.storage.StorageAdapter;
 import com.liferay.dynamic.data.mapping.storage.StorageAdapterRegistry;
 import com.liferay.osgi.util.ServiceTrackerFactory;
-import com.liferay.portal.kernel.util.ReflectionUtil;
 
 import java.util.List;
 import java.util.Map;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StorageAdapterRegistryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/storage/impl/StorageAdapterRegistryImpl.java
@@ -37,23 +37,18 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
  */
 public class StorageAdapterRegistryImpl implements StorageAdapterRegistry {
 
-	public StorageAdapterRegistryImpl() {
+	public StorageAdapterRegistryImpl() throws InvalidSyntaxException {
 		Class<?> clazz = getClass();
 
 		Bundle bundle = FrameworkUtil.getBundle(clazz);
 
 		_bundleContext = bundle.getBundleContext();
 
-		try {
-			_serviceTracker = ServiceTrackerFactory.open(
-					_bundleContext,
-					"(&(objectClass=" + StorageAdapter.class.getName() +
-							")(!(objectClass=" + clazz.getName() + ")))",
-					new StorageAdapterServiceTrackerCustomizer());
-		}
-		catch (InvalidSyntaxException ise) {
-			ReflectionUtil.throwException(ise);
-		}
+		_serviceTracker = ServiceTrackerFactory.open(
+				_bundleContext,
+				"(&(objectClass=" + StorageAdapter.class.getName() +
+						")(!(objectClass=" + clazz.getName() + ")))",
+				new StorageAdapterServiceTrackerCustomizer());
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-api/build.gradle
+++ b/modules/apps/export-import/export-import-api/build.gradle
@@ -4,6 +4,7 @@ configurations.compile {
 
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "org.osgi", name: "org.osgi.core", version: "6.0.0"

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/content/processor/ExportImportContentProcessorRegistryUtil.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/content/processor/ExportImportContentProcessorRegistryUtil.java
@@ -16,6 +16,7 @@ package com.liferay.exportimport.content.processor;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.registry.util.StringPlus;
 
@@ -56,11 +57,9 @@ public class ExportImportContentProcessorRegistryUtil {
 
 		_bundleContext = bundle.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			_bundleContext, ExportImportContentProcessor.class,
 			new ExportImportContentProcessorServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	private ExportImportContentProcessor _getExportImportContentProcessor(

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/ExportImportPortletPreferencesProcessorRegistryUtil.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/portlet/preferences/processor/ExportImportPortletPreferencesProcessorRegistryUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.exportimport.portlet.preferences.processor;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 
@@ -53,11 +54,9 @@ public class ExportImportPortletPreferencesProcessorRegistryUtil {
 
 		_bundleContext = bundle.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			_bundleContext, ExportImportPortletPreferencesProcessor.class,
 			new ExportImportPortletPreferencesProcessorServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	private ExportImportPortletPreferencesProcessor

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/staged/model/repository/StagedModelRepositoryRegistryUtil.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/staged/model/repository/StagedModelRepositoryRegistryUtil.java
@@ -16,6 +16,7 @@ package com.liferay.exportimport.staged.model.repository;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 
@@ -52,11 +53,12 @@ public class StagedModelRepositoryRegistryUtil {
 
 		_bundleContext = bundle.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
-			_bundleContext, StagedModelRepository.class.getName(),
-			new StagedModelRepositoryServiceTrackerCustomizer());
+		Class<StagedModelRepository<?>> clazz =
+			(Class)StagedModelRepository.class;
 
-		_serviceTracker.open();
+		_serviceTracker = ServiceTrackerFactory.open(
+			_bundleContext, clazz,
+			new StagedModelRepositoryServiceTrackerCustomizer());
 	}
 
 	private List<StagedModelRepository<?>> _getStagedModelRepositories() {

--- a/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/xstream/configurator/XStreamConfiguratorRegistryUtil.java
+++ b/modules/apps/export-import/export-import-api/src/main/java/com/liferay/exportimport/xstream/configurator/XStreamConfiguratorRegistryUtil.java
@@ -16,6 +16,7 @@ package com.liferay.exportimport.xstream.configurator;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.concurrent.ConcurrentHashSet;
 import com.liferay.portal.kernel.util.AggregateClassLoader;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -75,7 +76,7 @@ public class XStreamConfiguratorRegistryUtil {
 
 		_bundleContext = bundle.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			_bundleContext, XStreamConfigurator.class,
 			new XStreamConfiguratorServiceTrackerCustomizer());
 

--- a/modules/apps/item-selector/item-selector-api/build.gradle
+++ b/modules/apps/item-selector/item-selector-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/BaseItemSelectorCriterionHandler.java
+++ b/modules/apps/item-selector/item-selector-api/src/main/java/com/liferay/item/selector/BaseItemSelectorCriterionHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.item.selector;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.ClassUtil;
 
 import java.util.ArrayList;
@@ -60,11 +61,9 @@ public abstract class BaseItemSelectorCriterionHandler
 	}
 
 	protected void activate(BundleContext bundleContext) {
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			bundleContext, ItemSelectorView.class,
 			new ItemSelectorViewServiceTrackerCustomizer(bundleContext));
-
-		_serviceTracker.open();
 	}
 
 	private boolean _isItemSelectorViewSupported(

--- a/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/util/ItemSelectorCriterionSerializer.java
+++ b/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/util/ItemSelectorCriterionSerializer.java
@@ -17,6 +17,7 @@ package com.liferay.item.selector.web.util;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONContext;
 import com.liferay.portal.kernel.json.JSONDeserializer;
@@ -161,11 +162,9 @@ public class ItemSelectorCriterionSerializer<T extends ItemSelectorCriterion> {
 
 		_bundleContext = bundleContext;
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			bundleContext, ItemSelectorView.class,
 			new ItemSelectorReturnTypeServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	@Deactivate

--- a/modules/apps/journal/journal-api/build.gradle
+++ b/modules/apps/journal/journal-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compile project(":portal:portal-search")
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleImageUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleImageUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.journal.model.JournalArticleImage;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -899,14 +898,6 @@ public class JournalArticleImageUtil {
 	public void setPersistence(JournalArticleImagePersistence persistence) {
 	}
 
-	private static ServiceTracker<JournalArticleImagePersistence, JournalArticleImagePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(JournalArticleImageUtil.class);
-
-		_serviceTracker = new ServiceTracker<JournalArticleImagePersistence, JournalArticleImagePersistence>(bundle.getBundleContext(),
-				JournalArticleImagePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<JournalArticleImagePersistence, JournalArticleImagePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(JournalArticleImagePersistence.class);
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleResourceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleResourceUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.journal.model.JournalArticleResource;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -906,14 +905,6 @@ public class JournalArticleResourceUtil {
 	public void setPersistence(JournalArticleResourcePersistence persistence) {
 	}
 
-	private static ServiceTracker<JournalArticleResourcePersistence, JournalArticleResourcePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(JournalArticleResourceUtil.class);
-
-		_serviceTracker = new ServiceTracker<JournalArticleResourcePersistence, JournalArticleResourcePersistence>(bundle.getBundleContext(),
-				JournalArticleResourcePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<JournalArticleResourcePersistence, JournalArticleResourcePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(JournalArticleResourcePersistence.class);
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.journal.model.JournalArticle;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -8830,14 +8829,6 @@ public class JournalArticleUtil {
 	public void setPersistence(JournalArticlePersistence persistence) {
 	}
 
-	private static ServiceTracker<JournalArticlePersistence, JournalArticlePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(JournalArticleUtil.class);
-
-		_serviceTracker = new ServiceTracker<JournalArticlePersistence, JournalArticlePersistence>(bundle.getBundleContext(),
-				JournalArticlePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<JournalArticlePersistence, JournalArticlePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(JournalArticlePersistence.class);
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalContentSearchUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalContentSearchUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.journal.model.JournalContentSearch;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1676,14 +1675,6 @@ public class JournalContentSearchUtil {
 	public void setPersistence(JournalContentSearchPersistence persistence) {
 	}
 
-	private static ServiceTracker<JournalContentSearchPersistence, JournalContentSearchPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(JournalContentSearchUtil.class);
-
-		_serviceTracker = new ServiceTracker<JournalContentSearchPersistence, JournalContentSearchPersistence>(bundle.getBundleContext(),
-				JournalContentSearchPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<JournalContentSearchPersistence, JournalContentSearchPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(JournalContentSearchPersistence.class);
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFeedUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFeedUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.journal.model.JournalFeed;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -952,14 +951,6 @@ public class JournalFeedUtil {
 	public void setPersistence(JournalFeedPersistence persistence) {
 	}
 
-	private static ServiceTracker<JournalFeedPersistence, JournalFeedPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(JournalFeedUtil.class);
-
-		_serviceTracker = new ServiceTracker<JournalFeedPersistence, JournalFeedPersistence>(bundle.getBundleContext(),
-				JournalFeedPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<JournalFeedPersistence, JournalFeedPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(JournalFeedPersistence.class);
 }

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFolderUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalFolderUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.journal.model.JournalFolder;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -2392,14 +2391,6 @@ public class JournalFolderUtil {
 	public void setPersistence(JournalFolderPersistence persistence) {
 	}
 
-	private static ServiceTracker<JournalFolderPersistence, JournalFolderPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(JournalFolderUtil.class);
-
-		_serviceTracker = new ServiceTracker<JournalFolderPersistence, JournalFolderPersistence>(bundle.getBundleContext(),
-				JournalFolderPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<JournalFolderPersistence, JournalFolderPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(JournalFolderPersistence.class);
 }

--- a/modules/apps/marketplace/marketplace-api/build.gradle
+++ b/modules/apps/marketplace/marketplace-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/service/persistence/AppUtil.java
+++ b/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/service/persistence/AppUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.marketplace.model.App;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -967,14 +966,6 @@ public class AppUtil {
 	public void setPersistence(AppPersistence persistence) {
 	}
 
-	private static ServiceTracker<AppPersistence, AppPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(AppUtil.class);
-
-		_serviceTracker = new ServiceTracker<AppPersistence, AppPersistence>(bundle.getBundleContext(),
-				AppPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<AppPersistence, AppPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(AppPersistence.class);
 }

--- a/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/service/persistence/ModuleUtil.java
+++ b/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/service/persistence/ModuleUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.marketplace.model.Module;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1051,14 +1050,6 @@ public class ModuleUtil {
 	public void setPersistence(ModulePersistence persistence) {
 	}
 
-	private static ServiceTracker<ModulePersistence, ModulePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ModuleUtil.class);
-
-		_serviceTracker = new ServiceTracker<ModulePersistence, ModulePersistence>(bundle.getBundleContext(),
-				ModulePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ModulePersistence, ModulePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ModulePersistence.class);
 }

--- a/modules/apps/microblogs/microblogs-api/build.gradle
+++ b/modules/apps/microblogs/microblogs-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/apps/microblogs/microblogs-api/src/main/java/com/liferay/microblogs/service/persistence/MicroblogsEntryUtil.java
+++ b/modules/apps/microblogs/microblogs-api/src/main/java/com/liferay/microblogs/service/persistence/MicroblogsEntryUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.microblogs.model.MicroblogsEntry;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1935,14 +1934,6 @@ public class MicroblogsEntryUtil {
 	public void setPersistence(MicroblogsEntryPersistence persistence) {
 	}
 
-	private static ServiceTracker<MicroblogsEntryPersistence, MicroblogsEntryPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(MicroblogsEntryUtil.class);
-
-		_serviceTracker = new ServiceTracker<MicroblogsEntryPersistence, MicroblogsEntryPersistence>(bundle.getBundleContext(),
-				MicroblogsEntryPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<MicroblogsEntryPersistence, MicroblogsEntryPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(MicroblogsEntryPersistence.class);
 }

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/build.gradle
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/action/ActionHandlerManagerUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/action/ActionHandlerManagerUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.mobile.device.rules.action;
 
 import com.liferay.mobile.device.rules.model.MDRAction;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 
@@ -77,11 +78,9 @@ public class ActionHandlerManagerUtil {
 
 		_bundleContext = bundle.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			_bundleContext, ActionHandlerManager.class,
 			new ActionHandlerManagerServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	private ActionHandlerManager _getActionHandlerManager() {

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/rule/RuleGroupProcessorUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/rule/RuleGroupProcessorUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.mobile.device.rules.rule;
 
 import com.liferay.mobile.device.rules.model.MDRRuleGroupInstance;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 import com.liferay.portal.theme.ThemeDisplay;
 
@@ -71,11 +72,9 @@ public class RuleGroupProcessorUtil {
 
 		_bundleContext = bundle.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			_bundleContext, RuleGroupProcessor.class,
 			new RuleGroupProcessorServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	private RuleGroupProcessor _getRuleGroupProcessor() {

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRActionUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRActionUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.mobile.device.rules.model.MDRAction;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -834,14 +833,6 @@ public class MDRActionUtil {
 	public void setPersistence(MDRActionPersistence persistence) {
 	}
 
-	private static ServiceTracker<MDRActionPersistence, MDRActionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(MDRActionUtil.class);
-
-		_serviceTracker = new ServiceTracker<MDRActionPersistence, MDRActionPersistence>(bundle.getBundleContext(),
-				MDRActionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<MDRActionPersistence, MDRActionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(MDRActionPersistence.class);
 }

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRRuleGroupInstanceUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRRuleGroupInstanceUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.mobile.device.rules.model.MDRRuleGroupInstance;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1615,14 +1614,6 @@ public class MDRRuleGroupInstanceUtil {
 	public void setPersistence(MDRRuleGroupInstancePersistence persistence) {
 	}
 
-	private static ServiceTracker<MDRRuleGroupInstancePersistence, MDRRuleGroupInstancePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(MDRRuleGroupInstanceUtil.class);
-
-		_serviceTracker = new ServiceTracker<MDRRuleGroupInstancePersistence, MDRRuleGroupInstancePersistence>(bundle.getBundleContext(),
-				MDRRuleGroupInstancePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<MDRRuleGroupInstancePersistence, MDRRuleGroupInstancePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(MDRRuleGroupInstancePersistence.class);
 }

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRRuleGroupUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRRuleGroupUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.mobile.device.rules.model.MDRRuleGroup;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1033,14 +1032,6 @@ public class MDRRuleGroupUtil {
 	public void setPersistence(MDRRuleGroupPersistence persistence) {
 	}
 
-	private static ServiceTracker<MDRRuleGroupPersistence, MDRRuleGroupPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(MDRRuleGroupUtil.class);
-
-		_serviceTracker = new ServiceTracker<MDRRuleGroupPersistence, MDRRuleGroupPersistence>(bundle.getBundleContext(),
-				MDRRuleGroupPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<MDRRuleGroupPersistence, MDRRuleGroupPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(MDRRuleGroupPersistence.class);
 }

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRRuleUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/persistence/MDRRuleUtil.java
@@ -18,12 +18,11 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.mobile.device.rules.model.MDRRule;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -820,14 +819,6 @@ public class MDRRuleUtil {
 	public void setPersistence(MDRRulePersistence persistence) {
 	}
 
-	private static ServiceTracker<MDRRulePersistence, MDRRulePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(MDRRuleUtil.class);
-
-		_serviceTracker = new ServiceTracker<MDRRulePersistence, MDRRulePersistence>(bundle.getBundleContext(),
-				MDRRulePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<MDRRulePersistence, MDRRulePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(MDRRulePersistence.class);
 }

--- a/modules/apps/polls/polls-api/build.gradle
+++ b/modules/apps/polls/polls-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/service/persistence/PollsChoiceUtil.java
+++ b/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/service/persistence/PollsChoiceUtil.java
@@ -16,14 +16,13 @@ package com.liferay.polls.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.polls.model.PollsChoice;
 
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -884,14 +883,6 @@ public class PollsChoiceUtil {
 	public void setPersistence(PollsChoicePersistence persistence) {
 	}
 
-	private static ServiceTracker<PollsChoicePersistence, PollsChoicePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(PollsChoiceUtil.class);
-
-		_serviceTracker = new ServiceTracker<PollsChoicePersistence, PollsChoicePersistence>(bundle.getBundleContext(),
-				PollsChoicePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<PollsChoicePersistence, PollsChoicePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(PollsChoicePersistence.class);
 }

--- a/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/service/persistence/PollsQuestionUtil.java
+++ b/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/service/persistence/PollsQuestionUtil.java
@@ -16,14 +16,13 @@ package com.liferay.polls.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.polls.model.PollsQuestion;
 
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -897,14 +896,6 @@ public class PollsQuestionUtil {
 	public void setPersistence(PollsQuestionPersistence persistence) {
 	}
 
-	private static ServiceTracker<PollsQuestionPersistence, PollsQuestionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(PollsQuestionUtil.class);
-
-		_serviceTracker = new ServiceTracker<PollsQuestionPersistence, PollsQuestionPersistence>(bundle.getBundleContext(),
-				PollsQuestionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<PollsQuestionPersistence, PollsQuestionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(PollsQuestionPersistence.class);
 }

--- a/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/service/persistence/PollsVoteUtil.java
+++ b/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/service/persistence/PollsVoteUtil.java
@@ -16,14 +16,13 @@ package com.liferay.polls.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.polls.model.PollsVote;
 
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1041,14 +1040,6 @@ public class PollsVoteUtil {
 	public void setPersistence(PollsVotePersistence persistence) {
 	}
 
-	private static ServiceTracker<PollsVotePersistence, PollsVotePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(PollsVoteUtil.class);
-
-		_serviceTracker = new ServiceTracker<PollsVotePersistence, PollsVotePersistence>(bundle.getBundleContext(),
-				PollsVotePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<PollsVotePersistence, PollsVotePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(PollsVotePersistence.class);
 }

--- a/modules/apps/portlet-display-template/portlet-display-template/build.gradle
+++ b/modules/apps/portlet-display-template/portlet-display-template/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "util-taglib", version: liferay.portalVersion
 	compile group: "javax.servlet.jsp", name: "jsp-api", version: "2.1"

--- a/modules/apps/portlet-display-template/portlet-display-template/src/main/java/com/liferay/portlet/display/template/PortletDisplayTemplateUtil.java
+++ b/modules/apps/portlet-display-template/portlet-display-template/src/main/java/com/liferay/portlet/display/template/PortletDisplayTemplateUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.display.template;
 
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
@@ -25,7 +26,6 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -146,16 +146,9 @@ public class PortletDisplayTemplateUtil {
 	}
 
 	private static final ServiceTracker
-		<PortletDisplayTemplate, PortletDisplayTemplate> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(
-			PortletDisplayTemplateUtil.class);
-
-		_serviceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), PortletDisplayTemplate.class, null);
-
-		_serviceTracker.open();
-	}
+		<PortletDisplayTemplate, PortletDisplayTemplate> _serviceTracker =
+			ServiceTrackerFactory.open(
+				FrameworkUtil.getBundle(PortletDisplayTemplateUtil.class),
+				PortletDisplayTemplate.class);
 
 }

--- a/modules/apps/service-access-policy/service-access-policy-api/build.gradle
+++ b/modules/apps/service-access-policy/service-access-policy-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compile project(":apps:configuration-admin:configuration-admin-api")

--- a/modules/apps/service-access-policy/service-access-policy-api/src/main/java/com/liferay/service/access/policy/service/persistence/SAPEntryUtil.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/main/java/com/liferay/service/access/policy/service/persistence/SAPEntryUtil.java
@@ -16,14 +16,13 @@ package com.liferay.service.access.policy.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.service.access.policy.model.SAPEntry;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1312,14 +1311,6 @@ public class SAPEntryUtil {
 	public void setPersistence(SAPEntryPersistence persistence) {
 	}
 
-	private static ServiceTracker<SAPEntryPersistence, SAPEntryPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(SAPEntryUtil.class);
-
-		_serviceTracker = new ServiceTracker<SAPEntryPersistence, SAPEntryPersistence>(bundle.getBundleContext(),
-				SAPEntryPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<SAPEntryPersistence, SAPEntryPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(SAPEntryPersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/build.gradle
+++ b/modules/apps/shopping/shopping-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	compile project(":apps:configuration-admin:configuration-admin-api")

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingCartUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingCartUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingCart;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -641,14 +640,6 @@ public class ShoppingCartUtil {
 	public void setPersistence(ShoppingCartPersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingCartPersistence, ShoppingCartPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingCartUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingCartPersistence, ShoppingCartPersistence>(bundle.getBundleContext(),
-				ShoppingCartPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingCartPersistence, ShoppingCartPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingCartPersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingCategoryUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingCategoryUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingCategory;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -829,14 +828,6 @@ public class ShoppingCategoryUtil {
 	public void setPersistence(ShoppingCategoryPersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingCategoryPersistence, ShoppingCategoryPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingCategoryUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingCategoryPersistence, ShoppingCategoryPersistence>(bundle.getBundleContext(),
-				ShoppingCategoryPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingCategoryPersistence, ShoppingCategoryPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingCategoryPersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingCouponUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingCouponUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingCoupon;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -486,14 +485,6 @@ public class ShoppingCouponUtil {
 	public void setPersistence(ShoppingCouponPersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingCouponPersistence, ShoppingCouponPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingCouponUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingCouponPersistence, ShoppingCouponPersistence>(bundle.getBundleContext(),
-				ShoppingCouponPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingCouponPersistence, ShoppingCouponPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingCouponPersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingItemFieldUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingItemFieldUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingItemField;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -433,14 +432,6 @@ public class ShoppingItemFieldUtil {
 	public void setPersistence(ShoppingItemFieldPersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingItemFieldPersistence, ShoppingItemFieldPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingItemFieldUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingItemFieldPersistence, ShoppingItemFieldPersistence>(bundle.getBundleContext(),
-				ShoppingItemFieldPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingItemFieldPersistence, ShoppingItemFieldPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingItemFieldPersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingItemPriceUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingItemPriceUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingItemPrice;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -429,14 +428,6 @@ public class ShoppingItemPriceUtil {
 	public void setPersistence(ShoppingItemPricePersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingItemPricePersistence, ShoppingItemPricePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingItemPriceUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingItemPricePersistence, ShoppingItemPricePersistence>(bundle.getBundleContext(),
-				ShoppingItemPricePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingItemPricePersistence, ShoppingItemPricePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingItemPricePersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingItemUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingItemUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingItem;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -757,14 +756,6 @@ public class ShoppingItemUtil {
 	public void setPersistence(ShoppingItemPersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingItemPersistence, ShoppingItemPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingItemUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingItemPersistence, ShoppingItemPersistence>(bundle.getBundleContext(),
-				ShoppingItemPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingItemPersistence, ShoppingItemPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingItemPersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingOrderItemUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingOrderItemUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingOrderItem;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -431,14 +430,6 @@ public class ShoppingOrderItemUtil {
 	public void setPersistence(ShoppingOrderItemPersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingOrderItemPersistence, ShoppingOrderItemPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingOrderItemUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingOrderItemPersistence, ShoppingOrderItemPersistence>(bundle.getBundleContext(),
-				ShoppingOrderItemPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingOrderItemPersistence, ShoppingOrderItemPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingOrderItemPersistence.class);
 }

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingOrderUtil.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/service/persistence/ShoppingOrderUtil.java
@@ -16,14 +16,13 @@ package com.liferay.shopping.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.shopping.model.ShoppingOrder;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -906,14 +905,6 @@ public class ShoppingOrderUtil {
 	public void setPersistence(ShoppingOrderPersistence persistence) {
 	}
 
-	private static ServiceTracker<ShoppingOrderPersistence, ShoppingOrderPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(ShoppingOrderUtil.class);
-
-		_serviceTracker = new ServiceTracker<ShoppingOrderPersistence, ShoppingOrderPersistence>(bundle.getBundleContext(),
-				ShoppingOrderPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<ShoppingOrderPersistence, ShoppingOrderPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(ShoppingOrderPersistence.class);
 }

--- a/modules/apps/social/social-networking-api/build.gradle
+++ b/modules/apps/social/social-networking-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/service/persistence/MeetupsEntryUtil.java
+++ b/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/service/persistence/MeetupsEntryUtil.java
@@ -16,14 +16,13 @@ package com.liferay.social.networking.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.social.networking.model.MeetupsEntry;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -588,14 +587,6 @@ public class MeetupsEntryUtil {
 	public void setPersistence(MeetupsEntryPersistence persistence) {
 	}
 
-	private static ServiceTracker<MeetupsEntryPersistence, MeetupsEntryPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(MeetupsEntryUtil.class);
-
-		_serviceTracker = new ServiceTracker<MeetupsEntryPersistence, MeetupsEntryPersistence>(bundle.getBundleContext(),
-				MeetupsEntryPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<MeetupsEntryPersistence, MeetupsEntryPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(MeetupsEntryPersistence.class);
 }

--- a/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/service/persistence/MeetupsRegistrationUtil.java
+++ b/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/service/persistence/MeetupsRegistrationUtil.java
@@ -16,14 +16,13 @@ package com.liferay.social.networking.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.social.networking.model.MeetupsRegistration;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -686,14 +685,6 @@ public class MeetupsRegistrationUtil {
 	public void setPersistence(MeetupsRegistrationPersistence persistence) {
 	}
 
-	private static ServiceTracker<MeetupsRegistrationPersistence, MeetupsRegistrationPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(MeetupsRegistrationUtil.class);
-
-		_serviceTracker = new ServiceTracker<MeetupsRegistrationPersistence, MeetupsRegistrationPersistence>(bundle.getBundleContext(),
-				MeetupsRegistrationPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<MeetupsRegistrationPersistence, MeetupsRegistrationPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(MeetupsRegistrationPersistence.class);
 }

--- a/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/service/persistence/WallEntryUtil.java
+++ b/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/service/persistence/WallEntryUtil.java
@@ -16,14 +16,13 @@ package com.liferay.social.networking.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.social.networking.model.WallEntry;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -753,14 +752,6 @@ public class WallEntryUtil {
 	public void setPersistence(WallEntryPersistence persistence) {
 	}
 
-	private static ServiceTracker<WallEntryPersistence, WallEntryPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(WallEntryUtil.class);
-
-		_serviceTracker = new ServiceTracker<WallEntryPersistence, WallEntryPersistence>(bundle.getBundleContext(),
-				WallEntryPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<WallEntryPersistence, WallEntryPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(WallEntryPersistence.class);
 }

--- a/modules/apps/wiki/wiki-api/build.gradle
+++ b/modules/apps/wiki/wiki-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile project(":apps:configuration-admin:configuration-admin-api")
 	compile project(":apps:item-selector:item-selector-api")
 	compile project(":apps:item-selector:item-selector-criteria-api")

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiNodeUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiNodeUtil.java
@@ -16,14 +16,13 @@ package com.liferay.wiki.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.wiki.model.WikiNode;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1529,14 +1528,6 @@ public class WikiNodeUtil {
 	public void setPersistence(WikiNodePersistence persistence) {
 	}
 
-	private static ServiceTracker<WikiNodePersistence, WikiNodePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(WikiNodeUtil.class);
-
-		_serviceTracker = new ServiceTracker<WikiNodePersistence, WikiNodePersistence>(bundle.getBundleContext(),
-				WikiNodePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<WikiNodePersistence, WikiNodePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(WikiNodePersistence.class);
 }

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPageResourceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPageResourceUtil.java
@@ -16,14 +16,13 @@ package com.liferay.wiki.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.wiki.model.WikiPageResource;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -733,14 +732,6 @@ public class WikiPageResourceUtil {
 	public void setPersistence(WikiPageResourcePersistence persistence) {
 	}
 
-	private static ServiceTracker<WikiPageResourcePersistence, WikiPageResourcePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(WikiPageResourceUtil.class);
-
-		_serviceTracker = new ServiceTracker<WikiPageResourcePersistence, WikiPageResourcePersistence>(bundle.getBundleContext(),
-				WikiPageResourcePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<WikiPageResourcePersistence, WikiPageResourcePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(WikiPageResourcePersistence.class);
 }

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPageUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/persistence/WikiPageUtil.java
@@ -16,14 +16,13 @@ package com.liferay.wiki.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 
 import com.liferay.wiki.model.WikiPage;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -6823,14 +6822,6 @@ public class WikiPageUtil {
 	public void setPersistence(WikiPagePersistence persistence) {
 	}
 
-	private static ServiceTracker<WikiPagePersistence, WikiPagePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(WikiPageUtil.class);
-
-		_serviceTracker = new ServiceTracker<WikiPagePersistence, WikiPagePersistence>(bundle.getBundleContext(),
-				WikiPagePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<WikiPagePersistence, WikiPagePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(WikiPagePersistence.class);
 }

--- a/modules/apps/wiki/wiki-service/build.gradle
+++ b/modules/apps/wiki/wiki-service/build.gradle
@@ -5,6 +5,7 @@ buildService {
 }
 
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "1.0.2"
 	compile group: "com.liferay", name: "org.freemarker", version: "2.3.17.LIFERAY-PATCHED-1"
 	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/util/WikiUtil.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/util/WikiUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.wiki.util;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.diff.DiffHtmlUtil;
 import com.liferay.portal.kernel.diff.DiffVersion;
@@ -583,15 +584,11 @@ public class WikiUtil {
 	static {
 		Bundle bundle = FrameworkUtil.getBundle(WikiUtil.class);
 
-		_wikiEngineServiceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), WikiEngineTracker.class, null);
+		_wikiEngineServiceTracker = ServiceTrackerFactory.open(
+			bundle, WikiEngineTracker.class);
 
-		_wikiEngineServiceTracker.open();
-
-		_wikiImporterServiceTracker = new ServiceTracker<>(
-			bundle.getBundleContext(), WikiImporterTracker.class, null);
-
-		_wikiImporterServiceTracker.open();
+		_wikiImporterServiceTracker = ServiceTrackerFactory.open(
+			bundle, WikiImporterTracker.class);
 	}
 
 }

--- a/modules/portal-cache/portal-cache/build.gradle
+++ b/modules/portal-cache/portal-cache/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "commons-collections", name: "commons-collections", version: "3.2.1"

--- a/modules/portal-cache/portal-cache/src/main/java/com/liferay/portal/cache/internal/MultiVMPoolImpl.java
+++ b/modules/portal-cache/portal-cache/src/main/java/com/liferay/portal/cache/internal/MultiVMPoolImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.cache.internal;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheManager;
@@ -123,11 +124,9 @@ public class MultiVMPoolImpl implements MultiVMPool {
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			bundleContext, SPIPortalCacheManagerConfigurator.class,
 			new SPIPortalCacheManagerConfiguratorServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	@Deactivate

--- a/modules/portal-store/portal-store-cmis-test/build.gradle
+++ b/modules/portal-store/portal-store-cmis-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.eclipse.osgi", name: "org.eclipse.osgi.services", version: "3.5.0-SNAPSHOT"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal-store/portal-store-cmis-test/src/main/java/com/liferay/portal/store/cmis/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-cmis-test/src/main/java/com/liferay/portal/store/cmis/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.store.cmis.test.activator.configuration;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portlet.documentlibrary.store.Store;
@@ -25,7 +26,6 @@ import java.util.Hashtable;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -72,14 +72,10 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 
 			cmisStoreConfiguration.update(properties);
 
-			Filter filter = bundleContext.createFilter(
+			ServiceTracker<?, ?> serviceTracker = ServiceTrackerFactory.open(
+				bundleContext,
 				"(&(objectClass=" + Store.class.getName() +
 					")(store.type=com.liferay.portal.store.cmis.CMISStore))");
-
-			ServiceTracker<?, ?> serviceTracker = new ServiceTracker<>(
-				bundleContext, filter, null);
-
-			serviceTracker.open();
 
 			Object cmisStore = serviceTracker.waitForService(10000);
 

--- a/modules/portal-store/portal-store-file-system-test/build.gradle
+++ b/modules/portal-store/portal-store-file-system-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.eclipse.osgi", name: "org.eclipse.osgi.services", version: "3.5.0-SNAPSHOT"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal-store/portal-store-file-system-test/src/main/java/com/liferay/portal/store/file/system/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-file-system-test/src/main/java/com/liferay/portal/store/file/system/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.store.file.system.test.activator.configuration;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -24,7 +25,6 @@ import java.util.Hashtable;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -124,14 +124,10 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			String storeType)
 		throws Exception {
 
-		Filter filter = bundleContext.createFilter(
+		ServiceTracker<?, ?> serviceTracker = ServiceTrackerFactory.open(
+			bundleContext,
 			"(&(objectClass=" + Store.class.getName() + ")(store.type=" +
 				storeType + "))");
-
-		ServiceTracker<?, ?> serviceTracker = new ServiceTracker<>(
-			bundleContext, filter, null);
-
-		serviceTracker.open();
 
 		Object service = serviceTracker.waitForService(10000);
 

--- a/modules/portal-store/portal-store-jcr-test/build.gradle
+++ b/modules/portal-store/portal-store-jcr-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.eclipse.osgi", name: "org.eclipse.osgi.services", version: "3.5.0-SNAPSHOT"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal-store/portal-store-jcr-test/src/main/java/com/liferay/portal/store/jcr/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-jcr-test/src/main/java/com/liferay/portal/store/jcr/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.store.jcr.test.activator.configuration;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portlet.documentlibrary.store.Store;
 
 import java.io.IOException;
@@ -23,7 +24,6 @@ import java.util.Hashtable;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -64,14 +64,10 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 
 			jcrConfiguration.update(properties);
 
-			Filter filter = bundleContext.createFilter(
+			ServiceTracker<?, ?> serviceTracker = ServiceTrackerFactory.open(
+				bundleContext,
 				"(&(objectClass=" + Store.class.getName() +
 					")(store.type=com.liferay.portal.store.jcr.JCRStore))");
-
-			ServiceTracker<?, ?> serviceTracker = new ServiceTracker<>(
-				bundleContext, filter, null);
-
-			serviceTracker.open();
 
 			Object jcrStore = serviceTracker.waitForService(10000);
 

--- a/modules/portal-store/portal-store-s3-test/build.gradle
+++ b/modules/portal-store/portal-store-s3-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.eclipse.osgi", name: "org.eclipse.osgi.services", version: "3.5.0-SNAPSHOT"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal-store/portal-store-s3-test/src/main/java/com/liferay/portal/store/s3/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal-store/portal-store-s3-test/src/main/java/com/liferay/portal/store/s3/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.store.s3.test.activator.configuration;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portlet.documentlibrary.store.Store;
@@ -25,7 +26,6 @@ import java.util.Hashtable;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -70,14 +70,10 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 
 			s3StoreConfiguration.update(properties);
 
-			Filter filter = bundleContext.createFilter(
+			ServiceTracker<?, ?> serviceTracker = ServiceTrackerFactory.open(
+				bundleContext,
 				"(&(objectClass=" + Store.class.getName() +
 					")(store.type=com.liferay.portal.store.s3.S3Store))");
-
-			ServiceTracker<?, ?> serviceTracker = new ServiceTracker<>(
-				bundleContext, filter, null);
-
-			serviceTracker.open();
 
 			Object s3Store = serviceTracker.waitForService(10000);
 

--- a/modules/portal/portal-background-task-api/build.gradle
+++ b/modules/portal/portal-background-task-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/portal/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskUtil.java
+++ b/modules/portal/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.background.task.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -2513,14 +2512,6 @@ public class BackgroundTaskUtil {
 	public void setPersistence(BackgroundTaskPersistence persistence) {
 	}
 
-	private static ServiceTracker<BackgroundTaskPersistence, BackgroundTaskPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(BackgroundTaskUtil.class);
-
-		_serviceTracker = new ServiceTracker<BackgroundTaskPersistence, BackgroundTaskPersistence>(bundle.getBundleContext(),
-				BackgroundTaskPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<BackgroundTaskPersistence, BackgroundTaskPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(BackgroundTaskPersistence.class);
 }

--- a/modules/portal/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/test/ConfigurationPersistenceManagerTest.java
+++ b/modules/portal/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/test/ConfigurationPersistenceManagerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.configuration.persistence.test;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.configuration.persistence.ConfigurationPersistenceManager;
 import com.liferay.portal.kernel.test.rule.Sync;
 
@@ -33,7 +34,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -51,20 +51,14 @@ public class ConfigurationPersistenceManagerTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			ConfigurationPersistenceManagerTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		_configurationAdminServiceTracker = new ServiceTracker<>(
-			bundleContext, ConfigurationAdmin.class, null);
-
-		_configurationAdminServiceTracker.open();
+		_configurationAdminServiceTracker = ServiceTrackerFactory.open(
+			bundle, ConfigurationAdmin.class);
 
 		_configurationAdmin = _configurationAdminServiceTracker.waitForService(
 			5000);
 
-		_persistenceManagerServiceTracker = new ServiceTracker<>(
-			bundleContext, PersistenceManager.class, null);
-
-		_persistenceManagerServiceTracker.open();
+		_persistenceManagerServiceTracker = ServiceTrackerFactory.open(
+			bundle, PersistenceManager.class);
 
 		_persistenceManager = _persistenceManagerServiceTracker.waitForService(
 			5000);

--- a/modules/portal/portal-configuration-persistence/build.gradle
+++ b/modules/portal/portal-configuration-persistence/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.apache.felix", name: "org.apache.felix.configadmin", transitive: false, version: "1.8.7-SNAPSHOT"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal/portal-jmx/build.gradle
+++ b/modules/portal/portal-jmx/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"

--- a/modules/portal/portal-jmx/src/main/java/com/liferay/portal/jmx/internal/MBeanRegistryImpl.java
+++ b/modules/portal/portal-jmx/src/main/java/com/liferay/portal/jmx/internal/MBeanRegistryImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.jmx.internal;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.jmx.MBeanRegistry;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -36,7 +37,6 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
@@ -129,21 +129,16 @@ public class MBeanRegistryImpl implements MBeanRegistry {
 
 		_mBeanServer = ManagementFactory.getPlatformMBeanServer();
 
-		Filter filter = null;
-
 		try {
-			filter = _bundleContext.createFilter(
+			_serviceTracker = ServiceTrackerFactory.open(
+				_bundleContext,
 				"(&(jmx.objectname=*)(objectClass=*MBean)" +
-					"(!(objectClass=javax.management.DynamicMBean)))");
+					"(!(objectClass=javax.management.DynamicMBean)))",
+				new MBeanServiceTrackerCustomizer());
 		}
 		catch (InvalidSyntaxException ise) {
 			ReflectionUtil.throwException(ise);
 		}
-
-		_serviceTracker = new ServiceTracker<>(
-			_bundleContext, filter, new MBeanServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	@Reference(

--- a/modules/portal/portal-js-bundle-config-extender/build.gradle
+++ b/modules/portal/portal-js-bundle-config-extender/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal/portal-js-bundle-config-extender/src/main/java/com/liferay/portal/js/bundle/config/extender/JSBundleConfigTracker.java
+++ b/modules/portal/portal-js-bundle-config-extender/src/main/java/com/liferay/portal/js/bundle/config/extender/JSBundleConfigTracker.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.js.bundle.config.extender;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import java.net.URL;
 
 import java.util.Collection;
@@ -24,8 +26,6 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import javax.servlet.ServletContext;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.Filter;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -51,14 +51,11 @@ public class JSBundleConfigTracker
 			_serviceTracker.close();
 		}
 
-		Filter filter = FrameworkUtil.createFilter(
+		_serviceTracker = ServiceTrackerFactory.open(
+			componentContext.getBundleContext(),
 			"(&(objectClass=" + ServletContext.class.getName() +
-				")(osgi.web.contextpath=*))");
-
-		_serviceTracker = new ServiceTracker<>(
-			componentContext.getBundleContext(), filter, this);
-
-		_serviceTracker.open();
+				")(osgi.web.contextpath=*))",
+			this);
 	}
 
 	@Override

--- a/modules/portal/portal-js-loader-modules-extender/build.gradle
+++ b/modules/portal/portal-js-loader-modules-extender/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal/portal-js-loader-modules-extender/src/main/java/com/liferay/portal/js/loader/modules/extender/JSLoaderModulesTracker.java
+++ b/modules/portal/portal-js-loader-modules-extender/src/main/java/com/liferay/portal/js/loader/modules/extender/JSLoaderModulesTracker.java
@@ -16,14 +16,14 @@ package com.liferay.portal.js.loader.modules.extender;
 
 import aQute.lib.converter.Converter;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 import javax.servlet.ServletContext;
 
-import org.osgi.framework.Filter;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -51,14 +51,11 @@ public class JSLoaderModulesTracker
 
 		setDetails(Converter.cnv(Details.class, properties));
 
-		Filter filter = FrameworkUtil.createFilter(
+		_serviceTracker = ServiceTrackerFactory.open(
+			componentContext.getBundleContext(),
 			"(&(objectClass=" + ServletContext.class.getName() +
-				")(osgi.web.contextpath=*))");
-
-		_serviceTracker = new ServiceTracker<>(
-			componentContext.getBundleContext(), filter, this);
-
-		_serviceTracker.open();
+				")(osgi.web.contextpath=*))",
+			this);
 	}
 
 	@Override

--- a/modules/portal/portal-json-web-service-extender/build.gradle
+++ b/modules/portal/portal-json-web-service-extender/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"

--- a/modules/portal/portal-json-web-service-extender/src/main/java/com/liferay/portal/json/web/service/extender/internal/JSONWebServiceTracker.java
+++ b/modules/portal/portal-json-web-service-extender/src/main/java/com/liferay/portal/json/web/service/extender/internal/JSONWebServiceTracker.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.json.web.service.extender.internal;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceActionsManager;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceRegistrator;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceRegistratorFactory;
@@ -46,14 +47,11 @@ public class JSONWebServiceTracker
 		BundleContext bundleContext = componentContext.getBundleContext();
 
 		try {
-			_serviceTracker = new ServiceTracker<Object, Object>(
+			_serviceTracker = ServiceTrackerFactory.open(
 				bundleContext,
-				bundleContext.createFilter(
-					"(&(json.web.service.context.name=*)(json.web.service." +
-						"context.path=*))"),
-					this);
-
-			_serviceTracker.open();
+				"(&(json.web.service.context.name=*)(json.web.service." +
+					"context.path=*))",
+				this);
 		}
 		catch (InvalidSyntaxException ise) {
 			throw new RuntimeException(

--- a/modules/portal/portal-lock-api/build.gradle
+++ b/modules/portal/portal-lock-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/portal/portal-lock-api/src/main/java/com/liferay/portal/lock/service/persistence/LockUtil.java
+++ b/modules/portal/portal-lock-api/src/main/java/com/liferay/portal/lock/service/persistence/LockUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.lock.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.lock.model.Lock;
 import com.liferay.portal.service.ServiceContext;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -829,14 +828,6 @@ public class LockUtil {
 	public void setPersistence(LockPersistence persistence) {
 	}
 
-	private static ServiceTracker<LockPersistence, LockPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(LockUtil.class);
-
-		_serviceTracker = new ServiceTracker<LockPersistence, LockPersistence>(bundle.getBundleContext(),
-				LockPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<LockPersistence, LockPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(LockPersistence.class);
 }

--- a/modules/portal/portal-portlet-tracker/build.gradle
+++ b/modules/portal/portal-portlet-tracker/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay", name: "com.liferay.portal.servlet.jsp.compiler", version: "1.0.0-SNAPSHOT"
 	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion

--- a/modules/portal/portal-portlet-tracker/src/main/java/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
+++ b/modules/portal/portal-portlet-tracker/src/main/java/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.portlet.tracker.internal;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.application.type.ApplicationType;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
@@ -256,10 +257,8 @@ public class PortletTracker
 
 		BundleContext bundleContext = _componentContext.getBundleContext();
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			bundleContext, Portlet.class, this);
-
-		_serviceTracker.open();
 
 		if (_log.isInfoEnabled()) {
 			_log.info("Activated");

--- a/modules/portal/portal-rest-extender-test/build.gradle
+++ b/modules/portal/portal-rest-extender-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.0.1"
 	compile group: "org.apache.cxf", name: "cxf-core", version: "3.0.3"

--- a/modules/portal/portal-rest-extender-test/src/main/java/com/liferay/portal/rest/extender/test/activator/configuration/ConfigurationAdminBundleActivator.java
+++ b/modules/portal/portal-rest-extender-test/src/main/java/com/liferay/portal/rest/extender/test/activator/configuration/ConfigurationAdminBundleActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.rest.extender.test.activator.configuration;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.rest.extender.test.service.Greeter;
 
@@ -32,7 +33,6 @@ import org.apache.cxf.endpoint.ServerRegistry;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
@@ -87,15 +87,12 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			_serviceRegistration = bundleContext.registerService(
 				Application.class, new Greeter(), properties);
 
-			Filter filter = bundleContext.createFilter(
-				"(&(objectClass=" + Bus.class.getName() + ")(" +
-					HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH + "=" +
-						"/rest-test))");
-
-			ServiceTracker<Bus, Bus> serviceTracker = new ServiceTracker<>(
-				bundleContext, filter, null);
-
-			serviceTracker.open();
+			ServiceTracker<Bus, Bus> serviceTracker =
+				ServiceTrackerFactory.open(
+					bundleContext,
+					"(&(objectClass=" + Bus.class.getName() + ")(" +
+						HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH +
+							"=/rest-test))");
 
 			Bus bus = serviceTracker.waitForService(10000L);
 

--- a/modules/portal/portal-scheduler/build.gradle
+++ b/modules/portal/portal-scheduler/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/portal/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/portal/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.scheduler.internal;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.audit.AuditRouter;
 import com.liferay.portal.kernel.cal.DayAndPosition;
@@ -68,7 +69,6 @@ import javax.portlet.PortletRequest;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
@@ -763,15 +763,11 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 		}
 
 		if (GetterUtil.getBoolean(_props.get(PropsKeys.SCHEDULER_ENABLED))) {
-			Filter filter = _bundleContext.createFilter(
+			_serviceTracker = ServiceTrackerFactory.open(
+				_bundleContext,
 				"(objectClass=" +
-					SchedulerEventMessageListener.class.getName() + ")");
-
-			_serviceTracker = new ServiceTracker<>(
-				_bundleContext, filter,
+					SchedulerEventMessageListener.class.getName() + ")",
 				new SchedulerEventMessageListenerServiceTrackerCustomizer());
-
-			_serviceTracker.open();
 		}
 	}
 

--- a/modules/portal/portal-servlet-jsp-compiler/build.gradle
+++ b/modules/portal/portal-servlet-jsp-compiler/build.gradle
@@ -10,6 +10,7 @@ classes {
 
 dependencies {
 	compile group: "com.github.rotty3000", name: "phidias", version: "0.3.6"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "util-taglib", version: liferay.portalVersion
 	compile group: "org.glassfish", name: "javax.el", transitive: false, version: "3.0.1-b05"
 	compile group: "org.glassfish", name: "javax.servlet", transitive: false, version: "3.2-b06"

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspResourceResolver.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspResourceResolver.java
@@ -42,7 +42,6 @@ import org.apache.felix.utils.log.Logger;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleWire;
@@ -62,8 +61,6 @@ public class JspResourceResolver implements ResourceResolver {
 		_logger = logger;
 
 		BundleContext bundleContext = _bundle.getBundleContext();
-
-		Filter filter = null;
 
 		try {
 			_serviceTracker = ServiceTrackerFactory.open(

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspResourceResolver.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/internal/JspResourceResolver.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.servlet.jsp.compiler.internal;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
@@ -65,17 +66,14 @@ public class JspResourceResolver implements ResourceResolver {
 		Filter filter = null;
 
 		try {
-			filter = bundleContext.createFilter(
+			_serviceTracker = ServiceTrackerFactory.open(
+				bundleContext,
 				"(&(jsp.compiler.resource.map=*)(objectClass=" +
 					Map.class.getName() + "))");
 		}
 		catch (InvalidSyntaxException ise) {
 			throw new RuntimeException(ise);
 		}
-
-		_serviceTracker = new ServiceTracker<>(bundleContext, filter, null);
-
-		_serviceTracker.open();
 	}
 
 	@Override

--- a/modules/portal/portal-soap-extender-test/build.gradle
+++ b/modules/portal/portal-soap-extender-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.apache.cxf", name: "cxf-core", version: "3.0.3"
 	compile group: "org.apache.httpcomponents", name: "httpclient", version: "4.3.5"

--- a/modules/portal/portal-soap-extender-test/src/main/java/com/liferay/portal/soap/extender/test/activator/configuration/GreeterBundleActivator.java
+++ b/modules/portal/portal-soap-extender-test/src/main/java/com/liferay/portal/soap/extender/test/activator/configuration/GreeterBundleActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.soap.extender.test.activator.configuration;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.soap.extender.test.service.Greeter;
 import com.liferay.portal.soap.extender.test.service.GreeterImpl;
 
@@ -27,7 +28,6 @@ import org.apache.cxf.endpoint.ServerRegistry;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.osgi.util.tracker.ServiceTracker;
@@ -51,15 +51,11 @@ public class GreeterBundleActivator implements BundleActivator {
 
 		_configAdminBundleActivator.start(bundleContext);
 
-		Filter filter = bundleContext.createFilter(
+		ServiceTracker<Bus, Bus> serviceTracker = ServiceTrackerFactory.open(
+			bundleContext,
 			"(&(objectClass=" + Bus.class.getName() + ")(" +
 				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH + "=" +
 					"/soap-test))");
-
-		ServiceTracker<Bus, Bus> serviceTracker = new ServiceTracker<>(
-			bundleContext, filter, null);
-
-		serviceTracker.open();
 
 		Bus bus = serviceTracker.waitForService(10_000);
 

--- a/modules/portal/portal-soap-extender-test/src/main/java/com/liferay/portal/soap/extender/test/util/WaiterUtil.java
+++ b/modules/portal/portal-soap-extender-test/src/main/java/com/liferay/portal/soap/extender/test/util/WaiterUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.soap.extender.test.util;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -31,10 +33,8 @@ public class WaiterUtil {
 			BundleContext bundleContext, String filterString, long timeout)
 		throws Exception {
 
-		ServiceTracker<?, ?> serviceTracker = new ServiceTracker<>(
-			bundleContext, bundleContext.createFilter(filterString), null);
-
-		serviceTracker.open();
+		ServiceTracker<?, ?> serviceTracker = ServiceTrackerFactory.open(
+			bundleContext, filterString);
 
 		try {
 			if (serviceTracker.waitForService(timeout) == null) {

--- a/modules/portal/portal-soap-extender/build.gradle
+++ b/modules/portal/portal-soap-extender/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay", name: "com.liferay.portal.dependency.manager.tccl", transitive: false, version: "1.0.0-SNAPSHOT"
 	compile group: "com.liferay", name: "com.liferay.portal.http.service.api", transitive: false, version: "1.0.0-SNAPSHOT"
 	compile group: "org.apache.felix", name: "org.apache.felix.dependencymanager", version: "3.2.0"

--- a/modules/portal/portal-soap-extender/src/main/java/com/liferay/portal/soap/extender/internal/JaxWsApiEnabler.java
+++ b/modules/portal/portal-soap-extender/src/main/java/com/liferay/portal/soap/extender/internal/JaxWsApiEnabler.java
@@ -16,6 +16,7 @@ package com.liferay.portal.soap.extender.internal;
 
 import aQute.bnd.annotation.metatype.Configurable;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.soap.extender.configuration.JaxWsApiConfiguration;
 
 import java.util.Dictionary;
@@ -29,7 +30,6 @@ import org.apache.cxf.BusFactory;
 import org.apache.cxf.jaxws22.spi.ProviderImpl;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Filter;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
@@ -60,14 +60,11 @@ public class JaxWsApiEnabler {
 
 		String contextPath = jaxWsApiConfiguration.contextPath();
 
-		Filter filter = bundleContext.createFilter(
+		_serviceTracker = ServiceTrackerFactory.open(
+			bundleContext,
 			"(&(objectClass=org.apache.cxf.Bus)(" +
 				HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH + "=" +
 					contextPath + "))");
-
-		_serviceTracker = new ServiceTracker<>(bundleContext, filter, null);
-
-		_serviceTracker.open();
 
 		_bus = _serviceTracker.waitForService(jaxWsApiConfiguration.timeout());
 

--- a/modules/portal/portal-upgrade/build.gradle
+++ b/modules/portal/portal-upgrade/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "1.0.2"
 	compile group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compile project(":apps:configuration-admin:configuration-admin-api")

--- a/modules/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/registry/UpgradeStepRegistratorTracker.java
+++ b/modules/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/registry/UpgradeStepRegistratorTracker.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.upgrade.registry;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator.Registry;
@@ -102,11 +103,9 @@ public class UpgradeStepRegistratorTracker {
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
 
-		_serviceTracker = new ServiceTracker<>(
+		_serviceTracker = ServiceTrackerFactory.open(
 			bundleContext, UpgradeStepRegistrator.class,
 			new UpgradeStepRegistratorServiceTrackerCustomizer());
-
-		_serviceTracker.open();
 	}
 
 	protected List<UpgradeInfo> createUpgradeInfos(

--- a/modules/portal/portal-wab-extender/build.gradle
+++ b/modules/portal/portal-wab-extender/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay", name: "com.liferay.portal.servlet.jsp.compiler", version: "1.0.0-SNAPSHOT"
 	compile group: "com.liferay", name: "org.apache.axis", version: "1.4.LIFERAY-PATCHED-1"
 	compile group: "commons-fileupload", name: "commons-fileupload", transitive: false, version: "1.2.1"

--- a/modules/portal/portal-wab-extender/src/main/java/com/liferay/portal/wab/extender/internal/event/EventUtil.java
+++ b/modules/portal/portal-wab-extender/src/main/java/com/liferay/portal/wab/extender/internal/event/EventUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.wab.extender.internal.event;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.wab.extender.internal.WabUtil;
@@ -52,10 +53,8 @@ public class EventUtil
 
 		_webExtenderBundle = _bundleContext.getBundle();
 
-		_eventAdminServiceTracker = new ServiceTracker<>(
-			_bundleContext, EventAdmin.class.getName(), this);
-
-		_eventAdminServiceTracker.open();
+		_eventAdminServiceTracker = ServiceTrackerFactory.open(
+			_bundleContext, EventAdmin.class, this);
 	}
 
 	@Override

--- a/modules/portal/portal-workflow-kaleo-api/build.gradle
+++ b/modules/portal/portal-workflow-kaleo-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "2.4.1"
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.1"
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoActionUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoActionUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoAction;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1001,14 +1000,6 @@ public class KaleoActionUtil {
 	public void setPersistence(KaleoActionPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoActionPersistence, KaleoActionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoActionUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoActionPersistence, KaleoActionPersistence>(bundle.getBundleContext(),
-				KaleoActionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoActionPersistence, KaleoActionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoActionPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoConditionUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoConditionUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoCondition;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -662,14 +661,6 @@ public class KaleoConditionUtil {
 	public void setPersistence(KaleoConditionPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoConditionPersistence, KaleoConditionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoConditionUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoConditionPersistence, KaleoConditionPersistence>(bundle.getBundleContext(),
-				KaleoConditionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoConditionPersistence, KaleoConditionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoConditionPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoDefinitionUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1053,14 +1052,6 @@ public class KaleoDefinitionUtil {
 	public void setPersistence(KaleoDefinitionPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoDefinitionPersistence, KaleoDefinitionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoDefinitionUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoDefinitionPersistence, KaleoDefinitionPersistence>(bundle.getBundleContext(),
-				KaleoDefinitionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoDefinitionPersistence, KaleoDefinitionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoDefinitionPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoInstanceTokenUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoInstanceTokenUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1185,14 +1184,6 @@ public class KaleoInstanceTokenUtil {
 	public void setPersistence(KaleoInstanceTokenPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoInstanceTokenPersistence, KaleoInstanceTokenPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoInstanceTokenUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoInstanceTokenPersistence, KaleoInstanceTokenPersistence>(bundle.getBundleContext(),
-				KaleoInstanceTokenPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoInstanceTokenPersistence, KaleoInstanceTokenPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoInstanceTokenPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoInstanceUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoInstanceUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstance;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1366,14 +1365,6 @@ public class KaleoInstanceUtil {
 	public void setPersistence(KaleoInstancePersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoInstancePersistence, KaleoInstancePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoInstanceUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoInstancePersistence, KaleoInstancePersistence>(bundle.getBundleContext(),
-				KaleoInstancePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoInstancePersistence, KaleoInstancePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoInstancePersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoLogUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoLogUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoLog;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1355,14 +1354,6 @@ public class KaleoLogUtil {
 	public void setPersistence(KaleoLogPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoLogPersistence, KaleoLogPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoLogUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoLogPersistence, KaleoLogPersistence>(bundle.getBundleContext(),
-				KaleoLogPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoLogPersistence, KaleoLogPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoLogPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoNodeUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoNodeUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoNode;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -785,14 +784,6 @@ public class KaleoNodeUtil {
 	public void setPersistence(KaleoNodePersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoNodePersistence, KaleoNodePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoNodeUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoNodePersistence, KaleoNodePersistence>(bundle.getBundleContext(),
-				KaleoNodePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoNodePersistence, KaleoNodePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoNodePersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoNotificationRecipientUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoNotificationRecipientUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoNotificationRecipient;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -798,14 +797,6 @@ public class KaleoNotificationRecipientUtil {
 		KaleoNotificationRecipientPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoNotificationRecipientPersistence, KaleoNotificationRecipientPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoNotificationRecipientUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoNotificationRecipientPersistence, KaleoNotificationRecipientPersistence>(bundle.getBundleContext(),
-				KaleoNotificationRecipientPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoNotificationRecipientPersistence, KaleoNotificationRecipientPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoNotificationRecipientPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoNotificationUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoNotificationUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoNotification;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1009,14 +1008,6 @@ public class KaleoNotificationUtil {
 	public void setPersistence(KaleoNotificationPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoNotificationPersistence, KaleoNotificationPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoNotificationUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoNotificationPersistence, KaleoNotificationPersistence>(bundle.getBundleContext(),
-				KaleoNotificationPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoNotificationPersistence, KaleoNotificationPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoNotificationPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskAssignmentInstanceUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskAssignmentInstanceUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignmentInstance;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1533,14 +1532,6 @@ public class KaleoTaskAssignmentInstanceUtil {
 		KaleoTaskAssignmentInstancePersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoTaskAssignmentInstancePersistence, KaleoTaskAssignmentInstancePersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoTaskAssignmentInstanceUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoTaskAssignmentInstancePersistence, KaleoTaskAssignmentInstancePersistence>(bundle.getBundleContext(),
-				KaleoTaskAssignmentInstancePersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoTaskAssignmentInstancePersistence, KaleoTaskAssignmentInstancePersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoTaskAssignmentInstancePersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskAssignmentUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskAssignmentUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignment;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1014,14 +1013,6 @@ public class KaleoTaskAssignmentUtil {
 	public void setPersistence(KaleoTaskAssignmentPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoTaskAssignmentPersistence, KaleoTaskAssignmentPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoTaskAssignmentUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoTaskAssignmentPersistence, KaleoTaskAssignmentPersistence>(bundle.getBundleContext(),
-				KaleoTaskAssignmentPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoTaskAssignmentPersistence, KaleoTaskAssignmentPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoTaskAssignmentPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskInstanceTokenUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskInstanceTokenUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoTaskInstanceToken;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -1035,14 +1034,6 @@ public class KaleoTaskInstanceTokenUtil {
 	public void setPersistence(KaleoTaskInstanceTokenPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoTaskInstanceTokenPersistence, KaleoTaskInstanceTokenPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoTaskInstanceTokenUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoTaskInstanceTokenPersistence, KaleoTaskInstanceTokenPersistence>(bundle.getBundleContext(),
-				KaleoTaskInstanceTokenPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoTaskInstanceTokenPersistence, KaleoTaskInstanceTokenPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoTaskInstanceTokenPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTaskUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoTask;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -656,14 +655,6 @@ public class KaleoTaskUtil {
 	public void setPersistence(KaleoTaskPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoTaskPersistence, KaleoTaskPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoTaskUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoTaskPersistence, KaleoTaskPersistence>(bundle.getBundleContext(),
-				KaleoTaskPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoTaskPersistence, KaleoTaskPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoTaskPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTimerInstanceTokenUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTimerInstanceTokenUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoTimerInstanceToken;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -915,14 +914,6 @@ public class KaleoTimerInstanceTokenUtil {
 	public void setPersistence(KaleoTimerInstanceTokenPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoTimerInstanceTokenPersistence, KaleoTimerInstanceTokenPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoTimerInstanceTokenUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoTimerInstanceTokenPersistence, KaleoTimerInstanceTokenPersistence>(bundle.getBundleContext(),
-				KaleoTimerInstanceTokenPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoTimerInstanceTokenPersistence, KaleoTimerInstanceTokenPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoTimerInstanceTokenPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTimerUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTimerUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoTimer;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -662,14 +661,6 @@ public class KaleoTimerUtil {
 	public void setPersistence(KaleoTimerPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoTimerPersistence, KaleoTimerPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoTimerUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoTimerPersistence, KaleoTimerPersistence>(bundle.getBundleContext(),
-				KaleoTimerPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoTimerPersistence, KaleoTimerPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoTimerPersistence.class);
 }

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTransitionUtil.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/service/persistence/KaleoTransitionUtil.java
@@ -16,13 +16,12 @@ package com.liferay.portal.workflow.kaleo.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.osgi.util.ServiceTrackerFactory;
+
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.model.KaleoTransition;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import org.osgi.util.tracker.ServiceTracker;
 
@@ -897,14 +896,6 @@ public class KaleoTransitionUtil {
 	public void setPersistence(KaleoTransitionPersistence persistence) {
 	}
 
-	private static ServiceTracker<KaleoTransitionPersistence, KaleoTransitionPersistence> _serviceTracker;
-
-	static {
-		Bundle bundle = FrameworkUtil.getBundle(KaleoTransitionUtil.class);
-
-		_serviceTracker = new ServiceTracker<KaleoTransitionPersistence, KaleoTransitionPersistence>(bundle.getBundleContext(),
-				KaleoTransitionPersistence.class, null);
-
-		_serviceTracker.open();
-	}
+	private static ServiceTracker<KaleoTransitionPersistence, KaleoTransitionPersistence> _serviceTracker =
+		ServiceTrackerFactory.open(KaleoTransitionPersistence.class);
 }

--- a/modules/settings.gradle
+++ b/modules/settings.gradle
@@ -98,6 +98,7 @@ FileTree fileTree = fileTree(rootDir) {
 		include "portal-store/*/build.gradle"
 		include "portal/*/build.gradle"
 		include "util/ip-geocoder/build.gradle"
+		include "util/osgi-util/build.gradle"
 		include "util/pmd/build.gradle"
 		include "util/portal-tools-sample-sql-builder/build.gradle"
 		include "util/sass-compiler-jni/build.gradle"

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_util.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_util.ftl
@@ -4,6 +4,9 @@ import ${packagePath}.model.${entity.name};
 
 import aQute.bnd.annotation.ProviderType;
 
+<#if osgiModule>
+import com.liferay.osgi.util.ServiceTrackerFactory;
+</#if>
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.bean.PortletBeanLocatorUtil;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
@@ -181,15 +184,8 @@ public class ${entity.name}Util {
 	}
 
 	<#if osgiModule>
-		private static ServiceTracker<${entity.name}Persistence, ${entity.name}Persistence> _serviceTracker;
-
-		static {
-			Bundle bundle = FrameworkUtil.getBundle(${entity.name}Util.class);
-
-			_serviceTracker = new ServiceTracker<${entity.name}Persistence, ${entity.name}Persistence>(bundle.getBundleContext(), ${entity.name}Persistence.class, null);
-
-			_serviceTracker.open();
-		}
+		private static ServiceTracker<${entity.name}Persistence, ${entity.name}Persistence> _serviceTracker =
+			ServiceTrackerFactory.open(${entity.name}Persistence.class);
 	<#else>
 		private static ${entity.name}Persistence _persistence;
 	</#if>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_util.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_util.ftl
@@ -2,6 +2,9 @@ package ${packagePath}.service;
 
 import aQute.bnd.annotation.ProviderType;
 
+<#if osgiModule>
+import com.liferay.osgi.util.ServiceTrackerFactory;
+</#if>
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.bean.PortletBeanLocatorUtil;
 import com.liferay.portal.kernel.util.ReferenceRegistry;
@@ -158,15 +161,8 @@ public class ${entity.name}${sessionTypeName}ServiceUtil {
 	}
 
 	<#if osgiModule>
-		private static ServiceTracker<${entity.name}${sessionTypeName}Service, ${entity.name}${sessionTypeName}Service> _serviceTracker;
-
-		static {
-			Bundle bundle = FrameworkUtil.getBundle(${entity.name}${sessionTypeName}ServiceUtil.class);
-
-			_serviceTracker = new ServiceTracker<${entity.name}${sessionTypeName}Service, ${entity.name}${sessionTypeName}Service>(bundle.getBundleContext(), ${entity.name}${sessionTypeName}Service.class, null);
-
-			_serviceTracker.open();
-		}
+		private static ServiceTracker<${entity.name}${sessionTypeName}Service, ${entity.name}${sessionTypeName}Service> _serviceTracker =
+			ServiceTrackerFactory.open(${entity.name}${sessionTypeName}Service.class);
 	<#else>
 		private static ${entity.name}${sessionTypeName}Service _service;
 	</#if>


### PR DESCRIPTION
@brianchandotcom The problem was that `osgi-util` doesn't get deployed by default, and so it failed to find the required package at runtime.

The tests still fail because when running service builder, it is regenerating the *Util classes using the old templates, not the ones in 24fa29d. Not sure how to fix that so that we get a clean build.
