### PR TITLE
LPS-61051 Set bind address only when bindInetAddress is not null. bin…

### DIFF
--- a/modules/portal/portal-cluster/src/main/java/com/liferay/portal/cluster/internal/jgroups/JGroupsClusterChannel.java
+++ b/modules/portal/portal-cluster/src/main/java/com/liferay/portal/cluster/internal/jgroups/JGroupsClusterChannel.java
@@ -61,11 +61,13 @@ public class JGroupsClusterChannel implements ClusterChannel {
 		try {
 			_jChannel = new JChannel(channelProperties);
 
-			ProtocolStack protocolStack = _jChannel.getProtocolStack();
+			if (bindInetAddress != null) {
+				ProtocolStack protocolStack = _jChannel.getProtocolStack();
 
-			TP tp = protocolStack.getTransport();
+				TP tp = protocolStack.getTransport();
 
-			tp.setBindAddress(bindInetAddress);
+				tp.setBindAddress(bindInetAddress);
+			}
 
 			_jChannel.setReceiver(new JGroupsReceiver(clusterReceiver));
 


### PR DESCRIPTION
…dInetAddress can be null when "cluster.link.autodetect.address" is disabled or fail to resolve address
