### PR TITLE
LPS-61112 NetworkError: 404 Not Found when navigating to assigned users for a user group in the card view

### DIFF
--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/user_search_columns.jspf
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/user_search_columns.jspf
@@ -40,13 +40,14 @@
 		%>
 
 		<liferay-ui:search-container-column-text>
-			<liferay-frontend:vertical-card
+			<liferay-frontend:user-vertical-card
 				actionJspServletContext="<%= application %>"
 				cssClass="entry-display-style"
 				resultRow="<%= row %>"
 				rowChecker="<%= rowChecker %>"
 				subtitle="<%= user2.getScreenName() %>"
 				title="<%= user2.getFullName() %>"
+				userId="<%= user2.getUserId() %>"
 			/>
 		</liferay-ui:search-container-column-text>
 	</c:when>


### PR DESCRIPTION
This is an update for [LPS-61112](https://issues.liferay.com/browse/LPS-61112).<br><br>/cc @pei-jung @jorgeferrer @natecavanaugh @alee8888

@juliocamarero: it looks like if no `imageURL` attribute is given to a `liferay-frontend:vertical-card` taglib, this error will be thrown because the [img src is null](https://github.com/liferay/liferay-portal/blob/master/modules/frontend/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card/page.jsp#L23).  We could either make it a required attribute or check for null in the markup.  Thoughts?
