### PR TITLE
LPS-57933 prep next

### DIFF
--- a/modules/util/alloy-taglib/bnd.bnd
+++ b/modules/util/alloy-taglib/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Alloy Taglib
 Bundle-SymbolicName: com.liferay.alloy.taglib
-Bundle-Version: 1.1.5
+Bundle-Version: 1.1.6
 Include-Resource: @../../../lib/development/alloy-taglib.jar


### PR DESCRIPTION
Hi!

Can you please publish the new version of `modules/util/alloy-taglib`? I'm updating `build-module.gradle` to work when used on a separate repository, and I need to change [this line](https://github.com/liferay/liferay-portal/blob/master/modules/build-module.gradle#L128) so I can use an artifact dependency instead of a relative path.

Thank you! :blush: 
