### PR TITLE
LPS-61184 Allow MVCRenderCommand to render the response

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/portlet/bridges/mvc/MVCPortlet.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/bridges/mvc/MVCPortlet.java
@@ -276,6 +276,10 @@ public class MVCPortlet extends LiferayPortlet {
 					renderRequest, renderResponse);
 			}
 
+			if (mvcPath == MVCRenderCommand.DONT_DISPATCH_PATH) {
+				return;
+			}
+
 			renderRequest.setAttribute(
 				getMVCPathAttributeName(renderResponse.getNamespace()),
 				mvcPath);

--- a/portal-service/src/com/liferay/portal/kernel/portlet/bridges/mvc/MVCRenderCommand.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/bridges/mvc/MVCRenderCommand.java
@@ -72,6 +72,9 @@ import javax.portlet.RenderResponse;
  */
 public interface MVCRenderCommand extends MVCCommand {
 
+	public static final String DONT_DISPATCH_PATH =
+		MVCRenderCommand.class.getName() + "#DONT_DISPATCH_PATH";
+
 	public static final MVCRenderCommand EMPTY = new MVCRenderCommand() {
 
 		@Override


### PR DESCRIPTION
Hi Brian,

MVCRenderCommand must currently return a valid JSP file name that will be rendered by MVCPortlet. 

Thus it's not possible to generate any response inside MVCRenderCommand on it's own, MVCPortlet always tries to append some JSP output.

With this enhancement, when MVCRenderCommand returns the constant, MVCPortlet won't use request dispatcher to render any further JSP and so MVCRenderCommand can generate own content, include own JSP from a different servlet context.
