### PR TITLE
LPS-60963 Configuration icon shouldn't be displayed by the portlet placed on the shared layout, no matter whether the form is published or not

### DIFF
--- a/modules/addons/layout-type-controller/layout-type-controller-shared-portlet/src/main/java/com/liferay/layout/type/controller/shared/portlet/controller/SharedPortletLayoutTypeController.java
+++ b/modules/addons/layout-type-controller/layout-type-controller-shared-portlet/src/main/java/com/liferay/layout/type/controller/shared/portlet/controller/SharedPortletLayoutTypeController.java
@@ -52,7 +52,7 @@ public class SharedPortletLayoutTypeController
 
 	@Override
 	public boolean isBrowsable() {
-		return true;
+		return false;
 	}
 
 	@Override
@@ -62,7 +62,7 @@ public class SharedPortletLayoutTypeController
 
 	@Override
 	public boolean isFullPageDisplayable() {
-		return true;
+		return false;
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
@@ -180,20 +180,7 @@ public class DDLFormAdminDisplayContext {
 		return portletURL;
 	}
 
-	public DDLRecordSet getRecordSet() throws PortalException {
-		if (_recordSet != null) {
-			return _recordSet;
-		}
-
-		long recordSetId = ParamUtil.getLong(_renderRequest, "recordSetId");
-
-		_recordSet = DDLRecordSetLocalServiceUtil.fetchDDLRecordSet(
-			recordSetId);
-
-		return _recordSet;
-	}
-
-	public String getRecordSetLayoutURL() throws PortalException {
+	public String getPublishedFormURL() throws PortalException {
 		if (_recordSet == null) {
 			return StringPool.BLANK;
 		}
@@ -213,6 +200,19 @@ public class DDLFormAdminDisplayContext {
 		sb.append(_recordSet.getRecordSetId());
 
 		return sb.toString();
+	}
+
+	public DDLRecordSet getRecordSet() throws PortalException {
+		if (_recordSet != null) {
+			return _recordSet;
+		}
+
+		long recordSetId = ParamUtil.getLong(_renderRequest, "recordSetId");
+
+		_recordSet = DDLRecordSetLocalServiceUtil.fetchDDLRecordSet(
+			recordSetId);
+
+		return _recordSet;
 	}
 
 	public List<DDLRecordSet> getSearchContainerResults(

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
@@ -59,7 +59,6 @@ import com.liferay.portal.kernel.workflow.WorkflowEngineManagerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.model.Group;
-import com.liferay.portal.model.GroupConstants;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
@@ -185,7 +184,7 @@ public class DDLFormAdminDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		StringBundler sb = new StringBundler(6);
+		StringBundler sb = new StringBundler(4);
 
 		ThemeDisplay themeDisplay =
 			_ddlFormAdminRequestHelper.getThemeDisplay();
@@ -194,9 +193,7 @@ public class DDLFormAdminDisplayContext {
 
 		sb.append(themeDisplay.getPortalURL());
 		sb.append(group.getPathFriendlyURL(false, themeDisplay));
-		sb.append(GroupConstants.FORMS_FRIENDLY_URL);
-		sb.append("/shared");
-		sb.append("/-/form/");
+		sb.append("/forms/shared/-/form/");
 		sb.append(_recordSet.getRecordSetId());
 
 		return sb.toString();

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormAdminDisplayContext.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.workflow.WorkflowEngineManagerUtil;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.model.Group;
+import com.liferay.portal.model.GroupConstants;
 import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
@@ -197,7 +198,7 @@ public class DDLFormAdminDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(6);
 
 		ThemeDisplay themeDisplay =
 			_ddlFormAdminRequestHelper.getThemeDisplay();
@@ -206,9 +207,10 @@ public class DDLFormAdminDisplayContext {
 
 		sb.append(themeDisplay.getPortalURL());
 		sb.append(group.getPathFriendlyURL(false, themeDisplay));
-		sb.append(group.getFriendlyURL());
+		sb.append(GroupConstants.FORMS_FRIENDLY_URL);
 		sb.append("/shared");
-		sb.append(String.format("/-/form/%d", _recordSet.getRecordSetId()));
+		sb.append("/-/form/");
+		sb.append(_recordSet.getRecordSetId());
 
 		return sb.toString();
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormDisplayContext.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/display/context/DDLFormDisplayContext.java
@@ -95,7 +95,7 @@ public class DDLFormDisplayContext {
 			return _showConfigurationIcon;
 		}
 
-		if (isSharedURL() && isPublished() && isFormShared()) {
+		if (isSharedURL() && isFormShared()) {
 			_showConfigurationIcon = false;
 
 			return _showConfigurationIcon;

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/resources/META-INF/resources/admin/edit_record_set.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-form-web/src/main/resources/META-INF/resources/admin/edit_record_set.jsp
@@ -103,7 +103,7 @@ renderResponse.setTitle((recordSet == null) ? LanguageUtil.get(request, "new-for
 					</button>
 
 					<liferay-util:buffer var="publishedLink">
-						<a href="<%= ddlFormAdminDisplayContext.getRecordSetLayoutURL() %>" target="_blank"><%= ddlFormAdminDisplayContext.getRecordSetLayoutURL() %></a>
+						<a href="<%= ddlFormAdminDisplayContext.getPublishedFormURL() %>" target="_blank"><%= ddlFormAdminDisplayContext.getPublishedFormURL() %></a>
 						<span class="icon-external-link"></span>
 					</liferay-util:buffer>
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/events/AddDefaultSharedFormLayoutAction.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/events/AddDefaultSharedFormLayoutAction.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Leonardo Barros
  */
 @Component(immediate = true)
-public class AddDefaultSharedPortletLayoutAction extends SimpleAction {
+public class AddDefaultSharedFormLayoutAction extends SimpleAction {
 
 	@Override
 	public void run(String[] ids) throws ActionException {

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/events/AddDefaultSharedFormLayoutAction.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/events/AddDefaultSharedFormLayoutAction.java
@@ -87,7 +87,7 @@ public class AddDefaultSharedFormLayoutAction extends SimpleAction {
 			defaultUserId, GroupConstants.DEFAULT_PARENT_GROUP_ID, null, 0,
 			GroupConstants.DEFAULT_LIVE_GROUP_ID, nameMap, null,
 			GroupConstants.TYPE_SITE_PRIVATE, true,
-			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION, "/forms", true,
+			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION, "/forms", false,
 			false, true, new ServiceContext());
 	}
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/events/AddDefaultSharedFormLayoutAction.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/events/AddDefaultSharedFormLayoutAction.java
@@ -122,12 +122,12 @@ public class AddDefaultSharedFormLayoutAction extends SimpleAction {
 			group = addFormsGroup(companyId);
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
-			group.getGroupId(), false, "/shared");
-
-		if (layout == null) {
-			addSharedLayout(companyId, group.getGroupId());
-		}
+//		Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+//			group.getGroupId(), false, "/shared");
+//
+//		if (layout == null) {
+//			addSharedLayout(companyId, group.getGroupId());
+//		}
 	}
 
 	@Reference(unbind = "-")

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -308,7 +308,8 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		if (className.equals(Group.class.getName())) {
 			if (!site && (liveGroupId == 0) &&
-				!groupKey.equals(GroupConstants.CONTROL_PANEL)) {
+				(!(groupKey.equals(GroupConstants.CONTROL_PANEL) ||
+				   groupKey.equals("Forms")))) {
 
 				throw new IllegalArgumentException();
 			}

--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
@@ -208,13 +207,6 @@ public class LayoutsTreeUtil {
 				_paginateLayouts(
 					request, groupId, privateLayout, parentLayoutId, layouts,
 					treeId)) {
-
-			boolean hide = GetterUtil.getBoolean(
-				layout.getTypeSettingsProperty("hide"));
-
-			if (hide) {
-				continue;
-			}
 
 			LayoutTreeNode layoutTreeNode = new LayoutTreeNode(layout);
 

--- a/portal-service/src/com/liferay/portal/model/GroupConstants.java
+++ b/portal-service/src/com/liferay/portal/model/GroupConstants.java
@@ -33,6 +33,10 @@ public class GroupConstants {
 
 	public static final long DEFAULT_PARENT_GROUP_ID = 0;
 
+	public static final String FORMS = "Forms";
+
+	public static final String FORMS_FRIENDLY_URL = "/forms";
+
 	public static final String GLOBAL = "Global";
 
 	public static final String GLOBAL_FRIENDLY_URL = "/global";

--- a/portal-service/src/com/liferay/portal/model/GroupConstants.java
+++ b/portal-service/src/com/liferay/portal/model/GroupConstants.java
@@ -33,10 +33,6 @@ public class GroupConstants {
 
 	public static final long DEFAULT_PARENT_GROUP_ID = 0;
 
-	public static final String FORMS = "Forms";
-
-	public static final String FORMS_FRIENDLY_URL = "/forms";
-
 	public static final String GLOBAL = "Global";
 
 	public static final String GLOBAL_FRIENDLY_URL = "/global";


### PR DESCRIPTION
@danielkocsis, I think there's no need to skip the shared layout during staging after this change. We're scoping the shared layout into a different group.

cc @juliocamarero
