### PR TITLE
LRQA-20452 Remove print-thread-dump daemon from gradle-execute.

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -876,13 +876,6 @@ Please set the environment variable ANT_OPTS to the recommended value of
 				<isset property="env.JENKINS_HOME" />
 				<then>
 					<parallel>
-						<daemons>
-							<sequential>
-								<sleep hours="1" />
-
-								<print-thread-dump jps.name="GradleWrapperMain" />
-							</sequential>
-						</daemons>
 						<exec dir="@{dir}" executable="${project.dir}/gradlew${gradlew.suffix}" failonerror="@{failonerror}">
 							<args />
 							<arg value="--no-daemon" />


### PR DESCRIPTION
The print-thread-dump daemon does not automatically halt when the gradle-execute macrodef is completed so there is a daemon being spawned for each call to gradle-execute. Andrea agrees that this daemon is not really needed anymore so we can remove it.
