### PR TITLE
LPS-58975 Fix translation issues when displayed in Asset Publisher

### DIFF
--- a/modules/addons/layout-type-controller/layout-type-controller-full-page-application/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/addons/layout-type-controller/layout-type-controller-full-page-application/src/main/resources/META-INF/resources/init.jsp
@@ -22,7 +22,6 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.template.StringTemplateResource" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.UnicodeProperties" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
@@ -33,7 +32,6 @@ page import="com.liferay.portal.model.LayoutTemplateConstants" %><%@
 page import="com.liferay.portal.model.Portlet" %><%@
 page import="com.liferay.portal.service.LayoutTemplateLocalServiceUtil" %>
 
-<%@ page import="java.util.List" %><%@
-page import="java.util.ResourceBundle" %>
+<%@ page import="java.util.List" %>
 
 <liferay-theme:defineObjects />

--- a/modules/addons/layout-type-controller/layout-type-controller-full-page-application/src/main/resources/META-INF/resources/layout/edit/full_page_application.jsp
+++ b/modules/addons/layout-type-controller/layout-type-controller-full-page-application/src/main/resources/META-INF/resources/layout/edit/full_page_application.jsp
@@ -21,8 +21,6 @@ String selectedPortletId = StringPool.BLANK;
 if (selLayout != null) {
 	selectedPortletId = GetterUtil.getString(selLayout.getTypeSettingsProperty("fullPageApplicationPortlet"));
 }
-
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", themeDisplay.getLocale(), getClass());
 %>
 
 <aui:select label='<%= LanguageUtil.get(resourceBundle, "full-page-application") %>' name="TypeSettingsProperties--fullPageApplicationPortlet--" showEmptyOption="<%= true %>">

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/resources/META-INF/resources/custom_user_attributes.jsp
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/resources/META-INF/resources/custom_user_attributes.jsp
@@ -21,10 +21,7 @@
 
 <%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.GetterUtil" %>
-<%@ page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.StringPool" %>
-
-<%@ page import="java.util.ResourceBundle" %>
 
 <portlet:defineObjects />
 
@@ -32,8 +29,6 @@
 
 <%
 String customUserAttributes = GetterUtil.getString(portletPreferences.getValue("customUserAttributes", StringPool.BLANK));
-
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
 %>
 
 <aui:input helpMessage='<%= LanguageUtil.get(resourceBundle, "custom-user-attributes-help") %>' label='<%= LanguageUtil.get(resourceBundle, "displayed-assets-must-match-these-custom-user-profile-attributes") %>' name="preferences--customUserAttributes--" value="<%= customUserAttributes %>" />

--- a/modules/apps/blogs/blogs-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/blogs/blogs-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -37,19 +37,13 @@ page import="com.liferay.portal.kernel.search.SearchContextFactory" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.OrderByComparator" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowConstants" %><%@
 page import="com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil" %><%@
 page import="com.liferay.portlet.documentlibrary.util.DLUtil" %>
 
 <%@ page import="java.util.ArrayList" %><%@
-page import="java.util.List" %><%@
-page import="java.util.ResourceBundle" %>
+page import="java.util.List" %>
 
 <portlet:defineObjects />
 
 <liferay-theme:defineObjects/>
-
-<%
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
-%>

--- a/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/view_category.jsp
+++ b/modules/apps/control-menu/control-menu-web/src/main/resources/META-INF/resources/view_category.jsp
@@ -64,9 +64,9 @@ for (String portletId : portletIds) {
 		if (portletApp.isWARFile() && Validator.isNull(externalPortletCategory)) {
 			PortletConfig curPortletConfig = PortletConfigFactoryUtil.create(portlet, application);
 
-			ResourceBundle resourceBundle = curPortletConfig.getResourceBundle(locale);
+			ResourceBundle portletResourceBundle = curPortletConfig.getResourceBundle(locale);
 
-			externalPortletCategory = ResourceBundleUtil.getString(resourceBundle, portletCategory.getName());
+			externalPortletCategory = ResourceBundleUtil.getString(portletResourceBundle, portletCategory.getName());
 		}
 	}
 }

--- a/modules/apps/document-library/document-library-google-docs/src/main/resources/META-INF/resources/portal_settings/google_apps.jsp
+++ b/modules/apps/document-library/document-library-google-docs/src/main/resources/META-INF/resources/portal_settings/google_apps.jsp
@@ -23,8 +23,6 @@ PortletPreferences companyPortletPreferences = PrefsPropsUtil.getPreferences(com
 
 String googleAppsAPIKey = PrefsParamUtil.getString(companyPortletPreferences, request, "googleAppsAPIKey");
 String googleClientId = PrefsParamUtil.getString(companyPortletPreferences, request, "googleClientId");
-
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
 %>
 
 <aui:fieldset>

--- a/modules/apps/document-library/document-library-google-docs/src/main/resources/META-INF/resources/portal_settings/init.jsp
+++ b/modules/apps/document-library/document-library-google-docs/src/main/resources/META-INF/resources/portal_settings/init.jsp
@@ -25,8 +25,6 @@ page import="com.liferay.portal.kernel.util.PrefsPropsUtil" %><%@
 page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portlet.PortletURLUtil" %>
 
-<%@ page import="java.util.ResourceBundle" %>
-
 <%@ page import="javax.portlet.PortletPreferences" %><%@
 page import="javax.portlet.PortletURL" %>
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -199,7 +199,7 @@ if (portletTitleBasedNavigation) {
 							}
 							%>
 
-							<liferay-ui:icon iconCssClass="icon-plus" label="<%= true %>" message='<%= LanguageUtil.format(request, "uploaded-by-x-x", new Object[] {displayURL, HtmlUtil.escape(fileEntry.getUserName()), dateFormatDateTime.format(fileEntry.getCreateDate())}, false) %>' />
+							<liferay-ui:icon iconCssClass="icon-plus" label="<%= true %>" message='<%= LanguageUtil.format(resourceBundle, "uploaded-by-x-x", new Object[] {displayURL, HtmlUtil.escape(fileEntry.getUserName()), dateFormatDateTime.format(fileEntry.getCreateDate())}, false) %>' />
 						</span>
 
 						<c:if test="<%= dlPortletInstanceSettings.isEnableRatings() && fileEntry.isSupportsSocial() %>">
@@ -307,7 +307,7 @@ if (portletTitleBasedNavigation) {
 								<liferay-ui:icon
 									iconCssClass="icon-download"
 									label="<%= true %>"
-									message='<%= LanguageUtil.get(request, "download") + " (" + TextFormatter.formatStorageSize(fileVersion.getSize(), locale) + ")" %>'
+									message='<%= LanguageUtil.get(resourceBundle, "download") + " (" + TextFormatter.formatStorageSize(fileVersion.getSize(), locale) + ")" %>'
 									url="<%= DLUtil.getDownloadURL(fileEntry, fileVersion, themeDisplay, StringPool.BLANK) %>"
 								/>
 							</span>
@@ -322,7 +322,7 @@ if (portletTitleBasedNavigation) {
 									<liferay-ui:icon
 										iconCssClass="<%= DLUtil.getFileIconCssClass(conversion) %>"
 										label="<%= true %>"
-										message='<%= LanguageUtil.get(request, "download") + " (" + TextFormatter.formatStorageSize(fileVersion.getSize(), locale) + ")" %>'
+										message='<%= LanguageUtil.get(resourceBundle, "download") + " (" + TextFormatter.formatStorageSize(fileVersion.getSize(), locale) + ")" %>'
 										method="get"
 										url="<%= DLUtil.getDownloadURL(fileEntry, fileVersion, themeDisplay, StringPool.BLANK) %>"
 									/>
@@ -356,10 +356,10 @@ if (portletTitleBasedNavigation) {
 									String webDavHelpMessage = null;
 
 									if (BrowserSnifferUtil.isWindows(request)) {
-										webDavHelpMessage = LanguageUtil.format(request, "webdav-windows-help", new Object[] {"http://www.microsoft.com/downloads/details.aspx?FamilyId=17C36612-632E-4C04-9382-987622ED1D64", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV"}, false);
+										webDavHelpMessage = LanguageUtil.format(resourceBundle, "webdav-windows-help", new Object[] {"http://www.microsoft.com/downloads/details.aspx?FamilyId=17C36612-632E-4C04-9382-987622ED1D64", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV"}, false);
 									}
 									else {
-										webDavHelpMessage = LanguageUtil.format(request, "webdav-help", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV", false);
+										webDavHelpMessage = LanguageUtil.format(resourceBundle, "webdav-help", "http://www.liferay.com/web/guest/community/wiki/-/wiki/Main/WebDAV", false);
 									}
 									%>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_display.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/edit_template_display.jspf
@@ -49,7 +49,7 @@ if (Validator.isNotNull(scriptContent)) {
 								clazz = templateHandler.getClass();
 							}
 
-							ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, clazz);
+							ResourceBundle templateHandlerResourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, clazz);
 
 							for (TemplateVariableGroup templateVariableGroup : templateVariableGroups.values()) {
 								if (templateVariableGroup.isEmpty()) {
@@ -57,7 +57,7 @@ if (Validator.isNotNull(scriptContent)) {
 								}
 							%>
 
-								<liferay-ui:panel collapsible="<%= true %>" cssClass="palette-section" extended="<%= false %>" id="<%= templateVariableGroup.getLabel() %>" title="<%= LanguageUtil.get(request, resourceBundle, templateVariableGroup.getLabel()) %>">
+								<liferay-ui:panel collapsible="<%= true %>" cssClass="palette-section" extended="<%= false %>" id="<%= templateVariableGroup.getLabel() %>" title="<%= LanguageUtil.get(request, templateHandlerResourceBundle, templateVariableGroup.getLabel()) %>">
 									<ul class="palette-item-content">
 
 										<%
@@ -65,8 +65,8 @@ if (Validator.isNotNull(scriptContent)) {
 										%>
 
 											<li class="palette-item-container">
-												<span class="palette-item" data-content="<%= HtmlUtil.escapeAttribute(_getDataContent(templateVariableDefinition, language)) %>" data-title="<%= HtmlUtil.escapeAttribute(_getPaletteItemTitle(request, resourceBundle, templateVariableDefinition)) %>">
-													<%= HtmlUtil.escape(LanguageUtil.get(request, resourceBundle, templateVariableDefinition.getLabel())) %>
+												<span class="palette-item" data-content="<%= HtmlUtil.escapeAttribute(_getDataContent(templateVariableDefinition, language)) %>" data-title="<%= HtmlUtil.escapeAttribute(_getPaletteItemTitle(request, templateHandlerResourceBundle, templateVariableDefinition)) %>">
+													<%= HtmlUtil.escape(LanguageUtil.get(request, templateHandlerResourceBundle, templateVariableDefinition.getLabel())) %>
 
 													<c:if test="<%= templateVariableDefinition.isCollection() || templateVariableDefinition.isRepeatable() %>">*</c:if>
 												</span>

--- a/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-url-web/src/main/resources/META-INF/resources/init.jsp
@@ -21,15 +21,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.item.selector.url.web.ItemSelectorURLView" %><%@
 page import="com.liferay.item.selector.url.web.display.context.ItemSelectorURLViewDisplayContext" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %>
-
-<%@ page import="java.util.ResourceBundle" %>
+page import="com.liferay.portal.kernel.language.LanguageUtil" %>
 
 <portlet:defineObjects />
 
 <liferay-theme:defineObjects/>
-
-<%
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content/Language", locale, getClass());
-%>

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -32,14 +32,12 @@ page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.HttpUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portlet.PortletURLUtil" %>
 
-<%@ page import="java.util.List" %><%@
-page import="java.util.ResourceBundle" %>
+<%@ page import="java.util.List" %>
 
 <%@ page import="javax.portlet.PortletURL" %>
 

--- a/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/item-selector/item-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -34,11 +34,6 @@ List<String> titles = localizedItemSelectorRendering.getTitles();
 		%>
 
 		<div class="alert alert-info">
-
-			<%
-			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content/Language", locale, getClass());
-			%>
-
 			<%= LanguageUtil.get(resourceBundle, "selection-is-not-available") %>
 		</div>
 	</c:when>

--- a/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/resources/META-INF/resources/conversions.jsp
+++ b/modules/apps/journal/journal-content-asset-addon-entry/journal-content-asset-addon-entry-conversions/src/main/resources/META-INF/resources/conversions.jsp
@@ -26,12 +26,9 @@
 <%@ page import="com.liferay.portal.kernel.util.Constants" %>
 <%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.ParamUtil" %>
-<%@ page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.StringUtil" %>
 <%@ page import="com.liferay.portal.kernel.util.WebKeys" %>
 <%@ page import="com.liferay.portlet.documentlibrary.util.DLUtil" %>
-
-<%@ page import="java.util.ResourceBundle" %>
 
 <portlet:defineObjects />
 
@@ -42,8 +39,6 @@ JournalArticleDisplay articleDisplay = (JournalArticleDisplay)request.getAttribu
 
 String extension = (String)request.getAttribute("extension");
 String viewMode = ParamUtil.getString(request, "viewMode");
-
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
 %>
 
 <c:if test="<%= !viewMode.equals(Constants.PRINT) %>">

--- a/modules/apps/journal/journal-terms-of-use/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-terms-of-use/src/main/resources/META-INF/resources/configuration.jsp
@@ -19,8 +19,6 @@
 <%
 long termsOfUseGroupId = PrefsPropsUtil.getLong(themeDisplay.getCompanyId(), JournalServiceConfigurationKeys.TERMS_OF_USE_JOURNAL_ARTICLE_GROUP_ID, JournalServiceConfigurationValues.TERMS_OF_USE_JOURNAL_ARTICLE_GROUP_ID);
 String termsOfUseArticleId = PrefsPropsUtil.getString(themeDisplay.getCompanyId(), JournalServiceConfigurationKeys.TERMS_OF_USE_JOURNAL_ARTICLE_ID, JournalServiceConfigurationValues.TERMS_OF_USE_JOURNAL_ARTICLE_ID);
-
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", themeDisplay.getLocale(), getClass());
 %>
 
 <aui:field-wrapper helpMessage='<%= LanguageUtil.get(resourceBundle, "terms-of-use-web-content-help") %>' label='<%= LanguageUtil.get(resourceBundle, "terms-of-use-web-content") %>'>

--- a/modules/apps/journal/journal-terms-of-use/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-terms-of-use/src/main/resources/META-INF/resources/init.jsp
@@ -27,10 +27,7 @@ page import="com.liferay.journal.model.JournalArticle" %><%@
 page import="com.liferay.journal.service.JournalArticleLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.PrefsPropsUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portlet.asset.model.AssetRenderer" %>
-
-<%@ page import="java.util.ResourceBundle" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -179,14 +179,14 @@ renderResponse.setTitle(LanguageUtil.get(request, "add-new-page"));
 						continue;
 					}
 
-					ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, layoutTypeController.getClass());
+					ResourceBundle layoutTypeResourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, layoutTypeController.getClass());
 				%>
 
-					<aui:nav-item data-search='<%= LanguageUtil.get(request, resourceBundle, "layout.types." + type) %>'>
+					<aui:nav-item data-search='<%= LanguageUtil.get(request, layoutTypeResourceBundle, "layout.types." + type) %>'>
 						<div class="lfr-page-template-title toggler-header toggler-header-collapsed" data-type="<%= type %>">
-							<aui:input disabled="<%= (layoutsCount == 0) && !layoutTypeController.isFirstPageable() %>" id='<%= "addLayoutSelectedPageTemplate" + type %>' label='<%= LanguageUtil.get(request, resourceBundle, "layout.types." + type) %>' name="selectedPageTemplate" type="radio" />
+							<aui:input disabled="<%= (layoutsCount == 0) && !layoutTypeController.isFirstPageable() %>" id='<%= "addLayoutSelectedPageTemplate" + type %>' label='<%= LanguageUtil.get(request, layoutTypeResourceBundle, "layout.types." + type) %>' name="selectedPageTemplate" type="radio" />
 
-							<%= LanguageUtil.get(request, resourceBundle, "layout.types." + type + ".description") %>
+							<%= LanguageUtil.get(request, layoutTypeResourceBundle, "layout.types." + type + ".description") %>
 						</div>
 
 						<div class="lfr-page-template-options toggler-content toggler-content-collapsed">

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
@@ -160,10 +160,10 @@ StringBuilder friendlyURLBase = new StringBuilder();
 				continue;
 			}
 
-			ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, layoutTypeController.getClass());
+			ResourceBundle layoutTypeResourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, layoutTypeController.getClass());
 		%>
 
-			<aui:option disabled="<%= selLayout.isFirstParent() && !layoutTypeController.isFirstPageable() %>" label='<%= LanguageUtil.get(request, resourceBundle, "layout.types." + type) %>' selected="<%= selLayout.getType().equals(type) %>" value="<%= type %>" />
+			<aui:option disabled="<%= selLayout.isFirstParent() && !layoutTypeController.isFirstPageable() %>" label='<%= LanguageUtil.get(request, layoutTypeResourceBundle, "layout.types." + type) %>' selected="<%= selLayout.getType().equals(type) %>" value="<%= type %>" />
 
 		<%
 			}

--- a/modules/apps/mentions/mentions-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/mentions/mentions-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,18 +24,11 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.mentions.web.constants.MentionsPortletKeys" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portlet.social.util.SocialInteractionsConfiguration" %><%@
 page import="com.liferay.portlet.social.util.SocialInteractionsConfigurationUtil" %>
-
-<%@ page import="java.util.ResourceBundle" %>
 
 <portlet:defineObjects />
 
 <liferay-theme:defineObjects />
 
 <%@ include file="/init-ext.jsp" %>
-
-<%
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
-%>

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/init.jsp
@@ -22,10 +22,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %>
-
-<%@ page import="java.util.ResourceBundle" %>
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
 
 <portlet:defineObjects />
 

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -16,10 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<%
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", themeDisplay.getLocale(), getClass());
-%>
-
 <div id="<portlet:namespace />simulationDeviceContainer">
 	<aui:button cssClass="close" name="closeSimulationPanel" value="&times;" />
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -29,7 +29,6 @@ page import="com.liferay.application.list.constants.ApplicationListWebKeys" %><%
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringPool" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
@@ -48,8 +47,7 @@ page import="com.liferay.taglib.aui.AUIUtil" %>
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.HashMap" %><%@
 page import="java.util.List" %><%@
-page import="java.util.Map" %><%@
-page import="java.util.ResourceBundle" %>
+page import="java.util.Map" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@
 page import="javax.portlet.PortletURL" %>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -20,8 +20,6 @@
 PanelCategory panelCategory = (PanelCategory)request.getAttribute(ApplicationListWebKeys.PANEL_CATEGORY);
 
 SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDisplayContext = new SiteAdministrationPanelCategoryDisplayContext(liferayPortletRequest, liferayPortletResponse, null);
-
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
 %>
 
 <c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getGroup() != null %>">

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -20,8 +20,6 @@
 SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDisplayContext = new SiteAdministrationPanelCategoryDisplayContext(liferayPortletRequest, liferayPortletResponse, null);
 
 PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getPanelCategory();
-
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
 %>
 
 <aui:a cssClass="icon-sites" href="javascript:;" id="manageSitesLink" title='<%= LanguageUtil.get(resourceBundle, "go-to-other-site") %>'>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/init.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/init.jsp
@@ -34,7 +34,6 @@ page import="com.liferay.portal.kernel.search.SearchContextFactory" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.OrderByComparator" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.ResourceBundleUtil" %><%@
 page import="com.liferay.portal.portletfilerepository.PortletFileRepositoryUtil" %><%@
 page import="com.liferay.portlet.documentlibrary.model.DLFolderConstants" %><%@
 page import="com.liferay.portlet.documentlibrary.util.DLUtil" %><%@
@@ -44,13 +43,8 @@ page import="com.liferay.wiki.web.item.selector.view.WikiAttachmentItemSelectorV
 page import="com.liferay.wiki.web.item.selector.view.display.context.WikiAttachmentItemSelectorViewDisplayContext" %>
 
 <%@ page import="java.util.ArrayList" %><%@
-page import="java.util.List" %><%@
-page import="java.util.ResourceBundle" %>
+page import="java.util.List" %>
 
 <portlet:defineObjects />
 
 <liferay-theme:defineObjects />
-
-<%
-ResourceBundle resourceBundle = ResourceBundleUtil.getBundle("content.Language", locale, getClass());
-%>

--- a/portal-web/docroot/html/portal/layout/view/view_category.jsp
+++ b/portal-web/docroot/html/portal/layout/view/view_category.jsp
@@ -40,9 +40,9 @@ for (String portletId : portletIds) {
 		if (portletApp.isWARFile() && Validator.isNull(externalPortletCategory)) {
 			PortletConfig curPortletConfig = PortletConfigFactoryUtil.create(portlet, application);
 
-			ResourceBundle resourceBundle = curPortletConfig.getResourceBundle(locale);
+			ResourceBundle portletResourceBundle = curPortletConfig.getResourceBundle(locale);
 
-			externalPortletCategory = ResourceBundleUtil.getString(resourceBundle, portletCategory.getName());
+			externalPortletCategory = ResourceBundleUtil.getString(portletResourceBundle, portletCategory.getName());
 		}
 	}
 }

--- a/util-taglib/src/com/liferay/taglib/aui/ATag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ATag.java
@@ -22,10 +22,12 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.aui.base.BaseATag;
 import com.liferay.taglib.util.InlineUtil;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.io.IOException;
 
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletResponse;
 
@@ -46,10 +48,14 @@ public class ATag extends BaseATag {
 
 		if (Validator.isNotNull(getHref())) {
 			if (AUIUtil.isOpensNewWindow(getTarget())) {
+				ResourceBundle resourceBundle =
+					TagResourceBundleUtil.getResourceBundle(pageContext);
+
 				jspWriter.write(StringPool.SPACE);
 				jspWriter.write("<span class=\"icon-external-link\"></span>");
 				jspWriter.write("<span class=\"sr-only\">");
-				jspWriter.write(LanguageUtil.get(request, "opens-new-window"));
+				jspWriter.write(
+					LanguageUtil.get(resourceBundle, "opens-new-window"));
 				jspWriter.write("</span>");
 			}
 
@@ -131,14 +137,18 @@ public class ATag extends BaseATag {
 		if (Validator.isNotNull(title) ||
 			AUIUtil.isOpensNewWindow(getTarget())) {
 
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
 			jspWriter.write("title=\"");
 
 			if (Validator.isNotNull(title)) {
-				jspWriter.write(LanguageUtil.get(request, title));
+				jspWriter.write(LanguageUtil.get(resourceBundle, title));
 			}
 
 			if (AUIUtil.isOpensNewWindow(getTarget())) {
-				jspWriter.write(LanguageUtil.get(request, "opens-new-window"));
+				jspWriter.write(
+					LanguageUtil.get(resourceBundle, "opens-new-window"));
 			}
 
 			jspWriter.write("\" ");
@@ -154,7 +164,10 @@ public class ATag extends BaseATag {
 
 		if (Validator.isNotNull(label)) {
 			if (localizeLabel) {
-				jspWriter.write(LanguageUtil.get(request, label));
+				ResourceBundle resourceBundle =
+					TagResourceBundleUtil.getResourceBundle(pageContext);
+
+				jspWriter.write(LanguageUtil.get(resourceBundle, label));
 			}
 			else {
 				jspWriter.write(label);

--- a/util-taglib/src/com/liferay/taglib/aui/NavItemTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/NavItemTag.java
@@ -17,6 +17,9 @@ package com.liferay.taglib.aui;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.taglib.aui.base.BaseNavItemTag;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -49,7 +52,11 @@ public class NavItemTag extends BaseNavItemTag implements BodyTag {
 				title = StringPool.BLANK;
 			}
 
-			title = title.concat(LanguageUtil.get(request, "opens-new-window"));
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
+			title = title.concat(
+				LanguageUtil.get(resourceBundle, "opens-new-window"));
 
 			setNamespacedAttribute(request, "title", String.valueOf(title));
 		}

--- a/util-taglib/src/com/liferay/taglib/aui/NavTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/NavTag.java
@@ -28,6 +28,9 @@ import com.liferay.portal.model.User;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.taglib.aui.base.BaseNavTag;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletResponse;
 
@@ -93,8 +96,11 @@ public class NavTag extends BaseNavTag implements BodyTag {
 				try {
 					User user = themeDisplay.getUser();
 
+					ResourceBundle resourceBundle =
+						TagResourceBundleUtil.getResourceBundle(pageContext);
+
 					sb.append("<img alt=\"");
-					sb.append(LanguageUtil.get(request, "my-account"));
+					sb.append(LanguageUtil.get(resourceBundle, "my-account"));
 					sb.append("\" class=\"user-avatar-image\" ");
 					sb.append("src=\"");
 					sb.append(user.getPortraitURL(themeDisplay));

--- a/util-taglib/src/com/liferay/taglib/theme/DefineObjectsTag.java
+++ b/util-taglib/src/com/liferay/taglib/theme/DefineObjectsTag.java
@@ -16,6 +16,7 @@ package com.liferay.taglib.theme;
 
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.tagext.TagSupport;
@@ -68,6 +69,10 @@ public class DefineObjectsTag extends TagSupport {
 		pageContext.setAttribute("themeDisplay", themeDisplay);
 		pageContext.setAttribute("timeZone", themeDisplay.getTimeZone());
 		pageContext.setAttribute("user", themeDisplay.getUser());
+		pageContext.setAttribute(
+			"resourceBundle",
+			TagResourceBundleUtil.getResourceBundle(
+				pageContext, themeDisplay.getLocale()));
 
 		// Deprecated
 

--- a/util-taglib/src/com/liferay/taglib/theme/DefineObjectsTei.java
+++ b/util-taglib/src/com/liferay/taglib/theme/DefineObjectsTei.java
@@ -28,6 +28,7 @@ import com.liferay.portal.theme.ThemeDisplay;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.ResourceBundle;
 import java.util.TimeZone;
 
 import javax.servlet.jsp.tagext.TagData;
@@ -83,6 +84,9 @@ public class DefineObjectsTei extends TagExtraInfo {
 			VariableInfo.AT_END),
 		new VariableInfo(
 			"portletDisplay", PortletDisplay.class.getName(), true,
+			VariableInfo.AT_END),
+		new VariableInfo(
+			"resourceBundle", ResourceBundle.class.getName(), true,
 			VariableInfo.AT_END),
 
 		// Deprecated

--- a/util-taglib/src/com/liferay/taglib/ui/IconDeactivateTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconDeactivateTag.java
@@ -19,6 +19,9 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.taglib.FileAvailabilityUtil;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 /**
  * @author Brian Wing Shun Chan
@@ -45,12 +48,15 @@ public class IconDeactivateTag extends IconTag {
 				HttpUtil.encodeURL(url)).concat("');");
 		}
 
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
 		StringBundler sb = new StringBundler(5);
 
 		sb.append("javascript:if (confirm('");
 		sb.append(
 			UnicodeLanguageUtil.get(
-				request, "are-you-sure-you-want-to-deactivate-this"));
+				resourceBundle, "are-you-sure-you-want-to-deactivate-this"));
 		sb.append("')) { ");
 		sb.append(url);
 		sb.append(" } else { self.focus(); }");

--- a/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
@@ -22,6 +22,9 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.FileAvailabilityUtil;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 /**
  * @author Brian Wing Shun Chan
@@ -85,13 +88,18 @@ public class IconDeleteTag extends IconTag {
 
 			sb.append("javascript:if (confirm('");
 
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
 			if (Validator.isNotNull(_confirmation)) {
-				sb.append(UnicodeLanguageUtil.get(request, _confirmation));
+				sb.append(
+					UnicodeLanguageUtil.get(resourceBundle, _confirmation));
 			}
 			else {
 				String confirmation = "are-you-sure-you-want-to-delete-this";
 
-				sb.append(UnicodeLanguageUtil.get(request, confirmation));
+				sb.append(
+					UnicodeLanguageUtil.get(resourceBundle, confirmation));
 			}
 
 			sb.append("')) { ");

--- a/util-taglib/src/com/liferay/taglib/ui/IconHelpTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconHelpTag.java
@@ -19,6 +19,9 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.taglib.FileAvailabilityUtil;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.servlet.jsp.JspWriter;
 
@@ -43,6 +46,9 @@ public class IconHelpTag extends IconTag {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
 		JspWriter jspWriter = pageContext.getOut();
 
 		String id = StringUtil.randomId();
@@ -62,7 +68,7 @@ public class IconHelpTag extends IconTag {
 		jspWriter.write("id=\"");
 		jspWriter.write(id);
 		jspWriter.write("\" >");
-		jspWriter.write(LanguageUtil.get(request, getMessage()));
+		jspWriter.write(LanguageUtil.get(resourceBundle, getMessage()));
 		jspWriter.write("</span></span>");
 
 		return EVAL_PAGE;

--- a/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
@@ -31,6 +31,9 @@ import com.liferay.taglib.BaseBodyTagSupport;
 import com.liferay.taglib.FileAvailabilityUtil;
 import com.liferay.taglib.aui.ScriptTag;
 import com.liferay.taglib.util.PortalIncludeUtil;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -333,8 +336,11 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 
 					String message = _message;
 
+					ResourceBundle resourceBundle =
+						TagResourceBundleUtil.getResourceBundle(pageContext);
+
 					if (_localizeMessage) {
-						message = LanguageUtil.get(request, _message);
+						message = LanguageUtil.get(resourceBundle, _message);
 					}
 
 					jspWriter.write("\" href=\"javascript:;\" id=\"");
@@ -455,8 +461,11 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 
 		String message = _message;
 
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
 		if (_localizeMessage) {
-			message = LanguageUtil.get(request, _message);
+			message = LanguageUtil.get(resourceBundle, _message);
 		}
 
 		request.setAttribute("liferay-ui:icon-menu:message", message);

--- a/util-taglib/src/com/liferay/taglib/ui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconTag.java
@@ -35,12 +35,14 @@ import com.liferay.portal.model.Theme;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
 import com.liferay.taglib.util.IncludeTag;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletResponse;
 
@@ -192,8 +194,11 @@ public class IconTag extends IncludeTag {
 		if (_useDialog && Validator.isNull(data.get("title"))) {
 			String message = getProcessedMessage();
 
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
 			if (_localizeMessage) {
-				message = LanguageUtil.get(request, message);
+				message = LanguageUtil.get(resourceBundle, message);
 			}
 
 			data.put("title", HtmlUtil.stripHtml(message));
@@ -206,10 +211,13 @@ public class IconTag extends IncludeTag {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
 		String details = null;
 
 		if (_alt != null) {
-			details = " alt=\"" + LanguageUtil.get(request, _alt) + "\"";
+			details = " alt=\"" + LanguageUtil.get(resourceBundle, _alt) + "\"";
 		}
 		else if (isLabel()) {
 			details = " alt=\"\"";
@@ -218,18 +226,20 @@ public class IconTag extends IncludeTag {
 			StringBundler sb = new StringBundler(6);
 
 			sb.append(" alt=\"");
-			sb.append(LanguageUtil.get(request, getProcessedMessage()));
+			sb.append(LanguageUtil.get(resourceBundle, getProcessedMessage()));
 			sb.append("\"");
 
 			if (_toolTip) {
 				sb.append(" onmouseover=\"Liferay.Portal.ToolTip.show(this, '");
 				sb.append(
-					UnicodeLanguageUtil.get(request, getProcessedMessage()));
+					UnicodeLanguageUtil.get(
+						resourceBundle, getProcessedMessage()));
 				sb.append("')\"");
 			}
 			else {
 				sb.append(" title=\"");
-				sb.append(LanguageUtil.get(request, getProcessedMessage()));
+				sb.append(
+					LanguageUtil.get(resourceBundle, getProcessedMessage()));
 				sb.append("\"");
 			}
 

--- a/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
@@ -38,12 +38,14 @@ import com.liferay.registry.collections.ServiceTrackerCollections;
 import com.liferay.registry.collections.ServiceTrackerMap;
 import com.liferay.taglib.aui.AUIUtil;
 import com.liferay.taglib.util.IncludeTag;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.io.IOException;
 
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -387,8 +389,12 @@ public class InputEditorTag extends IncludeTag {
 		request.setAttribute(
 			"liferay-ui:input-editor:onInitMethod", _onInitMethod);
 
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
 		if (Validator.isNull(_placeholder)) {
-			_placeholder = LanguageUtil.get(request, "write-your-content-here");
+			_placeholder = LanguageUtil.get(
+				resourceBundle, "write-your-content-here");
 		}
 
 		request.setAttribute(

--- a/util-taglib/src/com/liferay/taglib/ui/InputSearchTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputSearchTag.java
@@ -18,6 +18,9 @@ import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.BaseValidatorTagSupport;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -98,10 +101,13 @@ public class InputSearchTag extends BaseValidatorTagSupport {
 
 	@Override
 	protected void setAttributes(HttpServletRequest request) {
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
 		String buttonLabel = _buttonLabel;
 
 		if (Validator.isNull(buttonLabel)) {
-			buttonLabel = LanguageUtil.get(request, "search");
+			buttonLabel = LanguageUtil.get(resourceBundle, "search");
 		}
 
 		String cssClass = _cssClass;
@@ -125,7 +131,7 @@ public class InputSearchTag extends BaseValidatorTagSupport {
 		String title = _title;
 
 		if (title == null) {
-			title = LanguageUtil.get(request, "search");
+			title = LanguageUtil.get(resourceBundle, "search");
 		}
 
 		request.setAttribute(

--- a/util-taglib/src/com/liferay/taglib/ui/MessageTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/MessageTag.java
@@ -22,6 +22,9 @@ import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -41,6 +44,9 @@ public class MessageTag extends TagSupport {
 			HttpServletRequest request =
 				(HttpServletRequest)pageContext.getRequest();
 
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
 			boolean unicode = GetterUtil.getBoolean(
 				request.getAttribute(WebKeys.JAVASCRIPT_CONTEXT));
 
@@ -53,27 +59,28 @@ public class MessageTag extends TagSupport {
 					value = _key;
 				}
 				else if (_escape) {
-					value = HtmlUtil.escape(LanguageUtil.get(request, _key));
+					value = HtmlUtil.escape(
+						LanguageUtil.get(resourceBundle, _key));
 				}
 				else if (_escapeAttribute) {
 					value = HtmlUtil.escapeAttribute(
-						LanguageUtil.get(request, _key));
+						LanguageUtil.get(resourceBundle, _key));
 				}
 				else if (_unicode) {
-					value = UnicodeLanguageUtil.get(request, _key);
+					value = UnicodeLanguageUtil.get(resourceBundle, _key);
 				}
 				else {
-					value = LanguageUtil.get(request, _key);
+					value = LanguageUtil.get(resourceBundle, _key);
 				}
 			}
 			else {
 				if (_unicode) {
 					value = UnicodeLanguageUtil.format(
-						request, _key, _arguments, _translateArguments);
+						resourceBundle, _key, _arguments, _translateArguments);
 				}
 				else {
 					value = LanguageUtil.format(
-						request, _key, _arguments, _translateArguments);
+						resourceBundle, _key, _arguments, _translateArguments);
 				}
 			}
 

--- a/util-taglib/src/com/liferay/taglib/ui/QuickAccessEntryTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/QuickAccessEntryTag.java
@@ -20,9 +20,11 @@ import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.BaseBodyTagSupport;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -51,7 +53,10 @@ public class QuickAccessEntryTag extends BaseBodyTagSupport implements BodyTag {
 	}
 
 	public void setLabel(String label) {
-		_label = LanguageUtil.get(getRequest(), label);
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
+		_label = LanguageUtil.get(resourceBundle, label);
 	}
 
 	public void setOnClick(String onClick) {

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerColumnButtonTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerColumnButtonTag.java
@@ -20,8 +20,10 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.taglib.search.ButtonSearchEntry;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.util.List;
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletURL;
 
@@ -49,13 +51,17 @@ public class SearchContainerColumnButtonTag<R>
 				index = searchEntries.size();
 			}
 
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
 			ButtonSearchEntry buttonSearchEntry = new ButtonSearchEntry();
 
 			buttonSearchEntry.setAlign(getAlign());
 			buttonSearchEntry.setColspan(getColspan());
 			buttonSearchEntry.setCssClass(getCssClass());
 			buttonSearchEntry.setHref(String.valueOf(getHref()));
-			buttonSearchEntry.setName(LanguageUtil.get(request, getName()));
+			buttonSearchEntry.setName(
+				LanguageUtil.get(resourceBundle, getName()));
 			buttonSearchEntry.setValign(getValign());
 
 			resultRow.addSearchEntry(index, buttonSearchEntry);

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerColumnTextTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerColumnTextTag.java
@@ -22,9 +22,11 @@ import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.search.TextSearchEntry;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletURL;
 
@@ -71,7 +73,10 @@ public class SearchContainerColumnTextTag<R>
 			}
 
 			if (_translate) {
-				_value = LanguageUtil.get(request, _value);
+				ResourceBundle resourceBundle =
+					TagResourceBundleUtil.getResourceBundle(pageContext);
+
+				_value = LanguageUtil.get(resourceBundle, _value);
 			}
 
 			if (index <= -1) {

--- a/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
@@ -28,6 +28,9 @@ import com.liferay.portal.service.UserLocalServiceUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.taglib.util.IncludeTag;
 import com.liferay.taglib.util.LexiconUtil;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -77,7 +80,10 @@ public class UserPortraitTag extends IncludeTag {
 		String userName = _userName;
 
 		if (Validator.isNull(userName)) {
-			userName = LanguageUtil.get(request, "user");
+			ResourceBundle resourceBundle =
+				TagResourceBundleUtil.getResourceBundle(pageContext);
+
+			userName = LanguageUtil.get(resourceBundle, "user");
 		}
 
 		String[] userNames = StringUtil.split(userName, StringPool.SPACE);

--- a/util-taglib/src/com/liferay/taglib/ui/display/context/InputAssetLinksDisplayContext.java
+++ b/util-taglib/src/com/liferay/taglib/ui/display/context/InputAssetLinksDisplayContext.java
@@ -44,12 +44,14 @@ import com.liferay.portlet.asset.service.AssetEntryLocalServiceUtil;
 import com.liferay.portlet.asset.service.AssetEntryServiceUtil;
 import com.liferay.portlet.asset.service.AssetLinkLocalServiceUtil;
 import com.liferay.portlet.asset.util.comparator.AssetRendererFactoryTypeNameComparator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletMode;
 import javax.portlet.PortletRequest;
@@ -270,11 +272,12 @@ public class InputAssetLinksDisplayContext {
 		String typeName = assetRendererFactory.getTypeName(
 			_themeDisplay.getLocale());
 
-		HttpServletRequest request =
-			(HttpServletRequest)_pageContext.getRequest();
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			_pageContext);
 
 		selectorEntryData.put(
-			"title", LanguageUtil.format(request, "select-x", typeName, false));
+			"title",
+			LanguageUtil.format(resourceBundle, "select-x", typeName, false));
 
 		selectorEntryData.put("type", assetRendererFactory.getClassName());
 
@@ -387,12 +390,12 @@ public class InputAssetLinksDisplayContext {
 
 		selectorEntryData.put("href", portletURL.toString());
 
-		HttpServletRequest request =
-			(HttpServletRequest)_pageContext.getRequest();
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			_pageContext);
 
 		selectorEntryData.put(
 			"title", LanguageUtil.format(
-				request, "select-x", classType.getName(), false));
+				resourceBundle, "select-x", classType.getName(), false));
 		selectorEntryData.put("type", classType.getName());
 
 		return selectorEntryData;

--- a/util-taglib/src/com/liferay/taglib/util/TagResourceBundleUtil.java
+++ b/util-taglib/src/com/liferay/taglib/util/TagResourceBundleUtil.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.taglib.util;
+
+import com.liferay.portal.kernel.util.AggregateResourceBundle;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.util.PortalUtil;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+import javax.portlet.PortletConfig;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.PageContext;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class TagResourceBundleUtil {
+
+	public static ResourceBundle getResourceBundle(PageContext pageContext) {
+		ResourceBundle resourceBundle =
+			(ResourceBundle)pageContext.getAttribute("resourceBundle");
+
+		if (resourceBundle != null) {
+			return resourceBundle;
+		}
+
+		HttpServletRequest request =
+			(HttpServletRequest)pageContext.getRequest();
+
+		Locale locale = PortalUtil.getLocale(request);
+
+		return getResourceBundle(pageContext, locale);
+	}
+
+	public static ResourceBundle getResourceBundle(
+		PageContext pageContext, Locale locale) {
+
+		ResourceBundle pageResourceBundle = getPageResourceBundle(
+			pageContext, locale);
+
+		HttpServletRequest request =
+			(HttpServletRequest)pageContext.getRequest();
+
+		ResourceBundle portletResourceBundle = getPortletResourceBundle(
+			request, locale);
+
+		ResourceBundle portalResourceBundle = PortalUtil.getResourceBundle(
+			locale);
+
+		return new AggregateResourceBundle(
+			pageResourceBundle, portletResourceBundle, portalResourceBundle);
+	}
+
+	protected static ResourceBundle getPageResourceBundle(
+		PageContext pageContext, Locale locale) {
+
+		try {
+			Object page = pageContext.getPage();
+
+			return ResourceBundleUtil.getBundle(
+				"content.Language", locale, page.getClass());
+		}
+		catch (MissingResourceException mre) {
+			return _emptyResourceBundle;
+		}
+	}
+
+	protected static ResourceBundle getPortletResourceBundle(
+		HttpServletRequest request, Locale locale) {
+
+		PortletConfig portletConfig = (PortletConfig)request.getAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG);
+
+		if (portletConfig != null) {
+			return portletConfig.getResourceBundle(locale);
+		}
+
+		return _emptyResourceBundle;
+	}
+
+	private static final ResourceBundle _emptyResourceBundle =
+		new EmptyResourceBundle();
+
+	private static class EmptyResourceBundle extends ResourceBundle {
+
+		@Override
+		public boolean containsKey(String key) {
+			return false;
+		}
+
+		@Override
+		public Enumeration<String> getKeys() {
+			return Collections.emptyEnumeration();
+		}
+
+		@Override
+		protected Object handleGetObject(String key) {
+			return null;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Hey @brianchandotcom

This is the same PR I sent to @peterfellwock the other day fixing the resource bundle issues. There are a couple of things about this fix that worry me, though.
## No way to override our defaults

By convention, we're looking up the "content.Language" resource bundle in the JSP classloader. While this will work for us, I think we should provide a way for developers to override this, as not everyone
developing on top of Liferay may use our conventions.

I think we should provide a new `liferay-util:resource-bundle` tag or another alternative (maybe an additional attribute to `defineObjects`?) so that people can use resource bundles on different locations.
## Sometimes the wrong resource bundle gets used

The `TagResourceBundleUtil` class will create an aggregate resource bundle composed of the page resourceBundle, the portlet one (if any), and finally the portal one.

The problem is that this is not always the right decission. There are three different cases here:
1. When the page is rendered by the portlet, the page and portlet resource bundle will usually be the same, so when looking up a non existant key in the aggregate, it will try twice in the same resource bundle.
2. When a portlet includes a JSP from another bundle (e.g. Asset Publisher does this) and the key is not found in the JSP, it will look for it in the portlet, but in this case it shouldn't. We're basically leaking resource bundles when portlets include external JSPs.

While these issues are not that important, it doesn't feel completely right. Sadly, the only easy solution to this that I can see is to let JSPs define explicitly the resource bundle they want to use.
## Need to always pass the resource bundle instead of the request when calling LanguageUtil

Finally, for JSPs to render correctly even when they're included from a different bundle, we may need to stop using the `LanguageUtil` methods that use the request, passing the resourceBundle to it instead.

We should at least do this for the ones that get included by Asset Publisher, but for consistency (and if the issues I described in the first point are not that important) we should change other calls also.

Any thoughts?

Thanks!
