### PR TITLE
LPS-55475 Due to the new UserTestUtil.addUser(Company) addition in fd…

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -889,7 +889,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		// Groups
 
-		if (groupIds != null) {
+		if (!ArrayUtil.isEmpty(groupIds)) {
 			List<Group> groups = new ArrayList<>();
 
 			for (long groupId : groupIds) {

--- a/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
@@ -82,7 +82,7 @@ public class OrganizationTestUtil {
 			long parentOrganizationId, String name, boolean site)
 		throws Exception {
 
-		User user = UserTestUtil.addUser(null);
+		User user = UserTestUtil.addUser();
 
 		return OrganizationLocalServiceUtil.addOrganization(
 			user.getUserId(), parentOrganizationId, name, site);


### PR DESCRIPTION
…db87ad416390dc2a7e337c403160bc4a5b1a00, UserTestUtil.addUser(null) can match both UserTestUtil.addUser(Company) and UserTestUtil.addUser(long...), this breaks compile on JDK8. This change allows UserLocalServiceImpl.addUserWithWorkflow() taking in empty groupIds array, so the OrganizationTestUtil can just pass in an empty groupIds array rather than a null one.

CC @tomwang2011 @cgoncas
