### PR TITLE
LRQA-20598 Add null check when looking for the childReport result JSONObject.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsPerformanceDataUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsPerformanceDataUtil.java
@@ -232,7 +232,9 @@ public class JenkinsPerformanceDataUtil {
 			JSONObject childJSONObject = childReportJSONObject.getJSONObject(
 				"child");
 
-			if (!childReportJSONObject.has("result")) {
+			if (!childReportJSONObject.has("result") ||
+				childReportJSONObject.isNull("result")) {
+
 				throw new IllegalArgumentException(
 					"Result is not available for " +
 						childJSONObject.getString("url"));


### PR DESCRIPTION
It appears that when the result object is not found, it is because the result object is there but set to null and getJSONObject throws the "result" is not a JSONObject error when its value is null.
