### PR TITLE
LPS-61671 Hack into Sun javac to let BundleJavaFileManager directly r…

### DIFF
--- a/portal-impl/src/system.properties
+++ b/portal-impl/src/system.properties
@@ -377,3 +377,8 @@
         sun.reflect.annotation.AnnotationInvocationHandler
 
     com.liferay.portal.kernel.security.SecureRandomUtil.buffer.size=65536
+
+##
+## Sun Javac
+##
+    sun.javac.hack.enabled=true


### PR DESCRIPTION
…eturns the ZipFileIndexFileObject's simple name to avoid the complex full class name construction. This is working because, in side Sun Javac even it is asking the JavaFileManager for full class name, it is only to strip off the package name to only use the simple name, so it is better to avoid the heavy ZipFileIndexFileObject full class name construction to directly return what it is needed.

CC @rotty3000 @mhan810
