### PR TITLE
LRQA-20765 Added more JSON error checking.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsPerformanceDataUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsPerformanceDataUtil.java
@@ -246,6 +246,12 @@ public class JenkinsPerformanceDataUtil {
 			JSONObject childReportJSONObject =
 				childReportsJSONArray.getJSONObject(i);
 
+			if (!childReportJSONObject.has("child") ||
+				childReportJSONObject.isNull("child")) {
+
+				throw new IllegalArgumentException("Child is not available.");
+			}
+
 			JSONObject childJSONObject = childReportJSONObject.getJSONObject(
 				"child");
 


### PR DESCRIPTION
It has been observed that the timing issue that was originally thought to be limited to the "results" JSONObject actually includes the "child" JSONObject as well.
