### PR TITLE
LPS-61742 As LCS Developer and License Manager developer I need License manager message type enum to support json string decoding - not message bus message

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/license/messaging/LicenseManagerMessageType.java
+++ b/portal-service/src/com/liferay/portal/kernel/license/messaging/LicenseManagerMessageType.java
@@ -31,13 +31,21 @@ public enum LicenseManagerMessageType {
 	public static String MESSAGE_BUS_DESTINATION_STATUS = "liferay/lcs_status";
 
 	public static JSONObject getMessagePayload(Message message) {
-		if (!(message.getPayload() instanceof String)) {
-			return null;
+		return getMessagePayload(message.getPayload());
+	}
+
+	public static JSONObject getMessagePayload(Object object) {
+		if (object instanceof String) {
+			return getMessagePayload((String)object);
 		}
 
+		return null;
+	}
+
+	public static JSONObject getMessagePayload(String jsonString) {
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-				(String)message.getPayload());
+				jsonString);
 
 			valueOf(jsonObject);
 
@@ -46,14 +54,6 @@ public enum LicenseManagerMessageType {
 		catch (Exception e) {
 			return null;
 		}
-	}
-
-	public static JSONObject getMessagePayload(Object object) {
-		if (!(object instanceof Message)) {
-			return null;
-		}
-
-		return getMessagePayload((Message)object);
 	}
 
 	public static LicenseManagerMessageType valueOf(JSONObject jsonObject) {


### PR DESCRIPTION
Hi Brian, here is enum update we need to easier handle synchronous messages between license manager and LCS Portlet. If you could backport it to (ee-)6.2 based branches I would be very thankful :) Thank you very much. @amosfong and @mhan810 this should be all we need in portal core to achieve planed use cases.
