### PR TITLE
Lps 61758

### DIFF
--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
@@ -14,7 +14,12 @@
 
 package com.liferay.portal.servlet.jsp.compiler;
 
+import com.liferay.portal.kernel.servlet.ServletContextPool;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.servlet.jsp.compiler.internal.JspBundleClassloader;
+import com.liferay.portal.util.PortalUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -173,6 +178,21 @@ public class JspServlet extends HttpServlet {
 		defaults.put("httpMethods", "GET,POST,HEAD");
 		defaults.put("keepgenerated", "false");
 		defaults.put("logVerbosityLevel", "NONE");
+
+		StringBundler sb = new StringBundler(5);
+
+		ServletContext portalServletContext = ServletContextPool.get(
+			PortalUtil.getServletContextName());
+
+		sb.append(
+			portalServletContext.getAttribute(
+				JavaConstants.JAVAX_SERVLET_CONTEXT_TEMPDIR));
+		sb.append(StringPool.SLASH);
+		sb.append(_bundle.getSymbolicName());
+		sb.append(StringPool.DASH);
+		sb.append(_bundle.getVersion());
+
+		defaults.put("scratchdir", sb.toString());
 
 		Enumeration<String> names = servletConfig.getInitParameterNames();
 		Set<String> nameSet = new HashSet<>(Collections.list(names));

--- a/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
+++ b/modules/portal/portal-servlet-jsp-compiler/src/main/java/com/liferay/portal/servlet/jsp/compiler/JspServlet.java
@@ -178,6 +178,7 @@ public class JspServlet extends HttpServlet {
 		defaults.put("httpMethods", "GET,POST,HEAD");
 		defaults.put("keepgenerated", "false");
 		defaults.put("logVerbosityLevel", "NONE");
+		defaults.put("saveBytecode", "true");
 
 		StringBundler sb = new StringBundler(5);
 


### PR DESCRIPTION
All optimizations is in master now, @tomwang2011 will run a performance comparing test to show the total performance improvements.

This is the 2nd part of the jsp compiler improvement. With this pull, on all appservers, portal-servlet-jsp-compiler can dump out the generated classes file into file system and reuse them after server reboot. So as long as the administrator does not wipe out the "working" folder, every jsp file will only be compiled once.

CC @rotty3000 @mhan810
