### PR TITLE
Lps 61258

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -72,6 +72,7 @@ import com.liferay.portlet.PortletURLImpl;
 import java.io.IOException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -402,8 +403,6 @@ public class LayoutImpl extends LayoutBaseImpl {
 
 	@Override
 	public List<Portlet> getEmbeddedPortlets(long groupId) {
-		List<Portlet> portlets = new ArrayList<>();
-
 		List<PortletPreferences> portletPreferences =
 			PortletPreferencesLocalServiceUtil.getPortletPreferences(
 				groupId, PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
@@ -427,6 +426,12 @@ public class LayoutImpl extends LayoutBaseImpl {
 						PortletKeys.PREFS_OWNER_TYPE_USER, getPlid()));
 			}
 		}
+
+		if (portletPreferences.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		List<Portlet> portlets = new ArrayList<>(portletPreferences.size());
 
 		for (PortletPreferences portletPreference : portletPreferences) {
 			String portletId = portletPreference.getPortletId();

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -806,21 +806,15 @@ public class LayoutTypePortletImpl
 
 	@Override
 	public boolean isPortletEmbedded(String portletId) {
-		Layout layout = getLayout();
+		List<Portlet> embeddedPortlets = getEmbeddedPortlets();
 
-		Portlet portlet = PortletLocalServiceUtil.getPortletById(
-			layout.getCompanyId(), portletId);
-
-		long scopeGroupId = PortalUtil.getScopeGroupId(layout, portletId);
-
-		if (PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
-				scopeGroupId, PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-				PortletKeys.PREFS_PLID_SHARED, portlet, false) < 1) {
-
-			return false;
+		for (Portlet embeddedPortlet : embeddedPortlets) {
+			if (portletId.equals(embeddedPortlet.getPortletId())) {
+				return true;
+			}
 		}
 
-		return true;
+		return false;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -806,9 +806,7 @@ public class LayoutTypePortletImpl
 
 	@Override
 	public boolean isPortletEmbedded(String portletId) {
-		List<Portlet> embeddedPortlets = getEmbeddedPortlets();
-
-		for (Portlet embeddedPortlet : embeddedPortlets) {
+		for (Portlet embeddedPortlet : getEmbeddedPortlets()) {
 			if (portletId.equals(embeddedPortlet.getPortletId())) {
 				return true;
 			}

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutTypePortletImpl.java
@@ -311,9 +311,7 @@ public class LayoutTypePortletImpl
 	public List<Portlet> getEmbeddedPortlets() {
 		Layout layout = getLayout();
 
-		_embeddedPortlets = layout.getEmbeddedPortlets();
-
-		return _embeddedPortlets;
+		return layout.getEmbeddedPortlets();
 	}
 
 	@Override
@@ -1503,7 +1501,6 @@ public class LayoutTypePortletImpl
 			(LayoutTypePortletImpl)LayoutTypePortletFactoryUtil.create(
 				getLayout());
 
-		defaultLayoutTypePortletImpl._embeddedPortlets = _embeddedPortlets;
 		defaultLayoutTypePortletImpl._layoutSetPrototypeLayout =
 			_layoutSetPrototypeLayout;
 		defaultLayoutTypePortletImpl._updatePermission = _updatePermission;
@@ -1908,7 +1905,6 @@ public class LayoutTypePortletImpl
 	private final Format _dateFormat =
 		FastDateFormatFactoryUtil.getSimpleDateFormat(
 			PropsValues.INDEX_DATE_FORMAT_PATTERN);
-	private transient List<Portlet> _embeddedPortlets;
 	private boolean _enablePortletLayoutListener = true;
 	private Layout _layoutSetPrototypeLayout;
 	private PortalPreferences _portalPreferences;


### PR DESCRIPTION
CC @jkappler @juliocamarero this is for the regression caused by LPS-60137

@dantewang @slnn, this pull removes most of the PortletReferences select in login test case, except the one fired from RuntimeTag. Due to the freemarker regression, you probably won't notice much improvement in the overall performance. But check the sql log, you will see the difference. By the time we fix the freemarker issue, we shall see a jump due to the aggregated affects.

@Preston-Crary I believe we can do the same thing for the RuntimeTag usage, just it is on a different execution path, we have to deal with it separately. Let's talk about it tomorrow.
