### PR TITLE
LPS-61937 Remove portlet preference finder calls from RuntimeTag

### DIFF
--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -212,11 +212,10 @@ public class RuntimeTag extends TagSupport {
 
 			boolean writeJSONObject = false;
 
-			if (PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
-					themeDisplay.getScopeGroupId(),
-					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
-					PortletKeys.PREFS_PLID_SHARED, portlet, false) < 1) {
+			LayoutTypePortlet layoutTypePortlet =
+				themeDisplay.getLayoutTypePortlet();
 
+			if (layoutTypePortlet.isPortletEmbedded(portlet.getPortletId())) {
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 					themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
 					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,


### PR DESCRIPTION
@dantewang @slnn performance check please, this should remove the last PortletPreference table query from RuntimeTag
