### PR TITLE
LPS-61953 ProductNavigationUserPersonalBarPortlet should not do anyth…

### DIFF
--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/portlet/ProductNavigationUserPersonalBarPortlet.java
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/java/com/liferay/product/navigation/user/personal/bar/web/portlet/ProductNavigationUserPersonalBarPortlet.java
@@ -20,6 +20,7 @@ import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.model.User;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.product.navigation.user.personal.bar.web.contants.ProductNavigationUserPersonalBarWebKeys;
 
@@ -62,19 +63,25 @@ public class ProductNavigationUserPersonalBarPortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
-		renderRequest.setAttribute(
-			ProductNavigationUserPersonalBarWebKeys.NOTIFICATIONS_COUNT,
-			getNotificationsCount(renderRequest));
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		User user = themeDisplay.getUser();
+
+		if (!user.isDefaultUser()) {
+			renderRequest.setAttribute(
+				ProductNavigationUserPersonalBarWebKeys.NOTIFICATIONS_COUNT,
+				getNotificationsCount(themeDisplay, renderRequest));
+		}
 
 		super.doDispatch(renderRequest, renderResponse);
 	}
 
-	protected int getNotificationsCount(RenderRequest renderRequest) {
+	protected int getNotificationsCount(
+		ThemeDisplay themeDisplay, RenderRequest renderRequest) {
+
 		PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(
 			_panelAppRegistry, _panelCategoryRegistry);
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
 
 		return panelCategoryHelper.getNotificationsCount(
 			PanelCategoryKeys.USER, themeDisplay.getPermissionChecker(),


### PR DESCRIPTION
…ing for guest user, as a guest there is nothing personal.

@juliocamarero this is fixing the performance regression caused by LPS-61388, basically ProductNavigationUserPersonalBarPortlet should not do anything unless the current user has logged in.

@dantewang @slnn as of this pull and https://github.com/brianchandotcom/liferay-portal/pull/34207 for login test, we are once again back to 0 sql after warmup. Please make sure you added sql log into daily monitoring tests to ensure no sql slips in again before the release.

CC @mhan810
