### PR TITLE
LPS-61999 PortletServletSession should use WeakReference to hold up t…

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletServletSession.java
+++ b/portal-impl/src/com/liferay/portlet/PortletServletSession.java
@@ -16,6 +16,9 @@ package com.liferay.portlet;
 
 import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
 
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+
 import javax.servlet.http.HttpSession;
 
 /**
@@ -28,16 +31,21 @@ public class PortletServletSession extends HttpSessionWrapper {
 
 		super(session);
 
-		_portletRequestImpl = portletRequestImpl;
+		_portletRequestImplReference = new WeakReference<>(portletRequestImpl);
 	}
 
 	@Override
 	public void invalidate() {
 		super.invalidate();
 
-		_portletRequestImpl.invalidateSession();
+		PortletRequestImpl portletRequestImpl =
+			_portletRequestImplReference.get();
+
+		if (portletRequestImpl != null) {
+			portletRequestImpl.invalidateSession();
+		}
 	}
 
-	private final PortletRequestImpl _portletRequestImpl;
+	private final Reference<PortletRequestImpl> _portletRequestImplReference;
 
 }


### PR DESCRIPTION
…he PortletRequestImpl

@dantewang @slnn performance check please, this should bring back at least 90% of the memory footprint regression caused by osgi whiteboard. We should expect a very noticeable performance jump.
