### PR TITLE
LPS-61971 Fix of source formatting regression

### DIFF
--- a/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/portlet/action/AssociateFacebookUserMVCRenderCommand.java
+++ b/modules/portal-security/portal-security-sso-facebook-connect/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/portlet/action/AssociateFacebookUserMVCRenderCommand.java
@@ -39,8 +39,9 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
-		"javax.portlet.name=", "javax.portlet.name=" + PortletKeys.LOGIN,
-		"mvc.command.name=/login/associate_facebook_user" + PortletKeys.FAST_LOGIN
+		"javax.portlet.name=" + PortletKeys.FAST_LOGIN,
+		"javax.portlet.name=" + PortletKeys.LOGIN,
+		"mvc.command.name=/login/associate_facebook_user"
 	},
 	service = MVCRenderCommand.class
 )


### PR DESCRIPTION
Hi Brian,

SourceFormatter incorrectly rewrote the javax.portlet.name property of the @Component annotation for AssociateFacebookUserMVCRenderCommand.
Since then SourceFormatter appears to have been fixed so this issue should not re-occur.

https://issues.liferay.com/browse/LPS-61971

Thanks.
