### PR TITLE
LPS-61642 Fixes the count of the total number of nodes

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
@@ -244,7 +244,7 @@ public class LayoutsTreeUtil {
 			layoutTreeNodes.add(layoutTreeNode);
 		}
 
-		return new LayoutTreeNodes(layoutTreeNodes, layoutTreeNodes.size());
+		return new LayoutTreeNodes(layoutTreeNodes, layouts.size());
 	}
 
 	private static int _getLoadedLayoutsCount(


### PR DESCRIPTION
@juliocamarero Turns out the issue was not due to an update on Alloy. It was caused by https://github.com/liferay/liferay-portal/commit/605714fb100e392a8afb191b5a2f2879056e1f2a#diff-40ed300630edef84263e86adf52139b0L247
