### PR TITLE
LPS-61839 Duplicating compile-tomcat in portal-web batch, so that fro…

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1234,6 +1234,8 @@ ${output.content}</echo>
 			<test-action>
 				<database-test-run-test database.type="mysql">
 					<test-action>
+						<ant dir="portal-web" target="compile-tomcat" />
+
 						<run-poshi-validation />
 
 						<if>


### PR DESCRIPTION
…nt end only pull can still have a jspc running.

@brianchandotcom this is duplicating the compile-tomcat in both portal-web and compile-jsp batches. For normal pulls, we will have 2 compile-tomcat running which is wasteful. But since I don't know where is the front end only pull detecting logic, let's do this for now, so that at least we still have one running for front end only pulls.

CC @michaelhashimoto
