### PR TITLE
Revert "LPS-62070 not used?"

### DIFF
--- a/modules/apps/staging/staging-api/build.gradle
+++ b/modules/apps/staging/staging-api/build.gradle
@@ -1,3 +1,9 @@
+configurations {
+	compile {
+		transitive = false
+	}
+}
+
 liferay {
 	deployDir = file("${liferayHome}/osgi/modules")
 }


### PR DESCRIPTION
hey @brianchandotcom we have this in all our modules. we've added it after a conversation with @rotty3000 so we can able to avoid unnecessary transitive dependencies. Currently it's might not be used, but I'd keep it there as a pattern for all modules, to avoid future problems.

What do you think?

cc @akosthurzo
