### PR TITLE
master-qa-21381

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -138,7 +138,7 @@
 		<execute function="SelectFrame" locator1="IFrame#PAGE_VARIATION_IFRAME" />
 		<execute function="AssertClick" locator1="Button#ADD_PAGE_VARIATION" value1="Add Page Variation" />
 		<execute function="Type" locator1="StagingManageVariations#MANAGE_VARIATION" value1="${pageVariationName}" />
-		<execute function="AssertClick" locator1="Button#ADD" value1="Add" />
+		<execute function="AssertClick" locator1="StagingManageVariations#ADD" value1="Add" />
 		<execute function="AssertTextEquals#assertPartialText" locator1="Message#SUCCESS" value1="Page variation was added." />
 
 		<execute function="SelectFrame" value1="relative=top" />
@@ -180,7 +180,7 @@
 			</then>
 		</if>
 
-		<execute function="AssertClick" locator1="Button#ADD" value1="Add" />
+		<execute function="AssertClick" locator1="StagingManageVariations#ADD" value1="Add" />
 		<execute function="AssertTextEquals#assertPartialText" locator1="Message#SUCCESS" value1="Site page variation was added." />
 
 		<execute function="SelectFrame" value1="relative=top" />

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingManageVariations.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/staging/StagingManageVariations.path
@@ -8,6 +8,16 @@
 <tr><td rowspan="1" colspan="3">StagingManageVariations</td></tr>
 </thead>
 <tbody>
+<tr>
+	<td>ADD</td>
+	<td>//button[@type='submit' and contains(.,'Add')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
 <!--SITE_VARIATION-->
 <tr>
 	<td>MANAGE_SITE_PAGES_VARIATIONS_IFRAME</td>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-21381

@brianchandotcom 
This should fix the two add page variation poshi failures happening right now. We can let the PR tester confirm whether or not it worked.

@kmaria
The add button in manage page variations has changed. Rather than try to reuse the generic locator (which right now does not work for it for some reason), I created a separate locator for the manage page variations add button. The generic one right now isn't specific enough, so it's picking up another add button first somewhere on the page.
