### PR TITLE
LPS-62204 Fix test failure: the order matters

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/service/OrganizationLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/OrganizationLocalServiceTest.java
@@ -329,12 +329,11 @@ public class OrganizationLocalServiceTest {
 			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
 			"Organization A", false);
 
-		_organizations.add(organizationA);
-
 		Organization organizationAA = OrganizationTestUtil.addOrganization(
 			organizationA.getOrganizationId(), "Organization AA", false);
 
 		_organizations.add(organizationAA);
+		_organizations.add(organizationA);
 
 		UserLocalServiceUtil.addOrganizationUser(
 			organizationAA.getOrganizationId(), TestPropsValues.getUserId());


### PR DESCRIPTION
Fix failures after @27cd33b955af0a8ee84bce2c5606a1324dbf2cb3

```
Job Results:

6050 Tests Passed.
11 Tests Failed.

    OrganizationLocalServiceTest.testHasUserOrganization2
    OrganizationLocalServiceTest.testAddOrganizationWithSiteToParentOrganizationWithoutSite
    OrganizationLocalServiceTest.testAddOrganizationWithSiteToParentOrganizationWithSite
```
