### PR TITLE
LPS-61099

### DIFF
--- a/modules/apps/unit-converter/build.gradle
+++ b/modules/apps/unit-converter/build.gradle
@@ -1,0 +1,18 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "latest.release"
+	}
+
+	repositories {
+		mavenLocal()
+
+		maven {
+			url "http://cdn.repository.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+subprojects {
+	apply plugin: "com.liferay.defaults.plugin"
+	apply plugin: "com.liferay.plugin"
+}

--- a/modules/apps/unit-converter/settings.gradle
+++ b/modules/apps/unit-converter/settings.gradle
@@ -1,0 +1,7 @@
+rootDir.eachDirMatch({
+	File bndBndFile = new File(it, "bnd.bnd")
+
+	bndBndFile.exists()
+}, {
+	include it.name
+})

--- a/modules/build-buildscript.gradle
+++ b/modules/build-buildscript.gradle
@@ -1,8 +1,8 @@
 dependencies {
-	classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "1.0.95"
-	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.cache", version: "1.0.3"
-	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.gulp", version: "1.0.0"
-	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.maven.plugin.builder", version: "1.0.4"
+	classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "latest.release"
+	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.cache", version: "latest.release"
+	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.gulp", version: "latest.release"
+	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.maven.plugin.builder", version: "latest.release"
 }
 
 repositories {

--- a/modules/build-buildscript.gradle
+++ b/modules/build-buildscript.gradle
@@ -6,11 +6,9 @@ dependencies {
 }
 
 repositories {
-	if (!Boolean.getBoolean("maven.local.ignore")) {
-		mavenLocal()
-	}
+	mavenLocal()
 
 	maven {
-		url System.properties["repository.url"] ?: "http://cdn.repository.liferay.com/nexus/content/groups/public"
+		url "http://cdn.repository.liferay.com/nexus/content/groups/public"
 	}
 }


### PR DESCRIPTION
Hi! :blush:
I came up with this approach for multi-project builds. The `build.gradle` and `settings.gradle` should never change. What do you think?

I used `unit-converter` as an example instead of `osgi-util` because `unit-converter` is already structured as a multi-project build, with one root and one or more sub-directories. A deeper nesting is not necessary, right?
