### PR TITLE
Lps 61952 implementation class name

### DIFF
--- a/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/model/BookmarksEntry.java
+++ b/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/model/BookmarksEntry.java
@@ -16,6 +16,7 @@ package com.liferay.bookmarks.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PermissionedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.bookmarks.model.impl.BookmarksEntryImpl")
 public interface BookmarksEntry extends BookmarksEntryModel, PermissionedModel,
 	TreeModel {
 	/*

--- a/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/model/BookmarksFolder.java
+++ b/modules/apps/bookmarks/bookmarks-api/src/main/java/com/liferay/bookmarks/model/BookmarksFolder.java
@@ -16,6 +16,7 @@ package com.liferay.bookmarks.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PermissionedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.bookmarks.model.impl.BookmarksFolderImpl")
 public interface BookmarksFolder extends BookmarksFolderModel, PermissionedModel,
 	TreeModel {
 	/*

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/Calendar.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/Calendar.java
@@ -16,6 +16,7 @@ package com.liferay.calendar.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PermissionedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PermissionedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.calendar.model.impl.CalendarImpl")
 public interface Calendar extends CalendarModel, PermissionedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBooking.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarBooking.java
@@ -16,6 +16,7 @@ package com.liferay.calendar.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PermissionedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PermissionedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.calendar.model.impl.CalendarBookingImpl")
 public interface CalendarBooking extends CalendarBookingModel, PermissionedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarNotificationTemplate.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarNotificationTemplate.java
@@ -16,6 +16,7 @@ package com.liferay.calendar.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.calendar.model.impl.CalendarNotificationTemplateImpl")
 public interface CalendarNotificationTemplate
 	extends CalendarNotificationTemplateModel, PersistedModel {
 	/*

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarResource.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/model/CalendarResource.java
@@ -16,6 +16,7 @@ package com.liferay.calendar.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PermissionedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PermissionedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.calendar.model.impl.CalendarResourceImpl")
 public interface CalendarResource extends CalendarResourceModel,
 	PermissionedModel {
 	/*

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecord.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecord.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.lists.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.lists.model.impl.DDLRecordImpl")
 public interface DDLRecord extends DDLRecordModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordSet.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordSet.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.lists.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.lists.model.impl.DDLRecordSetImpl")
 public interface DDLRecordSet extends DDLRecordSetModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordVersion.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/model/DDLRecordVersion.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.lists.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.lists.model.impl.DDLRecordVersionImpl")
 public interface DDLRecordVersion extends DDLRecordVersionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMContent.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMContent.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMContentImpl")
 public interface DDMContent extends DDMContentModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMDataProviderInstance.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMDataProviderInstance.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMDataProviderInstanceImpl")
 public interface DDMDataProviderInstance extends DDMDataProviderInstanceModel,
 	PersistedModel {
 	/*

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStorageLink.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStorageLink.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMStorageLinkImpl")
 public interface DDMStorageLink extends DDMStorageLinkModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructure.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructure.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMStructureImpl")
 public interface DDMStructure extends DDMStructureModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLayout.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLayout.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMStructureLayoutImpl")
 public interface DDMStructureLayout extends DDMStructureLayoutModel,
 	PersistedModel {
 	/*

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLink.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureLink.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMStructureLinkImpl")
 public interface DDMStructureLink extends DDMStructureLinkModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureVersion.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMStructureVersion.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMStructureVersionImpl")
 public interface DDMStructureVersion extends DDMStructureVersionModel,
 	PersistedModel {
 	/*

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMTemplate.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMTemplate.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMTemplateImpl")
 public interface DDMTemplate extends DDMTemplateModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMTemplateLink.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMTemplateLink.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMTemplateLinkImpl")
 public interface DDMTemplateLink extends DDMTemplateLinkModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMTemplateVersion.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMTemplateVersion.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.dynamic.data.mapping.model.impl.DDMTemplateVersionImpl")
 public interface DDMTemplateVersion extends DDMTemplateVersionModel,
 	PersistedModel {
 	/*

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
@@ -16,6 +16,7 @@ package com.liferay.journal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.journal.model.impl.JournalArticleImpl")
 public interface JournalArticle extends JournalArticleModel, PersistedModel,
 	TreeModel {
 	/*

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleImage.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleImage.java
@@ -16,6 +16,7 @@ package com.liferay.journal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.journal.model.impl.JournalArticleImageImpl")
 public interface JournalArticleImage extends JournalArticleImageModel,
 	PersistedModel {
 	/*

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleResource.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleResource.java
@@ -16,6 +16,7 @@ package com.liferay.journal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.journal.model.impl.JournalArticleResourceImpl")
 public interface JournalArticleResource extends JournalArticleResourceModel,
 	PersistedModel {
 	/*

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalContentSearch.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalContentSearch.java
@@ -16,6 +16,7 @@ package com.liferay.journal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.journal.model.impl.JournalContentSearchImpl")
 public interface JournalContentSearch extends JournalContentSearchModel,
 	PersistedModel {
 	/*

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalFeed.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalFeed.java
@@ -16,6 +16,7 @@ package com.liferay.journal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.journal.model.impl.JournalFeedImpl")
 public interface JournalFeed extends JournalFeedModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalFolder.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalFolder.java
@@ -16,6 +16,7 @@ package com.liferay.journal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.journal.model.impl.JournalFolderImpl")
 public interface JournalFolder extends JournalFolderModel, PersistedModel,
 	TreeModel {
 	/*

--- a/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/model/App.java
+++ b/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/model/App.java
@@ -16,6 +16,7 @@ package com.liferay.marketplace.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.marketplace.model.impl.AppImpl")
 public interface App extends AppModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/model/Module.java
+++ b/modules/apps/marketplace/marketplace-api/src/main/java/com/liferay/marketplace/model/Module.java
@@ -16,6 +16,7 @@ package com.liferay.marketplace.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.marketplace.model.impl.ModuleImpl")
 public interface Module extends ModuleModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/microblogs/microblogs-api/src/main/java/com/liferay/microblogs/model/MicroblogsEntry.java
+++ b/modules/apps/microblogs/microblogs-api/src/main/java/com/liferay/microblogs/model/MicroblogsEntry.java
@@ -16,6 +16,7 @@ package com.liferay.microblogs.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.microblogs.model.impl.MicroblogsEntryImpl")
 public interface MicroblogsEntry extends MicroblogsEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRAction.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRAction.java
@@ -16,6 +16,7 @@ package com.liferay.mobile.device.rules.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.mobile.device.rules.model.impl.MDRActionImpl")
 public interface MDRAction extends MDRActionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRRule.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRRule.java
@@ -16,6 +16,7 @@ package com.liferay.mobile.device.rules.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.mobile.device.rules.model.impl.MDRRuleImpl")
 public interface MDRRule extends MDRRuleModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRRuleGroup.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRRuleGroup.java
@@ -16,6 +16,7 @@ package com.liferay.mobile.device.rules.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.mobile.device.rules.model.impl.MDRRuleGroupImpl")
 public interface MDRRuleGroup extends MDRRuleGroupModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRRuleGroupInstance.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/model/MDRRuleGroupInstance.java
@@ -16,6 +16,7 @@ package com.liferay.mobile.device.rules.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.mobile.device.rules.model.impl.MDRRuleGroupInstanceImpl")
 public interface MDRRuleGroupInstance extends MDRRuleGroupInstanceModel,
 	PersistedModel {
 	/*

--- a/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/model/PollsChoice.java
+++ b/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/model/PollsChoice.java
@@ -16,6 +16,7 @@ package com.liferay.polls.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.polls.model.impl.PollsChoiceImpl")
 public interface PollsChoice extends PollsChoiceModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/model/PollsQuestion.java
+++ b/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/model/PollsQuestion.java
@@ -16,6 +16,7 @@ package com.liferay.polls.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.polls.model.impl.PollsQuestionImpl")
 public interface PollsQuestion extends PollsQuestionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/model/PollsVote.java
+++ b/modules/apps/polls/polls-api/src/main/java/com/liferay/polls/model/PollsVote.java
@@ -16,6 +16,7 @@ package com.liferay.polls.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.polls.model.impl.PollsVoteImpl")
 public interface PollsVote extends PollsVoteModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/service-access-policy/service-access-policy-api/src/main/java/com/liferay/service/access/policy/model/SAPEntry.java
+++ b/modules/apps/service-access-policy/service-access-policy-api/src/main/java/com/liferay/service/access/policy/model/SAPEntry.java
@@ -16,6 +16,7 @@ package com.liferay.service.access.policy.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.service.access.policy.model.impl.SAPEntryImpl")
 public interface SAPEntry extends SAPEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingCart.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingCart.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingCartImpl")
 public interface ShoppingCart extends ShoppingCartModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingCategory.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingCategory.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingCategoryImpl")
 public interface ShoppingCategory extends ShoppingCategoryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingCoupon.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingCoupon.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingCouponImpl")
 public interface ShoppingCoupon extends ShoppingCouponModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingItem.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingItem.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingItemImpl")
 public interface ShoppingItem extends ShoppingItemModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingItemField.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingItemField.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingItemFieldImpl")
 public interface ShoppingItemField extends ShoppingItemFieldModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingItemPrice.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingItemPrice.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingItemPriceImpl")
 public interface ShoppingItemPrice extends ShoppingItemPriceModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingOrder.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingOrder.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingOrderImpl")
 public interface ShoppingOrder extends ShoppingOrderModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingOrderItem.java
+++ b/modules/apps/shopping/shopping-api/src/main/java/com/liferay/shopping/model/ShoppingOrderItem.java
@@ -16,6 +16,7 @@ package com.liferay.shopping.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.shopping.model.impl.ShoppingOrderItemImpl")
 public interface ShoppingOrderItem extends ShoppingOrderItemModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/model/MeetupsEntry.java
+++ b/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/model/MeetupsEntry.java
@@ -16,6 +16,7 @@ package com.liferay.social.networking.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.social.networking.model.impl.MeetupsEntryImpl")
 public interface MeetupsEntry extends MeetupsEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/model/MeetupsRegistration.java
+++ b/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/model/MeetupsRegistration.java
@@ -16,6 +16,7 @@ package com.liferay.social.networking.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.social.networking.model.impl.MeetupsRegistrationImpl")
 public interface MeetupsRegistration extends MeetupsRegistrationModel,
 	PersistedModel {
 	/*

--- a/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/model/WallEntry.java
+++ b/modules/apps/social/social-networking-api/src/main/java/com/liferay/social/networking/model/WallEntry.java
@@ -16,6 +16,7 @@ package com.liferay.social.networking.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.social.networking.model.impl.WallEntryImpl")
 public interface WallEntry extends WallEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiNode.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiNode.java
@@ -16,6 +16,7 @@ package com.liferay.wiki.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.wiki.model.impl.WikiNodeImpl")
 public interface WikiNode extends WikiNodeModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPage.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPage.java
@@ -16,6 +16,7 @@ package com.liferay.wiki.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.wiki.model.impl.WikiPageImpl")
 public interface WikiPage extends WikiPageModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageResource.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageResource.java
@@ -16,6 +16,7 @@ package com.liferay.wiki.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.wiki.model.impl.WikiPageResourceImpl")
 public interface WikiPageResource extends WikiPageResourceModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-background-task-api/src/main/java/com/liferay/portal/background/task/model/BackgroundTask.java
+++ b/modules/portal/portal-background-task-api/src/main/java/com/liferay/portal/background/task/model/BackgroundTask.java
@@ -16,6 +16,7 @@ package com.liferay.portal.background.task.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.background.task.model.impl.BackgroundTaskImpl")
 public interface BackgroundTask extends BackgroundTaskModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-lock-api/src/main/java/com/liferay/portal/lock/model/Lock.java
+++ b/modules/portal/portal-lock-api/src/main/java/com/liferay/portal/lock/model/Lock.java
@@ -16,6 +16,7 @@ package com.liferay.portal.lock.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.lock.model.impl.LockImpl")
 public interface Lock extends LockModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoAction.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoAction.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoActionImpl")
 public interface KaleoAction extends KaleoActionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoCondition.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoCondition.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoConditionImpl")
 public interface KaleoCondition extends KaleoConditionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinition.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoDefinition.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoDefinitionImpl")
 public interface KaleoDefinition extends KaleoDefinitionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoInstance.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoInstance.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoInstanceImpl")
 public interface KaleoInstance extends KaleoInstanceModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoInstanceToken.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoInstanceToken.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoInstanceTokenImpl")
 public interface KaleoInstanceToken extends KaleoInstanceTokenModel,
 	PersistedModel {
 	/*

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoLog.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoLog.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoLogImpl")
 public interface KaleoLog extends KaleoLogModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoNode.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoNode.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoNodeImpl")
 public interface KaleoNode extends KaleoNodeModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoNotification.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoNotification.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoNotificationImpl")
 public interface KaleoNotification extends KaleoNotificationModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoNotificationRecipient.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoNotificationRecipient.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoNotificationRecipientImpl")
 public interface KaleoNotificationRecipient
 	extends KaleoNotificationRecipientModel, PersistedModel {
 	/*

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTask.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTask.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoTaskImpl")
 public interface KaleoTask extends KaleoTaskModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTaskAssignment.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTaskAssignment.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoTaskAssignmentImpl")
 public interface KaleoTaskAssignment extends KaleoTaskAssignmentModel,
 	PersistedModel {
 	/*

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTaskAssignmentInstance.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTaskAssignmentInstance.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoTaskAssignmentInstanceImpl")
 public interface KaleoTaskAssignmentInstance
 	extends KaleoTaskAssignmentInstanceModel, PersistedModel {
 	/*

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTaskInstanceToken.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTaskInstanceToken.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoTaskInstanceTokenImpl")
 public interface KaleoTaskInstanceToken extends KaleoTaskInstanceTokenModel,
 	PersistedModel {
 	/*

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTimer.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTimer.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoTimerImpl")
 public interface KaleoTimer extends KaleoTimerModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTimerInstanceToken.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTimerInstanceToken.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoTimerInstanceTokenImpl")
 public interface KaleoTimerInstanceToken extends KaleoTimerInstanceTokenModel,
 	PersistedModel {
 	/*

--- a/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTransition.java
+++ b/modules/portal/portal-workflow-kaleo-api/src/main/java/com/liferay/portal/workflow/kaleo/model/KaleoTransition.java
@@ -16,6 +16,7 @@ package com.liferay.portal.workflow.kaleo.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.workflow.kaleo.model.impl.KaleoTransitionImpl")
 public interface KaleoTransition extends KaleoTransitionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/extended_model.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/extended_model.ftl
@@ -2,6 +2,7 @@ package ${packagePath}.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.model.NestedSetsTreeNodeModel;
@@ -27,6 +28,7 @@ import com.liferay.portal.model.TreeModel;
 </#if>
 
 @ProviderType
+@ImplementationPath(implementationPath="${packagePath}.model.impl.${entity.name}Impl")
 public interface ${entity.name} extends
 	${entity.name}Model
 

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/extended_model.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/extended_model.ftl
@@ -2,7 +2,7 @@ package ${packagePath}.model;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.portal.kernel.annotation.ImplementationPath;
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.model.NestedSetsTreeNodeModel;
@@ -28,7 +28,7 @@ import com.liferay.portal.model.TreeModel;
 </#if>
 
 @ProviderType
-@ImplementationPath(implementationPath="${packagePath}.model.impl.${entity.name}Impl")
+@ImplementationClassName("${packagePath}.model.impl.${entity.name}Impl")
 public interface ${entity.name} extends
 	${entity.name}Model
 

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/finder.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/finder.ftl
@@ -2,6 +2,8 @@ package ${packagePath}.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationPath;
+
 /**
  * @author ${author}
 <#if classDeprecated>
@@ -15,6 +17,7 @@ import aQute.bnd.annotation.ProviderType;
 </#if>
 
 @ProviderType
+@ImplementationPath(implementationPath="${packagePath}.service.persistence.impl.${entity.name}FinderImpl")
 public interface ${entity.name}Finder {
 
 	<#list methods as method>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/finder.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/finder.ftl
@@ -2,8 +2,6 @@ package ${packagePath}.service.persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.portal.kernel.annotation.ImplementationPath;
-
 /**
  * @author ${author}
 <#if classDeprecated>
@@ -17,7 +15,6 @@ import com.liferay.portal.kernel.annotation.ImplementationPath;
 </#if>
 
 @ProviderType
-@ImplementationPath(implementationPath="${packagePath}.service.persistence.impl.${entity.name}FinderImpl")
 public interface ${entity.name}Finder {
 
 	<#list methods as method>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model.ftl
@@ -7,6 +7,7 @@ package ${packagePath}.model;
 import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.portal.LocaleException;
+import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.trash.TrashHandler;
@@ -61,6 +62,7 @@ import java.util.Map;
 </#if>
 
 @ProviderType
+@ImplementationPath(implementationPath="${packagePath}.model.impl.${entity.name}ModelImpl")
 public interface ${entity.name}Model extends
 	<#assign overrideColumnNames = []>
 

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model.ftl
@@ -7,7 +7,6 @@ package ${packagePath}.model;
 import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.portal.LocaleException;
-import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.trash.TrashHandler;
@@ -62,7 +61,6 @@ import java.util.Map;
 </#if>
 
 @ProviderType
-@ImplementationPath(implementationPath="${packagePath}.model.impl.${entity.name}ModelImpl")
 public interface ${entity.name}Model extends
 	<#assign overrideColumnNames = []>
 

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence.ftl
@@ -4,7 +4,6 @@ import ${packagePath}.model.${entity.name};
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -33,7 +32,6 @@ import java.util.Date;
 </#if>
 
 @ProviderType
-@ImplementationPath(implementationPath="${packagePath}.service.persistence.impl.${entity.name}PersistenceImpl")
 public interface ${entity.name}Persistence extends BasePersistence<${entity.name}> {
 
 	/*

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence.ftl
@@ -4,6 +4,7 @@ import ${packagePath}.model.${entity.name};
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
@@ -32,6 +33,7 @@ import java.util.Date;
 </#if>
 
 @ProviderType
+@ImplementationPath(implementationPath="${packagePath}.service.persistence.impl.${entity.name}PersistenceImpl")
 public interface ${entity.name}Persistence extends BasePersistence<${entity.name}> {
 
 	/*

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service.ftl
@@ -2,6 +2,7 @@ package ${packagePath}.service;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
@@ -72,6 +73,11 @@ import ${import};
 </#if>
 
 @ProviderType
+<#if sessionTypeName == "Local">
+@ImplementationPath(implementationPath="${packagePath}.service.impl.${entity.name}LocalServiceImpl")
+<#else>
+@ImplementationPath(implementationPath="${packagePath}.service.impl.${entity.name}ServiceImpl")
+</#if>
 @Transactional(isolation = Isolation.PORTAL, rollbackFor = {PortalException.class, SystemException.class})
 public interface ${entity.name}${sessionTypeName}Service
 	extends Base${sessionTypeName}Service

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service.ftl
@@ -2,7 +2,6 @@ package ${packagePath}.service;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
@@ -73,11 +72,6 @@ import ${import};
 </#if>
 
 @ProviderType
-<#if sessionTypeName == "Local">
-@ImplementationPath(implementationPath="${packagePath}.service.impl.${entity.name}LocalServiceImpl")
-<#else>
-@ImplementationPath(implementationPath="${packagePath}.service.impl.${entity.name}ServiceImpl")
-</#if>
 @Transactional(isolation = Isolation.PORTAL, rollbackFor = {PortalException.class, SystemException.class})
 public interface ${entity.name}${sessionTypeName}Service
 	extends Base${sessionTypeName}Service

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryFactoryImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.dao.orm.hibernate;
 
+import com.liferay.portal.kernel.annotation.ImplementationPath;
 import com.liferay.portal.kernel.concurrent.ConcurrentReferenceKeyHashMap;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactory;
@@ -81,10 +82,20 @@ public class DynamicQueryFactoryImpl implements DynamicQueryFactory {
 				classLoader = ClassLoaderUtil.getContextClassLoader();
 			}
 
-			Package pkg = clazz.getPackage();
+			String implClassName;
 
-			String implClassName =
-				pkg.getName() + ".impl." + clazz.getSimpleName() + "Impl";
+			if (!clazz.isAnnotationPresent(ImplementationPath.class)) {
+				_log.error(
+					"Unable find model " + className +
+						" no ImplementationPath annotation found");
+
+				return implClass;
+			}
+
+			ImplementationPath ip = clazz.getAnnotation(
+				ImplementationPath.class);
+
+			implClassName = ip.implementationPath();
 
 			try {
 				implClass = getImplClass(implClassName, classLoader);

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryFactoryImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.memory.FinalizeManager;
 import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
-import com.liferay.portal.kernel.util.ClassLoaderUtil;
 import com.liferay.portal.security.lang.DoPrivilegedUtil;
 
 import java.security.PrivilegedAction;
@@ -73,46 +72,39 @@ public class DynamicQueryFactoryImpl implements DynamicQueryFactory {
 	}
 
 	protected Class<?> getImplClass(Class<?> clazz, ClassLoader classLoader) {
+		ImplementationClassName implementationClassName = clazz.getAnnotation(
+			ImplementationClassName.class);
+
+		if (implementationClassName == null) {
+			String className = clazz.getName();
+
+			if (!className.endsWith("Impl")) {
+				_log.error("Unable find model for " + clazz);
+			}
+
+			PortalRuntimePermission.checkDynamicQuery(clazz);
+
+			return clazz;
+		}
+
 		Class<?> implClass = clazz;
 
-		String className = clazz.getName();
+		String implClassName = implementationClassName.value();
 
-		if (!className.endsWith("Impl")) {
-			if (classLoader == null) {
-				classLoader = ClassLoaderUtil.getContextClassLoader();
-			}
-
-			String implClassName;
-
-			if (!clazz.isAnnotationPresent(ImplementationClassName.class)) {
-				_log.error(
-					"Unable find model " + className +
-						" no ImplementationPath annotation found");
-
-				return implClass;
-			}
-
-			ImplementationClassName ip = clazz.getAnnotation(
-				ImplementationClassName.class);
-
-			implClassName = ip.value();
-
-			try {
-				implClass = getImplClass(implClassName, classLoader);
-			}
-			catch (Exception e1) {
-				if (classLoader != _portalClassLoader) {
-					try {
-						implClass = getImplClass(
-							implClassName, _portalClassLoader);
-					}
-					catch (Exception e2) {
-						_log.error("Unable find model " + implClassName, e2);
-					}
+		try {
+			implClass = getImplClass(implClassName, classLoader);
+		}
+		catch (Exception e1) {
+			if (classLoader != _portalClassLoader) {
+				try {
+					implClass = getImplClass(implClassName, _portalClassLoader);
 				}
-				else {
-					_log.error("Unable find model " + implClassName, e1);
+				catch (Exception e2) {
+					_log.error("Unable find model " + implClassName, e2);
 				}
+			}
+			else {
+				_log.error("Unable find model " + implClassName, e1);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/orm/hibernate/DynamicQueryFactoryImpl.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.dao.orm.hibernate;
 
-import com.liferay.portal.kernel.annotation.ImplementationPath;
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.concurrent.ConcurrentReferenceKeyHashMap;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQueryFactory;
@@ -84,7 +84,7 @@ public class DynamicQueryFactoryImpl implements DynamicQueryFactory {
 
 			String implClassName;
 
-			if (!clazz.isAnnotationPresent(ImplementationPath.class)) {
+			if (!clazz.isAnnotationPresent(ImplementationClassName.class)) {
 				_log.error(
 					"Unable find model " + className +
 						" no ImplementationPath annotation found");
@@ -92,10 +92,10 @@ public class DynamicQueryFactoryImpl implements DynamicQueryFactory {
 				return implClass;
 			}
 
-			ImplementationPath ip = clazz.getAnnotation(
-				ImplementationPath.class);
+			ImplementationClassName ip = clazz.getAnnotation(
+				ImplementationClassName.class);
 
-			implClassName = ip.implementationPath();
+			implClassName = ip.value();
 
 			try {
 				implClass = getImplClass(implClassName, classLoader);

--- a/portal-service/src/com/liferay/counter/model/Counter.java
+++ b/portal-service/src/com/liferay/counter/model/Counter.java
@@ -16,6 +16,7 @@ package com.liferay.counter.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.counter.model.impl.CounterImpl")
 public interface Counter extends CounterModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/kernel/annotation/ImplementationClassName.java
+++ b/portal-service/src/com/liferay/portal/kernel/annotation/ImplementationClassName.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface ImplementationPath {
+public @interface ImplementationClassName {
 
 	public String value();
 

--- a/portal-service/src/com/liferay/portal/kernel/annotation/ImplementationPath.java
+++ b/portal-service/src/com/liferay/portal/kernel/annotation/ImplementationPath.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author William Newbury
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ImplementationPath {
+
+	public String implementationPath();
+
+}

--- a/portal-service/src/com/liferay/portal/kernel/annotation/ImplementationPath.java
+++ b/portal-service/src/com/liferay/portal/kernel/annotation/ImplementationPath.java
@@ -26,6 +26,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface ImplementationPath {
 
-	public String implementationPath();
+	public String value();
 
 }

--- a/portal-service/src/com/liferay/portal/model/Account.java
+++ b/portal-service/src/com/liferay/portal/model/Account.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.AccountImpl")
 public interface Account extends AccountModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Address.java
+++ b/portal-service/src/com/liferay/portal/model/Address.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.AddressImpl")
 public interface Address extends AddressModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/BrowserTracker.java
+++ b/portal-service/src/com/liferay/portal/model/BrowserTracker.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.BrowserTrackerImpl")
 public interface BrowserTracker extends BrowserTrackerModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/ClassName.java
+++ b/portal-service/src/com/liferay/portal/model/ClassName.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ClassNameImpl")
 public interface ClassName extends ClassNameModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/ClusterGroup.java
+++ b/portal-service/src/com/liferay/portal/model/ClusterGroup.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ClusterGroupImpl")
 public interface ClusterGroup extends ClusterGroupModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Company.java
+++ b/portal-service/src/com/liferay/portal/model/Company.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.CompanyImpl")
 public interface Company extends CompanyModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Contact.java
+++ b/portal-service/src/com/liferay/portal/model/Contact.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ContactImpl")
 public interface Contact extends ContactModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Country.java
+++ b/portal-service/src/com/liferay/portal/model/Country.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.CountryImpl")
 public interface Country extends CountryModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/EmailAddress.java
+++ b/portal-service/src/com/liferay/portal/model/EmailAddress.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.EmailAddressImpl")
 public interface EmailAddress extends EmailAddressModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Group.java
+++ b/portal-service/src/com/liferay/portal/model/Group.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.GroupImpl")
 public interface Group extends GroupModel, PersistedModel, TreeModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Image.java
+++ b/portal-service/src/com/liferay/portal/model/Image.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ImageImpl")
 public interface Image extends ImageModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Layout.java
+++ b/portal-service/src/com/liferay/portal/model/Layout.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutImpl")
 public interface Layout extends LayoutModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/LayoutBranch.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutBranch.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutBranchImpl")
 public interface LayoutBranch extends LayoutBranchModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/LayoutFriendlyURL.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutFriendlyURL.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutFriendlyURLImpl")
 public interface LayoutFriendlyURL extends LayoutFriendlyURLModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/LayoutPrototype.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutPrototype.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutPrototypeImpl")
 public interface LayoutPrototype extends LayoutPrototypeModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/LayoutRevision.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutRevision.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutRevisionImpl")
 public interface LayoutRevision extends LayoutRevisionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/LayoutSet.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSet.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutSetImpl")
 public interface LayoutSet extends LayoutSetModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/LayoutSetBranch.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetBranch.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutSetBranchImpl")
 public interface LayoutSetBranch extends LayoutSetBranchModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/LayoutSetPrototype.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutSetPrototype.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.LayoutSetPrototypeImpl")
 public interface LayoutSetPrototype extends LayoutSetPrototypeModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/ListType.java
+++ b/portal-service/src/com/liferay/portal/model/ListType.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ListTypeImpl")
 public interface ListType extends ListTypeModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/MembershipRequest.java
+++ b/portal-service/src/com/liferay/portal/model/MembershipRequest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.MembershipRequestImpl")
 public interface MembershipRequest extends MembershipRequestModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/OrgGroupRole.java
+++ b/portal-service/src/com/liferay/portal/model/OrgGroupRole.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.OrgGroupRoleImpl")
 public interface OrgGroupRole extends OrgGroupRoleModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/OrgLabor.java
+++ b/portal-service/src/com/liferay/portal/model/OrgLabor.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.OrgLaborImpl")
 public interface OrgLabor extends OrgLaborModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Organization.java
+++ b/portal-service/src/com/liferay/portal/model/Organization.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.OrganizationImpl")
 public interface Organization extends OrganizationModel, PersistedModel,
 	TreeModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/PasswordPolicy.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordPolicy.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PasswordPolicyImpl")
 public interface PasswordPolicy extends PasswordPolicyModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/PasswordPolicyRel.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordPolicyRel.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PasswordPolicyRelImpl")
 public interface PasswordPolicyRel extends PasswordPolicyRelModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/PasswordTracker.java
+++ b/portal-service/src/com/liferay/portal/model/PasswordTracker.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PasswordTrackerImpl")
 public interface PasswordTracker extends PasswordTrackerModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Phone.java
+++ b/portal-service/src/com/liferay/portal/model/Phone.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PhoneImpl")
 public interface Phone extends PhoneModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/PluginSetting.java
+++ b/portal-service/src/com/liferay/portal/model/PluginSetting.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PluginSettingImpl")
 public interface PluginSetting extends PluginSettingModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/PortalPreferences.java
+++ b/portal-service/src/com/liferay/portal/model/PortalPreferences.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PortalPreferencesImpl")
 public interface PortalPreferences extends PortalPreferencesModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Portlet.java
+++ b/portal-service/src/com/liferay/portal/model/Portlet.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PortletImpl")
 public interface Portlet extends PortletModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/PortletItem.java
+++ b/portal-service/src/com/liferay/portal/model/PortletItem.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PortletItemImpl")
 public interface PortletItem extends PortletItemModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/PortletPreferences.java
+++ b/portal-service/src/com/liferay/portal/model/PortletPreferences.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.PortletPreferencesImpl")
 public interface PortletPreferences extends PortletPreferencesModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/RecentLayoutBranch.java
+++ b/portal-service/src/com/liferay/portal/model/RecentLayoutBranch.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.RecentLayoutBranchImpl")
 public interface RecentLayoutBranch extends RecentLayoutBranchModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/RecentLayoutRevision.java
+++ b/portal-service/src/com/liferay/portal/model/RecentLayoutRevision.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.RecentLayoutRevisionImpl")
 public interface RecentLayoutRevision extends RecentLayoutRevisionModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/RecentLayoutSetBranch.java
+++ b/portal-service/src/com/liferay/portal/model/RecentLayoutSetBranch.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.RecentLayoutSetBranchImpl")
 public interface RecentLayoutSetBranch extends RecentLayoutSetBranchModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/Region.java
+++ b/portal-service/src/com/liferay/portal/model/Region.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.RegionImpl")
 public interface Region extends RegionModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Release.java
+++ b/portal-service/src/com/liferay/portal/model/Release.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ReleaseImpl")
 public interface Release extends ReleaseModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Repository.java
+++ b/portal-service/src/com/liferay/portal/model/Repository.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.RepositoryImpl")
 public interface Repository extends RepositoryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/RepositoryEntry.java
+++ b/portal-service/src/com/liferay/portal/model/RepositoryEntry.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.RepositoryEntryImpl")
 public interface RepositoryEntry extends RepositoryEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/ResourceAction.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceAction.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ResourceActionImpl")
 public interface ResourceAction extends ResourceActionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/ResourceBlock.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceBlock.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ResourceBlockImpl")
 public interface ResourceBlock extends ResourceBlockModel, PermissionedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/ResourceBlockPermission.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceBlockPermission.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ResourceBlockPermissionImpl")
 public interface ResourceBlockPermission extends ResourceBlockPermissionModel,
 	PermissionedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/ResourcePermission.java
+++ b/portal-service/src/com/liferay/portal/model/ResourcePermission.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ResourcePermissionImpl")
 public interface ResourcePermission extends ResourcePermissionModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/ResourceTypePermission.java
+++ b/portal-service/src/com/liferay/portal/model/ResourceTypePermission.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ResourceTypePermissionImpl")
 public interface ResourceTypePermission extends ResourceTypePermissionModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/Role.java
+++ b/portal-service/src/com/liferay/portal/model/Role.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.util.LocaleThreadLocal;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.RoleImpl")
 public interface Role extends RoleModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/ServiceComponent.java
+++ b/portal-service/src/com/liferay/portal/model/ServiceComponent.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.ServiceComponentImpl")
 public interface ServiceComponent extends ServiceComponentModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Subscription.java
+++ b/portal-service/src/com/liferay/portal/model/Subscription.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.SubscriptionImpl")
 public interface Subscription extends SubscriptionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/SystemEvent.java
+++ b/portal-service/src/com/liferay/portal/model/SystemEvent.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.SystemEventImpl")
 public interface SystemEvent extends SystemEventModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Team.java
+++ b/portal-service/src/com/liferay/portal/model/Team.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.TeamImpl")
 public interface Team extends TeamModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Ticket.java
+++ b/portal-service/src/com/liferay/portal/model/Ticket.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.TicketImpl")
 public interface Ticket extends TicketModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/User.java
+++ b/portal-service/src/com/liferay/portal/model/User.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserImpl")
 public interface User extends UserModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/UserGroup.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroup.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserGroupImpl")
 public interface UserGroup extends UserGroupModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/UserGroupGroupRole.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupGroupRole.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserGroupGroupRoleImpl")
 public interface UserGroupGroupRole extends UserGroupGroupRoleModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/UserGroupRole.java
+++ b/portal-service/src/com/liferay/portal/model/UserGroupRole.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserGroupRoleImpl")
 public interface UserGroupRole extends UserGroupRoleModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/UserIdMapper.java
+++ b/portal-service/src/com/liferay/portal/model/UserIdMapper.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserIdMapperImpl")
 public interface UserIdMapper extends UserIdMapperModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/UserNotificationDelivery.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationDelivery.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserNotificationDeliveryImpl")
 public interface UserNotificationDelivery extends UserNotificationDeliveryModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/UserNotificationEvent.java
+++ b/portal-service/src/com/liferay/portal/model/UserNotificationEvent.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserNotificationEventImpl")
 public interface UserNotificationEvent extends UserNotificationEventModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/UserTracker.java
+++ b/portal-service/src/com/liferay/portal/model/UserTracker.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserTrackerImpl")
 public interface UserTracker extends UserTrackerModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/UserTrackerPath.java
+++ b/portal-service/src/com/liferay/portal/model/UserTrackerPath.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.UserTrackerPathImpl")
 public interface UserTrackerPath extends UserTrackerPathModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/VirtualHost.java
+++ b/portal-service/src/com/liferay/portal/model/VirtualHost.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.VirtualHostImpl")
 public interface VirtualHost extends VirtualHostModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/WebDAVProps.java
+++ b/portal-service/src/com/liferay/portal/model/WebDAVProps.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.WebDAVPropsImpl")
 public interface WebDAVProps extends WebDAVPropsModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/Website.java
+++ b/portal-service/src/com/liferay/portal/model/Website.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.WebsiteImpl")
 public interface Website extends WebsiteModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portal/model/WorkflowDefinitionLink.java
+++ b/portal-service/src/com/liferay/portal/model/WorkflowDefinitionLink.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.WorkflowDefinitionLinkImpl")
 public interface WorkflowDefinitionLink extends WorkflowDefinitionLinkModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portal/model/WorkflowInstanceLink.java
+++ b/portal-service/src/com/liferay/portal/model/WorkflowInstanceLink.java
@@ -16,6 +16,7 @@ package com.liferay.portal.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 
 /**
@@ -28,6 +29,7 @@ import com.liferay.portal.kernel.util.Accessor;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portal.model.impl.WorkflowInstanceLinkImpl")
 public interface WorkflowInstanceLink extends WorkflowInstanceLinkModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsDelivery.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsDelivery.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.announcements.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.announcements.model.impl.AnnouncementsDeliveryImpl")
 public interface AnnouncementsDelivery extends AnnouncementsDeliveryModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsEntry.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsEntry.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.announcements.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.announcements.model.impl.AnnouncementsEntryImpl")
 public interface AnnouncementsEntry extends AnnouncementsEntryModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsFlag.java
+++ b/portal-service/src/com/liferay/portlet/announcements/model/AnnouncementsFlag.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.announcements.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.announcements.model.impl.AnnouncementsFlagImpl")
 public interface AnnouncementsFlag extends AnnouncementsFlagModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetCategory.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetCategory.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.NestedSetsTreeNodeModel;
 import com.liferay.portal.model.PersistedModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.asset.model.impl.AssetCategoryImpl")
 public interface AssetCategory extends AssetCategoryModel,
 	NestedSetsTreeNodeModel, PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryProperty.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetCategoryProperty.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.asset.model.impl.AssetCategoryPropertyImpl")
 public interface AssetCategoryProperty extends AssetCategoryPropertyModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetEntry.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetEntry.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.asset.model.impl.AssetEntryImpl")
 public interface AssetEntry extends AssetEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetLink.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetLink.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.asset.model.impl.AssetLinkImpl")
 public interface AssetLink extends AssetLinkModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTag.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTag.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.asset.model.impl.AssetTagImpl")
 public interface AssetTag extends AssetTagModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetTagStats.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetTagStats.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.asset.model.impl.AssetTagStatsImpl")
 public interface AssetTagStats extends AssetTagStatsModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/asset/model/AssetVocabulary.java
+++ b/portal-service/src/com/liferay/portlet/asset/model/AssetVocabulary.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.asset.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.asset.model.impl.AssetVocabularyImpl")
 public interface AssetVocabulary extends AssetVocabularyModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/blogs/model/BlogsEntry.java
+++ b/portal-service/src/com/liferay/portlet/blogs/model/BlogsEntry.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.blogs.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.blogs.model.impl.BlogsEntryImpl")
 public interface BlogsEntry extends BlogsEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/blogs/model/BlogsStatsUser.java
+++ b/portal-service/src/com/liferay/portlet/blogs/model/BlogsStatsUser.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.blogs.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.blogs.model.impl.BlogsStatsUserImpl")
 public interface BlogsStatsUser extends BlogsStatsUserModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/calendar/model/CalEvent.java
+++ b/portal-service/src/com/liferay/portlet/calendar/model/CalEvent.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.calendar.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -31,6 +32,7 @@ import com.liferay.portal.model.PersistedModel;
  */
 @Deprecated
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.calendar.model.impl.CalEventImpl")
 public interface CalEvent extends CalEventModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLContent.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLContent.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLContentImpl")
 public interface DLContent extends DLContentModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntry.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntry.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLFileEntryImpl")
 public interface DLFileEntry extends DLFileEntryModel, PersistedModel, TreeModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryMetadata.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryMetadata.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLFileEntryMetadataImpl")
 public interface DLFileEntryMetadata extends DLFileEntryMetadataModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryType.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileEntryType.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLFileEntryTypeImpl")
 public interface DLFileEntryType extends DLFileEntryTypeModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileRank.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileRank.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLFileRankImpl")
 public interface DLFileRank extends DLFileRankModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcut.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileShortcut.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLFileShortcutImpl")
 public interface DLFileShortcut extends DLFileShortcutModel, PersistedModel,
 	TreeModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersion.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFileVersion.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLFileVersionImpl")
 public interface DLFileVersion extends DLFileVersionModel, PersistedModel,
 	TreeModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolder.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLFolder.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 import com.liferay.portal.model.TreeModel;
@@ -30,6 +31,7 @@ import com.liferay.portal.model.TreeModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLFolderImpl")
 public interface DLFolder extends DLFolderModel, PersistedModel, TreeModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/documentlibrary/model/DLSyncEvent.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/model/DLSyncEvent.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.documentlibrary.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.documentlibrary.model.impl.DLSyncEventImpl")
 public interface DLSyncEvent extends DLSyncEventModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoColumn.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoColumn.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.expando.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.expando.model.impl.ExpandoColumnImpl")
 public interface ExpandoColumn extends ExpandoColumnModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoRow.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoRow.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.expando.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.expando.model.impl.ExpandoRowImpl")
 public interface ExpandoRow extends ExpandoRowModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoTable.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoTable.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.expando.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.expando.model.impl.ExpandoTableImpl")
 public interface ExpandoTable extends ExpandoTableModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/expando/model/ExpandoValue.java
+++ b/portal-service/src/com/liferay/portlet/expando/model/ExpandoValue.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.expando.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.expando.model.impl.ExpandoValueImpl")
 public interface ExpandoValue extends ExpandoValueModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/exportimport/model/ExportImportConfiguration.java
+++ b/portal-service/src/com/liferay/portlet/exportimport/model/ExportImportConfiguration.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.exportimport.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.exportimport.model.impl.ExportImportConfigurationImpl")
 public interface ExportImportConfiguration
 	extends ExportImportConfigurationModel, PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBBan.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBBan.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBBanImpl")
 public interface MBBan extends MBBanModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBCategory.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBCategory.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBCategoryImpl")
 public interface MBCategory extends MBCategoryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBDiscussion.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBDiscussion.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBDiscussionImpl")
 public interface MBDiscussion extends MBDiscussionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBMailingList.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBMailingList.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBMailingListImpl")
 public interface MBMailingList extends MBMailingListModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBMessage.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBMessage.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBMessageImpl")
 public interface MBMessage extends MBMessageModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBStatsUser.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBStatsUser.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBStatsUserImpl")
 public interface MBStatsUser extends MBStatsUserModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBThread.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBThread.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBThreadImpl")
 public interface MBThread extends MBThreadModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadFlag.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/model/MBThreadFlag.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.messageboards.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.messageboards.model.impl.MBThreadFlagImpl")
 public interface MBThreadFlag extends MBThreadFlagModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/ratings/model/RatingsEntry.java
+++ b/portal-service/src/com/liferay/portlet/ratings/model/RatingsEntry.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.ratings.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.ratings.model.impl.RatingsEntryImpl")
 public interface RatingsEntry extends RatingsEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/ratings/model/RatingsStats.java
+++ b/portal-service/src/com/liferay/portlet/ratings/model/RatingsStats.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.ratings.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.ratings.model.impl.RatingsStatsImpl")
 public interface RatingsStats extends RatingsStatsModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivity.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivity.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialActivityImpl")
 public interface SocialActivity extends SocialActivityModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivityAchievement.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivityAchievement.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialActivityAchievementImpl")
 public interface SocialActivityAchievement
 	extends SocialActivityAchievementModel, PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivityCounter.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivityCounter.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialActivityCounterImpl")
 public interface SocialActivityCounter extends SocialActivityCounterModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivityLimit.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivityLimit.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialActivityLimitImpl")
 public interface SocialActivityLimit extends SocialActivityLimitModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivitySet.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivitySet.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialActivitySetImpl")
 public interface SocialActivitySet extends SocialActivitySetModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/social/model/SocialActivitySetting.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialActivitySetting.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialActivitySettingImpl")
 public interface SocialActivitySetting extends SocialActivitySettingModel,
 	PersistedModel {
 	/*

--- a/portal-service/src/com/liferay/portlet/social/model/SocialRelation.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialRelation.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialRelationImpl")
 public interface SocialRelation extends SocialRelationModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/social/model/SocialRequest.java
+++ b/portal-service/src/com/liferay/portlet/social/model/SocialRequest.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.social.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.social.model.impl.SocialRequestImpl")
 public interface SocialRequest extends SocialRequestModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/trash/model/TrashEntry.java
+++ b/portal-service/src/com/liferay/portlet/trash/model/TrashEntry.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.trash.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.trash.model.impl.TrashEntryImpl")
 public interface TrashEntry extends TrashEntryModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:

--- a/portal-service/src/com/liferay/portlet/trash/model/TrashVersion.java
+++ b/portal-service/src/com/liferay/portlet/trash/model/TrashVersion.java
@@ -16,6 +16,7 @@ package com.liferay.portlet.trash.model;
 
 import aQute.bnd.annotation.ProviderType;
 
+import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.model.PersistedModel;
 
@@ -29,6 +30,7 @@ import com.liferay.portal.model.PersistedModel;
  * @generated
  */
 @ProviderType
+@ImplementationClassName("com.liferay.portlet.trash.model.impl.TrashVersionImpl")
 public interface TrashVersion extends TrashVersionModel, PersistedModel {
 	/*
 	 * NOTE FOR DEVELOPERS:


### PR DESCRIPTION
@brianchandotcom this is a preparation for ServiceBuilder generated code split packages support.
As the new naming convention will break the way how DynamicQueryFactoryImpl assuming the impl classes' names. We'd better have SB explicitly tell the DynamicQueryFactoryImpl where to look for the actual impl classes by annotating the interface.
