### PR TITLE
LPS-62590 Remove getCurrentUser, now available in UserService

### DIFF
--- a/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensUserService.java
+++ b/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensUserService.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portal.kernel.transaction.Isolation;
-import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.service.BaseService;
 
@@ -50,9 +49,6 @@ public interface ScreensUserService extends BaseService {
 	 *
 	 * Never modify or reference this interface directly. Always use {@link ScreensUserServiceUtil} to access the screens user remote service. Add custom service methods to {@link com.liferay.screens.service.impl.ScreensUserServiceImpl} and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
-	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
-	public com.liferay.portal.model.User getCurrentUser()
-		throws PortalException;
 
 	/**
 	* Returns the OSGi service identifier.

--- a/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensUserServiceUtil.java
+++ b/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensUserServiceUtil.java
@@ -41,10 +41,6 @@ public class ScreensUserServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to {@link com.liferay.screens.service.impl.ScreensUserServiceImpl} and rerun ServiceBuilder to regenerate this class.
 	 */
-	public static com.liferay.portal.model.User getCurrentUser()
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService().getCurrentUser();
-	}
 
 	/**
 	* Returns the OSGi service identifier.

--- a/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensUserServiceWrapper.java
+++ b/modules/apps/screens/screens-api/src/main/java/com/liferay/screens/service/ScreensUserServiceWrapper.java
@@ -32,12 +32,6 @@ public class ScreensUserServiceWrapper implements ScreensUserService,
 		_screensUserService = screensUserService;
 	}
 
-	@Override
-	public com.liferay.portal.model.User getCurrentUser()
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _screensUserService.getCurrentUser();
-	}
-
 	/**
 	* Returns the OSGi service identifier.
 	*

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensUserServiceHttp.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensUserServiceHttp.java
@@ -55,37 +55,6 @@ import com.liferay.screens.service.ScreensUserServiceUtil;
  */
 @ProviderType
 public class ScreensUserServiceHttp {
-	public static com.liferay.portal.model.User getCurrentUser(
-		HttpPrincipal httpPrincipal)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		try {
-			MethodKey methodKey = new MethodKey(ScreensUserServiceUtil.class,
-					"getCurrentUser", _getCurrentUserParameterTypes0);
-
-			MethodHandler methodHandler = new MethodHandler(methodKey);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception e) {
-				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
-					throw (com.liferay.portal.kernel.exception.PortalException)e;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(e);
-			}
-
-			return (com.liferay.portal.model.User)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
-
-			throw se;
-		}
-	}
-
 	public static boolean sendPasswordByEmailAddress(
 		HttpPrincipal httpPrincipal, long companyId,
 		java.lang.String emailAddress)
@@ -93,7 +62,7 @@ public class ScreensUserServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(ScreensUserServiceUtil.class,
 					"sendPasswordByEmailAddress",
-					_sendPasswordByEmailAddressParameterTypes1);
+					_sendPasswordByEmailAddressParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, emailAddress);
@@ -126,7 +95,7 @@ public class ScreensUserServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(ScreensUserServiceUtil.class,
 					"sendPasswordByScreenName",
-					_sendPasswordByScreenNameParameterTypes2);
+					_sendPasswordByScreenNameParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, screenName);
@@ -157,7 +126,7 @@ public class ScreensUserServiceHttp {
 		long userId) throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(ScreensUserServiceUtil.class,
-					"sendPasswordByUserId", _sendPasswordByUserIdParameterTypes3);
+					"sendPasswordByUserId", _sendPasswordByUserIdParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, userId);
 
@@ -184,16 +153,13 @@ public class ScreensUserServiceHttp {
 	}
 
 	private static Log _log = LogFactoryUtil.getLog(ScreensUserServiceHttp.class);
-	private static final Class<?>[] _getCurrentUserParameterTypes0 = new Class[] {
-			
-		};
-	private static final Class<?>[] _sendPasswordByEmailAddressParameterTypes1 = new Class[] {
+	private static final Class<?>[] _sendPasswordByEmailAddressParameterTypes0 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _sendPasswordByScreenNameParameterTypes2 = new Class[] {
+	private static final Class<?>[] _sendPasswordByScreenNameParameterTypes1 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _sendPasswordByUserIdParameterTypes3 = new Class[] {
+	private static final Class<?>[] _sendPasswordByUserIdParameterTypes2 = new Class[] {
 			long.class
 		};
 }

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensUserServiceSoap.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/http/ScreensUserServiceSoap.java
@@ -54,20 +54,6 @@ import java.rmi.RemoteException;
  */
 @ProviderType
 public class ScreensUserServiceSoap {
-	public static com.liferay.portal.model.User getCurrentUser()
-		throws RemoteException {
-		try {
-			com.liferay.portal.model.User returnValue = ScreensUserServiceUtil.getCurrentUser();
-
-			return returnValue;
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-
-			throw new RemoteException(e.getMessage());
-		}
-	}
-
 	public static boolean sendPasswordByEmailAddress(long companyId,
 		java.lang.String emailAddress) throws RemoteException {
 		try {

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensUserServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensUserServiceImpl.java
@@ -30,11 +30,6 @@ import com.liferay.screens.service.base.ScreensUserServiceBaseImpl;
 public class ScreensUserServiceImpl extends ScreensUserServiceBaseImpl {
 
 	@Override
-	public User getCurrentUser() throws PortalException {
-		return getUser();
-	}
-
-	@Override
 	public boolean sendPasswordByEmailAddress(
 			long companyId, String emailAddress)
 		throws PortalException {

--- a/portal-impl/test/integration/com/liferay/portal/upgrade/v7_0_0/UpgradeKernelPackageTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/upgrade/v7_0_0/UpgradeKernelPackageTest.java
@@ -62,7 +62,8 @@ public class UpgradeKernelPackageTest extends UpgradeKernelPackage {
 		sb.append(increment(ResourceBlock.class));
 		sb.append(", ");
 		sb.append(TestPropsValues.getCompanyId());
-		sb.append(", " + TestPropsValues.getGroupId());
+		sb.append(", ");
+		sb.append(TestPropsValues.getGroupId());
 		sb.append( ", '");
 		sb.append(_OLD_CLASS_NAME);
 		sb.append("_POSTFIX', 'HASH', 1)");


### PR DESCRIPTION
The API call getCurrentUser is now available as a new API in UserService, removing it to use a clearer API.
