### PR TITLE
LPS-52269 Decorate MessageFormat for number arguments

### DIFF
--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -148,9 +148,7 @@
 		</property>
 	</bean>
 	<bean id="com.liferay.portal.kernel.language.LanguageUtil" class="com.liferay.portal.kernel.language.LanguageUtil">
-		<property name="language">
-			<bean class="com.liferay.portal.language.LanguageImpl" />
-		</property>
+		<property name="language" ref="com.liferay.portal.language.LanguageImpl" />
 	</bean>
 	<bean id="com.liferay.portal.kernel.language.UnicodeLanguageUtil" class="com.liferay.portal.kernel.language.UnicodeLanguageUtil">
 		<property name="unicodeLanguage">
@@ -401,6 +399,7 @@
 	<bean id="com.liferay.portal.kernel.zip.ZipWriterFactoryUtil" class="com.liferay.portal.kernel.zip.ZipWriterFactoryUtil">
 		<property name="zipWriterFactory" ref="com.liferay.portal.kernel.zip.ZipWriterFactory" />
 	</bean>
+	<bean id="com.liferay.portal.language.LanguageImpl" class="com.liferay.portal.language.LanguageImpl" />
 	<bean id="com.liferay.portal.language.LanguageResources" class="com.liferay.portal.language.LanguageResources">
 		<property name="config" value="content.Language,content.Language-ext" />
 	</bean>

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -60,6 +60,7 @@ import com.liferay.registry.dependency.ServiceDependencyManager;
 import java.io.Serializable;
 
 import java.text.MessageFormat;
+import java.text.NumberFormat;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -475,8 +476,8 @@ public class LanguageImpl implements Language, Serializable {
 					}
 				}
 
-				MessageFormat messageFormat = getMessageFormat(
-					request, pattern);
+				MessageFormat messageFormat = decorateMessageFormat(
+					request, pattern, formattedArguments);
 
 				value = messageFormat.format(formattedArguments);
 			}
@@ -1613,11 +1614,24 @@ public class LanguageImpl implements Language, Serializable {
 		CookieKeys.addCookie(request, response, languageIdCookie);
 	}
 
-	protected MessageFormat getMessageFormat(
-			HttpServletRequest request, String pattern)
+	protected MessageFormat decorateMessageFormat(
+			HttpServletRequest request, String pattern,
+			Object[] formattedArguments)
 		throws PortalException {
 
-		return new MessageFormat(pattern, _getLocale(request));
+		Locale locale = _getLocale(request);
+
+		MessageFormat messageFormat = new MessageFormat(pattern, locale);
+
+		for (int i = 0; i < formattedArguments.length; i++) {
+			Object formattedArgument = formattedArguments[i];
+
+			if (formattedArgument instanceof Number) {
+				messageFormat.setFormat(i, NumberFormat.getInstance(locale));
+			}
+		}
+
+		return messageFormat;
 	}
 
 	private static CompanyLocalesBag _getCompanyLocalesBag() {

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -475,7 +475,10 @@ public class LanguageImpl implements Language, Serializable {
 					}
 				}
 
-				value = MessageFormat.format(pattern, formattedArguments);
+				MessageFormat messageFormat = getMessageFormat(
+					request, pattern);
+
+				value = messageFormat.format(formattedArguments);
 			}
 			else {
 				value = pattern;
@@ -1608,6 +1611,13 @@ public class LanguageImpl implements Language, Serializable {
 		languageIdCookie.setMaxAge(CookieKeys.MAX_AGE);
 
 		CookieKeys.addCookie(request, response, languageIdCookie);
+	}
+
+	protected MessageFormat getMessageFormat(
+			HttpServletRequest request, String pattern)
+		throws PortalException {
+
+		return new MessageFormat(pattern, _getLocale(request));
 	}
 
 	private static CompanyLocalesBag _getCompanyLocalesBag() {

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -308,7 +308,10 @@ public class LanguageImpl implements Language, Serializable {
 					}
 				}
 
-				value = MessageFormat.format(pattern, formattedArguments);
+				MessageFormat messageFormat = decorateMessageFormat(
+					request, pattern, formattedArguments);
+
+				value = messageFormat.format(formattedArguments);
 			}
 			else {
 				value = pattern;

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -669,7 +669,10 @@ public class LanguageImpl implements Language, Serializable {
 					}
 				}
 
-				value = MessageFormat.format(pattern, formattedArguments);
+				MessageFormat messageFormat = decorateMessageFormat(
+					locale, pattern, formattedArguments);
+
+				value = messageFormat.format(formattedArguments);
 			}
 			else {
 				value = pattern;
@@ -815,7 +818,10 @@ public class LanguageImpl implements Language, Serializable {
 					}
 				}
 
-				value = MessageFormat.format(pattern, formattedArguments);
+				MessageFormat messageFormat = decorateMessageFormat(
+					resourceBundle.getLocale(), pattern, formattedArguments);
+
+				value = messageFormat.format(formattedArguments);
 			}
 			else {
 				value = pattern;
@@ -1623,6 +1629,13 @@ public class LanguageImpl implements Language, Serializable {
 		throws PortalException {
 
 		Locale locale = _getLocale(request);
+
+		return decorateMessageFormat(locale, pattern, formattedArguments);
+	}
+
+	protected MessageFormat decorateMessageFormat(
+			Locale locale, String pattern, Object[] formattedArguments)
+		throws PortalException {
 
 		MessageFormat messageFormat = new MessageFormat(pattern, locale);
 

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1637,6 +1637,10 @@ public class LanguageImpl implements Language, Serializable {
 			Locale locale, String pattern, Object[] formattedArguments)
 		throws PortalException {
 
+		if (locale == null) {
+			locale = LocaleUtil.getDefault();
+		}
+
 		MessageFormat messageFormat = new MessageFormat(pattern, locale);
 
 		for (int i = 0; i < formattedArguments.length; i++) {

--- a/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
@@ -38,6 +38,72 @@ import org.junit.runner.RunWith;
 @RunWith(Enclosed.class)
 public class LanguageImplTest {
 
+	public static final class WhenFormattingFromLocale {
+
+		@ClassRule
+		@Rule
+		public static final AggregateTestRule aggregateTestRule =
+			new LiferayIntegrationTestRule();
+
+		@Test
+		public void testFormatWithOneArgument() {
+			String format = _languageImpl.format(
+				LocaleUtil.US, _LANG_KEY_WITH_ARGUMENT, "31");
+
+			Assert.assertEquals("31 Hours", format);
+		}
+
+		@Test
+		public void testFormatWithOneNontranslatableAmericanArgument() {
+			Locale locale = LocaleUtil.US;
+
+			String format = _languageImpl.format(
+				locale, _LANG_KEY_WITH_ARGUMENT, _BIG_INTEGER, false);
+
+			Assert.assertEquals("1,234,567,890 Hours", format);
+
+			format = _languageImpl.format(
+				locale, _LANG_KEY_WITH_ARGUMENT, _BIG_DOUBLE, false);
+
+			Assert.assertEquals("1,234,567,890.12 Hours", format);
+
+			format = _languageImpl.format(
+				locale, _LANG_KEY_WITH_ARGUMENT, _BIG_FLOAT, false);
+
+			Assert.assertEquals("1,234,567.875 Hours", format);
+		}
+
+		@Test
+		public void testFormatWithOneNontranslatableSpanishArgument() {
+			Locale locale = LocaleUtil.SPAIN;
+
+			String format = _languageImpl.format(
+				locale, _LANG_KEY_WITH_ARGUMENT, _BIG_INTEGER, false);
+
+			Assert.assertEquals("1.234.567.890 horas", format);
+
+			format = _languageImpl.format(
+				locale, _LANG_KEY_WITH_ARGUMENT, _BIG_DOUBLE, false);
+
+			Assert.assertEquals("1.234.567.890,12 horas", format);
+
+			format = _languageImpl.format(
+				locale, _LANG_KEY_WITH_ARGUMENT, _BIG_FLOAT, false);
+
+			Assert.assertEquals("1.234.567,875 horas", format);
+		}
+
+		@Test
+		public void testFormatWithTwoArguments() {
+			String format = _languageImpl.format(
+				LocaleUtil.US, _LANG_KEY_WITH_ARGUMENTS,
+				new Object[] {"A", "B"});
+
+			Assert.assertEquals("A has invited you to join B.", format);
+		}
+
+	}
+
 	public static final class WhenFormattingFromRequest {
 
 		@ClassRule

--- a/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.language;
+
+import com.liferay.portal.kernel.language.LanguageWrapper;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.theme.ThemeDisplay;
+
+import java.util.Locale;
+
+import org.apache.struts.mock.MockHttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Manuel de la Peña
+ */
+public class LanguageImplTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testFormatWithOneArgument() {
+		MockLanguageServletRequest mockLanguageServletRequest =
+			new MockLanguageServletRequest(LocaleUtil.US);
+
+		String format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			"31");
+
+		Assert.assertEquals("31 Hours", format);
+	}
+
+	@Test
+	public void testFormatWithOneLanguageWrapper() {
+		MockLanguageServletRequest mockLanguageServletRequest =
+			new MockLanguageServletRequest(LocaleUtil.US);
+
+		String format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			new LanguageWrapper("a", "31", "a"));
+
+		Assert.assertEquals("a31a Hours", format);
+	}
+
+	@Test
+	public void testFormatWithOneNontranslatableAmericanArgument() {
+		MockLanguageServletRequest mockLanguageServletRequest =
+			new MockLanguageServletRequest(LocaleUtil.US);
+
+		String format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			_BIG_INTEGER, false);
+
+		Assert.assertEquals("1,234,567,890 Hours", format);
+	}
+
+	@Test
+	public void testFormatWithOneNontranslatableSpanishArgument() {
+		MockLanguageServletRequest mockLanguageServletRequest =
+			new MockLanguageServletRequest(LocaleUtil.SPAIN);
+
+		String format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			_BIG_INTEGER, false);
+
+		Assert.assertEquals("1.234.567.890 horas", format);
+	}
+
+	@Test
+	public void testFormatWithTwoArguments() {
+		MockLanguageServletRequest mockLanguageServletRequest =
+			new MockLanguageServletRequest(LocaleUtil.US);
+
+		String format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENTS,
+			new Object[] {"A", "B"});
+
+		Assert.assertEquals("A has invited you to join B.", format);
+	}
+
+	@Test
+	public void testFormatWithTwoLanguageWrappers() {
+		MockLanguageServletRequest mockLanguageServletRequest =
+			new MockLanguageServletRequest(LocaleUtil.US);
+
+		LanguageWrapper[] languageWrappers = new LanguageWrapper[2];
+
+		languageWrappers[0] = new LanguageWrapper("a", "A", "a");
+		languageWrappers[1] = new LanguageWrapper("b", "B", "b");
+
+		String format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENTS,
+			languageWrappers);
+
+		Assert.assertEquals("aAa has invited you to join bBb.", format);
+	}
+
+	private static final Integer _BIG_INTEGER = 1234567890;
+
+	private static final String _LANG_KEY_WITH_ARGUMENT = "x-hours";
+
+	private static final String _LANG_KEY_WITH_ARGUMENTS =
+		"x-has-invited-you-to-join-x";
+
+	private final LanguageImpl _languageImpl = new LanguageImpl();
+
+	private static final class MockLanguageServletRequest {
+
+		public MockLanguageServletRequest(Locale locale) {
+			ThemeDisplay themeDisplay = new ThemeDisplay();
+
+			themeDisplay.setLocale(locale);
+
+			_mockHttpServletRequest = new MockHttpServletRequest();
+
+			_mockHttpServletRequest.setAttribute(
+				WebKeys.THEME_DISPLAY, themeDisplay);
+		}
+
+		public MockHttpServletRequest getRequest() {
+			return _mockHttpServletRequest;
+		}
+
+		private final MockHttpServletRequest _mockHttpServletRequest;
+
+	}
+
+}

--- a/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.language;
 
+import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.language.LanguageWrapper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -26,6 +27,7 @@ import java.util.Locale;
 import org.apache.struts.mock.MockHttpServletRequest;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +46,12 @@ public class LanguageImplTest {
 		@Rule
 		public static final AggregateTestRule aggregateTestRule =
 			new LiferayIntegrationTestRule();
+
+		@Before
+		public void setUp() {
+			_languageImpl = (LanguageImpl)PortalBeanLocatorUtil.locate(
+				"com.liferay.portal.language.LanguageImpl");
+		}
 
 		@Test
 		public void testFormatWithOneArgument() {
@@ -110,6 +118,12 @@ public class LanguageImplTest {
 		@Rule
 		public static final AggregateTestRule aggregateTestRule =
 			new LiferayIntegrationTestRule();
+
+		@Before
+		public void setUp() {
+			_languageImpl = (LanguageImpl)PortalBeanLocatorUtil.locate(
+				"com.liferay.portal.language.LanguageImpl");
+		}
 
 		@Test
 		public void testFormatWithOneArgument() {
@@ -227,7 +241,7 @@ public class LanguageImplTest {
 	private static final String _LANG_KEY_WITH_ARGUMENTS =
 		"x-has-invited-you-to-join-x";
 
-	private static final LanguageImpl _languageImpl = new LanguageImpl();
+	private static LanguageImpl _languageImpl;
 
 	private static final class MockLanguageServletRequest {
 

--- a/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
@@ -29,116 +29,125 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
 /**
  * @author Manuel de la Peña
  */
+@RunWith(Enclosed.class)
 public class LanguageImplTest {
 
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+	public static final class WhenFormattingFromRequest {
 
-	@Test
-	public void testFormatWithOneArgument() {
-		MockLanguageServletRequest mockLanguageServletRequest =
-			new MockLanguageServletRequest(LocaleUtil.US);
+		@ClassRule
+		@Rule
+		public static final AggregateTestRule aggregateTestRule =
+			new LiferayIntegrationTestRule();
 
-		String format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			"31");
+		@Test
+		public void testFormatWithOneArgument() {
+			MockLanguageServletRequest mockLanguageServletRequest =
+				new MockLanguageServletRequest(LocaleUtil.US);
 
-		Assert.assertEquals("31 Hours", format);
-	}
+			String format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT, "31");
 
-	@Test
-	public void testFormatWithOneLanguageWrapper() {
-		MockLanguageServletRequest mockLanguageServletRequest =
-			new MockLanguageServletRequest(LocaleUtil.US);
+			Assert.assertEquals("31 Hours", format);
+		}
 
-		String format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			new LanguageWrapper("a", "31", "a"));
+		@Test
+		public void testFormatWithOneLanguageWrapper() {
+			MockLanguageServletRequest mockLanguageServletRequest =
+				new MockLanguageServletRequest(LocaleUtil.US);
 
-		Assert.assertEquals("a31a Hours", format);
-	}
+			String format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT,
+				new LanguageWrapper("a", "31", "a"));
 
-	@Test
-	public void testFormatWithOneNontranslatableAmericanArgument() {
-		MockLanguageServletRequest mockLanguageServletRequest =
-			new MockLanguageServletRequest(LocaleUtil.US);
+			Assert.assertEquals("a31a Hours", format);
+		}
 
-		String format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			_BIG_INTEGER, false);
+		@Test
+		public void testFormatWithOneNontranslatableAmericanArgument() {
+			MockLanguageServletRequest mockLanguageServletRequest =
+				new MockLanguageServletRequest(LocaleUtil.US);
 
-		Assert.assertEquals("1,234,567,890 Hours", format);
+			String format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT, _BIG_INTEGER, false);
 
-		format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			_BIG_DOUBLE, false);
+			Assert.assertEquals("1,234,567,890 Hours", format);
 
-		Assert.assertEquals("1,234,567,890.12 Hours", format);
+			format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT, _BIG_DOUBLE, false);
 
-		format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			_BIG_FLOAT, false);
+			Assert.assertEquals("1,234,567,890.12 Hours", format);
 
-		Assert.assertEquals("1,234,567.875 Hours", format);
-	}
+			format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT, _BIG_FLOAT, false);
 
-	@Test
-	public void testFormatWithOneNontranslatableSpanishArgument() {
-		MockLanguageServletRequest mockLanguageServletRequest =
-			new MockLanguageServletRequest(LocaleUtil.SPAIN);
+			Assert.assertEquals("1,234,567.875 Hours", format);
+		}
 
-		String format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			_BIG_INTEGER, false);
+		@Test
+		public void testFormatWithOneNontranslatableSpanishArgument() {
+			MockLanguageServletRequest mockLanguageServletRequest =
+				new MockLanguageServletRequest(LocaleUtil.SPAIN);
 
-		Assert.assertEquals("1.234.567.890 horas", format);
+			String format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT, _BIG_INTEGER, false);
 
-		format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			_BIG_DOUBLE, false);
+			Assert.assertEquals("1.234.567.890 horas", format);
 
-		Assert.assertEquals("1.234.567.890,12 horas", format);
+			format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT, _BIG_DOUBLE, false);
 
-		format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
-			_BIG_FLOAT, false);
+			Assert.assertEquals("1.234.567.890,12 horas", format);
 
-		Assert.assertEquals("1.234.567,875 horas", format);
-	}
+			format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENT, _BIG_FLOAT, false);
 
-	@Test
-	public void testFormatWithTwoArguments() {
-		MockLanguageServletRequest mockLanguageServletRequest =
-			new MockLanguageServletRequest(LocaleUtil.US);
+			Assert.assertEquals("1.234.567,875 horas", format);
+		}
 
-		String format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENTS,
-			new Object[] {"A", "B"});
+		@Test
+		public void testFormatWithTwoArguments() {
+			MockLanguageServletRequest mockLanguageServletRequest =
+				new MockLanguageServletRequest(LocaleUtil.US);
 
-		Assert.assertEquals("A has invited you to join B.", format);
-	}
+			String format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENTS,
+				new Object[] {"A", "B"});
 
-	@Test
-	public void testFormatWithTwoLanguageWrappers() {
-		MockLanguageServletRequest mockLanguageServletRequest =
-			new MockLanguageServletRequest(LocaleUtil.US);
+			Assert.assertEquals("A has invited you to join B.", format);
+		}
 
-		LanguageWrapper[] languageWrappers = new LanguageWrapper[2];
+		@Test
+		public void testFormatWithTwoLanguageWrappers() {
+			MockLanguageServletRequest mockLanguageServletRequest =
+				new MockLanguageServletRequest(LocaleUtil.US);
 
-		languageWrappers[0] = new LanguageWrapper("a", "A", "a");
-		languageWrappers[1] = new LanguageWrapper("b", "B", "b");
+			LanguageWrapper[] languageWrappers = new LanguageWrapper[2];
 
-		String format = _languageImpl.format(
-			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENTS,
-			languageWrappers);
+			languageWrappers[0] = new LanguageWrapper("a", "A", "a");
+			languageWrappers[1] = new LanguageWrapper("b", "B", "b");
 
-		Assert.assertEquals("aAa has invited you to join bBb.", format);
+			String format = _languageImpl.format(
+				mockLanguageServletRequest.getRequest(),
+				_LANG_KEY_WITH_ARGUMENTS, languageWrappers);
+
+			Assert.assertEquals("aAa has invited you to join bBb.", format);
+		}
+
 	}
 
 	private static final Double _BIG_DOUBLE = 1234567890.12D;
@@ -152,7 +161,7 @@ public class LanguageImplTest {
 	private static final String _LANG_KEY_WITH_ARGUMENTS =
 		"x-has-invited-you-to-join-x";
 
-	private final LanguageImpl _languageImpl = new LanguageImpl();
+	private static final LanguageImpl _languageImpl = new LanguageImpl();
 
 	private static final class MockLanguageServletRequest {
 

--- a/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
@@ -74,6 +74,18 @@ public class LanguageImplTest {
 			_BIG_INTEGER, false);
 
 		Assert.assertEquals("1,234,567,890 Hours", format);
+
+		format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			_BIG_DOUBLE, false);
+
+		Assert.assertEquals("1,234,567,890.12 Hours", format);
+
+		format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			_BIG_FLOAT, false);
+
+		Assert.assertEquals("1,234,567.875 Hours", format);
 	}
 
 	@Test
@@ -86,6 +98,18 @@ public class LanguageImplTest {
 			_BIG_INTEGER, false);
 
 		Assert.assertEquals("1.234.567.890 horas", format);
+
+		format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			_BIG_DOUBLE, false);
+
+		Assert.assertEquals("1.234.567.890,12 horas", format);
+
+		format = _languageImpl.format(
+			mockLanguageServletRequest.getRequest(), _LANG_KEY_WITH_ARGUMENT,
+			_BIG_FLOAT, false);
+
+		Assert.assertEquals("1.234.567,875 horas", format);
 	}
 
 	@Test
@@ -116,6 +140,10 @@ public class LanguageImplTest {
 
 		Assert.assertEquals("aAa has invited you to join bBb.", format);
 	}
+
+	private static final Double _BIG_DOUBLE = 1234567890.12D;
+
+	private static final Float _BIG_FLOAT = 1234567.85F;
 
 	private static final Integer _BIG_INTEGER = 1234567890;
 

--- a/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/language/LanguageImplTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.language;
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.language.LanguageWrapper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -51,6 +52,26 @@ public class LanguageImplTest {
 		public void setUp() {
 			_languageImpl = (LanguageImpl)PortalBeanLocatorUtil.locate(
 				"com.liferay.portal.language.LanguageImpl");
+		}
+
+		@Test
+		public void testFormatWithLocaleNull() {
+			Locale defaultLocale = LocaleThreadLocal.getDefaultLocale();
+
+			Locale nullableLocale = null;
+
+			try {
+				String format = _languageImpl.format(
+					nullableLocale, _LANG_KEY_WITH_ARGUMENT, "31");
+
+				String expectedMessage = _languageImpl.format(
+					nullableLocale, _LANG_KEY_WITH_ARGUMENT, "31");
+
+				Assert.assertEquals(expectedMessage, format);
+			}
+			finally {
+				LocaleThreadLocal.setDefaultLocale(defaultLocale);
+			}
 		}
 
 		@Test


### PR DESCRIPTION
Fixed the functional test :smile: When user account is locked, then locale is null, so the code was not dealing with nulls. cc/ @migue
