### PR TITLE
Lps 58039

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/InitStartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/InitStartupAction.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.events;
+
+import com.liferay.portal.kernel.events.SimpleAction;
+import com.liferay.portal.servlet.filters.init.InitFilter;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceRegistration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.Filter;
+
+/**
+ * @author Matthew Tambara
+ */
+public class InitStartupAction extends SimpleAction {
+
+	@Override
+	public void run(String[] ids) {
+		Map<String, Object> properties = new HashMap<>();
+
+		properties.put("dispatcher", new String[] {"FORWARD", "REQUEST"});
+		properties.put("servlet-context-name", "");
+		properties.put("servlet-filter-name", "Init Filter");
+		properties.put("url-pattern", "/c/*");
+
+		Registry registry = RegistryUtil.getRegistry();
+
+		InitFilter initFilter = new InitFilter();
+
+		ServiceRegistration<InitFilter> serviceRegistration =
+			registry.registerService(
+				Filter.class.getName(), initFilter, properties);
+
+		initFilter.setServiceRegistration(serviceRegistration);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/events/InitStartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/InitStartupAction.java
@@ -32,16 +32,16 @@ public class InitStartupAction extends SimpleAction {
 
 	@Override
 	public void run(String[] ids) {
+		Registry registry = RegistryUtil.getRegistry();
+
+		InitFilter initFilter = new InitFilter();
+
 		Map<String, Object> properties = new HashMap<>();
 
 		properties.put("dispatcher", new String[] {"FORWARD", "REQUEST"});
 		properties.put("servlet-context-name", "");
 		properties.put("servlet-filter-name", "Init Filter");
 		properties.put("url-pattern", "/c/*");
-
-		Registry registry = RegistryUtil.getRegistry();
-
-		InitFilter initFilter = new InitFilter();
 
 		ServiceRegistration<InitFilter> serviceRegistration =
 			registry.registerService(

--- a/portal-impl/src/com/liferay/portal/servlet/filters/init/InitFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/init/InitFilter.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.concurrent.CompeteLatch;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 import com.liferay.registry.ServiceRegistration;
 
+import java.util.concurrent.CountDownLatch;
+
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -31,6 +33,8 @@ public class InitFilter extends BasePortalFilter {
 		ServiceRegistration<InitFilter> serviceRegistration) {
 
 		_serviceRegistration = serviceRegistration;
+
+		_countDownLatch.countDown();
 	}
 
 	@Override
@@ -38,6 +42,8 @@ public class InitFilter extends BasePortalFilter {
 			HttpServletRequest request, HttpServletResponse response,
 			FilterChain filterChain)
 		throws Exception {
+
+		_countDownLatch.await();
 
 		if (_competeLatch.compete()) {
 			try {
@@ -59,6 +65,7 @@ public class InitFilter extends BasePortalFilter {
 	}
 
 	private final CompeteLatch _competeLatch = new CompeteLatch();
+	private final CountDownLatch _countDownLatch = new CountDownLatch(1);
 	private ServiceRegistration<InitFilter> _serviceRegistration;
 
 }

--- a/portal-impl/src/com/liferay/portal/servlet/filters/init/InitFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/init/InitFilter.java
@@ -60,9 +60,8 @@ public class InitFilter extends BasePortalFilter {
 		}
 	}
 
-	private static final CountDownLatch _countDownLatch = new CountDownLatch(1);
-	private static final AtomicBoolean _setup = new AtomicBoolean();
-
+	private final CountDownLatch _countDownLatch = new CountDownLatch(1);
 	private ServiceRegistration<InitFilter> _serviceRegistration;
+	private final AtomicBoolean _setup = new AtomicBoolean();
 
 }

--- a/portal-impl/src/com/liferay/portal/servlet/filters/init/InitFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/init/InitFilter.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.servlet.filters.init;
+
+import com.liferay.portal.servlet.filters.BasePortalFilter;
+import com.liferay.registry.ServiceRegistration;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Matthew Tambara
+ */
+public class InitFilter extends BasePortalFilter {
+
+	public void setServiceRegistration(
+		ServiceRegistration<InitFilter> serviceRegistration) {
+
+		_serviceRegistration = serviceRegistration;
+	}
+
+	@Override
+	protected void processFilter(
+			HttpServletRequest request, HttpServletResponse response,
+			FilterChain filterChain)
+		throws Exception {
+
+		if (_setup.compareAndSet(false, true)) {
+			try {
+				processFilter(
+					InitFilter.class.getName(), request, response, filterChain);
+			}
+			finally {
+				_serviceRegistration.unregister();
+
+				_countDownLatch.countDown();
+			}
+		}
+		else {
+			_countDownLatch.await();
+
+			processFilter(
+				InitFilter.class.getName(), request, response, filterChain);
+		}
+	}
+
+	private static final CountDownLatch _countDownLatch = new CountDownLatch(1);
+	private static final AtomicBoolean _setup = new AtomicBoolean();
+
+	private ServiceRegistration<InitFilter> _serviceRegistration;
+
+}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3840,7 +3840,7 @@
     #
     # Global startup event that runs once when the portal initializes.
     #
-    global.startup.events=com.liferay.portal.events.GlobalStartupAction,com.liferay.portal.events.CryptoStartupAction
+    global.startup.events=com.liferay.portal.events.GlobalStartupAction,com.liferay.portal.events.CryptoStartupAction,com.liferay.portal.events.InitStartupAction
 
     #
     # Application startup event that runs once for every web site instance of


### PR DESCRIPTION
@mhan810 @alee8888

This is more like a workaround, but it is an once for all solution. We have a lot of lazily created resource on the first hit. In case of concurrent hits on startup, there is a good chance we see some tx got rollback in the console, which is technically correct, but giving users a very bad first impression. Because there are too many of similar situations, it is impractical to fix them one by one.

The solution is, in a StartupAction, we register an one time only filter. It behaves as a gate keeper to ensure no concurrent hits for the first hit. After the first hit is done, it releases all blocked concurrent hitters and unregister itself, so after the initial hit there will be no further runtime performance price to pay for doing this.
