### PR TITLE
LPS-62335 User Personal Site fix (Fix Priority 5)

### DIFF
--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/display/context/logic/PanelCategoryHelper.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/display/context/logic/PanelCategoryHelper.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.User;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -80,6 +81,21 @@ public class PanelCategoryHelper {
 
 		return hasPortlet(
 			portletId, panelCategoryKey, permissionChecker, group);
+	}
+
+	public List<PanelApp> getAllPanelApps(String panelCategoryKey) {
+		List<PanelApp> panelApps = new ArrayList<>();
+
+		panelApps.addAll(_panelAppRegistry.getPanelApps(panelCategoryKey));
+
+		for (PanelCategory curPanelCategory :
+				_panelCategoryRegistry.getChildPanelCategories(
+					panelCategoryKey)) {
+
+			panelApps.addAll(getAllPanelApps(curPanelCategory.getKey()));
+		}
+
+		return panelApps;
 	}
 
 	public String getFirstPortletId(

--- a/modules/apps/application-list/application-list-test/src/testIntegration/resources/com/liferay/application/list/deploy/hot/test/dependencies/control-panel-entry-liferay-portlet.xml
+++ b/modules/apps/application-list/application-list-test/src/testIntegration/resources/com/liferay/application/list/deploy/hot/test/dependencies/control-panel-entry-liferay-portlet.xml
@@ -3,7 +3,7 @@
 <liferay-portlet-app>
 	<portlet>
 		<portlet-name>1</portlet-name>
-		<control-panel-entry-category>site_administration.content</control-panel-entry-category>
+		<control-panel-entry-category>control_panel.sites</control-panel-entry-category>
 		<control-panel-entry-weight>1.0</control-panel-entry-weight>
 	</portlet>
 </liferay-portlet-app>

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/bnd.bnd
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Liferay Application List User Personal Site Permissions
+Bundle-SymbolicName: com.liferay.application.list.user.personal.site.permissions
+Bundle-Version: 1.0.0
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title: Product Navigation
+-include: ../../../../marketplace/web-content-management/bnd.bnd

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/build.gradle
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/build.gradle
@@ -1,0 +1,18 @@
+dependencies {
+	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.5"
+	// @formatter:off
+	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
+	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
+	// @formatter:on
+	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
+	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compile project(":apps:application-list:application-list-api")
+	compile project(":portal:portal-instance-lifecycle")
+	compile project(":core:osgi-service-tracker-collections")
+}
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/modules")
+}

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/build.gradle
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/build.gradle
@@ -1,16 +1,15 @@
+configurations {
+	compile {
+		transitive = false
+	}
+}
+
 dependencies {
-	compile group: "com.liferay", name: "com.liferay.osgi.util", version: "2.0.5"
-	// @formatter:off
-	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
-	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
-	// @formatter:on
-	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
-	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
-	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
-	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
-	compile project(":apps:application-list:application-list-api")
-	compile project(":portal:portal-instance-lifecycle")
-	compile project(":core:osgi-service-tracker-collections")
+	provided group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
+	provided group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
+	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	provided project(":apps:application-list:application-list-api")
+	provided project(":portal:portal-instance-lifecycle")
 }
 
 liferay {

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/build.xml
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE project>
+
+<project>
+	<import file="../../../build-module.xml" />
+</project>

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/PanelAppPermissionsStartupListener.java
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/PanelAppPermissionsStartupListener.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.application.list.user.personal.site.permissions;
+
+import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.PanelAppRegistry;
+import com.liferay.application.list.PanelCategoryRegistry;
+import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
+import com.liferay.portal.model.Company;
+import com.liferay.portal.model.Portlet;
+import com.liferay.portal.service.PortletLocalService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@Component(immediate = true)
+public class PanelAppPermissionsStartupListener
+	implements PortalInstanceLifecycleListener {
+
+	@Override
+	public void portalInstanceRegistered(Company company) throws Exception {
+		PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(
+			_panelAppRegistry, _panelCategoryRegistry);
+
+		List<PanelApp> panelApps = panelCategoryHelper.getAllPanelApps(
+			PanelCategoryKeys.SITE_ADMINISTRATION);
+
+		List<Portlet> portlets = new ArrayList<>(panelApps.size());
+
+		for (PanelApp panelApp : panelApps) {
+			Portlet portlet = portletLocalService.getPortletById(
+				panelApp.getPortletId());
+
+			portlets.add(portlet);
+		}
+
+		_userPersonalSitePermissions.initPermissions(
+			company.getCompanyId(), portlets);
+	}
+
+	@Reference(unbind = "-")
+	protected void setPanelAppRegistry(PanelAppRegistry panelAppRegistry) {
+		_panelAppRegistry = panelAppRegistry;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPanelCategoryRegistry(
+		PanelCategoryRegistry panelCategoryRegistry) {
+
+		_panelCategoryRegistry = panelCategoryRegistry;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortletLocalService(
+		PortletLocalService portletLocalService) {
+
+		this.portletLocalService = portletLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setUserPersonalSitePermissions(
+		UserPersonalSitePermissions userPersonalSitePermissions) {
+
+		_userPersonalSitePermissions = userPersonalSitePermissions;
+	}
+
+	protected PortletLocalService portletLocalService;
+
+	private PanelAppRegistry _panelAppRegistry;
+	private PanelCategoryRegistry _panelCategoryRegistry;
+	private UserPersonalSitePermissions _userPersonalSitePermissions;
+
+}

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/PanelAppPermissionsStartupListener.java
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/PanelAppPermissionsStartupListener.java
@@ -19,6 +19,7 @@ import com.liferay.application.list.PanelAppRegistry;
 import com.liferay.application.list.PanelCategoryRegistry;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Portlet;
@@ -33,9 +34,9 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Tomas Polesovsky
  */
-@Component(immediate = true)
+@Component(immediate = true, service = PortalInstanceLifecycleListener.class)
 public class PanelAppPermissionsStartupListener
-	implements PortalInstanceLifecycleListener {
+	extends BasePortalInstanceLifecycleListener {
 
 	@Override
 	public void portalInstanceRegistered(Company company) throws Exception {

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/UserPersonalSitePermissions.java
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/UserPersonalSitePermissions.java
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.application.list.user.personal.site.permissions;
+
+import com.liferay.application.list.PanelApp;
+import com.liferay.application.list.constants.PanelCategoryKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.model.Company;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.Portlet;
+import com.liferay.portal.model.ResourceConstants;
+import com.liferay.portal.model.Role;
+import com.liferay.portal.model.RoleConstants;
+import com.liferay.portal.service.CompanyLocalService;
+import com.liferay.portal.service.GroupLocalService;
+import com.liferay.portal.service.PortletLocalService;
+import com.liferay.portal.service.ResourcePermissionLocalService;
+import com.liferay.portal.service.RoleLocalService;
+
+import java.util.List;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@Component(immediate = true)
+public class UserPersonalSitePermissions {
+
+	public void initPermissions(List<Company> companies, Portlet portlet) {
+		String rootPortletId = portlet.getRootPortletId();
+
+		for (Company company : companies) {
+			long companyId = company.getCompanyId();
+
+			Role powerUserRole = getPowerUserRole(companyId);
+
+			if (powerUserRole == null) {
+				continue;
+			}
+
+			Group userPersonalSite = getPersonalSiteGroup(companyId);
+
+			if (userPersonalSite == null) {
+				continue;
+			}
+
+			try {
+				initPermissions(
+					companyId, powerUserRole.getRoleId(), rootPortletId,
+					userPersonalSite.getGroupId());
+			}
+			catch (PortalException e) {
+				_log.error(
+					"Unable to initialize user personal site permissions" +
+						" for portlet " + portlet.getPortletId() +
+						" in company " + companyId
+					, e);
+			}
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext)
+		throws InvalidSyntaxException {
+
+		_bundleContext = bundleContext;
+
+		Filter filter = bundleContext.createFilter(
+			"(&(objectClass=" + PanelApp.class.getName() + ")" +
+				"(panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION +
+					"*))");
+
+		_serviceTracker = new ServiceTracker<>(
+			bundleContext, filter, new PanelAppServiceTrackerCustomizer());
+
+		_serviceTracker.open();
+	}
+
+	protected void deactivated() {
+		_serviceTracker.close();
+	}
+
+	protected Group getPersonalSiteGroup(long companyId) {
+		try {
+			return _groupLocalService.getUserPersonalSiteGroup(companyId);
+		}
+		catch (PortalException e) {
+			_log.error(
+				"Unable to obtain personal site in company " + companyId, e);
+		}
+
+		return null;
+	}
+
+	protected Role getPowerUserRole(long companyId) {
+		try {
+			return _roleLocalService.getRole(
+				companyId, RoleConstants.POWER_USER);
+		}
+		catch (PortalException e) {
+			_log.error(
+				"Unable to obtain power user role in company " + companyId, e);
+		}
+
+		return null;
+	}
+
+	protected void initPermissions(
+			long companyId, long powerUserRoleId, String rootPortletId,
+			long userPersonalSiteGroupId)
+		throws PortalException {
+
+		String primaryKey = String.valueOf(userPersonalSiteGroupId);
+
+		if (_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, rootPortletId, ResourceConstants.SCOPE_GROUP,
+				primaryKey) == 0) {
+
+			List<String> portletActionIds =
+				ResourceActionsUtil.getPortletResourceActions(rootPortletId);
+
+			_resourcePermissionLocalService.setResourcePermissions(
+				companyId, rootPortletId, ResourceConstants.SCOPE_GROUP,
+				String.valueOf(userPersonalSiteGroupId), powerUserRoleId,
+				portletActionIds.toArray(new String[0]));
+		}
+
+		String rootModelName = ResourceActionsUtil.getPortletRootModelResource(
+			rootPortletId);
+
+		if (Validator.isBlank(rootModelName)) {
+			return;
+		}
+
+		if (_resourcePermissionLocalService.getResourcePermissionsCount(
+				companyId, rootModelName, ResourceConstants.SCOPE_GROUP,
+				primaryKey) == 0) {
+
+			List<String> modelActionIds =
+				ResourceActionsUtil.getModelResourceActions(rootModelName);
+
+			_resourcePermissionLocalService.setResourcePermissions(
+				companyId, rootModelName, ResourceConstants.SCOPE_GROUP,
+				String.valueOf(userPersonalSiteGroupId), powerUserRoleId,
+				modelActionIds.toArray(new String[0]));
+		}
+	}
+
+	@Reference(unbind = "-")
+	protected void setCompanyLocalService(
+		CompanyLocalService companyLocalService) {
+
+		this._companyLocalService = companyLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setGroupLocalService(GroupLocalService groupLocalService) {
+		this._groupLocalService = groupLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortletLocalService(
+		PortletLocalService portletLocalService) {
+
+		this._portletLocalService = portletLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this._resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setRoleLocalService(RoleLocalService roleLocalService) {
+		this._roleLocalService = roleLocalService;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserPersonalSitePermissions.class);
+
+	private BundleContext _bundleContext;
+	private CompanyLocalService _companyLocalService;
+	private GroupLocalService _groupLocalService;
+	private PortletLocalService _portletLocalService;
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+	private RoleLocalService _roleLocalService;
+	private ServiceTracker<PanelApp, PanelApp> _serviceTracker;
+
+	private class PanelAppServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer<PanelApp, PanelApp> {
+
+		@Override
+		public PanelApp addingService(ServiceReference<PanelApp> reference) {
+			PanelApp panelApp = _bundleContext.getService(reference);
+
+			try {
+				Portlet portlet = panelApp.getPortlet();
+
+				if (portlet == null) {
+					portlet = _portletLocalService.getPortletById(
+						panelApp.getPortletId());
+				}
+
+				if (portlet == null) {
+					Class panelAppClass = panelApp.getClass();
+					_log.error(
+						"Unable to obtain portlet " + panelApp.getPortletId() +
+							" for PanelApp " + panelAppClass.getName() +
+							". Please register PanelApp to OSGi with " +
+							"satisfied reference to the portlet.");
+
+					return panelApp;
+				}
+
+				initPermissions(_companyLocalService.getCompanies(), portlet);
+
+				return panelApp;
+			}
+			catch (Throwable e) {
+				_bundleContext.ungetService(reference);
+
+				throw e;
+			}
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<PanelApp> reference, PanelApp service) {
+
+			removedService(reference, service);
+			addingService(reference);
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<PanelApp> reference, PanelApp service) {
+
+			_bundleContext.ungetService(reference);
+		}
+
+	}
+
+}

--- a/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/UserPersonalSitePermissions.java
+++ b/modules/apps/application-list/application-list-user-personal-site-permissions/src/main/java/com/liferay/application/list/user/personal/site/permissions/UserPersonalSitePermissions.java
@@ -48,7 +48,7 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 /**
  * @author Tomas Polesovsky
  */
-@Component(immediate = true)
+@Component(immediate = true, service = UserPersonalSitePermissions.class)
 public class UserPersonalSitePermissions {
 
 	public void initPermissions(List<Company> companies, Portlet portlet) {
@@ -73,6 +73,35 @@ public class UserPersonalSitePermissions {
 				initPermissions(
 					companyId, powerUserRole.getRoleId(), rootPortletId,
 					userPersonalSite.getGroupId());
+			}
+			catch (PortalException e) {
+				_log.error(
+					"Unable to initialize user personal site permissions" +
+						" for portlet " + portlet.getPortletId() +
+						" in company " + companyId
+					, e);
+			}
+		}
+	}
+
+	public void initPermissions(long companyId, List<Portlet> portlets) {
+		Role powerUserRole = getPowerUserRole(companyId);
+
+		if (powerUserRole == null) {
+			return;
+		}
+
+		Group userPersonalSite = getPersonalSiteGroup(companyId);
+
+		if (userPersonalSite == null) {
+			return;
+		}
+
+		for (Portlet portlet : portlets) {
+			try {
+				initPermissions(
+					companyId, powerUserRole.getRoleId(),
+					portlet.getRootPortletId(), userPersonalSite.getGroupId());
 			}
 			catch (PortalException e) {
 				_log.error(

--- a/modules/portal/portal-portlet-tracker/src/main/java/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
+++ b/modules/portal/portal-portlet-tracker/src/main/java/com/liferay/portal/portlet/tracker/internal/PortletTracker.java
@@ -340,8 +340,6 @@ public class PortletTracker
 
 			deployPortlet(serviceReference, portletModel, companies);
 
-			checkResources(serviceReference, portletModel, companies);
-
 			portletModel.setReady(true);
 
 			if (_log.isInfoEnabled()) {
@@ -431,39 +429,6 @@ public class PortletTracker
 					LanguageResources.getResourceBundle(locale), properties);
 
 			serviceRegistrations.addServiceRegistration(serviceRegistration);
-		}
-	}
-
-	protected void checkResources(
-			ServiceReference<Portlet> serviceReference,
-			com.liferay.portal.model.Portlet portletModel,
-			List<Company> companies)
-		throws PortalException {
-
-		List<String> portletActions =
-			_resourceActions.getPortletResourceActions(
-				portletModel.getPortletId());
-
-		_resourceActionLocalService.checkResourceActions(
-			portletModel.getPortletId(), portletActions);
-
-		List<String> modelNames = _resourceActions.getPortletModelResources(
-			portletModel.getPortletId());
-
-		for (String modelName : modelNames) {
-			List<String> modelActions =
-				_resourceActions.getModelResourceActions(modelName);
-
-			_resourceActionLocalService.checkResourceActions(
-				modelName, modelActions);
-		}
-
-		for (Company company : companies) {
-			com.liferay.portal.model.Portlet companyPortletModel =
-				_portletLocalService.getPortletById(
-					company.getCompanyId(), portletModel.getPortletId());
-
-			_portletLocalService.checkPortlet(companyPortletModel);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -96,7 +96,6 @@ import com.liferay.portal.service.base.GroupLocalServiceBaseImpl;
 import com.liferay.portal.theme.ThemeLoader;
 import com.liferay.portal.theme.ThemeLoaderFactory;
 import com.liferay.portal.util.PortalUtil;
-import com.liferay.portal.util.PortletCategoryKeys;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
@@ -4007,53 +4006,16 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			group, role, Layout.class.getName(),
 			new String[] {ActionKeys.VIEW});
 
-		setRolePermissions(
-			group, role, "com.liferay.portlet.blogs",
-			new String[] {
-				ActionKeys.ADD_ENTRY, ActionKeys.PERMISSIONS,
-				ActionKeys.SUBSCRIBE
-			});
-
 		// Power User role
 
 		role = roleLocalService.getRole(
 			group.getCompanyId(), RoleConstants.POWER_USER);
-
-		List<Portlet> portlets = portletLocalService.getPortlets(
-			group.getCompanyId(), false, false);
-
-		for (Portlet portlet : portlets) {
-			List<String> actions =
-				ResourceActionsUtil.getPortletResourceActions(
-					portlet.getPortletId());
-
-			String controlPanelEntryCategory = GetterUtil.getString(
-				portlet.getControlPanelEntryCategory());
-
-			if (actions.contains(ActionKeys.ACCESS_IN_CONTROL_PANEL) &&
-				controlPanelEntryCategory.startsWith(
-					PortletCategoryKeys.SITE_ADMINISTRATION)) {
-
-				setRolePermissions(
-					group, role, portlet.getPortletId(),
-					new String[] {ActionKeys.ACCESS_IN_CONTROL_PANEL});
-			}
-		}
 
 		setRolePermissions(
 			group, role, Group.class.getName(),
 			new String[] {
 				ActionKeys.MANAGE_LAYOUTS, ActionKeys.VIEW_SITE_ADMINISTRATION
 			});
-
-		setRolePermissions(group, role, "com.liferay.portlet.asset");
-		setRolePermissions(group, role, "com.liferay.portlet.blogs");
-		setRolePermissions(group, role, "com.liferay.portlet.bookmarks");
-		setRolePermissions(group, role, "com.liferay.portlet.documentlibrary");
-		setRolePermissions(group, role, "com.liferay.portlet.imagegallery");
-		setRolePermissions(group, role, "com.liferay.portlet.journal");
-		setRolePermissions(group, role, "com.liferay.portlet.messageboards");
-		setRolePermissions(group, role, "com.liferay.portlet.wiki");
 	}
 
 	protected boolean isParentGroup(long parentGroupId, long groupId)

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -329,6 +329,17 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		resourceActionLocalService.checkResourceActions(
 			portlet.getPortletId(), portletActions);
 
+		List<String> modelNames = ResourceActionsUtil.getPortletModelResources(
+			portlet.getPortletId());
+
+		for (String modelName : modelNames) {
+			List<String> modelActions =
+				ResourceActionsUtil.getModelResourceActions(modelName);
+
+			resourceActionLocalService.checkResourceActions(
+				modelName, modelActions);
+		}
+
 		PortletCategory portletCategory = (PortletCategory)WebAppPool.get(
 			portlet.getCompanyId(), WebKeys.PORTLET_CATEGORY);
 


### PR DESCRIPTION
Hi Brian,

here we fix User Personal Site, reviewed by @juliocamarero.

https://issues.liferay.com/browse/LPS-62335

**Problem**: After extracting portlets to OSGi, they can be started & stopped at any time. POWER_USER permissions assignments for portlets during portal startup no longer works, there are no portlets registered at that time (except 90).

**Fix**: Register POWER_USER permissions when OSGi portlet is started. To be more precise:
- init resource permission records when PanelApp is registered
- init resource permission records when a new portal instance is created
- we create portlet resource and root portlet-model resource permissions as it was previously in GroupLocalServiceImpl

The only change is that we init all actions for portlets so that power users can also configure the portlets (set blog email templates, etc.). Previously was only ACCESS_IN_CONTROL_PANEL and they were unable to use things like configuration, permissions, export/import.

On top, in 01a6d91 I fixed PortletTracker, some of resource actions were checked twice and `PortletLSI.checkPortlet()` was called also twice. `PortletLSI.deployRemotePortlet()` checked them before model resource actions actually existed in DB causing NO_SUCH_RESOURCE_EXIST exceptions.

Thanks.
