### PR TITLE
LPS-62533 DoS on ResourcePermission records using ppid

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -1127,46 +1127,49 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		throws PortalException {
 
 		long companyId = portlet.getCompanyId();
-		String name = portlet.getRootPortletId();
+		String portletName = portlet.getRootPortletId();
 
 		if (resourcePermissionLocalService.getResourcePermissionsCount(
-				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL,
-				name) >= 4) {
+				companyId, portletName, ResourceConstants.SCOPE_INDIVIDUAL,
+				portletName) > 0) {
 
 			return;
 		}
 
 		List<String> groupActions =
-			ResourceActionsUtil.getPortletResourceGroupDefaultActions(name);
+			ResourceActionsUtil.getPortletResourceGroupDefaultActions(
+				portletName);
 
-		Role organizationUserRole = roleLocalService.getRole(
-			companyId, RoleConstants.ORGANIZATION_USER);
 		Role siteMemberRole = roleLocalService.getRole(
 			companyId, RoleConstants.SITE_MEMBER);
 
 		resourcePermissionLocalService.setResourcePermissions(
-			companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name,
-			organizationUserRole.getRoleId(),
+			companyId, portletName, ResourceConstants.SCOPE_INDIVIDUAL,
+			portletName, siteMemberRole.getRoleId(),
 			groupActions.toArray(new String[0]));
-		resourcePermissionLocalService.setResourcePermissions(
-			companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name,
-			siteMemberRole.getRoleId(), groupActions.toArray(new String[0]));
 
 		Role guestRole = roleLocalService.getRole(
 			companyId, RoleConstants.GUEST);
+
 		List<String> guestActions =
-			ResourceActionsUtil.getPortletResourceGuestDefaultActions(name);
+			ResourceActionsUtil.getPortletResourceGuestDefaultActions(
+				portletName);
+
 		resourcePermissionLocalService.setResourcePermissions(
-			companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name,
-			guestRole.getRoleId(), guestActions.toArray(new String[0]));
+			companyId, portletName, ResourceConstants.SCOPE_INDIVIDUAL,
+			portletName, guestRole.getRoleId(),
+			guestActions.toArray(new String[0]));
 
 		Role ownerRole = roleLocalService.getRole(
 			companyId, RoleConstants.OWNER);
+
 		List<String> ownerActions =
-			ResourceActionsUtil.getPortletResourceActions(name);
+			ResourceActionsUtil.getPortletResourceActions(portletName);
+
 		resourcePermissionLocalService.setOwnerResourcePermissions(
-			companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, name,
-			ownerRole.getRoleId(), 0, ownerActions.toArray(new String[0]));
+			companyId, portletName, ResourceConstants.SCOPE_INDIVIDUAL,
+			portletName, ownerRole.getRoleId(), 0,
+			ownerActions.toArray(new String[0]));
 	}
 
 	private void _readLiferayDisplay(

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -148,41 +148,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 	@Override
 	public void checkPortlet(Portlet portlet) throws PortalException {
-		long companyId = portlet.getCompanyId();
-		String name = portlet.getRootPortletId();
-
 		_initPortletResourcePermissions(portlet);
 
-		if (portlet.isSystem()) {
-			return;
-		}
-
-		String[] roleNames = portlet.getRolesArray();
-
-		if (roleNames.length == 0) {
-			return;
-		}
-
-		int scope = ResourceConstants.SCOPE_COMPANY;
-		String primKey = String.valueOf(companyId);
-		String actionId = ActionKeys.ADD_TO_PAGE;
-
-		List<String> actionIds = ResourceActionsUtil.getPortletResourceActions(
-			name);
-
-		if (actionIds.contains(actionId)) {
-			for (String roleName : roleNames) {
-				Role role = roleLocalService.getRole(companyId, roleName);
-
-				resourcePermissionLocalService.addResourcePermission(
-					companyId, name, scope, primKey, role.getRoleId(),
-					actionId);
-			}
-		}
-
-		updatePortlet(
-			companyId, portlet.getPortletId(), StringPool.BLANK,
-			portlet.isActive());
+		_initPortletAddToPagePermissions(portlet);
 	}
 
 	@Override
@@ -1115,6 +1083,44 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		}
 
 		return configuration.get(propertyKey);
+	}
+
+	private void _initPortletAddToPagePermissions(Portlet portlet)
+		throws PortalException {
+
+		long companyId = portlet.getCompanyId();
+		String name = portlet.getRootPortletId();
+
+		if (portlet.isSystem()) {
+			return;
+		}
+
+		String[] roleNames = portlet.getRolesArray();
+
+		if (roleNames.length == 0) {
+			return;
+		}
+
+		int scope = ResourceConstants.SCOPE_COMPANY;
+		String primKey = String.valueOf(companyId);
+		String actionId = ActionKeys.ADD_TO_PAGE;
+
+		List<String> actionIds = ResourceActionsUtil.getPortletResourceActions(
+			name);
+
+		if (actionIds.contains(actionId)) {
+			for (String roleName : roleNames) {
+				Role role = roleLocalService.getRole(companyId, roleName);
+
+				resourcePermissionLocalService.addResourcePermission(
+					companyId, name, scope, primKey, role.getRoleId(),
+					actionId);
+			}
+		}
+
+		updatePortlet(
+			companyId, portlet.getPortletId(), StringPool.BLANK,
+			portlet.isActive());
 	}
 
 	private void _initPortletResourcePermissions(Portlet portlet)

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -148,7 +148,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 	@Override
 	public void checkPortlet(Portlet portlet) throws PortalException {
-		_initPortletResourcePermissions(portlet);
+		_initPortletDefaultPermissions(portlet);
 
 		_initPortletAddToPagePermissions(portlet);
 	}
@@ -1123,7 +1123,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 			portlet.isActive());
 	}
 
-	private void _initPortletResourcePermissions(Portlet portlet)
+	private void _initPortletDefaultPermissions(Portlet portlet)
 		throws PortalException {
 
 		long companyId = portlet.getCompanyId();

--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -27,10 +27,12 @@ import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutTypePortlet;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.PortletConstants;
+import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.impl.VirtualLayout;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
+import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.util.PortletCategoryKeys;
 import com.liferay.portlet.ControlPanelEntry;
 import com.liferay.portlet.exportimport.staging.permission.StagingPermissionUtil;
@@ -335,6 +337,13 @@ public class PortletPermissionImpl implements PortletPermission {
 		}
 
 		primKey = getPrimaryKey(layout.getPlid(), portletId);
+
+		if (ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
+				permissionChecker.getCompanyId(), name,
+				ResourceConstants.SCOPE_INDIVIDUAL, primKey) == 0) {
+
+			primKey = name;
+		}
 
 		if (strict) {
 			return permissionChecker.hasPermission(

--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -325,7 +325,8 @@ public class PortletPermissionImpl implements PortletPermission {
 
 		if (checkStagingPermission) {
 			Boolean hasPermission = StagingPermissionUtil.hasPermission(
-				permissionChecker, groupId, rootPortletId, groupId, rootPortletId, actionId);
+				permissionChecker, groupId, rootPortletId, groupId,
+				rootPortletId, actionId);
 
 			if (hasPermission != null) {
 				return hasPermission.booleanValue();

--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -338,10 +338,17 @@ public class PortletPermissionImpl implements PortletPermission {
 
 		resourcePermissionPrimKey = getPrimaryKey(layout.getPlid(), portletId);
 
+		boolean useDefaultPortletPermissions = false;
+
 		if (ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
 				permissionChecker.getCompanyId(), rootPortletId,
-				ResourceConstants.SCOPE_INDIVIDUAL, resourcePermissionPrimKey) == 0) {
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				resourcePermissionPrimKey) == 0) {
 
+			useDefaultPortletPermissions = true;
+		}
+
+		if (useDefaultPortletPermissions) {
 			resourcePermissionPrimKey = rootPortletId;
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -27,13 +27,10 @@ import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutTypePortlet;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.PortletConstants;
-import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.impl.VirtualLayout;
 import com.liferay.portal.service.GroupLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.PortletLocalServiceUtil;
-import com.liferay.portal.service.ResourceLocalServiceUtil;
-import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.util.PortletCategoryKeys;
 import com.liferay.portlet.ControlPanelEntry;
 import com.liferay.portlet.exportimport.staging.permission.StagingPermissionUtil;
@@ -352,12 +349,6 @@ public class PortletPermissionImpl implements PortletPermission {
 			return true;
 		}
 
-		if (!hasIndividualResource(permissionChecker, name, primKey)) {
-			ResourceLocalServiceUtil.addResources(
-				permissionChecker.getCompanyId(), groupId,
-				permissionChecker.getUserId(), name, primKey, true, true, true);
-		}
-
 		return permissionChecker.hasPermission(
 			groupId, name, primKey, actionId);
 	}
@@ -671,21 +662,6 @@ public class PortletPermissionImpl implements PortletPermission {
 		}
 
 		return false;
-	}
-
-	protected boolean hasIndividualResource(
-		PermissionChecker permissionChecker, String name, String primKey) {
-
-		int count =
-			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				permissionChecker.getCompanyId(), name,
-				ResourceConstants.SCOPE_INDIVIDUAL, primKey);
-
-		if (count == 0) {
-			return false;
-		}
-
-		return true;
 	}
 
 	private static final boolean _CHECK_STAGING_PERMISSION_DEFAULT = true;

--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -282,14 +282,14 @@ public class PortletPermissionImpl implements PortletPermission {
 		throws PortalException {
 
 		String name = null;
-		String primKey = null;
+		String resourcePermissionPrimKey = null;
 
 		if (layout == null) {
 			name = portletId;
-			primKey = portletId;
+			resourcePermissionPrimKey = portletId;
 
 			return permissionChecker.hasPermission(
-				groupId, name, primKey, actionId);
+				groupId, name, resourcePermissionPrimKey, actionId);
 		}
 
 		if ((layout instanceof VirtualLayout) && layout.isTypeControlPanel()) {
@@ -321,11 +321,11 @@ public class PortletPermissionImpl implements PortletPermission {
 
 		groupId = layout.getGroupId();
 
-		name = PortletConstants.getRootPortletId(portletId);
+		String rootPortletId = PortletConstants.getRootPortletId(portletId);
 
 		if (checkStagingPermission) {
 			Boolean hasPermission = StagingPermissionUtil.hasPermission(
-				permissionChecker, groupId, name, groupId, name, actionId);
+				permissionChecker, groupId, rootPortletId, groupId, rootPortletId, actionId);
 
 			if (hasPermission != null) {
 				return hasPermission.booleanValue();
@@ -336,18 +336,18 @@ public class PortletPermissionImpl implements PortletPermission {
 			return true;
 		}
 
-		primKey = getPrimaryKey(layout.getPlid(), portletId);
+		resourcePermissionPrimKey = getPrimaryKey(layout.getPlid(), portletId);
 
 		if (ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				permissionChecker.getCompanyId(), name,
-				ResourceConstants.SCOPE_INDIVIDUAL, primKey) == 0) {
+				permissionChecker.getCompanyId(), rootPortletId,
+				ResourceConstants.SCOPE_INDIVIDUAL, resourcePermissionPrimKey) == 0) {
 
-			primKey = name;
+			resourcePermissionPrimKey = rootPortletId;
 		}
 
 		if (strict) {
 			return permissionChecker.hasPermission(
-				groupId, name, primKey, actionId);
+				groupId, rootPortletId, resourcePermissionPrimKey, actionId);
 		}
 
 		if (hasConfigurePermission(
@@ -359,7 +359,7 @@ public class PortletPermissionImpl implements PortletPermission {
 		}
 
 		return permissionChecker.hasPermission(
-			groupId, name, primKey, actionId);
+			groupId, rootPortletId, resourcePermissionPrimKey, actionId);
 	}
 
 	public boolean contains(

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -701,8 +701,7 @@ public class PortalImpl implements Portal {
 			groupId = getScopeGroupId(layout, portlet.getPortletId());
 		}
 
-		addRootModelResource(
-			themeDisplay.getCompanyId(), groupId, portlet);
+		addRootModelResource(themeDisplay.getCompanyId(), groupId, portlet);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -701,8 +701,8 @@ public class PortalImpl implements Portal {
 			groupId = getScopeGroupId(layout, portlet.getPortletId());
 		}
 
-		addDefaultResource(
-			themeDisplay.getCompanyId(), groupId, layout, portlet, false);
+		addRootModelDefaultResource(
+			themeDisplay.getCompanyId(), groupId, portlet);
 	}
 
 	@Override
@@ -710,7 +710,9 @@ public class PortalImpl implements Portal {
 			long companyId, Layout layout, Portlet portlet)
 		throws PortalException {
 
-		addDefaultResource(companyId, layout, portlet, false);
+		long groupId = getScopeGroupId(layout, portlet.getPortletId());
+
+		addRootModelDefaultResource(companyId, groupId, portlet);
 	}
 
 	@Override
@@ -7112,6 +7114,7 @@ public class PortalImpl implements Portal {
 		return windowState;
 	}
 
+	@Deprecated
 	protected void addDefaultResource(
 			long companyId, Layout layout, Portlet portlet,
 			boolean portletActions)
@@ -7119,26 +7122,27 @@ public class PortalImpl implements Portal {
 
 		long groupId = getScopeGroupId(layout, portlet.getPortletId());
 
-		addDefaultResource(companyId, groupId, layout, portlet, portletActions);
+		addRootModelDefaultResource(companyId, groupId, portlet);
 	}
 
+	@Deprecated
 	protected void addDefaultResource(
 			long companyId, long groupId, Layout layout, Portlet portlet,
 			boolean portletActions)
 		throws PortalException {
 
-		String rootPortletId = portlet.getRootPortletId();
+		addRootModelDefaultResource(companyId, groupId, portlet);
+	}
 
-		String portletPrimaryKey = PortletPermissionUtil.getPrimaryKey(
-			layout.getPlid(), portlet.getPortletId());
+	protected void addRootModelDefaultResource(
+			long companyId, long groupId, Portlet portlet)
+		throws PortalException {
+
+		String rootPortletId = portlet.getRootPortletId();
 
 		String name = null;
 		String primaryKey = null;
 
-		if (portletActions) {
-			return;
-		}
-		else {
 			Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 
 			if ((group != null) && group.isStagingGroup()) {
@@ -7147,7 +7151,6 @@ public class PortalImpl implements Portal {
 
 			name = ResourceActionsUtil.getPortletBaseResource(rootPortletId);
 			primaryKey = String.valueOf(groupId);
-		}
 
 		if (Validator.isNull(name)) {
 			return;
@@ -7164,18 +7167,8 @@ public class PortalImpl implements Portal {
 
 		boolean addGuestPermissions = true;
 
-		if (portletActions) {
-			Group layoutGroup = layout.getGroup();
-
-			if (layout.isPrivateLayout() && !layoutGroup.isLayoutPrototype() &&
-				!layoutGroup.isLayoutSetPrototype()) {
-
-				addGuestPermissions = false;
-			}
-		}
-
 		ResourceLocalServiceUtil.addResources(
-			companyId, groupId, 0, name, primaryKey, portletActions, true,
+			companyId, groupId, 0, name, primaryKey, false, true,
 			addGuestPermissions);
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -7140,17 +7140,14 @@ public class PortalImpl implements Portal {
 
 		String rootPortletId = portlet.getRootPortletId();
 
-		String name = null;
-		String primaryKey = null;
+		Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 
-			Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+		if ((group != null) && group.isStagingGroup()) {
+			groupId = group.getLiveGroupId();
+		}
 
-			if ((group != null) && group.isStagingGroup()) {
-				groupId = group.getLiveGroupId();
-			}
-
-			name = ResourceActionsUtil.getPortletBaseResource(rootPortletId);
-			primaryKey = String.valueOf(groupId);
+		String name = ResourceActionsUtil.getPortletBaseResource(rootPortletId);
+		String primaryKey = String.valueOf(groupId);
 
 		if (Validator.isNull(name)) {
 			return;
@@ -7165,11 +7162,8 @@ public class PortalImpl implements Portal {
 			return;
 		}
 
-		boolean addGuestPermissions = true;
-
 		ResourceLocalServiceUtil.addResources(
-			companyId, groupId, 0, name, primaryKey, false, true,
-			addGuestPermissions);
+			companyId, groupId, 0, name, primaryKey, false, true, true);
 	}
 
 	protected String buildI18NPath(Locale locale) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -702,8 +702,6 @@ public class PortalImpl implements Portal {
 		}
 
 		addDefaultResource(
-			themeDisplay.getCompanyId(), groupId, layout, portlet, true);
-		addDefaultResource(
 			themeDisplay.getCompanyId(), groupId, layout, portlet, false);
 	}
 
@@ -712,7 +710,6 @@ public class PortalImpl implements Portal {
 			long companyId, Layout layout, Portlet portlet)
 		throws PortalException {
 
-		addDefaultResource(companyId, layout, portlet, true);
 		addDefaultResource(companyId, layout, portlet, false);
 	}
 
@@ -7139,8 +7136,7 @@ public class PortalImpl implements Portal {
 		String primaryKey = null;
 
 		if (portletActions) {
-			name = rootPortletId;
-			primaryKey = portletPrimaryKey;
+			return;
 		}
 		else {
 			Group group = GroupLocalServiceUtil.fetchGroup(groupId);

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -701,7 +701,7 @@ public class PortalImpl implements Portal {
 			groupId = getScopeGroupId(layout, portlet.getPortletId());
 		}
 
-		addRootModelDefaultResource(
+		addRootModelResource(
 			themeDisplay.getCompanyId(), groupId, portlet);
 	}
 
@@ -712,7 +712,7 @@ public class PortalImpl implements Portal {
 
 		long groupId = getScopeGroupId(layout, portlet.getPortletId());
 
-		addRootModelDefaultResource(companyId, groupId, portlet);
+		addRootModelResource(companyId, groupId, portlet);
 	}
 
 	@Override
@@ -7122,7 +7122,7 @@ public class PortalImpl implements Portal {
 
 		long groupId = getScopeGroupId(layout, portlet.getPortletId());
 
-		addRootModelDefaultResource(companyId, groupId, portlet);
+		addRootModelResource(companyId, groupId, portlet);
 	}
 
 	@Deprecated
@@ -7131,10 +7131,10 @@ public class PortalImpl implements Portal {
 			boolean portletActions)
 		throws PortalException {
 
-		addRootModelDefaultResource(companyId, groupId, portlet);
+		addRootModelResource(companyId, groupId, portlet);
 	}
 
-	protected void addRootModelDefaultResource(
+	protected void addRootModelResource(
 			long companyId, long groupId, Portlet portlet)
 		throws PortalException {
 

--- a/portal-impl/test/integration/com/liferay/portal/verify/VerifyPermissionTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/verify/VerifyPermissionTest.java
@@ -19,12 +19,10 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.Layout;
 import com.liferay.portal.model.LayoutConstants;
-import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.ResourcePermission;
 import com.liferay.portal.model.Role;
@@ -32,13 +30,12 @@ import com.liferay.portal.model.RoleConstants;
 import com.liferay.portal.model.User;
 import com.liferay.portal.service.CompanyLocalServiceUtil;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
-import com.liferay.portal.service.PortletLocalServiceUtil;
+import com.liferay.portal.service.ResourceLocalServiceUtil;
 import com.liferay.portal.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.service.RoleLocalServiceUtil;
 import com.liferay.portal.service.permission.PortletPermissionUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.theme.ThemeDisplay;
-import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.verify.test.BaseVerifyProcessTestCase;
 import com.liferay.portlet.util.test.PortletKeys;
 
@@ -144,14 +141,12 @@ public class VerifyPermissionTest extends BaseVerifyProcessTestCase {
 
 		Layout layout = layouts.get(0);
 
-		themeDisplay.setLayout(layout);
+		String primKey = PortletPermissionUtil.getPrimaryKey(
+			layout.getPlid(), PortletKeys.TEST);
 
-		_request.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
-
-		Portlet portlet = PortletLocalServiceUtil.getPortletById(
-			user.getCompanyId(), PortletKeys.TEST);
-
-		PortalUtil.addPortletDefaultResource(_request, portlet);
+		ResourceLocalServiceUtil.addResources(
+			company.getCompanyId(), layout.getGroupId(), 0, PortletKeys.TEST,
+			primKey, true, true, true);
 
 		return layout;
 	}


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-62533

**Problem**: Chicken and egg :) 

To check permissions we need to add them. So we add them during the first time render, however we need them before the render. So we add them every time somebody requests them => changing ppid in URL will create any number of records in DB.

**Solution:** Create a "default" company-wide set of ResourcePermission records for a portlet.

When we place a portlet on a page we add a default set of ResourcePermission records. If we place a portlet 20 times on the same page, there will be 20 sets with the same records (only primKey differs).

So instead of creating the set for every portlet instance we use the default records.

When admin changes permissions of a portlet on page then a new set of permissions is created, as it was before.

**TL;DR**: Before - every portlet on a page had own set of ResourcePermission records. After this pull - portlet has own set of ResourcePermission records only when they are different from the default set.

/cc @JorgeFerrer 
