### PR TITLE
LPS-62869

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/io/ProtectedObjectInputStream.java
+++ b/portal-service/src/com/liferay/portal/kernel/io/ProtectedObjectInputStream.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.io;
 
+import com.liferay.portal.kernel.util.ClassResolverUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.IOException;
@@ -40,7 +41,9 @@ public class ProtectedObjectInputStream extends ObjectInputStream {
 	protected Class<?> doResolveClass(ObjectStreamClass objectStreamClass)
 		throws ClassNotFoundException, IOException {
 
-		return super.resolveClass(objectStreamClass);
+		String name = objectStreamClass.getName();
+
+		return ClassResolverUtil.resolveByContextClassLoader(name);
 	}
 
 	@Override


### PR DESCRIPTION
LPS-62869 Using context classloader as otherwise classloader of ProtectedObjectInputStream because it has the first non system classloader in the call stack
