### PR TITLE
Liferay aui xml update

### DIFF
--- a/util-taglib/src/com/liferay/taglib/liferay-aui.xml
+++ b/util-taglib/src/com/liferay/taglib/liferay-aui.xml
@@ -1600,6 +1600,7 @@
 				<outputType>java.util.Locale[]</outputType>
 			</attribute>
 			<attribute>
+				<description>Whether to make the translation manager default language changeable. The default value is <![CDATA[<code>true</code>]]>.</description>
 				<name>changeableDefaultLanguage</name>
 				<inputType>boolean</inputType>
 				<outputType>boolean</outputType>


### PR DESCRIPTION
Previously, I should have updated this liferay-aui.xml file and then executed ant build-taglibs to propagate the changes to liferay-aui.tld. I now updated the XML file and ran the target; but of course the TLD already has the changes. So the XML file and TLD file are now in sync. 

Thanks for bringing this up with regards to the liferay-aui (aui) taglibs.
