### PR TITLE
LPS-62942 Explicitly list exported packages for correctness

### DIFF
--- a/modules/sdk/gradle-plugins-cache/bnd.bnd
+++ b/modules/sdk/gradle-plugins-cache/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Gradle Plugins Cache
 Bundle-SymbolicName: com.liferay.gradle.plugins.cache
 Bundle-Version: 1.0.4
-Export-Package: com.liferay.gradle.plugins.cache
+Export-Package: com.liferay.gradle.plugins.cache.*

--- a/modules/sdk/gradle-plugins-change-log-builder/bnd.bnd
+++ b/modules/sdk/gradle-plugins-change-log-builder/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Gradle Plugins Change Log Builder
 Bundle-SymbolicName: com.liferay.gradle.plugins.change.log.builder
 Bundle-Version: 1.0.1
-Export-Package: com.liferay.gradle.plugins.change.log.builder
+Export-Package: com.liferay.gradle.plugins.change.log.builder.*

--- a/modules/sdk/gradle-plugins-lang-merger/bnd.bnd
+++ b/modules/sdk/gradle-plugins-lang-merger/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Gradle Plugins Lang Merger
 Bundle-SymbolicName: com.liferay.gradle.plugins.lang.merger
 Bundle-Version: 1.0.1
-Export-Package: com.liferay.gradle.plugins.lang.merger
+Export-Package: com.liferay.gradle.plugins.lang.merger.*
 Include-Resource: classes

--- a/modules/sdk/gradle-plugins-maven-plugin-builder/bnd.bnd
+++ b/modules/sdk/gradle-plugins-maven-plugin-builder/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Gradle Plugins Maven Plugin Builder
 Bundle-SymbolicName: com.liferay.gradle.plugins.maven.plugin.builder
 Bundle-Version: 1.0.7
-Export-Package: com.liferay.gradle.plugins.maven.plugin.builder
+Export-Package: com.liferay.gradle.plugins.maven.plugin.builder.*

--- a/modules/sdk/gradle-plugins-node/bnd.bnd
+++ b/modules/sdk/gradle-plugins-node/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Gradle Plugins Node
 Bundle-SymbolicName: com.liferay.gradle.plugins.node
 Bundle-Version: 1.0.13
-Export-Package: com.liferay.gradle.plugins.node
+Export-Package: com.liferay.gradle.plugins.node.*

--- a/modules/sdk/gradle-plugins-test-integration/bnd.bnd
+++ b/modules/sdk/gradle-plugins-test-integration/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Gradle Plugins Test Integration
 Bundle-SymbolicName: com.liferay.gradle.plugins.test.integration
 Bundle-Version: 1.0.2
-Export-Package: com.liferay.gradle.plugins.test.integration
+Export-Package: com.liferay.gradle.plugins.test.integration.*

--- a/modules/sdk/gradle-plugins-tlddoc-builder/bnd.bnd
+++ b/modules/sdk/gradle-plugins-tlddoc-builder/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Gradle Plugins TLDDoc Builder
 Bundle-SymbolicName: com.liferay.gradle.plugins.tlddoc.builder
 Bundle-Version: 1.0.1
-Export-Package: com.liferay.gradle.plugins.tlddoc.builder
+Export-Package: com.liferay.gradle.plugins.tlddoc.builder.*

--- a/modules/sdk/gradle-plugins-workspace/bnd.bnd
+++ b/modules/sdk/gradle-plugins-workspace/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Gradle Plugins Workspace
 Bundle-SymbolicName: com.liferay.gradle.plugins.workspace
 Bundle-Version: 1.0.8
-Export-Package: com.liferay.gradle.plugins.workspace
+Export-Package: com.liferay.gradle.plugins.workspace.*
 -donotcopy: (\.gradle)

--- a/modules/sdk/gradle-plugins/bnd.bnd
+++ b/modules/sdk/gradle-plugins/bnd.bnd
@@ -1,4 +1,8 @@
 Bundle-Name: Liferay Gradle Plugins
 Bundle-SymbolicName: com.liferay.gradle.plugins
 Bundle-Version: 1.0.126
-Export-Package: com.liferay.gradle.plugins
+Export-Package:\
+	com.liferay.gradle.plugins,\
+	com.liferay.gradle.plugins.extensions,\
+	com.liferay.gradle.plugins.tasks,\
+	com.liferay.gradle.plugins.util

--- a/modules/sdk/gradle-util/bnd.bnd
+++ b/modules/sdk/gradle-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Gradle Utilities
 Bundle-SymbolicName: com.liferay.gradle.util
 Bundle-Version: 1.0.25
-Export-Package: com.liferay.gradle.util
+Export-Package: com.liferay.gradle.util.*


### PR DESCRIPTION
Hi!
This pull is only to fix the Bnd warnings that appear while building `gradle-plugins*` modules. There is no need to publish all of them again, we can do it lazily.

Thank you!
