### PR TITLE
LRDOCS-2179 Remove call to former target javadoc-all

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -544,7 +544,6 @@
 	<target name="doc">
 		<antcall target="dtddoc" />
 		<antcall target="javadoc" />
-		<antcall target="javadoc-all" />
 		<antcall target="propertiesdoc" />
 		<ant dir="util-taglib" target="taglibdoc" inheritAll="false" />
 	</target>


### PR DESCRIPTION
I removed the target in a previous PR, but left this call by mistake.

@ZoltanTakacs Please backport to 7.0 branch. Thanks.

cc/ @caustin582
