### PR TITLE
LPS-61795 Local staging permissions

### DIFF
--- a/modules/apps/staging/staging-security/build.gradle
+++ b/modules/apps/staging/staging-security/build.gradle
@@ -1,8 +1,10 @@
 dependencies {
+	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compile group: "org.springframework", name: "spring-aop", version: "3.2.15.RELEASE"
 }
 
 liferay {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionCheckerFactory.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/permission/StagingPermissionCheckerFactory.java
@@ -14,6 +14,7 @@
 
 package com.liferay.staging.security.permission;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
@@ -25,6 +26,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Tomas Polesovsky
@@ -68,6 +70,10 @@ public class StagingPermissionCheckerFactory
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleContext = bundleContext;
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
 	}
 
 	private BundleContext _bundleContext;

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public GroupLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(GroupLocalService.class);
+
+		initRelatedServiceBuilderMethods("Organization");
+		initRelatedServiceBuilderMethods("Role");
+		initRelatedServiceBuilderMethods("User");
+		initRelatedServiceBuilderMethods("UserGroup");
+
+		initCustomMethod("getUserGroupPrimaryKeys", 0, long.class);
+	}
+
+	protected void initRelatedServiceBuilderMethods(String relatedEntityName)
+		throws NoSuchMethodException {
+
+		Method[] relatedEntityMethods = GroupLocalService.class.getMethods();
+
+		for (String template : _SERVICE_BUILDER_GENERATED_TEMPLATES) {
+			String serviceBuilderMethodName = StringUtil.replace(
+				template, "$1", relatedEntityName);
+
+			for (Method method : relatedEntityMethods) {
+				if (method.getName().equals(serviceBuilderMethodName)) {
+					initCustomMethod(
+						serviceBuilderMethodName, 1,
+						method.getParameterTypes());
+				}
+			}
+		}
+	}
+
+	private static final String[] _SERVICE_BUILDER_GENERATED_TEMPLATES =
+		new String[] {
+			"add$1Group", "add$1Groups", "delete$1Group", "delete$1Groups",
+			"has$1Group", "set$1Groups", "unset$1Groups"
+		};
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -14,14 +14,19 @@
 
 package com.liferay.staging.security.spring;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.lang.reflect.Method;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public GroupLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -52,6 +57,19 @@ public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 				}
 			}
 		}
+	}
+
+	@Reference
+	protected void setService(GroupLocalService service) {
+		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
+	}
+
+	protected void unsetService(GroupLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final String[] _SERVICE_BUILDER_GENERATED_TEMPLATES =

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -43,6 +43,37 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		_localServiceClass = localServiceClass;
 	}
 
+	public void checkCoverage(List<String> falsePositivesList) {
+		Method[] methods = _localServiceClass.getMethods();
+
+		for (Method method : methods) {
+			String methodName = method.getName();
+			String methodNameWithoutUserGroup = StringUtil.replace(
+				methodName, "UserGroup", "");
+
+			if (methodNameWithoutUserGroup.contains("Group")) {
+				if (_serviceBuilderGeneratedMethods.contains(method)) {
+					continue;
+				}
+
+				if (_customMethods.containsKey(method)) {
+					continue;
+				}
+
+				if (falsePositivesList.contains(methodName)) {
+					continue;
+				}
+
+				_log.error(
+					"Please update " + getClass().getName() + " with " +
+					method + ". The method must be processed when it " +
+					"contains groupId, otherwise it's safe to add the method " +
+					"name to " + getClass().getSimpleName() +
+					"._GROUP_METHODS_WHITELIST");
+			}
+		}
+	}
+
 	public void initCustomMethod(
 			String methodName, Integer index, Class... parameterTypes)
 		throws NoSuchMethodException {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -90,7 +90,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 			_log.debug("Registering " + customMethod);
 		}
 
-		_customMethods.put(customMethod, new Integer[] {index});
+		_customMethods.put(customMethod, index);
 	}
 
 	public void initGroupServiceBuilderMethods() {
@@ -272,17 +272,15 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 
 		Method method = methodInvocation.getMethod();
 
-		Integer[] argumentIndexes = _customMethods.get(method);
+		Integer argumentIndex = _customMethods.get(method);
 
-		if (argumentIndexes == null) {
+		if (argumentIndex == null) {
 			return;
 		}
 
 		Object[] arguments = methodInvocation.getArguments();
 
-		for (Integer argumentIndex : argumentIndexes) {
-			replaceArgument(arguments, argumentIndex);
-		}
+		replaceArgument(arguments, argumentIndex);
 	}
 
 	protected void replaceStagingGroupIdsInServiceBuilderGeneratedMethod(
@@ -334,7 +332,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 	private static final Log _log = LogFactoryUtil.getLog(
 		LiveGroupStagingAdvice.class);
 
-	private final Map<Method, Integer[]> _customMethods = new HashMap<>();
+	private final Map<Method, Integer> _customMethods = new HashMap<>();
 	private final Class _localServiceClass;
 	private final List<Method> _serviceBuilderGeneratedMethods =
 		new ArrayList<>();

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -156,23 +156,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		}
 	}
 
-	protected Group replace(Group group) {
-		if (group == null) {
-			return group;
-		}
-
-		return StagingUtil.getLiveGroup(group.getGroupId());
-	}
-
-	protected long replace(long groupId) {
-		if (groupId == 0) {
-			return groupId;
-		}
-
-		return StagingUtil.getLiveGroupId(groupId);
-	}
-
-	protected void replace(Object[] arguments, int index) {
+	protected void replaceArgument(Object[] arguments, int index) {
 		if (arguments == null) {
 			return;
 		}
@@ -186,7 +170,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		if (object instanceof Long) {
 			long groupId = (Long)object;
 
-			arguments[index] = replace(groupId);
+			arguments[index] = replaceGroupIdArgument(groupId);
 
 			return;
 		}
@@ -194,7 +178,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		if (object instanceof Group) {
 			Group group = (Group)object;
 
-			arguments[index] = replace(group);
+			arguments[index] = replaceGroupArgument(group);
 
 			return;
 		}
@@ -203,7 +187,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 			long[] groupIds = (long[])object;
 
 			for (int i = 0; i < groupIds.length; i++) {
-				groupIds[i] = replace(groupIds[i]);
+				groupIds[i] = replaceGroupIdArgument(groupIds[i]);
 			}
 
 			return;
@@ -213,7 +197,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 			Long[] groupIds = (Long[])object;
 
 			for (int i = 0; i < groupIds.length; i++) {
-				groupIds[i] = replace(groupIds[i]);
+				groupIds[i] = replaceGroupIdArgument(groupIds[i]);
 			}
 
 			return;
@@ -223,7 +207,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 			Group[] groups = (Group[])object;
 
 			for (int i = 0; i < groups.length; i++) {
-				groups[i] = replace(groups[i]);
+				groups[i] = replaceGroupArgument(groups[i]);
 			}
 
 			return;
@@ -240,7 +224,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 				new Object[collection.size()]);
 
 			for (int i = 0; i < collectionArray.length; i++) {
-				replace(collectionArray, i);
+				replaceArgument(collectionArray, i);
 			}
 
 			if (object instanceof List) {
@@ -267,6 +251,22 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 			"Unknown type " + object.getClass());
 	}
 
+	protected Group replaceGroupArgument(Group group) {
+		if (group == null) {
+			return group;
+		}
+
+		return StagingUtil.getLiveGroup(group.getGroupId());
+	}
+
+	protected long replaceGroupIdArgument(long groupId) {
+		if (groupId == 0) {
+			return groupId;
+		}
+
+		return StagingUtil.getLiveGroupId(groupId);
+	}
+
 	protected void replaceStagingGroupIdsInCustomMethod(
 		MethodInvocation methodInvocation) {
 
@@ -281,7 +281,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		Object[] arguments = methodInvocation.getArguments();
 
 		for (Integer argumentIndex : argumentIndexes) {
-			replace(arguments, argumentIndex);
+			replaceArgument(arguments, argumentIndex);
 		}
 	}
 
@@ -296,7 +296,7 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 
 		Object[] arguments = methodInvocation.getArguments();
 
-		replace(arguments, 0);
+		replaceArgument(arguments, 0);
 	}
 
 	protected void unregisterAdvice(Object service) {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
+
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
+
+	public LiveGroupStagingAdvice(Class localServiceClass) {
+		_localServiceClass = localServiceClass;
+	}
+
+	public void initCustomMethod(
+			String methodName, Integer index, Class... parameterTypes)
+		throws NoSuchMethodException {
+
+		Method customMethod = _localServiceClass.getMethod(
+			methodName, parameterTypes);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Registering " + customMethod);
+		}
+
+		_customMethods.put(customMethod, new Integer[] {index});
+	}
+
+	public void initGroupServiceBuilderMethods() {
+		String className = _localServiceClass.getSimpleName();
+		String relatedEntityName = className.substring(
+			0, className.length() - _LOCAL_SERVICE.length());
+
+		Method[] relatedEntityMethods = _localServiceClass.getMethods();
+
+		for (String template : _SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES) {
+			String serviceBuilderMethodName = StringUtil.replace(
+				template, "$1", relatedEntityName);
+
+			for (Method method : relatedEntityMethods) {
+				if (method.getName().equals(serviceBuilderMethodName)) {
+					_serviceBuilderGeneratedMethods.add(method);
+
+					if (_log.isDebugEnabled()) {
+						_log.debug("Registering " + method);
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+		if (!StagingAdvicesThreadLocal.isEnabled()) {
+			return methodInvocation.proceed();
+		}
+
+		replaceStagingGroupIdsInServiceBuilderGeneratedMethod(methodInvocation);
+
+		replaceStagingGroupIdsInCustomMethod(methodInvocation);
+
+		return methodInvocation.proceed();
+	}
+
+	protected Group replace(Group group) {
+		if (group == null) {
+			return group;
+		}
+
+		return StagingUtil.getLiveGroup(group.getGroupId());
+	}
+
+	protected long replace(long groupId) {
+		if (groupId == 0) {
+			return groupId;
+		}
+
+		return StagingUtil.getLiveGroupId(groupId);
+	}
+
+	protected void replace(Object[] arguments, int index) {
+		if (arguments == null) {
+			return;
+		}
+
+		Object object = arguments[index];
+
+		if (object == null) {
+			return;
+		}
+
+		if (object instanceof Long) {
+			long groupId = (Long)object;
+
+			arguments[index] = replace(groupId);
+
+			return;
+		}
+
+		if (object instanceof Group) {
+			Group group = (Group)object;
+
+			arguments[index] = replace(group);
+
+			return;
+		}
+
+		if (object instanceof long[]) {
+			long[] groupIds = (long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replace(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Long[]) {
+			Long[] groupIds = (Long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replace(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Group[]) {
+			Group[] groups = (Group[])object;
+
+			for (int i = 0; i < groups.length; i++) {
+				groups[i] = replace(groups[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Collection) {
+			Collection collection = (Collection)object;
+
+			if (collection.size() == 0) {
+				return;
+			}
+
+			Object[] collectionArray = collection.toArray(
+				new Object[collection.size()]);
+
+			for (int i = 0; i < collectionArray.length; i++) {
+				replace(collectionArray, i);
+			}
+
+			if (object instanceof List) {
+				arguments[index] = new ArrayList();
+			}
+			else if (object instanceof Set) {
+				arguments[index] = new LinkedHashSet<>();
+			}
+			else {
+				throw new UnsupportedOperationException(
+					"Unknown collection type " + object.getClass());
+			}
+
+			Collection newCollection = (Collection)arguments[index];
+
+			for (Object group : collectionArray) {
+				newCollection.add(group);
+			}
+
+			return;
+		}
+
+		throw new UnsupportedOperationException(
+			"Unknown type " + object.getClass());
+	}
+
+	protected void replaceStagingGroupIdsInCustomMethod(
+		MethodInvocation methodInvocation) {
+
+		Method method = methodInvocation.getMethod();
+
+		Integer[] argumentIndexes = _customMethods.get(method);
+
+		if (argumentIndexes == null) {
+			return;
+		}
+
+		Object[] arguments = methodInvocation.getArguments();
+
+		for (Integer argumentIndex : argumentIndexes) {
+			replace(arguments, argumentIndex);
+		}
+	}
+
+	protected void replaceStagingGroupIdsInServiceBuilderGeneratedMethod(
+		MethodInvocation methodInvocation) {
+
+		Method method = methodInvocation.getMethod();
+
+		if (!_serviceBuilderGeneratedMethods.contains(method)) {
+			return;
+		}
+
+		Object[] arguments = methodInvocation.getArguments();
+
+		replace(arguments, 0);
+	}
+
+	private static final String _LOCAL_SERVICE = "LocalService";
+
+	private static final String[] _SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES =
+		new String[] {
+			"addGroup$1", "addGroup$1s", "clearGroup$1s", "deleteGroup$1",
+			"deleteGroup$1s", "getGroup$1s", "getGroup$1sCount", "hasGroup$1",
+			"hasGroup$1s", "setGroup$1s", "unsetGroup$1s"
+		};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiveGroupStagingAdvice.class);
+
+	private final Map<Method, Integer[]> _customMethods = new HashMap<>();
+	private final Class _localServiceClass;
+	private final List<Method> _serviceBuilderGeneratedMethods =
+		new ArrayList<>();
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -18,7 +18,10 @@ import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.spring.aop.ServiceBeanAopCacheManagerUtil;
+import com.liferay.portal.spring.aop.ServiceBeanAopProxy;
 import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
 
 import java.lang.reflect.Method;
@@ -33,6 +36,8 @@ import java.util.Set;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.aop.framework.AdvisedSupport;
 
 /**
  * @author Tomas Polesovsky
@@ -122,6 +127,33 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		replaceStagingGroupIdsInCustomMethod(methodInvocation);
 
 		return methodInvocation.proceed();
+	}
+
+	protected void registerAdvice(Object service) {
+		try {
+			Class<?> clazz = service.getClass();
+
+			if (!ProxyUtil.isProxyClass(clazz)) {
+				throw new RuntimeException(
+					"Unable to register advice " + getClass().getName() +
+						" for " + _localServiceClass.getName() +
+						", Spring bean " + clazz.getName() +
+						" is not proxy");
+			}
+
+			AdvisedSupport advisedSupport =
+				ServiceBeanAopProxy.getAdvisedSupport(service);
+
+			advisedSupport.addAdvice(this);
+
+			ServiceBeanAopCacheManagerUtil.reset();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(
+				"Unable to register advice for " +
+					_localServiceClass.getName(),
+				e);
+		}
 	}
 
 	protected Group replace(Group group) {
@@ -265,6 +297,29 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		Object[] arguments = methodInvocation.getArguments();
 
 		replace(arguments, 0);
+	}
+
+	protected void unregisterAdvice(Object service) {
+		Class<?> clazz = service.getClass();
+
+		if (!ProxyUtil.isProxyClass(clazz)) {
+			return;
+		}
+
+		try {
+			AdvisedSupport advisedSupport =
+				ServiceBeanAopProxy.getAdvisedSupport(service);
+
+			advisedSupport.removeAdvice(this);
+
+			ServiceBeanAopCacheManagerUtil.reset();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(
+				"Unable to register advice " + getClass().getName() +
+					" for " + _localServiceClass.getName(),
+				e);
+		}
 	}
 
 	private static final String _LOCAL_SERVICE = "LocalService";

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.OrganizationLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class OrganizationLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public OrganizationLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(OrganizationLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod(
+			"getGroupUserOrganizations", 0, long.class, long.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -14,14 +14,19 @@
 
 package com.liferay.staging.security.spring;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class OrganizationLocalServiceStagingAdvice
 	extends LiveGroupStagingAdvice {
 
@@ -36,6 +41,19 @@ public class OrganizationLocalServiceStagingAdvice
 			"getGroupUserOrganizations", 0, long.class, long.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(OrganizationLocalService service) {
+		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
+	}
+
+	protected void unsetService(OrganizationLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -31,6 +34,11 @@ public class OrganizationLocalServiceStagingAdvice
 
 		initCustomMethod(
 			"getGroupUserOrganizations", 0, long.class, long.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {"getGroupPrimaryKeys"});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -14,14 +14,19 @@
 
 package com.liferay.staging.security.spring;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.service.RoleLocalService;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public RoleLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -46,6 +51,19 @@ public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("getUserRelatedRoles", 1, long.class, List.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(RoleLocalService service) {
+		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
+	}
+
+	protected void unsetService(RoleLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -16,6 +16,7 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.kernel.service.RoleLocalService;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -43,6 +44,11 @@ public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("getUserRelatedRoles", 1, long.class, long.class);
 		initCustomMethod("getUserRelatedRoles", 1, long.class, long[].class);
 		initCustomMethod("getUserRelatedRoles", 1, long.class, List.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {"getGroupPrimaryKeys"});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.RoleLocalService;
+
+import java.util.List;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public RoleLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(RoleLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getDefaultGroupRole", 0, long.class);
+		initCustomMethod("getGroupRelatedRoles", 0, long.class);
+		initCustomMethod("getTeamRoleMap", 0, long.class);
+		initCustomMethod("getTeamRoles", 0, long.class);
+		initCustomMethod("getTeamRoles", 0, long.class, long[].class);
+		initCustomMethod("getUserGroupGroupRoles", 1, long.class, long.class);
+		initCustomMethod(
+			"getUserGroupGroupRoles", 1, long.class, long.class, int.class,
+			int.class);
+		initCustomMethod(
+			"getUserGroupGroupRolesCount", 1, long.class, long.class);
+		initCustomMethod("getUserGroupRoles", 1, long.class, long.class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, long.class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, long[].class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, List.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public UserGroupGroupRoleLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(UserGroupGroupRoleLocalService.class);
+
+		initCustomMethod(
+			"addUserGroupGroupRoles", 1, long.class, long.class, long[].class);
+
+		initCustomMethod(
+			"addUserGroupGroupRoles", 1, long[].class, long.class, long.class);
+
+		initCustomMethod("deleteUserGroupGroupRoles", 0, long.class, int.class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long.class, long.class,
+			long[].class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long.class, long[].class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long[].class, long.class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long[].class, long.class,
+			long.class);
+
+		initCustomMethod("deleteUserGroupGroupRolesByGroupId", 0, long.class);
+
+		initCustomMethod("getUserGroupGroupRoles", 1, long.class, long.class);
+
+		initCustomMethod(
+			"getUserGroupGroupRolesByGroupAndRole", 0, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupGroupRole", 1, long.class, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -61,6 +64,18 @@ public class UserGroupGroupRoleLocalServiceStagingAdvice
 
 		initCustomMethod(
 			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST =
+		Arrays.asList(new String[] {
+			"addUserGroupGroupRole", "createUserGroupGroupRole",
+			"deleteUserGroupGroupRole", "deleteUserGroupGroupRolesByRoleId",
+			"deleteUserGroupGroupRolesByUserGroupId", "fetchUserGroupGroupRole",
+			"getUserGroupGroupRole", "getUserGroupGroupRoles",
+			"getUserGroupGroupRolesByUser", "getUserGroupGroupRolesCount",
+			"updateUserGroupGroupRole"
+		});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -14,14 +14,19 @@
 
 package com.liferay.staging.security.spring;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserGroupGroupRoleLocalServiceStagingAdvice
 	extends LiveGroupStagingAdvice {
 
@@ -66,6 +71,19 @@ public class UserGroupGroupRoleLocalServiceStagingAdvice
 			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(UserGroupGroupRoleLocalService service) {
+		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
+	}
+
+	protected void unsetService(UserGroupGroupRoleLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST =

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -37,36 +37,25 @@ public class UserGroupGroupRoleLocalServiceStagingAdvice
 
 		initCustomMethod(
 			"addUserGroupGroupRoles", 1, long.class, long.class, long[].class);
-
 		initCustomMethod(
 			"addUserGroupGroupRoles", 1, long[].class, long.class, long.class);
-
 		initCustomMethod("deleteUserGroupGroupRoles", 0, long.class, int.class);
-
 		initCustomMethod(
 			"deleteUserGroupGroupRoles", 1, long.class, long.class,
 			long[].class);
-
 		initCustomMethod(
 			"deleteUserGroupGroupRoles", 1, long.class, long[].class);
-
 		initCustomMethod(
 			"deleteUserGroupGroupRoles", 1, long[].class, long.class);
-
 		initCustomMethod(
 			"deleteUserGroupGroupRoles", 1, long[].class, long.class,
 			long.class);
-
 		initCustomMethod("deleteUserGroupGroupRolesByGroupId", 0, long.class);
-
 		initCustomMethod("getUserGroupGroupRoles", 1, long.class, long.class);
-
 		initCustomMethod(
 			"getUserGroupGroupRolesByGroupAndRole", 0, long.class, long.class);
-
 		initCustomMethod(
 			"hasUserGroupGroupRole", 1, long.class, long.class, long.class);
-
 		initCustomMethod(
 			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
 

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserGroupLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(UserGroupLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getGroupUserUserGroups", 0, long.class, long.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -14,14 +14,19 @@
 
 package com.liferay.staging.security.spring;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public UserGroupLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -32,6 +37,19 @@ public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("getGroupUserUserGroups", 0, long.class, long.class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(UserGroupLocalService service) {
+		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
+	}
+
+	protected void unsetService(UserGroupLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -27,6 +30,11 @@ public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initGroupServiceBuilderMethods();
 
 		initCustomMethod("getGroupUserUserGroups", 0, long.class, long.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {"getGroupPrimaryKeys"});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public UserGroupRoleLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(UserGroupRoleLocalService.class);
+
+		initCustomMethod(
+			"addUserGroupRoles", 1, long.class, long.class, long[].class);
+		initCustomMethod(
+			"addUserGroupRoles", 1, long[].class, long.class, long.class);
+		initCustomMethod("deleteUserGroupRoles", 0, long.class, int.class);
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long.class, long.class, long[].class);
+		initCustomMethod("deleteUserGroupRoles", 1, long.class, long[].class);
+		initCustomMethod("deleteUserGroupRoles", 1, long[].class, long.class);
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long[].class, long.class, long.class);
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long[].class, long.class, int.class);
+		initCustomMethod("deleteUserGroupRolesByGroupId", 0, long.class);
+		initCustomMethod("getUserGroupRoles", 1, long.class, long.class);
+		initCustomMethod(
+			"getUserGroupRoles", 1, long.class, long.class, int.class,
+			int.class);
+		initCustomMethod("getUserGroupRolesByGroup", 0, long.class);
+		initCustomMethod(
+			"getUserGroupRolesByGroupAndRole", 0, long.class, long.class);
+		initCustomMethod(
+			"getUserGroupRolesByUserUserGroupAndGroup", 1, long.class,
+			long.class);
+		initCustomMethod("getUserGroupRolesCount", 1, long.class, long.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, long.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, long.class,
+			boolean.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, String.class);
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, String.class,
+			boolean.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -14,14 +14,19 @@
 
 package com.liferay.staging.security.spring;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserGroupRoleLocalServiceStagingAdvice
 	extends LiveGroupStagingAdvice {
 
@@ -69,7 +74,20 @@ public class UserGroupRoleLocalServiceStagingAdvice
 		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
 
+	@Reference
+	protected void setService(UserGroupRoleLocalService service) {
+		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
+	}
+
+	protected void unsetService(UserGroupRoleLocalService service) {
+		unregisterAdvice(service);
+	}
+
 	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
-		new String[] {});
+		new String[0]);
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -16,6 +16,9 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -62,6 +65,11 @@ public class UserGroupRoleLocalServiceStagingAdvice
 		initCustomMethod(
 			"hasUserGroupRole", 1, long.class, long.class, String.class,
 			boolean.class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST = Arrays.asList(
+		new String[] {});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -17,6 +17,9 @@ package com.liferay.staging.security.spring;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Tomas Polesovsky
  */
@@ -41,6 +44,13 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 			"updateGroups", 1, long.class, long[].class, ServiceContext.class);
 
 		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
+
+		checkCoverage(_GROUP_METHODS_WHITELIST);
 	}
+
+	private static final List<String> _GROUP_METHODS_WHITELIST =
+		Arrays.asList(new String[] {
+			"addDefaultGroups", "getGroupPrimaryKeys", "getNoGroups"
+		});
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -36,18 +36,14 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initGroupServiceBuilderMethods();
 
 		initCustomMethod("getGroupUserIds", 0, long.class);
-
 		initCustomMethod(
 			"searchSocial", 1, long.class, long[].class, String.class,
 			int.class, int.class);
-
 		initCustomMethod(
 			"searchSocial", 0, long[].class, long.class, int[].class,
 			String.class, int.class, int.class);
-
 		initCustomMethod(
 			"updateGroups", 1, long.class, long[].class, ServiceContext.class);
-
 		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -14,15 +14,20 @@
 
 package com.liferay.staging.security.spring;
 
+import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Tomas Polesovsky
  */
+@Component(immediate = true)
 public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public UserLocalServiceStagingAdvice() throws NoSuchMethodException {
@@ -46,6 +51,19 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
 
 		checkCoverage(_GROUP_METHODS_WHITELIST);
+	}
+
+	@Reference
+	protected void setService(UserLocalService service) {
+		registerAdvice(service);
+	}
+
+	@Reference(unbind = "-")
+	protected void setStaging(Staging staging) {
+	}
+
+	protected void unsetService(UserLocalService service) {
+		unregisterAdvice(service);
 	}
 
 	private static final List<String> _GROUP_METHODS_WHITELIST =

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(UserLocalService.class);
+
+		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getGroupUserIds", 0, long.class);
+
+		initCustomMethod(
+			"searchSocial", 1, long.class, long[].class, String.class,
+			int.class, int.class);
+
+		initCustomMethod(
+			"searchSocial", 0, long[].class, long.class, int[].class,
+			String.class, int.class, int.class);
+
+		initCustomMethod(
+			"updateGroups", 1, long.class, long[].class, ServiceContext.class);
+
+		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -867,17 +867,20 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 					group.getGroupId(), RoleConstants.TYPE_SITE);
 			}
 			else {
+				if (!group.isStagingGroup() || group.isStagedRemotely()) {
+
+					// Group roles
+
+					userGroupRoleLocalService.deleteUserGroupRolesByGroupId(
+						group.getGroupId());
+
+					// User group roles
+
+					userGroupGroupRoleLocalService.
+						deleteUserGroupGroupRolesByGroupId(group.getGroupId());
+				}
+
 				groupPersistence.remove(group);
-
-				// Group roles
-
-				userGroupRoleLocalService.deleteUserGroupRolesByGroupId(
-					group.getGroupId());
-
-				// User group roles
-
-				userGroupGroupRoleLocalService.
-					deleteUserGroupGroupRolesByGroupId(group.getGroupId());
 			}
 
 			// Permission cache

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6188,14 +6188,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		for (long oldGroupId : oldGroupIds) {
 			if (!ArrayUtil.contains(newGroupIds, oldGroupId)) {
-				unsetGroupUsers(
+				userLocalService.unsetGroupUsers(
 					oldGroupId, new long[] {userId}, serviceContext);
 			}
 		}
 
 		for (long newGroupId : newGroupIds) {
 			if (!ArrayUtil.contains(oldGroupIds, newGroupId)) {
-				addGroupUsers(newGroupId, new long[] {userId});
+				userLocalService.addGroupUsers(newGroupId, new long[] {userId});
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroup.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
@@ -299,22 +300,22 @@ public class VerifyGroup extends VerifyProcess {
 	protected void verifyStagingGroupOrganizationMembership(Group stagingGroup)
 		throws Exception {
 
-		List<Organization> staged =
+		List<Organization> stagingOrganizations =
 			OrganizationLocalServiceUtil.getGroupOrganizations(
 				stagingGroup.getGroupId());
 
-		if (staged.isEmpty()) {
+		if (ListUtil.isEmpty(stagingOrganizations)) {
 			return;
 		}
 
-		List<Organization> live =
+		List<Organization> liveOrganizations =
 			OrganizationLocalServiceUtil.getGroupOrganizations(
 				stagingGroup.getLiveGroupId());
 
-		for (Organization organization : staged) {
-			if (!live.contains(organization)) {
+		for (Organization stagingGroupOrganization : stagingOrganizations) {
+			if (!liveOrganizations.contains(stagingGroupOrganization)) {
 				OrganizationLocalServiceUtil.addGroupOrganization(
-					stagingGroup.getLiveGroupId(), organization);
+					stagingGroup.getLiveGroupId(), stagingGroupOrganization);
 			}
 		}
 
@@ -353,20 +354,20 @@ public class VerifyGroup extends VerifyProcess {
 	}
 
 	private void verifyStagingGroupRoleMembership(Group stagingGroup) {
-		List<Role> staged = RoleLocalServiceUtil.getGroupRoles(
+		List<Role> stagingRoles = RoleLocalServiceUtil.getGroupRoles(
 			stagingGroup.getGroupId());
 
-		if (staged.isEmpty()) {
+		if (ListUtil.isEmpty(stagingRoles)) {
 			return;
 		}
 
-		List<Role> live = RoleLocalServiceUtil.getGroupRoles(
+		List<Role> liveRoles = RoleLocalServiceUtil.getGroupRoles(
 			stagingGroup.getLiveGroupId());
 
-		for (Role role : staged) {
-			if (!live.contains(role)) {
+		for (Role stagingGroupRole : stagingRoles) {
+			if (!liveRoles.contains(stagingGroupRole)) {
 				RoleLocalServiceUtil.addGroupRole(
-					stagingGroup.getLiveGroupId(), role);
+					stagingGroup.getLiveGroupId(), stagingGroupRole);
 			}
 		}
 
@@ -374,20 +375,22 @@ public class VerifyGroup extends VerifyProcess {
 	}
 
 	private void verifyStagingGroupUserGroupMembership(Group stagingGroup) {
-		List<UserGroup> staged = UserGroupLocalServiceUtil.getGroupUserGroups(
-			stagingGroup.getGroupId());
+		List<UserGroup> stagingUserGroups =
+			UserGroupLocalServiceUtil.getGroupUserGroups(
+				stagingGroup.getGroupId());
 
-		if (staged.isEmpty()) {
+		if (ListUtil.isEmpty(stagingUserGroups)) {
 			return;
 		}
 
-		List<UserGroup> live = UserGroupLocalServiceUtil.getGroupUserGroups(
-			stagingGroup.getLiveGroupId());
+		List<UserGroup> liveUserGroups =
+			UserGroupLocalServiceUtil.getGroupUserGroups(
+				stagingGroup.getLiveGroupId());
 
-		for (UserGroup userGroup : staged) {
-			if (!live.contains(userGroup)) {
+		for (UserGroup stagingUserGroup : stagingUserGroups) {
+			if (!liveUserGroups.contains(stagingUserGroup)) {
 				UserGroupLocalServiceUtil.addGroupUserGroup(
-					stagingGroup.getLiveGroupId(), userGroup);
+					stagingGroup.getLiveGroupId(), stagingUserGroup);
 			}
 		}
 
@@ -396,20 +399,20 @@ public class VerifyGroup extends VerifyProcess {
 	}
 
 	private void verifyStagingGroupUserMembership(Group stagingGroup) {
-		List<User> staged = UserLocalServiceUtil.getGroupUsers(
+		List<User> stagingGroupUsers = UserLocalServiceUtil.getGroupUsers(
 			stagingGroup.getGroupId());
 
-		if (staged.isEmpty()) {
+		if (ListUtil.isEmpty(stagingGroupUsers)) {
 			return;
 		}
 
-		List<User> live = UserLocalServiceUtil.getGroupUsers(
+		List<User> liveGroupUsers = UserLocalServiceUtil.getGroupUsers(
 			stagingGroup.getLiveGroupId());
 
-		for (User user : staged) {
-			if (!live.contains(user)) {
+		for (User stagingGroupUser : stagingGroupUsers) {
+			if (!liveGroupUsers.contains(stagingGroupUser)) {
 				UserLocalServiceUtil.addGroupUser(
-					stagingGroup.getLiveGroupId(), user);
+					stagingGroup.getLiveGroupId(), stagingGroupUser);
 			}
 		}
 
@@ -456,24 +459,24 @@ public class VerifyGroup extends VerifyProcess {
 	}
 
 	private void verifyStagingUserGroupRolesAssignments(Group stagingGroup) {
-		List<UserGroupRole> staged =
+		List<UserGroupRole> stagingUserGroupRoles =
 			UserGroupRoleLocalServiceUtil.getUserGroupRolesByGroup(
 				stagingGroup.getGroupId());
 
-		if (staged.isEmpty()) {
+		if (ListUtil.isEmpty(stagingUserGroupRoles)) {
 			return;
 		}
 
-		List<UserGroupRole> live =
+		List<UserGroupRole> liveUserGroupRoles =
 			UserGroupRoleLocalServiceUtil.getUserGroupRolesByGroup(
 				stagingGroup.getLiveGroupId());
 
-		for (UserGroupRole userGroupRole : staged) {
-			userGroupRole.setGroupId(stagingGroup.getLiveGroupId());
+		for (UserGroupRole stagingUserGroupRole : stagingUserGroupRoles) {
+			stagingUserGroupRole.setGroupId(stagingGroup.getLiveGroupId());
 
-			if (!live.contains(userGroupRole)) {
+			if (!liveUserGroupRoles.contains(stagingUserGroupRole)) {
 				UserGroupRoleLocalServiceUtil.updateUserGroupRole(
-					userGroupRole);
+					stagingUserGroupRole);
 			}
 		}
 


### PR DESCRIPTION
Hi @brianchandotcom,

This is a second part of local staging permissions fixes you reviewed a couple months ago (https://github.com/topolik/liferay-portal/pull/228), you asked to move it into a module. You merged the first part here: https://github.com/brianchandotcom/liferay-portal/pull/34136

In local staging we use always live groupId for permission checking.
=> Based on a discussion with Ray, any Group related roles and site/organization/UserGroup assignments must be done using live groupId, otherwise permission framework won't find them.

(1) The core idea is to make sure API consumers use live groupId for roles assignments and site/organization/UserGroup/Role memberships. 
(2) Next idea is to harden portal framework instead of fixing portlets and API consumers.

A commit by commit explanation:

**LPS-61795 Move existing user/organization/user-group assignments (9670498)**

A VerifyProces that rewrites existing staging groupIds into live groupIds in Organization,Site,UserGroup and Role.

**LPS-61795 Fix ULSI to allow advices to intercept the calls (359e786)**

Make sure the call goes through advices stack

**LPS-61795 Create Spring advices around portal API (98291a0)**

Advices to replace groupId in portal API calls.

`LiveGroupStagingAdvice` is a parent for all advices which:
1, when invoked, iterates over registered *LocalService methods to replace the groupId, if needed
2, registers *LocalService methods that were generated by ServiceBuilder and are related to Group entity
3, supports registering of custom methods that developers introduced

The other `*StagingAdvices` implementations provide details about respective LocalService methods to register.

If a method doesn't exist an exception is thrown in runtime during advices initialization.

**LPS-61795 Poor man coverage check to warn developers (b82d761)**

Processes the related `LocalService`s and checks if there is a method we forget to cover or is a new one.

Also throws a runtime exception during advices initialization.

**LPS-61795 (1) First remove roles relations and after then the group … (a29c1cf)**

Bug fix - avoid NPE caused by incorrect order of entities removal.

**LPS-61795 Register Spring Advices onto corresponding Spring services (5113c01)**

This was a hard one because we don't have any support for portal advices in modules.

Basically hooks into each `LocalService` proxy to add the new advice.

**SF by Mate**

Made my code almost perfect :)

HTH. Thanks!
