### PR TITLE
LPS-61795 Local staging permissions II

### DIFF
--- a/modules/apps/staging/staging-security/build.gradle
+++ b/modules/apps/staging/staging-security/build.gradle
@@ -1,8 +1,10 @@
 dependencies {
+	compile group: "com.liferay.portal", name: "portal-impl", version: liferay.portalVersion
 	compile group: "com.liferay.portal", name: "portal-service", version: liferay.portalVersion
 	compile group: "javax.portlet", name: "portlet-api", version: "2.0"
 	compile group: "org.osgi", name: "org.osgi.compendium", version: "5.0.0"
 	compile group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compile group: "org.springframework", name: "spring-aop", version: "3.2.15.RELEASE"
 }
 
 liferay {

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -26,5 +26,36 @@ public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public GroupLocalServiceStagingAdvice() throws NoSuchMethodException {
 		super(GroupLocalService.class);
+
+		initRelatedServiceBuilderMethods("Organization");
+		initRelatedServiceBuilderMethods("Role");
+		initRelatedServiceBuilderMethods("User");
+		initRelatedServiceBuilderMethods("UserGroup");
 	}
+
+	protected void initRelatedServiceBuilderMethods(String relatedEntityName)
+		throws NoSuchMethodException {
+
+		Method[] relatedEntityMethods = GroupLocalService.class.getMethods();
+
+		for (String template : _SERVICE_BUILDER_GENERATED_TEMPLATES) {
+			String serviceBuilderMethodName = StringUtil.replace(
+				template, "$1", relatedEntityName);
+
+			for (Method method : relatedEntityMethods) {
+				if (method.getName().equals(serviceBuilderMethodName)) {
+					initCustomMethod(
+						serviceBuilderMethodName, 1,
+						method.getParameterTypes());
+				}
+			}
+		}
+	}
+
+	private static final String[] _SERVICE_BUILDER_GENERATED_TEMPLATES =
+		new String[] {
+			"add$1Group", "add$1Groups", "delete$1Group", "delete$1Groups",
+			"has$1Group", "set$1Groups", "unset$1Groups"
+		};
+
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public GroupLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(GroupLocalService.class);
+	}
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/GroupLocalServiceStagingAdvice.java
@@ -31,6 +31,8 @@ public class GroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		initRelatedServiceBuilderMethods("Role");
 		initRelatedServiceBuilderMethods("User");
 		initRelatedServiceBuilderMethods("UserGroup");
+
+		initCustomMethod("getUserGroupPrimaryKeys", 0, long.class);
 	}
 
 	protected void initRelatedServiceBuilderMethods(String relatedEntityName)

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -57,6 +57,29 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		_customMethods.put(customMethod, index);
 	}
 
+	public void initGroupServiceBuilderMethods() {
+		String className = _localServiceClass.getSimpleName();
+		String relatedEntityName = className.substring(
+			0, className.length() - _LOCAL_SERVICE.length());
+
+		Method[] relatedEntityMethods = _localServiceClass.getMethods();
+
+		for (String template : _SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES) {
+			String serviceBuilderMethodName = StringUtil.replace(
+				template, "$1", relatedEntityName);
+
+			for (Method method : relatedEntityMethods) {
+				if (method.getName().equals(serviceBuilderMethodName)) {
+					_serviceBuilderGeneratedMethods.add(method);
+
+					if (_log.isDebugEnabled()) {
+						_log.debug("Registering " + method);
+					}
+				}
+			}
+		}
+	}
+
 	@Override
 	public Object invoke(MethodInvocation methodInvocation) throws Throwable {
 		if (!StagingAdvicesThreadLocal.isEnabled()) {
@@ -64,6 +87,8 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		}
 
 		replaceStagingGroupIdsInCustomMethod(methodInvocation);
+
+		replaceStagingGroupIdsInServiceBuilderGeneratedMethod(methodInvocation);
 
 		return methodInvocation.proceed();
 	}
@@ -194,15 +219,40 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		replaceArgument(arguments, argumentIndex);
 	}
 
+	protected void replaceStagingGroupIdsInServiceBuilderGeneratedMethod(
+		MethodInvocation methodInvocation) {
+
+		Method method = methodInvocation.getMethod();
+
+		if (!_serviceBuilderGeneratedMethods.contains(method)) {
+			return;
+		}
+
+		Object[] arguments = methodInvocation.getArguments();
+
+		replaceArgument(arguments, 0);
+	}
+
 	protected void setStaging(Staging staging) {
 		_staging = staging;
 	}
+
+	private static final String _LOCAL_SERVICE = "LocalService";
+
+	private static final String[] _SERVICE_BUILDER_GENERATED_GROUP_TEMPLATES =
+		new String[] {
+			"addGroup$1", "addGroup$1s", "clearGroup$1s", "deleteGroup$1",
+			"deleteGroup$1s", "getGroup$1s", "getGroup$1sCount", "hasGroup$1",
+			"hasGroup$1s", "setGroup$1s", "unsetGroup$1s"
+		};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LiveGroupStagingAdvice.class);
 
 	private final Map<Method, Integer> _customMethods = new HashMap<>();
 	private final Class _localServiceClass;
+	private final List<Method> _serviceBuilderGeneratedMethods =
+		new ArrayList<>();
 	private Staging _staging;
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.exportimport.kernel.staging.Staging;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
+
+import java.lang.reflect.Method;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
+
+	public LiveGroupStagingAdvice(Class localServiceClass) {
+		_localServiceClass = localServiceClass;
+	}
+
+	@Override
+	public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+		if (!StagingAdvicesThreadLocal.isEnabled()) {
+			return methodInvocation.proceed();
+		}
+
+		/* noop in this commit */
+
+		return methodInvocation.proceed();
+	}
+
+	protected void replaceArgument(Object[] arguments, int index) {
+		if (arguments == null) {
+			return;
+		}
+
+		Object object = arguments[index];
+
+		if (object == null) {
+			return;
+		}
+
+		if (object instanceof Long) {
+			long groupId = (Long)object;
+
+			arguments[index] = replaceGroupIdArgument(groupId);
+
+			return;
+		}
+
+		if (object instanceof Group) {
+			Group group = (Group)object;
+
+			arguments[index] = replaceGroupArgument(group);
+
+			return;
+		}
+
+		if (object instanceof long[]) {
+			long[] groupIds = (long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replaceGroupIdArgument(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Long[]) {
+			Long[] groupIds = (Long[])object;
+
+			for (int i = 0; i < groupIds.length; i++) {
+				groupIds[i] = replaceGroupIdArgument(groupIds[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Group[]) {
+			Group[] groups = (Group[])object;
+
+			for (int i = 0; i < groups.length; i++) {
+				groups[i] = replaceGroupArgument(groups[i]);
+			}
+
+			return;
+		}
+
+		if (object instanceof Collection) {
+			Collection collection = (Collection)object;
+
+			if (collection.size() == 0) {
+				return;
+			}
+
+			Collection<Object> newCollection;
+
+			if (object instanceof List) {
+				newCollection = new ArrayList<>();
+			}
+			else if (object instanceof Set) {
+				newCollection = new LinkedHashSet<>();
+			}
+			else {
+				throw new UnsupportedOperationException(
+					"Unknown collection type " + object.getClass());
+			}
+
+			Object[] collectionArray = collection.toArray();
+
+			for (int i = 0; i < collectionArray.length; i++) {
+				replaceArgument(collectionArray, i);
+
+				newCollection.add(collectionArray[i]);
+			}
+
+			arguments[index] = newCollection;
+
+			return;
+		}
+
+		throw new UnsupportedOperationException(
+			"Unknown type " + object.getClass());
+	}
+
+	protected Group replaceGroupArgument(Group group) {
+		if (group == null) {
+			return group;
+		}
+
+		return _staging.getLiveGroup(group.getGroupId());
+	}
+
+	protected long replaceGroupIdArgument(long groupId) {
+		if (groupId == 0) {
+			return groupId;
+		}
+
+		return _staging.getLiveGroupId(groupId);
+	}
+
+	protected void setStaging(Staging staging) {
+		_staging = staging;
+	}
+
+	private final Class _localServiceClass;
+	private Staging _staging;
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/LiveGroupStagingAdvice.java
@@ -43,13 +43,27 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		_localServiceClass = localServiceClass;
 	}
 
+	public void initCustomMethod(
+			String methodName, Integer index, Class... parameterTypes)
+		throws NoSuchMethodException {
+
+		Method customMethod = _localServiceClass.getMethod(
+			methodName, parameterTypes);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Registering " + customMethod);
+		}
+
+		_customMethods.put(customMethod, index);
+	}
+
 	@Override
 	public Object invoke(MethodInvocation methodInvocation) throws Throwable {
 		if (!StagingAdvicesThreadLocal.isEnabled()) {
 			return methodInvocation.proceed();
 		}
 
-		/* noop in this commit */
+		replaceStagingGroupIdsInCustomMethod(methodInvocation);
 
 		return methodInvocation.proceed();
 	}
@@ -164,10 +178,30 @@ public abstract class LiveGroupStagingAdvice implements MethodInterceptor {
 		return _staging.getLiveGroupId(groupId);
 	}
 
+	protected void replaceStagingGroupIdsInCustomMethod(
+		MethodInvocation methodInvocation) {
+
+		Method method = methodInvocation.getMethod();
+
+		Integer argumentIndex = _customMethods.get(method);
+
+		if (argumentIndex == null) {
+			return;
+		}
+
+		Object[] arguments = methodInvocation.getArguments();
+
+		replaceArgument(arguments, argumentIndex);
+	}
+
 	protected void setStaging(Staging staging) {
 		_staging = staging;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiveGroupStagingAdvice.class);
+
+	private final Map<Method, Integer> _customMethods = new HashMap<>();
 	private final Class _localServiceClass;
 	private Staging _staging;
 

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -26,6 +26,8 @@ public class OrganizationLocalServiceStagingAdvice
 		throws NoSuchMethodException {
 
 		super(OrganizationLocalService.class);
+
+		initGroupServiceBuilderMethods();
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.OrganizationLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class OrganizationLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public OrganizationLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(OrganizationLocalService.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/OrganizationLocalServiceStagingAdvice.java
@@ -28,6 +28,9 @@ public class OrganizationLocalServiceStagingAdvice
 		super(OrganizationLocalService.class);
 
 		initGroupServiceBuilderMethods();
+
+		initCustomMethod(
+			"getGroupUserOrganizations", 0, long.class, long.class);
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -27,6 +27,25 @@ public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		super(RoleLocalService.class);
 
 		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getDefaultGroupRole", 0, long.class);
+		initCustomMethod("getGroupRelatedRoles", 0, long.class);
+		initCustomMethod("getTeamRoleMap", 0, long.class);
+		initCustomMethod("getTeamRoles", 0, long.class);
+		initCustomMethod("getTeamRoles", 0, long.class, long[].class);
+		initCustomMethod("getUserGroupGroupRoles", 1, long.class, long.class);
+
+		initCustomMethod(
+			"getUserGroupGroupRoles", 1, long.class, long.class, int.class,
+			int.class);
+
+		initCustomMethod(
+			"getUserGroupGroupRolesCount", 1, long.class, long.class);
+
+		initCustomMethod("getUserGroupRoles", 1, long.class, long.class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, long.class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, long[].class);
+		initCustomMethod("getUserRelatedRoles", 1, long.class, List.class);
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -25,6 +25,8 @@ public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public RoleLocalServiceStagingAdvice() throws NoSuchMethodException {
 		super(RoleLocalService.class);
+
+		initGroupServiceBuilderMethods();
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/RoleLocalServiceStagingAdvice.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.RoleLocalService;
+
+import java.util.List;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class RoleLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public RoleLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(RoleLocalService.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.UserGroupGroupRoleLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public UserGroupGroupRoleLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(UserGroupGroupRoleLocalService.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupGroupRoleLocalServiceStagingAdvice.java
@@ -26,6 +26,41 @@ public class UserGroupGroupRoleLocalServiceStagingAdvice
 		throws NoSuchMethodException {
 
 		super(UserGroupGroupRoleLocalService.class);
+
+		initCustomMethod(
+			"addUserGroupGroupRoles", 1, long.class, long.class, long[].class);
+
+		initCustomMethod(
+			"addUserGroupGroupRoles", 1, long[].class, long.class, long.class);
+
+		initCustomMethod("deleteUserGroupGroupRoles", 0, long.class, int.class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long.class, long.class,
+			long[].class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long.class, long[].class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long[].class, long.class);
+
+		initCustomMethod(
+			"deleteUserGroupGroupRoles", 1, long[].class, long.class,
+			long.class);
+
+		initCustomMethod("deleteUserGroupGroupRolesByGroupId", 0, long.class);
+
+		initCustomMethod("getUserGroupGroupRoles", 1, long.class, long.class);
+
+		initCustomMethod(
+			"getUserGroupGroupRolesByGroupAndRole", 0, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupGroupRole", 1, long.class, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupGroupRole", 1, long.class, long.class, String.class);
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.UserGroupLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserGroupLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(UserGroupLocalService.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -25,6 +25,8 @@ public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		super(UserGroupLocalService.class);
 
 		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getGroupUserUserGroups", 0, long.class, long.class);
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupLocalServiceStagingAdvice.java
@@ -23,6 +23,8 @@ public class UserGroupLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public UserGroupLocalServiceStagingAdvice() throws NoSuchMethodException {
 		super(UserGroupLocalService.class);
+
+		initGroupServiceBuilderMethods();
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -26,6 +26,60 @@ public class UserGroupRoleLocalServiceStagingAdvice
 		throws NoSuchMethodException {
 
 		super(UserGroupRoleLocalService.class);
+
+		initCustomMethod(
+			"addUserGroupRoles", 1, long.class, long.class, long[].class);
+
+		initCustomMethod(
+			"addUserGroupRoles", 1, long[].class, long.class, long.class);
+
+		initCustomMethod("deleteUserGroupRoles", 0, long.class, int.class);
+
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long.class, long.class, long[].class);
+
+		initCustomMethod("deleteUserGroupRoles", 1, long.class, long[].class);
+
+		initCustomMethod("deleteUserGroupRoles", 1, long[].class, long.class);
+
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long[].class, long.class, long.class);
+
+		initCustomMethod(
+			"deleteUserGroupRoles", 1, long[].class, long.class, int.class);
+
+		initCustomMethod("deleteUserGroupRolesByGroupId", 0, long.class);
+
+		initCustomMethod("getUserGroupRoles", 1, long.class, long.class);
+
+		initCustomMethod(
+			"getUserGroupRoles", 1, long.class, long.class, int.class,
+			int.class);
+
+		initCustomMethod("getUserGroupRolesByGroup", 0, long.class);
+
+		initCustomMethod(
+			"getUserGroupRolesByGroupAndRole", 0, long.class, long.class);
+
+		initCustomMethod(
+			"getUserGroupRolesByUserUserGroupAndGroup", 1, long.class,
+			long.class);
+
+		initCustomMethod("getUserGroupRolesCount", 1, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, long.class);
+
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, long.class,
+			boolean.class);
+
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, String.class);
+
+		initCustomMethod(
+			"hasUserGroupRole", 1, long.class, long.class, String.class,
+			boolean.class);
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserGroupRoleLocalServiceStagingAdvice.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserGroupRoleLocalServiceStagingAdvice
+	extends LiveGroupStagingAdvice {
+
+	public UserGroupRoleLocalServiceStagingAdvice()
+		throws NoSuchMethodException {
+
+		super(UserGroupRoleLocalService.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
+
+	public UserLocalServiceStagingAdvice() throws NoSuchMethodException {
+		super(UserLocalService.class);
+	}
+
+}

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -26,6 +26,21 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 		super(UserLocalService.class);
 
 		initGroupServiceBuilderMethods();
+
+		initCustomMethod("getGroupUserIds", 0, long.class);
+
+		initCustomMethod(
+			"searchSocial", 1, long.class, long[].class, String.class,
+			int.class, int.class);
+
+		initCustomMethod(
+			"searchSocial", 0, long[].class, long.class, int[].class,
+			String.class, int.class, int.class);
+
+		initCustomMethod(
+			"updateGroups", 1, long.class, long[].class, ServiceContext.class);
+
+		initCustomMethod("unsetGroupTeamsUsers", 0, long.class, long[].class);
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-security/src/main/java/com/liferay/staging/security/spring/UserLocalServiceStagingAdvice.java
@@ -24,6 +24,8 @@ public class UserLocalServiceStagingAdvice extends LiveGroupStagingAdvice {
 
 	public UserLocalServiceStagingAdvice() throws NoSuchMethodException {
 		super(UserLocalService.class);
+
+		initGroupServiceBuilderMethods();
 	}
 
 }

--- a/modules/apps/staging/staging-security/src/test/java/com/liferay/staging/security/spring/LiveGroupStagingAdviceTest.java
+++ b/modules/apps/staging/staging-security/src/test/java/com/liferay/staging/security/spring/LiveGroupStagingAdviceTest.java
@@ -1,0 +1,299 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.security.spring;
+
+import com.liferay.exportimport.kernel.staging.Staging;
+import com.liferay.portal.kernel.model.Group;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.Matchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@RunWith(PowerMockRunner.class)
+public class LiveGroupStagingAdviceTest extends PowerMockito {
+
+	@BeforeClass
+	public static void setUpClass() {
+		_liveGroupStagingAdvice = new LiveGroupStagingAdvice(null) {};
+
+		Staging staging = setUpStaging();
+
+		_liveGroupStagingAdvice.setStaging(staging);
+	}
+
+	@Test
+	public void testReplaceArgumentWithGroup() throws Exception {
+		Object[] argument = new Object[] {mockGroup(_STAGING_GROUP_ID)};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 0);
+
+		Assert.assertEquals(_LIVE_GROUP_ID, ((Group)argument[0]).getGroupId());
+
+		argument = new Object[] {
+			mockGroup(11111), mockGroup(_STAGING_GROUP_ID)
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 1);
+
+		Assert.assertEquals(11111, ((Group)argument[0]).getGroupId());
+		Assert.assertEquals(_LIVE_GROUP_ID, ((Group)argument[1]).getGroupId());
+	}
+
+	@Test
+	public void testReplaceArgumentWithGroupArray() throws Exception {
+		Object[] argument = new Object[] {
+			new Group[] {mockGroup(_STAGING_GROUP_ID)}
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 0);
+
+		Assert.assertEquals(
+			_LIVE_GROUP_ID, ((Group[])argument[0])[0].getGroupId());
+
+		argument = new Object[] {
+			new Group[] {mockGroup(11111)},
+			new Group[] {mockGroup(_STAGING_GROUP_ID)}
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 1);
+
+		Assert.assertEquals(11111, ((Group[])argument[0])[0].getGroupId());
+		Assert.assertEquals(
+			_LIVE_GROUP_ID, ((Group[])argument[1])[0].getGroupId());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testReplaceArgumentWithList() throws Exception {
+		Object[] argument = new Object[] {
+			Arrays.asList(new Group[] {mockGroup(_STAGING_GROUP_ID)})
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 0);
+
+		Assert.assertEquals(
+			_LIVE_GROUP_ID, ((List<Group>)argument[0]).get(0).getGroupId());
+
+		argument = new Object[] {
+			Arrays.asList(new Group[] {mockGroup(11111)}),
+			Arrays.asList(new Group[] {mockGroup(_STAGING_GROUP_ID)})
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 1);
+
+		Assert.assertEquals(
+			11111, ((List<Group>)argument[0]).get(0).getGroupId());
+
+		Assert.assertEquals(
+			_LIVE_GROUP_ID, ((List<Group>)argument[1]).get(0).getGroupId());
+	}
+
+	@Test
+	public void testReplaceArgumentWithLong() throws Exception {
+		Object[] argument = new Object[] {_STAGING_GROUP_ID};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 0);
+
+		Assert.assertEquals(_LIVE_GROUP_ID, argument[0]);
+
+		argument = new Object[] {11111, _STAGING_GROUP_ID};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 1);
+
+		Assert.assertEquals(11111, argument[0]);
+		Assert.assertEquals(_LIVE_GROUP_ID, argument[1]);
+	}
+
+	@Test
+	public void testReplaceArgumentWithLongArray() throws Exception {
+		Object[] argument = new Object[] {new long[] {_STAGING_GROUP_ID}};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 0);
+
+		Assert.assertEquals(_LIVE_GROUP_ID, ((long[])argument[0])[0]);
+
+		argument = new Object[] {
+			new long[] {11111}, new long[] {_STAGING_GROUP_ID}
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 1);
+
+		Assert.assertEquals(11111, ((long[])argument[0])[0]);
+		Assert.assertEquals(_LIVE_GROUP_ID, ((long[])argument[1])[0]);
+	}
+
+	@Test
+	public void testReplaceArgumentWithLongObjectArray() throws Exception {
+		Object[] argument = new Object[] {new Long[] {_STAGING_GROUP_ID}};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 0);
+
+		Assert.assertEquals(
+			Long.valueOf(_LIVE_GROUP_ID), ((Long[])argument[0])[0]);
+
+		argument = new Object[] {
+			new Long[] {Long.valueOf(11111)}, new Long[] {_STAGING_GROUP_ID}
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 1);
+
+		Assert.assertEquals(Long.valueOf(11111), ((Long[])argument[0])[0]);
+		Assert.assertEquals(
+			Long.valueOf(_LIVE_GROUP_ID), ((Long[])argument[1])[0]);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testReplaceArgumentWithSet() throws Exception {
+		Object[] argument = new Object[] {
+			new HashSet(
+				Arrays.asList(new Group[] {mockGroup(_STAGING_GROUP_ID)}))
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 0);
+
+		Assert.assertEquals(
+			_LIVE_GROUP_ID,
+			((Set<Group>)argument[0]).iterator().next().getGroupId());
+
+		argument = new Object[] {
+			new HashSet(Arrays.asList(new Group[] {mockGroup(11111)})),
+			new HashSet(
+				Arrays.asList(new Group[] {mockGroup(_STAGING_GROUP_ID)}))
+		};
+
+		_liveGroupStagingAdvice.replaceArgument(argument, 1);
+
+		Assert.assertEquals(
+			11111, ((Set<Group>)argument[0]).iterator().next().getGroupId());
+		Assert.assertEquals(
+			_LIVE_GROUP_ID,
+			((Set<Group>)argument[1]).iterator().next().getGroupId());
+	}
+
+	@Test
+	public void testReplaceGroupArgument() throws Exception {
+		Group group;
+
+		group = _liveGroupStagingAdvice.replaceGroupArgument(
+			mockGroup(_STAGING_GROUP_ID));
+		Assert.assertEquals(_LIVE_GROUP_ID, group.getGroupId());
+
+		group = _liveGroupStagingAdvice.replaceGroupArgument(mockGroup(11111));
+		Assert.assertEquals(11111, group.getGroupId());
+
+		group = _liveGroupStagingAdvice.replaceGroupArgument(null);
+		Assert.assertNull(group);
+	}
+
+	@Test
+	public void testReplaceGroupIdArgument() throws Exception {
+		long groupId;
+
+		groupId = _liveGroupStagingAdvice.replaceGroupIdArgument(
+			_STAGING_GROUP_ID);
+		Assert.assertEquals(_LIVE_GROUP_ID, groupId);
+
+		groupId = _liveGroupStagingAdvice.replaceGroupIdArgument(11111);
+		Assert.assertEquals(11111, groupId);
+	}
+
+	protected static Group mockGroup(long groupId) {
+		Group group = mock(Group.class);
+
+		when(
+			group.getGroupId()
+		).thenReturn(
+			groupId
+		);
+
+		return group;
+	}
+
+	protected static Staging setUpStaging() {
+		Staging staging = mock(Staging.class);
+
+		when(
+			staging.getLiveGroup(Matchers.anyLong())
+		).then(
+			new Answer<Group>() {
+
+				@Override
+				public Group answer(InvocationOnMock invocationOnMock)
+					throws Throwable {
+
+					Object[] args = invocationOnMock.getArguments();
+
+					long groupId = (long)args[0];
+
+					if (groupId == _STAGING_GROUP_ID) {
+						return mockGroup(_LIVE_GROUP_ID);
+					}
+
+					return mockGroup(groupId);
+				}
+
+			}
+		);
+
+		when(
+			staging.getLiveGroupId(Matchers.anyLong())
+		).then(
+			new Answer<Long>() {
+
+				@Override
+				public Long answer(InvocationOnMock invocationOnMock)
+					throws Throwable {
+
+					Object[] args = invocationOnMock.getArguments();
+
+					long groupId = (long)args[0];
+
+					if (groupId == _STAGING_GROUP_ID) {
+						return _LIVE_GROUP_ID;
+					}
+
+					return groupId;
+				}
+
+			}
+		);
+
+		return staging;
+	}
+
+	private static final long _LIVE_GROUP_ID = 12345;
+
+	private static final long _STAGING_GROUP_ID = 54321;
+
+	private static LiveGroupStagingAdvice _liveGroupStagingAdvice;
+
+}

--- a/modules/apps/staging/staging-security/src/test/java/com/liferay/staging/security/spring/LiveGroupStagingAdviceTest.java
+++ b/modules/apps/staging/staging-security/src/test/java/com/liferay/staging/security/spring/LiveGroupStagingAdviceTest.java
@@ -16,11 +16,16 @@ package com.liferay.staging.security.spring;
 
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+
+import java.lang.reflect.Method;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.aopalliance.intercept.MethodInvocation;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -47,6 +52,49 @@ public class LiveGroupStagingAdviceTest extends PowerMockito {
 		Staging staging = setUpStaging();
 
 		_liveGroupStagingAdvice.setStaging(staging);
+	}
+
+	@Test
+	public void testInvokeCustomMethod() throws Throwable {
+		LiveGroupStagingAdvice liveGroupStagingAdvice =
+			new LiveGroupStagingAdvice(GroupLocalService.class) {};
+
+		liveGroupStagingAdvice.setStaging(setUpStaging());
+
+		Method addUserGroupMethod = GroupLocalService.class.getMethod(
+			"addUserGroup", long.class, Group.class);
+
+		final int groupParameterIndex = 1;
+
+		Object[] arguments = new Object[
+			addUserGroupMethod.getParameterTypes().length];
+
+		arguments[groupParameterIndex] = mockGroup(_STAGING_GROUP_ID);
+
+		MethodInvocation methodInvocation = mock(MethodInvocation.class);
+
+		when (
+			methodInvocation.getMethod()
+		).thenReturn(
+			addUserGroupMethod
+		);
+
+		when (
+			methodInvocation.getArguments()
+		).thenReturn(
+			arguments
+		);
+
+		liveGroupStagingAdvice.initCustomMethod(
+			addUserGroupMethod.getName(), groupParameterIndex,
+			addUserGroupMethod.getParameterTypes());
+
+		liveGroupStagingAdvice.invoke(methodInvocation);
+
+		Object[] replacedArguments = methodInvocation.getArguments();
+		Group group = (Group)replacedArguments[groupParameterIndex];
+
+		Assert.assertEquals(_LIVE_GROUP_ID, group.getGroupId());
 	}
 
 	@Test

--- a/modules/apps/staging/staging-security/src/test/java/com/liferay/staging/security/spring/LiveGroupStagingAdviceTest.java
+++ b/modules/apps/staging/staging-security/src/test/java/com/liferay/staging/security/spring/LiveGroupStagingAdviceTest.java
@@ -17,6 +17,7 @@ package com.liferay.staging.security.spring;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 
 import java.lang.reflect.Method;
 
@@ -88,6 +89,47 @@ public class LiveGroupStagingAdviceTest extends PowerMockito {
 		liveGroupStagingAdvice.initCustomMethod(
 			addUserGroupMethod.getName(), groupParameterIndex,
 			addUserGroupMethod.getParameterTypes());
+
+		liveGroupStagingAdvice.invoke(methodInvocation);
+
+		Object[] replacedArguments = methodInvocation.getArguments();
+		Group group = (Group)replacedArguments[groupParameterIndex];
+
+		Assert.assertEquals(_LIVE_GROUP_ID, group.getGroupId());
+	}
+
+	@Test
+	public void testInvokeServiceBuilderMethod() throws Throwable {
+		LiveGroupStagingAdvice liveGroupStagingAdvice =
+			new LiveGroupStagingAdvice(UserLocalService.class) {};
+
+		liveGroupStagingAdvice.setStaging(setUpStaging());
+
+		liveGroupStagingAdvice.initGroupServiceBuilderMethods();
+
+		Method addGroupuserMethod = UserLocalService.class.getMethod(
+			"addGroupUser", long.class, long.class);
+
+		final int groupParameterIndex = 0;
+
+		Object[] arguments = new Object[
+			addGroupuserMethod.getParameterTypes().length];
+
+		arguments[groupParameterIndex] = mockGroup(_STAGING_GROUP_ID);
+
+		MethodInvocation methodInvocation = mock(MethodInvocation.class);
+
+		when (
+			methodInvocation.getMethod()
+		).thenReturn(
+			addGroupuserMethod
+		);
+
+		when (
+			methodInvocation.getArguments()
+		).thenReturn(
+			arguments
+		);
 
 		liveGroupStagingAdvice.invoke(methodInvocation);
 


### PR DESCRIPTION
Hi Brian,

second "the hardest" part of #35810. It has 600 lines + 400 lines of tests. There are only several patterns that repeats in each class.

Core idea of this PR is that only live groupId should be used for User/Organization/UserGroup to be assigned to Group roles and membership.

Here I introduced abstract `LiveGroupStagingAdvice` and specific advices for each LocalService:
1, One-To-Many relations between `Group` and `Organization`, `Role`, `User`, `UserGroup`
2, Many-To-Many relations (User-Group-Role, UserGroup-Group-Role)

When `LiveGroupStagingAdvice` is invoked it replaces method parameters - staging groupId into live groupId.

Each specific Spring advice registers methods to be covered, where the replace should happen. If a portal service method signature is changed a runtime error will be thrown and the module won't be started.

A commit by commit explanation:

**LPS-61795 Create abstract LiveGroupStagingAdvice and corresponding classes for staging-sensitive portal services**\* (8bd4cff)

Introducing classes and `LiveGroupStagingAdvice` with "replace" methods that are used later.

**LPS-61795 Service Builder methods in Group service for related entities (Organization, Role, User, UserGroup)** (262ad5a)

`GroupLocalServiceStagingAdvice` registers _One-To-Many_ methods generated by Service Builder for the related entities.

`LiveGroupStagingAdvice` added a new method to register the custom SB methods. (+ test)

**LPS-61795 Cover Group Service Builder methods in the related entities (Organization, Role, UserGroup, User)** (d51e96a)

(Organization, Role, User, UserGroup)`LocalStagingAdvice` register _Many-To-One_ methods generated by Service Builder for Group.

`LiveGroupStagingAdvice` added a new method to register the related entity SB methods (+ test)

**LPS-61795 Register custom methods...** (d9ee17e)

Registers _Many-To-Many_ methods for `UserGroupRoleLocalService` and `UserGroupGroupRoleLocalService`.

Also registers custom methods added by developers manually.
