### PR TITLE
LPS-61518 When "Display Site Facet" is unchecked, Search portlet results are restricted to current site starting from second search

### DIFF
--- a/modules/apps/search/search-web/src/main/java/com/liferay/search/web/constants/SearchPortletParameterNames.java
+++ b/modules/apps/search/search-web/src/main/java/com/liferay/search/web/constants/SearchPortletParameterNames.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.search.web.constants;
+
+/**
+ * @author André de Oliveira
+ */
+public class SearchPortletParameterNames {
+
+	public static final String FORMAT = "format";
+
+	public static final String GROUP_ID = "groupId";
+
+	public static final String KEYWORDS = "keywords";
+
+	public static final String SCOPE = "scope";
+
+}

--- a/modules/apps/search/search-web/src/main/java/com/liferay/search/web/display/context/SearchScope.java
+++ b/modules/apps/search/search-web/src/main/java/com/liferay/search/web/display/context/SearchScope.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.search.web.display.context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author André de Oliveira
+ */
+public enum SearchScope {
+
+	EVERYTHING("everything"), THIS_SITE("this-site");
+
+	public static SearchScope getSearchScope(String parameterString) {
+		SearchScope searchScope = _searchScopes.get(parameterString);
+
+		if (searchScope == null) {
+			throw new IllegalArgumentException(
+				"The string " + parameterString +
+					" does not correspond to a valid search scope");
+		}
+
+		return searchScope;
+	}
+
+	public String getParameterString() {
+		return _parameterString;
+	}
+
+	private SearchScope(String parameterString) {
+		_parameterString = parameterString;
+	}
+
+	private static final Map<String, SearchScope> _searchScopes =
+		new HashMap<>();
+
+	static {
+		for (SearchScope searchScope : SearchScope.values()) {
+			_searchScopes.put(searchScope._parameterString, searchScope);
+		}
+	}
+
+	private final String _parameterString;
+
+}

--- a/modules/apps/search/search-web/src/main/java/com/liferay/search/web/display/context/SearchScopePreference.java
+++ b/modules/apps/search/search-web/src/main/java/com/liferay/search/web/display/context/SearchScopePreference.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.search.web.display.context;
+
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author André de Oliveira
+ */
+public enum SearchScopePreference {
+
+	EVERYTHING("everything", SearchScope.EVERYTHING),
+	LET_THE_USER_CHOOSE("let-the-user-choose", null),
+	THIS_SITE("this-site", SearchScope.THIS_SITE);
+
+	public static SearchScopePreference getSearchScopePreference(
+		String preferenceString) {
+
+		if (Validator.isNull(preferenceString)) {
+			return SearchScopePreference.THIS_SITE;
+		}
+
+		SearchScopePreference searchScopePreference =
+			_searchScopePreferences.get(preferenceString);
+
+		if (searchScopePreference == null) {
+			throw new IllegalArgumentException(
+				"The string " + preferenceString +
+					" does not correspond to a valid search scope preference");
+		}
+
+		return searchScopePreference;
+	}
+
+	public String getPreferenceString() {
+		return _preferenceString;
+	}
+
+	public SearchScope getSearchScope() {
+		return _searchScope;
+	}
+
+	private SearchScopePreference(
+		String preferenceString, SearchScope searchScope) {
+
+		_preferenceString = preferenceString;
+		_searchScope = searchScope;
+	}
+
+	private static final Map<String, SearchScopePreference>
+		_searchScopePreferences = new HashMap<>();
+
+	static {
+		for (SearchScopePreference searchScopePreference :
+				SearchScopePreference.values()) {
+
+			_searchScopePreferences.put(
+				searchScopePreference._preferenceString, searchScopePreference);
+		}
+	}
+
+	private final String _preferenceString;
+	private final SearchScope _searchScope;
+
+}

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/display_settings.jspf
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/display_settings.jspf
@@ -14,7 +14,7 @@
  */
 --%>
 
-<aui:select label="scope" name="preferences--searchScope--" value="<%= searchDisplayContext.getSearchScope() %>">
+<aui:select label="scope" name="preferences--searchScope--" value="<%= searchDisplayContext.getSearchScopePreferenceString() %>">
 	<aui:option label="this-site" value="" />
 	<aui:option label="everything" />
 	<aui:option label="let-the-user-choose" />

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
@@ -16,6 +16,12 @@
 
 <%@ include file="/facets/init.jsp" %>
 
+<%
+if (Validator.isNull(fieldParam)) {
+	fieldParam = String.valueOf(searchDisplayContext.getSearchScopeGroupId());
+}
+%>
+
 <c:choose>
 	<c:when test="<%= termCollectors.isEmpty() %>">
 		<aui:input name="<%= HtmlUtil.escapeAttribute(facet.getFieldName()) %>" type="hidden" value="<%= fieldParam %>" />

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/init.jsp
@@ -88,6 +88,7 @@ page import="com.liferay.search.facet.SearchFacet" %><%@
 page import="com.liferay.search.facet.util.SearchFacetTracker" %><%@
 page import="com.liferay.search.facet.util.comparator.SearchFacetComparator" %><%@
 page import="com.liferay.search.web.constants.SearchPortletKeys" %><%@
+page import="com.liferay.search.web.constants.SearchPortletParameterNames" %><%@
 page import="com.liferay.search.web.display.context.SearchDisplayContext" %><%@
 page import="com.liferay.search.web.facet.AssetEntriesSearchFacet" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %><%@

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/search.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/search.jsp
@@ -23,9 +23,9 @@ if (Validator.isNotNull(redirect)) {
 	portletDisplay.setURLBack(redirect);
 }
 
-long groupId = ParamUtil.getLong(request, "groupId");
+long groupId = ParamUtil.getLong(request, SearchPortletParameterNames.GROUP_ID);
 
-String format = ParamUtil.getString(request, "format");
+String format = ParamUtil.getString(request, SearchPortletParameterNames.FORMAT);
 %>
 
 <liferay-ui:header
@@ -44,6 +44,7 @@ String format = ParamUtil.getString(request, "format");
 
 	<aui:fieldset id="searchContainer">
 		<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" inlineField="<%= true %>" label="" name="keywords" size="30" title="search" value="<%= HtmlUtil.escape(searchDisplayContext.getKeywords()) %>" />
+		<aui:input name="scope" type="hidden" value="<%= searchDisplayContext.getSearchScopeParameterString() %>" />
 
 		<aui:field-wrapper inlineField="<%= true %>">
 			<aui:button icon="icon-search" onClick='<%= renderResponse.getNamespace() + "search();" %>' value="search" />

--- a/modules/apps/search/search-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/search/search-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,9 +17,9 @@
 <%@ include file="/init.jsp" %>
 
 <%
-long groupId = ParamUtil.getLong(request, "groupId");
+long groupId = ParamUtil.getLong(request, SearchPortletParameterNames.GROUP_ID);
 
-String keywords = ParamUtil.getString(request, "keywords");
+boolean scopeEverything = (groupId == 0);
 
 PortletURL portletURL = renderResponse.createRenderURL();
 
@@ -35,7 +35,7 @@ pageContext.setAttribute("portletURL", portletURL);
 	<liferay-portlet:renderURLParams varImpl="portletURL" />
 
 	<aui:fieldset>
-		<aui:input cssClass="search-input" inlineField="<%= true %>" label="" name="keywords" placeholder="search" size="30" title="search" type="text" value="<%= HtmlUtil.escapeAttribute(keywords) %>" />
+		<aui:input cssClass="search-input" inlineField="<%= true %>" label="" name="keywords" placeholder="search" size="30" title="search" type="text" value="<%= HtmlUtil.escapeAttribute(searchDisplayContext.getKeywords()) %>" />
 
 		<%
 		String taglibOnClick = "Liferay.Util.focusFormField('#" + renderResponse.getNamespace() + "keywords');";
@@ -44,25 +44,17 @@ pageContext.setAttribute("portletURL", portletURL);
 		<liferay-ui:quick-access-entry label="skip-to-search" onClick="<%= taglibOnClick %>" />
 
 		<c:choose>
-			<c:when test='<%= Validator.equals(searchDisplayContext.getSearchScope(), "let-the-user-choose") %>'>
-				<aui:select cssClass="search-select" inlineField="<%= true %>" label="" name="groupId" title="scope">
-
-					<%
-					Group group = themeDisplay.getScopeGroup();
-					%>
-
-					<c:if test="<%= !group.isStagingGroup() %>">
-						<aui:option label="everything" selected="<%= (groupId == 0) %>" value="0" />
+			<c:when test="<%= searchDisplayContext.isSearchScopePreferenceLetTheUserChoose() %>">
+				<aui:select cssClass="search-select" inlineField="<%= true %>" label="" name="scope" title="scope">
+					<c:if test="<%= searchDisplayContext.isSearchScopePreferenceEverythingAvailable() %>">
+						<aui:option label="everything" selected="<%= scopeEverything %>" value="everything" />
 					</c:if>
 
-					<aui:option label="this-site" selected="<%= (groupId != 0) %>" value="<%= group.getGroupId() %>" />
+					<aui:option label="this-site" selected="<%= !scopeEverything %>" value="this-site" />
 				</aui:select>
 			</c:when>
-			<c:when test='<%= Validator.equals(searchDisplayContext.getSearchScope(), "everything") %>'>
-				<aui:input name="groupId" type="hidden" value="0" />
-			</c:when>
 			<c:otherwise>
-				<aui:input name="groupId" type="hidden" value="<%= themeDisplay.getScopeGroupId() %>" />
+				<aui:input name="scope" type="hidden" value="<%= searchDisplayContext.getSearchScopeParameterString() %>" />
 			</c:otherwise>
 		</c:choose>
 

--- a/portal-service/src/com/liferay/portal/kernel/search/SearchContextFactory.java
+++ b/portal-service/src/com/liferay/portal/kernel/search/SearchContextFactory.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.Serializable;
@@ -67,6 +68,20 @@ public class SearchContextFactory {
 				else {
 					attributes.put(name, values);
 				}
+			}
+		}
+
+		if (!parameters.containsKey("groupId")) {
+			String[] scopes = parameters.get("scope");
+
+			if (scopes != null) {
+				String groupId = "0";
+
+				if (Validator.equals(scopes[0], "this-site")) {
+					groupId = String.valueOf(themeDisplay.getScopeGroupId());
+				}
+
+				attributes.put("groupId", groupId);
 			}
 		}
 


### PR DESCRIPTION
Authors: @arboliveira @arturbr
Reviewer: @mhan810

Re-sending https://github.com/arboliveira/liferay-portal/pull/88.

Enforcing the distinction that enums aren't really constants (https://github.com/arboliveira/liferay-portal/pull/88#issuecomment-181586128), moved the `SearchScope` and `SearchScopePreference` enums out of `com.liferay.search.web.constants` and into `com.liferay.search.web.display.context` to be together with `SearchDisplayContext` where they're used.

fyi @ealonso @juliocamarero  

https://issues.liferay.com/browse/LPS-61518
