### PR TITLE
LPS-62918 revert the change: holding response in tags causes extensio…

### DIFF
--- a/util-taglib/src/com/liferay/taglib/util/ParamAndPropertyAncestorTagImpl.java
+++ b/util-taglib/src/com/liferay/taglib/util/ParamAndPropertyAncestorTagImpl.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.PageContext;
 
 /**
@@ -152,7 +151,6 @@ public class ParamAndPropertyAncestorTagImpl
 		super.release();
 
 		request = null;
-		response = null;
 		servletContext = null;
 
 		_allowEmptyParam = false;
@@ -176,7 +174,6 @@ public class ParamAndPropertyAncestorTagImpl
 		super.setPageContext(pageContext);
 
 		request = (HttpServletRequest)pageContext.getRequest();
-		response = (HttpServletResponse)pageContext.getResponse();
 
 		servletContext = (ServletContext)request.getAttribute(WebKeys.CTX);
 
@@ -190,7 +187,6 @@ public class ParamAndPropertyAncestorTagImpl
 	}
 
 	protected HttpServletRequest request;
-	protected HttpServletResponse response;
 	protected ServletContext servletContext;
 
 	private boolean _allowEmptyParam;


### PR DESCRIPTION
…n of response lifecycle, which results in much heavier old generation GC
