### PR TITLE
LPS-63499 A temporarily work around for the messed up jdbc connection…

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
@@ -54,6 +54,8 @@ public class ClassNameLocalServiceImpl
 	@Override
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public void checkClassNames() {
+		_classNames.clear();
+
 		List<ClassName> classNames = classNamePersistence.findAll();
 
 		for (ClassName className : classNames) {
@@ -139,7 +141,6 @@ public class ClassNameLocalServiceImpl
 
 	@Override
 	public void invalidate() {
-		_classNames.clear();
 	}
 
 	private static final Map<String, ClassName> _classNames =


### PR DESCRIPTION
… release in the middle of the tx. This must be reverted after finding and fixing the real cause.

@brianchandotcom those random journal failures are much more complex than I thought, basically something changed in last week, caused we start to disconnect hibernate session in the middle of a tx. Leaving a closed jdbc connection being used afterward.

At this moment, I don't really know whether this is a new issue, or just a long exist one exposed by something lately. It is too late for me to think straight on it.

@michaelhashimoto please send me the master monitoring link again, sorry, I keep forgetting about it. Maybe you can put it into the pr tester's report page, just easier to access. I need to pin-point the first build that started to see those journal random failures to better under what this really is. I will not be in office tomorrow, but I will go on Tuesday, please get those info ready, if possible find me find that build to save some time.

@brianchandotcom in this pull, I basically disabled the cache reset for ClassNameLocalServiceImpl, which is technically wrong, but still acceptable as one can always call checkClassNames to force the cache up to date. And it will stop the nested service txs launching within a finder call, therefore work around this issue. But we do need to figure out the real case and fix it from there. But at least this pull can make CI stable again. I will continue on this on Tuesday.
