### PR TITLE
Lps 63499

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/jdbc/CurrentConnectionImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/CurrentConnectionImpl.java
@@ -41,9 +41,10 @@ public class CurrentConnectionImpl implements CurrentConnection {
 
 			return null;
 		}
-		else {
-			return connectionHolder.getConnection();
-		}
+
+		connectionHolder.requested();
+
+		return connectionHolder.getConnection();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ClassNameLocalServiceImpl.java
@@ -54,8 +54,6 @@ public class ClassNameLocalServiceImpl
 	@Override
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public void checkClassNames() {
-		_classNames.clear();
-
 		List<ClassName> classNames = classNamePersistence.findAll();
 
 		for (ClassName className : classNames) {
@@ -141,6 +139,7 @@ public class ClassNameLocalServiceImpl
 
 	@Override
 	public void invalidate() {
+		_classNames.clear();
 	}
 
 	private static final Map<String, ClassName> _classNames =


### PR DESCRIPTION
@brianchandotcom this turns out to be a long exist issue. What caused it start to show is still an unknown factor which most likely is a complex combination of changes, but it does not really matter as it needs to be fixed anyway. This fix is the simplest right form we could take for now. But it is not the best way, as it enlarges the lifespan of certain jdbc connections, which could lead to some slight performance drawback. Later we will work on the best right fix, which is wiping out the Spring MappingSqlQuery/SqlUpdate completely, therefore we won't have this kind of wild leftover closed jdbc connection at all. 

@dantewang @slnn performance check please (I don't think it will actually affect the results, but the drawback does technically exist)

CC @mtambara
