### PR TITLE
LPS-63020 Permission framework must fail any check for missing SCOPE_INDIVIDUAL resource permission

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.Team;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -49,7 +48,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.TeamLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutSetPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
@@ -883,14 +881,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 			companyId = group.getCompanyId();
-		}
-		else if (name.equals(User.class.getName())) {
-			User user = UserLocalServiceUtil.fetchUser(
-				GetterUtil.getLong(primKey));
-
-			if (user != null) {
-				companyId = user.getCompanyId();
-			}
 		}
 
 		try {

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -867,6 +867,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		stopWatch.start();
 
+		if (isOmniadmin()) {
+			return true;
+		}
+
+		if (name.equals(Organization.class.getName())) {
+			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
+				return true;
+			}
+		}
+
 		long companyId = user.getCompanyId();
 
 		if (groupId > 0) {
@@ -880,29 +890,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			if (user != null) {
 				companyId = user.getCompanyId();
-			}
-		}
-
-		boolean hasLayoutManagerPermission = true;
-
-		// Check if the layout manager has permission to do this action for the
-		// current portlet
-
-		if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
-			primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
-
-			hasLayoutManagerPermission =
-				PortletPermissionUtil.hasLayoutManagerPermission(
-					name, actionId);
-		}
-
-		if (isOmniadmin()) {
-			return true;
-		}
-
-		if (name.equals(Organization.class.getName())) {
-			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
-				return true;
 			}
 		}
 
@@ -927,8 +914,23 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return true;
 		}
 
-		if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
-			return true;
+		if (isGroupAdminImpl(groupId)) {
+			boolean hasLayoutManagerPermission = true;
+
+			// Check if the layout manager has permission to do this action for
+			// the current portlet
+
+			if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
+				primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+
+				hasLayoutManagerPermission =
+					PortletPermissionUtil.hasLayoutManagerPermission(
+						name, actionId);
+			}
+
+			if (hasLayoutManagerPermission) {
+				return true;
+			}
 		}
 
 		return false;

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermiss
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.GroupedModel;
@@ -692,6 +693,27 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 	}
 
+	protected String fixLegacyPrimaryKey(
+		long companyId, String name, String primKey) {
+
+		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
+			(primKey.equals(String.valueOf(companyId)) &&
+			 !name.equals(Company.class.getName()))) {
+
+			String message =
+				"Legacy primary key " + primKey + " was used for " +
+					"permission checking of " + name + " in company " +
+					companyId + ". Please use " + name + " as the " +
+					"primary key.";
+
+			_log.error(message, new IllegalArgumentException(message));
+
+			return name;
+		}
+
+		return primKey;
+	}
+
 	/**
 	 * Returns representations of the resource at each scope level.
 	 *
@@ -798,8 +820,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		long companyId = user.getCompanyId();
 
-		List<Resource> resources = getResources(
-			companyId, groupId, name, primKey, actionId);
+		if (groupId > 0) {
+			Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+			companyId = group.getCompanyId();
+		}
 
 		try {
 			if (ResourceBlockLocalServiceUtil.isSupported(name)) {
@@ -810,6 +835,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					name, GetterUtil.getLong(primKey), actionId,
 					resourceBlockIdsBag);
 			}
+
+			primKey = fixLegacyPrimaryKey(companyId, name, primKey);
+
+			List<Resource> resources = getResources(
+				companyId, groupId, name, primKey, actionId);
 
 			return ResourceLocalServiceUtil.hasUserPermissions(
 				defaultUserId, groupId, resources, actionId,
@@ -882,6 +912,8 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			companyId = group.getCompanyId();
 		}
+
+		primKey = fixLegacyPrimaryKey(companyId, name, primKey);
 
 		try {
 			boolean hasPermission = doCheckPermission(

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -3358,6 +3358,7 @@
 		<exception>LayoutSetVirtualHost</exception>
 		<exception>LayoutType</exception>
 		<exception>MembershipRequestComments</exception>
+		<exception>MissingIndividualScopeResourcePermission</exception>
 		<exception>OldServiceComponent</exception>
 		<exception>OrganizationId</exception>
 		<exception>OrganizationName</exception>

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.Type;
+import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermissionException;
 import com.liferay.portal.kernel.exception.NoSuchResourcePermissionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -690,7 +691,10 @@ public class ResourcePermissionLocalServiceImpl
 				individualResource.getScope(),
 				individualResource.getPrimKey()) < 1) {
 
-			return false;
+			throw new MissingIndividualScopeResourcePermissionException(
+				"There is no " + individualResource.getName() +
+					" with primary key " + individualResource.getPrimKey() +
+						" and companyId " + individualResource.getCompanyId());
 		}
 
 		// Iterate the list of resources in reverse order to test permissions

--- a/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
+++ b/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.exception;
+
+import aQute.bnd.annotation.ProviderType;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+@ProviderType
+public class MissingIndividualScopeResourcePermissionException
+	extends PortalException {
+
+	public MissingIndividualScopeResourcePermissionException() {
+	}
+
+	public MissingIndividualScopeResourcePermissionException(String msg) {
+		super(msg);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(
+		String msg, Throwable cause) {
+
+		super(msg, cause);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(Throwable cause) {
+		super(cause);
+	}
+
+}


### PR DESCRIPTION
Hi Brian,

resending #36182 again (reviewed by @rotty3000).

I fixed all related permission bugs that revealed (wrong model, missing resources, portlet vs. model resource, ...) and all are merged.

Thanks.

https://issues.liferay.com/browse/LPS-63020

---

Update: 
- Tests to cover changes here and general permission framework tests: https://github.com/brianchandotcom/liferay-portal/pull/36574
- Only `PermissionCheckerTest.testHasPermission` is expected to fail here (fixed in the PR above)
