### PR TITLE
LPS-63613 Basic tests for permission framework

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.Team;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -49,7 +48,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.TeamLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutSetPrototypePermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
@@ -883,14 +881,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 			companyId = group.getCompanyId();
-		}
-		else if (name.equals(User.class.getName())) {
-			User user = UserLocalServiceUtil.fetchUser(
-				GetterUtil.getLong(primKey));
-
-			if (user != null) {
-				companyId = user.getCompanyId();
-			}
 		}
 
 		try {

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -867,6 +867,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		stopWatch.start();
 
+		if (isOmniadmin()) {
+			return true;
+		}
+
+		if (name.equals(Organization.class.getName())) {
+			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
+				return true;
+			}
+		}
+
 		long companyId = user.getCompanyId();
 
 		if (groupId > 0) {
@@ -880,29 +890,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			if (user != null) {
 				companyId = user.getCompanyId();
-			}
-		}
-
-		boolean hasLayoutManagerPermission = true;
-
-		// Check if the layout manager has permission to do this action for the
-		// current portlet
-
-		if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
-			primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
-
-			hasLayoutManagerPermission =
-				PortletPermissionUtil.hasLayoutManagerPermission(
-					name, actionId);
-		}
-
-		if (isOmniadmin()) {
-			return true;
-		}
-
-		if (name.equals(Organization.class.getName())) {
-			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
-				return true;
 			}
 		}
 
@@ -927,8 +914,23 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return true;
 		}
 
-		if (isGroupAdminImpl(groupId) && hasLayoutManagerPermission) {
-			return true;
+		if (isGroupAdminImpl(groupId)) {
+			boolean hasLayoutManagerPermission = true;
+
+			// Check if the layout manager has permission to do this action for
+			// the current portlet
+
+			if (Validator.isNotNull(name) && Validator.isNotNull(primKey) &&
+				primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+
+				hasLayoutManagerPermission =
+					PortletPermissionUtil.hasLayoutManagerPermission(
+						name, actionId);
+			}
+
+			if (hasLayoutManagerPermission) {
+				return true;
+			}
 		}
 
 		return false;

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermiss
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.GroupedModel;
@@ -692,6 +693,27 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		}
 	}
 
+	protected String fixLegacyPrimaryKey(
+		long companyId, String name, String primKey) {
+
+		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
+			(primKey.equals(String.valueOf(companyId)) &&
+			 !name.equals(Company.class.getName()))) {
+
+			String message =
+				"Legacy primary key " + primKey + " was used for " +
+					"permission checking of " + name + " in company " +
+					companyId + ". Please use " + name + " as the " +
+					"primary key.";
+
+			_log.error(message, new IllegalArgumentException(message));
+
+			return name;
+		}
+
+		return primKey;
+	}
+
 	/**
 	 * Returns representations of the resource at each scope level.
 	 *
@@ -798,8 +820,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		long companyId = user.getCompanyId();
 
-		List<Resource> resources = getResources(
-			companyId, groupId, name, primKey, actionId);
+		if (groupId > 0) {
+			Group group = GroupLocalServiceUtil.getGroup(groupId);
+
+			companyId = group.getCompanyId();
+		}
 
 		try {
 			if (ResourceBlockLocalServiceUtil.isSupported(name)) {
@@ -810,6 +835,11 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					name, GetterUtil.getLong(primKey), actionId,
 					resourceBlockIdsBag);
 			}
+
+			primKey = fixLegacyPrimaryKey(companyId, name, primKey);
+
+			List<Resource> resources = getResources(
+				companyId, groupId, name, primKey, actionId);
 
 			return ResourceLocalServiceUtil.hasUserPermissions(
 				defaultUserId, groupId, resources, actionId,
@@ -882,6 +912,8 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			companyId = group.getCompanyId();
 		}
+
+		primKey = fixLegacyPrimaryKey(companyId, name, primKey);
 
 		try {
 			boolean hasPermission = doCheckPermission(

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -895,16 +895,6 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		stopWatch.start();
 
-		if (isOmniadmin()) {
-			return true;
-		}
-
-		if (name.equals(Organization.class.getName())) {
-			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
-				return true;
-			}
-		}
-
 		long companyId = user.getCompanyId();
 
 		if (groupId > 0) {
@@ -930,6 +920,16 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 					"or there is a bug in permission framework caller: " +
 						misrpe.getMessage(),
 				misrpe);
+		}
+
+		if (isOmniadmin()) {
+			return true;
+		}
+
+		if (name.equals(Organization.class.getName())) {
+			if (isOrganizationAdminImpl(GetterUtil.getLong(primKey))) {
+				return true;
+			}
 		}
 
 		if (isCompanyAdminImpl(companyId)) {

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -3358,6 +3358,7 @@
 		<exception>LayoutSetVirtualHost</exception>
 		<exception>LayoutType</exception>
 		<exception>MembershipRequestComments</exception>
+		<exception>MissingIndividualScopeResourcePermission</exception>
 		<exception>OldServiceComponent</exception>
 		<exception>OrganizationId</exception>
 		<exception>OrganizationName</exception>

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.Type;
+import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermissionException;
 import com.liferay.portal.kernel.exception.NoSuchResourcePermissionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -690,7 +691,10 @@ public class ResourcePermissionLocalServiceImpl
 				individualResource.getScope(),
 				individualResource.getPrimKey()) < 1) {
 
-			return false;
+			throw new MissingIndividualScopeResourcePermissionException(
+				"There is no " + individualResource.getName() +
+					" with primary key " + individualResource.getPrimKey() +
+						" and companyId " + individualResource.getCompanyId());
 		}
 
 		// Iterate the list of resources in reverse order to test permissions

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -126,6 +127,10 @@ public class PermissionCheckerTest {
 				ResourceConstants.SCOPE_INDIVIDUAL, _PORTLET_RESOURCE_NAME);
 
 			ResourceLocalServiceUtil.deleteResource(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, _MODEL_RESOURCE_NAME);
+
+			ResourceLocalServiceUtil.deleteResource(
 				_user.getCompanyId(), _ROOT_MODEL_RESOURCE_NAME,
 				ResourceConstants.SCOPE_INDIVIDUAL, _ROOT_MODEL_RESOURCE_NAME);
 
@@ -165,6 +170,216 @@ public class PermissionCheckerTest {
 			ResourceLocalServiceUtil.deleteResource(
 				_user.getCompanyId(), _ROOT_MODEL_RESOURCE_NAME,
 				ResourceConstants.SCOPE_INDIVIDUAL, _group.getGroupId());
+		}
+	}
+
+	@Test
+	public void testHasPermissionWithCompanyScopeResourcePermission()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		_role = RoleTestUtil.addRole(
+			"PermissionTestRole", RoleConstants.TYPE_REGULAR);
+
+		UserLocalServiceUtil.setRoleUsers(
+			_role.getRoleId(), new long[] {_user.getUserId()});
+
+		PermissionChecker permissionChecker = _getPermissionChecker(_user);
+
+		long resourceId = 12345;
+
+		ResourceLocalServiceUtil.addResources(
+			_user.getCompanyId(), 0, 0, _MODEL_RESOURCE_NAME, resourceId, false,
+			false, false);
+
+		try {
+			boolean hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+				ActionKeys.DELETE);
+
+			Assert.assertFalse(hasPermission);
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_COMPANY,
+				String.valueOf(_user.getCompanyId()), _role.getRoleId(),
+				new String[] {ActionKeys.DELETE});
+
+			try {
+				hasPermission = permissionChecker.hasPermission(
+					_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+					ActionKeys.DELETE);
+
+				Assert.assertTrue(hasPermission);
+			}
+			finally {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+					ResourceConstants.SCOPE_COMPANY, resourceId);
+			}
+		}
+		finally {
+			ResourceLocalServiceUtil.deleteResource(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, resourceId);
+		}
+	}
+
+	@Test
+	public void testHasPermissionWithGroupScopeResourcePermission()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		_role = RoleTestUtil.addRole(
+			"PermissionTestRole", RoleConstants.TYPE_REGULAR);
+
+		UserLocalServiceUtil.setRoleUsers(
+			_role.getRoleId(), new long[] {_user.getUserId()});
+
+		PermissionChecker permissionChecker = _getPermissionChecker(_user);
+
+		long resourceId = 12345;
+
+		ResourceLocalServiceUtil.addResources(
+			_user.getCompanyId(), _group.getGroupId(), 0, _MODEL_RESOURCE_NAME,
+			resourceId, false, false, false);
+
+		try {
+			boolean hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+				ActionKeys.DELETE);
+
+			Assert.assertFalse(hasPermission);
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_GROUP,
+				String.valueOf(_group.getGroupId()), _role.getRoleId(),
+				new String[] {ActionKeys.DELETE});
+
+			try {
+				hasPermission = permissionChecker.hasPermission(
+					_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+					ActionKeys.DELETE);
+
+				Assert.assertTrue(hasPermission);
+			}
+			finally {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+					ResourceConstants.SCOPE_GROUP, _group.getGroupId());
+			}
+		}
+		finally {
+			ResourceLocalServiceUtil.deleteResource(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, resourceId);
+		}
+	}
+
+	@Test
+	public void testHasPermissionWithGroupTemplateScopeResourcePermission()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		_role = RoleTestUtil.addRole(
+			"PermissionTestRole", RoleConstants.TYPE_REGULAR);
+
+		UserLocalServiceUtil.setRoleUsers(
+			_role.getRoleId(), new long[] {_user.getUserId()});
+
+		PermissionChecker permissionChecker = _getPermissionChecker(_user);
+
+		long resourceId = 12345;
+
+		ResourceLocalServiceUtil.addResources(
+			_user.getCompanyId(), _group.getGroupId(), 0, _MODEL_RESOURCE_NAME,
+			resourceId, false, false, false);
+
+		try {
+			boolean hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+				ActionKeys.DELETE);
+
+			Assert.assertFalse(hasPermission);
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_GROUP_TEMPLATE, "0", _role.getRoleId(),
+				new String[] {ActionKeys.DELETE});
+
+			try {
+				hasPermission = permissionChecker.hasPermission(
+					_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+					ActionKeys.DELETE);
+
+				Assert.assertTrue(hasPermission);
+			}
+			finally {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+					ResourceConstants.SCOPE_GROUP_TEMPLATE, 0);
+			}
+		}
+		finally {
+			ResourceLocalServiceUtil.deleteResource(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, resourceId);
+		}
+	}
+
+	@Test
+	public void testHasPermissionWithIndividualScopeResourcePermission()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		_role = RoleTestUtil.addRole(
+			"PermissionTestRole", RoleConstants.TYPE_REGULAR);
+
+		UserLocalServiceUtil.setRoleUsers(
+			_role.getRoleId(), new long[] {_user.getUserId()});
+
+		PermissionChecker permissionChecker = _getPermissionChecker(_user);
+
+		long resourceId = 12345;
+
+		ResourceLocalServiceUtil.addResources(
+			_user.getCompanyId(), _group.getGroupId(), 0, _MODEL_RESOURCE_NAME,
+			resourceId, false, false, false);
+
+		try {
+			boolean hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+				ActionKeys.DELETE);
+
+			Assert.assertFalse(hasPermission);
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, String.valueOf(resourceId),
+				_role.getRoleId(), new String[] {ActionKeys.DELETE});
+
+			try {
+				hasPermission = permissionChecker.hasPermission(
+					_group.getGroupId(), _MODEL_RESOURCE_NAME, resourceId,
+					ActionKeys.DELETE);
+
+				Assert.assertTrue(hasPermission);
+			}
+			finally {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+					ResourceConstants.SCOPE_INDIVIDUAL, resourceId);
+			}
+		}
+		finally {
+			ResourceLocalServiceUtil.deleteResource(
+				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, resourceId);
 		}
 	}
 
@@ -523,6 +738,9 @@ public class PermissionCheckerTest {
 	}
 
 	private static final String _ADD_SITE_TEST_ACTION = "ADD_SITE_TEST";
+
+	private static final String _MODEL_RESOURCE_NAME =
+		"test.com.liferay.portal.security.permission.SiteTest";
 
 	private static final String _PORTLET_RESOURCE_NAME =
 		"com_liferay_portal_security_PermissionCheckerTestSiteRelatedPortlet";

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -127,6 +127,64 @@ public class PermissionCheckerTest {
 	}
 
 	@Test
+	public void testHasPermissionOnDefaultPortletResourcesWithNonSitePortlet()
+		throws Exception {
+
+		_user = UserTestUtil.addUser();
+
+		UserLocalServiceUtil.setGroupUsers(
+			_group.getGroupId(), new long[] {_user.getUserId()});
+
+		PermissionChecker permissionChecker = _getPermissionChecker(_user);
+
+		deployRemotePortlet(
+			_user.getCompanyId(), _NONSITE_PORTLET_RESOURCE_NAME);
+
+		try {
+			boolean hasPermission = permissionChecker.hasPermission(
+				0, _NONSITE_PORTLET_RESOURCE_NAME,
+				_NONSITE_PORTLET_RESOURCE_NAME, _ADD_TEST_RESULT_ACTION);
+
+			Assert.assertTrue(hasPermission);
+
+			hasPermission = permissionChecker.hasPermission(
+				0, _NONSITE_ROOT_MODEL_RESOURCE_NAME,
+				_NONSITE_ROOT_MODEL_RESOURCE_NAME, _ADD_TEST_ACTION);
+
+			Assert.assertFalse(hasPermission);
+
+			_role = RoleTestUtil.addRole(
+				"PermissionTestRole", RoleConstants.TYPE_REGULAR);
+
+			UserLocalServiceUtil.setRoleUsers(
+				_role.getRoleId(), new long[] {_user.getUserId()});
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				_user.getCompanyId(), _NONSITE_ROOT_MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_COMPANY,
+				String.valueOf(_user.getCompanyId()), _role.getRoleId(),
+				new String[] {_ADD_TEST_ACTION});
+
+			try {
+				hasPermission = permissionChecker.hasPermission(
+					0, _NONSITE_ROOT_MODEL_RESOURCE_NAME,
+					_NONSITE_ROOT_MODEL_RESOURCE_NAME, _ADD_TEST_ACTION);
+
+				Assert.assertTrue(hasPermission);
+			}
+			finally {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					_user.getCompanyId(), _NONSITE_ROOT_MODEL_RESOURCE_NAME,
+					ResourceConstants.SCOPE_COMPANY, _user.getCompanyId());
+			}
+		}
+		finally {
+			destroyRemotePortlet(
+				_user.getCompanyId(), _NONSITE_PORTLET_RESOURCE_NAME);
+		}
+	}
+
+	@Test
 	public void testHasPermissionOnRootModelResource() throws Exception {
 		_user = UserTestUtil.addUser();
 
@@ -757,8 +815,18 @@ public class PermissionCheckerTest {
 
 	private static final String _ADD_SITE_TEST_ACTION = "ADD_SITE_TEST";
 
+	private static final String _ADD_TEST_ACTION = "ADD_TEST";
+
+	private static final String _ADD_TEST_RESULT_ACTION = "ADD_TEST_RESULT";
+
 	private static final String _MODEL_RESOURCE_NAME =
 		"test.com.liferay.portal.security.permission.SiteTest";
+
+	private static final String _NONSITE_PORTLET_RESOURCE_NAME =
+		"com_liferay_portal_security_PermissionCheckerTestNonSitePortlet";
+
+	private static final String _NONSITE_ROOT_MODEL_RESOURCE_NAME =
+		"com.liferay.portal.security.permission.nonsite";
 
 	private static final String _PORTLET_RESOURCE_NAME =
 		"com_liferay_portal_security_PermissionCheckerTestSiteRelatedPortlet";

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -62,28 +62,6 @@ public class PermissionCheckerTest {
 	}
 
 	@Test
-	public void testHasPermission() throws Exception {
-		_user = UserTestUtil.addUser();
-
-		PermissionChecker permissionChecker = _getPermissionChecker(_user);
-
-		String withExceptionPortletId =
-			"com_liferay_blogs_web_portlet_BlogsAdminPortlet";
-		String withExceptionActionId = "ADD_TO_PAGE";
-		String withoutExceptionPortletId = "11";
-		String withoutExceptionActionId = "VIEW";
-
-		Assert.assertFalse(
-			permissionChecker.hasPermission(
-				_group.getGroupId(), withExceptionPortletId,
-				_group.getGroupId(), withExceptionActionId));
-		Assert.assertFalse(
-			permissionChecker.hasPermission(
-				_group.getGroupId(), withoutExceptionPortletId,
-				_group.getGroupId(), withoutExceptionActionId));
-	}
-
-	@Test
 	public void testIsCompanyAdminWithCompanyAdmin() throws Exception {
 		PermissionChecker permissionChecker = _getPermissionChecker(
 			TestPropsValues.getUser());

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -274,6 +274,65 @@ public class PermissionCheckerTest {
 	}
 
 	@Test
+	public void testHasPermissionWithDifferentCompanyAdmin() throws Exception {
+		long resourceId = 12345;
+
+		ResourceLocalServiceUtil.addResources(
+			_group.getCompanyId(), _group.getGroupId(), 0, _MODEL_RESOURCE_NAME,
+			resourceId, false, false, false);
+
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		try {
+			_company = CompanyTestUtil.addCompany();
+
+			CompanyThreadLocal.setCompanyId(_company.getCompanyId());
+
+			_user = UserTestUtil.addCompanyAdminUser(_company);
+
+			PermissionChecker permissionChecker = _getPermissionChecker(_user);
+
+			boolean isCompanyAdmin = permissionChecker.isCompanyAdmin(
+				_company.getCompanyId());
+
+			Assert.assertTrue(isCompanyAdmin);
+
+			permissionChecker.hasPermission(
+				0, _MODEL_RESOURCE_NAME, resourceId, ActionKeys.VIEW);
+
+			Assert.fail();
+		}
+		catch (Throwable t) {
+			boolean found = false;
+
+			Throwable cause = t;
+
+			while (!found && (cause != null)) {
+				if (cause instanceof
+						MissingIndividualScopeResourcePermissionException) {
+
+					found = true;
+				}
+
+				cause = cause.getCause();
+			}
+
+			if (!found) {
+				Assert.fail(t.getMessage());
+
+				throw t;
+			}
+		}
+		finally {
+			CompanyThreadLocal.setCompanyId(companyId);
+
+			ResourceLocalServiceUtil.deleteResource(
+				_group.getCompanyId(), _MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL, resourceId);
+		}
+	}
+
+	@Test
 	public void testHasPermissionWithGroupScopeResourcePermission()
 		throws Exception {
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.security.permission;
 
+import com.liferay.portal.kernel.exception.MissingIndividualScopeResourcePermissionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
@@ -426,6 +427,42 @@ public class PermissionCheckerTest {
 			ResourceLocalServiceUtil.deleteResource(
 				_user.getCompanyId(), _MODEL_RESOURCE_NAME,
 				ResourceConstants.SCOPE_INDIVIDUAL, resourceId);
+		}
+	}
+
+	@Test
+	public void testHasPermissionWithMissingResourcePermissions()
+		throws Exception {
+
+		PermissionChecker permissionChecker = _getPermissionChecker(
+			TestPropsValues.getUser());
+
+		try {
+			permissionChecker.hasPermission(
+				0, _MODEL_RESOURCE_NAME, 12345, ActionKeys.VIEW);
+
+			Assert.fail();
+		}
+		catch (Throwable t) {
+			boolean found = false;
+
+			Throwable cause = t;
+
+			while (!found && (cause != null)) {
+				if (cause instanceof
+						MissingIndividualScopeResourcePermissionException) {
+
+					found = true;
+				}
+
+				cause = cause.getCause();
+			}
+
+			if (!found) {
+				Assert.fail(t.getMessage());
+
+				throw t;
+			}
 		}
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
@@ -36,4 +36,25 @@
 			<guest-unsupported />
 		</permissions>
 	</model-resource>
+	<model-resource>
+		<model-name>test.com.liferay.portal.security.permission.SiteTest</model-name>
+		<portlet-ref>
+			<portlet-name>com_liferay_portal_security_PermissionCheckerTestSiteRelatedPortlet</portlet-name>
+		</portlet-ref>
+		<permissions>
+			<supports>
+				<action-key>DELETE</action-key>
+				<action-key>PERMISSIONS</action-key>
+				<action-key>UPDATE</action-key>
+				<action-key>VIEW</action-key>
+			</supports>
+			<site-member-defaults>
+				<action-key>UPDATE</action-key>
+			</site-member-defaults>
+			<guest-defaults>
+				<action-key>VIEW</action-key>
+			</guest-defaults>
+			<guest-unsupported />
+		</permissions>
+	</model-resource>
 </resource-action-mapping>

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE resource-action-mapping PUBLIC "-//Liferay//DTD Resource Action Mapping 7.0.0//EN" "http://www.liferay.com/dtd/liferay-resource-action-mapping_7_0_0.dtd">
+
+<resource-action-mapping>
+	<portlet-resource>
+		<portlet-name>com_liferay_portal_security_PermissionCheckerTestSiteRelatedPortlet</portlet-name>
+		<permissions>
+			<supports>
+				<action-key>ACCESS_IN_CONTROL_PANEL</action-key>
+				<action-key>CONFIGURATION</action-key>
+				<action-key>VIEW</action-key>
+			</supports>
+			<site-member-defaults>
+				<action-key>CONFIGURATION</action-key>
+			</site-member-defaults>
+			<guest-defaults>
+				<action-key>VIEW</action-key>
+			</guest-defaults>
+			<guest-unsupported />
+		</permissions>
+	</portlet-resource>
+</resource-action-mapping>

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
@@ -3,6 +3,23 @@
 
 <resource-action-mapping>
 	<portlet-resource>
+		<portlet-name>com_liferay_portal_security_PermissionCheckerTestNonSitePortlet</portlet-name>
+		<permissions>
+			<supports>
+				<action-key>ADD_TEST_RESULT</action-key>
+				<action-key>ACCESS_IN_CONTROL_PANEL</action-key>
+				<action-key>CONFIGURATION</action-key>
+				<action-key>VIEW</action-key>
+			</supports>
+			<site-member-defaults />
+			<guest-defaults>
+				<action-key>ADD_TEST_RESULT</action-key>
+				<action-key>VIEW</action-key>
+			</guest-defaults>
+			<guest-unsupported />
+		</permissions>
+	</portlet-resource>
+	<portlet-resource>
 		<portlet-name>com_liferay_portal_security_PermissionCheckerTestSiteRelatedPortlet</portlet-name>
 		<permissions>
 			<supports>
@@ -19,6 +36,21 @@
 			<guest-unsupported />
 		</permissions>
 	</portlet-resource>
+	<model-resource>
+		<model-name>com.liferay.portal.security.permission.nonsite</model-name>
+		<portlet-ref>
+			<portlet-name>com_liferay_portal_security_PermissionCheckerTestNonSitePortlet</portlet-name>
+		</portlet-ref>
+		<root>true</root>
+		<permissions>
+			<supports>
+				<action-key>ADD_TEST</action-key>
+			</supports>
+			<site-member-defaults />
+			<guest-defaults />
+			<guest-unsupported />
+		</permissions>
+	</model-resource>
 	<model-resource>
 		<model-name>com.liferay.portal.security.permission.site</model-name>
 		<portlet-ref>

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
@@ -19,4 +19,21 @@
 			<guest-unsupported />
 		</permissions>
 	</portlet-resource>
+	<model-resource>
+		<model-name>com.liferay.portal.security.permission.site</model-name>
+		<portlet-ref>
+			<portlet-name>com_liferay_portal_security_PermissionCheckerTestSiteRelatedPortlet</portlet-name>
+		</portlet-ref>
+		<root>true</root>
+		<permissions>
+			<supports>
+				<action-key>ADD_SITE_TEST</action-key>
+			</supports>
+			<site-member-defaults>
+				<action-key>ADD_SITE_TEST</action-key>
+			</site-member-defaults>
+			<guest-defaults />
+			<guest-unsupported />
+		</permissions>
+	</model-resource>
 </resource-action-mapping>

--- a/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
+++ b/portal-service/src/com/liferay/portal/kernel/exception/MissingIndividualScopeResourcePermissionException.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.exception;
+
+import aQute.bnd.annotation.ProviderType;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+@ProviderType
+public class MissingIndividualScopeResourcePermissionException
+	extends PortalException {
+
+	public MissingIndividualScopeResourcePermissionException() {
+	}
+
+	public MissingIndividualScopeResourcePermissionException(String msg) {
+		super(msg);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(
+		String msg, Throwable cause) {
+
+		super(msg, cause);
+	}
+
+	public MissingIndividualScopeResourcePermissionException(Throwable cause) {
+		super(cause);
+	}
+
+}


### PR DESCRIPTION
Hi Brian,

we don't have any tests for permission framework. I created several tests to cover basic scenarios we use in portal:
1. Default resources for portlet
2. Root model-resource, most common scenario is site level
3. Entity model-resources
4. Tests for portlet that is not scoped to site
5. Tests for missing SCOPE_INDIVIDUAL permissions

Beside tests I added one more related commit 372201e (the first one). We use Omniadmin for all tests and so permission checking is ignored in most tests, so I moved the omniAdmin check after regular permission checks to reveal permission issues in tests (these are already fixed and merged).

This PR contains commits from https://github.com/brianchandotcom/liferay-portal/pull/36571

Thanks.

https://issues.liferay.com/browse/LPS-63613
