### PR TITLE
Lps 63652

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_5_2_5_to_6_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_5_2_5_to_6_0_0.java
@@ -56,6 +56,8 @@ public class UpgradeProcess_5_2_5_to_6_0_0 extends UpgradeProcess {
 		upgrade(UpgradeResourceAction.class);
 		upgrade(UpgradeShopping.class);
 		upgrade(UpgradeWiki.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_5_2_7_to_6_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_5_2_7_to_6_0_0.java
@@ -52,6 +52,8 @@ public class UpgradeProcess_5_2_7_to_6_0_0 extends UpgradeProcess {
 		upgrade(UpgradePortletId.class);
 		upgrade(UpgradeResourceAction.class);
 		upgrade(UpgradeShopping.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_5_2_8_to_6_0_5.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_5_2_8_to_6_0_5.java
@@ -69,6 +69,8 @@ public class UpgradeProcess_5_2_8_to_6_0_5 extends UpgradeProcess {
 
 		upgrade(UpgradeJournal.class);
 		upgrade(UpgradeLayout.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_0.java
@@ -60,6 +60,8 @@ public class UpgradeProcess_6_0_0 extends UpgradeProcess {
 		upgrade(UpgradeShopping.class);
 		upgrade(UpgradeSocial.class);
 		upgrade(UpgradeWiki.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_1.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_1.java
@@ -34,6 +34,8 @@ public class UpgradeProcess_6_0_1 extends UpgradeProcess {
 		upgrade(UpgradeSchema.class);
 
 		upgrade(UpgradeDocumentLibrary.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_12_to_6_1_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_12_to_6_1_0.java
@@ -70,6 +70,8 @@ public class UpgradeProcess_6_0_12_to_6_1_0 extends UpgradeProcess {
 
 		upgrade(UpgradeAsset.class);
 		upgrade(UpgradeAssetPublisher.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_2.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_2.java
@@ -36,6 +36,8 @@ public class UpgradeProcess_6_0_2 extends UpgradeProcess {
 
 		upgrade(UpgradeExpando.class);
 		upgrade(UpgradeNestedPortlets.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_3.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_3.java
@@ -48,6 +48,8 @@ public class UpgradeProcess_6_0_3 extends UpgradeProcess {
 		upgrade(UpgradePermission.class);
 		upgrade(UpgradeScopes.class);
 		upgrade(UpgradeSitemap.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_5.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_5.java
@@ -36,6 +36,8 @@ public class UpgradeProcess_6_0_5 extends UpgradeProcess {
 
 		upgrade(UpgradeJournal.class);
 		upgrade(UpgradeLayout.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_6.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_0_6.java
@@ -34,6 +34,8 @@ public class UpgradeProcess_6_0_6 extends UpgradeProcess {
 		upgrade(UpgradeSchema.class);
 
 		upgrade(UpgradeRSS.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_0.java
@@ -86,6 +86,8 @@ public class UpgradeProcess_6_1_0 extends UpgradeProcess {
 
 		upgrade(UpgradeAsset.class);
 		upgrade(UpgradeAssetPublisher.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_1.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_1_1.java
@@ -40,6 +40,8 @@ public class UpgradeProcess_6_1_1 extends UpgradeProcess {
 		upgrade(UpgradeLayout.class);
 		upgrade(UpgradeLayoutSet.class);
 		upgrade(UpgradeLayoutSetBranch.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_2_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_2_0.java
@@ -89,6 +89,8 @@ public class UpgradeProcess_6_2_0 extends UpgradeProcess {
 		upgrade(UpgradeUser.class);
 		upgrade(UpgradeWiki.class);
 		upgrade(UpgradeWikiAttachments.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
@@ -97,6 +97,8 @@ public class UpgradeProcess_7_0_0 extends UpgradeProcess {
 		upgrade(UpgradeSharding.class);
 		upgrade(UpgradeSubscription.class);
 		upgrade(UpgradeWebsite.class);
+
+		clearIndexesCache();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/util/UpgradeMVCCVersion.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/UpgradeMVCCVersion.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 
 import java.util.List;
 
@@ -127,21 +126,6 @@ public class UpgradeMVCCVersion extends UpgradeProcess {
 
 	protected String[] getModuleTableNames() {
 		return new String[] {"BackgroundTask", "Lock_"};
-	}
-
-	protected String normalizeName(
-			String name, DatabaseMetaData databaseMetaData)
-		throws SQLException {
-
-		if (databaseMetaData.storesLowerCaseIdentifiers()) {
-			return StringUtil.toLowerCase(name);
-		}
-
-		if (databaseMetaData.storesUpperCaseIdentifiers()) {
-			return StringUtil.toUpperCase(name);
-		}
-
-		return name;
 	}
 
 	protected void upgradeMVCCVersion(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -24,7 +24,7 @@ public class UpgradeGroup extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		alterColumnType(GroupTable.class, "Group_", "STRING null");
+		alterColumnType(GroupTable.class, "name", "STRING null");
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -17,8 +17,6 @@ package com.liferay.portal.upgrade.v7_0_0;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.upgrade.v7_0_0.util.GroupTable;
 
-import java.sql.SQLException;
-
 /**
  * @author Eudaldo Alonso
  */
@@ -26,14 +24,7 @@ public class UpgradeGroup extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		try {
-			runSQL("alter_column_type Group_ name STRING null");
-		}
-		catch (SQLException sqle) {
-			upgradeTable(
-				GroupTable.TABLE_NAME, GroupTable.TABLE_COLUMNS,
-				GroupTable.TABLE_SQL_CREATE, GroupTable.TABLE_SQL_ADD_INDEXES);
-		}
+		alterColumnType(GroupTable.class, "Group_", "STRING null");
 	}
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-service/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -24,8 +24,11 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTable;
 import com.liferay.portal.kernel.upgrade.util.UpgradeTableFactoryUtil;
 import com.liferay.portal.kernel.util.ClassUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 
 /**
  * @author Brian Wing Shun Chan
@@ -130,6 +133,21 @@ public abstract class UpgradeProcess
 		DB db = DBManagerUtil.getDB();
 
 		return db.isSupportsUpdateWithInnerJoin();
+	}
+
+	protected String normalizeName(
+			String name, DatabaseMetaData databaseMetaData)
+		throws SQLException {
+
+		if (databaseMetaData.storesLowerCaseIdentifiers()) {
+			return StringUtil.toLowerCase(name);
+		}
+
+		if (databaseMetaData.storesUpperCaseIdentifiers()) {
+			return StringUtil.toUpperCase(name);
+		}
+
+		return name;
 	}
 
 	protected void upgradeTable(String tableName, Object[][] tableColumns)

--- a/portal-service/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-service/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -54,7 +54,7 @@ public abstract class UpgradeProcess
 	extends BaseDBProcess implements UpgradeStep {
 
 	public void clearIndexesCache() {
-		_portalIndexesSQL = null;
+		_portalIndexesSQL.clear();
 	}
 
 	public int getThreshold() {
@@ -298,11 +298,9 @@ public abstract class UpgradeProcess
 			return indexes;
 		}
 
-		if (_portalIndexesSQL != null) {
+		if (!_portalIndexesSQL.isEmpty()) {
 			return _portalIndexesSQL.get(tableName);
 		}
-
-		_portalIndexesSQL = new HashMap<>();
 
 		try (InputStream is = classLoader.getResourceAsStream(
 				"com/liferay/portal/tools/sql/dependencies/indexes.sql");
@@ -339,6 +337,7 @@ public abstract class UpgradeProcess
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeProcess.class);
 
-	private static Map<String, List<String>> _portalIndexesSQL;
+	private static final Map<String, List<String>> _portalIndexesSQL =
+		new HashMap<>();
 
 }

--- a/portal-service/src/com/liferay/portal/kernel/util/PortalClassLoaderUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PortalClassLoaderUtil.java
@@ -30,6 +30,16 @@ public class PortalClassLoaderUtil {
 		return _classLoader;
 	}
 
+	public static boolean isPortalClassLoader(ClassLoader classLoader) {
+		if ((classLoader == _classLoader) ||
+			(classLoader == _classLoader.getParent())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public static void setClassLoader(ClassLoader classLoader) {
 		PortalRuntimePermission.checkSetBeanProperty(
 			PortalClassLoaderUtil.class);


### PR DESCRIPTION
@migue @mhan810 @BrettSwaim, @Preston-Crary has a theory that the reason we need to fallback to upgradeTable when doing alter_column_type, is because certain exist index is stopping the column type altering.

So we try to drop off all exist indexes that include the altering column, then alter the column, then readd back the indexes. And still fallback to upgradeTable if for some reason it still fails.

We will need this new alterColumnType() abstract even this does not work, as @brianchandotcom prefer to avoid manually doing the catch fallback, too easy to get a human error. So if it does not work we will drop off the index manipulation logic, keep the rest, then apply globally.

@migue or @BrettSwaim, please run a quick test for us just for UpgradeGroup. From the doc @mhan810 shared, on HP db, the UpgradeGroup is currently falling back to the upgradeTable and spent 3095976ms. Please let us know with this new solution, whether we still fallback or not. If not, there should be a significant performance boost.
