### PR TITLE
Upgrade Process: use the same version for clarity although the services have not been extracted

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-service/bnd.bnd
+++ b/modules/apps/collaboration/document-library/document-library-service/bnd.bnd
@@ -7,5 +7,5 @@ Export-Package:\
 	com.liferay.document.library.verify
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Document Library
-Liferay-Require-SchemaVersion: 0.0.1
+Liferay-Require-SchemaVersion: 1.0.0
 -include: ../../../../../marketplace/collaboration/bnd.bnd

--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/upgrade/DLServiceUpgradeProcess.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/upgrade/DLServiceUpgradeProcess.java
@@ -28,7 +28,11 @@ public class DLServiceUpgradeProcess implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		registry.register(
-			"com.liferay.document.library.service", "0.0.0", "0.0.1",
+			"com.liferay.document.library.service", "0.0.0", "1.0.0",
+			new DummyUpgradeStep());
+
+		registry.register(
+			"com.liferay.document.library.service", "0.0.1", "1.0.0",
 			new DummyUpgradeStep());
 	}
 

--- a/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/verify/DLServiceVerifyProcess.java
+++ b/modules/apps/collaboration/document-library/document-library-service/src/main/java/com/liferay/document/library/verify/DLServiceVerifyProcess.java
@@ -648,7 +648,7 @@ public class DLServiceVerifyProcess extends VerifyProcess {
 	}
 
 	@Reference(
-		target = "(&(release.bundle.symbolic.name=com.liferay.document.library.service)(release.schema.version=0.0.1))",
+		target = "(&(release.bundle.symbolic.name=com.liferay.document.library.service)(release.schema.version=1.0.0))",
 		unbind = "-"
 	)
 	protected void setRelease(Release release) {


### PR DESCRIPTION
Guys, just to make it clear, we will have to remove the DummyStep when moving the services from the core to the module, otherwhise, tables won't be created at the time the portal is started from scratch
