### PR TITLE
LRQA-22899

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -72,6 +72,8 @@ public class JenkinsResultsParserUtil {
 		if ((jsonObject.getInt("duration") == 0) && result.equals("FAILURE")) {
 			String actualResult = getActualResult(url);
 
+			System.out.println("actual result: " + actualResult);
+
 			jsonObject.putOpt("result", actualResult);
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -219,7 +219,7 @@ public class JenkinsResultsParserUtil {
 			}
 
 			if (progressiveText.contains("Finished: UNSTABLE")) {
-				return "UNSTABLE";
+				return "FAILURE";
 			}
 
 			if (progressiveText.contains("Finished: FAILURE")) {


### PR DESCRIPTION
If we designate the unstable axis as UNSTABLE, UnstableMessageUtil will try to access the test report JSON when generating the GitHub message. Unfortunately, the Jenkins bug prevents the creation of the test report. As a workaround to this issue, we will designate unstable axis as FAILURE.
