### PR TITLE
master-qa-23004

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -2671,9 +2671,18 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 						</then>
 					</if>
 
-					<antcall target="delete-liferay-home">
-						<param name="keep.hypersonicdb" value="true" />
-					</antcall>
+					<get-testcase-property property.name="portal.version" />
+
+					<if>
+						<not>
+							<isset property="portal.version" />
+						</not>
+						<then>
+							<antcall target="delete-liferay-home">
+								<param name="keep.hypersonicdb" value="true" />
+							</antcall>
+						</then>
+					</if>
 
 					<if>
 						<equals arg1="${test.ant.launched.by.selenium}" arg2="true" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-23004

@brianchandotcom 
Our automated tests have been deleting the liferay home folder on server startup. However, our upgrade tests unzip the old data folder from the old liferay version into the home folder prior to server startup. 

I added in a conditional check so that it wouldn't do this for our upgrade tests. The "portal.version" property is only used in the context of our upgrade tests.

I didn't see the logic to delete liferay home on portal startup in any of the 6.2 or 6.1 branches, so I've only sent a pull for master.

CC @michaelhashimoto
