### PR TITLE
LPS-64031 artifact:ignore portal-configuration-metatype, portal-osgi-web | 7.0.x

### DIFF
--- a/modules/apps/platform/portal-configuration/portal-configuration-metatype/artifact.properties
+++ b/modules/apps/platform/portal-configuration/portal-configuration-metatype/artifact.properties
@@ -1,5 +1,0 @@
-artifact.git.id=978233a5d5b7b13f89c219b28223cf4d7f42dbf0
-artifact.javadoc.url=https://cdn.repository.liferay.com/nexus/content/repositories/liferay-releases-ce/com/liferay/com.liferay.portal.configuration.metatype/1.0.0/com.liferay.portal.configuration.metatype-1.0.0-javadoc.jar
-artifact.sources.url=https://cdn.repository.liferay.com/nexus/content/repositories/liferay-releases-ce/com/liferay/com.liferay.portal.configuration.metatype/1.0.0/com.liferay.portal.configuration.metatype-1.0.0-sources.jar
-artifact.taglibdoc.url=https://cdn.repository.liferay.com/nexus/content/repositories/liferay-releases-ce/com/liferay/com.liferay.portal.configuration.metatype/1.0.0/com.liferay.portal.configuration.metatype-1.0.0-taglibdoc.jar
-artifact.url=https://cdn.repository.liferay.com/nexus/content/repositories/liferay-releases-ce/com/liferay/com.liferay.portal.configuration.metatype/1.0.0/com.liferay.portal.configuration.metatype-1.0.0.jar

--- a/modules/apps/platform/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/artifact.properties
+++ b/modules/apps/platform/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/artifact.properties
@@ -1,4 +1,0 @@
-artifact.git.id=81f7c31687d1de594f74fcd4967d6f50fa58eef4
-artifact.javadoc.url=https://cdn.repository.liferay.com/nexus/content/repositories/liferay-releases-ce/com/liferay/com.liferay.portal.osgi.web.servlet.jsp.compiler/1.0.8/com.liferay.portal.osgi.web.servlet.jsp.compiler-1.0.8-javadoc.jar
-artifact.sources.url=https://cdn.repository.liferay.com/nexus/content/repositories/liferay-releases-ce/com/liferay/com.liferay.portal.osgi.web.servlet.jsp.compiler/1.0.8/com.liferay.portal.osgi.web.servlet.jsp.compiler-1.0.8-sources.jar
-artifact.url=https://cdn.repository.liferay.com/nexus/content/repositories/liferay-releases-ce/com/liferay/com.liferay.portal.osgi.web.servlet.jsp.compiler/1.0.8/com.liferay.portal.osgi.web.servlet.jsp.compiler-1.0.8.jar


### PR DESCRIPTION
Hi Brian,

I think it was accidentally forgotten in the platform suite in 7.0.x when the rename happened.
If I'm wrong, please just close this PR.

Thank you,
