### PR TITLE
LPS-63233 Avoid fallback to a theme that is designed for control panel

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ThemeLocalServiceImpl.java
@@ -264,7 +264,7 @@ public class ThemeLocalServiceImpl extends ThemeLocalServiceBaseImpl {
 		for (Map.Entry<String, Theme> entry : _themes.entrySet()) {
 			theme = entry.getValue();
 
-			if (theme != null) {
+			if ((theme != null) && !theme.isControlPanelTheme()) {
 				return theme;
 			}
 		}


### PR DESCRIPTION
My proposal for LPS-63233 is to exclude control panel themes as fallback themes. The ThemeLocalServiceImpl#getTheme method does already exclude them in the first fallback:

```
if (theme != null) {
    return theme;
}

if (_log.isWarnEnabled()) {
    _log.warn(
        "No theme found for specified theme id " + themeId +
            ". Returning the default theme.");
}

themeId = ThemeFactoryUtil.getDefaultRegularThemeId(companyId);
```

But in the second fallback, any installed theme (including control panel themes) were included, which was not consistent.

@natecavanaugh
@jbalsas
@juliocamarero
