### PR TITLE
Revert "LPS-48707 For testing, the module.framework.base.dir property…

### DIFF
--- a/portal-impl/test/portal-test.properties
+++ b/portal-impl/test/portal-test.properties
@@ -27,8 +27,6 @@ value.object.listener.com.liferay.portal.kernel.model.LayoutSet=
 
 buffered.increment.enabled=false
 
-module.framework.base.dir=../bundles/osgi
-
 scheduler.enabled=false
 
 admin.email.password.reset.subject=com/liferay/portlet/admin/test/dependencies/email_password_reset_subject.tmpl


### PR DESCRIPTION
… should point to the bundle directory"

This reverts commit ae04c357163b916cadb487182f5a59eba9fc9fb0.

The value is just wrong, we should use the default ${liferay.home}/osgi, then all developers need to do is just set liferay.home in portal-test-ext.properties

CC @cgoncas
