### PR TITLE
Lps 64225

### DIFF
--- a/modules/apps/collaboration/bookmarks/bookmarks-service/build.gradle
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/build.gradle
@@ -7,7 +7,7 @@ buildService {
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/service/impl/BookmarksFolderLocalServiceImpl.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/service/impl/BookmarksFolderLocalServiceImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
-import com.liferay.portal.kernel.model.TreeModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
@@ -502,26 +501,6 @@ public class BookmarksFolderLocalServiceImpl
 
 					bookmarksEntryLocalService.setTreePaths(
 						parentPrimaryKey, treePath, false);
-				}
-
-				@Override
-				public void reindexTreeModels(List<TreeModel> treeModels)
-					throws PortalException {
-
-					if (!reindex) {
-						return;
-					}
-
-					Indexer<BookmarksFolder> indexer =
-						IndexerRegistryUtil.nullSafeGetIndexer(
-							BookmarksFolder.class);
-
-					for (TreeModel treeModel : treeModels) {
-						BookmarksFolder bookmarkFolder =
-							(BookmarksFolder)treeModel;
-
-						indexer.reindex(bookmarkFolder);
-					}
 				}
 
 			});

--- a/modules/apps/web-experience/journal/journal-service/build.gradle
+++ b/modules/apps/web-experience/journal/journal-service/build.gradle
@@ -9,7 +9,7 @@ buildService {
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "commons-lang", name: "commons-lang", version: "2.1"

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderLocalServiceImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
-import com.liferay.portal.kernel.model.TreeModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.search.Indexable;
@@ -693,24 +692,6 @@ public class JournalFolderLocalServiceImpl
 
 					journalArticleLocalService.setTreePaths(
 						parentPrimaryKey, treePath, false);
-				}
-
-				@Override
-				public void reindexTreeModels(List<TreeModel> treeModels)
-					throws PortalException {
-
-					if (!reindex) {
-						return;
-					}
-
-					Indexer<JournalFolder> indexer =
-						IndexerRegistryUtil.nullSafeGetIndexer(
-							JournalFolder.class);
-
-					for (TreeModel treeModel : treeModels) {
-						JournalFolder journalFolder = (JournalFolder)treeModel;
-						indexer.reindex(journalFolder);
-					}
 				}
 
 			});

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.IndexWriterHelperUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.NotificationThreadLocal;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.VerifyThreadLocal;
 import com.liferay.portal.kernel.workflow.WorkflowThreadLocal;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
@@ -68,6 +69,8 @@ public class VerifyProcessUtil {
 		StagingAdvicesThreadLocal.setEnabled(false);
 		WorkflowThreadLocal.setEnabled(false);
 
+		VerifyThreadLocal.setVerifyInProgress(true);
+
 		try {
 			String[] verifyProcessClassNames = PropsUtil.getArray(
 				PropsKeys.VERIFY_PROCESSES);
@@ -87,6 +90,8 @@ public class VerifyProcessUtil {
 			NotificationThreadLocal.setEnabled(true);
 			StagingAdvicesThreadLocal.setEnabled(true);
 			WorkflowThreadLocal.setEnabled(true);
+
+			VerifyThreadLocal.setVerifyInProgress(false);
 		}
 
 		return ranVerifyProcess;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -45,7 +45,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
-import com.liferay.portal.kernel.model.TreeModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.repository.event.RepositoryEventTrigger;
@@ -742,24 +741,6 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 						parentPrimaryKey, treePath);
 					dlFileVersionLocalService.setTreePaths(
 						parentPrimaryKey, treePath);
-				}
-
-				@Override
-				public void reindexTreeModels(List<TreeModel> treeModels)
-					throws PortalException {
-
-					if (!reindex) {
-						return;
-					}
-
-					Indexer<DLFolder> indexer =
-						IndexerRegistryUtil.nullSafeGetIndexer(DLFolder.class);
-
-					for (TreeModel treeModel : treeModels) {
-						DLFolder dlFolder = (DLFolder)treeModel;
-
-						indexer.reindex(dlFolder);
-					}
 				}
 
 			});

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasks.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasks.java
@@ -31,4 +31,12 @@ public interface TreeModelTasks<T extends TreeModel> {
 			long parentPrimaryKey, String treePath)
 		throws PortalException;
 
+	/**
+	 * @throws PortalException
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
+	public void reindexTreeModels(List<TreeModel> treeModels)
+		throws PortalException;
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasks.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasks.java
@@ -31,7 +31,4 @@ public interface TreeModelTasks<T extends TreeModel> {
 			long parentPrimaryKey, String treePath)
 		throws PortalException;
 
-	public void reindexTreeModels(List<TreeModel> treeModels)
-		throws PortalException;
-
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasksAdapter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasksAdapter.java
@@ -41,12 +41,4 @@ public class TreeModelTasksAdapter<T extends TreeModel>
 		throws PortalException {
 	}
 
-	/**
-	 * @throws PortalException
-	 */
-	@Override
-	public void reindexTreeModels(List<TreeModel> treeModels)
-		throws PortalException {
-	}
-
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasksAdapter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreeModelTasksAdapter.java
@@ -41,4 +41,13 @@ public class TreeModelTasksAdapter<T extends TreeModel>
 		throws PortalException {
 	}
 
+	/**
+	 * @throws PortalException
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Override
+	public void reindexTreeModels(List<TreeModel> treeModels)
+		throws PortalException {
+	}
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
@@ -15,11 +15,15 @@
 package com.liferay.portal.kernel.util;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.TreeModel;
 
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.RecursiveAction;
 
 /**
  * @author Shinn Lok
@@ -30,6 +34,24 @@ public class TreePathUtil {
 			long companyId, long parentPrimaryKey, String parentTreePath,
 			TreeModelTasks<?> treeModelTasks)
 		throws PortalException {
+
+		if (VerifyThreadLocal.isVerifyInProgress() &&
+			_VERIFY_DATABASE_TRANSACTIONS_DISABLED) {
+
+			ForkJoinPool forkJoinPool = new ForkJoinPool();
+
+			try {
+				forkJoinPool.invoke(
+					new RecursiveRebuildTreeTask(
+						treeModelTasks, companyId, parentPrimaryKey,
+						parentTreePath, 0L));
+			}
+			finally {
+				forkJoinPool.shutdown();
+			}
+
+			return;
+		}
 
 		Deque<Object[]> traces = new LinkedList<>();
 
@@ -83,5 +105,85 @@ public class TreePathUtil {
 		GetterUtil.getInteger(
 			PropsUtil.get(
 				PropsKeys.MODEL_TREE_REBUILD_QUERY_RESULTS_BATCH_SIZE));
+
+	private static final boolean _VERIFY_DATABASE_TRANSACTIONS_DISABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.VERIFY_DATABASE_TRANSACTIONS_DISABLED));
+
+	private static final Log _log = LogFactoryUtil.getLog(TreePathUtil.class);
+
+	private static class RecursiveRebuildTreeTask extends RecursiveAction {
+
+		@Override
+		protected void compute() {
+			try {
+				_treeModelTasks.rebuildDependentModelsTreePaths(
+					_parentPrimaryKey, _parentTreePath);
+			}
+			catch (Exception e) {
+				_log.error(e, e);
+
+				return;
+			}
+
+			List<? extends TreeModel> treeModels =
+				_treeModelTasks.findTreeModels(
+					_previousPrimaryKey, _companyId, _parentPrimaryKey,
+					_MODEL_TREE_REBUILD_QUERY_RESULTS_BATCH_SIZE);
+
+			if (treeModels.isEmpty()) {
+				return;
+			}
+
+			if (treeModels.size() ==
+					_MODEL_TREE_REBUILD_QUERY_RESULTS_BATCH_SIZE) {
+
+				TreeModel treeModel = treeModels.get(treeModels.size() - 1);
+
+				RecursiveRebuildTreeTask recursiveRebuildTreeTask =
+					new RecursiveRebuildTreeTask(
+						_treeModelTasks, _companyId, _parentPrimaryKey,
+						_parentTreePath, (long)treeModel.getPrimaryKeyObj());
+
+				recursiveRebuildTreeTask.fork();
+			}
+
+			for (TreeModel treeModel : treeModels) {
+				String treePath = _parentTreePath.concat(
+					String.valueOf(treeModel.getPrimaryKeyObj())).concat(
+						StringPool.SLASH);
+
+				if (!treePath.equals(treeModel.getTreePath())) {
+					treeModel.updateTreePath(treePath);
+				}
+
+				RecursiveRebuildTreeTask recursiveRebuildTreeTask =
+					new RecursiveRebuildTreeTask(
+						_treeModelTasks, _companyId,
+						(long)treeModel.getPrimaryKeyObj(), treePath, 0L);
+
+				recursiveRebuildTreeTask.fork();
+			}
+		}
+
+		private RecursiveRebuildTreeTask(
+			TreeModelTasks<?> treeModelTasks, long companyId,
+			long parentPrimaryKey, String parentTreePath,
+			long previousPrimaryKey) {
+
+			_treeModelTasks = treeModelTasks;
+			_companyId = companyId;
+			_parentPrimaryKey = parentPrimaryKey;
+			_parentTreePath = parentTreePath;
+			_previousPrimaryKey = previousPrimaryKey;
+		}
+
+		private final long _companyId;
+		private final long _parentPrimaryKey;
+		private final String _parentTreePath;
+		private final long _previousPrimaryKey;
+		private final TreeModelTasks<?> _treeModelTasks;
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
@@ -17,7 +17,6 @@ package com.liferay.portal.kernel.util;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.TreeModel;
 
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -31,8 +30,6 @@ public class TreePathUtil {
 			long companyId, long parentPrimaryKey, String parentTreePath,
 			TreeModelTasks<?> treeModelTasks)
 		throws PortalException {
-
-		List<TreeModel> modifiedTreeModels = new ArrayList<>();
 
 		Deque<Object[]> traces = new LinkedList<>();
 
@@ -76,12 +73,8 @@ public class TreePathUtil {
 
 				traces.push(
 					new Object[] {treeModel.getPrimaryKeyObj(), treePath, 0L});
-
-				modifiedTreeModels.add(treeModel);
 			}
 		}
-
-		treeModelTasks.reindexTreeModels(modifiedTreeModels);
 	}
 
 	private static final int _MODEL_TREE_REBUILD_QUERY_RESULTS_BATCH_SIZE =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
@@ -120,10 +120,8 @@ public class TreePathUtil {
 				_treeModelTasks.rebuildDependentModelsTreePaths(
 					_parentPrimaryKey, _parentTreePath);
 			}
-			catch (Exception e) {
-				_log.error(e, e);
-
-				return;
+			catch (PortalException pe) {
+				ReflectionUtil.throwException(pe);
 			}
 
 			List<? extends TreeModel> treeModels =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TreePathUtil.java
@@ -69,7 +69,9 @@ public class TreePathUtil {
 					String.valueOf(treeModel.getPrimaryKeyObj())).concat(
 						StringPool.SLASH);
 
-				treeModel.updateTreePath(treePath);
+				if (!treePath.equals(treeModel.getTreePath())) {
+					treeModel.updateTreePath(treePath);
+				}
 
 				traces.push(
 					new Object[] {treeModel.getPrimaryKeyObj(), treePath, 0L});

--- a/portal-kernel/src/com/liferay/portal/kernel/util/VerifyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/VerifyThreadLocal.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+/**
+ * @author Preston Crary
+ */
+public class VerifyThreadLocal {
+
+	public static boolean isVerifyInProgress() {
+		return _verifyInProgress.get();
+	}
+
+	public static void setVerifyInProgress(boolean enabled) {
+		_verifyInProgress.set(enabled);
+	}
+
+	private static final ThreadLocal<Boolean> _verifyInProgress =
+		new AutoResetThreadLocal<>(
+			VerifyThreadLocal.class + "._verifyInProgress", false);
+
+}


### PR DESCRIPTION
CC @mhan810, we can only apply the ForkJoinPool for verify processes with verify.database.transactions.disabled=true. This is because in other cases, we have Spring Hibernate session delegation on, and the transaction mode does not allow us to go multi-threads, otherwise each job will have to turn on its own tx boundary, not only we will lose the global tx protection, the addition aop overhead will outrun the concurrent saving. However none of these is a problem for verify process with verify.database.transactions.disabled=true.

@BrettSwaim when you run test against this, make sure to have verify.database.transactions.disabled=true in your portal-ext.properties, otherwise the new logic won't run.
