### PR TITLE
Lps 64246

### DIFF
--- a/modules/core/registry-impl/build.gradle
+++ b/modules/core/registry-impl/build.gradle
@@ -1,6 +1,7 @@
 import com.liferay.gradle.util.copy.RenameDependencyClosure
 
 dependencies {
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "org.eclipse.osgi", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1"
 	provided project(":apps:foundation:osgi:osgi-service-tracker-collections")
 	provided project(":core:registry-api")

--- a/modules/core/registry-impl/src/main/java/com/liferay/registry/internal/RegistryImpl.java
+++ b/modules/core/registry-impl/src/main/java/com/liferay/registry/internal/RegistryImpl.java
@@ -14,6 +14,8 @@
 
 package com.liferay.registry.internal;
 
+import com.liferay.portal.kernel.concurrent.ConcurrentReferenceKeyHashMap;
+import com.liferay.portal.kernel.memory.FinalizeManager;
 import com.liferay.registry.Filter;
 import com.liferay.registry.Registry;
 import com.liferay.registry.ServiceReference;
@@ -34,7 +36,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -474,6 +475,7 @@ public class RegistryImpl implements Registry {
 	private final Set<ServiceDependencyManager> _serviceDependencyManagers =
 		new HashSet<>();
 	private final Map<org.osgi.util.tracker.ServiceTracker<?, ?>, Void>
-		_serviceTrackers = new WeakHashMap<>();
+		_serviceTrackers = new ConcurrentReferenceKeyHashMap<>(
+			FinalizeManager.WEAK_REFERENCE_FACTORY);
 
 }

--- a/modules/core/registry-impl/src/main/java/com/liferay/registry/internal/RegistryImpl.java
+++ b/modules/core/registry-impl/src/main/java/com/liferay/registry/internal/RegistryImpl.java
@@ -16,6 +16,7 @@ package com.liferay.registry.internal;
 
 import com.liferay.portal.kernel.concurrent.ConcurrentReferenceKeyHashMap;
 import com.liferay.portal.kernel.memory.FinalizeManager;
+import com.liferay.portal.kernel.util.MapBackedSet;
 import com.liferay.registry.Filter;
 import com.liferay.registry.Registry;
 import com.liferay.registry.ServiceReference;
@@ -52,7 +53,7 @@ public class RegistryImpl implements Registry {
 
 	public void closeServiceTrackers() {
 		for (org.osgi.util.tracker.ServiceTracker<?, ?> serviceTracker :
-				_serviceTrackers.keySet()) {
+				_serviceTrackers) {
 
 			try {
 				serviceTracker.close();
@@ -348,7 +349,7 @@ public class RegistryImpl implements Registry {
 			new org.osgi.util.tracker.ServiceTracker<S, T>(
 				_bundleContext, clazz, null);
 
-		_serviceTrackers.put(serviceTracker, null);
+		_serviceTrackers.add(serviceTracker);
 
 		return new ServiceTrackerWrapper<>(serviceTracker);
 	}
@@ -364,7 +365,7 @@ public class RegistryImpl implements Registry {
 				new ServiceTrackerCustomizerAdapter<S, T>(
 					serviceTrackerCustomizer));
 
-		_serviceTrackers.put(serviceTracker, null);
+		_serviceTrackers.add(serviceTracker);
 
 		return new ServiceTrackerWrapper<>(serviceTracker);
 	}
@@ -381,7 +382,7 @@ public class RegistryImpl implements Registry {
 			new org.osgi.util.tracker.ServiceTracker<S, T>(
 				_bundleContext, filterWrapper.getFilter(), null);
 
-		_serviceTrackers.put(serviceTracker, null);
+		_serviceTrackers.add(serviceTracker);
 
 		return new ServiceTrackerWrapper<>(serviceTracker);
 	}
@@ -403,7 +404,7 @@ public class RegistryImpl implements Registry {
 				new ServiceTrackerCustomizerAdapter<S, T>(
 					serviceTrackerCustomizer));
 
-		_serviceTrackers.put(serviceTracker, null);
+		_serviceTrackers.add(serviceTracker);
 
 		return new ServiceTrackerWrapper<>(serviceTracker);
 	}
@@ -414,7 +415,7 @@ public class RegistryImpl implements Registry {
 			new org.osgi.util.tracker.ServiceTracker<S, T>(
 				_bundleContext, className, null);
 
-		_serviceTrackers.put(serviceTracker, null);
+		_serviceTrackers.add(serviceTracker);
 
 		return new ServiceTrackerWrapper<>(serviceTracker);
 	}
@@ -430,7 +431,7 @@ public class RegistryImpl implements Registry {
 				new ServiceTrackerCustomizerAdapter<S, T>(
 					serviceTrackerCustomizer));
 
-		_serviceTrackers.put(serviceTracker, null);
+		_serviceTrackers.add(serviceTracker);
 
 		return new ServiceTrackerWrapper<>(serviceTracker);
 	}
@@ -474,8 +475,10 @@ public class RegistryImpl implements Registry {
 	private final BundleContext _bundleContext;
 	private final Set<ServiceDependencyManager> _serviceDependencyManagers =
 		new HashSet<>();
-	private final Map<org.osgi.util.tracker.ServiceTracker<?, ?>, Void>
-		_serviceTrackers = new ConcurrentReferenceKeyHashMap<>(
-			FinalizeManager.WEAK_REFERENCE_FACTORY);
+	private final Set<org.osgi.util.tracker.ServiceTracker<?, ?>>
+		_serviceTrackers = new MapBackedSet<>(
+			new ConcurrentReferenceKeyHashMap
+				<org.osgi.util.tracker.ServiceTracker<?, ?>, Boolean>(
+					FinalizeManager.WEAK_REFERENCE_FACTORY));
 
 }

--- a/modules/core/registry-test/build.gradle
+++ b/modules/core/registry-test/build.gradle
@@ -1,11 +1,33 @@
 import com.liferay.gradle.util.copy.RenameDependencyClosure
 
 task copyTestLibs(type: Copy)
+task copyTestPortalKernel(type: Jar)
+
+File testLibDir = file("test-lib")
 
 copyTestLibs {
+	dependsOn copyTestPortalKernel
+	exclude "com.liferay.portal.kernel-*.jar"
 	from configurations.provided
-	into "test-lib"
+	into testLibDir
 	rename new RenameDependencyClosure(project, configurations.provided.name)
+}
+
+copyTestPortalKernel {
+	archiveName = "com.liferay.portal.kernel.jar"
+	destinationDir = testLibDir
+
+	from {
+		File portalKernelJarFile = configurations.provided.find {
+			it.name.startsWith "com.liferay.portal.kernel-"
+		}
+
+		zipTree(portalKernelJarFile)
+	}
+
+	manifest {
+		attributes "Export-Package": 'com.liferay.portal.kernel.concurrent;version="7.0.0",com.liferay.portal.kernel.memory;version="7.0.0",com.liferay.portal.kernel.util;version="7.0.0"'
+	}
 }
 
 dependencies {

--- a/modules/core/registry-test/build.gradle
+++ b/modules/core/registry-test/build.gradle
@@ -9,6 +9,7 @@ copyTestLibs {
 }
 
 dependencies {
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "log4j", name: "log4j", version: "1.2.17"
 	provided group: "org.osgi", name: "org.osgi.service.log", version: "1.3.0"
 	provided group: "org.slf4j", name: "slf4j-log4j12", version: "1.5.6"

--- a/modules/core/registry-test/src/testIntegration/resources/framework.properties
+++ b/modules/core/registry-test/src/testIntegration/resources/framework.properties
@@ -1,5 +1,6 @@
 felix.auto.start.1=\
 	file:test-lib/com.liferay.osgi.service.tracker.collections.jar \
+	file:test-lib/com.liferay.portal.kernel.jar \
 	file:test-lib/com.liferay.registry.api.jar \
 	file:test-lib/com.liferay.registry.impl.jar \
 	file:test-lib/org.osgi.service.log.jar


### PR DESCRIPTION
CC @csierra this is caused by liferay@1372a7e

CC @michaelhashimoto

@brianchandotcom https://github.com/brianchandotcom/liferay-portal/commit/11e54051d0fdab22358685bdecd5aab22541d7c4 is a temp work around.

registry-impl needs the portal-kernel dependency to get over this infinite loop thread safety issue.

Later, either we have @Ithildir working out a proper auto replace build script logic, or @csierra rewrite those tests to do our arquillian way in a real tomcat, or we break down kernel into many many modules.

It is up to you @brianchandotcom to take which route.
