### PR TITLE
Lps 64313

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7748,6 +7748,7 @@ jdbc.default.password=${database.mysql.password}</echo>
 		/>
 
 		<property name="db.upgrade.classpath"><![CDATA[<path id="lib.classpath">
+			<fileset dir="${app.server.dir}/bin" includes="tomcat-juli.jar" />
 			<fileset dir="${app.server.dir}/lib" includes="*.jar" />
 			<fileset dir="${app.server.dir}/lib/ext" includes="*.jar" />
 			<fileset dir="${app.server.dir}/webapps/ROOT/WEB-INF/lib" includes="*.jar" />

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1064,8 +1064,8 @@
     #
     #jdbc.default.liferay.pool.provider=c3po
     #jdbc.default.liferay.pool.provider=dbcp
-    jdbc.default.liferay.pool.provider=hikaricp
-    #jdbc.default.liferay.pool.provider=tomcat
+    #jdbc.default.liferay.pool.provider=hikaricp
+    jdbc.default.liferay.pool.provider=tomcat
 
     #
     # The following properties will be read by C3PO if Liferay is configured to

--- a/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
@@ -215,10 +215,21 @@ public class CounterLocalServiceTest {
 
 			System.setProperty("catalina.base", ".");
 			System.setProperty("external-properties", "portal-test.properties");
+
+			// c3p0
+
 			System.setProperty("portal:jdbc.default.maxPoolSize", "1");
 			System.setProperty("portal:jdbc.default.minPoolSize", "0");
+
+			// HikariCP
+
 			System.setProperty("portal:jdbc.default.maximumPoolSize", "1");
 			System.setProperty("portal:jdbc.default.minimumIdle", "0");
+
+			// Tomcat JDBC Connection Pool
+
+			System.setProperty("portal:jdbc.default.maxActive", "1");
+			System.setProperty("portal:jdbc.default.minIdle", "0");
 
 			CacheKeyGeneratorUtil cacheKeyGeneratorUtil =
 				new CacheKeyGeneratorUtil();


### PR DESCRIPTION
Due to hikaricp's instability under concurrent jdbc statements usage. We have to switch back to tomcat pool for now.

If hikaricp releases 2.4.5 soon enough, we might still want to switch back before 7.0 final release. But for now let's at least keep CI stable.

@mhan810 @mtambara @dantewang
