### PR TITLE
LPS-64380 There are 2 issues here. 1)the original code cares only the…

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeSocial.java
@@ -57,15 +57,15 @@ public class UpgradeSocial extends UpgradeProcess {
 				classPK, type, extraData);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				JSONObject extraDataJSONObject = null;
-
-				while (resultSet.next()) {
-					extraDataJSONObject =
+				if (resultSet.next()) {
+					JSONObject extraDataJSONObject =
 						extraDataFactory.createExtraDataJSONObject(
 							resultSet, extraData);
+
+					return extraDataJSONObject.toString();
 				}
 
-				return extraDataJSONObject.toString();
+				return null;
 			}
 		}
 	}


### PR DESCRIPTION
… last result from the resultSet, but still procesing the ones before it, just to throw them away. Not really sure the original intention, but I guess we just want the 1st one. 2) When the resultSet is empty, the extraDataJSONObject stays null, then we call toString() on it. Caused by b34ba77c6afbc3b5a47a6fa5fe7964d15b24abae

CC @BrettSwaim @dsanz
