### PR TITLE
Lps 63495

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3885,6 +3885,8 @@ go]]></replacevalue>
 				<delete file="${test.app.server.liferay.home}/portal-setup-wizard.properties" />
 			</then>
 		</if>
+
+		<delete dir="/tmp/sprite-root" />
 	</target>
 
 	<target name="deploy-extra-apps">
@@ -4812,7 +4814,9 @@ mail.session.jndi.name=
 
 axis.servlet.hosts.allowed=
 
-tunnel.servlet.hosts.allowed=</echo>
+tunnel.servlet.hosts.allowed=
+
+sprite.root.dir=/tmp/sprite-root</echo>
 
 		<get-testcase-property property.name="captcha.max.challenges" />
 

--- a/build.properties
+++ b/build.properties
@@ -71,8 +71,6 @@
         apps/forms-and-workflow/portal-rules-engine/portal-rules-engine-sample-web/,\
         apps/foundation/frontend-taglib/frontend-taglib-aui-form-extension-sample/,\
         apps/foundation/frontend-theme/frontend-theme-product-app/,\
-        apps/foundation/frontend-theme/frontend-theme-user-horizontal/,\
-        apps/foundation/frontend-theme/frontend-theme-user-vertical/,\
         apps/foundation/ip-geocoder/ip-geocoder-sample-web/,\
         apps/foundation/portal-cache/portal-cache-memory/,\
         apps/foundation/portal-scripting/portal-scripting-beanshell/,\

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3976,7 +3976,7 @@
     #
     # Set the layout template ID of the private layout.
     #
-    default.user.private.layout.template.id=2_columns_ii
+    default.user.private.layout.template.id=1_column
 
     #
     # Set the portlet IDs for the columns specified in the layout template.
@@ -3994,7 +3994,7 @@
     #
     # Set the regular theme ID for the private layout.
     #
-    #default.user.private.layout.regular.theme.id=classic
+    default.user.private.layout.regular.theme.id=uservertical_WAR_userverticaltheme
 
     #
     # Set the regular color scheme ID for the private layout.
@@ -4032,7 +4032,7 @@
     #
     # Set the layout template ID of the public layout.
     #
-    default.user.public.layout.template.id=2_columns_ii
+    default.user.public.layout.template.id=1_column
 
     #
     # Set the portlet IDs for the columns specified in the layout template.
@@ -4050,7 +4050,7 @@
     #
     # Set the regular theme ID for the public layout.
     #
-    #default.user.public.layout.regular.theme.id=classic
+    default.user.public.layout.regular.theme.id=userhorizontal_WAR_userhorizontaltheme
 
     #
     # Set the regular color scheme ID for the public layout.


### PR DESCRIPTION
CC @Ithildir

Turns out this is a CI infrastructure issue, there is some instability of the network drive.

Under frequent write (The theme has too many image folders, each one becomes a sprite image that needs to write), the mounted drive will become unaccessable for a short period of time, probably due to some network syncing delay.

There is nothing at code level that I can fix for the network drive. I can only simply redirect it to a different location that is on local drive.
