### PR TITLE
LPS-64374 Add "Liferay" prefix to apps

### DIFF
--- a/modules/apps/sync/app.bnd
+++ b/modules/apps/sync/app.bnd
@@ -1,5 +1,5 @@
 Liferay-Releng-App-Description: The Sync Connector app lets users connect to their portals from the Liferay Sync desktop and mobile clients. It also lets administrators control how these clients interact with their portal. Once installed, the Sync Connector app provides the portal services required by the clients. No additional portal configuration is required. However, portal administrators can use the Sync Admin portlet installed with this app to control what sites are available for Sync. They can also use this portlet to disable Sync across the portal.<br /><br />After installing, the Sync Admin portlet is available in the Control Panel’s Configuration section.<br /><br />Please visit http://www.liferay.com/products/liferay-sync/features for more information on downloading the Liferay Sync desktop and mobile clients. Liferay Sync is compatible with Windows, Mac OS, iOS, and Android. The Sync Connector app requires version 3.0+ of the Sync desktop or mobile client.
-Liferay-Releng-App-Title: Sync Connector${liferay.releng.app.title.suffix}
+Liferay-Releng-App-Title: Liferay Sync Connector${liferay.releng.app.title.suffix}
 Liferay-Releng-Bundle: false
 Liferay-Releng-Category: Productivity
 Liferay-Releng-Demo-Url:


### PR DESCRIPTION
Added "Liferay" to Sync Connector's title.

Moving forward all Liferay apps will have "Liferay" in their app title.
