### PR TITLE
master-qa-23310

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestBlobPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestBlobPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test Blob" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestCLPPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestCLPPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test CLP" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestCacheConfigurationPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestCacheConfigurationPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test Cache Configuration" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestHookPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestHookPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test Hook" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestHttpClientPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestHttpClientPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test HTTP Client" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestKaleoPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestKaleoPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test Kaleo" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestLocalizedPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestLocalizedPortlet.testcase
@@ -21,7 +21,8 @@
 
 		<execute function="AssertClick" locator1="TestLocalized#CHINESE_LOCALIZATION" value1="Chinese" />
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 
 	<command name="ViewLocalizedEnglish" priority="4">
@@ -37,7 +38,8 @@
 
 		<execute function="AssertClick" locator1="TestLocalized#ENGLISH_LOCALIZATION" value1="English" />
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 
 	<command name="ViewLocalizedFrench" priority="4">
@@ -51,7 +53,8 @@
 
 		<execute function="AssertClick" locator1="TestLocalized#FRENCH_LOCALIZATION" value1="French" />
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 
 	<command name="ViewLocalizedSpanish" priority="4">
@@ -65,6 +68,7 @@
 
 		<execute function="AssertClick" locator1="TestLocalized#SPANISH_LOCALIZATION" value1="Spanish" />
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestLogPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestLogPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test Log" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestMiscPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestMiscPortlet.testcase
@@ -21,6 +21,7 @@
 			<var name="portletName" value="Test Misc Localized Title" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestResourceImporterPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestResourceImporterPortlet.testcase
@@ -20,6 +20,7 @@
 			<var name="portletName" value="Test Resources Importer" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestTransactionPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestTransactionPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test Transaction" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestUserAttributesPortlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/testinginfrastructure/pluginstesting/TestUserAttributesPortlet.testcase
@@ -19,6 +19,7 @@
 			<var name="portletName" value="Test User Attributes" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="TestBlob#TEST_PORTLET_BODY_FAILED" value1="FAILED" />
+		<execute function="AssertVisible" locator1="TestBlob#TEST_PORTLET_BODY_PASSED" />
+		<execute function="AssertTextNotPresent" value1="FAILED" />
 	</command>
 </definition>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-23310

CC @alee8888

Hey Albert, this may cause some of the test portlet plugin tests (like test resources importer portlet) to fail, but the ones in the PR tester should still be fine. This pull eliminates the possibility of us getting false PASS results from test portlets just because they don't have the word "FAIL" show up anywhere (because sometimes the portlets will be unavailable or fail to display their content altogether).
