### PR TITLE
LRQA-23640 Limit the size of _toStringCache to 50 entries

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -30,8 +30,9 @@ import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -434,11 +435,17 @@ public class JenkinsResultsParserUtil {
 
 				bufferedReader.close();
 
-				if (!url.startsWith("file:")) {
-					_toStringCache.put(key, sb.toString());
+				String content = sb.toString();
+
+				byte[] contentBytes = content.getBytes();
+
+				if (!url.startsWith("file:") &&
+					(contentBytes.length < (3 * 1024 * 1024))) {
+
+					_toStringCache.put(key, content);
 				}
 
-				return sb.toString();
+				return content;
 			}
 			catch (FileNotFoundException fnfe) {
 				retryCount++;
@@ -494,6 +501,15 @@ public class JenkinsResultsParserUtil {
 		"https://test.liferay.com/([0-9]+)/");
 	private static final Pattern _localURLPattern2 = Pattern.compile(
 		"https://(test-[0-9]+-[0-9]+).liferay.com/");
-	private static final Map<String, String> _toStringCache = new HashMap<>();
+
+	private static final Map<String, String> _toStringCache =
+		new LinkedHashMap<String, String>(50) {
+
+			@Override
+			protected boolean removeEldestEntry(Entry<String, String> entry) {
+				return size() > 50;
+			}
+
+		};
 
 }


### PR DESCRIPTION
And don't cache anything bigger than 3 MB.

https://issues.liferay.com/browse/LRQA-23640
