### PR TITLE
LPS-64522 Return whatever locale exists if the default returns nothing

### DIFF
--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensDDLRecordServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensDDLRecordServiceImpl.java
@@ -137,6 +137,19 @@ public class ScreensDDLRecordServiceImpl
 			if (fieldValue != null) {
 				ddlRecordMap.put(ddmFormFieldValue.getName(), fieldValue);
 			}
+			else {
+				for (Locale availableLocale : availableLocales) {
+					fieldValue = getFieldValue(
+						ddmFormFieldValue, availableLocale);
+
+					if (fieldValue != null) {
+						ddlRecordMap.put(
+							ddmFormFieldValue.getName(), fieldValue);
+
+						break;
+					}
+				}
+			}
 		}
 
 		ddlRecordJSONObject.put(


### PR DESCRIPTION
The information in the form fields could be stored in a different locale than the default of the form or the fields (for example with a portal with default locale pt_BR and form locale en_US).

In the case that the field has something stored but it's not the mobile locale or the field locale we want to return whatever value is stored.
