### PR TITLE
LPS-64529

### DIFF
--- a/modules/core/portal-bootstrap/build.gradle
+++ b/modules/core/portal-bootstrap/build.gradle
@@ -1,8 +1,10 @@
 import com.liferay.gradle.util.FileUtil
+import com.liferay.gradle.util.copy.RenameDependencyClosure
 
 import org.dm.gradle.plugins.bundle.JarBuilder
 
 task buildSystemPackagesExtraManifest
+task copySystemPackagesExtraLibs(type: Copy)
 task copySystemPackagesExtraManifest(type: Copy)
 
 File systemPackagesExtraBndFile = file("system.packages.extra.bnd")
@@ -10,7 +12,7 @@ File systemPackagesExtraManifestFile = file("system.packages.extra.mf")
 
 buildSystemPackagesExtraManifest {
 	dependsOn classes
-	dependsOn copyLibs
+	dependsOn copySystemPackagesExtraLibs
 
 	doLast {
 		JarBuilder jarBuilder = bundle.jarBuilderFactory.create()
@@ -33,6 +35,12 @@ buildSystemPackagesExtraManifest {
 			jarBuilder.writeManifestTo it
 		}
 	}
+}
+
+copySystemPackagesExtraLibs {
+	from configurations.provided
+	into "lib"
+	rename new RenameDependencyClosure(project, configurations.provided.name)
 }
 
 copySystemPackagesExtraManifest {

--- a/modules/core/portal-bootstrap/system.packages.extra.bnd
+++ b/modules/core/portal-bootstrap/system.packages.extra.bnd
@@ -201,9 +201,9 @@ Export-Package:\
 	*
 Import-Package: !*
 -includeresource:\
-	@com.liferay.osgi.service.tracker.collections-2.0.0.jar,\
-	@com.liferay.portal.app.license.api-1.0.0.jar,\
-	@com.liferay.registry.api-1.0.0.jar,\
+	@lib/com.liferay.osgi.service.tracker.collections.jar,\
+	@lib/com.liferay.portal.app.license.api.jar,\
+	@lib/com.liferay.registry.api.jar,\
 	@../../../lib/development/jms.jar,\
 	@../../../lib/development/mail.jar,\
 	@../../../lib/development/servlet-api.jar,\

--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Bnd-LastModified: 1458671029150
+Bnd-LastModified: 1458753692331
 Bundle-ManifestVersion: 2
 Bundle-Name: portal-bootstrap
 Bundle-SymbolicName: portal-bootstrap


### PR DESCRIPTION
Hi!
I think this is the simplest solution to avoid having version numbers inside `system.packages.extra.bnd`, at least for now. We can't use `-liferay-includeresource` because here we're calling directly Bnd via [gradle-bundle-plugin](https://github.com/TomDmitriev/gradle-bundle-plugin/) and our code in `gradle-plugins` is not triggered at all. It should be fine anyway, because that `copySystemPackagesExtraLibs` task runs only when it's time to regenerate `system.packages.extra.mf`, which doesn't happen every time.

Ray gave me an alternative way to have the same `-liferay-includeresource` functionality, but without any Gradle code (using only a Bnd macro). I'm going to look into it...
