### PR TITLE
LPS-64674 service.ranking shouldn't be used for ordering navigation entries and categories

### DIFF
--- a/modules/apps/collaboration/mentions/mentions-web/src/main/java/com/liferay/mentions/web/servlet/taglib/ui/MentionsCompanySettingsFormNavigatorEntry.java
+++ b/modules/apps/collaboration/mentions/mentions-web/src/main/java/com/liferay/mentions/web/servlet/taglib/ui/MentionsCompanySettingsFormNavigatorEntry.java
@@ -37,7 +37,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=90"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=90"},
 	service = FormNavigatorEntry.class
 )
 public class MentionsCompanySettingsFormNavigatorEntry

--- a/modules/apps/collaboration/mentions/mentions-web/src/main/java/com/liferay/mentions/web/servlet/taglib/ui/MentionsSitesFormNavigatorEntry.java
+++ b/modules/apps/collaboration/mentions/mentions-web/src/main/java/com/liferay/mentions/web/servlet/taglib/ui/MentionsSitesFormNavigatorEntry.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=90"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=90"},
 	service = FormNavigatorEntry.class
 )
 public class MentionsSitesFormNavigatorEntry

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/form/navigator/LayoutMobileDeviceRulesFormNavigatorEntry.java
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/form/navigator/LayoutMobileDeviceRulesFormNavigatorEntry.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=80"},
+	property = {"form.navigator.entry.order:Integer=80"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutMobileDeviceRulesFormNavigatorEntry

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/form/navigator/LayoutSetMobileDeviceRulesFormNavigatorEntry.java
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/form/navigator/LayoutSetMobileDeviceRulesFormNavigatorEntry.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=180"},
+	property = {"form.navigator.entry.order:Integer=180"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetMobileDeviceRulesFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAdditionalEmailAddressesFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAdditionalEmailAddressesFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=20"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsAdditionalEmailAddressesFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAddressesFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAddressesFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=40"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsAddressesFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAnalyticsFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAnalyticsFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=30"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsAnalyticsFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAuthenticationFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsAuthenticationFormNavigatorEntry.java
@@ -43,7 +43,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  * @author Tomas Polesovsky
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=70"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=70"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsAuthenticationFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsConfigurationFormNavigatorCategory.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsConfigurationFormNavigatorCategory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=40"},
+	immediate = true, property = {"form.navigator.category.order:Integer=40"},
 	service = FormNavigatorCategory.class
 )
 public class CompanySettingsConfigurationFormNavigatorCategory

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsContentSharingFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsContentSharingFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=20"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsContentSharingFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsDisplaySettingsFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsDisplaySettingsFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=40"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsDisplaySettingsFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsEmailNotificationsFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsEmailNotificationsFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=30"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsEmailNotificationsFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsGeneralFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsGeneralFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=80"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=80"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsGeneralFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsIdentificationFormNavigatorCategory.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsIdentificationFormNavigatorCategory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=30"},
+	immediate = true, property = {"form.navigator.category.order:Integer=30"},
 	service = FormNavigatorCategory.class
 )
 public class CompanySettingsIdentificationFormNavigatorCategory

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsMailHostNamesFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsMailHostNamesFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=40"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsMailHostNamesFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsMapsFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsMapsFormNavigatorEntry.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=20"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsMapsFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsMiscellaneousFormNavigatorCategory.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsMiscellaneousFormNavigatorCategory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=10"},
+	immediate = true, property = {"form.navigator.category.order:Integer=10"},
 	service = FormNavigatorCategory.class
 )
 public class CompanySettingsMiscellaneousFormNavigatorCategory

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsPhoneNumbersFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsPhoneNumbersFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=30"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsPhoneNumbersFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsRatingsFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsRatingsFormNavigatorEntry.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=100"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=100"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsRatingsFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsRecycleBinFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsRecycleBinFormNavigatorEntry.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=10"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsRecycleBinFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsSocialFormNavigatorCategory.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsSocialFormNavigatorCategory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=20"},
+	immediate = true, property = {"form.navigator.category.order:Integer=20"},
 	service = FormNavigatorCategory.class
 )
 public class CompanySettingsSocialFormNavigatorCategory

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsTermsOfUseFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsTermsOfUseFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=50"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=50"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsTermsOfUseFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsUsersFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsUsersFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=60"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=60"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsUsersFormNavigatorEntry

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsWebsitesFormNavigatorEntry.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/servlet/taglib/ui/CompanySettingsWebsitesFormNavigatorEntry.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Philip Jones
  */
 @Component(
-	immediate = true, property = {"service.ranking:Integer=10"},
+	immediate = true, property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class CompanySettingsWebsitesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationAdditionalEmailAddressesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationAdditionalEmailAddressesFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationAdditionalEmailAddressesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationAddressesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationAddressesFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=50"},
+	property = {"form.navigator.entry.order:Integer=50"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationAddressesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationCategorizationFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationCategorizationFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationCategorizationFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationCommentsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationCommentsFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationCommentsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationCustomFieldsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationCustomFieldsFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationCustomFieldsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationDetailsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationDetailsFormNavigatorEntry.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationDetailsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationIdentificationFormNavigatorCategory.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationIdentificationFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.category.order:Integer=20"},
 	service = FormNavigatorCategory.class
 )
 public class OrganizationIdentificationFormNavigatorCategory

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationMiscellaneousFormNavigatorCategory.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationMiscellaneousFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.category.order:Integer=10"},
 	service = FormNavigatorCategory.class
 )
 public class OrganizationMiscellaneousFormNavigatorCategory

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationOrganizationInformationFormNavigatorCategory.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationOrganizationInformationFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.category.order:Integer=30"},
 	service = FormNavigatorCategory.class
 )
 public class OrganizationOrganizationInformationFormNavigatorCategory

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationOrganizationSiteFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationOrganizationSiteFormNavigatorEntry.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationOrganizationSiteFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationPhoneNumbersFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationPhoneNumbersFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationPhoneNumbersFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationReminderQueriesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationReminderQueriesFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationReminderQueriesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationServicesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationServicesFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationServicesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationWebsitesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/OrganizationWebsitesFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class OrganizationWebsitesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserAdditionalEmailAddressesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserAdditionalEmailAddressesFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=60"},
+	property = {"form.navigator.entry.order:Integer=60"},
 	service = FormNavigatorEntry.class
 )
 public class UserAdditionalEmailAddressesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserAddressesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserAddressesFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=80"},
+	property = {"form.navigator.entry.order:Integer=80"},
 	service = FormNavigatorEntry.class
 )
 public class UserAddressesFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserAnnouncementsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserAnnouncementsFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class UserAnnouncementsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserCategorizationFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserCategorizationFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class UserCategorizationFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserCommentsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserCommentsFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class UserCommentsFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserCustomFieldsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserCustomFieldsFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class UserCustomFieldsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserDetailsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserDetailsFormNavigatorEntry.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=80"},
+	property = {"form.navigator.entry.order:Integer=80"},
 	service = FormNavigatorEntry.class
 )
 public class UserDetailsFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserDisplaySettingsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserDisplaySettingsFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class UserDisplaySettingsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserIdentificationFormNavigatorCategory.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserIdentificationFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.category.order:Integer=20"},
 	service = FormNavigatorCategory.class
 )
 public class UserIdentificationFormNavigatorCategory

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserInstantMessengerFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserInstantMessengerFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class UserInstantMessengerFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserMiscellaneousFormNavigatorCategory.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserMiscellaneousFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.category.order:Integer=10"},
 	service = FormNavigatorCategory.class
 )
 public class UserMiscellaneousFormNavigatorCategory

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserOpenIdFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserOpenIdFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class UserOpenIdFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserOrganizationsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserOrganizationsFormNavigatorEntry.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=60"},
+	property = {"form.navigator.entry.order:Integer=60"},
 	service = FormNavigatorEntry.class
 )
 public class UserOrganizationsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserPasswordFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserPasswordFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=70"},
+	property = {"form.navigator.entry.order:Integer=70"},
 	service = FormNavigatorEntry.class
 )
 public class UserPasswordFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserPersonalSiteFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserPersonalSiteFormNavigatorEntry.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class UserPersonalSiteFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserPhoneNumbersFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserPhoneNumbersFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=70"},
+	property = {"form.navigator.entry.order:Integer=70"},
 	service = FormNavigatorEntry.class
 )
 public class UserPhoneNumbersFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserRolesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserRolesFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class UserRolesFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserSitesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserSitesFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=50"},
+	property = {"form.navigator.entry.order:Integer=50"},
 	service = FormNavigatorEntry.class
 )
 public class UserSitesFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserSmsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserSmsFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class UserSmsFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserSocialNetworkFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserSocialNetworkFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class UserSocialNetworkFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserUserGroupsFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserUserGroupsFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class UserUserGroupsFormNavigatorEntry

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserUserInformationFormNavigatorCategory.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserUserInformationFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.category.order:Integer=30"},
 	service = FormNavigatorCategory.class
 )
 public class UserUserInformationFormNavigatorCategory

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserWebsitesFormNavigatorEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/servlet/taglib/ui/UserWebsitesFormNavigatorEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=50"},
+	property = {"form.navigator.entry.order:Integer=50"},
 	service = FormNavigatorEntry.class
 )
 public class UserWebsitesFormNavigatorEntry extends BaseUserFormNavigatorEntry {

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalContentFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalContentFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=90"},
+	property = {"form.navigator.entry.order:Integer=90"},
 	service = FormNavigatorEntry.class
 )
 public class JournalContentFormNavigatorEntry

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalDisplayPageFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalDisplayPageFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class JournalDisplayPageFormNavigatorEntry

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalMetadataFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalMetadataFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=60"},
+	property = {"form.navigator.entry.order:Integer=60"},
 	service = FormNavigatorEntry.class
 )
 public class JournalMetadataFormNavigatorEntry

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalPermissionsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalPermissionsFormNavigatorEntry.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class JournalPermissionsFormNavigatorEntry

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalRelatedAssetsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalRelatedAssetsFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class JournalRelatedAssetsFormNavigatorEntry

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalScheduleFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalScheduleFormNavigatorEntry.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=50"},
+	property = {"form.navigator.entry.order:Integer=50"},
 	service = FormNavigatorEntry.class
 )
 public class JournalScheduleFormNavigatorEntry

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalSmallImageFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalSmallImageFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=70"},
+	property = {"form.navigator.entry.order:Integer=70"},
 	service = FormNavigatorEntry.class
 )
 public class JournalSmallImageFormNavigatorEntry

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalStructureTemplateFormNavigatorEntry.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/servlet/taglib/ui/JournalStructureTemplateFormNavigatorEntry.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=80"},
+	property = {"form.navigator.entry.order:Integer=80"},
 	service = FormNavigatorEntry.class
 )
 public class JournalStructureTemplateFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutAdvancedFormNavigatorCategory.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutAdvancedFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.category.order:Integer=10"},
 	service = FormNavigatorCategory.class
 )
 public class LayoutAdvancedFormNavigatorCategory

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutAdvancedFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutAdvancedFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=100"},
+	property = {"form.navigator.entry.order:Integer=100"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutAdvancedFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCSSFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCSSFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=90"},
+	property = {"form.navigator.entry.order:Integer=90"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutCSSFormNavigatorEntry extends BaseLayoutFormNavigatorEntry {

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCategorizationFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCategorizationFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=100"},
+	property = {"form.navigator.entry.order:Integer=100"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutCategorizationFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCustomFieldsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCustomFieldsFormNavigatorEntry.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=50"},
+	property = {"form.navigator.entry.order:Integer=50"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutCustomFieldsFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCustomizationSettingsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutCustomizationSettingsFormNavigatorEntry.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=60"},
+	property = {"form.navigator.entry.order:Integer=60"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutCustomizationSettingsFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutDetailsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutDetailsFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=100"},
+	property = {"form.navigator.entry.order:Integer=100"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutDetailsFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutGeneralFormNavigatorCategory.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutGeneralFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.category.order:Integer=40"},
 	service = FormNavigatorCategory.class
 )
 public class LayoutGeneralFormNavigatorCategory

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutJavaScriptFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutJavaScriptFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=90"},
+	property = {"form.navigator.entry.order:Integer=90"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutJavaScriptFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutLookAndFeelFormNavigatorCategory.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutLookAndFeelFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.category.order:Integer=20"},
 	service = FormNavigatorCategory.class
 )
 public class LayoutLookAndFeelFormNavigatorCategory

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutLookAndFeelFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutLookAndFeelFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=100"},
+	property = {"form.navigator.entry.order:Integer=100"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutLookAndFeelFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSEOFormNavigatorCategory.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSEOFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.category.order:Integer=30"},
 	service = FormNavigatorCategory.class
 )
 public class LayoutSEOFormNavigatorCategory implements FormNavigatorCategory {

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSEOFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSEOFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"service.ranking:Integer=90"},
+	property = {"form.navigator.entry.order:Integer=90"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSEOFormNavigatorEntry extends BaseLayoutFormNavigatorEntry {

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetAdvancedFormNavigatorCategory.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetAdvancedFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.category.order:Integer=10"},
 	service = FormNavigatorCategory.class
 )
 public class LayoutSetAdvancedFormNavigatorCategory

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetAdvancedFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetAdvancedFormNavigatorEntry.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=190"},
+	property = {"form.navigator.entry.order:Integer=190"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetAdvancedFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetCSSFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetCSSFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=190"},
+	property = {"form.navigator.entry.order:Integer=190"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetCSSFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetJavaScriptFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetJavaScriptFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=200"},
+	property = {"form.navigator.entry.order:Integer=200"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetJavaScriptFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetLogoFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetLogoFormNavigatorEntry.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=180"},
+	property = {"form.navigator.entry.order:Integer=180"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetLogoFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetLookAndFeelFormNavigatorCategory.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetLookAndFeelFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Eudaldo Alonso
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.category.order:Integer=20"},
 	service = FormNavigatorCategory.class
 )
 public class LayoutSetLookAndFeelFormNavigatorCategory

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetLookAndFeelFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetLookAndFeelFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=200"},
+	property = {"form.navigator.entry.order:Integer=200"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetLookAndFeelFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetRobotsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetRobotsFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=170"},
+	property = {"form.navigator.entry.order:Integer=170"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetRobotsFormNavigatorEntry

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetSitemapFormNavigatorEntry.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/servlet/taglib/ui/LayoutSetSitemapFormNavigatorEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=160"},
+	property = {"form.navigator.entry.order:Integer=160"},
 	service = FormNavigatorEntry.class
 )
 public class LayoutSetSitemapFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteAnalyticsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteAnalyticsFormNavigatorEntry.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class SiteAnalyticsFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteCategorizationFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteCategorizationFormNavigatorEntry.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.entry.order:Integer=40"},
 	service = FormNavigatorEntry.class
 )
 public class SiteCategorizationFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteContentSharingFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteContentSharingFormNavigatorEntry.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class SiteContentSharingFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteCustomFieldsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteCustomFieldsFormNavigatorEntry.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=50"},
+	property = {"form.navigator.entry.order:Integer=50"},
 	service = FormNavigatorEntry.class
 )
 public class SiteCustomFieldsFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDefaultUserAssociationsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDefaultUserAssociationsFormNavigatorEntry.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=60"},
+	property = {"form.navigator.entry.order:Integer=60"},
 	service = FormNavigatorEntry.class
 )
 public class SiteDefaultUserAssociationsFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDetailsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDetailsFormNavigatorEntry.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=70"},
+	property = {"form.navigator.entry.order:Integer=70"},
 	service = FormNavigatorEntry.class
 )
 public class SiteDetailsFormNavigatorEntry extends BaseSiteFormNavigatorEntry {

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDisplaySettingsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDisplaySettingsFormNavigatorEntry.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class SiteDisplaySettingsFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDocumentsAndMediaFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteDocumentsAndMediaFormNavigatorEntry.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class SiteDocumentsAndMediaFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteMapsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteMapsFormNavigatorEntry.java
@@ -39,7 +39,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class SiteMapsFormNavigatorEntry extends BaseSiteFormNavigatorEntry {

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitePagesFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitePagesFormNavigatorEntry.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=60"},
+	property = {"form.navigator.entry.order:Integer=60"},
 	service = FormNavigatorEntry.class
 )
 public class SitePagesFormNavigatorEntry extends BaseSiteFormNavigatorEntry {

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteRatingsFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteRatingsFormNavigatorEntry.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=100"},
+	property = {"form.navigator.entry.order:Integer=100"},
 	service = FormNavigatorEntry.class
 )
 public class SiteRatingsFormNavigatorEntry extends BaseSiteFormNavigatorEntry {

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteRecycleBinFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteRecycleBinFormNavigatorEntry.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.entry.order:Integer=20"},
 	service = FormNavigatorEntry.class
 )
 public class SiteRecycleBinFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteSiteTemplateFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteSiteTemplateFormNavigatorEntry.java
@@ -40,7 +40,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.entry.order:Integer=10"},
 	service = FormNavigatorEntry.class
 )
 public class SiteSiteTemplateFormNavigatorEntry

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteSiteURLFormNavigatorEntry.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SiteSiteURLFormNavigatorEntry.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.entry.order:Integer=30"},
 	service = FormNavigatorEntry.class
 )
 public class SiteSiteURLFormNavigatorEntry extends BaseSiteFormNavigatorEntry {

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesAdvancedFormNavigatorCategory.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesAdvancedFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=10"},
+	property = {"form.navigator.category.order:Integer=10"},
 	service = FormNavigatorCategory.class
 )
 public class SitesAdvancedFormNavigatorCategory

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesGeneralFormNavigatorCategory.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesGeneralFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=40"},
+	property = {"form.navigator.category.order:Integer=40"},
 	service = FormNavigatorCategory.class
 )
 public class SitesGeneralFormNavigatorCategory

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesLanguagesFormNavigatorCategory.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesLanguagesFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=20"},
+	property = {"form.navigator.category.order:Integer=20"},
 	service = FormNavigatorCategory.class
 )
 public class SitesLanguagesFormNavigatorCategory

--- a/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesSocialFormNavigatorCategory.java
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/java/com/liferay/site/admin/web/servlet/taglib/ui/SitesSocialFormNavigatorCategory.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Sergio González
  */
 @Component(
-	property = {"service.ranking:Integer=30"},
+	property = {"form.navigator.category.order:Integer=30"},
 	service = FormNavigatorCategory.class
 )
 public class SitesSocialFormNavigatorCategory implements FormNavigatorCategory {

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 2.2.0
+Bundle-Version: 2.2.1
 Export-Package:\
 	!com.liferay.portal.kernel.test.*,\
 	\

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorCategoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorCategoryUtil.java
@@ -23,8 +23,11 @@ import com.liferay.registry.collections.ServiceReferenceMapper;
 import com.liferay.registry.collections.ServiceTrackerCollections;
 import com.liferay.registry.collections.ServiceTrackerMap;
 
+import java.io.Serializable;
+
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -112,7 +115,9 @@ public class FormNavigatorCategoryUtil {
 					registry.ungetService(serviceReference);
 				}
 
-			});
+			},
+			new PropertyServiceReferenceComparator(
+				"form.navigator.category.order"));
 	}
 
 	private static final FormNavigatorCategoryUtil _instance =
@@ -120,5 +125,58 @@ public class FormNavigatorCategoryUtil {
 
 	private final ServiceTrackerMap<String, List<FormNavigatorCategory>>
 		_formNavigatorCategories;
+
+	private class PropertyServiceReferenceComparator<T>
+		implements Comparator<ServiceReference<T>>, Serializable {
+
+		public PropertyServiceReferenceComparator(String propertyKey) {
+			_propertyKey = propertyKey;
+		}
+
+		@Override
+		public int compare(
+			ServiceReference<T> serviceReference1,
+			ServiceReference<T> serviceReference2) {
+
+			if (serviceReference1 == null) {
+				if (serviceReference2 == null) {
+					return 0;
+				}
+				else {
+					return 1;
+				}
+			}
+			else if (serviceReference2 == null) {
+				return -1;
+			}
+
+			Object propertyValue1 = serviceReference1.getProperty(_propertyKey);
+			Object propertyValue2 = serviceReference2.getProperty(_propertyKey);
+
+			if (propertyValue1 == null) {
+				if (propertyValue2 == null) {
+					return 0;
+				}
+				else {
+					return 1;
+				}
+			}
+			else if (propertyValue2 == null) {
+				return -1;
+			}
+
+			if (!(propertyValue2 instanceof Comparable)) {
+				return serviceReference2.compareTo(serviceReference1);
+			}
+
+			Comparable<Object> propertyValueComparable2 =
+				(Comparable<Object>)propertyValue2;
+
+			return propertyValueComparable2.compareTo(propertyValue1);
+		}
+
+		private final String _propertyKey;
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntryUtil.java
@@ -25,7 +25,11 @@ import com.liferay.registry.collections.ServiceReferenceMapper;
 import com.liferay.registry.collections.ServiceTrackerCollections;
 import com.liferay.registry.collections.ServiceTrackerMap;
 
+import java.io.Serializable;
+
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -162,7 +166,9 @@ public class FormNavigatorEntryUtil {
 					registry.ungetService(serviceReference);
 				}
 
-			});
+			},
+			new PropertyServiceReferenceComparator(
+				"form.navigator.entry.order"));
 	}
 
 	private static final FormNavigatorEntryUtil _instance =
@@ -171,5 +177,58 @@ public class FormNavigatorEntryUtil {
 	@SuppressWarnings("rawtypes")
 	private final ServiceTrackerMap<String, List<FormNavigatorEntry>>
 		_formNavigatorEntries;
+
+	private class PropertyServiceReferenceComparator<T>
+		implements Comparator<ServiceReference<T>>, Serializable {
+
+		public PropertyServiceReferenceComparator(String propertyKey) {
+			_propertyKey = propertyKey;
+		}
+
+		@Override
+		public int compare(
+			ServiceReference<T> serviceReference1,
+			ServiceReference<T> serviceReference2) {
+
+			if (serviceReference1 == null) {
+				if (serviceReference2 == null) {
+					return 0;
+				}
+				else {
+					return 1;
+				}
+			}
+			else if (serviceReference2 == null) {
+				return -1;
+			}
+
+			Object propertyValue1 = serviceReference1.getProperty(_propertyKey);
+			Object propertyValue2 = serviceReference2.getProperty(_propertyKey);
+
+			if (propertyValue1 == null) {
+				if (propertyValue2 == null) {
+					return 0;
+				}
+				else {
+					return 1;
+				}
+			}
+			else if (propertyValue2 == null) {
+				return -1;
+			}
+
+			if (!(propertyValue2 instanceof Comparable)) {
+				return serviceReference2.compareTo(serviceReference1);
+			}
+
+			Comparable<Object> propertyValueComparable2 =
+				(Comparable<Object>)propertyValue2;
+
+			return propertyValueComparable2.compareTo(propertyValue1);
+		}
+
+		private final String _propertyKey;
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/FormNavigatorEntryUtil.java
@@ -28,7 +28,6 @@ import com.liferay.registry.collections.ServiceTrackerMap;
 import java.io.Serializable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;


### PR DESCRIPTION
fyi @sergiogonzalez

Brian, we haven't found another way to use the existing comparators because they are in modules and this registry is in the core :(

We have made them private so that we can removed once this registry is extracted in the future.

thanks!
