### PR TITLE
LPS-64427 Removal of unnecessary inclusion of PortletBeanLocatorUtil

### DIFF
--- a/modules/apps/collaboration/bookmarks/bookmarks-web/bnd.bnd
+++ b/modules/apps/collaboration/bookmarks/bookmarks-web/bnd.bnd
@@ -8,6 +8,4 @@ Liferay-JS-Config: /META-INF/resources/bookmarks/js/config.js
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Bookmarks
 Web-ContextPath: /bookmarks-web
--liferay-includeresource:\
-	@com.liferay.util.java-*.jar!/com/liferay/util/bean/PortletBeanLocatorUtil.class,\
-	@com.liferay.util.java-*.jar!/com/liferay/util/portlet/PortletProps.class
+-liferay-includeresource: @com.liferay.util.java-*.jar!/com/liferay/util/portlet/PortletProps.class

--- a/modules/apps/collaboration/wiki/wiki-web/bnd.bnd
+++ b/modules/apps/collaboration/wiki/wiki-web/bnd.bnd
@@ -7,5 +7,4 @@ Liferay-Releng-Module-Group-Title: Wiki
 Web-ContextPath: /wiki-web
 -liferay-includeresource:\
 	@com.liferay.util.java-*.jar!/com/liferay/util/RSSUtil.class,\
-	@com.liferay.util.java-*.jar!/com/liferay/util/bean/PortletBeanLocatorUtil.class,\
 	@com.liferay.util.java-*.jar!/com/liferay/util/portlet/PortletProps.class

--- a/modules/apps/deprecated/shopping/shopping-web/bnd.bnd
+++ b/modules/apps/deprecated/shopping/shopping-web/bnd.bnd
@@ -22,6 +22,5 @@ Web-ContextPath: /shopping-web
 	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/CreditCard.class,\
 	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/State.class,\
 	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/StateUtil.class,\
-	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/bean/PortletBeanLocatorUtil.class,\
 	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/portlet/PortletProps.class
 -wab: docroot

--- a/modules/apps/forms-and-workflow/polls/polls-web/bnd.bnd
+++ b/modules/apps/forms-and-workflow/polls/polls-web/bnd.bnd
@@ -25,9 +25,7 @@ Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Polls
 Web-ContextPath: /polls-web
 -donotcopy: (docroot/WEB-INF/src|.*\.jar|.*\.java)
--liferay-includeresource:\
-	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/bean/PortletBeanLocatorUtil.class,\
-	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/portlet/PortletProps.class
+-liferay-includeresource: WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/bean/PortletBeanLocatorUtil.class
 -wab: docroot
 -wablib:\
 	../../../../../lib/portal/jcommon.jar,\

--- a/modules/apps/forms-and-workflow/portal-rules-engine/portal-rules-engine-sample-web/bnd.bnd
+++ b/modules/apps/forms-and-workflow/portal-rules-engine/portal-rules-engine-sample-web/bnd.bnd
@@ -19,6 +19,5 @@ Web-ContextPath: /portal-rules-engine-sample-web
 -donotcopy: (docroot/WEB-INF/src|.*\.jar|.*\.java)
 -liferay-includeresource:\
 	WEB-INF/classes/portlet.properties=docroot/WEB-INF/src/portlet.properties,\
-	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/bean/PortletBeanLocatorUtil.class,\
 	WEB-INF/classes/=@com.liferay.util.java-*.jar!/com/liferay/util/portlet/PortletProps.class
 -wab: docroot


### PR DESCRIPTION
@brianchandotcom this is just cleaning the bnd.bnd inclusions. I cannot find a specific use of PortletBeanLocatorUtil outside of the spring-extender. Running through ci to see if it fails.
