### PR TITLE
Revert "LPS-64106 Each module's upgrade process must disable the cache"

### DIFF
--- a/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManager.java
+++ b/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManager.java
@@ -20,6 +20,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBContext;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -353,6 +354,8 @@ public class ReleaseManager {
 					throw new RuntimeException(e);
 				}
 			}
+
+			CacheRegistryUtil.clear();
 		}
 
 		private final String _bundleSymbolicName;

--- a/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManager.java
+++ b/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManager.java
@@ -20,7 +20,6 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapListener;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBContext;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -326,42 +325,33 @@ public class ReleaseManager {
 
 		@Override
 		public void run() {
-			boolean active = CacheRegistryUtil.isActive();
+			for (UpgradeInfo upgradeInfo : _upgradeInfos) {
+				UpgradeStep upgradeStep = upgradeInfo.getUpgradeStep();
 
-			try {
-				CacheRegistryUtil.setActive(false);
+				try {
+					upgradeStep.upgrade(
+						new DBProcessContext() {
 
-				for (UpgradeInfo upgradeInfo : _upgradeInfos) {
-					UpgradeStep upgradeStep = upgradeInfo.getUpgradeStep();
+							@Override
+							public DBContext getDBContext() {
+								return new DBContext();
+							}
 
-					try {
-						upgradeStep.upgrade(
-							new DBProcessContext() {
+							@Override
+							public OutputStream getOutputStream() {
+								return _outputStream;
+							}
 
-								@Override
-								public DBContext getDBContext() {
-									return new DBContext();
-								}
+						});
 
-								@Override
-								public OutputStream getOutputStream() {
-									return _outputStream;
-								}
-
-							});
-
-						_releaseLocalService.updateRelease(
-							_bundleSymbolicName,
-							upgradeInfo.getToSchemaVersionString(),
-							upgradeInfo.getFromSchemaVersionString());
-					}
-					catch (Exception e) {
-						throw new RuntimeException(e);
-					}
+					_releaseLocalService.updateRelease(
+						_bundleSymbolicName,
+						upgradeInfo.getToSchemaVersionString(),
+						upgradeInfo.getFromSchemaVersionString());
 				}
-			}
-			finally {
-				CacheRegistryUtil.setActive(active);
+				catch (Exception e) {
+					throw new RuntimeException(e);
+				}
 			}
 		}
 


### PR DESCRIPTION
This reverts commit 2889e23eb2bcdb5b50ecc90a972d2228b95a2069.

@brianchandotcom @mhan810 this is the fix to the random BackgroundTask MVCC error in tomcat log scanning.

Basically we refactored the upgrade process, which made it no longer synchronously runs at the very beginning. As a result some of the upgrade logic for modules run concurrently with the rest of startup logic.

In this MVCC error case, modules upgrade logic runs together with Background tasks for startup indexing (on MB threads). And the upgrade logic for each module does this cache disable-enable thing due to 2889e23eb2bcdb5b50ecc90a972d2228b95a2069. As a result, we have case like this:
1) At time point 1, the cache is on. Background task saves something into the cache.
2) At time point 2, Background task modifies that entry, and does a persistence update. But the cache is off at this moment. So the update goes into DB, but not cache.
3) At time point 3, Background rereads that entry, and does another modification and update. And the cache is on, it reads the out of date result from 1), then proceed the modification and update, then rejected by hibernate due to an out of date MVCC version.

Basically we have changed the natural of the upgrade, it is no longer a startup only serialized thing, it can run concurrently with the rest of portal logic, and more importantly, if someone deploys a module with upgrade logic, after portal startup. There is a very good chance we blow off some runtime real business logic.

@mdelapenya on the ticket and commit, I don't see why it was added. For whatever reason the cache was disabled, we need to fix it in a different way. We can not flip the cache switch at runtime.

CC @willnewbury
