### PR TITLE
LPS-64713 JDK8 changed the filewalker's exception handling logic to d…

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/fabric/netty/fileserver/FileHelperUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/fabric/netty/fileserver/FileHelperUtilTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
 import com.liferay.portal.kernel.test.SwappableSecurityManager;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.JavaDetector;
 import com.liferay.portal.kernel.util.ReflectionUtil;
 
 import java.io.File;
@@ -140,7 +141,12 @@ public class FileHelperUtilTest {
 			Assert.fail();
 		}
 		catch (Exception e) {
-			Assert.assertSame(ioException, e);
+			if (JavaDetector.isJDK8()) {
+				Assert.assertSame(ioException, e.getCause());
+			}
+			else {
+				Assert.assertSame(ioException, e);
+			}
 		}
 		finally {
 			Files.delete(undeleteableFilePath);


### PR DESCRIPTION
…o a direct rethrow rather than unwrapping the DirectoryIteratorException first.
