### PR TITLE
LPS-64683 Do not override the @Reference because in this way the parent won't see the child's member attribute but the one in the parent will be null

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/util/FileSystemImporter.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/util/FileSystemImporter.java
@@ -241,7 +241,7 @@ public class FileSystemImporter extends BaseImporter {
 			String ddmStructureKey, String dirName, String fileName)
 		throws Exception {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
 			groupId, PortalUtil.getClassNameId(DDLRecordSet.class),
 			ddmStructureKey);
 
@@ -272,7 +272,7 @@ public class FileSystemImporter extends BaseImporter {
 			String ddmStructureKey, String dirName, String fileName)
 		throws Exception {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
 			groupId, PortalUtil.getClassNameId(DDLRecordSet.class),
 			ddmStructureKey);
 
@@ -322,7 +322,7 @@ public class FileSystemImporter extends BaseImporter {
 
 		String name = getName(fileName);
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+		DDMStructure ddmStructure = ddmStructureLocalService.fetchStructure(
 			groupId, PortalUtil.getClassNameId(DDLRecordSet.class),
 			getKey(fileName));
 
@@ -338,7 +338,7 @@ public class FileSystemImporter extends BaseImporter {
 			}
 
 			if (!updateModeEnabled) {
-				_ddmStructureLocalService.deleteDDMStructure(ddmStructure);
+				ddmStructureLocalService.deleteDDMStructure(ddmStructure);
 			}
 		}
 
@@ -352,7 +352,7 @@ public class FileSystemImporter extends BaseImporter {
 			DDMFormLayout ddmFormLayout = _ddm.getDefaultDDMFormLayout(ddmForm);
 
 			if (!updateModeEnabled || (ddmStructure == null)) {
-				ddmStructure = _ddmStructureLocalService.addStructure(
+				ddmStructure = ddmStructureLocalService.addStructure(
 					userId, groupId,
 					DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID,
 					PortalUtil.getClassNameId(DDLRecordSet.class),
@@ -361,7 +361,7 @@ public class FileSystemImporter extends BaseImporter {
 					DDMStructureConstants.TYPE_DEFAULT, serviceContext);
 			}
 			else {
-				ddmStructure = _ddmStructureLocalService.updateStructure(
+				ddmStructure = ddmStructureLocalService.updateStructure(
 					userId, ddmStructure.getStructureId(),
 					DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID,
 					getMap(name), null, ddmForm, ddmFormLayout, serviceContext);
@@ -425,7 +425,7 @@ public class FileSystemImporter extends BaseImporter {
 
 		String name = getName(fileName);
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+		DDMStructure ddmStructure = ddmStructureLocalService.fetchStructure(
 			groupId, PortalUtil.getClassNameId(JournalArticle.class),
 			getKey(fileName));
 
@@ -441,7 +441,7 @@ public class FileSystemImporter extends BaseImporter {
 			}
 
 			if (!updateModeEnabled) {
-				_ddmStructureLocalService.deleteDDMStructure(ddmStructure);
+				ddmStructureLocalService.deleteDDMStructure(ddmStructure);
 			}
 		}
 
@@ -468,7 +468,7 @@ public class FileSystemImporter extends BaseImporter {
 
 		try {
 			if (!updateModeEnabled || (ddmStructure == null)) {
-				ddmStructure = _ddmStructureLocalService.addStructure(
+				ddmStructure = ddmStructureLocalService.addStructure(
 					userId, groupId, parentDDMStructureKey,
 					PortalUtil.getClassNameId(JournalArticle.class),
 					getKey(fileName), getMap(name), null, ddmForm,
@@ -479,7 +479,7 @@ public class FileSystemImporter extends BaseImporter {
 			}
 			else {
 				DDMStructure parentStructure =
-					_ddmStructureLocalService.fetchStructure(
+					ddmStructureLocalService.fetchStructure(
 						groupId,
 						PortalUtil.getClassNameId(JournalArticle.class),
 						parentDDMStructureKey);
@@ -491,7 +491,7 @@ public class FileSystemImporter extends BaseImporter {
 					parentDDMStructureId = parentStructure.getStructureId();
 				}
 
-				ddmStructure = _ddmStructureLocalService.updateStructure(
+				ddmStructure = ddmStructureLocalService.updateStructure(
 					userId, ddmStructure.getStructureId(), parentDDMStructureId,
 					getMap(name), null, ddmForm, ddmFormLayout, serviceContext);
 			}
@@ -618,7 +618,7 @@ public class FileSystemImporter extends BaseImporter {
 
 		setServiceContext(fileName);
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
 			groupId, PortalUtil.getClassNameId(JournalArticle.class),
 			ddmStructureKey);
 
@@ -1675,7 +1675,7 @@ public class FileSystemImporter extends BaseImporter {
 	protected void setDDMStructureLocalService(
 		DDMStructureLocalService ddmStructureLocalService) {
 
-		_ddmStructureLocalService = ddmStructureLocalService;
+		ddmStructureLocalService = ddmStructureLocalService;
 	}
 
 	@Reference(unbind = "-")
@@ -1819,7 +1819,7 @@ public class FileSystemImporter extends BaseImporter {
 
 			_ddmTemplateLocalService.deleteTemplates(groupId);
 
-			_ddmStructureLocalService.deleteStructures(groupId);
+			ddmStructureLocalService.deleteStructures(groupId);
 		}
 
 		JSONObject jsonObject = getJSONObject(fileName);
@@ -1952,6 +1952,7 @@ public class FileSystemImporter extends BaseImporter {
 		}
 	}
 
+	protected DDMStructureLocalService ddmStructureLocalService;
 	protected ServiceContext serviceContext;
 
 	private static final String _APPLICATION_DISPLAY_TEMPLATE_DIR_NAME =
@@ -2001,7 +2002,6 @@ public class FileSystemImporter extends BaseImporter {
 	private DDM _ddm;
 	private DDMFormJSONDeserializer _ddmFormJSONDeserializer;
 	private DDMFormXSDDeserializer _ddmFormXSDDeserializer;
-	private DDMStructureLocalService _ddmStructureLocalService;
 	private final Set<String> _ddmStructures = new HashSet<>();
 	private DDMTemplateLocalService _ddmTemplateLocalService;
 	private DDMXML _ddmXML;

--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/util/ResourceImporter.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/util/ResourceImporter.java
@@ -18,7 +18,6 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplateConstants;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -37,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Raymond Augé
@@ -92,7 +90,7 @@ public class ResourceImporter extends FileSystemImporter {
 			String ddmStructureKey, String dirName, String fileName)
 		throws Exception {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
 			groupId, PortalUtil.getClassNameId(DDLRecordSet.class),
 			ddmStructureKey);
 
@@ -133,7 +131,7 @@ public class ResourceImporter extends FileSystemImporter {
 			String ddmStructureKey, String dirName, String fileName)
 		throws Exception {
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+		DDMStructure ddmStructure = ddmStructureLocalService.getStructure(
 			groupId, PortalUtil.getClassNameId(DDLRecordSet.class),
 			ddmStructureKey);
 
@@ -377,14 +375,6 @@ public class ResourceImporter extends FileSystemImporter {
 		return urlConnection.getInputStream();
 	}
 
-	@Reference(unbind = "-")
-	protected void setDDMStructureLocalService(
-		DDMStructureLocalService ddmStructureLocalService) {
-
-		_ddmStructureLocalService = ddmStructureLocalService;
-	}
-
-	private DDMStructureLocalService _ddmStructureLocalService;
 	private final Map<String, Long> _folderIds = new HashMap<>();
 
 }


### PR DESCRIPTION
/cc @danielkocsis I don't see how baseline could fail here since the classes you changed are not in exported packages
