### PR TITLE
LPS-64750 Remove unused Liferay-Releng properties from standalone apps

### DIFF
--- a/modules/apps/asset-tags-validator/asset-tags-validator/bnd.bnd
+++ b/modules/apps/asset-tags-validator/asset-tags-validator/bnd.bnd
@@ -1,5 +1,3 @@
 Bundle-Name: Liferay Asset Tags Validator
 Bundle-SymbolicName: com.liferay.asset.tags.validator
 Bundle-Version: 1.0.0
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Asset

--- a/modules/apps/document-library-file-version-discussion/document-library-file-version-discussion-web/bnd.bnd
+++ b/modules/apps/document-library-file-version-discussion/document-library-file-version-discussion-web/bnd.bnd
@@ -1,5 +1,3 @@
 Bundle-Name: Liferay Document Library File Version Discussion Web
 Bundle-SymbolicName: com.liferay.document.library.file.version.discussion.web
 Bundle-Version: 2.0.1
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Document Library File Version Discussion Web

--- a/modules/apps/document-library-google-docs/document-library-google-docs/bnd.bnd
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/bnd.bnd
@@ -17,7 +17,5 @@ Import-Package:\
 	\
 	!org.zeroturnaround.javarebel,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Document Library
 Web-ContextPath: /document-library-google-docs
 -liferay-includeresource: @org.freemarker-*.jar

--- a/modules/apps/portal-scripting-beanshell/portal-scripting-beanshell/bnd.bnd
+++ b/modules/apps/portal-scripting-beanshell/portal-scripting-beanshell/bnd.bnd
@@ -5,6 +5,4 @@ DynamicImport-Package: *
 Import-Package:\
 	!org.apache.bsf.*,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Scripting Engines
 -liferay-includeresource: @bsh-*.jar

--- a/modules/apps/portal-scripting-javascript/portal-scripting-javascript/bnd.bnd
+++ b/modules/apps/portal-scripting-javascript/portal-scripting-javascript/bnd.bnd
@@ -7,6 +7,4 @@ Import-Package:\
 	\
 	!org.apache.xmlbeans.*,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Scripting Engines
 -liferay-includeresource: @rhino-*.jar

--- a/modules/apps/portal-scripting-python/portal-scripting-python/bnd.bnd
+++ b/modules/apps/portal-scripting-python/portal-scripting-python/bnd.bnd
@@ -24,8 +24,6 @@ Import-Package:\
 	\
 	!sun.misc.*,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Scripting Engines
 -fixupmessages:\
 	"The default package '.' is not permitted by the Import-Package ...";is:=ignore,\
 	"The JAR is empty: ...";is:=ignore,\

--- a/modules/apps/portal-scripting-ruby/portal-scripting-ruby/bnd.bnd
+++ b/modules/apps/portal-scripting-ruby/portal-scripting-ruby/bnd.bnd
@@ -16,8 +16,6 @@ Import-Package:\
 	\
 	!sun.nio.cs*,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Scripting Engines
 -fixupmessages:\
 	"The default package '.' is not permitted by the Import-Package ...";is:=ignore,\
 	"The JAR is empty: ...";is:=ignore,\

--- a/modules/apps/portal-search-solr/portal-search-solr/bnd.bnd
+++ b/modules/apps/portal-search-solr/portal-search-solr/bnd.bnd
@@ -32,8 +32,6 @@ Import-Package:\
 	\
 	!org.relaxng.datatype.*,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Solr
 -liferay-includeresource:\
 	lib/commons-io.jar=commons-io-*.jar,\
 	lib/httpclient.jar=httpclient-*.jar,\

--- a/modules/apps/social-networking/social-networking-api/bnd.bnd
+++ b/modules/apps/social-networking/social-networking-api/bnd.bnd
@@ -2,5 +2,3 @@ Bundle-Name: Liferay Social Networking API
 Bundle-SymbolicName: com.liferay.social.networking.api
 Bundle-Version: 2.0.1
 Export-Package: com.liferay.social.networking.*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Social

--- a/modules/apps/social-networking/social-networking-service/bnd.bnd
+++ b/modules/apps/social-networking/social-networking-service/bnd.bnd
@@ -7,7 +7,5 @@ Export-Package:\
 	com.liferay.social.networking.members.social.*,\
 	com.liferay.social.networking.service.configuration.configurator.*,\
 	com.liferay.social.networking.wall.social.*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Social
 Liferay-Require-SchemaVersion: 1.0.1
 Liferay-Service: true

--- a/modules/apps/social-networking/social-networking-test/bnd.bnd
+++ b/modules/apps/social-networking/social-networking-test/bnd.bnd
@@ -1,5 +1,3 @@
 Bundle-Name: Liferay Social Networking Test
 Bundle-SymbolicName: com.liferay.social.networking.test
 Bundle-Version: 1.0.0
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Social

--- a/modules/apps/social-networking/social-networking-web/bnd.bnd
+++ b/modules/apps/social-networking/social-networking-web/bnd.bnd
@@ -1,6 +1,4 @@
 Bundle-Name: Liferay Social Networking Web
 Bundle-SymbolicName: com.liferay.social.networking.web
 Bundle-Version: 1.0.2
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Social
 Web-ContextPath: /social-networking-web

--- a/modules/apps/wiki-engine-jspwiki/wiki-engine-jspwiki/bnd.bnd
+++ b/modules/apps/wiki-engine-jspwiki/wiki-engine-jspwiki/bnd.bnd
@@ -19,8 +19,6 @@ Import-Package:\
 	\
 	!org.jgroups.*,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Wiki
 Web-ContextPath: /wiki-engine-jspwiki
 -includeresource:\
 	@../../../../../lib/portal/ecs.jar,\

--- a/modules/apps/wiki-engine-mediawiki/wiki-engine-mediawiki/bnd.bnd
+++ b/modules/apps/wiki-engine-mediawiki/wiki-engine-mediawiki/bnd.bnd
@@ -9,7 +9,5 @@ Import-Package:\
 	\
 	!org.incava.util.diff.*,\
 	*
-Liferay-Releng-Module-Group-Description:
-Liferay-Releng-Module-Group-Title: Wiki
 Web-ContextPath: /wiki-engine-mediawiki
 -liferay-includeresource: @org.jamwiki-*.jar


### PR DESCRIPTION
Standalone apps do not use "Liferay-Releng-Module-Group-Title" and "Liferay-Releng-Module-Group-Description".  If both are used, App Manager categorizes them as an App Suite.
