### PR TITLE
LPS-63462 Do not translate value in ConfigurationModelToDDMFormValuesConverter

### DIFF
--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormConverter.java
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormConverter.java
@@ -260,7 +260,7 @@ public class ConfigurationModelToDDMFormConverter {
 
 		LocalizedValue predefinedValue = new LocalizedValue(_locale);
 
-		predefinedValue.addString(_locale, translate(predefinedValueString));
+		predefinedValue.addString(_locale, predefinedValueString);
 
 		ddmFormField.setPredefinedValue(predefinedValue);
 	}

--- a/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormValuesConverter.java
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/util/ConfigurationModelToDDMFormValuesConverter.java
@@ -21,7 +21,6 @@ import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -151,23 +150,9 @@ public class ConfigurationModelToDDMFormValuesConverter {
 
 		LocalizedValue localizedValue = new LocalizedValue(_locale);
 
-		localizedValue.addString(_locale, translate(value));
+		localizedValue.addString(_locale, value);
 
 		ddmFormFieldValue.setValue(localizedValue);
-	}
-
-	protected String translate(String key) {
-		if ((_resourceBundle == null) || (key == null)) {
-			return key;
-		}
-
-		String value = ResourceBundleUtil.getString(_resourceBundle, key);
-
-		if (value == null) {
-			return key;
-		}
-
-		return value;
 	}
 
 	private final ConfigurationModel _configurationModel;


### PR DESCRIPTION
Hey Brian,

Please prioritize this fix. It makes System Settings barely usable.
