### PR TITLE
LRQA-24103 Disable forced cache when running the gradle baseline check

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1100,7 +1100,7 @@ ${output.content}</echo>
 									<sequential>
 										<echo>Executing baseline on @{modules.base.dir.name}.</echo>
 
-										<gradle-execute dir="@{modules.base.dir.name}" task="baseline" />
+										<gradle-execute dir="@{modules.base.dir.name}" forcedcacheenabled="false" task="baseline" />
 									</sequential>
 								</for>
 							</then>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-24103
