### PR TITLE
LPS-64198 Hook portal.properties is not read when -Dcompany-id-properties=true

### DIFF
--- a/modules/apps/foundation/server-admin/server-admin-web/build.gradle
+++ b/modules/apps/foundation/server-admin/server-admin-web/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.frontend.taglib", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"

--- a/modules/apps/foundation/server-admin/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/foundation/server-admin/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -62,7 +62,7 @@ serverURL.setParameter("tabs2", tabs2);
 	Properties properties = null;
 
 	if (tabs2.equals("portal-properties")) {
-		properties = PropsUtil.getProperties();
+		properties = PropsUtil.getProperties(true);
 	}
 	else {
 		properties = System.getProperties();

--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -1,11 +1,11 @@
 Manifest-Version: 1.0
-Bnd-LastModified: 1459569781447
+Bnd-LastModified: 1459851666381
 Bundle-ManifestVersion: 2
 Bundle-Name: portal-bootstrap
 Bundle-SymbolicName: portal-bootstrap
 Bundle-Vendor: Liferay, Inc.
 Bundle-Version: 1.0.0
-Created-By: 1.8.0_77 (Oracle Corporation)
+Created-By: 1.7.0_79 (Oracle Corporation)
 Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  u.impl;version="4.0.1";uses:="com.liferay.ibm.icu.math,com.liferay.ib
  m.icu.text,com.liferay.ibm.icu.util",com.liferay.ibm.icu.impl.coll;ve
@@ -3556,7 +3556,7 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  0.util;version="1.0.0",com.liferay.portal.upload;version="1.0.2";uses
  :="com.liferay.portal.kernel.servlet,com.liferay.portal.kernel.upload
  ,javax.portlet,javax.servlet,javax.servlet.http",com.liferay.portal.u
- til;version="1.3.0";uses:="com.liferay.expando.kernel.model,com.lifer
+ til;version="1.4.0";uses:="com.liferay.expando.kernel.model,com.lifer
  ay.layouts.admin.kernel.util,com.liferay.portal.kernel.configuration,
  com.liferay.portal.kernel.exception,com.liferay.portal.kernel.json,co
  m.liferay.portal.kernel.model,com.liferay.portal.kernel.openid,com.li

--- a/portal-impl/src/com/liferay/portal/util/PropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsUtil.java
@@ -88,9 +88,7 @@ public class PropsUtil {
 
 		Properties mergedProperties = (Properties)systemProperties.clone();
 
-		for(Map.Entry<Object, Object> entry : properties.entrySet()) {
-			mergedProperties.put(entry.getKey(), entry.getValue());
-		}
+		mergedProperties.putAll(properties);
 
 		return mergedProperties;
 	}

--- a/portal-impl/src/com/liferay/portal/util/PropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsUtil.java
@@ -73,7 +73,26 @@ public class PropsUtil {
 	}
 
 	public static Properties getProperties() {
-		return _instance._getProperties();
+		return getProperties(false);
+	}
+
+	public static Properties getProperties(boolean includeSystem) {
+		Properties properties = _instance._getProperties();
+
+		if (!includeSystem) {
+			return properties;
+		}
+
+		Properties systemProperties =
+			_instance._getProperties(CompanyConstants.SYSTEM);
+
+		Properties mergedProperties = (Properties)systemProperties.clone();
+
+		for(Map.Entry<Object, Object> entry : properties.entrySet()) {
+			mergedProperties.put(entry.getKey(), entry.getValue());
+		}
+
+		return mergedProperties;
 	}
 
 	public static Properties getProperties(
@@ -230,11 +249,13 @@ public class PropsUtil {
 	}
 
 	private Configuration _getConfiguration() {
+		return _getConfiguration(CompanyThreadLocal.getCompanyId());
+	}
+
+	private Configuration _getConfiguration(long companyId) {
 		if (_configurations == null) {
 			return _configuration;
 		}
-
-		Long companyId = CompanyThreadLocal.getCompanyId();
 
 		if (companyId > CompanyConstants.SYSTEM) {
 			Configuration configuration = _configurations.get(companyId);
@@ -325,6 +346,10 @@ public class PropsUtil {
 
 	private Properties _getProperties() {
 		return _getConfiguration().getProperties();
+	}
+
+	private Properties _getProperties(long companyId) {
+		return _getConfiguration(companyId).getProperties();
 	}
 
 	private Properties _getProperties(String prefix, boolean removePrefix) {

--- a/portal-impl/src/com/liferay/portal/util/PropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsUtil.java
@@ -83,10 +83,11 @@ public class PropsUtil {
 			return properties;
 		}
 
-		Properties systemProperties =
-			_instance._getProperties(CompanyConstants.SYSTEM);
+		Properties systemCompanyProperties = _instance._getProperties(
+			CompanyConstants.SYSTEM);
 
-		Properties mergedProperties = (Properties)systemProperties.clone();
+		Properties mergedProperties =
+			(Properties)systemCompanyProperties.clone();
 
 		mergedProperties.putAll(properties);
 


### PR DESCRIPTION
Hi Brian,

This pull comes from [here](https://github.com/brianchandotcom/liferay-portal/pull/37679).

Regarding your comment: "_If I go to portal.properties, I would not expect to see system.properties, but only the portal ones_". That makes sense, but in this case you're not seeing system properties, I can unstertand the confuse because the variable name was 'systemProperties' but it is related to company 0 properties, so I renamed it to avoid misunderstandings.

Regards,
