### PR TITLE
LPS-63695 SCOPE_GROUP root model-resource is missing by default, custom plugins will fail permission checking 

### DIFF
--- a/modules/apps/collaboration/microblogs/microblogs-web/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/collaboration/microblogs/microblogs-web/src/main/resources/resource-actions/default.xml
@@ -23,6 +23,7 @@
 			<portlet-name>com_liferay_microblogs_web_portlet_MicroblogsPortlet</portlet-name>
 			<portlet-name>com_liferay_microblogs_web_portlet_MicroblogsStatusUpdatePortlet</portlet-name>
 		</portlet-ref>
+		<root>true</root>
 		<permissions>
 			<supports>
 				<action-key>ADD_ENTRY</action-key>

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/resource-actions/default.xml
@@ -7,6 +7,7 @@
 		<portlet-ref>
 			<portlet-name>com_liferay_calendar_web_portlet_CalendarPortlet</portlet-name>
 		</portlet-ref>
+		<root>true</root>
 		<permissions>
 			<supports>
 				<action-key>ADD_RESOURCE</action-key>

--- a/modules/apps/web-experience/staging/staging-security/build.gradle
+++ b/modules/apps/web-experience/staging/staging-security/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -1,11 +1,11 @@
 Manifest-Version: 1.0
-Bnd-LastModified: 1459889013665
+Bnd-LastModified: 1459951128702
 Bundle-ManifestVersion: 2
 Bundle-Name: portal-bootstrap
 Bundle-SymbolicName: portal-bootstrap
 Bundle-Vendor: Liferay, Inc.
 Bundle-Version: 1.0.0
-Created-By: 1.7.0_71 (Oracle Corporation)
+Created-By: 1.8.0_72 (Oracle Corporation)
 Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  u.impl;version="4.0.1";uses:="com.liferay.ibm.icu.math,com.liferay.ib
  m.icu.text,com.liferay.ibm.icu.util",com.liferay.ibm.icu.impl.coll;ve
@@ -2935,7 +2935,7 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  y.portal.kernel.security.pacl;version="6.2.0",com.liferay.portal.kern
  el.security.pacl.permission;version="7.0.0";uses:="com.liferay.portal
  .kernel.util",com.liferay.portal.kernel.security.permission;version="
- 1.0.0";uses:="com.liferay.portal.kernel.exception,com.liferay.portal.
+ 1.1.0";uses:="com.liferay.portal.kernel.exception,com.liferay.portal.
  kernel.model,javax.portlet,javax.servlet.http",com.liferay.portal.ker
  nel.security.permission.comparator;version="1.0.0",com.liferay.portal
  .kernel.security.pwd;version="1.0.0";uses:="com.liferay.portal.kernel

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -601,6 +601,9 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		List<Resource> resources = getResources(
 			companyId, groupId, name, primKey, actionId);
 
+		resources = fixMissingResources(
+			companyId, groupId, name, primKey, actionId, resources);
+
 		logHasUserPermission(groupId, name, primKey, actionId, stopWatch, 3);
 
 		// Check if user has access to perform the action on the given resource
@@ -760,6 +763,14 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 		return primKey;
 	}
 
+	protected List<Resource> fixMissingResources(
+			long companyId, long groupId, String name, String primKey,
+			String actionId, List<Resource> resources)
+		throws Exception {
+
+		return resources;
+	}
+
 	/**
 	 * Returns representations of the resource at each scope level.
 	 *
@@ -886,6 +897,9 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 			List<Resource> resources = getResources(
 				companyId, groupId, name, primKey, actionId);
+
+			resources = fixMissingResources(
+				companyId, groupId, name, primKey, actionId, resources);
 
 			return ResourceLocalServiceUtil.hasUserPermissions(
 				defaultUserId, groupId, resources, actionId,

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -795,6 +795,24 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return resources;
 		}
 
+		if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+
+			// There are no custom permissions defined for portlet, use defaults
+
+			Resource individualResource = resources.get(0);
+
+			if (individualResource.getScope() !=
+				ResourceConstants.SCOPE_INDIVIDUAL) {
+
+				throw new IllegalArgumentException(
+					"The first resource must be an individual scope");
+			}
+
+			individualResource.setPrimKey(name);
+
+			return resources;
+		}
+
 		return resources;
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -748,17 +748,18 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 
 		String newIndividualResourcePrimKey = null;
 
-		if ((groupId > 0) && ResourceActionsUtil.isRootModelResource(name)) {
+		if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
 
-			// There are no custom permissions defined for root model-resource,
-			// use defaults
+			// There are no custom permissions defined for portlet, use defaults
 
 			newIndividualResourcePrimKey = name;
 		}
 
-		else if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+		else if ((groupId > 0) &&
+				 ResourceActionsUtil.isRootModelResource(name)) {
 
-			// There are no custom permissions defined for portlet, use defaults
+			// There are no custom permissions defined for root model-resource,
+			// use defaults
 
 			newIndividualResourcePrimKey = name;
 		}

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -746,46 +746,28 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			return resources;
 		}
 
+		String newIndividualResourcePrimKey = null;
+
 		if ((groupId > 0) && ResourceActionsUtil.isRootModelResource(name)) {
 
 			// There are no custom permissions defined for root model-resource,
 			// use defaults
 
-			Resource individualResource = resources.get(0);
-
-			if (individualResource.getScope() !=
-					ResourceConstants.SCOPE_INDIVIDUAL) {
-
-				throw new IllegalArgumentException(
-					"The first resource must be an individual scope");
-			}
-
-			individualResource.setPrimKey(name);
-
-			return resources;
+			newIndividualResourcePrimKey = name;
 		}
 
-		if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
+		else if (primKey.contains(PortletConstants.LAYOUT_SEPARATOR)) {
 
 			// There are no custom permissions defined for portlet, use defaults
 
-			Resource individualResource = resources.get(0);
-
-			if (individualResource.getScope() !=
-				ResourceConstants.SCOPE_INDIVIDUAL) {
-
-				throw new IllegalArgumentException(
-					"The first resource must be an individual scope");
-			}
-
-			individualResource.setPrimKey(name);
-
-			return resources;
+			newIndividualResourcePrimKey = name;
 		}
 
-		if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
-			(primKey.equals(String.valueOf(companyId)) &&
-				!name.equals(Company.class.getName()))) {
+		else if (((primKey.length() == 1) && (primKey.charAt(0) == 48)) ||
+				 (primKey.equals(String.valueOf(companyId)) &&
+				  !name.equals(Company.class.getName()))) {
+
+			newIndividualResourcePrimKey = name;
 
 			if (_log.isWarnEnabled()) {
 				StringBundler sb = new StringBundler(9);
@@ -803,19 +785,19 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 				_log.warn(
 					sb.toString(), new IllegalArgumentException(sb.toString()));
 			}
+		}
 
+		if (newIndividualResourcePrimKey != null) {
 			Resource individualResource = resources.get(0);
 
 			if (individualResource.getScope() !=
-				ResourceConstants.SCOPE_INDIVIDUAL) {
+					ResourceConstants.SCOPE_INDIVIDUAL) {
 
 				throw new IllegalArgumentException(
 					"The first resource must be an individual scope");
 			}
 
 			individualResource.setPrimKey(name);
-
-			return resources;
 		}
 
 		return resources;

--- a/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java
@@ -768,6 +768,33 @@ public class AdvancedPermissionChecker extends BasePermissionChecker {
 			String actionId, List<Resource> resources)
 		throws Exception {
 
+		int count =
+			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey);
+
+		if (count > 0) {
+			return resources;
+		}
+
+		if ((groupId > 0) && ResourceActionsUtil.isRootModelResource(name)) {
+
+			// There are no custom permissions defined for root model-resource,
+			// use defaults
+
+			Resource individualResource = resources.get(0);
+
+			if (individualResource.getScope() !=
+					ResourceConstants.SCOPE_INDIVIDUAL) {
+
+				throw new IllegalArgumentException(
+					"The first resource must be an individual scope");
+			}
+
+			individualResource.setPrimKey(name);
+
+			return resources;
+		}
+
 		return resources;
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -576,6 +576,12 @@ public class ResourceActionsImpl implements ResourceActions {
 	}
 
 	@Override
+	public String[] getRootModelResources() {
+		return _rootModelResources.toArray(
+			new String[_rootModelResources.size()]);
+	}
+
+	@Override
 	public boolean hasModelResourceActions(String name) {
 		ModelResourceActionsBag modelResourceActionsBag =
 			getModelResourceActionsBag(name);
@@ -603,6 +609,16 @@ public class ResourceActionsImpl implements ResourceActions {
 	@Override
 	public boolean isPortalModelResource(String modelResource) {
 		if (_portalModelResources.contains(modelResource)) {
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean isRootModelResource(String modelResource) {
+		if (_rootModelResources.contains(modelResource)) {
 			return true;
 		}
 		else {
@@ -1099,6 +1115,8 @@ public class ResourceActionsImpl implements ResourceActions {
 				modelResourceElement.elementText("root"));
 
 			if (root) {
+				_rootModelResources.add(name);
+
 				Map<String, String> portletRootModelResource =
 					portletResourceActionsBag.getPortletRootModelResources();
 
@@ -1260,5 +1278,6 @@ public class ResourceActionsImpl implements ResourceActions {
 	private Map<String, PortletResourceActionsBag> _portletResourceActionsBags;
 	private final ServiceTrackerList<ResourceBundleLoader>
 		_resourceBundleLoaders;
+	private final Set<String> _rootModelResources = new HashSet<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -150,6 +150,8 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 	public void checkPortlet(Portlet portlet) throws PortalException {
 		initPortletDefaultPermissions(portlet);
 
+		initPortletRootModelDefaultPermissions(portlet);
+
 		initPortletModelDefaultPermissions(portlet);
 
 		initPortletAddToPagePermissions(portlet);
@@ -1185,6 +1187,47 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				portlet.getCompanyId(), 0, 0, modelResource, modelResource,
 				false, false, true);
 		}
+	}
+
+	protected void initPortletRootModelDefaultPermissions(Portlet portlet)
+		throws PortalException {
+
+		String rootModel = ResourceActionsUtil.getPortletRootModelResource(
+			portlet.getRootPortletId());
+
+		if (Validator.isBlank(rootModel)) {
+			return;
+		}
+
+		Role guestRole = roleLocalService.getRole(
+			portlet.getCompanyId(), RoleConstants.GUEST);
+		List<String> guestActions =
+			ResourceActionsUtil.getModelResourceGuestDefaultActions(rootModel);
+
+		resourcePermissionLocalService.setResourcePermissions(
+			portlet.getCompanyId(), rootModel,
+			ResourceConstants.SCOPE_INDIVIDUAL, rootModel,
+			guestRole.getRoleId(), guestActions.toArray(new String[0]));
+
+		Role ownerRole = roleLocalService.getRole(
+			portlet.getCompanyId(), RoleConstants.OWNER);
+		List<String> ownerActionIds =
+			ResourceActionsUtil.getModelResourceActions(rootModel);
+
+		resourcePermissionLocalService.setOwnerResourcePermissions(
+			portlet.getCompanyId(), rootModel,
+			ResourceConstants.SCOPE_INDIVIDUAL, rootModel,
+			ownerRole.getRoleId(), 0, ownerActionIds.toArray(new String[0]));
+
+		Role siteMemberRole = roleLocalService.getRole(
+			portlet.getCompanyId(), RoleConstants.SITE_MEMBER);
+		List<String> groupActionIds =
+			ResourceActionsUtil.getModelResourceGroupDefaultActions(rootModel);
+
+		resourcePermissionLocalService.setResourcePermissions(
+			portlet.getCompanyId(), rootModel,
+			ResourceConstants.SCOPE_INDIVIDUAL, rootModel,
+			siteMemberRole.getRoleId(), groupActionIds.toArray(new String[0]));
 	}
 
 	protected void readLiferayDisplay(

--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletConstants;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -33,7 +32,6 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermission;
@@ -341,21 +339,6 @@ public class PortletPermissionImpl implements PortletPermission {
 		}
 
 		resourcePermissionPrimKey = getPrimaryKey(layout.getPlid(), portletId);
-
-		boolean useDefaultPortletPermissions = false;
-
-		int count =
-			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				permissionChecker.getCompanyId(), rootPortletId,
-				ResourceConstants.SCOPE_INDIVIDUAL, resourcePermissionPrimKey);
-
-		if (count == 0) {
-			useDefaultPortletPermissions = true;
-		}
-
-		if (useDefaultPortletPermissions) {
-			resourcePermissionPrimKey = rootPortletId;
-		}
 
 		if (strict) {
 			return permissionChecker.hasPermission(

--- a/portal-impl/src/com/liferay/portlet/announcements/service/permission/AnnouncementsEntryPermission.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/permission/AnnouncementsEntryPermission.java
@@ -18,12 +18,10 @@ import com.liferay.announcements.kernel.model.AnnouncementsEntry;
 import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 
 /**
@@ -105,23 +103,8 @@ public class AnnouncementsEntryPermission {
 			layout = virtualLayout.getSourceLayout();
 		}
 
-		boolean useDefaultPortletPermissions = false;
-
 		String primKey = PortletPermissionUtil.getPrimaryKey(
 			layout.getPlid(), portletId);
-
-		int count =
-			ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-				permissionChecker.getCompanyId(), portletId,
-				ResourceConstants.SCOPE_INDIVIDUAL, primKey);
-
-		if (count == 0) {
-			useDefaultPortletPermissions = true;
-		}
-
-		if (useDefaultPortletPermissions) {
-			primKey = portletId;
-		}
 
 		return permissionChecker.hasPermission(
 			layout.getGroupId(), portletId, primKey, actionId);

--- a/portal-impl/src/resource-actions/asset.xml
+++ b/portal-impl/src/resource-actions/asset.xml
@@ -25,6 +25,7 @@
 		<portlet-ref>
 			<portlet-name>com_liferay_asset_categories_admin_web_portlet_AssetCategoriesAdminPortlet</portlet-name>
 		</portlet-ref>
+		<root>true</root>
 		<weight>1</weight>
 		<permissions>
 			<supports>

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -122,6 +122,12 @@ public class PermissionCheckerTest {
 				_PORTLET_RESOURCE_NAME, ActionKeys.ACCESS_IN_CONTROL_PANEL);
 
 			Assert.assertFalse(hasPermission);
+
+			hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _ROOT_MODEL_RESOURCE_NAME,
+				_ROOT_MODEL_RESOURCE_NAME, _ADD_SITE_TEST_ACTION);
+
+			Assert.assertTrue(hasPermission);
 		}
 		finally {
 			_destroyRemotePortlet(_user.getCompanyId(), _PORTLET_RESOURCE_NAME);
@@ -190,6 +196,12 @@ public class PermissionCheckerTest {
 	public void testHasPermissionOnRootModelResource() throws Exception {
 		_user = UserTestUtil.addUser();
 
+		_role = RoleTestUtil.addRole(
+			RandomTestUtil.randomString(), RoleConstants.TYPE_SITE);
+
+		UserLocalServiceUtil.setRoleUsers(
+			_role.getRoleId(), new long[] {_user.getUserId()});
+
 		PermissionChecker permissionChecker = _getPermissionChecker(_user);
 
 		ResourceLocalServiceUtil.addResources(
@@ -213,6 +225,31 @@ public class PermissionCheckerTest {
 				_group.getGroupId(), _ADD_SITE_TEST_ACTION);
 
 			Assert.assertTrue(hasPermission);
+
+			hasPermission = permissionChecker.hasPermission(
+				_group.getGroupId(), _ROOT_MODEL_RESOURCE_NAME,
+				_group.getGroupId(), _ADD_SITE_TEST2_ACTION);
+
+			Assert.assertFalse(hasPermission);
+
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				_user.getCompanyId(), _ROOT_MODEL_RESOURCE_NAME,
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(_group.getGroupId()), _role.getRoleId(),
+				new String[] {_ADD_SITE_TEST2_ACTION});
+
+			try {
+				hasPermission = permissionChecker.hasPermission(
+					_group.getGroupId(), _ROOT_MODEL_RESOURCE_NAME,
+					_group.getGroupId(), _ADD_SITE_TEST2_ACTION);
+
+				Assert.assertTrue(hasPermission);
+			}
+			finally {
+				ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+					_user.getCompanyId(), _ROOT_MODEL_RESOURCE_NAME,
+					ResourceConstants.SCOPE_INDIVIDUAL, _group.getGroupId());
+			}
 		}
 		finally {
 			ResourceLocalServiceUtil.deleteResource(
@@ -909,6 +946,8 @@ public class PermissionCheckerTest {
 	}
 
 	private static final String _ADD_SITE_TEST_ACTION = "ADD_SITE_TEST";
+
+	private static final String _ADD_SITE_TEST2_ACTION = "ADD_SITE_TEST2";
 
 	private static final String _ADD_TEST_ACTION = "ADD_TEST";
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/dependencies/resource-actions.xml
@@ -60,6 +60,7 @@
 		<permissions>
 			<supports>
 				<action-key>ADD_SITE_TEST</action-key>
+				<action-key>ADD_SITE_TEST2</action-key>
 			</supports>
 			<site-member-defaults>
 				<action-key>ADD_SITE_TEST</action-key>

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/BaseResourcePermissionChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/BaseResourcePermissionChecker.java
@@ -18,10 +18,7 @@ import com.liferay.exportimport.kernel.staging.permission.StagingPermissionUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 
 /**
  * @author Preston Crary
@@ -37,25 +34,6 @@ public abstract class BaseResourcePermissionChecker
 
 		if ((group != null) && group.isStagingGroup()) {
 			classPK = group.getLiveGroupId();
-		}
-
-		try {
-			int count =
-				ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
-					permissionChecker.getCompanyId(), name,
-					ResourceConstants.SCOPE_INDIVIDUAL,
-					String.valueOf(classPK));
-
-			if (count == 0) {
-				ResourceLocalServiceUtil.addResources(
-					permissionChecker.getCompanyId(), classPK, 0, name, classPK,
-					false, true, true);
-			}
-		}
-		catch (Exception e) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(e, e);
-			}
 		}
 
 		return permissionChecker.hasPermission(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.security.permission;
 
+import aQute.bnd.annotation.ProviderType;
 import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
@@ -30,6 +31,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author Brian Wing Shun Chan
  * @author Daeyoung Song
  */
+@ProviderType
 public interface ResourceActions {
 
 	public void checkAction(String name, String actionId)

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.security.permission;
 
 import aQute.bnd.annotation.ProviderType;
+
 import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActions.java
@@ -116,11 +116,15 @@ public interface ResourceActions {
 	public List<Role> getRoles(
 		long companyId, Group group, String modelResource, int[] roleTypes);
 
+	public String[] getRootModelResources();
+
 	public boolean hasModelResourceActions(String name);
 
 	public boolean isOrganizationModelResource(String modelResource);
 
 	public boolean isPortalModelResource(String modelResource);
+
+	public boolean isRootModelResource(String modelResource);
 
 	public void read(
 			String servletContextName, ClassLoader classLoader, String source)

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActionsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/ResourceActionsUtil.java
@@ -223,6 +223,10 @@ public class ResourceActionsUtil {
 			companyId, group, modelResource, roleTypes);
 	}
 
+	public static String[] getRootModelResources() {
+		return getResourceActions().getRootModelResources();
+	}
+
 	public static boolean hasModelResourceActions(String name) {
 		return getResourceActions().hasModelResourceActions(name);
 	}
@@ -233,6 +237,10 @@ public class ResourceActionsUtil {
 
 	public static boolean isPortalModelResource(String modelResource) {
 		return getResourceActions().isPortalModelResource(modelResource);
+	}
+
+	public static boolean isRootModelResource(String modelResource) {
+		return getResourceActions().isRootModelResource(modelResource);
 	}
 
 	public static void read(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Hi Brian,

resending https://github.com/brianchandotcom/liferay-portal/pull/38485. 

https://issues.liferay.com/browse/LPS-63695

It wasn't system.packages.extra.mf this time but `com.liferay.portal.kernel.security.permission` super-package version change. 

Staging-security module implements PermissionChecker from that package and need to update referenced version to be compatible with what is provided in runtime.

Thanks.
