### PR TITLE
LPS-64788 Autogenerated

### DIFF
--- a/modules/util/portal-tools-service-builder/build.gradle
+++ b/modules/util/portal-tools-service-builder/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 	compile group: "log4j", name: "log4j", version: "1.2.17"
 	compile group: "org.freemarker", name: "freemarker", transitive: false, version: "2.3.23"
 
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "org.apache.ant", name: "ant", transitive: false, version: "1.9.4"

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1725,7 +1725,9 @@
 		<field name="userNotificationEventId" type="long" />
 		<field name="companyId" type="long" />
 		<field name="userId" type="long" />
-		<field name="type" type="String" />
+		<field name="type" type="String">
+			<hint name="max-length">200</hint>
+		</field>
 		<field name="timestamp" type="long" />
 		<field name="deliveryType" type="int" />
 		<field name="deliverBy" type="long" />

--- a/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
@@ -95,7 +95,7 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 		TABLE_COLUMNS_MAP.put("archived", Types.BOOLEAN);
 	}
 
-	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(75) null,timestamp LONG,deliveryType INTEGER,deliverBy LONG,delivered BOOLEAN,payload TEXT null,actionRequired BOOLEAN,archived BOOLEAN)";
+	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(200) null,timestamp LONG,deliveryType INTEGER,deliverBy LONG,delivered BOOLEAN,payload TEXT null,actionRequired BOOLEAN,archived BOOLEAN)";
 	public static final String TABLE_SQL_DROP = "drop table UserNotificationEvent";
 	public static final String ORDER_BY_JPQL = " ORDER BY userNotificationEvent.timestamp DESC";
 	public static final String ORDER_BY_SQL = " ORDER BY UserNotificationEvent.timestamp DESC";

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
@@ -34,6 +34,7 @@ import com.liferay.portal.upgrade.v7_0_0.UpgradeLookAndFeel;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMembershipRequest;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMessageBoards;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeModules;
+import com.liferay.portal.upgrade.v7_0_0.UpgradeNotifications;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeOrgLabor;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeOrganization;
 import com.liferay.portal.upgrade.v7_0_0.UpgradePhone;
@@ -85,6 +86,7 @@ public class UpgradeProcess_7_0_0 extends UpgradeProcess {
 		upgrade(UpgradeMembershipRequest.class);
 		upgrade(UpgradeMessageBoards.class);
 		upgrade(UpgradeModules.class);
+		upgrade(UpgradeNotifications.class);
 		upgrade(UpgradeOrganization.class);
 		upgrade(UpgradeOrgLabor.class);
 		upgrade(UpgradePhone.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.v7_0_0.util.UserNotificationEventTable;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class UpgradeNotifications extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		alter(
+			UserNotificationEventTable.class,
+			new AlterColumnType("type_", "VARCHAR(200) null"));
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/util/UserNotificationEventTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/util/UserNotificationEventTable.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class UserNotificationEventTable {
+
+	public static final String TABLE_NAME = "UserNotificationEvent";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT},
+		{"uuid_", Types.VARCHAR},
+		{"userNotificationEventId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"type_", Types.VARCHAR},
+		{"timestamp", Types.BIGINT},
+		{"deliveryType", Types.INTEGER},
+		{"deliverBy", Types.BIGINT},
+		{"delivered", Types.BOOLEAN},
+		{"payload", Types.CLOB},
+		{"actionRequired", Types.BOOLEAN},
+		{"archived", Types.BOOLEAN}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("userNotificationEventId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("type_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("timestamp", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("deliveryType", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("deliverBy", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("delivered", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("payload", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("actionRequired", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("archived", Types.BOOLEAN);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(75) null,timestamp LONG,deliveryType INTEGER,deliverBy LONG,delivered BOOLEAN,payload TEXT null,actionRequired BOOLEAN,archived BOOLEAN)";
+
+	public static final String TABLE_SQL_DROP = "drop table UserNotificationEvent";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:75$])",
+		"create index IX_5CE95F03 on UserNotificationEvent (userId, actionRequired, archived)",
+		"create index IX_3DBB361A on UserNotificationEvent (userId, archived)",
+		"create index IX_E32CC19 on UserNotificationEvent (userId, delivered, actionRequired)",
+		"create index IX_C4EFBD45 on UserNotificationEvent (userId, deliveryType, actionRequired, archived)",
+		"create index IX_A87A585C on UserNotificationEvent (userId, deliveryType, archived)",
+		"create index IX_A6F83617 on UserNotificationEvent (userId, deliveryType, delivered, actionRequired)",
+		"create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:75$], deliveryType, delivered)",
+		"create index IX_A6BAFDFE on UserNotificationEvent (uuid_[$COLUMN_LENGTH:75$], companyId)"
+	};
+
+}

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -501,14 +501,14 @@ create unique index IX_D1C44A6E on UserIdMapper (userId, type_[$COLUMN_LENGTH:75
 
 create unique index IX_8B6E3ACE on UserNotificationDelivery (userId, portletId[$COLUMN_LENGTH:200$], classNameId, notificationType, deliveryType);
 
-create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:75$]);
+create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:200$]);
 create index IX_5CE95F03 on UserNotificationEvent (userId, actionRequired, archived);
 create index IX_3DBB361A on UserNotificationEvent (userId, archived);
 create index IX_E32CC19 on UserNotificationEvent (userId, delivered, actionRequired);
 create index IX_C4EFBD45 on UserNotificationEvent (userId, deliveryType, actionRequired, archived);
 create index IX_A87A585C on UserNotificationEvent (userId, deliveryType, archived);
 create index IX_A6F83617 on UserNotificationEvent (userId, deliveryType, delivered, actionRequired);
-create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:75$], deliveryType, delivered);
+create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:200$], deliveryType, delivered);
 create index IX_A6BAFDFE on UserNotificationEvent (uuid_[$COLUMN_LENGTH:75$], companyId);
 
 create index IX_29BA1CF5 on UserTracker (companyId);

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -1648,7 +1648,7 @@ create table UserNotificationEvent (
 	userNotificationEventId LONG not null primary key,
 	companyId LONG,
 	userId LONG,
-	type_ VARCHAR(75) null,
+	type_ VARCHAR(200) null,
 	timestamp LONG,
 	deliveryType INTEGER,
 	deliverBy LONG,


### PR DESCRIPTION
@brianchandotcom @sergiogonzalez I didn't put the new `UpgradeNotifications` step in 7.0.1, as this fixes a bug in the 7.0.0 upgrade. If `UpgradeNotifications` is moved into 7.0.1, `UpgradePortletId` will fail in 7.0.0 if there are notifications for portlets with a portlet Id > 75 characters.

Thanks!
