### PR TITLE
Lps 64990

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -63,6 +63,7 @@ import java.io.Serializable;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1911,12 +1912,16 @@ public class LanguageImpl implements Language, Serializable {
 					LocaleUtil.fromLanguageId(languageId, false));
 			}
 
-			_availableLocales = new HashSet<>(_languageIdLocalesMap.values());
+			_availableLocales = Collections.unmodifiableSet(
+				new HashSet<>(_languageIdLocalesMap.values()));
 
-			_supportedLocalesSet = new HashSet<>(
+			Set<Locale> supportedLocalesSet = new HashSet<>(
 				_languageIdLocalesMap.values());
 
-			_supportedLocalesSet.removeAll(_localesBetaSet);
+			supportedLocalesSet.removeAll(_localesBetaSet);
+
+			_supportedLocalesSet = Collections.unmodifiableSet(
+				supportedLocalesSet);
 		}
 
 		private final Set<Locale> _availableLocales;


### PR DESCRIPTION
@brianchandotcom it was actually me that added the copy protection a couple weeks ago to the _availableLocales as a side affect(not on purpose) of a logic change. Before that we were just returning the inner mutable set. So I thought we should restore the behavior. But if you prefer to unmodifiable it, that's good too, just we have to do the same to _supportedLocalesSet too to keep things consistent.
