### PR TITLE
LPS-61099

### DIFF
--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayDefaultsPlugin.java
@@ -524,6 +524,23 @@ public class LiferayDefaultsPlugin extends BaseDefaultsPlugin<LiferayPlugin> {
 				StringUtil.capitalize(installCacheTask.getName()),
 			MavenPlugin.INSTALL_TASK_NAME);
 
+		installCacheTask.doFirst(
+			new Action<Task>() {
+
+				@Override
+				public void execute(Task task) {
+					String result = getGitResult(
+						task.getProject(), "status", "--porcelain", ".");
+
+					if (Validator.isNotNull(result)) {
+						throw new GradleException(
+							"Unable to install project to the local Gradle " +
+								"cache, commit changes first");
+					}
+				}
+
+			});
+
 		installCacheTask.setArtifactGroup(
 			new Callable<Object>() {
 

--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayDefaultsPlugin.java
@@ -812,7 +812,8 @@ public class LiferayDefaultsPlugin extends BaseDefaultsPlugin<LiferayPlugin> {
 
 				@Override
 				public String call() throws Exception {
-					return getGitHead(writePropertiesTask.getProject());
+					return getGitResult(
+						writePropertiesTask.getProject(), "rev-parse", "HEAD");
 				}
 
 			});
@@ -2484,7 +2485,7 @@ public class LiferayDefaultsPlugin extends BaseDefaultsPlugin<LiferayPlugin> {
 		return (Map<String, String>)bundleExtension.getInstructions();
 	}
 
-	protected String getGitHead(Project project) {
+	protected String getGitResult(Project project, final Object ... args) {
 		final ByteArrayOutputStream byteArrayOutputStream =
 			new ByteArrayOutputStream();
 
@@ -2493,15 +2494,16 @@ public class LiferayDefaultsPlugin extends BaseDefaultsPlugin<LiferayPlugin> {
 
 				@Override
 				public void execute(ExecSpec execSpec) {
-					execSpec.commandLine("git", "rev-parse", "HEAD");
+					execSpec.args(args);
+					execSpec.setExecutable("git");
 					execSpec.setStandardOutput(byteArrayOutputStream);
 				}
 
 			});
 
-		String gitHead = byteArrayOutputStream.toString();
+		String result = byteArrayOutputStream.toString();
 
-		return gitHead.trim();
+		return result.trim();
 	}
 
 	protected File getLibDir(Project project) {

--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/util/FileUtil.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/util/FileUtil.java
@@ -19,6 +19,7 @@ import com.liferay.gradle.util.ArrayUtil;
 import groovy.lang.Closure;
 
 import java.io.File;
+import java.io.FileFilter;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,6 +39,22 @@ import org.gradle.api.tasks.TaskInputs;
  * @author Andrea Di Giorgi
  */
 public class FileUtil extends com.liferay.gradle.util.FileUtil {
+
+	public static File[] getDirectories(File dir) {
+		return dir.listFiles(
+			new FileFilter() {
+
+				@Override
+				public boolean accept(File file) {
+					if (file.isDirectory()) {
+						return true;
+					}
+
+					return false;
+				}
+
+			});
+	}
 
 	public static FileTree getJarsFileTree(
 		Project project, File dir, String ... excludes) {


### PR DESCRIPTION
Hi!
This PR adds a check so it's not possible to run `gradlew installCache` if the module dir is dirty. Moreover, it creates a new `commitCache` task, which:
1. calls `installCache`
2. remove the current version of a module in the cache, if it's the only one
3. adds and commit the new cached jar/pom

It's possible to call `gradlew installCache -Psnapshot` or `gradlew commitCache -Psnapshot` to add a snapshot version instead of a release.
