### PR TITLE
LPS-65115 "app.title.suffix" should be consistent with marketplace title

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1549,12 +1549,12 @@ rerun your task.
 					<matches pattern="ee-.+" string="${liferay.releng.branch}" />
 				</or>
 				<then>
-					<var name="liferay.releng.app.title.suffix" value="\s EE" />
+					<var name="liferay.releng.app.title.suffix" value="" />
 					<var name="liferay.releng.public" value="false" />
 					<var name="liferay.releng.supported" value="true" />
 				</then>
 				<else>
-					<var name="liferay.releng.app.title.suffix" value="" />
+					<var name="liferay.releng.app.title.suffix" value="\s CE" />
 					<var name="liferay.releng.public" value="true" />
 					<var name="liferay.releng.supported" value="false" />
 				</else>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-65115
Marketplace titles will have "CE" for CE apps and no suffix for EE apps.  
app titles in app.bnd should be consistent with app title on marketplace. 
