### PR TITLE
LPS-65086 PACL test should allow oracle driver to read system properties

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/test/dependencies/WEB-INF/liferay-plugin-package.properties
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/test/dependencies/WEB-INF/liferay-plugin-package.properties
@@ -103,6 +103,7 @@ security-manager-properties-read=\
     base.path,\
     java.home,\
     java.util.logging.*,\
+    oracle.jdbc.driver.*,\
     org.postgresql.*
 
 security-manager-search-engine-ids=\


### PR DESCRIPTION
Please sync back to ee-7.0.x
