### PR TITLE
LPS-64795 Forward port to master: LPS-60259 Asset publisher cannot order by a date field of a web content based on a structure

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/util/impl/DDMIndexerImpl.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/util/impl/DDMIndexerImpl.java
@@ -106,10 +106,10 @@ public class DDMIndexerImpl implements DDMIndexer {
 						document.addKeywordSortable(name, (Boolean[])value);
 					}
 					else if (value instanceof Date) {
-						document.addDate(name, (Date)value);
+						document.addDateSortable(name, (Date)value);
 					}
 					else if (value instanceof Date[]) {
-						document.addDate(name, (Date[])value);
+						document.addDateSortable(name, (Date[])value);
 					}
 					else if (value instanceof Double) {
 						document.addNumberSortable(name, (Double)value);

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/search/TestOrderHelper.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/search/TestOrderHelper.java
@@ -86,6 +86,13 @@ public abstract class TestOrderHelper {
 			FieldConstants.BOOLEAN, DDMFormFieldType.CHECKBOX);
 	}
 
+	public void testOrderByDDMDateField() throws Exception {
+		testOrderByDDMField(
+			new String[] {"20160417192501", "20160417192510", "20160417192503"},
+			new String[] {"20160417192501", "20160417192503", "20160417192510"},
+			FieldConstants.DATE, DDMFormFieldType.DATE);
+	}
+
 	public void testOrderByDDMIntegerField() throws Exception {
 		testOrderByDDMField(
 			new String[] {"1", "10", "3", "2"},

--- a/modules/apps/foundation/portal-search/portal-search/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.2.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "commons-lang", name: "commons-lang", version: "2.6"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "6.0.0"

--- a/modules/apps/web-experience/journal/journal-test/build.gradle
+++ b/modules/apps/web-experience/journal/journal-test/build.gradle
@@ -15,11 +15,11 @@ dependencies {
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.0.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.dynamic.data.mapping.io", version: "2.0.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.dynamic.data.mapping.service", version: "2.0.0"
-	testIntegrationCompile group: "com.liferay", name: "com.liferay.dynamic.data.mapping.test.util", version: "2.0.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.journal.api", version: "2.0.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.journal.service", version: "2.0.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.journal.web", version: "1.0.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	testIntegrationCompile project(":apps:forms-and-workflow:dynamic-data-mapping:dynamic-data-mapping-test-util")
 }

--- a/modules/apps/web-experience/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
+++ b/modules/apps/web-experience/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
@@ -167,6 +167,14 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 	}
 
 	@Test
+	public void testOrderByDDMDateField() throws Exception {
+		TestOrderHelper testOrderHelper =
+			new JournalArticleSearchTestOrderHelper(_ddmIndexer, group);
+
+		testOrderHelper.testOrderByDDMDateField();
+	}
+
+	@Test
 	public void testOrderByDDMIntegerField() throws Exception {
 		TestOrderHelper testOrderHelper =
 			new JournalArticleSearchTestOrderHelper(_ddmIndexer, group);

--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -1,11 +1,11 @@
 Manifest-Version: 1.0
-Bnd-LastModified: 1460926291243
+Bnd-LastModified: 1460939914276
 Bundle-ManifestVersion: 2
 Bundle-Name: portal-bootstrap
 Bundle-SymbolicName: portal-bootstrap
 Bundle-Vendor: Liferay, Inc.
 Bundle-Version: 1.0.0
-Created-By: 1.7.0_71 (Oracle Corporation)
+Created-By: 1.7.0_45 (Oracle Corporation)
 Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  u.impl;version="4.0.1";uses:="com.liferay.ibm.icu.math,com.liferay.ib
  m.icu.text,com.liferay.ibm.icu.util",com.liferay.ibm.icu.impl.coll;ve
@@ -2860,7 +2860,7 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  rtal.kernel.messaging,com.liferay.portal.kernel.scheduler",com.lifera
  y.portal.kernel.scripting;version="7.0.0";uses:="com.liferay.portal.k
  ernel.exception,javax.portlet",com.liferay.portal.kernel.search;versi
- on="7.1.0";uses:="com.liferay.asset.kernel.model,com.liferay.expando.
+ on="7.2.0";uses:="com.liferay.asset.kernel.model,com.liferay.expando.
  kernel.model,com.liferay.portal.kernel.backgroundtask,com.liferay.por
  tal.kernel.comment,com.liferay.portal.kernel.exception,com.liferay.po
  rtal.kernel.json,com.liferay.portal.kernel.messaging,com.liferay.port
@@ -4369,6 +4369,8 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  0.0",org.apache.commons.validator.routines;version="1.5.0",org.apache
  .xml.serializer;version="2.7.1",org.objectweb.asm.attrs;version="5.0.
  1"
+Git-Descriptor: 51c60f6-dirty
+Git-SHA: 51c60f68b200e8f0e07092c2f3cc9fb4fe92be87
 Javac-Debug: on
 Javac-Deprecation: off
 Javac-Encoding: UTF-8

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.search;
 
+import aQute.bnd.annotation.ProviderType;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +33,7 @@ import java.util.Map;
  * @author Brian Wing Shun Chan
  * @author Bruno Farache
  */
+@ProviderType
 public interface Document extends Cloneable, Serializable {
 
 	public void add(Field field);

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Document.java
@@ -39,6 +39,10 @@ public interface Document extends Cloneable, Serializable {
 
 	public void addDate(String name, Date[] values);
 
+	public void addDateSortable(String name, Date value);
+
+	public void addDateSortable(String name, Date[] values);
+
 	public void addFile(String name, byte[] bytes, String fileExt)
 		throws IOException;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java
@@ -144,6 +144,34 @@ public class DocumentImpl implements Document {
 	}
 
 	@Override
+	public void addDateSortable(String name, Date value) {
+		if (value == null) {
+			return;
+		}
+
+		addDateSortable(name, new Date[] {value});
+	}
+
+	@Override
+	public void addDateSortable(String name, Date[] values) {
+		if (values == null) {
+			return;
+		}
+
+		String[] dates = new String[values.length];
+		Long[] datesTime = new Long[values.length];
+
+		for (int i = 0; i < values.length; i++) {
+			dates[i] = _dateFormat.format(values[i]);
+			datesTime[i] = values[i].getTime();
+		}
+
+		createSortableNumericField(name, true, datesTime);
+
+		addKeyword(name, dates);
+	}
+
+	@Override
 	public void addFile(String name, byte[] bytes, String fileExt) {
 		InputStream is = new UnsyncByteArrayInputStream(bytes);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0


### PR DESCRIPTION
Author: @juangon
Reviewer: @arboliveira

@brianchandotcom Both this PR and https://github.com/brianchandotcom/liferay-portal/pull/38866 add new methods to the Document interface in portal-kernel, with a minor packageinfo bump. Semver commits were duplicated just to make CI happy.
