### PR TITLE
LPS-65150 Return record and journal information when querying a list of assets

### DIFF
--- a/modules/apps/screens/screens-service/build.gradle
+++ b/modules/apps/screens/screens-service/build.gradle
@@ -5,6 +5,7 @@ buildService {
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.asset.publisher.web", version: "1.0.0"
+	provided group: "com.liferay", name: "com.liferay.calendar.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.lists.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.lists.service", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.0.0"

--- a/modules/apps/screens/screens-service/service.xml
+++ b/modules/apps/screens/screens-service/service.xml
@@ -13,6 +13,7 @@
 		<reference entity="PortletItem" package-path="com.liferay.portal" />
 		<reference entity="PortletPreferences" package-path="com.liferay.portal" />
 		<reference entity="AssetEntry" package-path="com.liferay.portlet.asset" />
+		<reference entity="BlogsEntry" package-path="com.liferay.portlet.blogs" />
 		<reference entity="DLApp" package-path="com.liferay.portlet.documentlibrary" />
 		<reference entity="DLFileEntry" package-path="com.liferay.portlet.documentlibrary" />
 	</entity>

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/base/ScreensAssetEntryServiceBaseImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/base/ScreensAssetEntryServiceBaseImpl.java
@@ -16,6 +16,8 @@ package com.liferay.screens.service.base;
 
 import com.liferay.asset.kernel.service.persistence.AssetEntryPersistence;
 
+import com.liferay.blogs.kernel.service.persistence.BlogsEntryPersistence;
+
 import com.liferay.document.library.kernel.service.persistence.DLFileEntryPersistence;
 
 import com.liferay.dynamic.data.lists.service.persistence.DDLRecordPersistence;
@@ -692,6 +694,63 @@ public abstract class ScreensAssetEntryServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the blogs entry local service.
+	 *
+	 * @return the blogs entry local service
+	 */
+	public com.liferay.blogs.kernel.service.BlogsEntryLocalService getBlogsEntryLocalService() {
+		return blogsEntryLocalService;
+	}
+
+	/**
+	 * Sets the blogs entry local service.
+	 *
+	 * @param blogsEntryLocalService the blogs entry local service
+	 */
+	public void setBlogsEntryLocalService(
+		com.liferay.blogs.kernel.service.BlogsEntryLocalService blogsEntryLocalService) {
+		this.blogsEntryLocalService = blogsEntryLocalService;
+	}
+
+	/**
+	 * Returns the blogs entry remote service.
+	 *
+	 * @return the blogs entry remote service
+	 */
+	public com.liferay.blogs.kernel.service.BlogsEntryService getBlogsEntryService() {
+		return blogsEntryService;
+	}
+
+	/**
+	 * Sets the blogs entry remote service.
+	 *
+	 * @param blogsEntryService the blogs entry remote service
+	 */
+	public void setBlogsEntryService(
+		com.liferay.blogs.kernel.service.BlogsEntryService blogsEntryService) {
+		this.blogsEntryService = blogsEntryService;
+	}
+
+	/**
+	 * Returns the blogs entry persistence.
+	 *
+	 * @return the blogs entry persistence
+	 */
+	public BlogsEntryPersistence getBlogsEntryPersistence() {
+		return blogsEntryPersistence;
+	}
+
+	/**
+	 * Sets the blogs entry persistence.
+	 *
+	 * @param blogsEntryPersistence the blogs entry persistence
+	 */
+	public void setBlogsEntryPersistence(
+		BlogsEntryPersistence blogsEntryPersistence) {
+		this.blogsEntryPersistence = blogsEntryPersistence;
+	}
+
+	/**
 	 * Returns the d l app local service.
 	 *
 	 * @return the d l app local service
@@ -892,6 +951,12 @@ public abstract class ScreensAssetEntryServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.asset.kernel.service.AssetEntryService assetEntryService;
 	@ServiceReference(type = AssetEntryPersistence.class)
 	protected AssetEntryPersistence assetEntryPersistence;
+	@ServiceReference(type = com.liferay.blogs.kernel.service.BlogsEntryLocalService.class)
+	protected com.liferay.blogs.kernel.service.BlogsEntryLocalService blogsEntryLocalService;
+	@ServiceReference(type = com.liferay.blogs.kernel.service.BlogsEntryService.class)
+	protected com.liferay.blogs.kernel.service.BlogsEntryService blogsEntryService;
+	@ServiceReference(type = BlogsEntryPersistence.class)
+	protected BlogsEntryPersistence blogsEntryPersistence;
 	@ServiceReference(type = com.liferay.document.library.kernel.service.DLAppLocalService.class)
 	protected com.liferay.document.library.kernel.service.DLAppLocalService dlAppLocalService;
 	@ServiceReference(type = com.liferay.document.library.kernel.service.DLAppService.class)

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.PortletItem;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -189,6 +190,9 @@ public class ScreensAssetEntryServiceImpl
 		else if (className.equals("com.liferay.journal.model.JournalArticle")) {
 			return getJournalArticleJSONObject(assetEntry);
 		}
+		else if (className.equals(User.class.getName())) {
+			return getUserJSONObject(assetEntry);
+		}
 
 		return JSONFactoryUtil.createJSONObject();
 	}
@@ -283,6 +287,21 @@ public class ScreensAssetEntryServiceImpl
 		jsonObject.remove("content");
 
 		return journalArticleJSONObject;
+	}
+
+	protected JSONObject getUserJSONObject(AssetEntry assetEntry)
+		throws PortalException {
+
+		User user = userService.getUserById(assetEntry.getClassPK());
+
+		JSONObject userJSONObject = JSONFactoryUtil.createJSONObject();
+
+		userJSONObject.put(
+			"user",
+			JSONFactoryUtil.createJSONObject(
+				JSONFactoryUtil.looseSerialize(user)));
+
+		return userJSONObject;
 	}
 
 	protected JSONArray toJSONArray(

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -17,6 +17,8 @@ package com.liferay.screens.service.impl;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
+import com.liferay.blogs.kernel.model.BlogsEntry;
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleResource;
 import com.liferay.journal.service.permission.JournalArticlePermission;
@@ -172,9 +174,10 @@ public class ScreensAssetEntryServiceImpl
 
 		String className = assetEntry.getClassName();
 
-		if (className.equals(
-				"com.liferay.document.library.kernel.model.DLFileEntry")) {
-
+		if (className.equals(BlogsEntry.class.getName())) {
+			return getBlogsEntryJSONObject(assetEntry);
+		}
+		else if (className.equals(DLFileEntry.class.getName())) {
 			return getFileEntryJSONObject(assetEntry);
 		}
 		else if (className.equals(
@@ -188,6 +191,22 @@ public class ScreensAssetEntryServiceImpl
 		}
 
 		return JSONFactoryUtil.createJSONObject();
+	}
+
+	protected JSONObject getBlogsEntryJSONObject(AssetEntry assetEntry)
+		throws PortalException {
+
+		BlogsEntry blogsEntry = blogsEntryService.getEntry(
+			assetEntry.getClassPK());
+
+		JSONObject blogsEntryJSONObject = JSONFactoryUtil.createJSONObject();
+
+		blogsEntryJSONObject.put(
+			"blogsEntry",
+			JSONFactoryUtil.createJSONObject(
+				JSONFactoryUtil.looseSerialize(blogsEntry)));
+
+		return blogsEntryJSONObject;
 	}
 
 	protected JSONObject getFileEntryJSONObject(AssetEntry assetEntry)

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -18,6 +18,8 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.publisher.web.util.AssetPublisherUtil;
 import com.liferay.blogs.kernel.model.BlogsEntry;
+import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.calendar.service.CalendarBookingService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleResource;
@@ -46,6 +48,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.spring.extender.service.ServiceReference;
 import com.liferay.portlet.asset.service.permission.AssetEntryPermission;
 import com.liferay.screens.service.base.ScreensAssetEntryServiceBaseImpl;
 
@@ -178,6 +181,9 @@ public class ScreensAssetEntryServiceImpl
 		if (className.equals(BlogsEntry.class.getName())) {
 			return getBlogsEntryJSONObject(assetEntry);
 		}
+		else if (className.equals(CalendarBooking.class.getName())) {
+			return getCalendarJSONObject(assetEntry);
+		}
 		else if (className.equals(DLFileEntry.class.getName())) {
 			return getFileEntryJSONObject(assetEntry);
 		}
@@ -211,6 +217,23 @@ public class ScreensAssetEntryServiceImpl
 				JSONFactoryUtil.looseSerialize(blogsEntry)));
 
 		return blogsEntryJSONObject;
+	}
+
+	protected JSONObject getCalendarJSONObject(AssetEntry assetEntry)
+		throws PortalException {
+
+		CalendarBooking calendarBooking =
+			_calendarBookingService.getCalendarBooking(assetEntry.getClassPK());
+
+		JSONObject calendarBookingJSONObject =
+			JSONFactoryUtil.createJSONObject();
+
+		calendarBookingJSONObject.put(
+			"calendarBooking",
+			JSONFactoryUtil.createJSONObject(
+				JSONFactoryUtil.looseSerialize(calendarBooking)));
+
+		return calendarBookingJSONObject;
 	}
 
 	protected JSONObject getFileEntryJSONObject(AssetEntry assetEntry)
@@ -325,5 +348,8 @@ public class ScreensAssetEntryServiceImpl
 
 		return jsonArray;
 	}
+
+	@ServiceReference(type = CalendarBookingService.class)
+	private CalendarBookingService _calendarBookingService;
 
 }

--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.blogs.kernel.model.BlogsEntry;
 import com.liferay.calendar.model.CalendarBooking;
 import com.liferay.calendar.service.CalendarBookingService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleResource;
 import com.liferay.journal.service.permission.JournalArticlePermission;
@@ -187,13 +188,11 @@ public class ScreensAssetEntryServiceImpl
 		else if (className.equals(DLFileEntry.class.getName())) {
 			return getFileEntryJSONObject(assetEntry);
 		}
-		else if (className.equals(
-					"com.liferay.dynamic.data.lists.model.DDLRecord")) {
-
+		else if (className.equals(DDLRecord.class.getName())) {
 			return screensDDLRecordService.getDDLRecord(
 				assetEntry.getClassPK(), locale);
 		}
-		else if (className.equals("com.liferay.journal.model.JournalArticle")) {
+		else if (className.equals(JournalArticle.class.getName())) {
 			return getJournalArticleJSONObject(assetEntry);
 		}
 		else if (className.equals(User.class.getName())) {


### PR DESCRIPTION
As a developer querying for assets I want to receive the full entity instead of just the asset generic information to be able to create real entities and show specific fields of those entities in the results

I'll send also the 6.2 pull
