### PR TITLE
LPS-65204 Return className in asset list

### DIFF
--- a/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
+++ b/modules/apps/screens/screens-service/src/main/java/com/liferay/screens/service/impl/ScreensAssetEntryServiceImpl.java
@@ -313,6 +313,7 @@ public class ScreensAssetEntryServiceImpl
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 				JSONFactoryUtil.looseSerialize(assetEntry));
 
+			jsonObject.put("className", assetEntry.getClassName());
 			jsonObject.put("description", assetEntry.getDescription(locale));
 			jsonObject.put("locale", String.valueOf(locale));
 			jsonObject.put(


### PR DESCRIPTION
Right now we return the asset information and the asset classNameId. But we want to differenciate the type of asset for something more permanent instead of relying on attributes of the json object.
