### PR TITLE
LPS-65210 Fix typo in upgrade properties

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -136,7 +136,7 @@
         com.liferay.portal.upgrade.UpgradeProcess_6_1_0\,\
         com.liferay.portal.upgrade.UpgradeProcess_6_1_1\,\
         com.liferay.portal.upgrade.UpgradeProcess_6_2_0\,\
-        com.liferay.portal.upgrade.UpgradeProcess_7_0_0,\
+        com.liferay.portal.upgrade.UpgradeProcess_7_0_0\,\
         com.liferay.portal.upgrade.UpgradeProcess_7_0_1
 
     upgrade.processes.5203=${upgrade.processes.master}


### PR DESCRIPTION
Hi @brianchandotcom,

This issue was caused by:
https://github.com/liferay/liferay-portal/commit/995673309c5c6a80c193ef4ab7dc66850660e4c3#diff-70e7a8b9586d2a3f809fcc9e9e22e2b3R139

and that commit was tagged as LPS-40069, however that issue is not related to this kind of change, is there an error in the tag?

Thanks!
