### PR TITLE
LRQA-22944 Exclude the 'modules/private/util' folder from compilation

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -74,6 +74,7 @@
         apps/foundation/portal-cache/portal-cache-memory/,\
         apps/portal-search-solr/,\
         apps/wiki-engine-jspwiki/,\
+        private/util/,\
         sdk/,\
         test/,\
         third-party/,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-22944
