### PR TITLE
LPS-65039 Signed in user can became portal admin by common security misconfiguration and not following secure-by-default for admin.default.role.names

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8097,7 +8097,7 @@
     # Input a list of default regular role names separated by \n characters
     # that are associated with newly created users.
     #
-    admin.default.role.names=Power User\nUser
+    admin.default.role.names=User
 
     #
     # Input a list of default user group names separated by \n characters that


### PR DESCRIPTION
Hi Brian,

a small change with big impact. 

Default configuration was that every registered user was automatically power user. This is potentially dangerous as shown in the ticket because Power Users are trusted users. They have personal pages and can create content, program templates using portal services, upload files.

We agreed this change with @jorgeferrer and @david-truong.

/cc @stian-sigvartsen

Thanks.
