### PR TITLE
master-qa-24694

### DIFF
--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -217,6 +217,10 @@
 			<contains>com.liferay.portal.kernel.search.SearchException: Unable to delete</contains>
 			<matches></matches>
 		</ignore-error>
+		<ignore-error description="LPS-65283, temporarily ignore until issue is fixed.">
+			<contains>Unable to load class com.liferay.social.kernel.model.SocialActivityConstants</contains>
+			<matches></matches>
+		</ignore-error>
 		<ignore-error description="LRQA-14442, temporary workaround until Kiyoshi Lee fixes it">
 			<contains>[org_eclipse_equinox_http_servlet.*Framework Event Dispatcher: Equinox Container:</contains>
 			<matches></matches>


### PR DESCRIPTION
@brianchandotcom, we have 6 tests failing on CI that fail because of the error message in https://issues.liferay.com/browse/LPS-65283. This issue began occuring some time yesterday afternoon. This pull will ignore that error for now, so we can have cleaner results but the issue will still need to be fixed.
