### PR TITLE
LPS-64513 Search filters are not remembered when there is no result

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/facet/display/context/ScopeSearchFacetDisplayContext.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/facet/display/context/ScopeSearchFacetDisplayContext.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.facet.display.context;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author André de Oliveira
+ */
+public class ScopeSearchFacetDisplayContext {
+
+	public ScopeSearchFacetDisplayContext(
+		Facet facet, String fieldParam, Locale locale, int countThreshold,
+		int maxTerms, boolean showCounts, GroupLocalService groupLocalService) {
+
+		_facet = facet;
+		_fieldParam = fieldParam;
+		_locale = locale;
+		_countThreshold = countThreshold;
+		_maxTerms = maxTerms;
+		_showCounts = showCounts;
+		_groupLocalService = groupLocalService;
+
+		_groupId = GetterUtil.getLong(fieldParam);
+	}
+
+	public String getFieldParamInputName() {
+		return _facet.getFieldId();
+	}
+
+	public String getFieldParamInputValue() {
+		return _fieldParam;
+	}
+
+	public List<ScopeSearchFacetTermDisplayContext> getTermDisplayContexts() {
+		FacetCollector facetCollector = _facet.getFacetCollector();
+
+		List<TermCollector> termCollectors = facetCollector.getTermCollectors();
+
+		if (termCollectors.isEmpty()) {
+			return getEmptySearchResultTermDisplayContexts();
+		}
+
+		List<ScopeSearchFacetTermDisplayContext>
+			scopeSearchFacetTermDisplayContexts = new ArrayList<>(
+				termCollectors.size());
+
+		int limit = termCollectors.size();
+
+		if ((_maxTerms > 0) && (limit > _maxTerms)) {
+			limit = _maxTerms;
+		}
+
+		for (int i = 0; i < limit; i++) {
+			TermCollector termCollector = termCollectors.get(i);
+
+			long groupId = GetterUtil.getLong(termCollector.getTerm());
+
+			ScopeSearchFacetTermDisplayContext
+				scopeSearchFacetTermDisplayContext = getTermDisplayContext(
+					groupId, termCollector);
+
+			if (scopeSearchFacetTermDisplayContext != null) {
+				scopeSearchFacetTermDisplayContexts.add(
+					scopeSearchFacetTermDisplayContext);
+			}
+		}
+
+		return scopeSearchFacetTermDisplayContexts;
+	}
+
+	public boolean isNothingSelected() {
+		if (_fieldParam.equals("0")) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public boolean isRenderNothing() {
+		if (_groupId != 0) {
+			return false;
+		}
+
+		FacetCollector facetCollector = _facet.getFacetCollector();
+
+		List<TermCollector> termCollectors = facetCollector.getTermCollectors();
+
+		if (!termCollectors.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	protected List<ScopeSearchFacetTermDisplayContext>
+		getEmptySearchResultTermDisplayContexts() {
+
+		ScopeSearchFacetTermDisplayContext scopeSearchFacetTermDisplayContext =
+			getTermDisplayContext(_groupId, 0, true);
+
+		if (scopeSearchFacetTermDisplayContext == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.singletonList(scopeSearchFacetTermDisplayContext);
+	}
+
+	protected ScopeSearchFacetTermDisplayContext getTermDisplayContext(
+		long groupId, int count, boolean selected) {
+
+		Group group = _groupLocalService.fetchGroup(groupId);
+
+		if (group == null) {
+			return null;
+		}
+
+		return new ScopeSearchFacetTermDisplayContext(
+			group, selected, count, _showCounts, _locale);
+	}
+
+	protected ScopeSearchFacetTermDisplayContext getTermDisplayContext(
+		long groupId, TermCollector termCollector) {
+
+		int count = termCollector.getFrequency();
+
+		if ((_countThreshold > 0) && (_countThreshold > count)) {
+			return null;
+		}
+
+		boolean selected = false;
+
+		if (groupId == _groupId) {
+			selected = true;
+		}
+
+		return getTermDisplayContext(groupId, count, selected);
+	}
+
+	private final int _countThreshold;
+	private final Facet _facet;
+	private final String _fieldParam;
+	private final long _groupId;
+	private final GroupLocalService _groupLocalService;
+	private final Locale _locale;
+	private final int _maxTerms;
+	private final boolean _showCounts;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/facet/display/context/ScopeSearchFacetTermDisplayContext.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/facet/display/context/ScopeSearchFacetTermDisplayContext.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.facet.display.context;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+
+import java.util.Locale;
+
+/**
+ * @author André de Oliveira
+ */
+public class ScopeSearchFacetTermDisplayContext {
+
+	public ScopeSearchFacetTermDisplayContext(
+		Group group, boolean selected, int count, boolean showCount,
+		Locale locale) {
+
+		_group = group;
+		_selected = selected;
+		_count = count;
+		_showCount = showCount;
+		_locale = locale;
+	}
+
+	public int getCount() {
+		return _count;
+	}
+
+	public String getDescriptiveName() throws PortalException {
+		return _group.getDescriptiveName(_locale);
+	}
+
+	public long getGroupId() {
+		return _group.getGroupId();
+	}
+
+	public boolean isSelected() {
+		return _selected;
+	}
+
+	public boolean isShowCount() {
+		return _showCount;
+	}
+
+	private final int _count;
+	private final Group _group;
+	private final Locale _locale;
+	private final boolean _selected;
+	private final boolean _showCount;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/init.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/init.jsp
@@ -16,6 +16,9 @@
 
 <%@ include file="/init.jsp" %>
 
+<%@ page import="com.liferay.portal.search.web.facet.display.context.ScopeSearchFacetDisplayContext" %><%@
+page import="com.liferay.portal.search.web.facet.display.context.ScopeSearchFacetTermDisplayContext" %>
+
 <%
 String randomNamespace = PortalUtil.generateRandomKey(request, _RANDOM_KEY_INPUT) + StringPool.UNDERLINE;
 

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
@@ -20,10 +20,12 @@
 if (Validator.isNull(fieldParam)) {
 	fieldParam = String.valueOf(searchDisplayContext.getSearchScopeGroupId());
 }
+
+long groupId = GetterUtil.getInteger(fieldParam);
 %>
 
 <c:choose>
-	<c:when test="<%= termCollectors.isEmpty() %>">
+	<c:when test="<%= termCollectors.isEmpty() && (groupId == 0) %>">
 		<aui:input autocomplete="off" name="<%= HtmlUtil.escapeAttribute(facet.getFieldName()) %>" type="hidden" value="<%= fieldParam %>" />
 	</c:when>
 	<c:otherwise>
@@ -50,7 +52,21 @@ if (Validator.isNull(fieldParam)) {
 						</li>
 
 						<%
-						long groupId = GetterUtil.getInteger(fieldParam);
+						if (termCollectors.isEmpty()) {
+							Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+
+							if (group != null) {
+						%>
+
+								<li class="facet-value">
+									<a class="<%= "text-primary" %>" data-value="<%= groupId %>" href="javascript:;">
+										<%= HtmlUtil.escape(group.getDescriptiveName(locale)) %>
+									</a>
+								</li>
+
+						<%
+							}
+						}
 
 						for (int i = 0; i < termCollectors.size(); i++) {
 							TermCollector termCollector = termCollectors.get(i);

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
@@ -21,21 +21,19 @@ if (Validator.isNull(fieldParam)) {
 	fieldParam = String.valueOf(searchDisplayContext.getSearchScopeGroupId());
 }
 
-long groupId = GetterUtil.getInteger(fieldParam);
+ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext =
+	new ScopeSearchFacetDisplayContext(
+		facet, fieldParam, locale, dataJSONObject.getInt("frequencyThreshold"),
+		dataJSONObject.getInt("maxTerms"),
+		dataJSONObject.getBoolean("showAssetCount", true),
+		GroupLocalServiceUtil.getService());
 %>
 
 <c:choose>
-	<c:when test="<%= termCollectors.isEmpty() && (groupId == 0) %>">
-		<aui:input autocomplete="off" name="<%= HtmlUtil.escapeAttribute(facet.getFieldName()) %>" type="hidden" value="<%= fieldParam %>" />
+	<c:when test="<%= scopeSearchFacetDisplayContext.isRenderNothing() %>">
+		<aui:input autocomplete="off" name="<%= HtmlUtil.escapeAttribute(scopeSearchFacetDisplayContext.getFieldParamInputName()) %>" type="hidden" value="<%= scopeSearchFacetDisplayContext.getFieldParamInputValue() %>" />
 	</c:when>
 	<c:otherwise>
-
-		<%
-		int frequencyThreshold = dataJSONObject.getInt("frequencyThreshold");
-		int maxTerms = dataJSONObject.getInt("maxTerms");
-		boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
-		%>
-
 		<div class="panel panel-default">
 			<div class="panel-heading">
 				<div class="panel-title">
@@ -44,52 +42,25 @@ long groupId = GetterUtil.getInteger(fieldParam);
 			</div>
 			<div class="panel-body">
 				<div class="<%= cssClass %>" data-facetFieldName="<%= HtmlUtil.escapeAttribute(facet.getFieldId()) %>" id="<%= randomNamespace %>facet">
-					<aui:input autocomplete="off" name="<%= HtmlUtil.escapeAttribute(facet.getFieldId()) %>" type="hidden" value="<%= fieldParam %>" />
+					<aui:input autocomplete="off" name="<%= HtmlUtil.escapeAttribute(scopeSearchFacetDisplayContext.getFieldParamInputName()) %>" type="hidden" value="<%= scopeSearchFacetDisplayContext.getFieldParamInputValue() %>" />
 
 					<ul class="list-unstyled scopes">
 						<li class="default facet-value">
-							<a class="<%= fieldParam.equals("0") ? "text-primary" : "text-default" %>" data-value="0" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
+							<a class="<%= scopeSearchFacetDisplayContext.isNothingSelected() ? "text-primary" : "text-default" %>" data-value="0" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
 						</li>
 
 						<%
-						if (termCollectors.isEmpty()) {
-							Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+						List<ScopeSearchFacetTermDisplayContext> scopeSearchFacetTermDisplayContexts = scopeSearchFacetDisplayContext.getTermDisplayContexts();
 
-							if (group != null) {
-						%>
-
-								<li class="facet-value">
-									<a class="<%= "text-primary" %>" data-value="<%= groupId %>" href="javascript:;">
-										<%= HtmlUtil.escape(group.getDescriptiveName(locale)) %>
-									</a>
-								</li>
-
-						<%
-							}
-						}
-
-						for (int i = 0; i < termCollectors.size(); i++) {
-							TermCollector termCollector = termCollectors.get(i);
-
-							long curGroupId = GetterUtil.getInteger(termCollector.getTerm());
-
-							Group group = GroupLocalServiceUtil.fetchGroup(curGroupId);
-
-							if (group == null) {
-								continue;
-							}
-
-							if (((maxTerms > 0) && (i >= maxTerms)) || ((frequencyThreshold > 0) && (frequencyThreshold > termCollector.getFrequency()))) {
-								break;
-							}
+						for (ScopeSearchFacetTermDisplayContext scopeSearchFacetTermDisplayContext : scopeSearchFacetTermDisplayContexts) {
 						%>
 
 							<li class="facet-value">
-								<a class="<%= groupId == curGroupId ? "text-primary" : "text-default" %>" data-value="<%= curGroupId %>" href="javascript:;">
-									<%= HtmlUtil.escape(group.getDescriptiveName(locale)) %>
+								<a class="<%= scopeSearchFacetTermDisplayContext.isSelected() ? "text-primary" : "text-default" %>" data-value="<%= scopeSearchFacetTermDisplayContext.getGroupId() %>" href="javascript:;">
+									<%= HtmlUtil.escape(scopeSearchFacetTermDisplayContext.getDescriptiveName()) %>
 
-									<c:if test="<%= showAssetCount %>">
-										<span class="frequency">(<%= termCollector.getFrequency() %>)</span>
+									<c:if test="<%= scopeSearchFacetTermDisplayContext.isShowCount() %>">
+										<span class="frequency">(<%= scopeSearchFacetTermDisplayContext.getCount() %>)</span>
 									</c:if>
 								</a>
 							</li>

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/init.jsp
@@ -37,7 +37,6 @@ page import="com.liferay.portal.kernel.json.JSONArray" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
-page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayPortletRequest" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayPortletResponse" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@

--- a/modules/apps/foundation/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/facet/display/context/ScopeSearchFacetDisplayContextTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/facet/display/context/ScopeSearchFacetDisplayContextTest.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.facet.display.context;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author André de Oliveira
+ */
+public class ScopeSearchFacetDisplayContextTest {
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		Mockito.doReturn(
+			_facetCollector
+		).when(
+			_facet
+		).getFacetCollector();
+	}
+
+	@Test
+	public void testEmptySearchResults() throws Exception {
+		String facetParam = "0";
+
+		ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext =
+			createDisplayContext(facetParam);
+
+		List<ScopeSearchFacetTermDisplayContext>
+			scopeSearchFacetTermDisplayContexts =
+				scopeSearchFacetDisplayContext.getTermDisplayContexts();
+
+		Assert.assertEquals(0, scopeSearchFacetTermDisplayContexts.size());
+
+		Assert.assertEquals(
+			facetParam,
+			scopeSearchFacetDisplayContext.getFieldParamInputValue());
+		Assert.assertTrue(scopeSearchFacetDisplayContext.isNothingSelected());
+		Assert.assertTrue(scopeSearchFacetDisplayContext.isRenderNothing());
+	}
+
+	@Test
+	public void testEmptySearchResultsWithPreviousSelection() throws Exception {
+		long groupId = RandomTestUtil.randomLong();
+		String name = RandomTestUtil.randomString();
+
+		addGroup(groupId, name);
+
+		String facetParam = String.valueOf(groupId);
+
+		ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext =
+			createDisplayContext(facetParam);
+
+		List<ScopeSearchFacetTermDisplayContext>
+			scopeSearchFacetTermDisplayContexts =
+				scopeSearchFacetDisplayContext.getTermDisplayContexts();
+
+		Assert.assertEquals(1, scopeSearchFacetTermDisplayContexts.size());
+
+		ScopeSearchFacetTermDisplayContext scopeSearchFacetTermDisplayContext =
+			scopeSearchFacetTermDisplayContexts.get(0);
+
+		Assert.assertEquals(0, scopeSearchFacetTermDisplayContext.getCount());
+		Assert.assertEquals(
+			name, scopeSearchFacetTermDisplayContext.getDescriptiveName());
+		Assert.assertEquals(
+			groupId, scopeSearchFacetTermDisplayContext.getGroupId());
+		Assert.assertTrue(scopeSearchFacetTermDisplayContext.isSelected());
+		Assert.assertTrue(scopeSearchFacetTermDisplayContext.isShowCount());
+
+		Assert.assertEquals(
+			facetParam,
+			scopeSearchFacetDisplayContext.getFieldParamInputValue());
+		Assert.assertFalse(scopeSearchFacetDisplayContext.isNothingSelected());
+		Assert.assertFalse(scopeSearchFacetDisplayContext.isRenderNothing());
+	}
+
+	@Test
+	public void testOneTerm() throws Exception {
+		long groupId = RandomTestUtil.randomLong();
+		String name = RandomTestUtil.randomString();
+
+		addGroup(groupId, name);
+
+		int count = RandomTestUtil.randomInt();
+
+		setUpOneTermCollector(groupId, count);
+
+		String facetParam = "0";
+
+		ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext =
+			createDisplayContext(facetParam);
+
+		List<ScopeSearchFacetTermDisplayContext>
+			scopeSearchFacetTermDisplayContexts =
+				scopeSearchFacetDisplayContext.getTermDisplayContexts();
+
+		Assert.assertEquals(1, scopeSearchFacetTermDisplayContexts.size());
+
+		ScopeSearchFacetTermDisplayContext scopeSearchFacetTermDisplayContext =
+			scopeSearchFacetTermDisplayContexts.get(0);
+
+		Assert.assertEquals(
+			count, scopeSearchFacetTermDisplayContext.getCount());
+		Assert.assertEquals(
+			name, scopeSearchFacetTermDisplayContext.getDescriptiveName());
+		Assert.assertEquals(
+			groupId, scopeSearchFacetTermDisplayContext.getGroupId());
+		Assert.assertFalse(scopeSearchFacetTermDisplayContext.isSelected());
+		Assert.assertTrue(scopeSearchFacetTermDisplayContext.isShowCount());
+
+		Assert.assertEquals(
+			facetParam,
+			scopeSearchFacetDisplayContext.getFieldParamInputValue());
+		Assert.assertTrue(scopeSearchFacetDisplayContext.isNothingSelected());
+		Assert.assertFalse(scopeSearchFacetDisplayContext.isRenderNothing());
+	}
+
+	@Test
+	public void testOneTermWithPreviousSelection() throws Exception {
+		long groupId = RandomTestUtil.randomLong();
+		String name = RandomTestUtil.randomString();
+
+		addGroup(groupId, name);
+
+		int count = RandomTestUtil.randomInt();
+
+		setUpOneTermCollector(groupId, count);
+
+		String facetParam = String.valueOf(groupId);
+
+		ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext =
+			createDisplayContext(facetParam);
+
+		List<ScopeSearchFacetTermDisplayContext>
+			scopeSearchFacetTermDisplayContexts =
+				scopeSearchFacetDisplayContext.getTermDisplayContexts();
+
+		Assert.assertEquals(1, scopeSearchFacetTermDisplayContexts.size());
+
+		ScopeSearchFacetTermDisplayContext scopeSearchFacetTermDisplayContext =
+			scopeSearchFacetTermDisplayContexts.get(0);
+
+		Assert.assertEquals(
+			count, scopeSearchFacetTermDisplayContext.getCount());
+		Assert.assertEquals(
+			name, scopeSearchFacetTermDisplayContext.getDescriptiveName());
+		Assert.assertEquals(
+			groupId, scopeSearchFacetTermDisplayContext.getGroupId());
+		Assert.assertTrue(scopeSearchFacetTermDisplayContext.isSelected());
+		Assert.assertTrue(scopeSearchFacetTermDisplayContext.isShowCount());
+
+		Assert.assertEquals(
+			facetParam,
+			scopeSearchFacetDisplayContext.getFieldParamInputValue());
+		Assert.assertFalse(scopeSearchFacetDisplayContext.isNothingSelected());
+		Assert.assertFalse(scopeSearchFacetDisplayContext.isRenderNothing());
+	}
+
+	protected void addGroup(long groupId, String name) throws Exception {
+		Mockito.doReturn(
+			createGroup(groupId, name)
+		).when(
+			_groupLocalService
+		).fetchGroup(
+			groupId
+		);
+	}
+
+	protected ScopeSearchFacetDisplayContext createDisplayContext(
+		String facetParam) {
+
+		return new ScopeSearchFacetDisplayContext(
+			_facet, facetParam, null, 0, 0, true, _groupLocalService);
+	}
+
+	protected Group createGroup(long groupId, String name) throws Exception {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.doReturn(
+			name
+		).when(
+			group
+		).getDescriptiveName(
+			Mockito.<Locale>any()
+		);
+
+		Mockito.doReturn(
+			groupId
+		).when(
+			group
+		).getGroupId();
+
+		return group;
+	}
+
+	protected TermCollector createTermCollector(long groupId, int count) {
+		TermCollector termCollector = Mockito.mock(TermCollector.class);
+
+		Mockito.doReturn(
+			count
+		).when(
+			termCollector
+		).getFrequency();
+
+		Mockito.doReturn(
+			String.valueOf(groupId)
+		).when(
+			termCollector
+		).getTerm();
+
+		return termCollector;
+	}
+
+	protected void setUpOneTermCollector(long groupId, int count) {
+		Mockito.doReturn(
+			Collections.singletonList(createTermCollector(groupId, count))
+		).when(
+			_facetCollector
+		).getTermCollectors();
+	}
+
+	@Mock
+	private Facet _facet;
+
+	@Mock
+	private FacetCollector _facetCollector;
+
+	@Mock
+	private GroupLocalService _groupLocalService;
+
+}


### PR DESCRIPTION
Moved `DisplayContext` classes to correct package `...display.context`, as pointed out in https://github.com/brianchandotcom/liferay-portal/pull/38998#issuecomment-213522287.

Author: @moltam89
Reviewer: @arboliveira
