### PR TITLE
master-qa-24713

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7967,7 +7967,7 @@ jdbc.default.password=${database.mysql.password}</echo>
 				<waitfor maxwait="15" maxwaitunit="minute" timeoutproperty="upgrade.timeout.error">
 					<resourcecontains
 						resource="${liferay.home}/db_upgrade_log"
-						substring="Running modules upgrades. Connect to your Gogo Shell to check the status."
+						substring="Running modules upgrades."
 					/>
 				</waitfor>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-24713

@brianchandotcom 
This will fix the upgrade timeout failure on the functional-tomcat batches appearing on all pulls. (e.g. https://github.com/brianchandotcom/liferay-portal/pull/39041 and https://github.com/brianchandotcom/liferay-portal/pull/39040).

The upgrade tests wait for a particular string to appear in the console at the end of the core upgrade, but the message has changed earlier today. I removed the second half of the string we look for because our goal is just to make sure the upgrade completed and not to assert the text.

I didn't backport to 6.2/6.1 because this target only exists in master.
