### PR TITLE
#ping LPS-65365 XSS in MBMessage

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -282,14 +282,14 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", discussion);
 
-		body = SanitizerUtil.sanitize(
-			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
-			messageId, "text/" + format, Sanitizer.MODE_ALL, body, options);
-
 		validate(subject, body);
 
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
+
+		body = SanitizerUtil.sanitize(
+			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
+			messageId, "text/" + format, Sanitizer.MODE_ALL, body, options);
 
 		MBMessage message = mbMessagePersistence.create(messageId);
 
@@ -1609,15 +1609,15 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", message.isDiscussion());
 
-		body = SanitizerUtil.sanitize(
-			message.getCompanyId(), message.getGroupId(), userId,
-			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
-			Sanitizer.MODE_ALL, body, options);
-
 		validate(subject, body);
 
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
+
+		body = SanitizerUtil.sanitize(
+			message.getCompanyId(), message.getGroupId(), userId,
+			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
+			Sanitizer.MODE_ALL, body, options);
 
 		message.setModifiedDate(modifiedDate);
 		message.setSubject(subject);

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -282,14 +282,14 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", discussion);
 
-		validate(subject, body);
-
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
 
 		body = SanitizerUtil.sanitize(
 			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
 			messageId, "text/" + format, Sanitizer.MODE_ALL, body, options);
+
+		validate(subject, body);
 
 		MBMessage message = mbMessagePersistence.create(messageId);
 
@@ -1609,8 +1609,6 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", message.isDiscussion());
 
-		validate(subject, body);
-
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
 
@@ -1618,6 +1616,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			message.getCompanyId(), message.getGroupId(), userId,
 			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
 			Sanitizer.MODE_ALL, body, options);
+
+		validate(subject, body);
 
 		message.setModifiedDate(modifiedDate);
 		message.setSubject(subject);

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
@@ -102,6 +102,8 @@ public class MBMessageLocalServiceTest {
 			subject, body, "html", inputStreamOVPs, false, 0.0, false,
 			serviceContext);
 
+		Assert.assertEquals(subject, message.getSubject());
+
 		if (Validator.isNotNull(message.getBody())) {
 			Assert.fail("Message body should have been sanitized.");
 		}

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
@@ -86,7 +86,7 @@ public class MBMessageLocalServiceTest {
 	}
 
 	@Test
-	public void testAddXSSMessage() throws Exception {
+	public void testAddXSSSubjectWithEmptyBodyMessage() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId());

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -82,6 +83,28 @@ public class MBMessageLocalServiceTest {
 			_attachmentFile, "image/png");
 
 		Assert.assertEquals(1, message.getAttachmentsFileEntriesCount());
+	}
+
+	@Test
+	public void testAddXSSMessage() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			Collections.emptyList();
+		String subject = "<script>alert(1)</script>";
+		String body = StringPool.BLANK;
+
+		MBMessage message = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, body, "html", inputStreamOVPs, false, 0.0, false,
+			serviceContext);
+
+		if (Validator.isNotNull(message.getBody())) {
+			Assert.fail("Message body should have been sanitized.");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Hey Brian,

The idea is that when we add a MBMessage with a blank body, it will use the subject as the body. Then, in case the subject contains XSS the body will also contain that XSS. However, we were sanitizing the body before we were inheriting the subject (then we were sanitizing a blank body and after that we were just using the subject with the XSS)

@topolik sent a fix so the sanitizer is done at the very end to make sure that in case we inherit the subject, we also sanitize it. 

Therfore, the test should add a MBMessage with a blank body and an XSS subject. I changed the test name and I also did an assert on the subject so the test is more understandable.

Let me know if you still have any question.

Thanks!
