### PR TITLE
[See description] XSS issues in MB

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -252,6 +252,10 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		subject = ModelHintsUtil.trimString(
 			MBMessage.class.getName(), "subject", subject);
 
+		if (!MBUtil.isValidMessageFormat(format)) {
+			format = "html";
+		}
+
 		MBGroupServiceSettings mbGroupServiceSettings =
 			MBGroupServiceSettings.getInstance(groupId);
 

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -282,14 +282,14 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", discussion);
 
-		body = SanitizerUtil.sanitize(
-			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
-			messageId, "text/" + format, Sanitizer.MODE_ALL, body, options);
-
 		validate(subject, body);
 
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
+
+		body = SanitizerUtil.sanitize(
+			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
+			messageId, "text/" + format, Sanitizer.MODE_ALL, body, options);
 
 		MBMessage message = mbMessagePersistence.create(messageId);
 
@@ -1609,15 +1609,15 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", message.isDiscussion());
 
-		body = SanitizerUtil.sanitize(
-			message.getCompanyId(), message.getGroupId(), userId,
-			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
-			Sanitizer.MODE_ALL, body, options);
-
 		validate(subject, body);
 
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
+
+		body = SanitizerUtil.sanitize(
+			message.getCompanyId(), message.getGroupId(), userId,
+			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
+			Sanitizer.MODE_ALL, body, options);
 
 		message.setModifiedDate(modifiedDate);
 		message.setSubject(subject);

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -282,14 +282,14 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", discussion);
 
-		validate(subject, body);
-
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
 
 		body = SanitizerUtil.sanitize(
 			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
 			messageId, "text/" + format, Sanitizer.MODE_ALL, body, options);
+
+		validate(subject, body);
 
 		MBMessage message = mbMessagePersistence.create(messageId);
 
@@ -1609,8 +1609,6 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		options.put("discussion", message.isDiscussion());
 
-		validate(subject, body);
-
 		subject = getSubject(subject, body);
 		body = getBody(subject, body);
 
@@ -1618,6 +1616,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 			message.getCompanyId(), message.getGroupId(), userId,
 			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
 			Sanitizer.MODE_ALL, body, options);
+
+		validate(subject, body);
 
 		message.setModifiedDate(modifiedDate);
 		message.setSubject(subject);

--- a/portal-impl/src/com/liferay/portlet/messageboards/util/MBUtil.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/util/MBUtil.java
@@ -20,6 +20,7 @@ import com.liferay.message.boards.kernel.model.MBBan;
 import com.liferay.message.boards.kernel.model.MBCategory;
 import com.liferay.message.boards.kernel.model.MBCategoryConstants;
 import com.liferay.message.boards.kernel.model.MBMessage;
+import com.liferay.message.boards.kernel.model.MBMessageConstants;
 import com.liferay.message.boards.kernel.model.MBStatsUser;
 import com.liferay.message.boards.kernel.model.MBThread;
 import com.liferay.message.boards.kernel.service.MBCategoryLocalServiceUtil;
@@ -817,6 +818,10 @@ public class MBUtil {
 		if (messageFormat.equals("bbcode") &&
 			!editorName.equals("ckeditor_bbcode")) {
 
+			return false;
+		}
+
+		if (!ArrayUtil.contains(MBMessageConstants.FORMATS, messageFormat)) {
 			return false;
 		}
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
@@ -101,6 +101,7 @@ public class MBMessageLocalServiceTest {
 			subject, body, "html", inputStreamOVPs, false, 0.0, false,
 			serviceContext);
 
+		Assert.assertEquals(subject, message.getSubject());
 		Assert.assertEquals(StringPool.BLANK, message.getBody());
 	}
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
@@ -85,7 +85,7 @@ public class MBMessageLocalServiceTest {
 	}
 
 	@Test
-	public void testAddXSSMessage() throws Exception {
+	public void testAddXSSSubjectWithEmptyBodyMessage() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId());

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
@@ -85,6 +85,26 @@ public class MBMessageLocalServiceTest {
 	}
 
 	@Test
+	public void testAddXSSMessage() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			Collections.emptyList();
+		String subject = "<script>alert(1)</script>";
+		String body = StringPool.BLANK;
+
+		MBMessage message = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, body, "html", inputStreamOVPs, false, 0.0, false,
+			serviceContext);
+
+		Assert.assertEquals(StringPool.BLANK, message.getBody());
+	}
+
+	@Test
 	public void testDeleteAttachmentsWhenUpdatingMessageAndTrashDisabled()
 		throws Exception {
 

--- a/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/messageboards/service/MBMessageLocalServiceTest.java
@@ -85,6 +85,29 @@ public class MBMessageLocalServiceTest {
 	}
 
 	@Test
+	public void testAddXSSMessageWithInvalidFormat() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		List<ObjectValuePair<String, InputStream>> inputStreamOVPs =
+			Collections.emptyList();
+		String subject = "<script>alert(1)</script>";
+		String body = "<script>alert(2)</script>";
+		String format = "text/plain";
+
+		MBMessage message = MBMessageLocalServiceUtil.addMessage(
+			TestPropsValues.getUserId(), RandomTestUtil.randomString(),
+			_group.getGroupId(), MBCategoryConstants.DEFAULT_PARENT_CATEGORY_ID,
+			subject, body, format, inputStreamOVPs, false, 0.0, false,
+			serviceContext);
+
+		Assert.assertEquals(subject, message.getSubject());
+		Assert.assertEquals(StringPool.BLANK, message.getBody());
+		Assert.assertEquals("html", message.getFormat());
+	}
+
+	@Test
 	public void testAddXSSSubjectWithEmptyBodyMessage() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(


### PR DESCRIPTION
Hey Brian,

This pull contains 2 fixes that are related (they are both XSS issues in Message boards. The first one (    LPS-65365) is the same as https://github.com/brianchandotcom/liferay-portal/pull/39112 and I'll explain the changes here and I hope it's more clear now with the changes I did. Second one (    LPS-65368) is easier.
## 

Regarding the first issue that I sent you in https://github.com/brianchandotcom/liferay-portal/pull/39112:

The idea is that when we add a MBMessage with a blank body, it will use the subject as the body. Then, in case the subject contains XSS the body will also contain that XSS. However, we were sanitizing the body before we were inheriting the subject (then we were sanitizing a blank body and after that we were just using the subject with the XSS)

@topolik sent a fix so the sanitizer is done at the very end to make sure that in case we inherit the subject, we also sanitize it.

Therfore, the test should add a MBMessage with a blank body and an XSS subject. I changed the test name and I also did an assert on the subject so the test is more understandable.

Let me know if you still have any question.

Thanks!
