### PR TITLE
LPS-57272 default-value hint not generating the default value in DB

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/ServiceBuilder.java
@@ -4289,6 +4289,10 @@ public class ServiceBuilder {
 			sb.append(col.getDBName());
 			sb.append(" ");
 
+			Map<String, String> hints = ModelHintsUtil.getHints(
+				_packagePath + ".model." + entity.getName(), colName);
+
+
 			if (StringUtil.equalsIgnoreCase(colType, "boolean")) {
 				sb.append("BOOLEAN");
 			}
@@ -4313,9 +4317,6 @@ public class ServiceBuilder {
 				sb.append("DATE");
 			}
 			else if (colType.equals("String")) {
-				Map<String, String> hints = ModelHintsUtil.getHints(
-					_packagePath + ".model." + entity.getName(), colName);
-
 				int maxLength = 75;
 
 				if (hints != null) {
@@ -4352,6 +4353,18 @@ public class ServiceBuilder {
 			}
 			else if (colType.equals("Date") || colType.equals("String")) {
 				sb.append(" null");
+			}
+
+			if (hints != null) {
+				String defaultValue = hints.get("default-value");
+
+				if(Validator.isNotNull(defaultValue)){
+					if (colType.equals("String")) {
+						sb.append(" DEFAULT '").append(defaultValue).append("'");
+					} else {
+						sb.append(" DEFAULT ").append(defaultValue);
+					}
+				}
 			}
 
 			if (Validator.isNotNull(colIdType) &&


### PR DESCRIPTION
**Fix for issue**: 
LPS-57272 default-value hint not generating the default value in DB

**Environment used:**
Liferay 6.2.x 
Application Server : Tomcat (7.0.42)
DB : MySQL(5.1)

**Test Data**:

```
<model name="com.liferay.sample.model.Foo">
        <field name="fooId" type="long" />
        <field name="userId" type="long">
            <hint name="default-value">100</hint>
        </field>
        <field name="userName" type="String">
            <hint name="default-value">Hello</hint>
        </field>
        <field name="createDate" type="Date">
            <hint name="default-value">CURRENT_TIMESTAMP</hint>
        </field>
        <field name="field1" type="boolean">
            <hint name="default-value">true</hint>
        </field>
        <field name="field2" type="int">
            <hint name="default-value">50</hint>
        </field>
        <field name="field3" type="String" />
    </model>
```
