### PR TITLE
LPS-65396 Undeployed portlet referenced from page (after upgrade) throws exception in permission checker

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -282,6 +282,13 @@ public class PortletPermissionImpl implements PortletPermission {
 			boolean checkStagingPermission)
 		throws PortalException {
 
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(
+			permissionChecker.getCompanyId(), portletId);
+
+		if ((portlet == null) || portlet.isUndeployedPortlet()) {
+			return false;
+		}
+
 		String name = null;
 		String resourcePermissionPrimKey = null;
 


### PR DESCRIPTION
Hi Brian,

fix for a regression for undeployed / missing portlets.

https://issues.liferay.com/browse/LPS-65396

Thanks.
