### PR TITLE
LPS-65396 Undeployed portlet referenced from page (after upgrade) throws exception in permission checker

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/PortletPermissionImpl.java
@@ -282,6 +282,13 @@ public class PortletPermissionImpl implements PortletPermission {
 			boolean checkStagingPermission)
 		throws PortalException {
 
+		Portlet portlet = PortletLocalServiceUtil.getPortletById(
+			permissionChecker.getCompanyId(), portletId);
+
+		if ((portlet == null) || portlet.isUndeployedPortlet()) {
+			return false;
+		}
+
 		String name = null;
 		String resourcePermissionPrimKey = null;
 

--- a/portal-impl/test/integration/com/liferay/portal/upgrade/UpgradePortletIdTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/upgrade/UpgradePortletIdTest.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -153,9 +152,10 @@ public class UpgradePortletIdTest extends UpgradePortletId {
 			String portletPrimaryKey = PortletPermissionUtil.getPrimaryKey(
 				layout.getPlid(), portletId);
 
-			ResourcePermissionServiceUtil.setIndividualResourcePermissions(
-				layout.getGroupId(), TestPropsValues.getCompanyId(),
-				oldPortletId, portletPrimaryKey, roleIdsToActionIds);
+			ResourcePermissionLocalServiceUtil.setResourcePermissions(
+				TestPropsValues.getCompanyId(), oldPortletId,
+				ResourceConstants.SCOPE_INDIVIDUAL, portletPrimaryKey,
+				roleIdsToActionIds);
 
 			PortletLocalServiceUtil.destroyPortlet(portlet);
 		}


### PR DESCRIPTION
Hi Brian,

fix for a regression for undeployed / missing portlets.

https://issues.liferay.com/browse/LPS-65396

Thanks.
