### PR TITLE
LPS-65067 Ensure the deploymentDirPath is created on startup, so that…

### DIFF
--- a/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
+++ b/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
@@ -79,9 +79,7 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 
 		Path deploymentDirPath = Paths.get(deploymentDir);
 
-		if (Files.notExists(deploymentDirPath)) {
-			return;
-		}
+		Files.createDirectories(deploymentDirPath);
 
 		Files.walkFileTree(
 			deploymentDirPath,


### PR DESCRIPTION
… marketplace has the folder to drop off lpkg files.

@brianchandotcom this will make sure deployment folder is created after boot up. Since portal-lpkg-deployer is deployed before marketplace, it is safe.

If for any reason an user needs to manually drop off lpkg files before the very first portal startup. They would have to manually create it. We did the same thing for felix fileinstall deployment folders.
