### PR TITLE
master-qa-24837-b

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -2929,39 +2929,11 @@ plugins.includes=</echo>
 			<format pattern="yyyyMMddkkmmssSSS" property="tstamp.value" />
 		</tstamp>
 
-		<mkdir dir="${tstamp.value}/lib" />
+		<mkdir dir="${tstamp.value}" />
 
 		<copy todir="${tstamp.value}">
 			<fileset
 				dir="${liferay.home}/tools/portal-tools-db-upgrade-client"
-			/>
-		</copy>
-
-		<copy todir="${tstamp.value}/lib">
-			<fileset
-				dir="portal-impl"
-				includes="portal-impl.jar"
-			/>
-			<fileset
-				dir="portal-kernel"
-				includes="portal-kernel.jar"
-			/>
-			<fileset
-				dir="lib/development"
-			/>
-			<fileset
-				dir="lib/global"
-			/>
-			<fileset
-				dir="lib/portal"
-			/>
-			<fileset
-				dir="util-java"
-				includes="util-java.jar"
-			/>
-			<fileset
-				dir="util-taglib"
-				includes="util-taglib.jar"
 			/>
 		</copy>
 

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -2933,7 +2933,7 @@ plugins.includes=</echo>
 
 		<copy todir="${tstamp.value}">
 			<fileset
-				dir="tools/db-upgrade"
+				dir="${liferay.home}/tools/portal-tools-db-upgrade-client"
 			/>
 		</copy>
 

--- a/build-dist.xml
+++ b/build-dist.xml
@@ -2968,13 +2968,6 @@ plugins.includes=</echo>
 		<zip destfile="dist/liferay-portal-db-upgrade-${lp.version}.zip">
 			<zipfileset
 				dir="${tstamp.value}"
-				excludes="run.sh"
-				prefix="liferay-portal-db-upgrade-${lp.version}"
-			/>
-			<zipfileset
-				dir="${tstamp.value}"
-				filemode="744"
-				includes="run.sh"
 				prefix="liferay-portal-db-upgrade-${lp.version}"
 			/>
 		</zip>


### PR DESCRIPTION
This replaces the old upgrade script with the new standalone java tool when building the db-upgrade zip file for the release server. I already had @CAustin582 review this. The unnecessary additional jars were also removed

cc @brianchiu @jrhoun @jhendley
