### PR TITLE
master-qa-24847

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -8008,7 +8008,7 @@ jdbc.default.password=${database.mysql.password}</echo>
 		<delete file="${liferay.home}/build-db-upgrade.xml" />
 		<delete file="${liferay.home}/db_upgrade_log" />
 		<delete file="${liferay.home}/portal-ext.properties" />
-		<delete file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexWriterHelperConfiguration.cfg" />
+		<delete file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexStatusManagerConfiguration.cfg" />
 
 		<copy
 			file="tools/db-upgrade/build.xml"
@@ -8035,7 +8035,7 @@ jdbc.default.password=${database.mysql.password}</echo>
 			tofile="${liferay.home}/portal-ext.properties"
 		/>
 
-		<echo file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexWriterHelperConfiguration.cfg">index.read.only=true</echo>
+		<echo file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexStatusManagerConfiguration.cfg">indexReadOnly=true</echo>
 
 		<record action="start" name="${liferay.home}/db_upgrade_log" />
 
@@ -8106,7 +8106,7 @@ jdbc.default.password=${database.mysql.password}</echo>
 		<delete file="${liferay.home}/build-db-upgrade.xml" />
 		<delete file="${liferay.home}/db_upgrade_log" />
 		<delete file="${liferay.home}/portal-ext.properties" />
-		<delete file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexWriterHelperConfiguration.cfg" />
+		<delete file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexStatusManagerConfiguration.cfg" />
 	</target>
 
 	<target name="wait-for-plugins-deployment">

--- a/build-test.xml
+++ b/build-test.xml
@@ -8106,7 +8106,8 @@ jdbc.default.password=${database.mysql.password}</echo>
 		<delete file="${liferay.home}/build-db-upgrade.xml" />
 		<delete file="${liferay.home}/db_upgrade_log" />
 		<delete file="${liferay.home}/portal-ext.properties" />
-		<delete file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexStatusManagerConfiguration.cfg" />
+
+		<echo file="${liferay.home}/osgi/configs/com.liferay.portal.search.configuration.IndexStatusManagerConfiguration.cfg">indexReadOnly=false</echo>
 	</target>
 
 	<target name="wait-for-plugins-deployment">


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-24847

@brianchandotcom 
This is a resend of https://github.com/brianchandotcom/liferay-portal/pull/39239. I re-ran the test against a pull to myself and wasn't able to reproduce the FacetedSearcherTest.testSearchByKeywordsIgnoresInactiveSites failure.

From https://github.com/brianchandotcom/liferay-portal/pull/39239:
"We received word from André that the index.read.only property was moved to indexReadOnly and that the file we're supposed to set it in has changed too (see: https://issues.liferay.com/browse/LPS-64975). So we have to change it for our upgrade tests too.

Additionally, Miguel told us that we have to set the indexReadOnly property back to false for portal startup, because otherwise there would be issues in the portal."
