### PR TITLE
LPS-63436 Dark scheme is selected by default

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-look-and-feel.xml
+++ b/portal-web/docroot/WEB-INF/liferay-look-and-feel.xml
@@ -24,6 +24,7 @@
 			<role-name>User</role-name>
 		</roles>
 		<color-scheme id="01" name="Default">
+			<default-cs>true</default-cs>
 			<css-class>default</css-class>
 			<color-scheme-images-path>${images-path}/color_schemes/${css-class}</color-scheme-images-path>
 		</color-scheme>


### PR DESCRIPTION
Added code in liferay-look-and-feel.xml to fix the default color scheme selection within classic theme.

Test Env :
Application server – Tomcat 7
DB Server - MySQL 5.1
Browser – Chrome/IE/Mozilla Firefox
