### PR TITLE
Lps 65510

### DIFF
--- a/modules/apps/foundation/portal-cache/portal-cache-single/build.gradle
+++ b/modules/apps/foundation/portal-cache/portal-cache-single/build.gradle
@@ -3,4 +3,5 @@ dependencies {
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:portal:portal-profile-activator")
 }

--- a/modules/apps/foundation/portal-cache/portal-cache-single/src/main/java/com/liferay/portal/cache/single/internal/activator/GatekeeperActivator.java
+++ b/modules/apps/foundation/portal-cache/portal-cache-single/src/main/java/com/liferay/portal/cache/single/internal/activator/GatekeeperActivator.java
@@ -16,11 +16,14 @@ package com.liferay.portal.cache.single.internal.activator;
 
 import com.liferay.portal.cache.single.internal.bootstrap.SinglePortalCacheBootstrapLoaderFactory;
 import com.liferay.portal.cache.single.internal.distribution.SinglePortalCacheReplicatorFactory;
-import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.profile.activator.ProfileActivator;
+
+import java.util.Collections;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Shuyang Zhou
@@ -30,16 +33,14 @@ public class GatekeeperActivator {
 
 	@Activate
 	public void activate(ComponentContext componentContext) {
-		String name = ReleaseInfo.getName();
-
-		if (!name.contains("Community")) {
-			return;
-		}
-
-		componentContext.enableComponent(
-			SinglePortalCacheBootstrapLoaderFactory.class.getName());
-		componentContext.enableComponent(
+		_profileActivator.activateByProfiles(
+			componentContext,
+			Collections.singleton(ProfileActivator.CE_PROFILE),
+			SinglePortalCacheBootstrapLoaderFactory.class.getName(),
 			SinglePortalCacheReplicatorFactory.class.getName());
 	}
+
+	@Reference
+	private ProfileActivator _profileActivator;
 
 }

--- a/modules/apps/foundation/portal-scheduler/portal-scheduler-single/build.gradle
+++ b/modules/apps/foundation/portal-scheduler/portal-scheduler-single/build.gradle
@@ -4,4 +4,5 @@ dependencies {
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:portal:portal-profile-activator")
 }

--- a/modules/apps/foundation/portal-scheduler/portal-scheduler-single/src/main/java/com/liferay/portal/scheduler/single/internal/activator/GatekeeperActivator.java
+++ b/modules/apps/foundation/portal-scheduler/portal-scheduler-single/src/main/java/com/liferay/portal/scheduler/single/internal/activator/GatekeeperActivator.java
@@ -14,12 +14,15 @@
 
 package com.liferay.portal.scheduler.single.internal.activator;
 
-import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.profile.activator.ProfileActivator;
 import com.liferay.portal.scheduler.single.internal.SingleSchedulerEngineConfigurator;
+
+import java.util.Collections;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Shuyang Zhou
@@ -29,14 +32,13 @@ public class GatekeeperActivator {
 
 	@Activate
 	public void activate(ComponentContext componentContext) {
-		String name = ReleaseInfo.getName();
-
-		if (!name.contains("Community")) {
-			return;
-		}
-
-		componentContext.enableComponent(
+		_profileActivator.activateByProfiles(
+			componentContext,
+			Collections.singleton(ProfileActivator.CE_PROFILE),
 			SingleSchedulerEngineConfigurator.class.getName());
 	}
+
+	@Reference
+	private ProfileActivator _profileActivator;
 
 }

--- a/modules/apps/foundation/portal/portal-cluster-single/build.gradle
+++ b/modules/apps/foundation/portal/portal-cluster-single/build.gradle
@@ -3,4 +3,5 @@ dependencies {
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:portal:portal-profile-activator")
 }

--- a/modules/apps/foundation/portal/portal-cluster-single/src/main/java/com/liferay/portal/cluster/single/internal/activator/GatekeeperActivator.java
+++ b/modules/apps/foundation/portal/portal-cluster-single/src/main/java/com/liferay/portal/cluster/single/internal/activator/GatekeeperActivator.java
@@ -17,11 +17,14 @@ package com.liferay.portal.cluster.single.internal.activator;
 import com.liferay.portal.cluster.single.internal.SingleClusterExecutor;
 import com.liferay.portal.cluster.single.internal.SingleClusterLink;
 import com.liferay.portal.cluster.single.internal.SingleClusterMasterExecutor;
-import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.profile.activator.ProfileActivator;
+
+import java.util.Collections;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Shuyang Zhou
@@ -31,16 +34,15 @@ public class GatekeeperActivator {
 
 	@Activate
 	public void activate(ComponentContext componentContext) {
-		String name = ReleaseInfo.getName();
-
-		if (!name.contains("Community")) {
-			return;
-		}
-
-		componentContext.enableComponent(SingleClusterExecutor.class.getName());
-		componentContext.enableComponent(SingleClusterLink.class.getName());
-		componentContext.enableComponent(
+		_profileActivator.activateByProfiles(
+			componentContext,
+			Collections.singleton(ProfileActivator.CE_PROFILE),
+			SingleClusterExecutor.class.getName(),
+			SingleClusterLink.class.getName(),
 			SingleClusterMasterExecutor.class.getName());
 	}
+
+	@Reference
+	private ProfileActivator _profileActivator;
 
 }

--- a/modules/apps/foundation/portal/portal-profile-activator/bnd.bnd
+++ b/modules/apps/foundation/portal/portal-profile-activator/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Portal Profile Activator
+Bundle-SymbolicName: com.liferay.portal.profile.activator
+Bundle-Version: 1.0.0
+Export-Package: com.liferay.portal.profile.activator

--- a/modules/apps/foundation/portal/portal-profile-activator/build.gradle
+++ b/modules/apps/foundation/portal/portal-profile-activator/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	provided group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+}

--- a/modules/apps/foundation/portal/portal-profile-activator/src/main/java/com/liferay/portal/profile/activator/ProfileActivator.java
+++ b/modules/apps/foundation/portal/portal-profile-activator/src/main/java/com/liferay/portal/profile/activator/ProfileActivator.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.profile.activator;
+
+import java.util.Set;
+
+import org.osgi.service.component.ComponentContext;
+
+/**
+ * @author Shuyang Zhou
+ */
+public interface ProfileActivator {
+
+	public static final String CE_PROFILE = "CE";
+
+	public static final String EE_PROFILE = "EE";
+
+	public static final String PORTAL_PROFILES = "portal.profiles";
+
+	public void activateByProfiles(
+		ComponentContext componentContext, Set<String> profiles,
+		String... componentNames);
+
+}

--- a/modules/apps/foundation/portal/portal-profile-activator/src/main/java/com/liferay/portal/profile/activator/internal/ProfileActivatorImpl.java
+++ b/modules/apps/foundation/portal/portal-profile-activator/src/main/java/com/liferay/portal/profile/activator/internal/ProfileActivatorImpl.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.profile.activator.internal;
+
+import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.profile.activator.ProfileActivator;
+
+import java.util.Set;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Shuyang Zhou
+ */
+@Component(immediate = true)
+public class ProfileActivatorImpl implements ProfileActivator {
+
+	@Activate
+	public void activate(BundleContext bundleContext) {
+		String[] portalProfiles = StringUtil.split(
+			bundleContext.getProperty(PORTAL_PROFILES));
+
+		if (portalProfiles.length == 0) {
+			String name = ReleaseInfo.getName();
+
+			if (name.contains("Community")) {
+				_portalProfiles = new String[] {CE_PROFILE};
+			}
+			else {
+				_portalProfiles = new String[] {EE_PROFILE};
+			}
+		}
+		else {
+			_portalProfiles = portalProfiles;
+		}
+	}
+
+	@Override
+	public void activateByProfiles(
+		ComponentContext componentContext, Set<String> profiles,
+		String... componentNames) {
+
+		BundleContext bundleContext = componentContext.getBundleContext();
+
+		Bundle bundle = bundleContext.getBundle();
+
+		String symbolicName = bundle.getSymbolicName();
+
+		for (String portalProfile : _portalProfiles) {
+			if (profiles.contains(portalProfile) ||
+				symbolicName.equals(portalProfile)) {
+
+				for (String componentName : componentNames) {
+					componentContext.enableComponent(componentName);
+				}
+
+				return;
+			}
+		}
+	}
+
+	private String[] _portalProfiles;
+
+}


### PR DESCRIPTION
@mtambara if @brianchandotcom is ok with the solution, please apply it to EE too.

@michaelhashimoto there are 2 ways to configure profiles.
1) system-ext.properties
portal.profiles=CE,EE,bundle symbolic names

2) portal-ext.properties
module.framework.properties.portal.profiles=CE,EE,bundle symbolic names

portal-ext.properties takes higher priority than system-ext.properties

CE and EE are 2 buildin common profiles. bundle symbolic names are supported too.
