### PR TITLE
LRDOCS-2232 styled API docs for ce.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -563,6 +563,7 @@
 			showFixmeTags="false"
 			showHiddenTags="false"
 			sourceDir="${definitions.dir}"
+			stylesheet="${project.dir}/tools/styles/${lp.style.edition}/dtddoc.css"
 		>
 			<include name="liferay-*${lp.version.dtd}.dtd" />
 		</DTDDoc>
@@ -652,7 +653,7 @@
 			maxmemory="2048m"
 			noqualifier="java.*"
 			overview="${module.dir}/src/overview.html"
-			stylesheetfile="${project.dir}/tools/javadoc.css"
+			stylesheetfile="${project.dir}/tools/styles/${lp.style.edition}/javadoc.css"
 			useexternalfile="yes"
 			use="yes"
 			windowtitle="Liferay ${lp.version} ${module.dir} API"
@@ -686,7 +687,7 @@
 			maxmemory="2048m"
 			noqualifier="java.*"
 			overview="${module.dir}/src/overview.html"
-			stylesheetfile="${project.dir}/tools/javadoc.css"
+			stylesheetfile="${project.dir}/tools/styles/${lp.style.edition}/javadoc.css"
 			useexternalfile="yes"
 			use="yes"
 			windowtitle="Liferay ${lp.version} ${module.dir} API"

--- a/portal-impl/src/com/liferay/portal/tools/propertiesdoc/dependencies/properties.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/propertiesdoc/dependencies/properties.ftl
@@ -1,27 +1,34 @@
 <html>
 	<style type="text/css">
 		h1 {
-			color: red;
+			color: #124680;
 		}
+
 		h2 {
-			color: blue;
+			color: #1B75BB;
 		}
+
 		h3 {
-			color: darkgreen;
+			color: #1B75BB;
 		}
+
 		#toc {
-			border: 1px dotted #555;
+			border: 1px solid #555;
 			color: #555;
+			padding: 20px;
 			width: 700px;
 		}
+
 		#toc li {
 			font-size: 14px;
 		}
+
 		.defaults {
-			background-color: #EFE;
+			background-color: #8BB8E8;
 		}
+
 		.examples {
-			background-color: #EEE;
+			background-color: #E3E4E5;
 		}
 	</style>
 	<head>

--- a/release.properties
+++ b/release.properties
@@ -83,6 +83,12 @@
     sonatype.snapshot.username=
 
 ##
+## Styles
+##
+
+    lp.style.edition=ce
+
+##
 ## SVN
 ##
 

--- a/tools/styles/ce/dtddoc.css
+++ b/tools/styles/ce/dtddoc.css
@@ -1,0 +1,163 @@
+body {
+	background-color: white;
+	font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
+	font-size: small;
+}
+
+table {
+	border-width: 0;
+}
+
+th.title {
+	font-weight: bold;
+	padding-left: 1em;
+	padding-right: 1em;
+	text-align: center;
+}
+
+th.subtitle {
+	font-weight: normal;
+	padding-left: 1em;
+	padding-right: 1em;
+	text-align: left;
+}
+
+td {
+	padding-left: 1em;
+	padding-right: 1em;
+	text-align: left;
+	vertical-align: baseline;
+}
+
+td.construct {
+	padding-left: 1em;
+	padding-right: 1em;
+	vertical-align: top;
+}
+
+th.ruler {
+	background-color: black;
+	color: black;
+}
+
+table.elementTitle {
+	background-color: #1B75BB;
+	width: 100%;
+}
+
+td.leftElementTitle {
+	font-size: medium;
+	font-weight: bold;
+}
+
+td.rightElementTitle {
+	text-align: right;
+}
+
+table.attributeTitle {
+	background-color: #8BB8E8;
+	width: 100%;
+}
+
+td.leftAttributeTitle {
+	font-size: medium;
+	font-weight: bold;
+}
+
+td.rightAttributeTitle {
+	text-align: right;
+}
+
+p {
+	text-align: justify;
+}
+
+p.model {
+	font-style: italic;
+	padding-left: 3em;
+	text-align: left;
+}
+
+p.DTDSource {
+	background-color: #8BB8E8;
+	text-align: right;
+	width: 100%;
+}
+
+p.emptyTagNote {
+	font-style: italic;
+}
+
+h1 {
+	font-family: Arial;
+	font-size: x-large;
+}
+
+h2 {
+	font-size: medium;
+}
+
+h2.TOCTitle {
+	font-family: Arial;
+	font-size: medium;
+}
+
+.inTextTitle {
+	font-weight: bold;
+}
+
+pre, code {
+	font-family: "Courier New", Courier, monospace;
+	font-size: small;
+}
+
+pre#dtd_source {
+	border: dotted 1px Gray;
+	padding: 6pt;
+}
+
+.xml_plain {
+	color: #000;
+}
+
+.dtd_tag_symbols {
+	color: #003BFF;
+}
+
+.dtd_comment {
+	background-color: #F8F8F8;
+	color: #555;
+}
+
+.dtd_attribute_name {
+	color: #000;
+}
+
+.dtd_tag_name {
+	color: #3F3FBF;
+}
+
+.dtd_char_data {
+	color: #000;
+}
+
+.dtd_processing_instruction {
+	color: #000;
+	font-style: italic;
+	font-weight: bold;
+}
+
+.dtd_attribute_value {
+	color: #C10000;
+}
+
+.dtd_dtddoc_tag {
+	background-color: #F7F7F7;
+	color: #939393;
+	font-style: italic;
+	font-weight: bold;
+}
+
+.dtd_keyword {
+	color: #800000;
+}

--- a/tools/styles/ce/javadoc.css
+++ b/tools/styles/ce/javadoc.css
@@ -1,0 +1,58 @@
+BODY {
+	background-color: #FFF;
+}
+
+.TableHeadingColor {
+	background: #8BB8E8;
+}
+
+.TableSubHeadingColor {
+	background: #1B75BB;
+}
+
+.TableRowColor {
+	background: #FFF;
+}
+
+.FrameTitleFont  {
+	font-family: Helvetica, Arial, san-serif;
+	font-size: 10pts;
+}
+
+.FrameHeadingFont {
+	font-family: Helvetica, Arial, san-serif;
+	font-size: 10pts;
+}
+
+.FrameItemFont {
+	font-family: Helvetica, Arial, sans-serif;
+	font-size: 10pt;
+}
+
+.NavBarCell1 {
+	background-color: #1B75BB;
+}
+
+.NavBarCell1Rev {
+	background-color: #8BB8E8;
+}
+
+.NavBarFont1 {
+	color: #000;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.NavBarFont1Rev {
+	color: #FFF;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.NavBarCell2 {
+	background-color: #FFF;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.NavBarCell3 {
+	background-color: #FFF;
+	font-family: Arial, Helvetica, sans-serif;
+}

--- a/tools/styles/ce/propertiesdoc.css
+++ b/tools/styles/ce/propertiesdoc.css
@@ -1,0 +1,30 @@
+h1 {
+	color: #124680;
+}
+
+h2 {
+	color: #1B75BB;
+}
+
+h3 {
+	color: #1B75BB;
+}
+
+#toc {
+	border: 1px solid #555;
+	color: #555;
+	padding: 20px;
+	width: 700px;
+}
+
+#toc li {
+	font-size: 14px;
+}
+
+.defaults {
+	background-color: #8BB8E8;
+}
+
+.examples {
+	background-color: #E3E4E5;
+}

--- a/tools/styles/ce/taglibs/stylesheet.css
+++ b/tools/styles/ce/taglibs/stylesheet.css
@@ -1,0 +1,58 @@
+BODY {
+	background-color: #FFF;
+}
+
+.TableHeadingColor {
+	background: #8BB8E8;
+}
+
+.TableSubHeadingColor {
+	background: #1B75BB;
+}
+
+.TableRowColor {
+	background: #FFF;
+}
+
+.FrameTitleFont  {
+	font-family: Helvetica, Arial, san-serif;
+	font-size: 10pts;
+}
+
+.FrameHeadingFont {
+	font-family: Helvetica, Arial, san-serif;
+	font-size: 10pts;
+}
+
+.FrameItemFont {
+	font-family: Helvetica, Arial, sans-serif;
+	font-size: 10pt;
+}
+
+.NavBarCell1 {
+	background-color: #1B75BB;
+}
+
+.NavBarCell1Rev {
+	background-color: #8BB8E8;
+}
+
+.NavBarFont1 {
+	color: #000;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.NavBarFont1Rev {
+	color: #FFF;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.NavBarCell2 {
+	background-color: #FFF;
+	font-family: Arial, Helvetica, sans-serif;
+}
+
+.NavBarCell3 {
+	background-color: #FFF;
+	font-family: Arial, Helvetica, sans-serif;
+}

--- a/util-taglib/build.xml
+++ b/util-taglib/build.xml
@@ -147,6 +147,7 @@
 		>
 			<arg line="-d ${doc.taglibs.dir}" />
 			<arg line="${tld.files}" />
+			<arg line="-xslt ${project.dir}/tools/styles/${lp.style.edition}/taglibs/" />
 		</java>
 
 		<copy overwrite="true" preservelastmodified="true" todir="${doc.taglibs.dir}/images">


### PR DESCRIPTION
The reference doc styles for each edition (ce and dxp) are nested under `/tools/styles/${lp.style.edition}/`.

The DXP styles are in https://github.com/brianchandotcom/liferay-portal-ee/pull/13131.

Since the TLD doc generator expects a stylesheet named `stylesheet.css` and it takes the stylesheet folder path as a parameter, we put the taglib doc stylesheet under `/tools/styles/${lp.style.edition}/taglibs/`.

cc/ @mwilliams2014 @Ithildir
