### PR TITLE
Lps 65067 autodeploy

### DIFF
--- a/modules/apps/marketplace/marketplace-deployer/bnd.bnd
+++ b/modules/apps/marketplace/marketplace-deployer/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Liferay Marketplace Deployer
+Bundle-SymbolicName: com.liferay.marketplace.deployer
+Bundle-Version: 2.0.3
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title:

--- a/modules/apps/marketplace/marketplace-deployer/build.gradle
+++ b/modules/apps/marketplace/marketplace-deployer/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+	provided group: "com.liferay", name: "com.liferay.marketplace.api", version: "3.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "org.apache.felix", name: "org.apache.felix.fileinstall", version: "3.5.1-20150728.201454-4"
+	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":core:portal-lpkg-deployer");
+}

--- a/modules/apps/marketplace/marketplace-deployer/src/main/java/com/liferay/marketplace/deployer/LPKGArtifactInstaller.java
+++ b/modules/apps/marketplace/marketplace-deployer/src/main/java/com/liferay/marketplace/deployer/LPKGArtifactInstaller.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.marketplace.deployer;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.lpkg.deployer.LPKGDeployer;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.Dictionary;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.apache.felix.fileinstall.ArtifactInstaller;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Shuyang Zhou
+ */
+@Component(immediate = true)
+public class LPKGArtifactInstaller implements ArtifactInstaller {
+
+	@Activate
+	public void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	@Override
+	public boolean canHandle(File file) {
+		String name = StringUtil.toLowerCase(file.getName());
+
+		return name.endsWith(".lpkg");
+	}
+
+	@Override
+	public void install(File file) throws Exception {
+		Properties properties = _readMarketplaceProperties(file);
+
+		if (GetterUtil.getBoolean(
+				properties.getProperty("restart-required"), true)) {
+
+			return;
+		}
+
+		for (Bundle bundle : _lpkgDeployer.deploy(_bundleContext, file)) {
+			Dictionary<String, String> headers = bundle.getHeaders();
+
+			String fragmentHost = headers.get(Constants.FRAGMENT_HOST);
+
+			if (fragmentHost != null) {
+				continue;
+			}
+
+			try {
+				bundle.start();
+			}
+			catch (BundleException be) {
+				_log.error("Unable to start " + bundle + " for " + file, be);
+			}
+		}
+	}
+
+	@Override
+	public void uninstall(File file) throws Exception {
+		Bundle bundle = _bundleContext.getBundle(file.getCanonicalPath());
+
+		if (bundle != null) {
+			bundle.uninstall();
+		}
+	}
+
+	@Override
+	public void update(File file) throws Exception {
+		Properties properties = _readMarketplaceProperties(file);
+
+		if (GetterUtil.getBoolean(
+				properties.getProperty("restart-required"), true)) {
+
+			return;
+		}
+
+		Bundle bundle = _bundleContext.getBundle(file.getCanonicalPath());
+
+		if (bundle != null) {
+			Version currentVersion = bundle.getVersion();
+			Version newVersion = new Version(properties.getProperty("version"));
+
+			if (newVersion.compareTo(currentVersion) > 0) {
+				bundle.update(_lpkgDeployer.toBundle(file));
+			}
+		}
+	}
+
+	private Properties _readMarketplaceProperties(File file) {
+		try (ZipFile zipFile = new ZipFile(file)) {
+			ZipEntry zipEntry = zipFile.getEntry(
+				"liferay-marketplace.properties");
+
+			if (zipEntry == null) {
+				return null;
+			}
+
+			Properties properties = new Properties();
+
+			try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
+				properties.load(inputStream);
+			}
+
+			return properties;
+		}
+		catch (Exception e) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to read liferay-marketplace.properties from " +
+						file.getName(),
+					e);
+			}
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LPKGArtifactInstaller.class);
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private LPKGDeployer _lpkgDeployer;
+
+}

--- a/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/LPKGDeployer.java
+++ b/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/LPKGDeployer.java
@@ -16,6 +16,7 @@ package com.liferay.portal.lpkg.deployer;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 import java.util.List;
 import java.util.Map;
@@ -32,5 +33,7 @@ public interface LPKGDeployer {
 		throws IOException;
 
 	public Map<Bundle, List<Bundle>> getDeployedLPKGBundles();
+
+	public InputStream toBundle(File lpkgFile) throws IOException;
 
 }

--- a/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
+++ b/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
@@ -193,7 +193,7 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 			List<Bundle> bundles = new ArrayList<>();
 
 			Bundle lpkgBundle = bundleContext.installBundle(
-				lpkgFile.getCanonicalPath(), _toBundle(lpkgFile));
+				lpkgFile.getCanonicalPath(), toBundle(lpkgFile));
 
 			BundleStartLevel bundleStartLevel = lpkgBundle.adapt(
 				BundleStartLevel.class);
@@ -221,13 +221,8 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 		return _lpkgBundleTracker.getTracked();
 	}
 
-	@Deactivate
-	protected void deactivate() {
-		_lpkgBundleTracker.close();
-		_warWrapperBundlerTracker.close();
-	}
-
-	private InputStream _toBundle(File lpkgFile) throws IOException {
+	@Override
+	public InputStream toBundle(File lpkgFile) throws IOException {
 		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
 				new UnsyncByteArrayOutputStream()) {
 
@@ -257,6 +252,12 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 				unsyncByteArrayOutputStream.unsafeGetByteArray(), 0,
 				unsyncByteArrayOutputStream.size());
 		}
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_lpkgBundleTracker.close();
+		_warWrapperBundlerTracker.close();
 	}
 
 	private void _writeManifest(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6421,6 +6421,7 @@
     #
     module.framework.auto.deploy.dirs=\
         ${module.framework.base.dir}/configs,\
+        ${module.framework.base.dir}/marketplace,\
         ${module.framework.base.dir}/modules,\
         ${module.framework.base.dir}/war
 

--- a/portal-kernel/src/com/liferay/portal/kernel/deploy/auto/AutoDeployDir.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/deploy/auto/AutoDeployDir.java
@@ -70,18 +70,18 @@ public class AutoDeployDir {
 		String fileName = file.getName();
 
 		if (StringUtil.endsWith(fileName, ".lpkg")) {
-			String lpkgDeployerDirName = PropsUtil.get(
+			String lpkgDeployerDirString = PropsUtil.get(
 				PropsKeys.MODULE_FRAMEWORK_PROPERTIES.concat(
 					"lpkg.deployer.dir"));
 
-			File lpkgDeployerDir = new File(lpkgDeployerDirName);
+			File lpkgDeployerDir = new File(lpkgDeployerDirString);
 
 			FileUtil.move(file, new File(lpkgDeployerDir, file.getName()));
 
 			if (_log.isInfoEnabled()) {
 				_log.info(
 					"Restart is required to complete the installation of " +
-						fileName);
+						file.getName());
 			}
 
 			try {
@@ -90,8 +90,7 @@ public class AutoDeployDir {
 			catch (Exception e) {
 				_log.error(
 					"Unable to automatically shutdown the portal to " +
-						"complete the installation of " + fileName,
-					e);
+						"complete installation.");
 			}
 
 			return;


### PR DESCRIPTION
@brianchandotcom @mhan810 @rotty3000

With this change, the auto deployment for lpkg is working closely with the bootup time installation.
To make a lpkg runtime deployable, it must has "restart-required=false" in its liferay-marketplace.propeties, whose value defaults to true on absent. When the lpkg requires a restart, it will be picked up on next bootup time by lpkg deployer.

The fileinstall integration is smart enough to only take on "restart-required=false" lpkg bundles, and do a version check before update, so that the same lpkg won't be installed by bootup time lpkg deployer, then updated by runtime auto deployer again.

@lionah please do some tests on your side. I have tested some scenarios, but better to have more eyes on it.
