### PR TITLE
LPS-65398 Exclude ".sass-cache" files from the digest calculation

### DIFF
--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/build.gradle
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/build.gradle
@@ -10,7 +10,7 @@ cache {
 
 		testFile "build.gradle"
 		testFile "package.json"
-		testFile fileTree(dir: "src/main/resources/META-INF/resources")
+		testFile fileTree(dir: "src/main/resources/META-INF/resources", exclude: "**/.sass-cache/")
 	}
 }
 


### PR DESCRIPTION
@jbalsas, we should exclude the `.sass-cache` from the cache digest calculation. Unfortunately I'm unable to regenerate the cache on Windows, because of this error:

```
apps:foundation:frontend-image-editor:frontend-image-editor-web:transpileJS
Running 'build'...
                   Compiling soy

stream.js:74
      throw er; // Unhandled stream error in pipe.
      ^
Error: Compile error:
errors during Soy compilation
In file ImageEditor.soy:1:24: parse error at '
                                                 ': expected eof, {alias, {deltemplate, or {template
{namespace ImageEditor}
                       ^

In file ImageEditorLoading.soy:1:31: parse error at '
                                                        ': expected eof, {alias, {deltemplate, or {template
{namespace ImageEditorLoading}
                              ^
```

@brianchandotcom, can you please regenerate the cache? I'm sure it'll work on Mac!

Also, do we need the empty [Language.properties](https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/content/Language.properties) in `frontend-image-editor-web`?
