### PR TITLE
Lps 65067 arquillian test

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -694,6 +694,10 @@ app.server.type=@{app.server.type}]]></echo>
 							<trycatch>
 								<try>
 									<antcall inheritall="false" target="start-app-server" />
+
+									<gradle-execute dir="modules/core/portal-lpkg-deployer-test" task="testIntegration">
+										<arg value="-Dmodules.only.build=true" />
+									</gradle-execute>
 								</try>
 
 								<finally>

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -695,6 +695,8 @@ app.server.type=@{app.server.type}]]></echo>
 								<try>
 									<antcall inheritall="false" target="start-app-server" />
 
+									<delete dir="${app.server.parent.dir}/osgi/test" />
+
 									<gradle-execute dir="modules/core/portal-lpkg-deployer-test" task="testIntegration">
 										<arg value="-Dmodules.only.build=true" />
 									</gradle-execute>

--- a/build-test.xml
+++ b/build-test.xml
@@ -2213,6 +2213,7 @@ ${tomcat-gc-log}
 						directoryScanner.setExcludes(
 							new String[] {
 								"portal-kernel/test/unit/com/liferay/portal/log/assertor/PortalLogAssertorTest.java",
+								"modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java",
 								"*/pacl/test/[\\w]+Test.class",
 								"**/*ServiceHttpTest.java",
 								"**/*ServiceJsonTest.java",

--- a/modules/core/portal-lpkg-deployer-test/bnd.bnd
+++ b/modules/core/portal-lpkg-deployer-test/bnd.bnd
@@ -1,4 +1,3 @@
 Bundle-Name: Liferay Portal LPKG Deployer Test
 Bundle-SymbolicName: com.liferay.portal.lpkg.deployer.test
 Bundle-Version: 1.0.0
-Private-Package: com.liferay.portal.lpkg.deployer.test

--- a/modules/core/portal-lpkg-deployer-test/bnd.bnd
+++ b/modules/core/portal-lpkg-deployer-test/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Portal LPKG Deployer Test
+Bundle-SymbolicName: com.liferay.portal.lpkg.deployer.test
+Bundle-Version: 1.0.0
+Private-Package: com.liferay.portal.lpkg.deployer.test

--- a/modules/core/portal-lpkg-deployer-test/bnd.bnd
+++ b/modules/core/portal-lpkg-deployer-test/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Portal LPKG Deployer Test
 Bundle-SymbolicName: com.liferay.portal.lpkg.deployer.test
 Bundle-Version: 1.0.0
+-includeresource: test-classes/integration

--- a/modules/core/portal-lpkg-deployer-test/build.gradle
+++ b/modules/core/portal-lpkg-deployer-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	provided project(":core:portal-lpkg-deployer")
+
+	testIntegrationCompile group: "com.liferay", name: "com.liferay.arquillian.extension.junit.bridge", version: "1.0.5"
+}

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -30,6 +30,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
@@ -120,12 +121,17 @@ public class LPKGDeployerTest {
 				"No matching lpkg bundle for " + file.getCanonicalPath(),
 				lpkgBundle);
 
-			List<Bundle> bundles = bundleMap.get(lpkgBundle);
+			List<Bundle> expectedAppBundles = new ArrayList<>(
+				bundleMap.get(lpkgBundle));
 
 			Assert.assertNotNull(
 				"Registered lpkg bundles " + bundleMap.keySet() +
 					" do not contain " + lpkgBundle,
-				bundles);
+				expectedAppBundles);
+
+			Collections.sort(expectedAppBundles);
+
+			List<Bundle> actualAppBundles = new ArrayList<>();
 
 			ZipFile zipFile = new ZipFile(file);
 
@@ -142,12 +148,18 @@ public class LPKGDeployerTest {
 
 					Assert.assertNotNull(
 						"No matching app bundle for /" + name, bundle);
-					Assert.assertTrue(
-						"Registered app bundles " + bundles +
-							" do not contain " + bundle,
-						bundles.contains(bundle));
+
+					actualAppBundles.add(bundle);
 				}
 			}
+
+			Collections.sort(actualAppBundles);
+
+			Assert.assertEquals(
+				"For lpkg bundle " + lpkgBundle + ", expected app bundles " +
+					expectedAppBundles + ", actual app bundles " +
+						actualAppBundles,
+				expectedAppBundles, actualAppBundles);
 		}
 	}
 

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -97,8 +97,8 @@ public class LPKGDeployerTest {
 
 			});
 
-		Assert.assertTrue(
-			"No lpkg file in " + deploymentDir, !lpkgFiles.isEmpty());
+		Assert.assertFalse(
+			"No lpkg file in " + deploymentDir, lpkgFiles.isEmpty());
 
 		ServiceTracker<LPKGDeployer, LPKGDeployer> serviceTracker =
 			new ServiceTracker<>(bundleContext, LPKGDeployer.class, null);

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -142,7 +142,7 @@ public class LPKGDeployerTest {
 
 				String name = zipEntry.getName();
 
-				if (name.endsWith(".jar") || name.endsWith("*.war")) {
+				if (name.endsWith(".jar") || name.endsWith(".war")) {
 					Bundle bundle = bundleContext.getBundle(
 						StringPool.SLASH + name);
 

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -122,8 +122,13 @@ public class LPKGDeployerTest {
 			Bundle lpkgBundle = bundleContext.getBundle(
 				file.getCanonicalPath());
 
-			Assert.assertNotNull(lpkgBundle);
-			Assert.assertTrue(bundleMap.containsKey(lpkgBundle));
+			Assert.assertNotNull(
+				"No matching lpkg bundle for " + file.getCanonicalPath(),
+				lpkgBundle);
+			Assert.assertTrue(
+				"Registered lpkg bundles " + bundleMap.keySet() +
+					" do not contain " + lpkgBundle,
+				bundleMap.containsKey(lpkgBundle));
 
 			ZipFile zipFile = new ZipFile(file);
 

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -64,9 +64,10 @@ public class LPKGDeployerTest {
 
 		Path deploymentDirPath = Paths.get(deploymentDir);
 
-		final List<File> lpkgFiles = new ArrayList<>();
+		Assert.assertTrue(
+			deploymentDir + " does not exist", Files.exists(deploymentDirPath));
 
-		Files.createDirectories(deploymentDirPath);
+		final List<File> lpkgFiles = new ArrayList<>();
 
 		Files.walkFileTree(
 			deploymentDirPath,

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -140,8 +140,12 @@ public class LPKGDeployerTest {
 					Bundle bundle = bundleContext.getBundle(
 						StringPool.SLASH + name);
 
-					Assert.assertNotNull(bundle);
-					Assert.assertTrue(bundles.contains(bundle));
+					Assert.assertNotNull(
+						"No matching app bundle for /" + name, bundle);
+					Assert.assertTrue(
+						"Registered app bundles " + bundles +
+							" do not contain " + bundle,
+						bundles.contains(bundle));
 				}
 			}
 		}

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lpkg.deployer.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.lpkg.deployer.LPKGDeployer;
+import com.liferay.portal.util.PropsValues;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Matthew Tambara
+ */
+@RunWith(Arquillian.class)
+public class LPKGDeployerTest {
+
+	@Test
+	public void testDeployedLPKGs() throws Exception {
+		Bundle testBundle = FrameworkUtil.getBundle(LPKGDeployerTest.class);
+
+		BundleContext bundleContext = testBundle.getBundleContext();
+
+		String deploymentDir = GetterUtil.getString(
+			bundleContext.getProperty("lpkg.deployer.dir"),
+			PropsValues.MODULE_FRAMEWORK_BASE_DIR + "/marketplace");
+
+		Path deploymentDirPath = Paths.get(deploymentDir);
+
+		final List<File> lpkgFiles = new ArrayList<>();
+
+		Files.createDirectories(deploymentDirPath);
+
+		Files.walkFileTree(
+			deploymentDirPath,
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult visitFile(
+						Path filePath, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path fileNamePath = filePath.getFileName();
+
+					String fileName = StringUtil.toLowerCase(
+						fileNamePath.toString());
+
+					if (!fileName.endsWith(".lpkg")) {
+						return FileVisitResult.CONTINUE;
+					}
+
+					lpkgFiles.add(filePath.toFile());
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+
+		Assert.assertTrue(!lpkgFiles.isEmpty());
+
+		ServiceTracker<LPKGDeployer, LPKGDeployer> serviceTracker =
+			new ServiceTracker<>(bundleContext, LPKGDeployer.class, null);
+
+		serviceTracker.open();
+
+		LPKGDeployer lpkgDeployer = serviceTracker.getService();
+
+		serviceTracker.close();
+
+		Map<Bundle, List<Bundle>> bundleMap =
+			lpkgDeployer.getDeployedLPKGBundles();
+
+		List<Bundle> lpkgBundles = new ArrayList<>(bundleMap.keySet());
+
+		List<Bundle> bundles = new ArrayList<>();
+
+		for (List<Bundle> bundleList : bundleMap.values()) {
+			bundles.addAll(bundleList);
+		}
+
+		for (File file : lpkgFiles) {
+			Bundle lpkgBundle = bundleContext.getBundle(
+				file.getCanonicalPath());
+
+			Assert.assertNotNull(lpkgBundle);
+			Assert.assertTrue(lpkgBundles.contains(lpkgBundle));
+
+			ZipFile zipFile = new ZipFile(file);
+
+			Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+
+			while (zipEntries.hasMoreElements()) {
+				ZipEntry zipEntry = zipEntries.nextElement();
+
+				String name = zipEntry.getName();
+
+				if (name.endsWith(".jar") || name.endsWith("*.war")) {
+					Bundle bundle = bundleContext.getBundle(
+						StringPool.SLASH + name);
+
+					Assert.assertNotNull(bundle);
+					Assert.assertTrue(bundles.contains(bundle));
+				}
+			}
+		}
+	}
+
+}

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -97,7 +97,8 @@ public class LPKGDeployerTest {
 
 			});
 
-		Assert.assertTrue(!lpkgFiles.isEmpty());
+		Assert.assertTrue(
+			"No lpkg file in " + deploymentDir, !lpkgFiles.isEmpty());
 
 		ServiceTracker<LPKGDeployer, LPKGDeployer> serviceTracker =
 			new ServiceTracker<>(bundleContext, LPKGDeployer.class, null);

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -57,7 +57,8 @@ public class LPKGDeployerTest {
 
 		BundleContext bundleContext = testBundle.getBundleContext();
 
-		String deploymentDir = bundleContext.getProperty("lpkg.deployer.dir");
+		final String deploymentDir = bundleContext.getProperty(
+			"lpkg.deployer.dir");
 
 		Assert.assertNotNull(
 			"Missing configuration for \"lpkg.deployer.dir\"", deploymentDir);
@@ -84,7 +85,9 @@ public class LPKGDeployerTest {
 						fileNamePath.toString());
 
 					if (!fileName.endsWith(".lpkg")) {
-						return FileVisitResult.CONTINUE;
+						Assert.fail(
+							"Unexpected file " + filePath + " in " +
+								deploymentDir);
 					}
 
 					lpkgFiles.add(filePath.toFile());

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -112,12 +112,6 @@ public class LPKGDeployerTest {
 		Map<Bundle, List<Bundle>> bundleMap =
 			lpkgDeployer.getDeployedLPKGBundles();
 
-		List<Bundle> bundles = new ArrayList<>();
-
-		for (List<Bundle> bundleList : bundleMap.values()) {
-			bundles.addAll(bundleList);
-		}
-
 		for (File file : lpkgFiles) {
 			Bundle lpkgBundle = bundleContext.getBundle(
 				file.getCanonicalPath());
@@ -125,10 +119,13 @@ public class LPKGDeployerTest {
 			Assert.assertNotNull(
 				"No matching lpkg bundle for " + file.getCanonicalPath(),
 				lpkgBundle);
-			Assert.assertTrue(
+
+			List<Bundle> bundles = bundleMap.get(lpkgBundle);
+
+			Assert.assertNotNull(
 				"Registered lpkg bundles " + bundleMap.keySet() +
 					" do not contain " + lpkgBundle,
-				bundleMap.containsKey(lpkgBundle));
+				bundles);
 
 			ZipFile zipFile = new ZipFile(file);
 

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -15,11 +15,9 @@
 package com.liferay.portal.lpkg.deployer.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.lpkg.deployer.LPKGDeployer;
-import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,9 +57,10 @@ public class LPKGDeployerTest {
 
 		BundleContext bundleContext = testBundle.getBundleContext();
 
-		String deploymentDir = GetterUtil.getString(
-			bundleContext.getProperty("lpkg.deployer.dir"),
-			PropsValues.MODULE_FRAMEWORK_BASE_DIR + "/marketplace");
+		String deploymentDir = bundleContext.getProperty("lpkg.deployer.dir");
+
+		Assert.assertNotNull(
+			"Missing configuration for \"lpkg.deployer.dir\"", deploymentDir);
 
 		Path deploymentDirPath = Paths.get(deploymentDir);
 

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -129,10 +129,10 @@ public class LPKGDeployerTest {
 
 			ZipFile zipFile = new ZipFile(file);
 
-			Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+			Enumeration<? extends ZipEntry> enumeration = zipFile.entries();
 
-			while (zipEntries.hasMoreElements()) {
-				ZipEntry zipEntry = zipEntries.nextElement();
+			while (enumeration.hasMoreElements()) {
+				ZipEntry zipEntry = enumeration.nextElement();
 
 				String name = zipEntry.getName();
 

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -112,8 +112,6 @@ public class LPKGDeployerTest {
 		Map<Bundle, List<Bundle>> bundleMap =
 			lpkgDeployer.getDeployedLPKGBundles();
 
-		List<Bundle> lpkgBundles = new ArrayList<>(bundleMap.keySet());
-
 		List<Bundle> bundles = new ArrayList<>();
 
 		for (List<Bundle> bundleList : bundleMap.values()) {
@@ -125,7 +123,7 @@ public class LPKGDeployerTest {
 				file.getCanonicalPath());
 
 			Assert.assertNotNull(lpkgBundle);
-			Assert.assertTrue(lpkgBundles.contains(lpkgBundle));
+			Assert.assertTrue(bundleMap.containsKey(lpkgBundle));
 
 			ZipFile zipFile = new ZipFile(file);
 

--- a/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
+++ b/modules/core/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/test/LPKGDeployerTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.lpkg.deployer.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.lpkg.deployer.LPKGDeployer;
@@ -142,7 +143,7 @@ public class LPKGDeployerTest {
 
 				String name = zipEntry.getName();
 
-				if (name.endsWith(".jar") || name.endsWith(".war")) {
+				if (name.endsWith(".jar")) {
 					Bundle bundle = bundleContext.getBundle(
 						StringPool.SLASH + name);
 
@@ -150,6 +151,43 @@ public class LPKGDeployerTest {
 						"No matching app bundle for /" + name, bundle);
 
 					actualAppBundles.add(bundle);
+				}
+
+				if (name.endsWith(".war")) {
+					Bundle bundle = bundleContext.getBundle(
+						StringPool.SLASH + name);
+
+					Assert.assertNotNull(
+						"No matching app bundle for /" + name, bundle);
+
+					actualAppBundles.add(bundle);
+
+					String contextName = name.substring(
+						0, name.lastIndexOf(".war"));
+
+					int index = contextName.lastIndexOf('-');
+
+					if (index >= 0) {
+						contextName = contextName.substring(0, index);
+					}
+
+					StringBundler sb = new StringBundler(8);
+
+					sb.append("webbundle:lpkg://");
+					sb.append(lpkgBundle.getSymbolicName());
+					sb.append(StringPool.DASH);
+					sb.append(lpkgBundle.getVersion());
+					sb.append(StringPool.SLASH);
+					sb.append(contextName);
+					sb.append(".war?Web-ContextPath=/");
+					sb.append(contextName);
+
+					String location = sb.toString();
+
+					Assert.assertNotNull(
+						"Missing war bundle for wrapper bundle " + bundle +
+							" with expected location " + location,
+						bundleContext.getBundle(location));
 				}
 			}
 


### PR DESCRIPTION
@Ithildir please see the last commit in this pull.

This is actually a painful issue that tortures tester runners for a very long time. Until I started to see this pull randomly fails on CI with a very good chance, I started to look into it. And I finally figured out what's going on here.

On symptom side, for any arquillian test, 1st run is always good (assume your test is correct of course). But after the 1st run, there is a very good chance, you will get the following exception.

```
java.lang.NullPointerException
    at org.eclipse.osgi.internal.framework.legacy.PackageAdminImpl$ExportedPackageImpl.getImportingBundles(PackageAdminImpl.java:336)
    at org.apache.aries.jmx.util.FrameworkUtils.getBundleImportedPackagesRaw(FrameworkUtils.java:285)
    at org.apache.aries.jmx.util.FrameworkUtils.getBundleDependencies(FrameworkUtils.java:491)
    at org.apache.aries.jmx.codec.BundleData.<init>(BundleData.java:219)
    at org.apache.aries.jmx.framework.BundleState.listBundles(BundleState.java:341)
    at org.apache.aries.jmx.framework.BundleState.listBundles(BundleState.java:329)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at sun.reflect.misc.Trampoline.invoke(MethodUtil.java:75)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at sun.reflect.misc.MethodUtil.invoke(MethodUtil.java:279)
    at com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:112)
    at com.sun.jmx.mbeanserver.StandardMBeanIntrospector.invokeM2(StandardMBeanIntrospector.java:46)
    at com.sun.jmx.mbeanserver.MBeanIntrospector.invokeM(MBeanIntrospector.java:237)
    at com.sun.jmx.mbeanserver.PerInterface.invoke(PerInterface.java:138)
    at com.sun.jmx.mbeanserver.MBeanSupport.invoke(MBeanSupport.java:252)
    at javax.management.StandardMBean.invoke(StandardMBean.java:405)
    at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:819)
    at com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801)
    at javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1487)
    at javax.management.remote.rmi.RMIConnectionImpl.access$300(RMIConnectionImpl.java:97)
    at javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1328)
    at javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1420)
    at javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:848)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:322)
    at sun.rmi.transport.Transport$2.run(Transport.java:202)
    at sun.rmi.transport.Transport$2.run(Transport.java:199)
    at java.security.AccessController.doPrivileged(Native Method)
    at sun.rmi.transport.Transport.serviceCall(Transport.java:198)
    at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:567)
    at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
    at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.access$400(TCPTransport.java:619)
    at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$1.run(TCPTransport.java:684)
    at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$1.run(TCPTransport.java:681)
    at java.security.AccessController.doPrivileged(Native Method)
    at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:681)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
```

The root cause of this issue is:

**com.liferay.gradle.plugins.test.integration.tasks.SetupTestableTomcatTask.setupOsgiModules()**

For the 1st run, it copies all test jars from osgi/test to osgi/modules for the 1st time, causing them to install, then starts the test.

For all runs after the 1st time, those test bundles are already installed, but the jars are copied again. Cause fileinstall to update those bundles, if the test runs while the bundles are reloading, we will get this NPE.

My hacky fix here is to remove all test jars after <antcall inheritall="false" target="start-app-server" /> which internal does the copy already. Then the setupOsgiModules() has nothing to copy, so that run-lpkg-startup-test can work normally.

But we still need to fix it in a formal way to release test runner from this painfull NPE when running arquillian tests locally.

There are 2 simple ways to fix it:
1. In _com.liferay.gradle.plugins.test.integration.tasks.SetupTestableTomcatTask.setupOsgiModules()_, do a simple file exist checking before copying, if the test jars are already there, don't copy them, then there will be no bundle reloading.
2. Add **com.liferay.gradle.plugins.test.integration.tasks.SetupTestableTomcatTask.tearDownOsgiModules()**, invoke it after the test runs. So that the next test run will have to do a fresh test bundles installation rather than update.

I think we should do both. 1) ensures we already have the protection. 2) ensures if developers modifiy the test bundles, the newer versions can still be picked up.

Make sense? please let me know if you have any question.

Once after you fix the issue, please revert my last commit, thanks!
