### PR TITLE
Revert "LPS-65528 Add SF ignore for spi-provider-web"

### DIFF
--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -249,7 +249,6 @@
         modules/apps/foundation/petra/petra-xml/src/main/java/com/liferay/petra/xml/Dom4jUtil.java,\
         modules/apps/foundation/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/definition/WebXMLDefinitionLoader.java,\
         modules/apps/web-experience/xsl-content/xsl-content-web/src/main/java/com/liferay/xsl/content/web/util/XSLContentUtil.java,\
-        modules/private/apps/spi/spi-provider-web/docroot/WEB-INF/src/com/liferay/portal/resiliency/spi/provider/tomcat/TomcatRemoteSPI.java,\
         modules/sdk/ant-bnd/src/main/java/com/liferay/ant/bnd/social/SocialAnalyzerPlugin.java,\
         modules/sdk/gradle-plugins-maven-plugin-builder/src/main/java/com/liferay/gradle/plugins/maven/plugin/builder/util/XMLUtil.java,\
         portal-impl/src/com/liferay/portal/security/xml/SecureXMLFactoryProviderImpl.java,\


### PR DESCRIPTION
Hi!
I saw SF errors on CI, so I guess we have to keep the SF exclusions for `private` modules only on `ee-7.0.x.`. Can we have different `source-formatter.properties` in the two branches?
