### PR TITLE
LPS-65740 Print out more context info on failure.

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
+++ b/portal-impl/src/com/liferay/portal/tools/deploy/BaseDeployer.java
@@ -239,6 +239,17 @@ public class BaseDeployer implements AutoDeployer, Deployer {
 		}
 
 		if (Validator.isNull(appServerType)) {
+			String appServerType2 = ServerDetector.getServerId();
+
+			ServerDetector.init(StringPool.BLANK);
+
+			String appServerType3 = ServerDetector.getServerId();
+
+			_log.error(
+				"Null appServerType:" + appServerType +
+					", from ServerDetector:" + appServerType2 +
+						", ServerDetector reloaded:" + appServerType3);
+
 			throw new IllegalArgumentException(
 				"The system property deployer.app.server.type is not set");
 		}


### PR DESCRIPTION
@brianchandotcom This is for the random FTL failures.

Basically when it happens, ThemeAutoDeployer fails to see the correct appServerType, which I don't really know why, so need to add some context info output to gather more info.

This won't stop the failure from happening, if you see them again, ping me on the pull, I will go check the output, hopefully it can give us more input on this issue.
