### PR TITLE
LRQA-25026 Move some methods used for matrix plugin workaround into JenkinsResultsParserUtil.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -182,7 +182,7 @@ public class FilePropagator {
 			}
 		}
 
-		sb.append("';");
+		sb.append("'");
 
 		Process process = JenkinsResultsParserUtil.executeBashCommands(
 			sb.toString());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -147,8 +147,12 @@ public class FilePropagator {
 
 		try {
 			if (_executeRemoteCommands(commands, targetSlave) != 0) {
-				throw new RuntimeException(
-					"Unable to copy from source. Executed: " + commands);
+				_errorSlaves.add(targetSlave);
+				_targetSlaves.remove(targetSlave);
+
+				_copyFromSource();
+
+				targetSlave = null;
 			}
 		}
 		catch (Exception e) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -471,26 +471,29 @@ public class JenkinsResultsParserUtil {
 			String body, String from, String subject, String to)
 		throws Exception {
 
-		File file = new File("/tmp/notification_email_body.txt");
-
-		if (file.exists()) {
-			file.delete();
-		}
+		File file = new File("/tmp/" + body.hashCode() + ".txt");
 
 		write(file, body);
 
-		StringBuffer sb = new StringBuffer();
+		try {
+			StringBuffer sb = new StringBuffer();
 
-		sb.append("cat /tmp/notification_email_body.txt | mail -v -s ");
-		sb.append("\"");
-		sb.append(subject);
-		sb.append("\" -r \"");
-		sb.append(from);
-		sb.append("\" \"");
-		sb.append(to);
-		sb.append("\"\n");
+			sb.append("cat ");
+			sb.append(file.getAbsolutePath());
+			sb.append(" | mail -v -s ");
+			sb.append("\"");
+			sb.append(subject);
+			sb.append("\" -r \"");
+			sb.append(from);
+			sb.append("\" \"");
+			sb.append(to);
+			sb.append("\"");
 
-		executeBashCommands(sb.toString());
+			executeBashCommands(sb.toString());
+		}
+		finally {
+			file.delete();
+		}
 	}
 
 	public static void sleep(long duration) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -135,7 +135,7 @@ public class JenkinsResultsParserUtil {
 			sb.append(" ");
 		}
 
-		sb.append("echo COMPLETE\n");
+		sb.append("echo BASH COMMANDS COMPLETE\n");
 
 		bashCommands[2] = sb.toString();
 


### PR DESCRIPTION
There are some methods that I wrote in beanshell for the Matrix plugin bug workaround that I think belongs in JenkinsResultsParserUtil. I've also used some of these methods to simplify the implementation of the FilePropagator class so that we no longer need to create a shell script file when executing the ssh rsync commands.

**Please publish a new jenkins results parser jar after merging this pull.**
