### PR TITLE
LPS-65843 only the rome root package should be included here

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6568,6 +6568,7 @@
         com.sun.media.*,\
         com.sun.msv.*,\
         com.sun.org.*,\
+        com.sun.syndication,\
         com.sun.tools.*,\
         com.sun.xml.*,\
         com.yourkit.*,\


### PR DESCRIPTION
The root package IS needed! The reason is because packages exported from the system bundle don't natively support access to package resources. This is a security measure to limit access to privileged information accessible only to the framework itself (like encryption keys, etc.)
