### PR TITLE
Move tomcat-mysql functional test batches to use JDK8

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -883,16 +883,16 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-functional-test app.server.type="tomcat" database.type="hypersonic" />
 	</target>
 
-	<target name="functional-tomcat8-mysql55-jdk7">
+	<target name="functional-tomcat8-mysql55-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.5" />
 	</target>
 
-	<target name="functional-tomcat8-mysql56-jdk7">
+	<target name="functional-tomcat8-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 
-	<target name="functional-tomcat8-mysql56-jdk7-quarantine">
-		<antcall target="functional-tomcat8-mysql56-jdk7" />
+	<target name="functional-tomcat8-mysql56-jdk8-quarantine">
+		<antcall target="functional-tomcat8-mysql56-jdk8" />
 	</target>
 
 	<target name="functional-tomcat8-oracle12-jdk8">

--- a/test.properties
+++ b/test.properties
@@ -880,8 +880,8 @@
         #functional-resin40-mysql56-jdk8,\
         #functional-tcserver26-mysql56-jdk8,\
         functional-tomcat8-hypersonic20-jdk7,\
-        functional-tomcat8-mysql56-jdk7,\
-        functional-tomcat8-mysql56-jdk7-quarantine,\
+        functional-tomcat8-mysql56-jdk8,\
+        functional-tomcat8-mysql56-jdk8-quarantine,\
         functional-tomcat8-oracle12-jdk8,\
         functional-tomcat8-postgresql94-jdk8,\
         functional-tomcat8-sybase16-jdk8,\
@@ -929,10 +929,10 @@
     test.batch.run.property.values[functional-tcserver26-mysql56-jdk8]=true
     test.batch.run.property.names[functional-tomcat8-hypersonic20-jdk7]=portal.acceptance.tomcat.hypersonic
     test.batch.run.property.values[functional-tomcat8-hypersonic20-jdk7]=true
-    test.batch.run.property.names[functional-tomcat8-mysql56-jdk7]=portal.acceptance,portal.acceptance.tomcat.mysql
-    test.batch.run.property.values[functional-tomcat8-mysql56-jdk7]=true,true
-    test.batch.run.property.names[functional-tomcat8-mysql56-jdk7-quarantine]=portal.acceptance.quarantine
-    test.batch.run.property.values[functional-tomcat8-mysql56-jdk7-quarantine]=true
+    test.batch.run.property.names[functional-tomcat8-mysql56-jdk8]=portal.acceptance,portal.acceptance.tomcat.mysql
+    test.batch.run.property.values[functional-tomcat8-mysql56-jdk8]=true,true
+    test.batch.run.property.names[functional-tomcat8-mysql56-jdk8-quarantine]=portal.acceptance.quarantine
+    test.batch.run.property.values[functional-tomcat8-mysql56-jdk8-quarantine]=true
     test.batch.run.property.names[functional-tomcat8-oracle12-jdk8]=portal.smoke
     test.batch.run.property.values[functional-tomcat8-oracle12-jdk8]=true
     test.batch.run.property.names[functional-tomcat8-postgresql94-jdk8]=portal.smoke


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-25211

CC @michaelhashimoto

We want to move our existing db upgrade automation to use the new upgrade tool. However, the new upgrade tool only works with JDK8. For now, I'm just moving all the tomcat mysql functional test batches to JDK8, and I tested it here: https://github.com/brianchiu/liferay-portal/pull/1356 so there isn't an impact to the current functional tests.
