### PR TITLE
LPS-65153 Redeploy of com.liferay.portal.search.elasticsearch makes Search unusable

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
@@ -38,7 +38,6 @@ import java.util.Map;
 
 import org.apache.commons.lang.time.StopWatch;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
@@ -203,17 +202,18 @@ public class EmbeddedElasticsearchConnection
 	}
 
 	protected void configurePlugin(String name, Settings settings) {
-		String version = Version.CURRENT.toString();
-
-		String zip = "/plugins/" + name + "-" + version + ".zip";
+		EmbeddedElasticsearchPluginManager embeddedElasticsearchPluginManager =
+			new EmbeddedElasticsearchPluginManager(
+				name, settings.get("path.plugins"),
+				new PluginManagerFactoryImpl(settings),
+				new PluginZipFactoryImpl());
 
 		try {
-			EmbeddedElasticsearchPluginManager.installPlugin(
-				name, zip, getClass(), settings);
+			embeddedElasticsearchPluginManager.install();
 		}
 		catch (IOException ioe) {
 			throw new RuntimeException(
-				"Unable to install " + name + " plugin from " + zip, ioe);
+				"Unable to install " + name + " plugin", ioe);
 		}
 	}
 

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchPluginManager.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchPluginManager.java
@@ -14,20 +14,17 @@
 
 package com.liferay.portal.search.elasticsearch.internal.connection;
 
-import com.liferay.portal.search.elasticsearch.internal.util.ResourceUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.io.File;
 import java.io.IOException;
 
-import java.net.URI;
-import java.net.URL;
+import java.nio.file.Path;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.cli.Terminal;
 import org.elasticsearch.common.cli.Terminal.Verbosity;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.env.Environment;
-import org.elasticsearch.plugins.PluginManager;
 
 /**
  * @author Artur Aquino
@@ -35,37 +32,107 @@ import org.elasticsearch.plugins.PluginManager;
  */
 public class EmbeddedElasticsearchPluginManager {
 
-	public static void installPlugin(
-			String pluginName, String resourceName, Class<?> clazz,
-			Settings settings)
-		throws IOException {
+	public EmbeddedElasticsearchPluginManager(
+		String pluginName, String pluginsPath,
+		PluginManagerFactory pluginManagerFactory,
+		PluginZipFactory pluginZipFactory) {
 
-		File file = new File(settings.get("path.plugins"));
+		_pluginName = pluginName;
+		_pluginsPath = pluginsPath;
+		_pluginManagerFactory = pluginManagerFactory;
+		_pluginZipFactory = pluginZipFactory;
+	}
+
+	public void install() throws IOException {
+		if (isAlreadyInstalled()) {
+			return;
+		}
+
+		PluginZip pluginZip = createPluginZip();
+
+		try {
+			downloadAndExtract(pluginZip);
+		}
+		finally {
+			pluginZip.delete();
+		}
+	}
+
+	protected PluginZip createPluginZip() throws IOException {
+		String version = Version.CURRENT.toString();
+
+		String resource = "/plugins/" + _pluginName + "-" + version + ".zip";
+
+		return _pluginZipFactory.createPluginZip(resource);
+	}
+
+	protected void downloadAndExtract(PluginZip pluginZip) throws IOException {
+		File file = new File(_pluginsPath);
 
 		file.mkdirs();
 
-		File tempFile = ResourceUtil.getResourceAsTempFile(clazz, resourceName);
+		PluginManager pluginManager = _pluginManagerFactory.createPluginManager(
+			pluginZip);
+
+		Terminal terminal = Terminal.DEFAULT;
+
+		terminal.verbosity(Verbosity.SILENT);
 
 		try {
-			URI uri = tempFile.toURI();
-
-			URL url = uri.toURL();
-
-			PluginManager pluginManager = new PluginManager(
-				new Environment(settings), url, PluginManager.OutputMode.SILENT,
-				TimeValue.timeValueMinutes(1));
-
-			Terminal terminal = Terminal.DEFAULT;
-
-			terminal.verbosity(Verbosity.SILENT);
-
-			pluginManager.removePlugin(pluginName, terminal);
-
-			pluginManager.downloadAndExtract(pluginName, terminal, true);
+			pluginManager.downloadAndExtract(_pluginName, terminal, true);
 		}
-		finally {
-			tempFile.delete();
+		catch (IOException ioe) {
+			if (!handle(ioe)) {
+				throw ioe;
+			}
 		}
 	}
+
+	protected boolean handle(IOException ioe) {
+		String message = ioe.getMessage();
+
+		if (message == null) {
+			return false;
+		}
+
+		if (message.contains(
+				"already exists. To update the plugin, uninstall it first")) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Plugin " + _pluginName + " already installed. Skipping...",
+					ioe);
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected boolean isAlreadyInstalled() throws IOException {
+		PluginManager pluginManager =
+			_pluginManagerFactory.createPluginManager();
+
+		Path[] paths = pluginManager.getInstalledPluginsPaths();
+
+		if (paths != null) {
+			for (Path path : paths) {
+				if (path.endsWith(_pluginName)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		EmbeddedElasticsearchPluginManager.class);
+
+	private final PluginManagerFactory _pluginManagerFactory;
+	private final String _pluginName;
+	private final String _pluginsPath;
+	private final PluginZipFactory _pluginZipFactory;
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManager.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManager.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import java.io.IOException;
+
+import java.nio.file.Path;
+
+import org.elasticsearch.common.cli.Terminal;
+
+/**
+ * @author Artur Aquino
+ * @author André de Oliveira
+ */
+public interface PluginManager {
+
+	public void downloadAndExtract(
+			String name, Terminal terminal, boolean batch)
+		throws IOException;
+
+	public Path[] getInstalledPluginsPaths() throws IOException;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManagerFactory.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManagerFactory.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+/**
+ * @author André de Oliveira
+ */
+public interface PluginManagerFactory {
+
+	public PluginManager createPluginManager();
+
+	public PluginManager createPluginManager(PluginZip pluginZip);
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManagerFactoryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManagerFactoryImpl.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import java.net.URL;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.env.Environment;
+
+/**
+ * @author André de Oliveira
+ */
+public class PluginManagerFactoryImpl implements PluginManagerFactory {
+
+	public PluginManagerFactoryImpl(Settings settings) {
+		_settings = settings;
+	}
+
+	@Override
+	public PluginManager createPluginManager() {
+		return doCreatePluginManager(null);
+	}
+
+	@Override
+	public PluginManager createPluginManager(PluginZip pluginZip) {
+		return doCreatePluginManager(pluginZip.getURL());
+	}
+
+	protected PluginManager doCreatePluginManager(URL url) {
+		return new PluginManagerImpl(
+			new Environment(_settings), url,
+			org.elasticsearch.plugins.PluginManager.OutputMode.SILENT,
+			TimeValue.timeValueMinutes(1));
+	}
+
+	private final Settings _settings;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManagerImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginManagerImpl.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import java.io.IOException;
+
+import java.net.URL;
+
+import java.nio.file.Path;
+
+import org.elasticsearch.common.cli.Terminal;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.plugins.PluginManager.OutputMode;
+
+/**
+ * @author Artur Aquino
+ * @author André de Oliveira
+ */
+public class PluginManagerImpl implements PluginManager {
+
+	public PluginManagerImpl(
+		Environment environment, URL url, OutputMode outputMode,
+		TimeValue timeout) {
+
+		_pluginManager = new org.elasticsearch.plugins.PluginManager(
+			environment, url, outputMode, timeout);
+	}
+
+	@Override
+	public void downloadAndExtract(
+			String name, Terminal terminal, boolean batch)
+		throws IOException {
+
+		_pluginManager.downloadAndExtract(name, terminal, batch);
+	}
+
+	@Override
+	public Path[] getInstalledPluginsPaths() throws IOException {
+		return _pluginManager.getListInstalledPlugins();
+	}
+
+	private final org.elasticsearch.plugins.PluginManager _pluginManager;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZip.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZip.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import java.net.URL;
+
+/**
+ * @author André de Oliveira
+ */
+public interface PluginZip {
+
+	public void delete();
+
+	public URL getURL();
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZipFactory.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZipFactory.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import java.io.IOException;
+
+/**
+ * @author André de Oliveira
+ */
+public interface PluginZipFactory {
+
+	public PluginZip createPluginZip(String resource) throws IOException;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZipFactoryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZipFactoryImpl.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import com.liferay.portal.search.elasticsearch.internal.util.ResourceUtil;
+
+import java.io.IOException;
+
+/**
+ * @author André de Oliveira
+ */
+public class PluginZipFactoryImpl implements PluginZipFactory {
+
+	@Override
+	public PluginZip createPluginZip(String resource) {
+		try {
+			return new PluginZipImpl(
+				ResourceUtil.getResourceAsTempFile(getClass(), resource));
+		}
+		catch (IOException ioe) {
+			throw new RuntimeException(
+				"Unable to write temporary plugin zip file from resource " +
+					resource,
+				ioe);
+		}
+	}
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZipImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/PluginZipImpl.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import java.io.File;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * @author André de Oliveira
+ */
+public class PluginZipImpl implements PluginZip {
+
+	public PluginZipImpl(File file) {
+		_file = file;
+	}
+
+	@Override
+	public void delete() {
+		_file.delete();
+	}
+
+	@Override
+	public URL getURL() {
+		URI uri = _file.toURI();
+
+		try {
+			return uri.toURL();
+		}
+		catch (MalformedURLException murle) {
+			throw new RuntimeException("Invalid file: " + _file, murle);
+		}
+	}
+
+	private final File _file;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchPluginManagerTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchPluginManagerTest.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.connection;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.io.IOException;
+
+import java.nio.file.Path;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.cli.Terminal;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author André de Oliveira
+ */
+public class EmbeddedElasticsearchPluginManagerTest {
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		setUpPluginManagerFactory();
+		setUpPluginZipFactory();
+	}
+
+	@Test
+	public void testInstallForTheFirstTime() throws Exception {
+		install();
+
+		Mockito.verify(
+			_pluginManager
+		).downloadAndExtract(
+			Mockito.eq(_PLUGIN_NAME), Mockito.<Terminal>any(), Mockito.eq(true)
+		);
+
+		Mockito.verify(
+			_pluginZipFactory
+		).createPluginZip(
+			"/plugins/" + _PLUGIN_NAME + "-" + Version.CURRENT + ".zip"
+		);
+
+		Mockito.verify(
+			_pluginZip
+		).delete();
+	}
+
+	@Test
+	public void testInstallForTheSecondTime() throws Exception {
+		Mockito.doReturn(
+			new Path[] {createPath(_PLUGIN_NAME)}
+		).when(
+			_pluginManager
+		).getInstalledPluginsPaths();
+
+		install();
+
+		Mockito.verify(
+			_pluginManager, Mockito.never()
+		).downloadAndExtract(
+			Mockito.anyString(), Mockito.<Terminal>any(), Mockito.anyBoolean()
+		);
+
+		Mockito.verify(
+			_pluginZipFactory, Mockito.never()
+		).createPluginZip(
+			Mockito.anyString()
+		);
+
+		Mockito.verifyZeroInteractions(_pluginZip);
+	}
+
+	@Test
+	public void testPluginZipIsDeletedOnError() throws Exception {
+		IOException ioException = new IOException();
+
+		setUpBrokenDownloadAndExtract(ioException);
+
+		try {
+			install();
+
+			Assert.fail();
+		}
+		catch (IOException ioe) {
+			Assert.assertSame(ioException, ioe);
+		}
+
+		Mockito.verify(
+			_pluginZip
+		).delete();
+	}
+
+	@Test
+	public void testSurviveConcurrentInstallInSameDir() throws Exception {
+		setUpBrokenDownloadAndExtract(
+			new IOException(
+				"already exists. To update the plugin, uninstall it first"));
+
+		install();
+
+		Mockito.verify(
+			_pluginZip
+		).delete();
+	}
+
+	protected Path createPath(String string) {
+		Path path = Mockito.mock(Path.class);
+
+		Mockito.doReturn(
+			true
+		).when(
+			path
+		).endsWith(
+			string
+		);
+
+		return path;
+	}
+
+	protected void install() throws IOException {
+		EmbeddedElasticsearchPluginManager embeddedElasticsearchPluginManager =
+			new EmbeddedElasticsearchPluginManager(
+				_PLUGIN_NAME, _PLUGINS_PATH, _pluginManagerFactory,
+				_pluginZipFactory);
+
+		embeddedElasticsearchPluginManager.install();
+	}
+
+	protected void setUpBrokenDownloadAndExtract(IOException ioException)
+		throws Exception {
+
+		Mockito.doThrow(
+			ioException
+		).when(
+			_pluginManager
+		).downloadAndExtract(
+			Mockito.anyString(), Mockito.<Terminal>any(), Mockito.anyBoolean()
+		);
+	}
+
+	protected void setUpPluginManagerFactory() {
+		Mockito.doReturn(
+			_pluginManager
+		).when(
+			_pluginManagerFactory
+		).createPluginManager();
+
+		Mockito.doReturn(
+			_pluginManager
+		).when(
+			_pluginManagerFactory
+		).createPluginManager(
+			Mockito.<PluginZip>any()
+		);
+	}
+
+	protected void setUpPluginZipFactory() throws IOException {
+		Mockito.doReturn(
+			_pluginZip
+		).when(
+			_pluginZipFactory
+		).createPluginZip(
+			Mockito.anyString()
+		);
+	}
+
+	private static final String _PLUGIN_NAME = RandomTestUtil.randomString();
+
+	private static final String _PLUGINS_PATH = ".";
+
+	@Mock
+	private PluginManager _pluginManager;
+
+	@Mock
+	private PluginManagerFactory _pluginManagerFactory;
+
+	@Mock
+	private PluginZip _pluginZip;
+
+	@Mock
+	private PluginZipFactory _pluginZipFactory;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetTagNamesFacetTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetTagNamesFacetTest.java
@@ -25,14 +25,16 @@ import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcher;
 import com.liferay.portal.kernel.test.IdempotentRetryAssert;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.search.test.util.AssertUtils;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,20 +85,27 @@ public class AssetTagNamesFacetTest extends BaseFacetedSearcherTestCase {
 
 					FacetCollector facetCollector = facet.getFacetCollector();
 
-					List<TermCollector> termCollectors =
-						facetCollector.getTermCollectors();
-
-					Assert.assertEquals(1, termCollectors.size());
-
-					TermCollector termCollector = termCollectors.get(0);
-
-					Assert.assertEquals(tag, termCollector.getTerm());
-					Assert.assertEquals(1, termCollector.getFrequency());
+					AssertUtils.assertEquals(
+						searchContext.getKeywords(),
+						Collections.singletonMap(tag, 1),
+						toMap(facetCollector.getTermCollectors()));
 
 					return null;
 				}
 
 			});
+	}
+
+	protected static Map<String, Integer> toMap(
+		List<TermCollector> termCollectors) {
+
+		Map<String, Integer> map = new HashMap<>(termCollectors.size());
+
+		for (TermCollector termCollector : termCollectors) {
+			map.put(termCollector.getTerm(), termCollector.getFrequency());
+		}
+
+		return map;
 	}
 
 	protected SearchContext getSearchContext(String keywords) throws Exception {

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ModifiedFacetTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ModifiedFacetTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcher;
 import com.liferay.portal.kernel.test.IdempotentRetryAssert;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
+import com.liferay.portal.search.test.util.AssertUtils;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
@@ -70,14 +71,14 @@ public class ModifiedFacetTest extends BaseFacetedSearcherTestCase {
 		final String configRange2 = "[19990202020202 TO 22220202020202]";
 		final String customRange = "[11110101010101 TO 22220202020202]";
 
-		final Collection<String> frequencies = toEntryStrings(
+		final HashMap<String, Integer> frequencies =
 			new HashMap<String, Integer>() {
 				{
 					put(configRange1, 0);
 					put(configRange2, 1);
 					put(customRange, 1);
 				}
-			});
+			};
 
 		IdempotentRetryAssert.retryAssert(
 			10, TimeUnit.SECONDS,
@@ -166,16 +167,6 @@ public class ModifiedFacetTest extends BaseFacetedSearcherTestCase {
 		return list.toString();
 	}
 
-	protected static List<String> toEntryStrings(Map<?, ?> map) {
-		List<String> strings = new ArrayList<>(map.size());
-
-		for (Map.Entry<?, ?> entry : map.entrySet()) {
-			strings.add(entry.toString());
-		}
-
-		return strings;
-	}
-
 	protected static Map<String, Integer> toMap(
 		List<TermCollector> termCollectors) {
 
@@ -189,7 +180,7 @@ public class ModifiedFacetTest extends BaseFacetedSearcherTestCase {
 	}
 
 	protected void assertRanges(
-			Collection<String> expected, ModifiedFacet modifiedFacet,
+			Map<String, Integer> expected, ModifiedFacet modifiedFacet,
 			SearchContext searchContext)
 		throws SearchException {
 
@@ -203,9 +194,9 @@ public class ModifiedFacetTest extends BaseFacetedSearcherTestCase {
 
 		FacetCollector facetCollector = facet.getFacetCollector();
 
-		assertEquals(
-			expected,
-			toEntryStrings(toMap(facetCollector.getTermCollectors())));
+		AssertUtils.assertEquals(
+			searchContext.getKeywords(), expected,
+			toMap(facetCollector.getTermCollectors()));
 	}
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/util/AssertUtils.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/util/AssertUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+
+/**
+ * @author André de Oliveira
+ */
+public class AssertUtils {
+
+	public static void assertEquals(
+		String message, Map<?, ?> expectedMap, Map<?, ?> actualMap) {
+
+		Assert.assertEquals(
+			message, _toString(expectedMap), _toString(actualMap));
+	}
+
+	private static String _toString(Map<?, ?> map) {
+		List<String> list = new ArrayList<>(map.size());
+
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			list.add(entry.toString());
+		}
+
+		Collections.sort(list);
+
+		return list.toString();
+	}
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/util/UserSearchFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/util/UserSearchFixture.java
@@ -43,21 +43,23 @@ public class UserSearchFixture {
 		return group;
 	}
 
-	public void addUser(Group group, String... assetTagNames) throws Exception {
-		User user = UserTestUtil.addUser(group.getGroupId());
+	public User addUser(Group group, String... assetTagNames) throws Exception {
+		User user1 = UserTestUtil.addUser(group.getGroupId());
 
-		_users.add(user);
+		_users.add(user1);
 
 		ServiceContext serviceContext = getServiceContext(group);
 
 		serviceContext.setAssetTagNames(assetTagNames);
 
-		UserTestUtil.updateUser(user, serviceContext);
+		User user2 = UserTestUtil.updateUser(user1, serviceContext);
 
 		List<AssetTag> assetTags = AssetTagLocalServiceUtil.getTags(
-			user.getModelClassName(), user.getPrimaryKey());
+			user2.getModelClassName(), user2.getPrimaryKey());
 
 		_assetTags.addAll(assetTags);
+
+		return user2;
 	}
 
 	public List<AssetTag> getAssetTags() {


### PR DESCRIPTION
Addressed https://github.com/brianchandotcom/liferay-portal/pull/39587#issuecomment-219487721.
- `AssertUtils` moved to `com.liferay.portal.search.test.util`
- Method that returns `Path[]` is now called `getInstalledPluginsPaths()`

Authors: @arturbr @arboliveira
Reviewer: @arboliveira
