### PR TITLE
Lps 65510 alerting servlet context name

### DIFF
--- a/modules/apps/foundation/portal-osgi-web/portal-osgi-web-wab-generator/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/artifact/WarArtifactUrlTransformer.java
+++ b/modules/apps/foundation/portal-osgi-web/portal-osgi-web-wab-generator/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/artifact/WarArtifactUrlTransformer.java
@@ -52,7 +52,7 @@ public class WarArtifactUrlTransformer implements ArtifactUrlTransformer {
 
 		String path = artifact.getPath();
 
-		int x = path.lastIndexOf("/");
+		int x = path.lastIndexOf('/');
 		int y = path.lastIndexOf(".war");
 
 		String contextName = path.substring(x + 1, y);


### PR DESCRIPTION
@jorgeferrer This allow one to configure the servlet context name for wab war. (In liferay-plugin-package.properties, add a new property called serlvet-context-name=xyz)

After this gets merged in, we need to pick names for themes that have both CE and DXP versions. And make sure the CE and DXP counterparts match on name, so that the DXP one can seamlessly swaps out the CE one.

@brianchandotcom let me know how would you like to name them, I can send a follow up pull on EE side to update the names.
