### PR TITLE
LRQA-25107 Add interface data for lportal_BS backup server.

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -130,6 +130,10 @@
 					<echo file="/opt/sybase/interfaces">lportal
 		master tcp ether ${hostname} 5000
 		query tcp ether ${hostname} 5000
+
+lportal_BS
+		master tcp ether ${hostname} 5001
+		query tcp ether ${hotsname} 5001
 					</echo>
 				</then>
 				<else>


### PR DESCRIPTION
Sybase requires a backup server to create and load database dumps. The backup server needs these entries to be in the interfaces file. I've reviewed this with Sam Tran and he has already made the change in the interfaces files that are currently running on the slaves but they keep getting reset.
