### PR TITLE
LPS-65062 Don't use target service class to get Bundle, that target s…

### DIFF
--- a/modules/apps/foundation/osgi/osgi-util/src/main/java/com/liferay/osgi/util/ServiceTrackerFactory.java
+++ b/modules/apps/foundation/osgi/osgi-util/src/main/java/com/liferay/osgi/util/ServiceTrackerFactory.java
@@ -71,7 +71,8 @@ public class ServiceTrackerFactory {
 	}
 
 	public static <T> ServiceTracker<T, T> create(Class<T> clazz) {
-		return create(FrameworkUtil.getBundle(clazz), clazz);
+		return create(
+			FrameworkUtil.getBundle(ServiceTrackerFactory.class), clazz);
 	}
 
 	public static <T> ServiceTracker<T, T> open(Bundle bundle, Class<T> clazz) {


### PR DESCRIPTION
…ervice class bundle might not be fully initialized yet, therefore it might not have a BundleContext attached. All we need here is a BundleContext to create ServiceTracker, it can be any BundleContext, so just use osgi-util's own BundleContext which is for sure to be ready to use.

CC @marcellustavares sorry for the delay, I have been busy lately. But here is your fix, let me know if you still have any issue with the redeploy.
