### PR TITLE
LPS-66003 Create default SAP entry for push-notifications-service

### DIFF
--- a/modules/apps/push-notifications/push-notifications-api/src/main/java/com/liferay/push/notifications/service/PushNotificationsDeviceService.java
+++ b/modules/apps/push-notifications/push-notifications-api/src/main/java/com/liferay/push/notifications/service/PushNotificationsDeviceService.java
@@ -58,12 +58,15 @@ public interface PushNotificationsDeviceService extends BaseService {
 		java.lang.String token, java.lang.String platform)
 		throws PortalException;
 
-	@AccessControlled(guestAccessEnabled = true)
 	public PushNotificationsDevice deletePushNotificationsDevice(
 		java.lang.String token) throws PortalException;
 
 	public PushNotificationsDevice deletePushNotificationsDevice(
 		long pushNotificationsDeviceId) throws PortalException;
+
+	@AccessControlled(guestAccessEnabled = true)
+	public PushNotificationsDevice deletePushNotificationsDeviceWithToken(
+		java.lang.String token) throws PortalException;
 
 	/**
 	* Returns the OSGi service identifier.

--- a/modules/apps/push-notifications/push-notifications-api/src/main/java/com/liferay/push/notifications/service/PushNotificationsDeviceServiceUtil.java
+++ b/modules/apps/push-notifications/push-notifications-api/src/main/java/com/liferay/push/notifications/service/PushNotificationsDeviceServiceUtil.java
@@ -60,6 +60,12 @@ public class PushNotificationsDeviceServiceUtil {
 				   .deletePushNotificationsDevice(pushNotificationsDeviceId);
 	}
 
+	public static com.liferay.push.notifications.model.PushNotificationsDevice deletePushNotificationsDeviceWithToken(
+		java.lang.String token)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().deletePushNotificationsDeviceWithToken(token);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*

--- a/modules/apps/push-notifications/push-notifications-api/src/main/java/com/liferay/push/notifications/service/PushNotificationsDeviceServiceWrapper.java
+++ b/modules/apps/push-notifications/push-notifications-api/src/main/java/com/liferay/push/notifications/service/PushNotificationsDeviceServiceWrapper.java
@@ -56,6 +56,13 @@ public class PushNotificationsDeviceServiceWrapper
 		return _pushNotificationsDeviceService.deletePushNotificationsDevice(pushNotificationsDeviceId);
 	}
 
+	@Override
+	public com.liferay.push.notifications.model.PushNotificationsDevice deletePushNotificationsDeviceWithToken(
+		java.lang.String token)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _pushNotificationsDeviceService.deletePushNotificationsDeviceWithToken(token);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*

--- a/modules/apps/push-notifications/push-notifications-service/build.gradle
+++ b/modules/apps/push-notifications/push-notifications-service/build.gradle
@@ -6,6 +6,7 @@ buildService {
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.portal.security.service.access.policy.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"

--- a/modules/apps/push-notifications/push-notifications-service/build.gradle
+++ b/modules/apps/push-notifications/push-notifications-service/build.gradle
@@ -6,9 +6,11 @@ buildService {
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.security.service.access.policy.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:push-notifications:push-notifications-api")
 }

--- a/modules/apps/push-notifications/push-notifications-service/build.gradle
+++ b/modules/apps/push-notifications/push-notifications-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.security.service.access.policy.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/security/service/access/policy/PushNotificationsDefaultPolicy.java
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/security/service/access/policy/PushNotificationsDefaultPolicy.java
@@ -14,7 +14,12 @@
 
 package com.liferay.push.notifications.security.service.access.policy;
 
+import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
+import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -28,7 +33,11 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -36,6 +45,13 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(immediate = true)
 public class PushNotificationsDefaultPolicy {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = bundleContext.registerService(
+			PortalInstanceLifecycleListener.class,
+			new PolicyPortalInstanceLifecycleListener(), null);
+	}
 
 	protected void create(long companyId) throws PortalException {
 		SAPEntry sapEntry = _sapEntryLocalService.fetchSAPEntry(
@@ -66,13 +82,43 @@ public class PushNotificationsDefaultPolicy {
 			_PUSH_NOTIFICATIONS_DEFAULT, titleMap, new ServiceContext());
 	}
 
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
 	private static final String _PUSH_NOTIFICATIONS_DEFAULT =
 		"PUSH_NOTIFICATIONS_DEFAULT";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PushNotificationsDefaultPolicy.class);
 
 	@Reference(unbind = "-")
 	private SAPEntryLocalService _sapEntryLocalService;
 
+	private ServiceRegistration<PortalInstanceLifecycleListener>
+		_serviceRegistration;
+
 	@Reference(unbind = "-")
 	private UserLocalService _userLocalService;
+
+	private class PolicyPortalInstanceLifecycleListener
+		extends BasePortalInstanceLifecycleListener {
+
+		public void portalInstanceRegistered(Company company) throws Exception {
+			try {
+				create(company.getCompanyId());
+			}
+			catch (PortalException pe) {
+				_log.error(
+					"Unable to add PushNotificationsDefaultPolicy " +
+						"for company " + company.getCompanyId(),
+					pe);
+			}
+		}
+
+	}
 
 }

--- a/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/security/service/access/policy/PushNotificationsDefaultPolicy.java
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/security/service/access/policy/PushNotificationsDefaultPolicy.java
@@ -22,14 +22,16 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.AggregateResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
 import com.liferay.push.notifications.service.PushNotificationsDeviceService;
 
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -73,8 +75,16 @@ public class PushNotificationsDefaultPolicy {
 		boolean defaultSAPEntry = true;
 		boolean enabled = true;
 
-		Map<Locale, String> titleMap = new HashMap<>();
-		titleMap.put(LocaleUtil.getDefault(), _PUSH_NOTIFICATIONS_DEFAULT);
+		ResourceBundleLoader resourceBundleLoader =
+			new AggregateResourceBundleLoader(
+				ResourceBundleUtil.getResourceBundleLoader(
+					"content.Language",
+					PushNotificationsDefaultPolicy.class.getClassLoader()),
+				LanguageResources.RESOURCE_BUNDLE_LOADER);
+
+		Map<Locale, String> titleMap = ResourceBundleUtil.getLocalizationMap(
+			resourceBundleLoader,
+			"push-notifications-default-service-access-policy-title");
 
 		_sapEntryLocalService.addSAPEntry(
 			_userLocalService.getDefaultUserId(companyId),

--- a/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/security/service/access/policy/PushNotificationsDefaultPolicy.java
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/security/service/access/policy/PushNotificationsDefaultPolicy.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.push.notifications.security.service.access.policy;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.security.service.access.policy.model.SAPEntry;
+import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
+import com.liferay.push.notifications.service.PushNotificationsDeviceService;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Tomas Polesovsky
+ */
+@Component(immediate = true)
+public class PushNotificationsDefaultPolicy {
+
+	protected void create(long companyId) throws PortalException {
+		SAPEntry sapEntry = _sapEntryLocalService.fetchSAPEntry(
+			companyId, _PUSH_NOTIFICATIONS_DEFAULT);
+
+		if (sapEntry != null) {
+			return;
+		}
+
+		StringBundler sb = new StringBundler(5);
+
+		sb.append(PushNotificationsDeviceService.class.getName());
+		sb.append("#addPushNotificationsDevice");
+		sb.append(StringPool.NEW_LINE);
+		sb.append(PushNotificationsDeviceService.class.getName());
+		sb.append("#deletePushNotificationsDeviceWithToken");
+
+		String allowedServiceSignatures = sb.toString();
+		boolean defaultSAPEntry = true;
+		boolean enabled = true;
+
+		Map<Locale, String> titleMap = new HashMap<>();
+		titleMap.put(LocaleUtil.getDefault(), _PUSH_NOTIFICATIONS_DEFAULT);
+
+		_sapEntryLocalService.addSAPEntry(
+			_userLocalService.getDefaultUserId(companyId),
+			allowedServiceSignatures, defaultSAPEntry, enabled,
+			_PUSH_NOTIFICATIONS_DEFAULT, titleMap, new ServiceContext());
+	}
+
+	private static final String _PUSH_NOTIFICATIONS_DEFAULT =
+		"PUSH_NOTIFICATIONS_DEFAULT";
+
+	@Reference(unbind = "-")
+	private SAPEntryLocalService _sapEntryLocalService;
+
+	@Reference(unbind = "-")
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/service/http/PushNotificationsDeviceServiceHttp.java
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/service/http/PushNotificationsDeviceServiceHttp.java
@@ -154,12 +154,44 @@ public class PushNotificationsDeviceServiceHttp {
 		}
 	}
 
+	public static com.liferay.push.notifications.model.PushNotificationsDevice deletePushNotificationsDeviceWithToken(
+		HttpPrincipal httpPrincipal, java.lang.String token)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(PushNotificationsDeviceServiceUtil.class,
+					"deletePushNotificationsDeviceWithToken",
+					_deletePushNotificationsDeviceWithTokenParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, token);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.push.notifications.model.PushNotificationsDevice)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static void sendPushNotification(HttpPrincipal httpPrincipal,
 		long[] toUserIds, java.lang.String payload)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(PushNotificationsDeviceServiceUtil.class,
-					"sendPushNotification", _sendPushNotificationParameterTypes3);
+					"sendPushNotification", _sendPushNotificationParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					toUserIds, payload);
@@ -188,7 +220,7 @@ public class PushNotificationsDeviceServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(PushNotificationsDeviceServiceUtil.class,
-					"sendPushNotification", _sendPushNotificationParameterTypes4);
+					"sendPushNotification", _sendPushNotificationParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					platform, tokens, payload);
@@ -219,10 +251,12 @@ public class PushNotificationsDeviceServiceHttp {
 		new Class[] { long.class };
 	private static final Class<?>[] _deletePushNotificationsDeviceParameterTypes2 =
 		new Class[] { java.lang.String.class };
-	private static final Class<?>[] _sendPushNotificationParameterTypes3 = new Class[] {
+	private static final Class<?>[] _deletePushNotificationsDeviceWithTokenParameterTypes3 =
+		new Class[] { java.lang.String.class };
+	private static final Class<?>[] _sendPushNotificationParameterTypes4 = new Class[] {
 			long[].class, java.lang.String.class
 		};
-	private static final Class<?>[] _sendPushNotificationParameterTypes4 = new Class[] {
+	private static final Class<?>[] _sendPushNotificationParameterTypes5 = new Class[] {
 			java.lang.String.class, java.util.List.class, java.lang.String.class
 		};
 }

--- a/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/service/http/PushNotificationsDeviceServiceSoap.java
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/service/http/PushNotificationsDeviceServiceSoap.java
@@ -112,6 +112,21 @@ public class PushNotificationsDeviceServiceSoap {
 		}
 	}
 
+	public static com.liferay.push.notifications.model.PushNotificationsDeviceSoap deletePushNotificationsDeviceWithToken(
+		java.lang.String token) throws RemoteException {
+		try {
+			com.liferay.push.notifications.model.PushNotificationsDevice returnValue =
+				PushNotificationsDeviceServiceUtil.deletePushNotificationsDeviceWithToken(token);
+
+			return com.liferay.push.notifications.model.PushNotificationsDeviceSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static void sendPushNotification(long[] toUserIds,
 		java.lang.String payload) throws RemoteException {
 		try {

--- a/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/service/impl/PushNotificationsDeviceServiceImpl.java
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/java/com/liferay/push/notifications/service/impl/PushNotificationsDeviceServiceImpl.java
@@ -82,8 +82,6 @@ public class PushNotificationsDeviceServiceImpl
 			deletePushNotificationsDevice(pushNotificationsDeviceId);
 	}
 
-	@AccessControlled(guestAccessEnabled = true)
-	@Override
 	public PushNotificationsDevice deletePushNotificationsDevice(String token)
 		throws PortalException {
 
@@ -114,6 +112,15 @@ public class PushNotificationsDeviceServiceImpl
 		}
 
 		return pushNotificationsDevice;
+	}
+
+	@AccessControlled(guestAccessEnabled = true)
+	@Override
+	public PushNotificationsDevice deletePushNotificationsDeviceWithToken(
+			String token)
+		throws PortalException {
+
+		return deletePushNotificationsDevice(token);
 	}
 
 	@Override

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ar.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=سياسة منح وصول الجمهور إلى دفع الإخطار API لتسجيل وحذف الجهاز (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_bg.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Политика за предоставяне на достъп на обществеността да прокара уведомяване API да се регистрирате и изтриване на устройството (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ca.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Política de concedir accés públic per empènyer notificació API per registrar-se i suprimir el dispositiu (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_cs.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Zásady k udělení přístupu veřejnosti k Push oznámení API pro registraci a odstranění zařízení (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_da.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_da.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_de.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_de.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_el.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_el.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Πολιτική για να παραχωρήσετε πρόσβαση του κοινού σε Push κοινοποίηση API για την εγγραφή και διαγραφή συσκευής (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_en.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_en.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_es.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_es.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Política para conceder acceso público a empuje notificación API para registrar y borrar dispositivo (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_et.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_et.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Poliitika avaliku juurdepääsu andmiseks nendele Push teate API registreerida ja kustutage seadme (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_eu.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_fa.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=سیاست اعطای دسترسی عمومی به فشار API اطلاع رسانی برای ثبت نام و حذف دستگاه (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_fi.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_fr.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Stratégie pour accorder l’accès du public à l’API de Notification Push pour enregistrer et supprimer des périphériques (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_gl.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_hi_IN.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=पुश अधिसूचना रजिस्टर और डिवाइस को हटाने के लिए API करने के लिए सार्वजनिक पहुँच प्रदान करने के लिए नीति (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_hr.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_hu.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=A politika nyilvános hozzáférés nyomja értesítés API-hoz beiktat és törlése eszköz (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_in.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_in.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Kebijakan untuk memberikan akses publik ke Push Notifikasi API untuk mendaftar dan menghapus perangkat (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_it.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_it.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Criteri per concedere l'accesso del pubblico all'API di notifica Push per registrare ed eliminare il dispositivo (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_iw.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=מדיניות כדי להעניק גישה ציבורית API ההודעות לדחוף לשם רישום ומחיקה של התקן (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ja.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ko.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=푸시 알림 API 등록 하 고 삭제 하는 장치에 공용 액세스를 부여 하는 정책 (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_lo.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_lt.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Politikos leisti visuomenei susipažinti su Push pranešimų API užsiregistruoti ir ištrinti įrenginio (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_nb.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=For å gi publikum tilgang til Push Notification API å registrere og fjerne enheten (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_nl.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_nl_BE.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_pl.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Zasady przyznania publicznego dostępu do Push powiadomienia API rejestrowania i usuwania urządzenia (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_pt_BR.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Política de conceder acesso público a API de notificação Push para registrar e excluir o dispositivo (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_pt_PT.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Política de conceder acesso público a API de notificação Push para registrar e excluir o dispositivo (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ro.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Politica acorda accesul public Push notificare API pentru a înregistra şi şterge dispozitivul (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_ru.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Политика предоставления общественности доступа к Push уведомлений API для регистрации и удаления устройства (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sk.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Politiku prístupu verejnosti poskytnúť Push oznámenia API sa zaregistrovať a odstránenie zariadenia (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sl.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Politiko dostopa javnosti do Push obvestila API v register ter izbrisati napravo (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sr_RS.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_sv.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Policy to grant public access to Push Notification API to register and delete device (Automatic Copy)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_tr.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=İtin bildirim kaydetmek ve aygıtı silmek için API için kamu erişimi verme ilkesi (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_uk.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Політика для надання громадськості доступу Push повідомлення API для реєстрації і видалити пристрій (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_vi.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=Các chính sách để cấp truy cập công cộng cho Push Notification API để đăng ký và xoá thiết bị (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_zh_CN.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=政策，公共访问权限授予推送通知 API 来注册和删除设备 (Automatic Translation)

--- a/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/push-notifications/push-notifications-service/src/main/resources/content/Language_zh_TW.properties
@@ -1,0 +1,1 @@
+push-notifications-default-service-access-policy-title=政策，公共存取權限授予推送通知 API 來註冊和刪除設備 (Automatic Translation)


### PR DESCRIPTION
Hi Brian,

The code adds a new SAPEntry to whitelist some remote methods of `PushNotificationDeviceService` to be accessible without authentication.

@brunofarache wanted me to skip him in the review process.

https://issues.liferay.com/browse/LPS-66003

Thanks!
