### PR TITLE
LPS-60027 Fix NPE caused by ddc51a75ef00f8dae76a151565ca76c4bd3c55b8,…

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/ResourcesImporterBundleActivator.java
+++ b/modules/apps/web-experience/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/ResourcesImporterBundleActivator.java
@@ -67,6 +67,10 @@ public class ResourcesImporterBundleActivator implements BundleActivator {
 
 	@Override
 	public void stop(BundleContext bundleContext) {
+		if (_serviceRegistration == null) {
+			return;
+		}
+
 		Destination destination = bundleContext.getService(
 			_serviceRegistration.getReference());
 


### PR DESCRIPTION
… but this logic is still very fishy. Carlos, are you sure we should just shortcut on missing DestinationFactory in start()? I think we should use ServiceTracker to track DestinationFactory in order to create the destination when DestinationFactory shows up.

@csierra
