### PR TITLE
Lps 66023

### DIFF
--- a/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LPKGLicensedBundleTrackerCustomizer.java
+++ b/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LPKGLicensedBundleTrackerCustomizer.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.license.deployer;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.net.URL;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.nio.file.StandardCopyOption;
+import java.util.Enumeration;
+
+import org.apache.felix.fileinstall.ArtifactInstaller;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.util.tracker.BundleTrackerCustomizer;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class LPKGLicensedBundleTrackerCustomizer
+	implements BundleTrackerCustomizer<Bundle> {
+
+	public LPKGLicensedBundleTrackerCustomizer(
+		ArtifactInstaller licenseInstaller) {
+
+		_licenseInstaller = licenseInstaller;
+	}
+
+	@Override
+	public Bundle addingBundle(Bundle bundle, BundleEvent bundleEvent) {
+		URL url = bundle.getEntry("liferay-marketplace.properties");
+
+		if (url == null) {
+			return null;
+		}
+
+		Enumeration<URL> enumeration = bundle.findEntries("/", "*.xml", false);
+
+		if (enumeration == null) {
+			return null;
+		}
+
+		boolean hasLicense = false;
+
+		try {
+			while (enumeration.hasMoreElements()) {
+				url = enumeration.nextElement();
+
+				Path tempFilePath = Files.createTempFile(null, ".xml");
+
+				try (InputStream inputStream = url.openStream()) {
+					Files.copy(
+						inputStream, tempFilePath,
+						StandardCopyOption.REPLACE_EXISTING);
+
+					File file = tempFilePath.toFile();
+
+					if (_licenseInstaller.canHandle(file)) {
+						_licenseInstaller.install(file);
+
+						hasLicense = true;
+					}
+				}
+				finally {
+					Files.delete(tempFilePath);
+				}
+			}
+		}
+		catch (Exception e) {
+			_log.error("Unable to register license", e);
+
+			return null;
+		}
+
+		if (hasLicense) {
+			return bundle;
+		}
+
+		return null;
+	}
+
+	@Override
+	public void modifiedBundle(
+		Bundle bundle, BundleEvent bundleEvent, Bundle trackedBundle) {
+	}
+
+	@Override
+	public void removedBundle(
+		Bundle bundle, BundleEvent bundleEvent, Bundle trackedBundle) {
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LPKGLicensedBundleTrackerCustomizer.class);
+
+	private final ArtifactInstaller _licenseInstaller;
+
+}

--- a/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LicenseDeployerActivator.java
+++ b/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LicenseDeployerActivator.java
@@ -16,9 +16,6 @@ package com.liferay.portal.license.deployer;
 
 import com.liferay.portal.license.deployer.installer.LicenseInstaller;
 
-import java.util.Dictionary;
-import java.util.Hashtable;
-
 import org.apache.felix.fileinstall.ArtifactInstaller;
 import org.apache.felix.fileinstall.ArtifactListener;
 
@@ -48,16 +45,12 @@ public class LicenseDeployerActivator {
 	protected ServiceRegistration<?> registerArtifactListener(
 		BundleContext bundleContext) {
 
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("installer.type", "license");
-
 		return bundleContext.registerService(
 			new String[] {
 				ArtifactInstaller.class.getName(),
 				ArtifactListener.class.getName()
 			},
-			new LicenseInstaller(), properties);
+			new LicenseInstaller(), null);
 	}
 
 	private ServiceRegistration<?> _artifactListenerServiceRegistration;

--- a/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LicenseDeployerActivator.java
+++ b/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LicenseDeployerActivator.java
@@ -50,7 +50,7 @@ public class LicenseDeployerActivator {
 
 		Dictionary<String, Object> properties = new Hashtable<>();
 
-		properties.put("lpkg.deployer.artifact.installer.type", "license");
+		properties.put("installer.type", "license");
 
 		return bundleContext.registerService(
 			new String[] {

--- a/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LicenseDeployerActivator.java
+++ b/modules/apps/foundation/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/LicenseDeployerActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.license.deployer;
 
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.license.deployer.installer.LicenseInstaller;
 
 import org.apache.felix.fileinstall.ArtifactInstaller;
@@ -25,6 +26,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.util.tracker.BundleTracker;
 
 /**
@@ -61,6 +63,11 @@ public class LicenseDeployerActivator {
 				ArtifactListener.class.getName()
 			},
 			artifactInstaller, null);
+	}
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
+	protected void setModuleServiceLifecycle(
+		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
 	private ServiceRegistration<?> _artifactListenerServiceRegistration;

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 2e4618d7a555f07e881c255c5864fb8076f82ce6
+	commit = 05fc8f1574f94c863237cc315567188a19da57e1
 	mode = push
-	parent = 676e56cad9fb7ca1103a88302ffd71506439ca66
+	parent = 06b9182fb6bad35cc0b536f411f5ab17774d7649
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/core/portal-lpkg-deployer/build.gradle
+++ b/modules/core/portal-lpkg-deployer/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
-	provided group: "org.apache.felix", name: "org.apache.felix.fileinstall", version: "3.5.1-20150728.201454-4"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":core:portal-target-platform-indexer")

--- a/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBundleTrackerCustomizer.java
+++ b/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBundleTrackerCustomizer.java
@@ -30,9 +30,9 @@ import com.liferay.portal.lpkg.deployer.internal.wrapper.bundle.URLStreamHandler
 import com.liferay.portal.lpkg.deployer.internal.wrapper.bundle.WARBundleWrapperBundleActivator;
 import com.liferay.portal.util.PropsValues;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.File;
 
 import java.net.URL;
 
@@ -71,8 +71,8 @@ public class LPKGBundleTrackerCustomizer
 		ArtifactInstaller licenseArtifactInstaller) {
 
 		_bundleContext = bundleContext;
-		_urls = urls;
 		_licenseArtifactInstaller = licenseArtifactInstaller;
+		_urls = urls;
 	}
 
 	@Override

--- a/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
+++ b/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
@@ -305,7 +305,7 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 	@Reference
 	private LPKGWARBundleRegistry _lpkgWarBundleRegistry;
 
-	@Reference(target = "(lpkg.deployer.artifact.installer.type=license)")
+	@Reference(target = "(installer.type=license)")
 	private ArtifactInstaller _licenseArtifactInstaller;
 
 	private final Map<String, URL> _urls = new ConcurrentHashMap<>();

--- a/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
+++ b/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
@@ -54,8 +54,6 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.felix.fileinstall.ArtifactInstaller;
-
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -94,8 +92,7 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 
 		_lpkgBundleTracker = new BundleTracker<>(
 			bundleContext, ~Bundle.UNINSTALLED,
-			new LPKGBundleTrackerCustomizer(
-				bundleContext, _urls, _licenseArtifactInstaller));
+			new LPKGBundleTrackerCustomizer(bundleContext, _urls));
 
 		_lpkgBundleTracker.open();
 
@@ -304,9 +301,6 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 
 	@Reference
 	private LPKGWARBundleRegistry _lpkgWarBundleRegistry;
-
-	@Reference(target = "(installer.type=license)")
-	private ArtifactInstaller _licenseArtifactInstaller;
 
 	private final Map<String, URL> _urls = new ConcurrentHashMap<>();
 	private BundleTracker<Bundle> _warWrapperBundlerTracker;

--- a/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
+++ b/modules/core/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGDeployerImpl.java
@@ -297,9 +297,6 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 	private static final Log _log = LogFactoryUtil.getLog(
 		LPKGDeployerImpl.class);
 
-	@Reference(target = "(lpkg.deployer.artifact.installer.type=license)")
-	private ArtifactInstaller _licenseArtifactInstaller;
-
 	private BundleTracker<List<Bundle>> _lpkgBundleTracker;
 
 	@Reference
@@ -307,6 +304,9 @@ public class LPKGDeployerImpl implements LPKGDeployer {
 
 	@Reference
 	private LPKGWARBundleRegistry _lpkgWarBundleRegistry;
+
+	@Reference(target = "(lpkg.deployer.artifact.installer.type=license)")
+	private ArtifactInstaller _licenseArtifactInstaller;
 
 	private final Map<String, URL> _urls = new ConcurrentHashMap<>();
 	private BundleTracker<Bundle> _warWrapperBundlerTracker;


### PR DESCRIPTION
@lionah and @amosfong, I need to make this change, as you can see the lpkg test batch is failing due to changes in LPS-66023.
The license install has dependencies on portal, it can not be invoked from lpkg deployer, which is way before portal is loaded.

I remember you guys said, the license needs to be installed before modules inside lpkg bundle is resolved. That is not possible, not until you get rid of all the portal dependencies from portal-lictense-deployer. That change must go first.

For now, with my changes here, runtime lpkg deployment with licenses will work normally, and as long as there is no bootup time lpkg bundle with license. The startup will be fine too.

And @amosfong, don't we want to support uninstall license? What's the expected behavior when someone uninstall/update a lpkg with license?
