### PR TITLE
master-qa-25461

### DIFF
--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -205,6 +205,10 @@
 			<contains></contains>
 			<matches>.*osgi.compendium:service=.*version=1.[0-9]+.*</matches>
 		</ignore-error>
+		<ignore-error description="LPS-65878, temporary workaround until Tina Tian fixes it">
+			<contains>The addSearchEngineConfigurator method has thrown an exception</contains>
+			<matches></matches>
+		</ignore-error>
 		<ignore-error description="LRQA-14442, temporary workaround until Kiyoshi Lee fixes it">
 			<contains>[org_eclipse_equinox_http_servlet.*Framework Event Dispatcher: Equinox Container:</contains>
 			<matches></matches>

--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -209,6 +209,10 @@
 			<contains>The addSearchEngineConfigurator method has thrown an exception</contains>
 			<matches></matches>
 		</ignore-error>
+		<ignore-error description="LPS-65961">
+			<contains>Unable to add taglib</contains>
+			<matches></matches>
+		</ignore-error>
 		<ignore-error description="LRQA-14442, temporary workaround until Kiyoshi Lee fixes it">
 			<contains>[org_eclipse_equinox_http_servlet.*Framework Event Dispatcher: Equinox Container:</contains>
 			<matches></matches>


### PR DESCRIPTION
@brianchandotcom 

I've added two test ignores in this pull because they unnecessarily cause random poshi failures.
- https://issues.liferay.com/browse/LPS-65878 - This is randomly causing the upgrade tests to fail because our upgrade tests check for errors in the console. Tina is already on it.
- https://issues.liferay.com/browse/LPS-65961 - This one also randomly causes tests to fail, and according to Kenji, whether or not there is functional impact depends on which taglib fails to load. Ray has mentioned that this is very difficult/complicated to fix and that we won't be able to do it in time for DXP release.

cc @kenjiheigel @alee8888
