### PR TITLE
LPS-66041 lang.user.name.* property values (in Language*.properties) are translated (but should never be translated)

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 04a8dc114a3e654fd0f9f1052fa44b978ec94dc8
+	commit = fc02c1a293964df69324209f9937d39bd07c6030
 	mode = push
-	parent = 62fb1558b8d7e9d58989430e58eb4ffae5682c19
+	parent = 6492aef795d40dc9e15bbf5d92134495d1867167
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/portal-impl/src/content/Language_ca.properties
+++ b/portal-impl/src/content/Language_ca.properties
@@ -7,7 +7,7 @@ lang.line.begin=left
 lang.line.end=right
 lang.user.name.field.names=prefix,first-name,last-name
 lang.user.name.prefix.values=Sr.,Sra.,Dr.,Dra.
-lang.user.name.required.field.names=cognom
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_es.properties
+++ b/portal-impl/src/content/Language_es.properties
@@ -5,9 +5,9 @@
 lang.dir=ltr
 lang.line.begin=left
 lang.line.end=right
-lang.user.name.field.names=prefijo,nombre,primer apellido,segundo apellido,sufijo
-lang.user.name.prefix.values=Dr,Sr,Sra,Sta
-lang.user.name.required.field.names=Apellido
+lang.user.name.field.names=prefix,first-name,last-name
+lang.user.name.prefix.values=Sr,Sra,Sta,Dr,Dra
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_fr.properties
+++ b/portal-impl/src/content/Language_fr.properties
@@ -5,9 +5,9 @@
 lang.dir=ltr
 lang.line.begin=left
 lang.line.end=right
-lang.user.name.field.names=préfixe,prénom,2e prénom,nom de famille,suffixe
+lang.user.name.field.names=prefix,first-name,middle-name,last-name
 lang.user.name.prefix.values=M.,Mme,Mlle
-lang.user.name.required.field.names=nom de famille
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_hr.properties
+++ b/portal-impl/src/content/Language_hr.properties
@@ -5,8 +5,6 @@
 lang.dir=ltr
 lang.line.begin=left
 lang.line.end=right
-lang.user.name.field.names=prefiks,ime,srednje ime,prezime,sufiks
-lang.user.name.required.field.names=prezime
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_hu.properties
+++ b/portal-impl/src/content/Language_hu.properties
@@ -5,9 +5,9 @@
 lang.dir=ltr
 lang.line.begin=left
 lang.line.end=right
-lang.user.name.field.names=rangjelzés,utónév,második utónév,családi név,egyéb név
-lang.user.name.prefix.values=Dr.,Úr,Hölgy,Asszony
-lang.user.name.required.field.names=családi név
+lang.user.name.field.names=prefix,last-name,first-name,middle-name
+lang.user.name.prefix.values=Dr.,Prof.,Úr,Asszony,Kisasszony,ifj.,id.,özv.
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_it.properties
+++ b/portal-impl/src/content/Language_it.properties
@@ -7,7 +7,7 @@ lang.line.begin=left
 lang.line.end=right
 lang.user.name.field.names=prefix,first-name,middle-name,last-name
 lang.user.name.prefix.values=Dott.,Dr.,Sig.,Sig.ra,Sig.na
-lang.user.name.required.field.names=cognome
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_ja.properties
+++ b/portal-impl/src/content/Language_ja.properties
@@ -5,8 +5,8 @@
 lang.dir=ltr
 lang.line.begin=left
 lang.line.end=right
-lang.user.name.field.names=名字,名前
-lang.user.name.required.field.names=名字
+lang.user.name.field.names=last-name,first-name
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_nl.properties
+++ b/portal-impl/src/content/Language_nl.properties
@@ -5,7 +5,7 @@
 lang.dir=ltr
 lang.line.begin=left
 lang.line.end=right
-lang.user.name.field.names=prefix,first-name,middle-name,last-name,suffix
+lang.user.name.field.names=prefix,first-name,middle-name,last-name
 lang.user.name.prefix.values=Dhr.,Mevr.,Dr.,Drs.,Mr.
 lang.user.name.required.field.names=last-name
 lang.user.name.suffix.values=Jr.,Sr.

--- a/portal-impl/src/content/Language_pt_PT.properties
+++ b/portal-impl/src/content/Language_pt_PT.properties
@@ -7,7 +7,7 @@ lang.line.begin=left
 lang.line.end=right
 lang.user.name.field.names=prefix,first-name,middle-name,last-name
 lang.user.name.prefix.values=Sr,Sra,Sta,Dr,Dra
-lang.user.name.required.field.names=Apelido
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles

--- a/portal-impl/src/content/Language_zh_CN.properties
+++ b/portal-impl/src/content/Language_zh_CN.properties
@@ -5,8 +5,8 @@
 lang.dir=ltr
 lang.line.begin=left
 lang.line.end=right
-lang.user.name.field.names=前缀，名，中间名，姓，后缀
-lang.user.name.required.field.names=姓
+lang.user.name.field.names=last-name,first-name
+lang.user.name.required.field.names=last-name
 
 ##
 ## Portlet descriptions and titles


### PR DESCRIPTION
This is an update for [LPS-66041](https://issues.liferay.com/browse/LPS-66041).<br><br>Hey Brian, `ant build-lang` didn't seem to undo any of these changes.  This at least gets the forms working again.  I'm still trying to reproduce how they got changed in the first place.
