### PR TITLE
master-bc-1378

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4175,7 +4175,23 @@ go]]></replacevalue>
 
 						<dirname file="${osgi.module.bnd.file}" property="osgi.module.dir" />
 
-						<gradle-execute dir="${osgi.module.dir}" task="deploy" />
+						<if>
+							<contains string="${osgi.module.dir}" substring="modules" />
+							<then>
+								<gradle-execute dir="${osgi.module.dir}" task="deploy" />
+							</then>
+							<else>
+								<var name="osgi.module.dir" unset="true" />
+
+								<dirset dir="${project.dir}/modules" id="dir.id">
+									<include name="**/@{osgi.module}" />
+								</dirset>
+
+								<property name="osgi.module.dir" refid="dir.id" />
+
+								<gradle-execute dir="modules/${osgi.module.dir}" task="deploy" />
+							</else>
+						</if>
 					</sequential>
 				</for>
 			</then>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/webform/pgwebform/PGWebform.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/webform/pgwebform/PGWebform.testcase
@@ -1,6 +1,6 @@
 <definition component-name="portal-web-forms-and-data-lists">
 	<property name="portal.release" value="true" />
-	<property name="portlet.plugins.includes" value="web-form-portlet" />
+	<property name="osgi.modules.includes" value="web-form-portlet" />
 	<property name="testray.main.component.name" value="Web Form" />
 
 	<var name="pageName" value="Web Form Test Page" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-25355

@brianchandotcom 
Web Form portlet has been moved out of the plugins repo to the modules/apps/deprecated folder. We were asked to still have tests for it since deprecated doesn't equate to unsupported.

The current logic looks for the bnd.bnd file then runs a gradle deploy from there. But the web form module doesn't have a bnd.bnd file. Victor added in a catch for this. If it finds the bnd.bnd file (which means ${osgi.module.dir} will have "modules" in it, then it runs the default. However, if it doesn't, then it'll execute Victor's logic.

CC @vicnate5 
