### PR TITLE
LPS-64788 Use latest version

### DIFF
--- a/modules/apps/collaboration/microblogs/microblogs-service/build.gradle
+++ b/modules/apps/collaboration/microblogs/microblogs-service/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/portal-impl/src/META-INF/portal-model-hints.xml
+++ b/portal-impl/src/META-INF/portal-model-hints.xml
@@ -1726,7 +1726,9 @@
 		<field name="userNotificationEventId" type="long" />
 		<field name="companyId" type="long" />
 		<field name="userId" type="long" />
-		<field name="type" type="String" />
+		<field name="type" type="String">
+			<hint name="max-length">200</hint>
+		</field>
 		<field name="timestamp" type="long" />
 		<field name="deliveryType" type="int" />
 		<field name="deliverBy" type="long" />

--- a/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/UserNotificationEventModelImpl.java
@@ -95,7 +95,7 @@ public class UserNotificationEventModelImpl extends BaseModelImpl<UserNotificati
 		TABLE_COLUMNS_MAP.put("archived", Types.BOOLEAN);
 	}
 
-	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(75) null,timestamp LONG,deliveryType INTEGER,deliverBy LONG,delivered BOOLEAN,payload TEXT null,actionRequired BOOLEAN,archived BOOLEAN)";
+	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(200) null,timestamp LONG,deliveryType INTEGER,deliverBy LONG,delivered BOOLEAN,payload TEXT null,actionRequired BOOLEAN,archived BOOLEAN)";
 	public static final String TABLE_SQL_DROP = "drop table UserNotificationEvent";
 	public static final String ORDER_BY_JPQL = " ORDER BY userNotificationEvent.timestamp DESC";
 	public static final String ORDER_BY_SQL = " ORDER BY UserNotificationEvent.timestamp DESC";

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_0.java
@@ -34,6 +34,7 @@ import com.liferay.portal.upgrade.v7_0_0.UpgradeLookAndFeel;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMembershipRequest;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeMessageBoards;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeModules;
+import com.liferay.portal.upgrade.v7_0_0.UpgradeNotifications;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeOrgLabor;
 import com.liferay.portal.upgrade.v7_0_0.UpgradeOrganization;
 import com.liferay.portal.upgrade.v7_0_0.UpgradePhone;
@@ -85,6 +86,7 @@ public class UpgradeProcess_7_0_0 extends UpgradeProcess {
 		upgrade(UpgradeMembershipRequest.class);
 		upgrade(UpgradeMessageBoards.class);
 		upgrade(UpgradeModules.class);
+		upgrade(UpgradeNotifications.class);
 		upgrade(UpgradeOrganization.class);
 		upgrade(UpgradeOrgLabor.class);
 		upgrade(UpgradePhone.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_1.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_1.java
@@ -16,6 +16,7 @@ package com.liferay.portal.upgrade;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ReleaseInfo;
+import com.liferay.portal.upgrade.v7_0_0.UpgradeNotifications;
 import com.liferay.portal.upgrade.v7_0_1.UpgradeCompany;
 import com.liferay.portal.upgrade.v7_0_1.UpgradeDocumentLibrary;
 import com.liferay.portal.upgrade.v7_0_1.UpgradeMessageBoards;
@@ -40,6 +41,7 @@ public class UpgradeProcess_7_0_1 extends UpgradeProcess {
 		upgrade(UpgradeDocumentLibrary.class);
 		upgrade(UpgradeMessageBoards.class);
 		upgrade(UpgradeModules.class);
+		upgrade(UpgradeNotifications.class);
 
 		clearIndexesCache();
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.v7_0_0.util.UserNotificationEventTable;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class UpgradeNotifications extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		alter(
+			UserNotificationEventTable.class,
+			new AlterColumnType("type_", "VARCHAR(200) null"));
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
@@ -14,18 +14,9 @@
 
 package com.liferay.portal.upgrade.v7_0_0;
 
-import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.dao.db.DBMetadata;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.upgrade.v7_0_0.util.UserNotificationEventTable;
-
-import java.lang.reflect.Field;
-
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Adolfo Pérez
@@ -34,7 +25,9 @@ public class UpgradeNotifications extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (!hasType(
+		DBMetadata dbMetadata = new DBMetadata(connection);
+
+		if (!dbMetadata.hasType(
 				UserNotificationEventTable.class, "type_",
 				"VARCHAR(200) null")) {
 
@@ -43,115 +36,5 @@ public class UpgradeNotifications extends UpgradeProcess {
 				new AlterColumnType("type_", "VARCHAR(200) null"));
 		}
 	}
-
-	protected int getColumnType(Class<?> tableClass, String columnName)
-		throws Exception {
-
-		Field tableColumnsField = tableClass.getField("TABLE_COLUMNS");
-
-		Object[][] tableColumns = (Object[][])tableColumnsField.get(null);
-
-		for (Object[] tableColumn : tableColumns) {
-			if (tableColumn[0].equals(columnName)) {
-				return (int)tableColumn[1];
-			}
-		}
-
-		throw new UpgradeException(
-			"Table class " + tableClass +
-				" has no row in TABLE_COLUMNS for column " + columnName);
-	}
-
-	protected boolean hasType(
-			Class<?> tableClass, String columnName, String typeName)
-		throws Exception {
-
-		Field tableNameField = tableClass.getField("TABLE_NAME");
-
-		String tableName = (String)tableNameField.get(null);
-
-		DatabaseMetaData databaseMetaData = connection.getMetaData();
-
-		try (ResultSet rs = databaseMetaData.getColumns(
-				null, null, tableName, columnName)) {
-
-			if (!rs.next()) {
-				return false;
-			}
-
-			int columnType = getColumnType(tableClass, columnName);
-			int columnTypeSize = parseColumnTypeSize(typeName);
-			boolean columnTypeNullable = isColumnTypeNullable(typeName);
-
-			int columnSize = rs.getInt("COLUMN_SIZE");
-			int dataType = rs.getInt("DATA_TYPE");
-			int nullable = rs.getInt("NULLABLE");
-
-			if ((columnTypeSize != -1) && (columnTypeSize != columnSize)) {
-				return false;
-			}
-
-			if (dataType != columnType) {
-				return false;
-			}
-
-			if ((columnTypeNullable &&
-				 (nullable != DatabaseMetaData.columnNullable)) ||
-				(!columnTypeNullable &&
-				 (nullable != DatabaseMetaData.columnNoNulls))) {
-
-				return false;
-			}
-
-			return true;
-		}
-	}
-
-	protected boolean isColumnTypeNullable(String typeName) {
-		typeName = typeName.trim();
-
-		int i = typeName.indexOf("null");
-
-		if (i == -1) {
-			return false;
-		}
-
-		if ((i > 0) && !Character.isSpaceChar(typeName.charAt(i - 1))) {
-			return false;
-		}
-
-		if ((i + 4) < typeName.length()) {
-			return false;
-		}
-
-		return true;
-	}
-
-	protected int parseColumnTypeSize(String typeName) throws UpgradeException {
-		Matcher matcher = _columnTypeSizePattern.matcher(typeName);
-
-		if (!matcher.matches()) {
-			return -1;
-		}
-
-		String size = matcher.group(1);
-
-		if (Validator.isNotNull(size)) {
-			try {
-				return Integer.parseInt(size);
-			}
-			catch (NumberFormatException nfe) {
-				throw new UpgradeException(
-					"Invalid SQL type " + typeName +
-						". Type size must be a non negative integer.",
-					nfe);
-			}
-		}
-
-		return -1;
-	}
-
-	private static final Pattern _columnTypeSizePattern = Pattern.compile(
-		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeNotifications.java
@@ -14,8 +14,18 @@
 
 package com.liferay.portal.upgrade.v7_0_0;
 
+import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.upgrade.v7_0_0.util.UserNotificationEventTable;
+
+import java.lang.reflect.Field;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Adolfo Pérez
@@ -24,9 +34,124 @@ public class UpgradeNotifications extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		alter(
-			UserNotificationEventTable.class,
-			new AlterColumnType("type_", "VARCHAR(200) null"));
+		if (!hasType(
+				UserNotificationEventTable.class, "type_",
+				"VARCHAR(200) null")) {
+
+			alter(
+				UserNotificationEventTable.class,
+				new AlterColumnType("type_", "VARCHAR(200) null"));
+		}
 	}
+
+	protected int getColumnType(Class<?> tableClass, String columnName)
+		throws Exception {
+
+		Field tableColumnsField = tableClass.getField("TABLE_COLUMNS");
+
+		Object[][] tableColumns = (Object[][])tableColumnsField.get(null);
+
+		for (Object[] tableColumn : tableColumns) {
+			if (tableColumn[0].equals(columnName)) {
+				return (int)tableColumn[1];
+			}
+		}
+
+		throw new UpgradeException(
+			"Table class " + tableClass +
+				" has no row in TABLE_COLUMNS for column " + columnName);
+	}
+
+	protected boolean hasType(
+			Class<?> tableClass, String columnName, String typeName)
+		throws Exception {
+
+		Field tableNameField = tableClass.getField("TABLE_NAME");
+
+		String tableName = (String)tableNameField.get(null);
+
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+		try (ResultSet rs = databaseMetaData.getColumns(
+				null, null, tableName, columnName)) {
+
+			if (!rs.next()) {
+				return false;
+			}
+
+			int columnType = getColumnType(tableClass, columnName);
+			int columnTypeSize = parseColumnTypeSize(typeName);
+			boolean columnTypeNullable = isColumnTypeNullable(typeName);
+
+			int columnSize = rs.getInt("COLUMN_SIZE");
+			int dataType = rs.getInt("DATA_TYPE");
+			int nullable = rs.getInt("NULLABLE");
+
+			if ((columnTypeSize != -1) && (columnTypeSize != columnSize)) {
+				return false;
+			}
+
+			if (dataType != columnType) {
+				return false;
+			}
+
+			if ((columnTypeNullable &&
+				 (nullable != DatabaseMetaData.columnNullable)) ||
+				(!columnTypeNullable &&
+				 (nullable != DatabaseMetaData.columnNoNulls))) {
+
+				return false;
+			}
+
+			return true;
+		}
+	}
+
+	protected boolean isColumnTypeNullable(String typeName) {
+		typeName = typeName.trim();
+
+		int i = typeName.indexOf("null");
+
+		if (i == -1) {
+			return false;
+		}
+
+		if ((i > 0) && !Character.isSpaceChar(typeName.charAt(i - 1))) {
+			return false;
+		}
+
+		if ((i + 4) < typeName.length()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	protected int parseColumnTypeSize(String typeName) throws UpgradeException {
+		Matcher matcher = _columnTypeSizePattern.matcher(typeName);
+
+		if (!matcher.matches()) {
+			return -1;
+		}
+
+		String size = matcher.group(1);
+
+		if (Validator.isNotNull(size)) {
+			try {
+				return Integer.parseInt(size);
+			}
+			catch (NumberFormatException nfe) {
+				throw new UpgradeException(
+					"Invalid SQL type " + typeName +
+						". Type size must be a non negative integer.",
+					nfe);
+			}
+		}
+
+		return -1;
+	}
+
+	private static final Pattern _columnTypeSizePattern = Pattern.compile(
+		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/util/UserNotificationEventTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/util/UserNotificationEventTable.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class UserNotificationEventTable {
+
+	public static final String TABLE_NAME = "UserNotificationEvent";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT},
+		{"uuid_", Types.VARCHAR},
+		{"userNotificationEventId", Types.BIGINT},
+		{"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT},
+		{"type_", Types.VARCHAR},
+		{"timestamp", Types.BIGINT},
+		{"deliveryType", Types.INTEGER},
+		{"deliverBy", Types.BIGINT},
+		{"delivered", Types.BOOLEAN},
+		{"payload", Types.CLOB},
+		{"actionRequired", Types.BOOLEAN},
+		{"archived", Types.BOOLEAN}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP = new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("userNotificationEventId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("type_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("timestamp", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("deliveryType", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("deliverBy", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("delivered", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("payload", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("actionRequired", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("archived", Types.BOOLEAN);
+
+}
+	public static final String TABLE_SQL_CREATE = "create table UserNotificationEvent (mvccVersion LONG default 0 not null,uuid_ VARCHAR(75) null,userNotificationEventId LONG not null primary key,companyId LONG,userId LONG,type_ VARCHAR(75) null,timestamp LONG,deliveryType INTEGER,deliverBy LONG,delivered BOOLEAN,payload TEXT null,actionRequired BOOLEAN,archived BOOLEAN)";
+
+	public static final String TABLE_SQL_DROP = "drop table UserNotificationEvent";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:75$])",
+		"create index IX_5CE95F03 on UserNotificationEvent (userId, actionRequired, archived)",
+		"create index IX_3DBB361A on UserNotificationEvent (userId, archived)",
+		"create index IX_E32CC19 on UserNotificationEvent (userId, delivered, actionRequired)",
+		"create index IX_C4EFBD45 on UserNotificationEvent (userId, deliveryType, actionRequired, archived)",
+		"create index IX_A87A585C on UserNotificationEvent (userId, deliveryType, archived)",
+		"create index IX_A6F83617 on UserNotificationEvent (userId, deliveryType, delivered, actionRequired)",
+		"create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:75$], deliveryType, delivered)",
+		"create index IX_A6BAFDFE on UserNotificationEvent (uuid_[$COLUMN_LENGTH:75$], companyId)"
+	};
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -14,19 +14,15 @@
 
 package com.liferay.portal.kernel.dao.db;
 
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.IOException;
 
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 import javax.naming.NamingException;
@@ -114,47 +110,17 @@ public abstract class BaseDBProcess implements DBProcess {
 	}
 
 	protected boolean doHasTable(String tableName) throws Exception {
-		PreparedStatement ps = null;
-		ResultSet rs = null;
+		DBMetadata dbMetadata = new DBMetadata(connection);
 
-		try {
-			DatabaseMetaData metadata = connection.getMetaData();
-
-			rs = metadata.getTables(null, null, tableName, null);
-
-			while (rs.next()) {
-				return true;
-			}
-		}
-		finally {
-			DataAccess.cleanUp(ps, rs);
-		}
-
-		return false;
+		return dbMetadata.hasTable(tableName, true);
 	}
 
 	protected boolean hasColumn(String tableName, String columnName)
 		throws Exception {
 
-		try (PreparedStatement ps = connection.prepareStatement(
-				"select * from " + tableName);
-			ResultSet rs = ps.executeQuery()) {
+		DBMetadata dbMetadata = new DBMetadata(connection);
 
-			ResultSetMetaData rsmd = rs.getMetaData();
-
-			for (int i = 0; i < rsmd.getColumnCount(); i++) {
-				String curColumnName = rsmd.getColumnName(i + 1);
-
-				if (StringUtil.equalsIgnoreCase(curColumnName, columnName)) {
-					return true;
-				}
-			}
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-		}
-
-		return false;
+		return dbMetadata.hasColumn(tableName, columnName);
 	}
 
 	protected boolean hasRows(Connection connection, String tableName) {
@@ -182,14 +148,9 @@ public abstract class BaseDBProcess implements DBProcess {
 	}
 
 	protected boolean hasTable(String tableName) throws Exception {
-		if (doHasTable(StringUtil.toLowerCase(tableName)) ||
-			doHasTable(StringUtil.toUpperCase(tableName)) ||
-			doHasTable(tableName)) {
+		DBMetadata dbMetadata = new DBMetadata(connection);
 
-			return true;
-		}
-
-		return false;
+		return dbMetadata.hasTable(tableName);
 	}
 
 	protected Connection connection;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBMetadata.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBMetadata.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.dao.db;
+
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.lang.reflect.Field;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class DBMetadata {
+
+	public DBMetadata(Connection connection) {
+		_connection = connection;
+	}
+
+	public boolean hasType(
+			Class<?> tableClass, String columnName, String typeName)
+		throws Exception {
+
+		Field tableNameField = tableClass.getField("TABLE_NAME");
+
+		String tableName = (String)tableNameField.get(null);
+
+		DatabaseMetaData databaseMetaData = _connection.getMetaData();
+
+		try (ResultSet rs = databaseMetaData.getColumns(
+				null, null, tableName, columnName)) {
+
+			if (!rs.next()) {
+				return false;
+			}
+
+			int columnType = getColumnType(tableClass, columnName);
+			int columnTypeSize = parseColumnTypeSize(typeName);
+			boolean columnTypeNullable = isColumnTypeNullable(typeName);
+
+			int columnSize = rs.getInt("COLUMN_SIZE");
+			int dataType = rs.getInt("DATA_TYPE");
+			int nullable = rs.getInt("NULLABLE");
+
+			if ((columnTypeSize != -1) && (columnTypeSize != columnSize)) {
+				return false;
+			}
+
+			if (dataType != columnType) {
+				return false;
+			}
+
+			if ((columnTypeNullable &&
+				 (nullable != DatabaseMetaData.columnNullable)) ||
+				(!columnTypeNullable &&
+				 (nullable != DatabaseMetaData.columnNoNulls))) {
+
+				return false;
+			}
+
+			return true;
+		}
+	}
+
+	protected int getColumnType(Class<?> tableClass, String columnName)
+		throws Exception {
+
+		Field tableColumnsField = tableClass.getField("TABLE_COLUMNS");
+
+		Object[][] tableColumns = (Object[][])tableColumnsField.get(null);
+
+		for (Object[] tableColumn : tableColumns) {
+			if (tableColumn[0].equals(columnName)) {
+				return (int)tableColumn[1];
+			}
+		}
+
+		throw new UpgradeException(
+			"Table class " + tableClass +
+				" has no row in TABLE_COLUMNS for column " + columnName);
+	}
+
+	protected boolean isColumnTypeNullable(String typeName) {
+		typeName = typeName.trim();
+
+		int i = typeName.indexOf("null");
+
+		if (i == -1) {
+			return false;
+		}
+
+		if ((i > 0) && !Character.isSpaceChar(typeName.charAt(i - 1))) {
+			return false;
+		}
+
+		if ((i + 4) < typeName.length()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	protected int parseColumnTypeSize(String typeName) throws UpgradeException {
+		Matcher matcher = _columnTypeSizePattern.matcher(typeName);
+
+		if (!matcher.matches()) {
+			return -1;
+		}
+
+		String size = matcher.group(1);
+
+		if (Validator.isNotNull(size)) {
+			try {
+				return Integer.parseInt(size);
+			}
+			catch (NumberFormatException nfe) {
+				throw new UpgradeException(
+					"Invalid SQL type " + typeName +
+						". Type size must be a non negative integer.",
+					nfe);
+			}
+		}
+
+		return -1;
+	}
+
+	private static final Pattern _columnTypeSizePattern = Pattern.compile(
+		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
+
+	private final Connection _connection;
+
+}

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -503,14 +503,14 @@ create unique index IX_D1C44A6E on UserIdMapper (userId, type_[$COLUMN_LENGTH:75
 
 create unique index IX_8B6E3ACE on UserNotificationDelivery (userId, portletId[$COLUMN_LENGTH:200$], classNameId, notificationType, deliveryType);
 
-create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:75$]);
+create index IX_BF29100B on UserNotificationEvent (type_[$COLUMN_LENGTH:200$]);
 create index IX_5CE95F03 on UserNotificationEvent (userId, actionRequired, archived);
 create index IX_3DBB361A on UserNotificationEvent (userId, archived);
 create index IX_E32CC19 on UserNotificationEvent (userId, delivered, actionRequired);
 create index IX_C4EFBD45 on UserNotificationEvent (userId, deliveryType, actionRequired, archived);
 create index IX_A87A585C on UserNotificationEvent (userId, deliveryType, archived);
 create index IX_A6F83617 on UserNotificationEvent (userId, deliveryType, delivered, actionRequired);
-create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:75$], deliveryType, delivered);
+create index IX_8FB65EC1 on UserNotificationEvent (userId, type_[$COLUMN_LENGTH:200$], deliveryType, delivered);
 create index IX_A6BAFDFE on UserNotificationEvent (uuid_[$COLUMN_LENGTH:75$], companyId);
 
 create index IX_29BA1CF5 on UserTracker (companyId);

--- a/sql/portal-tables.sql
+++ b/sql/portal-tables.sql
@@ -1648,7 +1648,7 @@ create table UserNotificationEvent (
 	userNotificationEventId LONG not null primary key,
 	companyId LONG,
 	userId LONG,
-	type_ VARCHAR(75) null,
+	type_ VARCHAR(200) null,
 	timestamp LONG,
 	deliveryType INTEGER,
 	deliverBy LONG,


### PR DESCRIPTION
@brianchandotcom Here I've simply removed the commits where the base class methods were deprecated and their usages removed.

We still need to execute the upgrade in 7.0, because otherwise when upgrading from 6.x the upgrade will fail before finishing the 7.0 upgrade with a fatal db error (column truncation). We also need to put it on 7.0.1 in case someone is upgrading from 7.0.0.

Note also that this error only occurs on SQLServer (and probably also Oracle and Postgres); MySQL will ignore the truncation error and continue happily, and that's why it is possible for someone upgrading from 7.0 to have the incorrect column size.

Thanks!
