### PR TITLE
LRQA-25603 Modify LoadBalancer to track recent batch sizes in-memory instead of using the file system

### DIFF
--- a/modules/apps/collaboration/announcements/.gitrepo
+++ b/modules/apps/collaboration/announcements/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7e69c473ab9142ef40cd3579ad7bf3f8d98c56ae
+	commit = 8e974754b392d13e35db7e1400876042ccf6a57a
 	mode = push
-	parent = ae3f3584e18218b9290eec375d46ad1f596a442c
+	parent = d54728afd321ddb504464d93a5cbd94bfdcbd0ef
 	remote = git@github.com:liferay/com-liferay-announcements.git

--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 1af77224fb37ed6afdfd2f5aa3ba250dc9ba31e3
+	commit = e5434cec58611f7f86f542b31488c529f0291819
 	mode = push
-	parent = 266cf72850614e59847d5d2e9b894aafe3db7065
+	parent = c2a4498918c01b37a7addcf41234fa5340b8a36a
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/directory/.gitrepo
+++ b/modules/apps/collaboration/directory/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4652a22e7a1edccb96ed39afc9b9d41d8cce952f
+	commit = b5b2824310b0248f115ea9cdd57c55ba9b33b732
 	mode = push
-	parent = 26b91e4374759bcf5f4a471f83942cc670ed6036
+	parent = 925c24fa6c78971489893a42f5b591e5841575f6
 	remote = git@github.com:liferay/com-liferay-directory.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 6e7a2f9dcc4dbf9d251d66a07cfb1dcb70a34e18
+	commit = 6c7983bf26253e07a1710918d861e65b6cdf626c
 	mode = push
-	parent = f742264d6939f54e95a76a8da0d2cc67cace46f2
+	parent = 4432bc4ba1958dbbea827d2e9c6573aecc65d124
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/item-selector/.gitrepo
+++ b/modules/apps/collaboration/item-selector/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 8fa06ca1d3394773b7e7300c7f789b00df4c3b3a
+	commit = 33520fc44f4b5236919d219b58eef4d3fbe484ae
 	mode = push
-	parent = c6ea4d3f092456c5667f02db2f0c83efe8a77f6b
+	parent = 3b28811dc8ddeb437fd789568b2ff01e7db27521
 	remote = git@github.com:liferay/com-liferay-item-selector.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = aebb0f95012a3aa9ed3c180711ea7e1a31f57eba
+	commit = f5dfa8aaf2428f52e8a311ab0935c114d099170a
 	mode = push
-	parent = cb45c4b27e9713cbc6e288d7a35ce9d20a60dcf8
+	parent = 1a3ca70c9887b173aea5437d5c97171db3d2564a
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/microblogs/.gitrepo
+++ b/modules/apps/collaboration/microblogs/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = cfe5617d5bdc68df6e1a9572e4d2920ff7cc51ba
+	commit = 8c20678482b2924047cbcaf50d1a271fd659bd1a
 	mode = push
-	parent = 24794394774d022f63a55c0b78957a1620795af6
+	parent = fa2376e3b98f0fdf4d6085790ccd12ef52472146
 	remote = git@github.com:liferay/com-liferay-microblogs.git

--- a/modules/apps/collaboration/ratings/.gitrepo
+++ b/modules/apps/collaboration/ratings/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3c6019c0ef6595bfc999ee64a7f301b6104ace9c
+	commit = 9b99ab713405e636a55cea1f85d9fb7cd73a05b0
 	mode = push
-	parent = 651210aa3ec081dbabda48d28d0598c402c452be
+	parent = 5a95582ecf3b5ed4013ce6c8c05a0fc76c716140
 	remote = git@github.com:liferay/com-liferay-ratings.git

--- a/modules/apps/collaboration/recent-documents/.gitrepo
+++ b/modules/apps/collaboration/recent-documents/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 228a06e8dd9541efcdfc67c04eba63305649bde4
+	commit = b6d5bf2f3fa494dfc917b1691d8b2dcf51e1c51e
 	mode = push
-	parent = 984137206e7d4e6987bf1a8514ccfaf30752e0a2
+	parent = efd29a0d38851c92df280f89d281a3fe84d6c448
 	remote = git@github.com:liferay/com-liferay-recent-documents.git

--- a/modules/apps/collaboration/social/.gitrepo
+++ b/modules/apps/collaboration/social/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 1b60f52b33d00abbf275b0aaaa290cd52fae0637
+	commit = b48dbf847eeffe2e5fc088c54e218fdcc96d323d
 	mode = push
-	parent = 16b251a7f028406d60291a869cfb3acc529bfecd
+	parent = 288eea03362660810a62bbd319a96f4f7c821618
 	remote = git@github.com:liferay/com-liferay-social.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = c9985eee331fbcdce509339882dead51a6a97989
+	commit = 620ef7313edb2df8186daa09c716372b7f6fa031
 	mode = push
-	parent = 2330a426991713469673dff1208881fb20b586d2
+	parent = ca5d2649bceee797c0e0d2caf6b8da8b245b2707
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -46,7 +46,7 @@ public class LoadBalancerUtilTest extends BaseJenkinsResultsParserTestCase {
 
 	@Test
 	public void testGetMostAvailableMasterURL() throws Exception {
-		LoadBalancerUtil.recentBuildsPeriod = 0;
+		LoadBalancerUtil.recentBatchPeriod = 0;
 
 		assertSamples();
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -46,7 +46,7 @@ public class LoadBalancerUtilTest extends BaseJenkinsResultsParserTestCase {
 
 	@Test
 	public void testGetMostAvailableMasterURL() throws Exception {
-		LoadBalancerUtil.recentJobPeriod = 0;
+		LoadBalancerUtil.recentBuildsPeriod = 0;
 
 		assertSamples();
 	}


### PR DESCRIPTION
LoadBalancer no longer needs to use the local file system to track recent batch sizes and to synchronize LoadBalancer instances. Currently, the LoadBalancer service doesn't track recent batch sizes because it is using the tmp directory. When the tmp directory is cleared, the ability to track recent batch sizes is broken until the next time the service is bounced. Instead of moving the files elsewhere, it makes more sense to remove the need to use the file system at all.

I've also included some refactoring in this pull to rename "job" to "batch".

Please publish a new com.liferay.jenkins.results.parser.jar when this is merged.
