### PR TITLE
LPS-66061 Add Validator and Tests for Language property keys and values

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ddfa828e5223a4cc3653bcdc934c7ac4556ca3dd
+	commit = c496f420ff77f9eb6a1527c6c962a6368f048c24
 	mode = push
-	parent = 639bab41bcf3792c3861e8c281d171e5edbc5078
+	parent = 33d87d1e5f77e3d50ab55aa9a973385b36da2119
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.dynamic.data.mapping.api", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.2.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/BaseDDMFormFieldRenderer.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/BaseDDMFormFieldRenderer.java
@@ -19,6 +19,7 @@ import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
+import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
@@ -102,7 +103,8 @@ public abstract class BaseDDMFormFieldRenderer implements DDMFormFieldRenderer {
 			template.put("childElementsHTML", childElementsHTML);
 		}
 
-		template.put("dir", LanguageUtil.get(locale, "lang.dir"));
+		template.put(
+			"dir", LanguageUtil.get(locale, LanguageConstants.KEY_DIR));
 		template.put("label", ddmFormFieldRenderingContext.getLabel());
 		template.put("name", ddmFormFieldRenderingContext.getName());
 		template.put(

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/render/impl/DDMFormFieldFreeMarkerRenderer.java
@@ -27,6 +27,7 @@ import com.liferay.dynamic.data.mapping.util.impl.DDMFieldsCounter;
 import com.liferay.dynamic.data.mapping.util.impl.DDMImpl;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
+import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.template.ClassLoaderTemplateResource;
 import com.liferay.portal.kernel.template.Template;
@@ -490,7 +491,8 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 		freeMarkerContext.put("parentFieldStructure", parentFieldContext);
 		freeMarkerContext.put("portletNamespace", portletNamespace);
 		freeMarkerContext.put(
-			"requestedLanguageDir", LanguageUtil.get(locale, "lang.dir"));
+			"requestedLanguageDir",
+			LanguageUtil.get(locale, LanguageConstants.KEY_DIR));
 		freeMarkerContext.put("requestedLocale", locale);
 		freeMarkerContext.put("showEmptyFieldLabel", showEmptyFieldLabel);
 

--- a/modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java
+++ b/modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.io.OutputStreamWriter;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedWriter;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
+import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.NaturalOrderStringComparator;
 import com.liferay.portal.kernel.util.PropertiesUtil;
@@ -25,6 +26,7 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.util.LanguageValidator;
 import com.liferay.portal.tools.ArgumentsUtil;
 
 import com.memetix.mst.language.Language;
@@ -66,7 +68,8 @@ public class LangBuilder {
 		System.setProperty("line.separator", StringPool.NEW_LINE);
 
 		String langDirName = GetterUtil.getString(
-			arguments.get("lang.dir"), LangBuilderArgs.LANG_DIR_NAME);
+			arguments.get(LanguageConstants.KEY_DIR),
+			LangBuilderArgs.LANG_DIR_NAME);
 		String langFileName = GetterUtil.getString(
 			arguments.get("lang.file"), LangBuilderArgs.LANG_FILE_NAME);
 		boolean plugin = GetterUtil.getBoolean(
@@ -211,6 +214,20 @@ public class LangBuilder {
 		_createProperties(content, "vi"); // Vietnamese
 	}
 
+	private static String _getDefaultLanguageSettingValue(String key) {
+		if (key.equals(LanguageConstants.KEY_DIR)) {
+			return LanguageConstants.VALUE_LTR;
+		}
+		else if (key.equals(LanguageConstants.KEY_LINE_BEGIN)) {
+			return LanguageConstants.VALUE_LEFT;
+		}
+		else if (key.equals(LanguageConstants.KEY_LINE_END)) {
+			return LanguageConstants.VALUE_RIGHT;
+		}
+
+		return StringPool.BLANK;
+	}
+
 	private void _copyProperties(File file, String languageId)
 		throws IOException {
 
@@ -346,17 +363,11 @@ public class LangBuilder {
 								translatedText = value + AUTOMATIC_COPY;
 							}
 						}
-						else if (key.equals("lang.dir")) {
-							translatedText = "ltr";
-						}
-						else if (key.equals("lang.line.begin")) {
-							translatedText = "left";
-						}
-						else if (key.equals("lang.line.end")) {
-							translatedText = "right";
-						}
-						else if (key.startsWith("lang.user.name.")) {
-							translatedText = "";
+						else if (LanguageValidator.isLanguageSettingsProperty(
+									key)) {
+
+							translatedText = _getDefaultLanguageSettingValue(
+								key);
 						}
 						else if (languageId.equals("el") &&
 								 (key.equals("enabled") || key.equals("on") ||

--- a/portal-impl/src/com/liferay/portal/language/util/LanguageValidator.java
+++ b/portal-impl/src/com/liferay/portal/language/util/LanguageValidator.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.language.util;
+
+import com.liferay.portal.kernel.language.LanguageConstants;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Drew Brokke
+ */
+public class LanguageValidator {
+
+	public static boolean isLanguageSettingsProperty(String key) {
+		return ArrayUtil.contains(
+			LanguageConstants.KEYS_SPECIAL_PROPERTIES, key);
+	}
+
+	public static boolean isValid(String key, String value) {
+		if (key.equals(LanguageConstants.KEY_DIR)) {
+			return ArrayUtil.contains(LanguageConstants.VALUES_DIR, value);
+		}
+		else if (key.equals(LanguageConstants.KEY_LINE_BEGIN) ||
+				 key.equals(LanguageConstants.KEY_LINE_END)) {
+
+			return ArrayUtil.contains(LanguageConstants.VALUES_LINE, value);
+		}
+		else if (key.equals(LanguageConstants.KEY_USER_NAME_FIELD_NAMES)) {
+			return _isValidUserNameFieldNamesValue(value);
+		}
+		else if (key.equals(
+					LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES)) {
+
+			return _isValidUserNameRequiredFieldNamesValue(value);
+		}
+
+		return true;
+	}
+
+	private static boolean _isValidUserNameFieldNamesValue(String value) {
+		String[] valuesArray = StringUtil.split(value);
+
+		if (ArrayUtil.isEmpty(valuesArray)) {
+			return false;
+		}
+
+		if (!ArrayUtil.contains(
+				valuesArray, LanguageConstants.VALUE_FIRST_NAME) ||
+			!ArrayUtil.contains(
+				valuesArray, LanguageConstants.VALUE_LAST_NAME)) {
+
+			return false;
+		}
+
+		if (ArrayUtil.contains(
+				valuesArray, LanguageConstants.VALUE_PREFIX) &&
+			!valuesArray[0].equals(LanguageConstants.VALUE_PREFIX)) {
+
+			return false;
+		}
+
+		int lastIndex = valuesArray.length - 1;
+
+		if (ArrayUtil.contains(
+				valuesArray, LanguageConstants.VALUE_SUFFIX) &&
+			!valuesArray[lastIndex].equals(
+				LanguageConstants.VALUE_SUFFIX)) {
+
+			return false;
+		}
+
+		for (String curValue : valuesArray) {
+			if (!ArrayUtil.contains(
+					LanguageConstants.VALUES_USER_NAME_FIELD_NAMES, curValue)) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static boolean _isValidUserNameRequiredFieldNamesValue(
+		String value) {
+
+		String[] valuesArray = StringUtil.split(value);
+
+		if (ArrayUtil.isEmpty(valuesArray)) {
+			return false;
+		}
+
+		for (String curValue : valuesArray) {
+			if (!ArrayUtil.contains(
+					LanguageConstants.VALUES_USER_NAME_FIELD_NAMES, curValue)) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.exception.RSSFeedException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.image.ImageToolUtil;
+import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -6337,7 +6338,7 @@ public class PortalImpl implements Portal {
 
 		Locale locale = LocaleUtil.fromLanguageId(languageId);
 
-		String langDir = LanguageUtil.get(locale, "lang.dir");
+		String langDir = LanguageUtil.get(locale, LanguageConstants.KEY_DIR);
 
 		return langDir.equals("rtl");
 	}

--- a/portal-impl/test/unit/com/liferay/portal/language/util/LanguagePropertyTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/language/util/LanguagePropertyTest.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.language.util;
+
+import com.liferay.portal.kernel.language.LanguageConstants;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class LanguagePropertyTest {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		List<String> coreFilePaths = _getPaths(_CORE_GLOB);
+		List<String> moduleFilePaths = _getPaths(_MODULES_GLOB);
+
+		_corePropertiesMap = _getPropertiesMap(coreFilePaths);
+		_modulePropertiesMap = _getPropertiesMap(moduleFilePaths);
+	}
+
+	@Test
+	public void testModulesNoLanguageSettingsKeyDir() {
+		_assertLanguageSettingNotPresent(LanguageConstants.KEY_DIR);
+	}
+
+	@Test
+	public void testModulesNoLanguageSettingsKeyLineBegin() {
+		_assertLanguageSettingNotPresent(LanguageConstants.KEY_LINE_BEGIN);
+	}
+
+	@Test
+	public void testModulesNoLanguageSettingsKeyLineEnd() {
+		_assertLanguageSettingNotPresent(LanguageConstants.KEY_LINE_END);
+	}
+
+	@Test
+	public void testModulesNoLanguageSettingsKeyUserNameFieldNames() {
+		_assertLanguageSettingNotPresent(
+			LanguageConstants.KEY_USER_NAME_FIELD_NAMES);
+	}
+
+	@Test
+	public void testModulesNoLanguageSettingsKeyUserNamePrefixValues() {
+		_assertLanguageSettingNotPresent(
+			LanguageConstants.KEY_USER_NAME_PREFIX_VALUES);
+	}
+
+	@Test
+	public void testModulesNoLanguageSettingsKeyUserNameRequiredFieldNames() {
+		_assertLanguageSettingNotPresent(
+			LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES);
+	}
+
+	@Test
+	public void testModulesNoLanguageSettingsKeyUserNameSuffixValues() {
+		_assertLanguageSettingNotPresent(
+			LanguageConstants.KEY_USER_NAME_SUFFIX_VALUES);
+	}
+
+	@Test
+	public void testUserNameRequiredFieldNamesSubsetOfUserNameFieldNames() {
+		Set<String> paths = _corePropertiesMap.keySet();
+
+		List<String> failureMessages = new ArrayList<>();
+
+		for (String path : paths) {
+			Properties properties = _corePropertiesMap.get(path);
+
+			String userNameFieldNamesString = properties.getProperty(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES);
+			String userNameRequiredFieldNamesString = properties.getProperty(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES);
+
+			if ((userNameFieldNamesString == null) ||
+				(userNameRequiredFieldNamesString == null)) {
+
+				continue;
+			}
+
+			String[] userNameFieldNames = StringUtil.split(
+				userNameFieldNamesString);
+			String[] userNameRequiredFieldNames = StringUtil.split(
+				userNameRequiredFieldNamesString);
+
+			for (String userNameRequiredFieldName :
+					userNameRequiredFieldNames) {
+
+				if (!ArrayUtil.contains(
+						userNameFieldNames, userNameRequiredFieldName)) {
+
+					failureMessages.add(path);
+				}
+			}
+		}
+
+		if (!failureMessages.isEmpty()) {
+			Assert.fail(
+				"Required field names are not a subset of user name field " +
+					"names in " + failureMessages);
+		}
+	}
+
+	@Test
+	public void testValidLanguageSettingValueLangDir() {
+		_assertValidLanguageSettingValue(LanguageConstants.KEY_DIR);
+	}
+
+	@Test
+	public void testValidLanguageSettingValueLangLineBegin() {
+		_assertValidLanguageSettingValue(LanguageConstants.KEY_LINE_BEGIN);
+	}
+
+	@Test
+	public void testValidLanguageSettingValueLangLineEnd() {
+		_assertValidLanguageSettingValue(LanguageConstants.KEY_LINE_END);
+	}
+
+	@Test
+	public void testValidLanguageSettingValueLangUserNameFieldNames() {
+		_assertValidLanguageSettingValue(
+			LanguageConstants.KEY_USER_NAME_FIELD_NAMES);
+	}
+
+	@Test
+	public void testValidLanguageSettingValueLangUserNameRequiredFieldNames() {
+		_assertValidLanguageSettingValue(
+			LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES);
+	}
+
+	private static List<String> _getPaths(String glob) throws IOException {
+		final PathMatcher includePatternMatcher =
+			FileSystems.getDefault().getPathMatcher("glob:" + glob);
+
+		final List<String> paths = new ArrayList<>();
+
+		FileVisitor<Path> simpleFileVisitor = new SimpleFileVisitor<Path>() {
+
+			@Override
+			public FileVisitResult visitFile(
+					Path path, BasicFileAttributes attrs)
+				throws IOException {
+
+				if (includePatternMatcher.matches(path)) {
+					paths.add(path.toString());
+				}
+
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFileFailed(Path file, IOException exc)
+				throws IOException {
+
+				return FileVisitResult.CONTINUE;
+			}
+
+		};
+
+		Files.walkFileTree(Paths.get(_BASE_DIR), simpleFileVisitor);
+
+		return paths;
+	}
+
+	private static Map<String, Properties> _getPropertiesMap(List<String> paths)
+		throws IOException {
+
+		Map<String, Properties> propertiesMap = new HashMap<>();
+
+		for (String path : paths) {
+			Properties properties = new Properties();
+
+			try (InputStream inputStream = new FileInputStream(path)) {
+				properties.load(inputStream);
+			}
+
+			propertiesMap.put(path, properties);
+		}
+
+		return propertiesMap;
+	}
+
+	private void _assertLanguageSettingNotPresent(String key) {
+		Set<String> paths = _modulePropertiesMap.keySet();
+
+		List<String> failureMessages = new ArrayList<>();
+
+		for (String path : paths) {
+			Properties properties = _modulePropertiesMap.get(path);
+
+			Set<String> propertyNames = properties.stringPropertyNames();
+
+			if (propertyNames.contains(key)) {
+				failureMessages.add(path);
+			}
+		}
+
+		if (!failureMessages.isEmpty()) {
+			Assert.fail(
+				"Language setting \"" + key + "\" found in " + failureMessages);
+		}
+	}
+
+	private void _assertValidLanguageSettingValue(String key) {
+		Set<String> paths = _corePropertiesMap.keySet();
+
+		List<String> failureMessages = new ArrayList<>();
+
+		for (String path : paths) {
+			Properties properties = _corePropertiesMap.get(path);
+
+			String value = properties.getProperty(key);
+
+			if ((value != null) && !LanguageValidator.isValid(key, value)) {
+				failureMessages.add(path);
+			}
+		}
+
+		if (!failureMessages.isEmpty()) {
+			Assert.fail(
+				"Invalid values for Language setting \"" + key +
+					"\" found in " + failureMessages);
+		}
+	}
+
+	private static final String _BASE_DIR = "./";
+
+	private static final String _CORE_GLOB =
+		"./portal-impl/src/**/Language*.properties";
+
+	private static final String _MODULES_GLOB =
+		"./modules/**/src/**/Language*.properties";
+
+	private static Map<String, Properties> _corePropertiesMap;
+	private static Map<String, Properties> _modulePropertiesMap;
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/language/util/LanguageValidatorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/language/util/LanguageValidatorTest.java
@@ -1,0 +1,419 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.language.util;
+
+import com.liferay.portal.kernel.language.LanguageConstants;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class LanguageValidatorTest {
+
+	@Test
+	public void testLangDirValues() {
+		Assert.assertTrue(
+			LanguageValidator.isValid(LanguageConstants.KEY_DIR, "ltr"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(LanguageConstants.KEY_DIR, "rtl"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(LanguageConstants.KEY_DIR, "tlr"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(LanguageConstants.KEY_DIR, "lrt"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_DIR, "Any other value"));
+	}
+
+	@Test
+	public void testLineBeginValues() {
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_LINE_BEGIN, "left"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_LINE_BEGIN, "right"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(LanguageConstants.KEY_LINE_BEGIN, "up"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_LINE_BEGIN, "down"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_LINE_BEGIN, "any-other-value"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_LINE_BEGIN, "Any other value"));
+	}
+
+	@Test
+	public void testLineEndValues() {
+		Assert.assertTrue(
+			LanguageValidator.isValid(LanguageConstants.KEY_LINE_END, "left"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(LanguageConstants.KEY_LINE_END, "right"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(LanguageConstants.KEY_LINE_END, "up"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(LanguageConstants.KEY_LINE_END, "down"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_LINE_END, "any-other-value"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_LINE_END, "Any other value"));
+	}
+
+	@Test
+	public void testUserNameFieldNameValues() {
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,middle-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,last-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,middle-name,first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,middle-name,last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,last-name,first-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,last-name,middle-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,middle-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,last-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,middle-name,first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,middle-name,last-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,last-name,first-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,last-name,middle-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,last-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"first-name,middle-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"first-name,last-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"middle-name,first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"middle-name,last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"last-name,first-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"last-name,middle-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"first-name,middle-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"first-name,last-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"middle-name,first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"middle-name,last-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"last-name,first-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"last-name,middle-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"last-name,first-name"));
+
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"first-name,prefix,middle-name,last-name,suffix"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,middle-name,suffix,last-name"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,middle-name,last-name,suffix"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"prefix,first-name,middle-name,suffix"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES, "first-name"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES, "last-name"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"Prefix,First Name,Middle Name,Last Name,Suffix"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"Any other values"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES,
+				"any,other,values"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_FIELD_NAMES, ""));
+	}
+
+	@Test
+	public void testUserNameRequireFieldNamesValues() {
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,first-name,middle-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,first-name,last-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,middle-name,first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,middle-name,last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,last-name,first-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,last-name,middle-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,first-name,middle-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,first-name,last-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,middle-name,first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,middle-name,last-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,last-name,first-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,last-name,middle-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix,last-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"first-name,middle-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"first-name,last-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"middle-name,first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"middle-name,last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"last-name,first-name,middle-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"last-name,middle-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"first-name,last-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"last-name,first-name,suffix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"first-name,middle-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"first-name,last-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"middle-name,first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"middle-name,last-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"last-name,first-name,middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"last-name,middle-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"first-name,last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"last-name,first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"prefix"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"first-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"middle-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"last-name"));
+		Assert.assertTrue(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"suffix"));
+
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"Prefix,First Name,Middle Name,Last Name,Suffix"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"Any other values"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+				"any,other,values"));
+		Assert.assertFalse(
+			LanguageValidator.isValid(
+				LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES, ""));
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/editor/configuration/BaseEditorConfigContributor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/editor/configuration/BaseEditorConfigContributor.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -38,7 +39,7 @@ public abstract class BaseEditorConfigContributor
 
 		Locale contentsLocale = getContentsLocale(inputEditorTaglibAttributes);
 
-		return LanguageUtil.get(contentsLocale, "lang.dir");
+		return LanguageUtil.get(contentsLocale, LanguageConstants.KEY_DIR);
 	}
 
 	protected String getContentsLanguageId(

--- a/portal-kernel/src/com/liferay/portal/kernel/language/LanguageConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/language/LanguageConstants.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.language;
+
+/**
+ * @author Drew Brokke
+ */
+public class LanguageConstants {
+
+	public static final String KEY_DIR = "lang.dir";
+
+	public static final String KEY_LINE_BEGIN = "lang.line.begin";
+
+	public static final String KEY_LINE_END = "lang.line.end";
+
+	public static final String KEY_USER_NAME_FIELD_NAMES =
+		"lang.user.name.field.names";
+
+	public static final String KEY_USER_NAME_PREFIX_VALUES =
+		"lang.user.name.prefix.values";
+
+	public static final String KEY_USER_NAME_REQUIRED_FIELD_NAMES =
+		"lang.user.name.required.field.names";
+
+	public static final String KEY_USER_NAME_SUFFIX_VALUES =
+		"lang.user.name.suffix.values";
+
+	public static final String[] KEYS_SPECIAL_PROPERTIES = {
+		KEY_DIR, KEY_LINE_BEGIN, KEY_LINE_END, KEY_USER_NAME_FIELD_NAMES,
+		KEY_USER_NAME_PREFIX_VALUES, KEY_USER_NAME_REQUIRED_FIELD_NAMES,
+		KEY_USER_NAME_SUFFIX_VALUES
+	};
+
+	public static final String VALUE_FIRST_NAME = "first-name";
+
+	public static final String VALUE_LAST_NAME = "last-name";
+
+	public static final String VALUE_LEFT = "left";
+
+	public static final String VALUE_LTR = "ltr";
+
+	public static final String VALUE_MIDDLE_NAME = "middle-name";
+
+	public static final String VALUE_PREFIX = "prefix";
+
+	public static final String VALUE_RIGHT = "right";
+
+	public static final String VALUE_RTL = "rtl";
+
+	public static final String VALUE_SUFFIX = "suffix";
+
+	public static final String[] VALUES_DIR = {VALUE_LTR, VALUE_RTL};
+
+	public static final String[] VALUES_LINE = {VALUE_LEFT, VALUE_RIGHT};
+
+	public static final String[] VALUES_USER_NAME_FIELD_NAMES = {
+		VALUE_PREFIX, VALUE_FIRST_NAME, VALUE_MIDDLE_NAME, VALUE_LAST_NAME,
+		VALUE_SUFFIX
+	};
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/FullNameDefinitionFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/FullNameDefinitionFactory.java
@@ -36,6 +36,35 @@ public class FullNameDefinitionFactory {
 	private FullNameDefinitionFactory() {
 	}
 
+	private FullNameField _getFullNameField(
+		Locale locale, String userNameField, boolean required) {
+
+		FullNameField fullNameField = new FullNameField();
+
+		fullNameField.setName(userNameField);
+
+		String[] values = null;
+
+		if (userNameField.equals(LanguageConstants.VALUE_PREFIX)) {
+			values = StringUtil.split(
+				LanguageUtil.get(
+					locale, LanguageConstants.KEY_USER_NAME_PREFIX_VALUES,
+					StringPool.BLANK));
+		}
+		else if (userNameField.equals(LanguageConstants.VALUE_SUFFIX)) {
+			values = StringUtil.split(
+				LanguageUtil.get(
+					locale, LanguageConstants.KEY_USER_NAME_SUFFIX_VALUES,
+					StringPool.BLANK));
+		}
+
+		fullNameField.setValues(values);
+
+		fullNameField.setRequired(required);
+
+		return fullNameField;
+	}
+
 	private FullNameDefinition _getInstance(Locale locale) {
 		FullNameDefinition fullNameDefinition = _fullNameDefinitions.get(
 			locale);
@@ -59,28 +88,8 @@ public class FullNameDefinitionFactory {
 		fieldNames = _includeRequiredFieldNames(requiredFieldNames, fieldNames);
 
 		for (String userNameField : fieldNames) {
-			FullNameField fullNameField = new FullNameField();
-
-			fullNameField.setName(userNameField);
-
-			String[] values = null;
-
-			if (userNameField.equals(LanguageConstants.VALUE_PREFIX)) {
-				values = StringUtil.split(
-					LanguageUtil.get(
-						locale, LanguageConstants.KEY_USER_NAME_PREFIX_VALUES,
-						StringPool.BLANK));
-			}
-			else if (userNameField.equals(LanguageConstants.VALUE_SUFFIX)) {
-				values = StringUtil.split(
-					LanguageUtil.get(
-						locale, LanguageConstants.KEY_USER_NAME_SUFFIX_VALUES,
-						StringPool.BLANK));
-			}
-
-			fullNameField.setValues(values);
-
-			fullNameField.setRequired(
+			FullNameField fullNameField = _getFullNameField(
+				locale, userNameField,
 				fullNameDefinition.isFieldRequired(userNameField));
 
 			fullNameDefinition.addFullNameField(fullNameField);
@@ -117,7 +126,7 @@ public class FullNameDefinitionFactory {
 		fieldNames = ArrayUtil.unique(fieldNames);
 
 		ArrayUtil.reverse(fieldNames);
-		
+
 		return fieldNames;
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/FullNameDefinitionFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/FullNameDefinitionFactory.java
@@ -56,13 +56,7 @@ public class FullNameDefinitionFactory {
 			LanguageUtil.get(
 				locale, LanguageConstants.KEY_USER_NAME_FIELD_NAMES));
 
-		fieldNames = ArrayUtil.append(requiredFieldNames, fieldNames);
-
-		ArrayUtil.reverse(fieldNames);
-
-		fieldNames = ArrayUtil.unique(fieldNames);
-
-		ArrayUtil.reverse(fieldNames);
+		fieldNames = _includeRequiredFieldNames(requiredFieldNames, fieldNames);
 
 		for (String userNameField : fieldNames) {
 			FullNameField fullNameField = new FullNameField();
@@ -111,6 +105,20 @@ public class FullNameDefinitionFactory {
 		}
 
 		return requiredFieldNames;
+	}
+
+	private String[] _includeRequiredFieldNames(
+		String[] requiredFieldNames, String[] fieldNames) {
+
+		fieldNames = ArrayUtil.append(requiredFieldNames, fieldNames);
+
+		ArrayUtil.reverse(fieldNames);
+
+		fieldNames = ArrayUtil.unique(fieldNames);
+
+		ArrayUtil.reverse(fieldNames);
+		
+		return fieldNames;
 	}
 
 	private static final FullNameDefinitionFactory _instance =

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/FullNameDefinitionFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/FullNameDefinitionFactory.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.security.auth;
 
+import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -52,7 +53,8 @@ public class FullNameDefinitionFactory {
 		}
 
 		String[] fieldNames = StringUtil.split(
-			LanguageUtil.get(locale, "lang.user.name.field.names"));
+			LanguageUtil.get(
+				locale, LanguageConstants.KEY_USER_NAME_FIELD_NAMES));
 
 		fieldNames = ArrayUtil.append(requiredFieldNames, fieldNames);
 
@@ -67,10 +69,20 @@ public class FullNameDefinitionFactory {
 
 			fullNameField.setName(userNameField);
 
-			String[] values = StringUtil.split(
-				LanguageUtil.get(
-					locale, "lang.user.name." + userNameField + ".values",
-					StringPool.BLANK));
+			String[] values = null;
+
+			if (userNameField.equals(LanguageConstants.VALUE_PREFIX)) {
+				values = StringUtil.split(
+					LanguageUtil.get(
+						locale, LanguageConstants.KEY_USER_NAME_PREFIX_VALUES,
+						StringPool.BLANK));
+			}
+			else if (userNameField.equals(LanguageConstants.VALUE_SUFFIX)) {
+				values = StringUtil.split(
+					LanguageUtil.get(
+						locale, LanguageConstants.KEY_USER_NAME_SUFFIX_VALUES,
+						StringPool.BLANK));
+			}
 
 			fullNameField.setValues(values);
 
@@ -87,11 +99,15 @@ public class FullNameDefinitionFactory {
 
 	private String[] _getRequiredFieldNames(Locale locale) {
 		String[] requiredFieldNames = StringUtil.split(
-			LanguageUtil.get(locale, "lang.user.name.required.field.names"));
+			LanguageUtil.get(
+				locale, LanguageConstants.KEY_USER_NAME_REQUIRED_FIELD_NAMES));
 
-		if (!ArrayUtil.contains(requiredFieldNames, "first-name")) {
+		if (!ArrayUtil.contains(
+				requiredFieldNames, LanguageConstants.VALUE_FIRST_NAME)) {
+
 			requiredFieldNames = ArrayUtil.append(
-				new String[] {"first-name"}, requiredFieldNames);
+				new String[] {LanguageConstants.VALUE_FIRST_NAME},
+				requiredFieldNames);
 		}
 
 		return requiredFieldNames;

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -145,8 +145,8 @@
         modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/configuration/JournalServiceConfigurationValues.java,\
         modules/apps/web-experience/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/util/ProductNavigationControlMenuCategoryRegistry.java@124,\
         modules/core/osgi-service-tracker-collections/src/testIntegration/java/com/liferay/osgi/service/tracker/collections/map/test/ObjectServiceTrackerMapTest.java@414,\
-        modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java@511,\
-        modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java@519,\
+        modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java@522,\
+        modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java@530,\
         modules/util/pmd/src/main/java/com/liferay/pmd/rules/java/OverrideBothEqualsAndHashcodeRule.java@28,\
         modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java,\
         portal-impl/src/com/liferay/portal/fabric/netty/client/NettyFabricClientConfig.java@69,\

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -152,7 +152,7 @@
         portal-impl/src/com/liferay/portal/fabric/netty/client/NettyFabricClientConfig.java@69,\
         portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java@260,\
         portal-impl/src/com/liferay/portal/tools/WebXML23Converter.java@81,\
-        portal-impl/src/com/liferay/portal/util/PortalImpl.java@545,\
+        portal-impl/src/com/liferay/portal/util/PortalImpl.java@546,\
         portal-impl/src/com/liferay/portal/util/WebKeys.java,\
         portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigContributorTest.java,\
         portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigTransformerTest.java,\


### PR DESCRIPTION
This is an update for [LPS-66061](https://issues.liferay.com/browse/LPS-66061).

Hey @brianchandotcom, all commits beginning with a filename update files throughout portal and modules to use LanguageConstants.  If you'd rather merge these in separately that's fine.

@marcellustavares: 88a059a 3f52871

/cc @jorgeferrer @pei-jung
