### PR TITLE
[Technical Support] Create index for legacy image columns in DLFileEntry table

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryModelImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/model/impl/DLFileEntryModelImpl.java
@@ -166,16 +166,20 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 				"value.object.column.bitmask.enabled.com.liferay.document.library.kernel.model.DLFileEntry"),
 			true);
 	public static final long COMPANYID_COLUMN_BITMASK = 1L;
-	public static final long FILEENTRYTYPEID_COLUMN_BITMASK = 2L;
-	public static final long FILENAME_COLUMN_BITMASK = 4L;
-	public static final long FOLDERID_COLUMN_BITMASK = 8L;
-	public static final long GROUPID_COLUMN_BITMASK = 16L;
-	public static final long MIMETYPE_COLUMN_BITMASK = 32L;
-	public static final long NAME_COLUMN_BITMASK = 64L;
-	public static final long REPOSITORYID_COLUMN_BITMASK = 128L;
-	public static final long TITLE_COLUMN_BITMASK = 256L;
-	public static final long USERID_COLUMN_BITMASK = 512L;
-	public static final long UUID_COLUMN_BITMASK = 1024L;
+	public static final long CUSTOM1IMAGEID_COLUMN_BITMASK = 2L;
+	public static final long CUSTOM2IMAGEID_COLUMN_BITMASK = 4L;
+	public static final long FILEENTRYTYPEID_COLUMN_BITMASK = 8L;
+	public static final long FILENAME_COLUMN_BITMASK = 16L;
+	public static final long FOLDERID_COLUMN_BITMASK = 32L;
+	public static final long GROUPID_COLUMN_BITMASK = 64L;
+	public static final long LARGEIMAGEID_COLUMN_BITMASK = 128L;
+	public static final long MIMETYPE_COLUMN_BITMASK = 256L;
+	public static final long NAME_COLUMN_BITMASK = 512L;
+	public static final long REPOSITORYID_COLUMN_BITMASK = 1024L;
+	public static final long SMALLIMAGEID_COLUMN_BITMASK = 2048L;
+	public static final long TITLE_COLUMN_BITMASK = 4096L;
+	public static final long USERID_COLUMN_BITMASK = 8192L;
+	public static final long UUID_COLUMN_BITMASK = 16384L;
 
 	/**
 	 * Converts the soap model instance into a normal model instance.
@@ -994,7 +998,19 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 
 	@Override
 	public void setSmallImageId(long smallImageId) {
+		_columnBitmask |= SMALLIMAGEID_COLUMN_BITMASK;
+
+		if (!_setOriginalSmallImageId) {
+			_setOriginalSmallImageId = true;
+
+			_originalSmallImageId = _smallImageId;
+		}
+
 		_smallImageId = smallImageId;
+	}
+
+	public long getOriginalSmallImageId() {
+		return _originalSmallImageId;
 	}
 
 	@JSON
@@ -1005,7 +1021,19 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 
 	@Override
 	public void setLargeImageId(long largeImageId) {
+		_columnBitmask |= LARGEIMAGEID_COLUMN_BITMASK;
+
+		if (!_setOriginalLargeImageId) {
+			_setOriginalLargeImageId = true;
+
+			_originalLargeImageId = _largeImageId;
+		}
+
 		_largeImageId = largeImageId;
+	}
+
+	public long getOriginalLargeImageId() {
+		return _originalLargeImageId;
 	}
 
 	@JSON
@@ -1016,7 +1044,19 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 
 	@Override
 	public void setCustom1ImageId(long custom1ImageId) {
+		_columnBitmask |= CUSTOM1IMAGEID_COLUMN_BITMASK;
+
+		if (!_setOriginalCustom1ImageId) {
+			_setOriginalCustom1ImageId = true;
+
+			_originalCustom1ImageId = _custom1ImageId;
+		}
+
 		_custom1ImageId = custom1ImageId;
+	}
+
+	public long getOriginalCustom1ImageId() {
+		return _originalCustom1ImageId;
 	}
 
 	@JSON
@@ -1027,7 +1067,19 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 
 	@Override
 	public void setCustom2ImageId(long custom2ImageId) {
+		_columnBitmask |= CUSTOM2IMAGEID_COLUMN_BITMASK;
+
+		if (!_setOriginalCustom2ImageId) {
+			_setOriginalCustom2ImageId = true;
+
+			_originalCustom2ImageId = _custom2ImageId;
+		}
+
 		_custom2ImageId = custom2ImageId;
+	}
+
+	public long getOriginalCustom2ImageId() {
+		return _originalCustom2ImageId;
 	}
 
 	@JSON
@@ -1365,6 +1417,22 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 		dlFileEntryModelImpl._originalFileEntryTypeId = dlFileEntryModelImpl._fileEntryTypeId;
 
 		dlFileEntryModelImpl._setOriginalFileEntryTypeId = false;
+
+		dlFileEntryModelImpl._originalSmallImageId = dlFileEntryModelImpl._smallImageId;
+
+		dlFileEntryModelImpl._setOriginalSmallImageId = false;
+
+		dlFileEntryModelImpl._originalLargeImageId = dlFileEntryModelImpl._largeImageId;
+
+		dlFileEntryModelImpl._setOriginalLargeImageId = false;
+
+		dlFileEntryModelImpl._originalCustom1ImageId = dlFileEntryModelImpl._custom1ImageId;
+
+		dlFileEntryModelImpl._setOriginalCustom1ImageId = false;
+
+		dlFileEntryModelImpl._originalCustom2ImageId = dlFileEntryModelImpl._custom2ImageId;
+
+		dlFileEntryModelImpl._setOriginalCustom2ImageId = false;
 
 		dlFileEntryModelImpl._columnBitmask = 0;
 	}
@@ -1773,9 +1841,17 @@ public class DLFileEntryModelImpl extends BaseModelImpl<DLFileEntry>
 	private long _size;
 	private int _readCount;
 	private long _smallImageId;
+	private long _originalSmallImageId;
+	private boolean _setOriginalSmallImageId;
 	private long _largeImageId;
+	private long _originalLargeImageId;
+	private boolean _setOriginalLargeImageId;
 	private long _custom1ImageId;
+	private long _originalCustom1ImageId;
+	private boolean _setOriginalCustom1ImageId;
 	private long _custom2ImageId;
+	private long _originalCustom2ImageId;
+	private boolean _setOriginalCustom2ImageId;
 	private boolean _manualCheckInRequired;
 	private Date _lastPublishDate;
 	private long _columnBitmask;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -210,6 +210,12 @@
 			<finder-column arrayable-operator="OR" name="folderId" />
 			<finder-column name="fileEntryTypeId" />
 		</finder>
+		<finder name="S_L_C1_C2" return-type="Collection">
+			<finder-column name="smallImageId" />
+			<finder-column name="largeImageId" />
+			<finder-column name="custom1ImageId" />
+			<finder-column name="custom2ImageId" />
+		</finder>
 
 		<!-- References -->
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryPersistenceImpl.java
@@ -11776,6 +11776,644 @@ public class DLFileEntryPersistenceImpl extends BasePersistenceImpl<DLFileEntry>
 	private static final String _FINDER_COLUMN_G_F_F_FOLDERID_2 = "dlFileEntry.folderId = ? AND ";
 	private static final String _FINDER_COLUMN_G_F_F_FOLDERID_7 = "dlFileEntry.folderId IN (";
 	private static final String _FINDER_COLUMN_G_F_F_FILEENTRYTYPEID_2 = "dlFileEntry.fileEntryTypeId = ?";
+	public static final FinderPath FINDER_PATH_WITH_PAGINATION_FIND_BY_S_L_C1_C2 =
+		new FinderPath(DLFileEntryModelImpl.ENTITY_CACHE_ENABLED,
+			DLFileEntryModelImpl.FINDER_CACHE_ENABLED, DLFileEntryImpl.class,
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByS_L_C1_C2",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName(),
+				Long.class.getName(),
+				
+			Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			});
+	public static final FinderPath FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_S_L_C1_C2 =
+		new FinderPath(DLFileEntryModelImpl.ENTITY_CACHE_ENABLED,
+			DLFileEntryModelImpl.FINDER_CACHE_ENABLED, DLFileEntryImpl.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByS_L_C1_C2",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName(),
+				Long.class.getName()
+			},
+			DLFileEntryModelImpl.SMALLIMAGEID_COLUMN_BITMASK |
+			DLFileEntryModelImpl.LARGEIMAGEID_COLUMN_BITMASK |
+			DLFileEntryModelImpl.CUSTOM1IMAGEID_COLUMN_BITMASK |
+			DLFileEntryModelImpl.CUSTOM2IMAGEID_COLUMN_BITMASK |
+			DLFileEntryModelImpl.FOLDERID_COLUMN_BITMASK |
+			DLFileEntryModelImpl.NAME_COLUMN_BITMASK);
+	public static final FinderPath FINDER_PATH_COUNT_BY_S_L_C1_C2 = new FinderPath(DLFileEntryModelImpl.ENTITY_CACHE_ENABLED,
+			DLFileEntryModelImpl.FINDER_CACHE_ENABLED, Long.class,
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByS_L_C1_C2",
+			new String[] {
+				Long.class.getName(), Long.class.getName(), Long.class.getName(),
+				Long.class.getName()
+			});
+
+	/**
+	 * Returns all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @return the matching document library file entries
+	 */
+	@Override
+	public List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId) {
+		return findByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param start the lower bound of the range of document library file entries
+	 * @param end the upper bound of the range of document library file entries (not inclusive)
+	 * @return the range of matching document library file entries
+	 */
+	@Override
+	public List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end) {
+		return findByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param start the lower bound of the range of document library file entries
+	 * @param end the upper bound of the range of document library file entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching document library file entries
+	 */
+	@Override
+	public List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end, OrderByComparator<DLFileEntry> orderByComparator) {
+		return findByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	 * </p>
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param start the lower bound of the range of document library file entries
+	 * @param end the upper bound of the range of document library file entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param retrieveFromCache whether to retrieve from the finder cache
+	 * @return the ordered range of matching document library file entries
+	 */
+	@Override
+	public List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end, OrderByComparator<DLFileEntry> orderByComparator,
+		boolean retrieveFromCache) {
+		boolean pagination = true;
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+			pagination = false;
+			finderPath = FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_S_L_C1_C2;
+			finderArgs = new Object[] {
+					smallImageId, largeImageId, custom1ImageId, custom2ImageId
+				};
+		}
+		else {
+			finderPath = FINDER_PATH_WITH_PAGINATION_FIND_BY_S_L_C1_C2;
+			finderArgs = new Object[] {
+					smallImageId, largeImageId, custom1ImageId, custom2ImageId,
+					
+					start, end, orderByComparator
+				};
+		}
+
+		List<DLFileEntry> list = null;
+
+		if (retrieveFromCache) {
+			list = (List<DLFileEntry>)finderCache.getResult(finderPath,
+					finderArgs, this);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (DLFileEntry dlFileEntry : list) {
+					if ((smallImageId != dlFileEntry.getSmallImageId()) ||
+							(largeImageId != dlFileEntry.getLargeImageId()) ||
+							(custom1ImageId != dlFileEntry.getCustom1ImageId()) ||
+							(custom2ImageId != dlFileEntry.getCustom2ImageId())) {
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler query = null;
+
+			if (orderByComparator != null) {
+				query = new StringBundler(6 +
+						(orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				query = new StringBundler(6);
+			}
+
+			query.append(_SQL_SELECT_DLFILEENTRY_WHERE);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_SMALLIMAGEID_2);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_LARGEIMAGEID_2);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_CUSTOM1IMAGEID_2);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_CUSTOM2IMAGEID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(query, _ORDER_BY_ENTITY_ALIAS,
+					orderByComparator);
+			}
+			else
+			 if (pagination) {
+				query.append(DLFileEntryModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(smallImageId);
+
+				qPos.add(largeImageId);
+
+				qPos.add(custom1ImageId);
+
+				qPos.add(custom2ImageId);
+
+				if (!pagination) {
+					list = (List<DLFileEntry>)QueryUtil.list(q, getDialect(),
+							start, end, false);
+
+					Collections.sort(list);
+
+					list = Collections.unmodifiableList(list);
+				}
+				else {
+					list = (List<DLFileEntry>)QueryUtil.list(q, getDialect(),
+							start, end);
+				}
+
+				cacheResult(list);
+
+				finderCache.putResult(finderPath, finderArgs, list);
+			}
+			catch (Exception e) {
+				finderCache.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry
+	 * @throws NoSuchFileEntryException if a matching document library file entry could not be found
+	 */
+	@Override
+	public DLFileEntry findByS_L_C1_C2_First(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator)
+		throws NoSuchFileEntryException {
+		DLFileEntry dlFileEntry = fetchByS_L_C1_C2_First(smallImageId,
+				largeImageId, custom1ImageId, custom2ImageId, orderByComparator);
+
+		if (dlFileEntry != null) {
+			return dlFileEntry;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("smallImageId=");
+		msg.append(smallImageId);
+
+		msg.append(", largeImageId=");
+		msg.append(largeImageId);
+
+		msg.append(", custom1ImageId=");
+		msg.append(custom1ImageId);
+
+		msg.append(", custom2ImageId=");
+		msg.append(custom2ImageId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchFileEntryException(msg.toString());
+	}
+
+	/**
+	 * Returns the first document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
+	 */
+	@Override
+	public DLFileEntry fetchByS_L_C1_C2_First(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator) {
+		List<DLFileEntry> list = findByS_L_C1_C2(smallImageId, largeImageId,
+				custom1ImageId, custom2ImageId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry
+	 * @throws NoSuchFileEntryException if a matching document library file entry could not be found
+	 */
+	@Override
+	public DLFileEntry findByS_L_C1_C2_Last(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator)
+		throws NoSuchFileEntryException {
+		DLFileEntry dlFileEntry = fetchByS_L_C1_C2_Last(smallImageId,
+				largeImageId, custom1ImageId, custom2ImageId, orderByComparator);
+
+		if (dlFileEntry != null) {
+			return dlFileEntry;
+		}
+
+		StringBundler msg = new StringBundler(10);
+
+		msg.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		msg.append("smallImageId=");
+		msg.append(smallImageId);
+
+		msg.append(", largeImageId=");
+		msg.append(largeImageId);
+
+		msg.append(", custom1ImageId=");
+		msg.append(custom1ImageId);
+
+		msg.append(", custom2ImageId=");
+		msg.append(custom2ImageId);
+
+		msg.append(StringPool.CLOSE_CURLY_BRACE);
+
+		throw new NoSuchFileEntryException(msg.toString());
+	}
+
+	/**
+	 * Returns the last document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
+	 */
+	@Override
+	public DLFileEntry fetchByS_L_C1_C2_Last(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator) {
+		int count = countByS_L_C1_C2(smallImageId, largeImageId,
+				custom1ImageId, custom2ImageId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<DLFileEntry> list = findByS_L_C1_C2(smallImageId, largeImageId,
+				custom1ImageId, custom2ImageId, count - 1, count,
+				orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the document library file entries before and after the current document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * @param fileEntryId the primary key of the current document library file entry
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next document library file entry
+	 * @throws NoSuchFileEntryException if a document library file entry with the primary key could not be found
+	 */
+	@Override
+	public DLFileEntry[] findByS_L_C1_C2_PrevAndNext(long fileEntryId,
+		long smallImageId, long largeImageId, long custom1ImageId,
+		long custom2ImageId, OrderByComparator<DLFileEntry> orderByComparator)
+		throws NoSuchFileEntryException {
+		DLFileEntry dlFileEntry = findByPrimaryKey(fileEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			DLFileEntry[] array = new DLFileEntryImpl[3];
+
+			array[0] = getByS_L_C1_C2_PrevAndNext(session, dlFileEntry,
+					smallImageId, largeImageId, custom1ImageId, custom2ImageId,
+					orderByComparator, true);
+
+			array[1] = dlFileEntry;
+
+			array[2] = getByS_L_C1_C2_PrevAndNext(session, dlFileEntry,
+					smallImageId, largeImageId, custom1ImageId, custom2ImageId,
+					orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception e) {
+			throw processException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected DLFileEntry getByS_L_C1_C2_PrevAndNext(Session session,
+		DLFileEntry dlFileEntry, long smallImageId, long largeImageId,
+		long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator, boolean previous) {
+		StringBundler query = null;
+
+		if (orderByComparator != null) {
+			query = new StringBundler(7 +
+					(orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			query = new StringBundler(6);
+		}
+
+		query.append(_SQL_SELECT_DLFILEENTRY_WHERE);
+
+		query.append(_FINDER_COLUMN_S_L_C1_C2_SMALLIMAGEID_2);
+
+		query.append(_FINDER_COLUMN_S_L_C1_C2_LARGEIMAGEID_2);
+
+		query.append(_FINDER_COLUMN_S_L_C1_C2_CUSTOM1IMAGEID_2);
+
+		query.append(_FINDER_COLUMN_S_L_C1_C2_CUSTOM2IMAGEID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields = orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				query.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(WHERE_GREATER_THAN);
+					}
+					else {
+						query.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			query.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				query.append(_ORDER_BY_ENTITY_ALIAS);
+				query.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						query.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						query.append(ORDER_BY_ASC);
+					}
+					else {
+						query.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			query.append(DLFileEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = query.toString();
+
+		Query q = session.createQuery(sql);
+
+		q.setFirstResult(0);
+		q.setMaxResults(2);
+
+		QueryPos qPos = QueryPos.getInstance(q);
+
+		qPos.add(smallImageId);
+
+		qPos.add(largeImageId);
+
+		qPos.add(custom1ImageId);
+
+		qPos.add(custom2ImageId);
+
+		if (orderByComparator != null) {
+			Object[] values = orderByComparator.getOrderByConditionValues(dlFileEntry);
+
+			for (Object value : values) {
+				qPos.add(value);
+			}
+		}
+
+		List<DLFileEntry> list = q.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63; from the database.
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 */
+	@Override
+	public void removeByS_L_C1_C2(long smallImageId, long largeImageId,
+		long custom1ImageId, long custom2ImageId) {
+		for (DLFileEntry dlFileEntry : findByS_L_C1_C2(smallImageId,
+				largeImageId, custom1ImageId, custom2ImageId,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+			remove(dlFileEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	 *
+	 * @param smallImageId the small image ID
+	 * @param largeImageId the large image ID
+	 * @param custom1ImageId the custom1 image ID
+	 * @param custom2ImageId the custom2 image ID
+	 * @return the number of matching document library file entries
+	 */
+	@Override
+	public int countByS_L_C1_C2(long smallImageId, long largeImageId,
+		long custom1ImageId, long custom2ImageId) {
+		FinderPath finderPath = FINDER_PATH_COUNT_BY_S_L_C1_C2;
+
+		Object[] finderArgs = new Object[] {
+				smallImageId, largeImageId, custom1ImageId, custom2ImageId
+			};
+
+		Long count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+
+		if (count == null) {
+			StringBundler query = new StringBundler(5);
+
+			query.append(_SQL_COUNT_DLFILEENTRY_WHERE);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_SMALLIMAGEID_2);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_LARGEIMAGEID_2);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_CUSTOM1IMAGEID_2);
+
+			query.append(_FINDER_COLUMN_S_L_C1_C2_CUSTOM2IMAGEID_2);
+
+			String sql = query.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query q = session.createQuery(sql);
+
+				QueryPos qPos = QueryPos.getInstance(q);
+
+				qPos.add(smallImageId);
+
+				qPos.add(largeImageId);
+
+				qPos.add(custom1ImageId);
+
+				qPos.add(custom2ImageId);
+
+				count = (Long)q.uniqueResult();
+
+				finderCache.putResult(finderPath, finderArgs, count);
+			}
+			catch (Exception e) {
+				finderCache.removeResult(finderPath, finderArgs);
+
+				throw processException(e);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_S_L_C1_C2_SMALLIMAGEID_2 = "dlFileEntry.smallImageId = ? AND ";
+	private static final String _FINDER_COLUMN_S_L_C1_C2_LARGEIMAGEID_2 = "dlFileEntry.largeImageId = ? AND ";
+	private static final String _FINDER_COLUMN_S_L_C1_C2_CUSTOM1IMAGEID_2 = "dlFileEntry.custom1ImageId = ? AND ";
+	private static final String _FINDER_COLUMN_S_L_C1_C2_CUSTOM2IMAGEID_2 = "dlFileEntry.custom2ImageId = ?";
 
 	public DLFileEntryPersistenceImpl() {
 		setModelClass(DLFileEntry.class);
@@ -12493,6 +13131,31 @@ public class DLFileEntryPersistenceImpl extends BasePersistenceImpl<DLFileEntry>
 
 				finderCache.removeResult(FINDER_PATH_COUNT_BY_G_F_F, args);
 				finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_G_F_F,
+					args);
+			}
+
+			if ((dlFileEntryModelImpl.getColumnBitmask() &
+					FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_S_L_C1_C2.getColumnBitmask()) != 0) {
+				Object[] args = new Object[] {
+						dlFileEntryModelImpl.getOriginalSmallImageId(),
+						dlFileEntryModelImpl.getOriginalLargeImageId(),
+						dlFileEntryModelImpl.getOriginalCustom1ImageId(),
+						dlFileEntryModelImpl.getOriginalCustom2ImageId()
+					};
+
+				finderCache.removeResult(FINDER_PATH_COUNT_BY_S_L_C1_C2, args);
+				finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_S_L_C1_C2,
+					args);
+
+				args = new Object[] {
+						dlFileEntryModelImpl.getSmallImageId(),
+						dlFileEntryModelImpl.getLargeImageId(),
+						dlFileEntryModelImpl.getCustom1ImageId(),
+						dlFileEntryModelImpl.getCustom2ImageId()
+					};
+
+				finderCache.removeResult(FINDER_PATH_COUNT_BY_S_L_C1_C2, args);
+				finderCache.removeResult(FINDER_PATH_WITHOUT_PAGINATION_FIND_BY_S_L_C1_C2,
 					args);
 			}
 		}

--- a/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/documentlibrary/service/persistence/test/DLFileEntryPersistenceTest.java
@@ -410,6 +410,15 @@ public class DLFileEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByS_L_C1_C2() throws Exception {
+		_persistence.countByS_L_C1_C2(RandomTestUtil.nextLong(),
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
+			RandomTestUtil.nextLong());
+
+		_persistence.countByS_L_C1_C2(0L, 0L, 0L, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		DLFileEntry newDLFileEntry = addDLFileEntry();
 

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryPersistence.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryPersistence.java
@@ -2845,6 +2845,182 @@ public interface DLFileEntryPersistence extends BasePersistence<DLFileEntry> {
 		long fileEntryTypeId);
 
 	/**
+	* Returns all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @return the matching document library file entries
+	*/
+	public java.util.List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId);
+
+	/**
+	* Returns a range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @return the range of matching document library file entries
+	*/
+	public java.util.List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end);
+
+	/**
+	* Returns an ordered range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching document library file entries
+	*/
+	public java.util.List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntry> orderByComparator);
+
+	/**
+	* Returns an ordered range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @param retrieveFromCache whether to retrieve from the finder cache
+	* @return the ordered range of matching document library file entries
+	*/
+	public java.util.List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntry> orderByComparator,
+		boolean retrieveFromCache);
+
+	/**
+	* Returns the first document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library file entry
+	* @throws NoSuchFileEntryException if a matching document library file entry could not be found
+	*/
+	public DLFileEntry findByS_L_C1_C2_First(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntry> orderByComparator)
+		throws NoSuchFileEntryException;
+
+	/**
+	* Returns the first document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
+	*/
+	public DLFileEntry fetchByS_L_C1_C2_First(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntry> orderByComparator);
+
+	/**
+	* Returns the last document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library file entry
+	* @throws NoSuchFileEntryException if a matching document library file entry could not be found
+	*/
+	public DLFileEntry findByS_L_C1_C2_Last(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntry> orderByComparator)
+		throws NoSuchFileEntryException;
+
+	/**
+	* Returns the last document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
+	*/
+	public DLFileEntry fetchByS_L_C1_C2_Last(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntry> orderByComparator);
+
+	/**
+	* Returns the document library file entries before and after the current document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param fileEntryId the primary key of the current document library file entry
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next document library file entry
+	* @throws NoSuchFileEntryException if a document library file entry with the primary key could not be found
+	*/
+	public DLFileEntry[] findByS_L_C1_C2_PrevAndNext(long fileEntryId,
+		long smallImageId, long largeImageId, long custom1ImageId,
+		long custom2ImageId,
+		com.liferay.portal.kernel.util.OrderByComparator<DLFileEntry> orderByComparator)
+		throws NoSuchFileEntryException;
+
+	/**
+	* Removes all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63; from the database.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	*/
+	public void removeByS_L_C1_C2(long smallImageId, long largeImageId,
+		long custom1ImageId, long custom2ImageId);
+
+	/**
+	* Returns the number of document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @return the number of matching document library file entries
+	*/
+	public int countByS_L_C1_C2(long smallImageId, long largeImageId,
+		long custom1ImageId, long custom2ImageId);
+
+	/**
 	* Caches the document library file entry in the entity cache if it is enabled.
 	*
 	* @param dlFileEntry the document library file entry

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/DLFileEntryUtil.java
@@ -3493,6 +3493,223 @@ public class DLFileEntryUtil {
 	}
 
 	/**
+	* Returns all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @return the matching document library file entries
+	*/
+	public static List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId) {
+		return getPersistence()
+				   .findByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId);
+	}
+
+	/**
+	* Returns a range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @return the range of matching document library file entries
+	*/
+	public static List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end) {
+		return getPersistence()
+				   .findByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId, start, end);
+	}
+
+	/**
+	* Returns an ordered range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @return the ordered range of matching document library file entries
+	*/
+	public static List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end, OrderByComparator<DLFileEntry> orderByComparator) {
+		return getPersistence()
+				   .findByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId, start, end, orderByComparator);
+	}
+
+	/**
+	* Returns an ordered range of all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* <p>
+	* Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to {@link QueryUtil#ALL_POS} will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent and pagination is required (<code>start</code> and <code>end</code> are not {@link QueryUtil#ALL_POS}), then the query will include the default ORDER BY logic from {@link DLFileEntryModelImpl}. If both <code>orderByComparator</code> and pagination are absent, for performance reasons, the query will not have an ORDER BY clause and the returned result set will be sorted on by the primary key in an ascending order.
+	* </p>
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param start the lower bound of the range of document library file entries
+	* @param end the upper bound of the range of document library file entries (not inclusive)
+	* @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	* @param retrieveFromCache whether to retrieve from the finder cache
+	* @return the ordered range of matching document library file entries
+	*/
+	public static List<DLFileEntry> findByS_L_C1_C2(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId, int start,
+		int end, OrderByComparator<DLFileEntry> orderByComparator,
+		boolean retrieveFromCache) {
+		return getPersistence()
+				   .findByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId, start, end, orderByComparator, retrieveFromCache);
+	}
+
+	/**
+	* Returns the first document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library file entry
+	* @throws NoSuchFileEntryException if a matching document library file entry could not be found
+	*/
+	public static DLFileEntry findByS_L_C1_C2_First(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator)
+		throws com.liferay.document.library.kernel.exception.NoSuchFileEntryException {
+		return getPersistence()
+				   .findByS_L_C1_C2_First(smallImageId, largeImageId,
+			custom1ImageId, custom2ImageId, orderByComparator);
+	}
+
+	/**
+	* Returns the first document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the first matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
+	*/
+	public static DLFileEntry fetchByS_L_C1_C2_First(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator) {
+		return getPersistence()
+				   .fetchByS_L_C1_C2_First(smallImageId, largeImageId,
+			custom1ImageId, custom2ImageId, orderByComparator);
+	}
+
+	/**
+	* Returns the last document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library file entry
+	* @throws NoSuchFileEntryException if a matching document library file entry could not be found
+	*/
+	public static DLFileEntry findByS_L_C1_C2_Last(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator)
+		throws com.liferay.document.library.kernel.exception.NoSuchFileEntryException {
+		return getPersistence()
+				   .findByS_L_C1_C2_Last(smallImageId, largeImageId,
+			custom1ImageId, custom2ImageId, orderByComparator);
+	}
+
+	/**
+	* Returns the last document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the last matching document library file entry, or <code>null</code> if a matching document library file entry could not be found
+	*/
+	public static DLFileEntry fetchByS_L_C1_C2_Last(long smallImageId,
+		long largeImageId, long custom1ImageId, long custom2ImageId,
+		OrderByComparator<DLFileEntry> orderByComparator) {
+		return getPersistence()
+				   .fetchByS_L_C1_C2_Last(smallImageId, largeImageId,
+			custom1ImageId, custom2ImageId, orderByComparator);
+	}
+
+	/**
+	* Returns the document library file entries before and after the current document library file entry in the ordered set where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param fileEntryId the primary key of the current document library file entry
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	* @return the previous, current, and next document library file entry
+	* @throws NoSuchFileEntryException if a document library file entry with the primary key could not be found
+	*/
+	public static DLFileEntry[] findByS_L_C1_C2_PrevAndNext(long fileEntryId,
+		long smallImageId, long largeImageId, long custom1ImageId,
+		long custom2ImageId, OrderByComparator<DLFileEntry> orderByComparator)
+		throws com.liferay.document.library.kernel.exception.NoSuchFileEntryException {
+		return getPersistence()
+				   .findByS_L_C1_C2_PrevAndNext(fileEntryId, smallImageId,
+			largeImageId, custom1ImageId, custom2ImageId, orderByComparator);
+	}
+
+	/**
+	* Removes all the document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63; from the database.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	*/
+	public static void removeByS_L_C1_C2(long smallImageId, long largeImageId,
+		long custom1ImageId, long custom2ImageId) {
+		getPersistence()
+			.removeByS_L_C1_C2(smallImageId, largeImageId, custom1ImageId,
+			custom2ImageId);
+	}
+
+	/**
+	* Returns the number of document library file entries where smallImageId = &#63; and largeImageId = &#63; and custom1ImageId = &#63; and custom2ImageId = &#63;.
+	*
+	* @param smallImageId the small image ID
+	* @param largeImageId the large image ID
+	* @param custom1ImageId the custom1 image ID
+	* @param custom2ImageId the custom2 image ID
+	* @return the number of matching document library file entries
+	*/
+	public static int countByS_L_C1_C2(long smallImageId, long largeImageId,
+		long custom1ImageId, long custom2ImageId) {
+		return getPersistence()
+				   .countByS_L_C1_C2(smallImageId, largeImageId,
+			custom1ImageId, custom2ImageId);
+	}
+
+	/**
 	* Caches the document library file entry in the entity cache if it is enabled.
 	*
 	* @param dlFileEntry the document library file entry

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/sql/indexes.sql
+++ b/sql/indexes.sql
@@ -106,6 +106,7 @@ create unique index IX_ED5CA615 on DLFileEntry (groupId, folderId, title[$COLUMN
 create index IX_D20C434D on DLFileEntry (groupId, userId, folderId);
 create index IX_D9492CF6 on DLFileEntry (mimeType[$COLUMN_LENGTH:75$]);
 create index IX_1B352F4A on DLFileEntry (repositoryId, folderId);
+create index IX_25F5CAB9 on DLFileEntry (smallImageId, largeImageId, custom1ImageId, custom2ImageId);
 create index IX_31079DE8 on DLFileEntry (uuid_[$COLUMN_LENGTH:75$], companyId);
 create unique index IX_BC2E7E6A on DLFileEntry (uuid_[$COLUMN_LENGTH:75$], groupId);
 


### PR DESCRIPTION
Hi Sergio,

according to our earlier discussion we created an index in the DLFileEntry for the legacy image ids that are coming from the former Image Gallery portlet.

We though of having a covering index as the particular query that cause slowness are processing over all of the 4 columns together also.

See

https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryFinderImpl.java#L204-L239 (fetchByAnyImageId method in the DLFileEntryFinderImpl class)

and

https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/custom-sql/documentlibrary.xml#L65-L77 (the custom query, with name findByAnyImageId) 

for more.

Thank you,
Zsigmond
