### PR TITLE
Lps 65693 lpkg index

### DIFF
--- a/modules/core/portal-target-platform-indexer/src/main/java/com/liferay/portal/target/platform/indexer/internal/LPKGIndexer.java
+++ b/modules/core/portal-target-platform-indexer/src/main/java/com/liferay/portal/target/platform/indexer/internal/LPKGIndexer.java
@@ -19,6 +19,8 @@ import com.liferay.portal.target.platform.indexer.Indexer;
 import java.io.File;
 import java.io.OutputStream;
 
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -52,6 +54,18 @@ public class LPKGIndexer implements Indexer {
 
 	@Override
 	public void index(OutputStream outputStream) throws Exception {
+		try (FileSystem fileSystem = FileSystems.newFileSystem(
+				_lpkgFile.toPath(), null)) {
+
+			Path indexPath = fileSystem.getPath("index.xml");
+
+			if (Files.exists(indexPath)) {
+				Files.copy(indexPath, outputStream);
+
+				return;
+			}
+		}
+
 		Path tempPath = Files.createTempDirectory(null);
 
 		File tempDir = tempPath.toFile();


### PR DESCRIPTION
Now when all lpkg indexes are pre-built and the integrity.properties is up to date. The whole process adds about 1+sec to tomcat startup for me locally.

CC @rotty3000 @mhan810 @jhendley

I will be working with @mtambara to try to finish the "static bundles in lpkgs" support today. After that we still have 2 missing pieces.
1) We need build process support to actually move static bundles to proper lpkgs. (Not sure what mapping rules we should use here)
2) Wait for @rotty3000 to make the runtime target platform indexing matching the command line one, and integrate it into the current command line tool to support build time index and integrity generation.
