### PR TITLE
LPS-66213 system.packages.extra.mf

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-navigation-web/build.gradle
+++ b/modules/apps/collaboration/wiki/wiki-navigation-web/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "default"
 	provided group: "com.liferay", name: "com.liferay.wiki.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.wiki.service", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
@@ -9,4 +8,5 @@ dependencies {
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:portal:portal-upgrade")
 }

--- a/modules/apps/collaboration/wiki/wiki-navigation-web/build.gradle
+++ b/modules/apps/collaboration/wiki/wiki-navigation-web/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "default"
 	provided group: "com.liferay", name: "com.liferay.wiki.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.wiki.service", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"

--- a/modules/apps/collaboration/wiki/wiki-navigation-web/src/main/java/com/liferay/wiki/navigation/web/upgrade/WikiNavigationWebUpgrade.java
+++ b/modules/apps/collaboration/wiki/wiki-navigation-web/src/main/java/com/liferay/wiki/navigation/web/upgrade/WikiNavigationWebUpgrade.java
@@ -15,7 +15,7 @@
 package com.liferay.wiki.navigation.web.upgrade;
 
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.upgrade.BaseUpgradeRelease;
+import com.liferay.portal.upgrade.release.BaseUpgradeRelease;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;

--- a/modules/apps/collaboration/wiki/wiki-navigation-web/src/main/java/com/liferay/wiki/navigation/web/upgrade/WikiNavigationWebUpgrade.java
+++ b/modules/apps/collaboration/wiki/wiki-navigation-web/src/main/java/com/liferay/wiki/navigation/web/upgrade/WikiNavigationWebUpgrade.java
@@ -15,10 +15,10 @@
 package com.liferay.wiki.navigation.web.upgrade;
 
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.upgrade.release.BaseUpgradeRelease;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 import com.liferay.wiki.navigation.web.upgrade.v1_0_0.UpgradePortletPreferences;
 import com.liferay.wiki.navigation.web.upgrade.v1_0_1.UpgradePortletId;
 
@@ -33,19 +33,21 @@ public class WikiNavigationWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeRelease upgradeRelease = new BaseUpgradeRelease() {
+		BaseUpgradeWebModuleRelease upgradeRelease =
+			new BaseUpgradeWebModuleRelease() {
 
-			protected String getBundleSymbolicName() {
-				return "com.liferay.wiki.navigation.web";
-			}
+				protected String getBundleSymbolicName() {
+					return "com.liferay.wiki.navigation.web";
+				}
 
-			protected String[] getPortletIds() {
-				return new String[] {
-					"1_WAR_wikinavigationportlet", "2_WAR_wikinavigationportlet"
-				};
-			}
+				protected String[] getPortletIds() {
+					return new String[] {
+						"1_WAR_wikinavigationportlet",
+						"2_WAR_wikinavigationportlet"
+					};
+				}
 
-		};
+			};
 
 		try {
 			upgradeRelease.upgrade();

--- a/modules/apps/foundation/portal/portal-upgrade/bnd.bnd
+++ b/modules/apps/foundation/portal/portal-upgrade/bnd.bnd
@@ -1,7 +1,9 @@
 Bundle-Name: Liferay Portal Upgrade
 Bundle-SymbolicName: com.liferay.portal.upgrade
 Bundle-Version: 2.1.1
-Export-Package: com.liferay.portal.upgrade.registry
+Export-Package:\
+	com.liferay.portal.upgrade.registry,\
+	com.liferay.portal.upgrade.release
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Upgrade and Verify
 -includeresource:\

--- a/modules/apps/foundation/portal/portal-upgrade/build.gradle
+++ b/modules/apps/foundation/portal/portal-upgrade/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.output.stream.container", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "org.apache.felix", name: "org.apache.felix.utils", version: "1.6.0"
 	provided group: "org.jgrapht", name: "jgrapht-core", version: "0.9.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"

--- a/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/release/BaseUpgradeRelease.java
+++ b/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/release/BaseUpgradeRelease.java
@@ -12,9 +12,10 @@
  * details.
  */
 
-package com.liferay.portal.kernel.upgrade;
+package com.liferay.portal.upgrade.release;
 
 import com.liferay.portal.kernel.model.dao.ReleaseDAO;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.StringBundler;
 

--- a/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/release/BaseUpgradeWebModuleRelease.java
+++ b/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/release/BaseUpgradeWebModuleRelease.java
@@ -27,7 +27,7 @@ import java.sql.SQLException;
 /**
  * @author Adolfo Pérez
  */
-public abstract class BaseUpgradeRelease extends UpgradeProcess {
+public abstract class BaseUpgradeWebModuleRelease extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {

--- a/modules/apps/youtube/youtube-web/build.gradle
+++ b/modules/apps/youtube/youtube-web/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "default"
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
@@ -8,4 +7,5 @@ dependencies {
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:portal:portal-upgrade")
 }

--- a/modules/apps/youtube/youtube-web/build.gradle
+++ b/modules/apps/youtube/youtube-web/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "default"
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/youtube/youtube-web/src/main/java/com/liferay/youtube/web/upgrade/YouTubeWebUpgrade.java
+++ b/modules/apps/youtube/youtube-web/src/main/java/com/liferay/youtube/web/upgrade/YouTubeWebUpgrade.java
@@ -15,10 +15,10 @@
 package com.liferay.youtube.web.upgrade;
 
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.upgrade.release.BaseUpgradeRelease;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.release.BaseUpgradeWebModuleRelease;
 import com.liferay.youtube.web.upgrade.v1_0_0.UpgradePortletId;
 
 import org.osgi.service.component.annotations.Component;
@@ -32,17 +32,18 @@ public class YouTubeWebUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
-		BaseUpgradeRelease upgradeRelease = new BaseUpgradeRelease() {
+		BaseUpgradeWebModuleRelease upgradeRelease =
+			new BaseUpgradeWebModuleRelease() {
 
-			protected String getBundleSymbolicName() {
-				return "com.liferay.youtube.web";
-			}
+				protected String getBundleSymbolicName() {
+					return "com.liferay.youtube.web";
+				}
 
-			protected String[] getPortletIds() {
-				return new String[] {"1_WAR_youtubeportlet"};
-			}
+				protected String[] getPortletIds() {
+					return new String[] {"1_WAR_youtubeportlet"};
+				}
 
-		};
+			};
 
 		try {
 			upgradeRelease.upgrade();

--- a/modules/apps/youtube/youtube-web/src/main/java/com/liferay/youtube/web/upgrade/YouTubeWebUpgrade.java
+++ b/modules/apps/youtube/youtube-web/src/main/java/com/liferay/youtube/web/upgrade/YouTubeWebUpgrade.java
@@ -15,7 +15,7 @@
 package com.liferay.youtube.web.upgrade;
 
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.upgrade.BaseUpgradeRelease;
+import com.liferay.portal.upgrade.release.BaseUpgradeRelease;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;

--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -1,11 +1,11 @@
 Manifest-Version: 1.0
-Bnd-LastModified: 1464842053033
+Bnd-LastModified: 1464880986927
 Bundle-ManifestVersion: 2
 Bundle-Name: system.packages.extra
 Bundle-SymbolicName: system.packages.extra
 Bundle-Vendor: Liferay, Inc.
 Bundle-Version: 1.0.0
-Created-By: 1.7.0_71 (Oracle Corporation)
+Created-By: 1.8.0_45 (Oracle Corporation)
 Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  u.impl;version="4.0.1";uses:="com.liferay.ibm.icu.math,com.liferay.ib
  m.icu.text,com.liferay.ibm.icu.util",com.liferay.ibm.icu.impl.coll;ve

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.0
+version 7.1.0


### PR DESCRIPTION
Hey @brianchandotcom 

After speaking with @migue and @csierra about the previous PR for LPS-66213, we have found a couple of issues with it:
- The infrastructure team has plans to extend the upgrade framework to handle legacy plugin upgrades. So, to avoid confusion in the future, we believe it would be better to move the BaseUpgradeRelease back into `portal-upgrade` so that it is less visible. The idea is to deprecate that class once the general mechanism is ready, and modify `YoutubeWebUpgrade` and `WikiNavigationWebUpgrade` to use the new one.
- The name "BaseUpgradeRelease" is too general, and implies that it handles all aspects of fixing the Release, but in reality, it only does that for web modules extracted from legacy plugins. I've renamed it to `BaseUpgradeWebModuleRelease` to make it more explicit that it is only for web modules.

Thanks a lot!
