### PR TITLE
LPS-66093 Wait for yellow state before index check to alleviate IndexAlreadyExistsException

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
@@ -82,7 +82,7 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 		validateBackupName(backupName);
 
 		ClusterAdminClient clusterAdminClient =
-			_elasticsearchConnectionManager.getClusterAdminClient();
+			elasticsearchConnectionManager.getClusterAdminClient();
 
 		CreateSnapshotRequestBuilder createSnapshotRequestBuilder =
 			clusterAdminClient.prepareCreateSnapshot(
@@ -112,10 +112,10 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 		waitForYellowStatus();
 
 		try {
-			_indexFactory.createIndices(
-				_elasticsearchConnectionManager.getAdminClient(), companyId);
+			indexFactory.createIndices(
+				elasticsearchConnectionManager.getAdminClient(), companyId);
 
-			_elasticsearchConnectionManager.registerCompanyId(companyId);
+			elasticsearchConnectionManager.registerCompanyId(companyId);
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);
@@ -129,7 +129,7 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 		throws SearchException {
 
 		ClusterAdminClient clusterAdminClient =
-			_elasticsearchConnectionManager.getClusterAdminClient();
+			elasticsearchConnectionManager.getClusterAdminClient();
 
 		try {
 			if (!hasBackupRepository(clusterAdminClient)) {
@@ -155,10 +155,10 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 		super.removeCompany(companyId);
 
 		try {
-			_indexFactory.deleteIndices(
-				_elasticsearchConnectionManager.getAdminClient(), companyId);
+			indexFactory.deleteIndices(
+				elasticsearchConnectionManager.getAdminClient(), companyId);
 
-			_elasticsearchConnectionManager.unregisterCompanyId(companyId);
+			elasticsearchConnectionManager.unregisterCompanyId(companyId);
 		}
 		catch (Exception e) {
 			if (_log.isWarnEnabled()) {
@@ -176,7 +176,7 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 		validateBackupName(backupName);
 
 		AdminClient adminClient =
-			_elasticsearchConnectionManager.getAdminClient();
+			elasticsearchConnectionManager.getAdminClient();
 
 		IndicesAdminClient indicesAdminClient = adminClient.indices();
 
@@ -195,7 +195,7 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 		}
 
 		ClusterAdminClient clusterAdminClient =
-			_elasticsearchConnectionManager.getClusterAdminClient();
+			elasticsearchConnectionManager.getClusterAdminClient();
 
 		RestoreSnapshotRequestBuilder restoreSnapshotRequestBuilder =
 			clusterAdminClient.prepareRestoreSnapshot(
@@ -231,13 +231,13 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 	}
 
 	public void unsetElasticsearchConnectionManager(
-		ElasticsearchConnectionManager elasticsearchConnectionManager) {
+		ElasticsearchConnectionManager elasticsearchConnectionManager2) {
 
-		_elasticsearchConnectionManager = null;
+		elasticsearchConnectionManager = null;
 	}
 
-	public void unsetIndexFactory(IndexFactory indexFactory) {
-		_indexFactory = null;
+	public void unsetIndexFactory(IndexFactory indexFactory2) {
+		indexFactory = null;
 	}
 
 	@Activate
@@ -338,7 +338,7 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 		}
 
 		ClusterHealthResponse clusterHealthResponse =
-			_elasticsearchConnectionManager.getClusterHealthResponse(timeout);
+			elasticsearchConnectionManager.getClusterHealthResponse(timeout);
 
 		if (clusterHealthResponse.getStatus() == ClusterHealthStatus.RED) {
 			throw new IllegalStateException(
@@ -348,17 +348,17 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 	}
 
 	@Reference
+	protected ElasticsearchConnectionManager elasticsearchConnectionManager;
+
+	@Reference
+	protected IndexFactory indexFactory;
+
+	@Reference
 	protected IndexNameBuilder indexNameBuilder;
 
 	private static final String _BACKUP_REPOSITORY_NAME = "liferay_backup";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ElasticsearchSearchEngine.class);
-
-	@Reference
-	private ElasticsearchConnectionManager _elasticsearchConnectionManager;
-
-	@Reference
-	private IndexFactory _indexFactory;
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
@@ -109,6 +109,8 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 	public void initialize(long companyId) {
 		super.initialize(companyId);
 
+		waitForYellowStatus();
+
 		try {
 			_indexFactory.createIndices(
 				_elasticsearchConnectionManager.getAdminClient(), companyId);

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
@@ -119,20 +119,7 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 			throw new IllegalStateException(e);
 		}
 
-		long timeout = 30 * Time.SECOND;
-
-		if (PortalRunMode.isTestMode()) {
-			timeout = Time.HOUR;
-		}
-
-		ClusterHealthResponse clusterHealthResponse =
-			_elasticsearchConnectionManager.getClusterHealthResponse(timeout);
-
-		if (clusterHealthResponse.getStatus() == ClusterHealthStatus.RED) {
-			throw new IllegalStateException(
-				"Unable to initialize Elasticsearch cluster: " +
-					clusterHealthResponse);
-		}
+		waitForYellowStatus();
 	}
 
 	@Override
@@ -226,20 +213,7 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 			throw new SearchException(e);
 		}
 
-		long timeout = 30 * Time.SECOND;
-
-		if (PortalRunMode.isTestMode()) {
-			timeout = Time.HOUR;
-		}
-
-		ClusterHealthResponse clusterHealthResponse =
-			_elasticsearchConnectionManager.getClusterHealthResponse(timeout);
-
-		if (clusterHealthResponse.getStatus() == ClusterHealthStatus.RED) {
-			throw new IllegalStateException(
-				"Unable to initialize Elasticsearch cluster: " +
-					clusterHealthResponse);
-		}
+		waitForYellowStatus();
 	}
 
 	@Override
@@ -351,6 +325,23 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 					"Backup name must not contain invalid file name " +
 						"characters");
 			}
+		}
+	}
+
+	protected void waitForYellowStatus() {
+		long timeout = 30 * Time.SECOND;
+
+		if (PortalRunMode.isTestMode()) {
+			timeout = Time.HOUR;
+		}
+
+		ClusterHealthResponse clusterHealthResponse =
+			_elasticsearchConnectionManager.getClusterHealthResponse(timeout);
+
+		if (clusterHealthResponse.getStatus() == ClusterHealthStatus.RED) {
+			throw new IllegalStateException(
+				"Unable to initialize Elasticsearch cluster: " +
+					clusterHealthResponse);
 		}
 	}
 

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngine.java
@@ -231,13 +231,13 @@ public class ElasticsearchSearchEngine extends BaseSearchEngine {
 	}
 
 	public void unsetElasticsearchConnectionManager(
-		ElasticsearchConnectionManager elasticsearchConnectionManager2) {
+		ElasticsearchConnectionManager elasticsearchConnectionManager) {
 
-		elasticsearchConnectionManager = null;
+		this.elasticsearchConnectionManager = null;
 	}
 
-	public void unsetIndexFactory(IndexFactory indexFactory2) {
-		indexFactory = null;
+	public void unsetIndexFactory(IndexFactory indexFactory) {
+		this.indexFactory = null;
 	}
 
 	@Activate

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/connection/TestElasticsearchConnectionManager.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/connection/TestElasticsearchConnectionManager.java
@@ -23,8 +23,7 @@ public class TestElasticsearchConnectionManager
 	extends ElasticsearchConnectionManager {
 
 	public TestElasticsearchConnectionManager(
-			ElasticsearchFixture elasticsearchFixture)
-		throws Exception {
+		ElasticsearchFixture elasticsearchFixture) {
 
 		setEmbeddedElasticsearchConnection(
 			elasticsearchFixture.getEmbeddedElasticsearchConnection());

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngineTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchSearchEngineTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.elasticsearch.connection.ElasticsearchConnection;
+import com.liferay.portal.search.elasticsearch.connection.ElasticsearchConnectionManager;
+import com.liferay.portal.search.elasticsearch.connection.TestElasticsearchConnectionManager;
+import com.liferay.portal.search.elasticsearch.index.IndexNameBuilder;
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch.internal.index.CompanyIdIndexNameBuilder;
+import com.liferay.portal.search.elasticsearch.internal.index.CompanyIndexFactory;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public class ElasticsearchSearchEngineTest {
+
+	@Before
+	public void setUp() throws Exception {
+		_elasticsearchFixture = new ElasticsearchFixture(
+			ElasticsearchSearchEngineTest.class.getSimpleName());
+
+		_elasticsearchFixture.setUp();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	@Test
+	public void testInitializeAfterReconnect() {
+		ElasticsearchConnectionManager elasticsearchConnectionManager =
+			createElasticsearchConnectionManager();
+
+		ElasticsearchSearchEngine elasticsearchSearchEngine =
+			createElasticsearchSearchEngine(elasticsearchConnectionManager);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		elasticsearchSearchEngine.initialize(companyId);
+
+		reconnect(elasticsearchConnectionManager);
+
+		elasticsearchSearchEngine.initialize(companyId);
+	}
+
+	protected CompanyIndexFactory createCompanyIndexFactory() {
+		return new CompanyIndexFactory() {
+			{
+				indexNameBuilder = createIndexNameBuilder();
+			}
+		};
+	}
+
+	protected ElasticsearchConnectionManager
+		createElasticsearchConnectionManager() {
+
+		return new TestElasticsearchConnectionManager(_elasticsearchFixture);
+	}
+
+	protected ElasticsearchSearchEngine createElasticsearchSearchEngine(
+		final ElasticsearchConnectionManager elasticsearchConnectionManager2) {
+
+		return new ElasticsearchSearchEngine() {
+			{
+				indexFactory = createCompanyIndexFactory();
+				elasticsearchConnectionManager =
+					elasticsearchConnectionManager2;
+			}
+		};
+	}
+
+	protected IndexNameBuilder createIndexNameBuilder() {
+		return new CompanyIdIndexNameBuilder() {
+			{
+				setIndexNamePrefix(null);
+			}
+		};
+	}
+
+	protected void reconnect(
+		ElasticsearchConnectionManager elasticsearchConnectionManager) {
+
+		ElasticsearchConnection elasticsearchConnection =
+			elasticsearchConnectionManager.getElasticsearchConnection();
+
+		elasticsearchConnection.close();
+
+		elasticsearchConnectionManager.connect();
+	}
+
+	private ElasticsearchFixture _elasticsearchFixture;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/CompanyIdIndexNameBuilderTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/CompanyIdIndexNameBuilderTest.java
@@ -38,7 +38,7 @@ public class CompanyIdIndexNameBuilderTest {
 	@Before
 	public void setUp() throws Exception {
 		_elasticsearchFixture = new ElasticsearchFixture(
-			LiferayTypeMappingsTest.class.getSimpleName());
+			CompanyIdIndexNameBuilderTest.class.getSimpleName());
 
 		_elasticsearchFixture.setUp();
 	}


### PR DESCRIPTION
Hi Brian, re-sending https://github.com/brianchandotcom/liferay-portal/pull/40172#issuecomment-221670463. The broken `integration-*` from the first time will likely remain broken -- they're caused by LPS-66024, which predates and is unrelated to my changes.

_Fix BaseUpgradePortletIdTest and FindActionTest combination failure_
https://issues.liferay.com/browse/LPS-66024

Please see:
https://issues.liferay.com/browse/LPS-66024?focusedCommentId=791183&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-791183 

I put together a pull that makes the contaminating test from LPS-66024 die on itself right after its bad cleanup, with the same exception manifested in my pull:

https://github.com/mhan810/liferay-portal/pull/1208#issuecomment-223388823

So if `VerifyResourcePermissionsTest.testVerifyMoreThanOneCompany` breaks in any `integration-*` suites with `NoSuchResourceActionException: 47#ACCESS_IN_CONTROL_PANEL`, would you kindly disregard it?

Thanks :smiley:

Author: @arboliveira
Reviewer: @mhan810 
