### PR TITLE
SYNC-1593 Disable failing tests

### DIFF
--- a/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListenerTest.java
+++ b/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/filesystem/listener/SyncSiteWatchEventListenerTest.java
@@ -30,11 +30,13 @@ import java.util.Collections;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Shinn Lok
  */
+@Ignore
 public class SyncSiteWatchEventListenerTest extends BaseTestCase {
 
 	@Before

--- a/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/model/ModelListenerTest.java
+++ b/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/model/ModelListenerTest.java
@@ -23,11 +23,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Shinn Lok
  */
+@Ignore
 public class ModelListenerTest extends BaseTestCase {
 
 	@Test

--- a/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/model/SyncAccountModelListenerTest.java
+++ b/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/model/SyncAccountModelListenerTest.java
@@ -22,11 +22,13 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Shinn Lok
  */
+@Ignore
 public class SyncAccountModelListenerTest extends BaseTestCase {
 
 	@Before

--- a/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/model/SyncSiteModelListenerTest.java
+++ b/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/model/SyncSiteModelListenerTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.slf4j.Logger;
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Shinn Lok
  */
+@Ignore
 public class SyncSiteModelListenerTest extends BaseTestCase {
 
 	@Before

--- a/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncAccountServiceTest.java
+++ b/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncAccountServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -42,6 +43,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 /**
  * @author Shinn Lok
  */
+@Ignore
 @PrepareForTest(FileUtil.class)
 @RunWith(PowerMockRunner.class)
 public class SyncAccountServiceTest extends BaseTestCase {

--- a/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncFileServiceTest.java
+++ b/modules/apps/sync/sync-engine/src/test/java/com/liferay/sync/engine/service/SyncFileServiceTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,6 +44,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 /**
  * @author Shinn Lok
  */
+@Ignore
 @PrepareForTest({FileEventUtil.class})
 @RunWith(PowerMockRunner.class)
 public class SyncFileServiceTest extends BaseTestCase {


### PR DESCRIPTION
@dejuknow since this pull https://github.com/brianchandotcom/liferay-portal/pull/40381 14 sync tests are failing. We need to disable those tests to let others show, otherwise they just got buried up.

Please fix those tests and revert this commit to re-enable them.

You can reproduce those failures locally by running "gradlew test" under "modules/apps/sync/sync-engine"

Thanks
Shuyang
