### PR TITLE
LRQA-25108 DB2 support changes

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6918,6 +6918,10 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 							<os family="windows" />
 							<then>
 								<exec executable="${db2.executable}">
+									<arg line="/c /w db2 disconnect lportal" />
+								</exec>
+
+								<exec executable="${db2.executable}">
 									<arg line="/c /w db2 drop db lportal" />
 								</exec>
 
@@ -6926,6 +6930,10 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								</exec>
 							</then>
 							<else>
+								<exec executable="${db2.executable}">
+									<arg line="disconnect lportal" />
+								</exec>
+
 								<exec executable="${db2.executable}">
 									<arg line="drop db lportal" />
 								</exec>

--- a/build-test.xml
+++ b/build-test.xml
@@ -8006,7 +8006,6 @@ jdbc.default.password=${database.mysql.password}</echo>
 				<equals arg1="${os.name}" arg2="SunOS" />
 			</not>
 			<then>
-				<antcall inheritAll="false" target="clean-up-db2-processes" />
 				<antcall inheritAll="false" target="clean-up-java-processes" />
 			</then>
 		</if>

--- a/modules/apps/foundation/expando/.gitrepo
+++ b/modules/apps/foundation/expando/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5c501a21c7b42baeb650243605cada6f16e25e71
+	commit = 2a36cf9448f04511f5bada78ae500143a59090bb
 	mode = push
-	parent = 77a190eefb50e0fafbb9cc3b57498f0f1b9095f0
+	parent = a44bee351d45a62ec18c8d15b36b311efbe68528
 	remote = git@github.com:liferay/com-liferay-expando.git

--- a/modules/apps/foundation/frontend-css/.gitrepo
+++ b/modules/apps/foundation/frontend-css/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 8250856981f33ebda29e7a3775684fc3a6cc94f8
+	commit = 2d10568e8ad09febf749a036a9770650eea41010
 	mode = push
-	parent = f2a292b673b7e582cbcc335081ae063bdcf45e9f
+	parent = 4a0af96dddaead7ea0af049514f4e6c4a31fb17d
 	remote = git@github.com:liferay/com-liferay-frontend-css.git

--- a/modules/apps/foundation/frontend-editor/.gitrepo
+++ b/modules/apps/foundation/frontend-editor/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 46423c2e23f2edcff970a77c6587ec10e161b635
+	commit = eaa2861a622918f8c23bed38fef352604d6483f1
 	mode = push
-	parent = eb380d262b3e477e1903151f56e974baa993c375
+	parent = 2f7626217c8921ae4779658a8d33172e1464b103
 	remote = git@github.com:liferay/com-liferay-frontend-editor.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = dd622ee60c4f407693ee277b15774f4c6f16d165
+	commit = f829afbb948183facefd4e0d3bd0aee79e3b0d98
 	mode = push
-	parent = 958cb8d480939cf4b23aef354f9b28583d69283c
+	parent = e21839d2c915200a5686b1fb46f4662939bb2bfb
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/frontend-taglib/.gitrepo
+++ b/modules/apps/foundation/frontend-taglib/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 253f8712f0ba8a552b4a6318127c9e538cc067bf
+	commit = c14865f981e921a639d2a916df12644dfd0e67da
 	mode = push
-	parent = 5745237c929e1db72f635f49c648554d9c04c466
+	parent = 3c3d41a1ccccf59362f848eae31969a628813747
 	remote = git@github.com:liferay/com-liferay-frontend-taglib.git

--- a/modules/apps/foundation/hello-velocity/.gitrepo
+++ b/modules/apps/foundation/hello-velocity/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b0f97fcb0c39efb7fb4f6aba572e44907a111f1c
+	commit = f54365d8da8541dc3cca615803cc9a27cd483529
 	mode = push
-	parent = 0a17900fcbb718f6e4826895c867bc7fe309d903
+	parent = f72be2871e93437f4116d259503058b9818cf70e
 	remote = git@github.com:liferay/com-liferay-hello-velocity.git

--- a/modules/apps/foundation/login/.gitrepo
+++ b/modules/apps/foundation/login/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 42c5e6492fca0556ceae871870f2bf7816c7b84f
+	commit = d3d791316acfe82f9aac0f34a0b7679299ad57a0
 	mode = push
-	parent = 9355620bc32df68c5fa875d7379bda29aecc33b0
+	parent = 8ecee3a3a2e6eebdf75cbc7292e1c7329902e0b5
 	remote = git@github.com:liferay/com-liferay-login.git

--- a/modules/apps/foundation/map/.gitrepo
+++ b/modules/apps/foundation/map/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 8562b5c14f07a7f0170978fc2c9db9d3aa1f00b1
+	commit = 32b9e74820b8e1345140647ecb7f86b73e480c03
 	mode = push
-	parent = 4392cfeef6478f50182d23b4e14e33b787be947f
+	parent = fbb2a80c26fdbc30d41f09658ceb4420bd37933b
 	remote = git@github.com:liferay/com-liferay-map.git

--- a/modules/apps/foundation/mobile-device-rules/.gitrepo
+++ b/modules/apps/foundation/mobile-device-rules/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0cc89f754063e763fcb38dd57cd2e33d3f971627
+	commit = 2dfa8531dfd93181d7939b55c566efc42861d6f4
 	mode = push
-	parent = 4f2b731b8414ab0740e91cfec6972c6034f2872f
+	parent = ff578b3195353d321698f6a6848632343c286a14
 	remote = git@github.com:liferay/com-liferay-mobile-device-rules.git

--- a/modules/apps/foundation/monitoring/.gitrepo
+++ b/modules/apps/foundation/monitoring/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 729f92acdf761b5afc8e228276f21e0aaf2095eb
+	commit = df5459340b4e1b318a08b6403642e992e2a1a2e0
 	mode = push
-	parent = dfa87375a4eff1ffb496ada4aa1e1c405bc1d51f
+	parent = 3c6d13b516e0e996c7b6a16dbaf4379eb227ed1f
 	remote = git@github.com:liferay/com-liferay-monitoring.git

--- a/modules/apps/foundation/my-account/.gitrepo
+++ b/modules/apps/foundation/my-account/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 1162f6e167b231c8d32753945042a684b62cdbed
+	commit = 2e38ec3c5ed39c09a74b9bd0ef1b42a04723348c
 	mode = push
-	parent = 5d9d54beb2b8a7db0822877dbafade920c8cb466
+	parent = 5b3ac1b7d5b450396479261d4221559b6be2939a
 	remote = git@github.com:liferay/com-liferay-my-account.git

--- a/modules/apps/foundation/password-policies-admin/.gitrepo
+++ b/modules/apps/foundation/password-policies-admin/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ccb32834536ad7e78c8414d31a3be456e4222bb6
+	commit = a7550d0ee0bea7d111a5cd13b3b23de1df4d5e36
 	mode = push
-	parent = c64784c3357452b89f303f7c9f751396bf8ee3d0
+	parent = b6b894276de61e33cd43b163ce7b506f77875804
 	remote = git@github.com:liferay/com-liferay-password-policies-admin.git

--- a/modules/apps/foundation/petra/.gitrepo
+++ b/modules/apps/foundation/petra/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 68c47d4f98777311605976e43f59e46c2e66f811
+	commit = 9264c4d7a9d6da55a9fc50a32a3ea6e00c804861
 	mode = push
-	parent = 15e6a3c402ba2e199458ae18c8a72a5cee596131
+	parent = 09ddb3749a7096f736a3803e45eb86f172947bfc
 	remote = git@github.com:liferay/com-liferay-petra.git

--- a/modules/apps/foundation/plugins-admin/.gitrepo
+++ b/modules/apps/foundation/plugins-admin/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b4a081a56daccdd0dc9dc07187351fe0123966b3
+	commit = 8d32482381dfb8861992829927f7cc5b46d8294c
 	mode = push
-	parent = 91b3d896e7b3f47a08a80d1962eaee66c692dd8e
+	parent = 34fdc2d96981a504e240b6bc34ebe60560619f0e
 	remote = git@github.com:liferay/com-liferay-plugins-admin.git

--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 40198853b6befa9f2a166206c47d0d9ffc45d9fb
+	commit = 7495943a83bf084358270968b017f4e8c86a5a35
 	mode = push
-	parent = 6977c65d119f91442875f57b189ca476418de0d7
+	parent = f9fe7237657fb76a3a10b5ea211347c47704c4fa
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/foundation/portal-configuration/.gitrepo
+++ b/modules/apps/foundation/portal-configuration/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 85e67791d0d10a7b24e5f590842bb4e65825889c
+	commit = 593eebe53ee45b4b4d2a7b155245e9e759691c5d
 	mode = push
-	parent = 9f3a95ae7e355eafcf18e26d838e1631ccd81f56
+	parent = 13edf5d580c9e359e0072e073797981de4b785d3
 	remote = git@github.com:liferay/com-liferay-portal-configuration.git

--- a/modules/apps/foundation/portal-instances/.gitrepo
+++ b/modules/apps/foundation/portal-instances/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3636c5f1b9f288f20b558c4bd3e1e5b79928f8f2
+	commit = 30a4f6827651a485e06f91af7a91e032d4be6f8b
 	mode = push
-	parent = dd0833c813f9433a9eafc41abac5f7029929803c
+	parent = b68ee1e0760baae4df92f63df0daca229c717a46
 	remote = git@github.com:liferay/com-liferay-portal-instances.git

--- a/modules/apps/foundation/portal-portlet-bridge/.gitrepo
+++ b/modules/apps/foundation/portal-portlet-bridge/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a1c15755284a8ea7294ecb5875a4f2ba90cd17d2
+	commit = c1f2c2089dcdba77e2bfa3d00b6b0914e10c5055
 	mode = push
-	parent = c12c8539871dd5bc88dc1471f8d312b8e0ad6b3c
+	parent = 9eda432d48821cdb6b52bc8aad02d32de7b968d9
 	remote = git@github.com:liferay/com-liferay-portal-portlet-bridge.git

--- a/modules/apps/foundation/portal-remote/.gitrepo
+++ b/modules/apps/foundation/portal-remote/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = cf6a8e38e7030a4442fcd0e3b72d03fb54f57133
+	commit = c5344ff803ed83a8923a6c5a0e9a3dea18117589
 	mode = push
-	parent = 3482188fec32ff55cedd3a7a95bcf3e3db556ec0
+	parent = 3dc3b97416acf76a6dfb129b55c425c50229b591
 	remote = git@github.com:liferay/com-liferay-portal-remote.git

--- a/modules/apps/foundation/portal-scheduler/.gitrepo
+++ b/modules/apps/foundation/portal-scheduler/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3e1beee0fd9d4ae39f3a3f66c87394c7516c8abe
+	commit = 4c2b016bbf08cbd9b1b44c09cd0570401059a1e1
 	mode = push
-	parent = 924a5889a4cb509e20c0ca25f48d9e2df054c060
+	parent = fac6557e6fd79845a8b7abb614f4a6a29ce257ee
 	remote = git@github.com:liferay/com-liferay-portal-scheduler.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ee6a29673367f9431bdc9a66da8b480f5e92885e
+	commit = 8fe85078b94e239e411390e546708bf125f5f27c
 	mode = push
-	parent = f83f923f489194615411c98de63ceb865726066f
+	parent = 57621d770a85802fddc117dd121cdaf842b991af
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = adc1e50ba1531361d8d8699959364cc9c72ae5c9
+	commit = a80d5edc736df1d69de69331ced2dd16256c1ab1
 	mode = push
-	parent = 917cfdfb88b0d5403d8eb532774319b7a34764e8
+	parent = b333f1b9e5aa82581684829745ee8488d44ea09a
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal-settings/.gitrepo
+++ b/modules/apps/foundation/portal-settings/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 62fb46eaef7499bffa30001b706fedee8fe0f4fb
+	commit = 852d1f9e4885828381104600e752ee0b1f945335
 	mode = push
-	parent = 4a145b59e87ca1434848273e472502f3613ab00b
+	parent = 33d81f5ae5a5295b073e5116246158ed125cee0a
 	remote = git@github.com:liferay/com-liferay-portal-settings.git

--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 62dfc711f780a524c11529d1d3d2aaf0f2b806d5
+	commit = e1bf758d008d6f56e8a401b2b17ef912c3f6212d
 	mode = push
-	parent = bbc9f502f0541e1703944b9fa423f2168a6f35cf
+	parent = fa0f5df2dc44beea3e31a3ac4a1c8cd2c63790ea
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 646ac81f0c33c3b0e4417056ce2ce7734ac5e658
+	commit = 0ef3d1ebc8f5e26501e4ecc6e26733a7a9ab6fae
 	mode = push
-	parent = 2e1ebbac865a256c076830cf9da08964b4f73930
+	parent = 6f5909123441e518723cdf3b6aabe785cd235cbf
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/ip-geocoder/.gitrepo
+++ b/modules/apps/ip-geocoder/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 476cb4ad325a6c7f7267e73609c6242572069716
+	commit = 416c7c46755aee044e6e879559294403654c949f
 	mode = push
-	parent = 1700ef599e4d9ed32e234ce6d50e2336c1b7d849
+	parent = 26f680f234e709784c4e82f060078941a2cc7373
 	remote = git@github.com:liferay/com-liferay-ip-geocoder.git

--- a/modules/apps/static/osgi/.gitrepo
+++ b/modules/apps/static/osgi/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7e75391151697cc39c8b45e4fb97a523e166438f
+	commit = 399ad7345cc7400f33f920982b86953fe6bd1a0b
 	mode = push
-	parent = 4dead3d570e25258f526ecc68f76f12204cfdcf1
+	parent = de32180b5d1b22f0717a3b53fa11b9e7b0d02336
 	remote = git@github.com:liferay/com-liferay-osgi.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ceda5fa5ecf250fafc0b0d3ac3ad8f1f4fe7946b
+	commit = fbee7ad0c93e415054e154ddbd7bd981c5132a48
 	mode = push
-	parent = 900eff9b899e8ac3f5556fea17b9c66d39543b28
+	parent = 17b0e5d2db1c5d8e8b03bf0f2e9c37f2ad03f597
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/web-experience/application-list/.gitrepo
+++ b/modules/apps/web-experience/application-list/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d3bd9e7fac453d860c140f4304f5f13e9623959b
+	commit = e1206c998708a9b868ab427ae701aafac95a3e64
 	mode = push
-	parent = fa4b718993aa4bfb9d62aeeacd5b1cb9ca335a44
+	parent = 87e4e1270ba31087dafe5d29568ddc3d399c9d29
 	remote = git@github.com:liferay/com-liferay-application-list.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a51f64dc3bc5d8b3bf72ae3ca381677884bf31c4
+	commit = 4bc38ec682af3775cc2424e2a3d61c147ae929fd
 	mode = push
-	parent = bed5cc2ba8859fc66709daf9563ecbee40bb8b91
+	parent = 0231e4c071d1f3aaad327a6e893721f6297410ef
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3fad40dfb60b3123a64ea4863baa11a31c4e14c9
+	commit = c58aa509c242dc6a5ad09300466e1dfc3bdb2080
 	mode = push
-	parent = edf3c385eaec41a7f4f51b85380ce0b5cf8a3882
+	parent = 0e8b2fc4903207be35bc005c0af5a1679724624d
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ef127e9d4b5126a4ea9d0fc893819ed85b2f5cb8
+	commit = ff7c8c707b1ba07dc8bedfdf6d2109ccc5c97c6b
 	mode = push
-	parent = 9c34f4952a6b78bbdb632e22532d9dd56192c87b
+	parent = c3013baa0b9180117f22dd8cecd6bda9b5e6e46e
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = c1f43b5b2137212ed083599ab1c73b2b86ce0914
+	commit = 8b8da6d0fab893dfc0bd180c24556a76ae74e983
 	mode = push
-	parent = 6e17d4a1a0386e128e0e0036ae293ea8f570f285
+	parent = eb0d216e9f5f27e97e8948cf8f967438fec8100a
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/modules/apps/web-experience/nested-portlets/.gitrepo
+++ b/modules/apps/web-experience/nested-portlets/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a3f4eaa9b3ced59c6cdc6aeee966a0a4054fad9a
+	commit = 6bc009601a36b05b56e6a23cc49a3d99b917af6f
 	mode = push
-	parent = 238e93a406890eac14de64f6b20f5d48b4538c1b
+	parent = 5a30232054f3ada1fbe178b1c1494cdcdb183c90
 	remote = git@github.com:liferay/com-liferay-nested-portlets.git

--- a/modules/apps/web-experience/product-navigation/.gitrepo
+++ b/modules/apps/web-experience/product-navigation/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 48f39b560580e90f019bba9cc4c6cc990cc09434
+	commit = 68648a869499d3289513385342707d66d2ccbad1
 	mode = push
-	parent = 55c418b2a4d13be9e0cf112a8e5c4199b216aa94
+	parent = 0f5e7aee88e06dd5e2e8b57786d67cf321a4760d
 	remote = git@github.com:liferay/com-liferay-product-navigation.git

--- a/modules/apps/web-experience/rss/.gitrepo
+++ b/modules/apps/web-experience/rss/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 09e38134e6157011948649ca6811b55040fbbb82
+	commit = 45fea5bbbf6e251cec2231fb32ca26a193b2099e
 	mode = push
-	parent = 2b41e5f2e1996646f1f6c9a6e80361c2f5926084
+	parent = 759ad004007950d690dd63f17821b83a1b090469
 	remote = git@github.com:liferay/com-liferay-rss.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4779dc9436952abf0f6d5104e35758babfc3db06
+	commit = 3dacada16a229dd0dfbc7cc1e3d3f3f30ada6545
 	mode = push
-	parent = d41fb0ccc4af4a21629e68991ddb912f5b416de6
+	parent = 73a24a7213c7c9a92d631d89cd733d7d3459bc80
 	remote = git@github.com:liferay/com-liferay-site.git

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f135f39c337d14bfc2c4ad137c2d9af71d5b43c1
+	commit = 89a7979d8fa461f29e84d1ad2b4f1047d54c1fbc
 	mode = push
-	parent = a441e1d6b8999d68cf035f4e00c9516fe04624ff
+	parent = 347da958ff4f4621f2ee84a90373b3fa5586edf3
 	remote = git@github.com:liferay/com-liferay-staging.git

--- a/modules/apps/web-experience/trash/.gitrepo
+++ b/modules/apps/web-experience/trash/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0bfbce37e2404ee66927c92c42de07d600ba8839
+	commit = 9de8de9726acd8a97120c02e5e192d090b239596
 	mode = push
-	parent = 8388299340e7befeff0bea95f61205aa9d163aac
+	parent = bfd93ff0054e553019b5bb2c2ec897b0cac1497e
 	remote = git@github.com:liferay/com-liferay-trash.git


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-25108

Fixes the way the DB2 database is rebuilt before a functional test. This is needed to support automated legacy data dumps for DB2.
