### PR TITLE
LPS-66343 Only display fail message if module.stale.artifacts not empty

### DIFF
--- a/modules/build-app.xml
+++ b/modules/build-app.xml
@@ -74,9 +74,7 @@
 
 		<fail message="Stale artifacts detected:${line.separator}${module.stale.artifacts}">
 			<condition>
-				<not>
-					<equals arg1="${stale.artifacts.output}" arg2="" />
-				</not>
+				<isset property="module.stale.artifacts" />
 			</condition>
 		</fail>
 	</target>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-66343
