### PR TITLE
LPS-63943

### DIFF
--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -33,14 +33,6 @@ gradle.beforeProject {
 		pluginManager.withPlugin("com.liferay.osgi.plugin") {
 			apply plugin: "pmd"
 
-			/*afterEvaluate {
-				def baselineTask = tasks.findByName("baseline")
-
-				if (baselineTask && baselineTask.hasProperty("ignoreFailures")) {
-					baselineTask.ignoreFailures = true
-				}
-			}*/
-
 			afterEvaluate {
 				bundle.jarBuilderFactory.contextClassLoader = buildscript.classLoader
 

--- a/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayOSGiDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins/src/main/java/com/liferay/gradle/plugins/LiferayOSGiDefaultsPlugin.java
@@ -477,6 +477,14 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 				});
 
+			String ignoreFailures = GradleUtil.getTaskPrefixedProperty(
+				baselineTask, "ignoreFailures");
+
+			if (Validator.isNotNull(ignoreFailures)) {
+				baselineTask.setIgnoreFailures(
+					Boolean.parseBoolean(ignoreFailures));
+			}
+
 			baselineTask.setNewJarFile(
 				new Callable<File>() {
 


### PR DESCRIPTION
Hi,
You can prevent baseline to fail the build by calling the task like this:

```
gradlew baseline -Dbaseline.ignoreFailures=true
```

_P.S._: I had to add the LPS to the revert commit. Without it, CI closed the pull: https://github.com/brianchandotcom/liferay-portal/pull/40483#issuecomment-223702844
