### PR TITLE
[See desc] LPS-66368 Initialize Release table properly

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/upgrade/KnowledgeBaseServiceUpgrade.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/upgrade/KnowledgeBaseServiceUpgrade.java
@@ -15,6 +15,7 @@
 package com.liferay.knowledge.base.upgrade;
 
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -28,6 +29,16 @@ public class KnowledgeBaseServiceUpgrade implements UpgradeStepRegistrator {
 
 	@Override
 	public void register(Registry registry) {
+		try {
+			UpgradeServiceModuleRelease upgradeServiceModuleRelease =
+				new UpgradeServiceModuleRelease();
+
+			upgradeServiceModuleRelease.upgrade();
+		}
+		catch (UpgradeException ue) {
+			throw new RuntimeException(ue);
+		}
+
 		registry.register(
 			"com.liferay.knowledge.base.service", "0.0.1", "1.0.0",
 			new com.liferay.knowledge.base.upgrade.v1_0_0.UpgradeRatingsEntry(),

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/upgrade/KnowledgeBaseServiceUpgrade.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/upgrade/KnowledgeBaseServiceUpgrade.java
@@ -14,9 +14,11 @@
 
 package com.liferay.knowledge.base.upgrade;
 
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Adolfo Pérez
@@ -88,6 +90,11 @@ public class KnowledgeBaseServiceUpgrade implements UpgradeStepRegistrator {
 			"com.liferay.knowledge.base.service", "1.3.5", "2.0.0",
 			new com.liferay.knowledge.base.upgrade.v2_0_0.UpgradeClassNames(),
 			new com.liferay.knowledge.base.upgrade.v2_0_0.UpgradeRepository());
+	}
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
+	protected void setModuleServiceLifecycle(
+		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/upgrade/UpgradeServiceModuleRelease.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/upgrade/UpgradeServiceModuleRelease.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.knowledge.base.upgrade;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.CharPool;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author Adolfo Pérez
+ */
+class UpgradeServiceModuleRelease extends UpgradeProcess {
+
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement ps = connection.prepareStatement(
+				"select buildNumber from Release_ where " +
+					"servletContextName = ?")) {
+
+			ps.setString(1, _OLD_SERVLET_CONTEXT_NAME);
+
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					String buildNumber = rs.getString("buildNumber");
+
+					_updateRelease(_toSchemaVersion(buildNumber));
+				}
+			}
+		}
+	}
+
+	private void _updateRelease(String schemaVersion) throws SQLException {
+		try (PreparedStatement ps = connection.prepareStatement(
+				"update Release_ set servletContextName = ?, " +
+					"schemaVersion = ? where servletContextName = ?")) {
+
+			ps.setString(1, _NEW_SERVLET_CONTEXT_NAME);
+			ps.setString(2, schemaVersion);
+			ps.setString(3, _OLD_SERVLET_CONTEXT_NAME);
+
+			ps.execute();
+		}
+	}
+
+	private String _toSchemaVersion(String buildNumber) {
+		StringBuilder sb = new StringBuilder(2 * buildNumber.length());
+
+		for (int i = 0; i < buildNumber.length(); i++) {
+			sb.append(buildNumber.charAt(i));
+			sb.append(CharPool.PERIOD);
+		}
+
+		if (buildNumber.length() > 0) {
+			sb.setLength(sb.length() - 1);
+		}
+
+		return sb.toString();
+	}
+
+	private static final String _NEW_SERVLET_CONTEXT_NAME =
+		"com.liferay.knowledge.base.service";
+
+	private static final String _OLD_SERVLET_CONTEXT_NAME =
+		"knowledge-base-portlet";
+
+}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/upgrade/KnowledgeBaseWebUpgrade.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/upgrade/KnowledgeBaseWebUpgrade.java
@@ -16,6 +16,7 @@ package com.liferay.knowledge.base.web.upgrade;
 
 import com.liferay.knowledge.base.web.upgrade.v1_0_0.UpgradePortletId;
 import com.liferay.knowledge.base.web.upgrade.v1_0_0.UpgradePortletSettings;
+import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
@@ -68,6 +69,11 @@ public class KnowledgeBaseWebUpgrade implements UpgradeStepRegistrator {
 			"com.liferay.knowledge.base.web", "0.0.1", "1.0.0",
 			new UpgradePortletId(),
 			new UpgradePortletSettings(_settingsFactory));
+	}
+
+	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED, unbind = "-")
+	protected void setModuleServiceLifecycle(
+		ModuleServiceLifecycle moduleServiceLifecycle) {
 	}
 
 	@Reference(unbind = "-")


### PR DESCRIPTION
From @adolfopa 

---

While the UpgradeServiceModuleRelease handles the general case, I've kept it private so that we can remove it later safely, once the Infrastructure team extends the upgrade API to handle this case. For the same reason, there is a bit of duplication (the toSchemaVersion method is also in UpgradeRelease) that I didn't clean up.

Thanks!
