### PR TITLE
LPS-66376 Marketplace app title should be consistent

### DIFF
--- a/modules/.releng/apps/marketplace/app.properties
+++ b/modules/.releng/apps/marketplace/app.properties
@@ -1,4 +1,4 @@
 app.marketplace.id=25019275
-app.marketplace.title=Marketplace
+app.marketplace.title=Liferay Marketplace
 app.marketplace.version=7.0
 app.portal.build=7001


### PR DESCRIPTION
Using "Liferay Marketplace" instead of "Liferay CE Marketplace" because CE and EE use the same marketplace entry
