### PR TITLE
LPS-66483 Call "bnd print" for all jars at the end of the build

### DIFF
--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a1f0c29865b2ce8864ebea451327fa1bef7fdcec
+	commit = c26025d75150e42fb730472f31d071f77cf79b8d
 	mode = push
-	parent = acb18029ce732b276a2957506eb5a32565073525
+	parent = 965a1151a0261172d849e30fa4ad50e941ee2990
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -1,8 +1,30 @@
 import com.liferay.gradle.util.FileUtil
 import com.liferay.gradle.util.GradleUtil
 
+import java.util.concurrent.ConcurrentSkipListSet
+
 buildscript {
 	apply from: rootProject.file("build-buildscript.gradle"), to: buildscript
+}
+
+Set<File> bndPrintJarFiles = null
+
+if (System.getenv("JENKINS_HOME")) {
+	configurations {
+		bnd
+	}
+
+	dependencies {
+		bnd group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "3.2.0"
+	}
+
+	repositories {
+		maven {
+			url System.properties["repository.url"] ?: "https://cdn.lfrs.sl/repository.liferay.com/nexus/content/groups/public"
+		}
+	}
+
+	bndPrintJarFiles = new ConcurrentSkipListSet<File>()
 }
 
 buildDir = new File(rootDir.parentFile, "build")
@@ -87,6 +109,14 @@ gradle.beforeProject {
 				classpath = null
 			}
 
+			if (bndPrintJarFiles != null) {
+				jar {
+					doLast {
+						bndPrintJarFiles << archivePath
+					}
+				}
+			}
+
 			if (gradle.hasProperty("testClassGroupIndex")) {
 				configure([test, testIntegration]) {
 					include gradle.testClasses
@@ -114,6 +144,20 @@ gradle.beforeProject {
 						throw new GradleException("Unable to use Node.js on CI, please configure com.liferay.cache or update the cache")
 					}
 				}
+			}
+		}
+	}
+}
+
+if (bndPrintJarFiles != null) {
+	gradle.buildFinished {
+		bndPrintJarFiles.each {
+			File jarFile ->
+
+			javaexec {
+				args "print", jarFile
+				classpath = configurations.bnd
+				main = "aQute.bnd.main.bnd"
 			}
 		}
 	}


### PR DESCRIPTION
Hi,
I have to call `bnd print` at the end, otherwise the various logs would mix because of the parallel build.
