### PR TITLE
LPS-66588 : Faceted Search : Asset Category not showing parenthesis a

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_categories.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_categories.jsp
@@ -110,7 +110,7 @@ boolean showAssetCount = dataJSONObject.getBoolean("showAssetCount", true);
 								<%= HtmlUtil.escape(curAssetCategory.getTitle(locale)) %>
 
 								<c:if test="<%= showAssetCount %>">
-									<span class="frequency"><%= termCollector.getFrequency() %></span>
+									<span class="frequency">(<%= termCollector.getFrequency() %>)</span>
 								</c:if>
 							</a>
 						</li>


### PR DESCRIPTION
Fixed the code to add parenthesis around search count for asset category

Environment Details:

Tomcat : 8.0.32
Database: MySql 5.6
Browsers : IE/Mozilla Firefox/Google Chrome
