### PR TITLE
LPS-66691 Create the .gradle dir if it does not exist

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1390,6 +1390,8 @@ rerun your task.
 
 			<property location="${basedir}/.gradle/gradle.properties" name="gradle.properties.file" />
 
+			<mkdir dir="${basedir}/.gradle" />
+
 			<delete file="${gradle.properties.file}" />
 
 			<condition else="false" property="jsp.precompile.enabled">


### PR DESCRIPTION
Hi @brianchandotcom and @CAustin582!

This pull only solves one problem. The src zip contains the `.releng` dir, which means all the Gradle release tasks are added to the build. The problem is that these tasks assume we are in a Git repository, otherwise they will fail the build. Do we really have to include the `.releng` dir in the src zip? If yes, I can change the Gradle plugin so it can fail gracefully.

Thank you!
