### PR TITLE
LPS-66332 Solr 5.x distro uses 8983 as default port

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/configuration/SolrConfiguration.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/configuration/SolrConfiguration.java
@@ -47,10 +47,10 @@ public interface SolrConfiguration {
 	)
 	public boolean logExceptionsOnly();
 
-	@Meta.AD(deflt = "http://localhost:8080/solr/liferay", required = false)
+	@Meta.AD(deflt = "http://localhost:8983/solr/liferay", required = false)
 	public String[] readURL();
 
-	@Meta.AD(deflt = "http://localhost:8080/solr/liferay", required = false)
+	@Meta.AD(deflt = "http://localhost:8983/solr/liferay", required = false)
 	public String[] writeURL();
 
 	@Meta.AD(deflt = "localhost:9983", required = false)


### PR DESCRIPTION
Author: @lipusz 
Reviewer: @arboliveira
