### PR TITLE
LPS-66640 Polls Display portlet is temporarily unavailable when selected Poll is deleted

### DIFF
--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
@@ -17,7 +17,11 @@
 <%@ include file="/polls_display/init.jsp" %>
 
 <%
-PollsQuestion question = PollsUtil.getQuestionByPortlet(portletPreferences);
+PollsQuestion question = null;
+try {
+	question = PollsUtil.getQuestionByPortlet(portletPreferences);
+} catch (NoSuchQuestionException nsqe) {
+}
 %>
 
 <%@ include file="/polls_display/view_options.jspf" %>


### PR DESCRIPTION
Fixed the issue to not let portlet go into "unavailable" mode upon receiving exception.

Environment Details -

Liferay : 7.0.x
Tomcat : 8.0.32
MySql - 5.6
Browser : IE/Mozilla/Chrome
