### PR TITLE
LRQA-25603 Modify LoadBalancer to track recent batch sizes in-memory instead of using the file system

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LoadBalancerUtil.java
@@ -314,7 +314,7 @@ public class LoadBalancerUtil {
 			return 0;
 		}
 
-		int batchSizeTotal = 0;
+		int recentBatchSizesTotal = 0;
 
 		List<BatchSizeRecord> hostRecentBatchSizeEntriesToBeRemoved =
 			new ArrayList<>(hostRecentBatchSizes.size());
@@ -323,7 +323,7 @@ public class LoadBalancerUtil {
 			if ((recentBatchSizeRecord.timestamp + recentBatchPeriod) >
 					System.currentTimeMillis()) {
 
-				batchSizeTotal += recentBatchSizeRecord.size;
+				recentBatchSizesTotal += recentBatchSizeRecord.size;
 			}
 			else {
 				hostRecentBatchSizeEntriesToBeRemoved.add(
@@ -333,7 +333,7 @@ public class LoadBalancerUtil {
 
 		hostRecentBatchSizes.removeAll(hostRecentBatchSizeEntriesToBeRemoved);
 
-		return batchSizeTotal;
+		return recentBatchSizesTotal;
 	}
 
 	protected static void startParallelTasks(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -118,8 +118,8 @@ public class LoadBalancerUtilTest extends BaseJenkinsResultsParserTestCase {
 	protected void downloadSample(File sampleDir, URL url) throws Exception {
 		Properties properties = getDownloadProperties(sampleDir.getName());
 
-		List<String> hostNames = LoadBalancerUtil.getHostNames(
-			properties, sampleDir.getName());
+		List<String> hostNames = LoadBalancerUtil.getMasters(
+			sampleDir.getName(), properties);
 
 		for (int i = 1; i <= hostNames.size(); i++) {
 			downloadSampleURL(

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -46,7 +46,7 @@ public class LoadBalancerUtilTest extends BaseJenkinsResultsParserTestCase {
 
 	@Test
 	public void testGetMostAvailableMasterURL() throws Exception {
-		LoadBalancerUtil.recentBuildsPeriod = 0;
+		LoadBalancerUtil.recentBatchPeriod = 0;
 
 		assertSamples();
 	}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/LoadBalancerUtilTest.java
@@ -46,7 +46,7 @@ public class LoadBalancerUtilTest extends BaseJenkinsResultsParserTestCase {
 
 	@Test
 	public void testGetMostAvailableMasterURL() throws Exception {
-		LoadBalancerUtil.recentJobPeriod = 0;
+		LoadBalancerUtil.recentBuildsPeriod = 0;
 
 		assertSamples();
 	}


### PR DESCRIPTION
LoadBalancer no longer needs to use the local file system to track recent batch sizes and to synchronize LoadBalancer instances. Currently, the LoadBalancer service doesn't track recent batch sizes because it is using the tmp directory. When the tmp directory is cleared, the ability to track recent batch sizes is broken until the next time the service is bounced. Instead of moving the files elsewhere, it makes more sense to remove the need to use the file system at all.

I've also included some refactoring in this pull to rename "job" to "batch".

Please publish a new com.liferay.jenkins.results.parser.jar when this is merged.
