### PR TITLE
7.0.x-qa-26054

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/socialnetworking/youtube/OSGiYoutubeportlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/socialnetworking/youtube/OSGiYoutubeportlet.testcase
@@ -1,4 +1,4 @@
-<definition component-name="portal-plugins-osgi">
+<definition component-name="portal-legacy">
 	<property name="portal.release" value="true" />
 	<property name="plugins.deployment.type" value="osgi" />
 	<property name="testray.main.component.name" value="Social Networking" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/endusermarketplace/plugins/portlets/MPYoutubeportlet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/endusermarketplace/plugins/portlets/MPYoutubeportlet.testcase
@@ -1,4 +1,4 @@
-<definition component-name="portal-plugins-deployment">
+<definition component-name="portal-legacy">
 	<property name="testray.main.component.name" value="Plugin Installer" />
 
 	<set-up>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-26054 Resend of #41000 @brianchandotcom I am only disabling this and other failing tests in LRQA-26047 in 7.0.x/ee-7.0.x because the portlet is broken and not planned to be released anytime soon. Allowing these tests to run will add extra noise as QA begins to conduct analysis on fix packs.
