### PR TITLE
master-qa-26209

### DIFF
--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 01b837373c987cf8e550a69b418e6ba98ce0f76a
+	commit = 4297e6481f0bc538446bc9ab78861bea34770326
 	mode = push
-	parent = 3b01a1056a7bcf91fdecc847aed29980c7259ed6
+	parent = fe9f98b45f43982d6380f4beea7c1547776b0dfc
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 591ac26ad2f367b3a218cd3e63403bada7cabc0e
+	commit = 4654b57c74f51479a68ce1c381ce966760156a00
 	mode = push
-	parent = 53d87680d3abe14dc01d1b5614bfc83bd99e478b
+	parent = 694cb8e133cf73a3d8219fffec5c692dac7fc02d
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a76ae8619923c5d77114ad10c8d825d5b43d0b32
+	commit = 4e4bed6cc3499692d4d80d4fbdd55bc228042aea
 	mode = push
-	parent = 4ec4a0f8434cca23d5e7908172b5141d6f6f122e
+	parent = 9233fb844d0379082ca1651a5ca39de95c3ca3b4
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 689a2c9d1a61f12e3f421413e8cb7a84e9e0c0a5
+	commit = 972f31b8603278293b664b2867670a05efcc41e6
 	mode = push
-	parent = 9216d81e5957db5ccfbecaa06cd46f69f26488ac
+	parent = b57cc3543ab435711c020acd531e6f04a97ca169
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -217,6 +217,10 @@
 			<contains>Unable to add folder menu item</contains>
 			<matches></matches>
 		</ignore-error>
+		<ignore-error description="LPS-66736, temporary workaround until Marcos Castro fixes it">
+			<contains></contains>
+			<matches>.*Unable to process message.*product-app-theme.*</matches>
+		</ignore-error>
 		<ignore-error description="LRQA-14442, temporary workaround until Kiyoshi Lee fixes it">
 			<contains>[org_eclipse_equinox_http_servlet.*Framework Event Dispatcher: Equinox Container:</contains>
 			<matches></matches>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-26209

@brianchandotcom 
This will ignore the startup error from https://issues.liferay.com/browse/LPS-66736 that causes failures in the ee-7.0.x PR tester. This won't make all the tests green because some of the other environments have their own errors, but the one from LPS-66736 happens on all environments, so this should at least resolve some of the failures.

I'm running a test here as well: https://github.com/brianchiu/liferay-portal-ee/pull/4410
