### PR TITLE
7.0.x-qa-26209

### DIFF
--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 96e9eb713fecc26158c454af9838bcb074405d07
+	commit = 85c8addc56ceaaa7c31d4ead5c1d229cc8249a99
 	mode = push
-	parent = 3b3f355be73a7ffb041849d9cfa9442fd1e63367
+	parent = 1f6a89f3f2e09e7801ff737ab68a981dc1b7a20e
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 1706ac3d28e5a5b13ee5d126edca73690aabd8d2
+	commit = 7e73c598f931ad1518d7395a68d2736f446eed62
 	mode = push
-	parent = af36f50f254556674fca6ce06da73b3efdf5f1e5
+	parent = 475c7129ceec497aa250323a625e2de457531309
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0b6280c69cdf2ed32e0f85ad63cf015205af9f51
+	commit = 3d8e7d733fa446e7b48b32bb5b4398bc30d507c4
 	mode = push
-	parent = a48970275a42e5517750a8fcf47b92da41ae98bc
+	parent = 1d64bf2eb613bbef9227f0fc0002adba36a44593
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d7c49dbf0074eb779bd6f8e47f9198eb3899adb4
+	commit = 85b51b20680c42e40b05e2721db7e07250f168e3
 	mode = push
-	parent = 72b10d9c268bfc2c67d2bb799a0bf15cdb214f3d
+	parent = 5290af8fa1874df439ad0a8dc4f44b0a92aad646
 	remote = git@github.com:liferay/com-liferay-dynamic-data-mapping.git

--- a/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
+++ b/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 32aa0cb369b102757eeb3595f545eb2ce511a3e8
+	commit = f9f8d36d7e9366c2e011cbe98ec248ed290af9eb
 	mode = push
-	parent = 3cd030c9ff11bb020bc8defe0917cbe5108ef6a7
+	parent = 6f41d35d953e3294a6a13629e3395abe5ed76e29
 	remote = git@github.com:liferay/com-liferay-portal-workflow.git

--- a/modules/apps/foundation/configuration-admin/.gitrepo
+++ b/modules/apps/foundation/configuration-admin/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 31a577578c3bd53fff8b2cf9e0d0d4b2ca729f62
+	commit = 330b221f2669bd89bebf58b3722279156e4c5354
 	mode = push
-	parent = 2324af035ef1356457b6200492a3b0cfcb20f828
+	parent = 1d420d74b923a31a28c0ba3c7dbad6d4dadccbf9
 	remote = git@github.com:liferay/com-liferay-configuration-admin.git

--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5d08c3813474b6572c128ec00a164fcfd49c8690
+	commit = 103dad31524d82c9285733a389fcffe09028f899
 	mode = push
-	parent = 5081e4721dfe9e3e790005e9a749f6eb252ebed3
+	parent = 47d60634b2231941ad930258a25160ec3557e0f4
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7013a84e15a7d14a988bfa007d3707bd5c17f54a
+	commit = f48f528c0f8832d46427dddfe4dc580eb40d41c5
 	mode = push
-	parent = 2f0f98c5fee2e1962d9f9fda3c656c972064b0d6
+	parent = 326c3142996c910c93e7b68ba1451f75181cb510
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 2057e67ea7fce7f0426652b74cea368a0b19ef57
+	commit = 17fec17bedcaae639a15fd5cfd036e395068612d
 	mode = push
-	parent = e25d5e78bc14c43c3c15ff3a0b5c135919eae0d5
+	parent = bb6be2939bc72fb72c7463a5c122d60e49542f21
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -217,6 +217,10 @@
 			<contains>Unable to add folder menu item</contains>
 			<matches></matches>
 		</ignore-error>
+		<ignore-error description="LPS-66736, temporary workaround until Marcos Castro fixes it">
+			<contains></contains>
+			<matches>.*Unable to process message.*product-app-theme.*</matches>
+		</ignore-error>
 		<ignore-error description="LRQA-14442, temporary workaround until Kiyoshi Lee fixes it">
 			<contains>[org_eclipse_equinox_http_servlet.*Framework Event Dispatcher: Equinox Container:</contains>
 			<matches></matches>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-26209

@brianchandotcom 
This will ignore the startup error from https://issues.liferay.com/browse/LPS-66736 that causes failures in the ee-7.0.x PR tester. This won't make all the tests green because some of the other environments have their own errors, but the one from LPS-66736 happens on all environments, so this should at least resolve some of the failures.

I'm running a test here as well: https://github.com/brianchiu/liferay-portal-ee/pull/4410
