### PR TITLE
Code commit for LPS-54096 - ldap type not selected properly

### DIFF
--- a/portal-impl/src/com/liferay/portlet/portalsettings/action/EditLDAPServerAction.java
+++ b/portal-impl/src/com/liferay/portlet/portalsettings/action/EditLDAPServerAction.java
@@ -261,7 +261,7 @@ public class EditLDAPServerAction extends PortletAction {
 		PropsKeys.LDAP_SECURITY_CREDENTIALS, PropsKeys.LDAP_SECURITY_PRINCIPAL,
 		PropsKeys.LDAP_SERVER_NAME, PropsKeys.LDAP_USER_CUSTOM_MAPPINGS,
 		PropsKeys.LDAP_USER_DEFAULT_OBJECT_CLASSES,
-		PropsKeys.LDAP_USER_MAPPINGS, PropsKeys.LDAP_USERS_DN
+		PropsKeys.LDAP_USER_MAPPINGS, PropsKeys.LDAP_USERS_DN, "ldap.server.type"
 	};
 
 }

--- a/portal-web/docroot/html/portlet/portal_settings/authentication/ldap.jsp
+++ b/portal-web/docroot/html/portlet/portal_settings/authentication/ldap.jsp
@@ -42,6 +42,7 @@ if (ldapAuthEnabled && (ldapServerIds.length <= 0) && Validator.isNull(PrefsProp
 	String ldapGroupDefaultObjectClasses = ParamUtil.getString(request, "settings--" + PropsKeys.LDAP_GROUP_DEFAULT_OBJECT_CLASSES + "--", PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_GROUP_DEFAULT_OBJECT_CLASSES));
 	String ldapUserMappings = ParamUtil.getString(request, "settings--" + PropsKeys.LDAP_USER_MAPPINGS + "--", PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_USER_MAPPINGS));
 	String ldapGroupMappings = ParamUtil.getString(request, "settings--" + PropsKeys.LDAP_GROUP_MAPPINGS + "--", PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_GROUP_MAPPINGS));
+	String ldapType = ParamUtil.getString(request, "settings--" + "ldap.server.type" + "--", PrefsPropsUtil.getString(company.getCompanyId(), "ldap.server.type"));
 
 	if (Validator.isNotNull(ldapBaseProviderUrl)) {
 		long ldapServerId = CounterLocalServiceUtil.increment();
@@ -66,11 +67,13 @@ if (ldapAuthEnabled && (ldapServerIds.length <= 0) && Validator.isNull(PrefsProp
 		properties.put(PropsKeys.LDAP_GROUP_DEFAULT_OBJECT_CLASSES + postfix, ldapGroupDefaultObjectClasses);
 		properties.put(PropsKeys.LDAP_USER_MAPPINGS + postfix, ldapUserMappings);
 		properties.put(PropsKeys.LDAP_GROUP_MAPPINGS + postfix, ldapGroupMappings);
+		properties.put("ldap.server.type" + postfix, ldapServerName);
 		properties.put("ldap.server.ids", StringUtil.merge(ldapServerIds));
 
 		List<String> keys = new ArrayList<String>();
 
 		keys.add("ldap.server.name");
+		keys.add("ldap.server.type");
 		keys.add(PropsKeys.LDAP_BASE_PROVIDER_URL);
 		keys.add(PropsKeys.LDAP_BASE_DN);
 		keys.add(PropsKeys.LDAP_SECURITY_PRINCIPAL);

--- a/portal-web/docroot/html/portlet/portal_settings/edit_ldap_server.jsp
+++ b/portal-web/docroot/html/portlet/portal_settings/edit_ldap_server.jsp
@@ -25,9 +25,11 @@ long ldapServerId = ParamUtil.getLong(request, "ldapServerId", 0);
 String postfix = LDAPSettingsUtil.getPropertyPostfix(ldapServerId);
 
 String ldapServerName = PrefsPropsUtil.getString(company.getCompanyId(), "ldap.server.name" + postfix, StringPool.BLANK);
+String ldapServerType = PrefsPropsUtil.getString(company.getCompanyId(), "ldap.server.type" + postfix, StringPool.BLANK);
 String ldapBaseProviderUrl = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_BASE_PROVIDER_URL + postfix);
 String ldapBaseDN = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_BASE_DN + postfix);
 String ldapSecurityPrincipal = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_SECURITY_PRINCIPAL + postfix);
+pageContext.setAttribute("ldapServerType", ldapServerType);
 
 String ldapSecurityCredentials = PrefsPropsUtil.getString(company.getCompanyId(), PropsKeys.LDAP_SECURITY_CREDENTIALS + postfix);
 
@@ -178,14 +180,13 @@ for (int i = 0 ; i < groupMappingArray.length ; i++) {
 
 	<aui:fieldset>
 		<aui:field-wrapper>
-			<aui:input label="Apache Directory Server" name="defaultLdap" type="radio" value="apache" />
-			<aui:input label="Fedora Directory Server" name="defaultLdap" type="radio" value="fedora" />
-			<aui:input label="Microsoft Active Directory Server" name="defaultLdap" type="radio" value="microsoft" />
-			<aui:input label="Novell eDirectory" name="defaultLdap" type="radio" value="novell" />
-			<aui:input label="OpenLDAP" name="defaultLdap" type="radio" value="open" />
-			<aui:input label="other-directory-server" name="defaultLdap" type="radio" value="other" />
+			<aui:input label="Apache Directory Server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="apache" checked="${ldapServerType eq 'apache'}"/>
+			<aui:input label="Fedora Directory Server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="fedora" checked="${ldapServerType eq 'fedora'}"/>
+			<aui:input label="Microsoft Active Directory Server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="microsoft" checked="${ldapServerType eq 'microsoft'}"/>
+			<aui:input label="Novell eDirectory" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="novell" checked="${ldapServerType eq 'novell'}"/>
+			<aui:input label="OpenLDAP" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="open" checked="${ldapServerType eq 'open'}"/>
+			<aui:input label="other-directory-server" name='<%= "settings--ldap.server.type" + postfix + "--" %>' type="radio" value="other" checked="${ldapServerType eq 'other'}"/>
 		</aui:field-wrapper>
-
 		<aui:button-row>
 			<aui:button onClick='<%= renderResponse.getNamespace() + "updateDefaultLdap();" %>' value="reset-values" />
 		</aui:button-row>
@@ -448,7 +449,7 @@ for (int i = 0 ; i < groupMappingArray.length ; i++) {
 			var exportMappingGroupDefaultObjectClass = "";
 
 			if (!ldapType) {
-				A.all(document.<portlet:namespace />fm.<portlet:namespace />defaultLdap).some(
+				A.all(document.<portlet:namespace />fm['<portlet:namespace />settings--ldap.server.type<%= postfix %>--']).some(
 					function(item, index, collection) {
 						var checked = item.get('checked');
 


### PR DESCRIPTION
Fixed the code to retain LDAP type selection as-is while Editing earlier saved settings for LDAP..

Environment Details:
Liferay Portal : 6.2.x
Tomcat : 7.0.62
Databse : MySql 5.6
Browsers : IE/Mozilla Firefox/Google Chrome

The issue of , Post save from edit LDAP configuration page, the page was being redirected to display setting, mentioned in the bug description is not reproducible.
Here are the steps performed - 
1.  Add the following entry in portal-ext.properties:
   locales=en_US (As per the steps reported in JIRA)
2.  Restart the server.
3.  Login as Administration and navigate to Control Panel->Portal Settings ->Authentication tab
4.  Edit any Existing LDAP configuration and click on save.
5.  Post save, the page is redirecting to the Authentication Tab -> General category
