### PR TITLE
LRQA-24859 Ignore 'No binary licenses found' error

### DIFF
--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -56,6 +56,10 @@
 			<contains>INFO:</contains>
 			<matches></matches>
 		</ignore-error>
+		<ignore-error description="">
+			<contains>No binary licenses found</contains>
+			<matches></matches>
+		</ignore-error>
 		<ignore-error description="LPS-22821">
 			<contains>Exception sending context destroyed event to listener instance of class com.liferay.portal.spring.context.PortalContextLoaderListener</contains>
 			<matches></matches>

--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -56,7 +56,7 @@
 			<contains>INFO:</contains>
 			<matches></matches>
 		</ignore-error>
-		<ignore-error description="">
+		<ignore-error description="LRQA-24859">
 			<contains>No binary licenses found</contains>
 			<matches></matches>
 		</ignore-error>


### PR DESCRIPTION
This ignore was mistakenly removed by testing team. It has been causing problems for the patcher job.
https://issues.liferay.com/browse/LRQA-24859
