### PR TITLE
LPS-67128 The key name is used for Class.forName(), both name and can…

### DIFF
--- a/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/FreeMarkerManager.java
+++ b/modules/apps/foundation/portal-template/portal-template-freemarker/src/main/java/com/liferay/portal/template/freemarker/FreeMarkerManager.java
@@ -122,7 +122,7 @@ public class FreeMarkerManager extends BaseSingleTemplateManager {
 				beansWrapper.getStaticModels();
 
 			TemplateModel templateModel = templateHashModel.get(
-				variableClass.getCanonicalName());
+				variableClass.getName());
 
 			contextObjects.put(variableName, templateModel);
 		}


### PR DESCRIPTION
…onical name can be used for this purpose, therefore we should use the cheaper one.

@dantewang @slnn performance check please, should be hardly noticeable, but run it anyway.
