### PR TITLE
Lps 65510

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9947153e0f58ceb88005ba25548c2c93ce8effe1
+	commit = eac670e03c28c3e9d28bf7c8186c74c358ad693b
 	mode = push
-	parent = 0b6416dcd31c3f3696be9576d0add845857c4d0e
+	parent = 85780ee02ac6a675d1c94e8d5639a373a8c20b1b
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d18d029094aa0b05a458ca66cdd7363afa5842a9
+	commit = 598dfed1d860d3633f40414569bc4fab12647351
 	mode = push
-	parent = 257c0d4ff05026a7015c09d9e3724d82e35170c7
+	parent = 6436aeae5551315bb34f91d6a3606c467eb5be88
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5ffa46cc96157ed7683b3ef2ae37581a4cfbb47b
+	commit = 2f71d5c020a24711d53670c391008818d96418a0
 	mode = push
-	parent = 0f29a42ce37aa007fb6a613bf1fafc74dc910e0b
+	parent = 741b48f5622397051647dc9da3b27e27357fb897
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 400cea694785fa75ff6c3d088a3f065145631826
+	commit = 9ceec6cb8845d0865b7a9473a77133169f9e5ef2
 	mode = push
-	parent = 94e8551c5bc5444346416b654c4a959275d7fdf5
+	parent = 4ea56ea5f77e5b929deae3005c49d2a1aa6d9cd8
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4ce08c9bebd75b06597a89e71533e8a0d7932974
+	commit = 91639c0dbb627a663c2f4f5c3467b7b976f19bd7
 	mode = push
-	parent = daa8042093bef14d49cfdef1c376e0d4a40c2ed4
+	parent = 959c7e866c6f267f44daacf4e3fa51b021220486
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/foundation/contacts/.gitrepo
+++ b/modules/apps/foundation/contacts/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4957b25268a5b8baf950c54aa3bf5360e44ff7ef
+	commit = 28e3ab722bda202bdd34093fef9272ff1c1d36d8
 	mode = push
-	parent = 43b458a61c40949477d494fdb5de47ccc34d6893
+	parent = 76f2eb7dbc0cb5a3d50c597290972978de987ca2
 	remote = git@github.com:liferay/com-liferay-contacts.git

--- a/modules/apps/foundation/frontend-theme/frontend-theme-product-app/src/WEB-INF/liferay-plugin-package.properties
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-product-app/src/WEB-INF/liferay-plugin-package.properties
@@ -1,6 +1,7 @@
 author=Liferay, Inc.
 change-log=
 licenses=LGPL
+liferay-portal-profile-names=CE
 liferay-versions=7.0.1+
 long-description=
 module-group-id=liferay

--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 314f0d861fd274913b8266009377577cf9b381a8
+	commit = 7049f6b6660f624d4f219e646cde869f4561187d
 	mode = push
-	parent = 4bbc78d38562d26b596bc5a4e4ab3c80fa0ed324
+	parent = ee4b86a9e39b549d9b7e87d33e459854b296de13
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 004a82ba355127d190921927fe724b1cc0d4d179
+	commit = 52b57f037f1072b44b9451e513ae41778d49d671
 	mode = push
-	parent = b8a97c65291561ba34a05ae683dd68f4a2f728f8
+	parent = af7108de58cd2c5a2ca24707f923557c52caf964
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = bf98fccb9941c8d3cc65ac3236b0a76fad5cf562
+	commit = 99d958b97352836e525fe2fafbbe5c12dce63717
 	mode = push
-	parent = 8c0ff335ab862a99bdf800dcc94035aa4621ec44
+	parent = d9fe5bcd0dc04749acb642fe4cfc9ea47aa3949b
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 25c95af8c62c7d8d257e415885232ce24101b35d
+	commit = 2474aeed066d4556e60e0b27b6d5cf2620d51955
 	mode = push
-	parent = 8d55ce7fada6e2c6d2241c08b953223a59dc96df
+	parent = 5d59cf2335c3faa605183dc9c1c8385adfa12470
 	remote = git@github.com:liferay/com-liferay-site.git


### PR DESCRIPTION
Fixes the `LAR build number 7001 does not match portal build number 7010` error on `ee-7.0.x`

The problem is that DXP is trying to deploy `frontend-theme-product-app` when it is marked for `liferay-versions=7.0.1+`. It looks like we split the other themes into CE and DXP versions with different `liferay-versions`, seems like we should do that with product-app as well. 
