### PR TITLE
LPS-66359 Update Wiki macro to use Panel#expand macro for Configuration panel

### DIFF
--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 31de040ebe5311a693ac15d30729adaa4a38af4d
+	commit = 3b8db87e36111486de80cb23c75b025364eabe6d
 	mode = push
-	parent = 895706542465a1ab7423176c961325117dc8a228
+	parent = be313c235c4c50175b7c12a770ea186dc0f708f0
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/modified.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/modified.jsp
@@ -24,7 +24,7 @@ JSONObject dataJSONObject = searchFacet.getData();
 JSONArray rangesJSONArray = dataJSONObject.getJSONArray("ranges");
 %>
 
-<aui:fieldset id="rangesId">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "rangesId" %>'>
 
 	<%
 	int[] rangesIndexes = new int[rangesJSONArray.length()];

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/search.jsp
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/search.jsp
@@ -37,7 +37,7 @@ String format = ParamUtil.getString(request, SearchPortletParameterNames.FORMAT)
 	<aui:input name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" type="hidden" value="<%= ParamUtil.getInteger(request, SearchContainer.DEFAULT_CUR_PARAM, SearchContainer.DEFAULT_CUR) %>" />
 	<aui:input name="format" type="hidden" value="<%= format %>" />
 
-	<aui:fieldset id="searchContainer">
+	<aui:fieldset id='<%= renderResponse.getNamespace() + "searchContainer" %>'>
 		<aui:input autoFocus="<%= windowState.equals(WindowState.MAXIMIZED) %>" inlineField="<%= true %>" label="" name="keywords" size="30" title="search" value="<%= HtmlUtil.escape(searchDisplayContext.getKeywords()) %>" />
 		<aui:input name="scope" type="hidden" value="<%= searchDisplayContext.getSearchScopeParameterString() %>" />
 

--- a/modules/apps/foundation/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/ratings.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/ratings.jsp
@@ -28,7 +28,7 @@ CompanyPortletRatingsDefinitionDisplayContext companyPortletRatingsDefinitionDis
 
 <p><liferay-ui:message key="select-the-default-ratings-type-for-the-following-applications" /></p>
 
-<aui:fieldset id="ratingsSettingsContainer">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "ratingsSettingsContainer" %>'>
 
 	<%
 	Map<String, Map<String, RatingsType>> companyRatingsTypeMaps = companyPortletRatingsDefinitionDisplayContext.getCompanyRatingsTypeMaps();

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/additional_email_addresses.jsp
@@ -69,7 +69,7 @@ else {
 <liferay-ui:error exception="<%= EmailAddressException.class %>" message="please-enter-a-valid-email-address" />
 <liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + className + ListTypeConstants.EMAIL_ADDRESS %>" message="please-select-a-type" />
 
-<aui:fieldset id="additionalEmailAddresses">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "additionalEmailAddresses" %>'>
 
 	<%
 	for (int i = 0; i < emailAddressesIndexes.length; i++) {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -73,7 +73,7 @@ else {
 <liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + className + ListTypeConstants.ADDRESS %>" message="please-select-a-type" />
 <liferay-ui:error exception="<%= NoSuchRegionException.class %>" message="please-select-a-region" />
 
-<aui:fieldset cssClass="addresses" id="addresses">
+<aui:fieldset cssClass="addresses" id='<%= renderResponse.getNamespace() + "addresses" %>'>
 
 	<%
 	for (int i = 0; i < addressesIndexes.length; i++) {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/phone_numbers.jsp
@@ -70,7 +70,7 @@ else {
 <liferay-ui:error exception="<%= PhoneNumberException.class %>" message="please-enter-a-valid-phone-number" />
 <liferay-ui:error exception="<%= PhoneNumberExtensionException.class %>" message="please-enter-a-valid-phone-number-extension" />
 
-<aui:fieldset id="phoneNumbers">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "phoneNumbers" %>'>
 
 	<%
 	for (int i = 0; i < phonesIndexes.length; i++) {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/websites.jsp
@@ -69,7 +69,7 @@ else {
 <liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + className + ListTypeConstants.WEBSITE %>" message="please-select-a-type" />
 <liferay-ui:error exception="<%= WebsiteURLException.class %>" message="please-enter-a-valid-url" />
 
-<aui:fieldset id="websites">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "websites" %>'>
 
 	<%
 	for (int i = 0; i < websitesIndexes.length; i++) {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/services.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/services.jsp
@@ -101,7 +101,7 @@ Format timeFormat = FastDateFormatFactoryUtil.getSimpleDateFormat("HH:mm", local
 
 <liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + Organization.class.getName() + ListTypeConstants.ORGANIZATION_SERVICE %>" message="please-select-a-type" />
 
-<aui:fieldset id="services">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "services" %>'>
 
 	<%
 	Calendar cal = CalendarFactoryUtil.getCalendar();

--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -48,7 +48,7 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 
 					<aui:fieldset-group markupView="lexicon">
 						<div class="tab-pane">
-							<aui:fieldset id="portlet-config">
+							<aui:fieldset id='<%= renderResponse.getNamespace() + "portlet-config" %>'>
 								<aui:input name="use-custom-title" type="toggle-switch" />
 
 								<span class="field-row">
@@ -115,7 +115,7 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 								</span>
 							</aui:fieldset>
 
-							<aui:fieldset id="text-styles">
+							<aui:fieldset id='<%= renderResponse.getNamespace() + "text-styles" %>'>
 								<aui:row>
 									<aui:col width="<%= 33 %>">
 										<aui:select label="font" name="lfr-font-family" showEmptyOption="<%= true %>">
@@ -226,11 +226,11 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 								</aui:row>
 							</aui:fieldset>
 
-							<aui:fieldset id="background-styles">
+							<aui:fieldset id='<%= renderResponse.getNamespace() + "background-styles" %>'>
 								<aui:input label="background-color" name="lfr-bg-color" />
 							</aui:fieldset>
 
-							<aui:fieldset id="border-styles">
+							<aui:fieldset id='<%= renderResponse.getNamespace() + "border-styles" %>'>
 								<aui:row>
 									<aui:col cssClass="lfr-border-width use-for-all-column" width="<%= 33 %>">
 										<aui:fieldset label="border-width">
@@ -435,7 +435,7 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 								</aui:row>
 							</aui:fieldset>
 
-							<aui:fieldset id="css-styling">
+							<aui:fieldset id='<%= renderResponse.getNamespace() + "css-styling" %>'>
 								<aui:input label="enter-your-custom-css-class-names" name="lfr-custom-css-class-name" type="text" />
 
 								<aui:input cssClass="lfr-textarea-container" label="enter-your-custom-css" name="lfr-custom-css" type="textarea" />

--- a/modules/apps/web-experience/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/web-experience/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -40,7 +40,7 @@
 							</div>
 						</aui:fieldset>
 
-						<aui:fieldset id="checkBoxes">
+						<aui:fieldset id='<%= renderResponse.getNamespace() + "checkBoxes" %>'>
 							<aui:col width="<%= 50 %>">
 								<aui:input data-key='<%= "_" + HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) + "_showCurrentGroup" %>' label="show-current-site" name="preferences--showCurrentGroup--" type="toggle-switch" value="<%= siteNavigationBreadcrumbDisplayContext.isShowCurrentGroup() %>" />
 								<aui:input data-key='<%= "_" + HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) + "_showGuestGroup" %>' label="show-guest-site" name="preferences--showGuestGroup--" type="toggle-switch" value="<%= siteNavigationBreadcrumbDisplayContext.isShowGuestGroup() %>" />

--- a/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/site/display_settings.jsp
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/site/display_settings.jsp
@@ -56,7 +56,7 @@ if (publicLayoutSet.isLayoutSetPrototypeLinkEnabled() || privateLayoutSet.isLayo
 
 <aui:input checked="<%= !inheritLocales %>" disabled="<%= disabledLocaleInput %>" id="customLocales" label="define-a-custom-default-language-and-additional-available-languages-for-this-site" name="TypeSettingsProperties--inheritLocales--" type="radio" value="<%= false %>" />
 
-<aui:fieldset id="customLocalesFieldset">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "customLocalesFieldset" %>'>
 	<aui:fieldset cssClass="default-language">
 		<h4 class="text-muted"><liferay-ui:message key="default-language" /></h4>
 
@@ -90,7 +90,7 @@ if (publicLayoutSet.isLayoutSetPrototypeLinkEnabled() || privateLayoutSet.isLayo
 	</aui:fieldset>
 </aui:fieldset>
 
-<aui:fieldset id="inheritLocalesFieldset">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "inheritLocalesFieldset" %>'>
 	<liferay-ui:error exception="<%= LocaleException.class %>">
 
 		<%

--- a/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/site/ratings.jsp
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/site/ratings.jsp
@@ -39,7 +39,7 @@ CompanyPortletRatingsDefinitionDisplayContext companyPortletRatingsDefinitionDis
 
 <p class="text-muted"><liferay-ui:message key="select-the-ratings-type-for-the-following-applications" /></p>
 
-<aui:fieldset id="ratingsSettingsContainer">
+<aui:fieldset id='<%= renderResponse.getNamespace() + "ratingsSettingsContainer" %>'>
 
 	<%
 	Map<String, Map<String, RatingsType>> groupRatingsTypeMaps = groupPortletRatingsDefinitionDisplayContext.getGroupRatingsTypeMaps();

--- a/modules/apps/youtube/youtube-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/youtube/youtube-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -21,7 +21,7 @@
 <aui:form action="<%= configurationActionURL %>" method="post" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "saveConfiguration();" %>'>
 	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 
-	<aui:fieldset id="controls" label="video-properties">
+	<aui:fieldset id='<%= renderResponse.getNamespace() + "controls" %>' label="video-properties">
 		<aui:input label="video-id" name="preferences--url--" value="<%= url %>" />
 
 		<aui:select inlineField="<%= true %>" label="preset-frame-size" name="preferences--presetSize--" onChange='<%= renderResponse.getNamespace() + "updateFrameSize(this.value);" %>' value="<%= presetSize %>">

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/start.jsp
@@ -28,7 +28,7 @@ else if (collapsible) {
 }
 %>
 
-<fieldset aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel panel-default" : StringPool.BLANK %> <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + namespace + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
+<fieldset aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel panel-default" : StringPool.BLANK %> <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
 	<c:if test="<%= Validator.isNotNull(label) %>">
 		<liferay-util:buffer var="header">
 			<liferay-ui:message key="<%= label %>" localizeKey="<%= localizeLabel %>" />

--- a/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/start.jsp
@@ -16,7 +16,7 @@
 
 <%@ include file="/html/taglib/aui/fieldset/init.jsp" %>
 
-<fieldset class="fieldset <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + namespace + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
+<fieldset class="fieldset <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 	<c:if test="<%= Validator.isNotNull(label) %>">
 		<legend class="fieldset-legend">
 			<span class="legend">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiEntry.macro
@@ -51,7 +51,9 @@
 		<if>
 			<condition function="IsNotVisible" locator1="Wiki#ADD_PAGE_FORMAT_DROPDOWN" />
 			<then>
-				<execute function="AssertClick" locator1="Panel#ENTRY_CONFIGURATION" value1="Configuration" />
+				<execute macro="Panel#expandPanel">
+					<var name="panelHeading" value="Configuration" />
+				</execute>
 
 				<execute function="SelectNoError#pauseSelect" locator1="Wiki#ADD_PAGE_FORMAT_DROPDOWN" value1="${pageFormat}" />
 			</then>

--- a/util-taglib/src/com/liferay/taglib/aui/FieldsetTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/FieldsetTag.java
@@ -75,8 +75,10 @@ public class FieldsetTag extends BaseFieldsetTag {
 			getCollapsible()) {
 
 			setId(
-				PortalUtil.getUniqueElementId(
-					request, _getNamespace(), AUIUtil.normalizeId(getLabel())));
+				_getNamespace() +
+					PortalUtil.getUniqueElementId(
+						request, _getNamespace(),
+						AUIUtil.normalizeId(getLabel())));
 		}
 
 		super.setAttributes(request);


### PR DESCRIPTION
Hey @brianchandotcom 

I sent you an email with some reasons about why this pr is the way it is. In case you didn't see it, a quick summary follows:
- In others tags, the `id` attribute is never namespaced automatically.
- As a convenience, tags offer a `name` attribute that will be namespaced and used as an ID if none provided explicitly.
- This tag didn't provide a `name` attribute, and added the namespace to `id` instead.

This removes the inconsistent usage of the `id` attribute. It is still missing the `name` attribute; if you're ok with this fix, I will send another commit adding the attribute to the tag.

Thanks!

/cc @jbalsas @sharonchoi 
