### PR TITLE
LPS-67382 Compatibility plugin doesn't update if there is a previous version installed in release mode

### DIFF
--- a/modules/apps/screens/screens-service/bnd.bnd
+++ b/modules/apps/screens/screens-service/bnd.bnd
@@ -3,4 +3,5 @@ Bundle-SymbolicName: com.liferay.screens.service
 Bundle-Version: 1.0.8
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title:
+Liferay-Require-SchemaVersion: 1.0.8
 Liferay-Service: true

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f4a66689b73267dccca36bc8dde9f4706110f93b
+	commit = a82334f202c0cfd1e6ca79eea5a0fb5be3385ff9
 	mode = push
-	parent = 2e980627ab41fa2deec6a14dabb5e2cb3512aaa4
+	parent = 45556583c0dbf021e2e91f69d9d7386a16083349
 	remote = git@github.com:liferay/com-liferay-sync.git


### PR DESCRIPTION
As @csierra told us, there is a dev mode and a production mode in upgrades, controlled by the Liferay-Require-SchemaVersion property. The upgrade process control if the services have to be deployed or not.

We didn't have an upgrade so the services are not deploying if there is already a release entry in the corresponding table. We have to add an explicit schema version to force updating
