### PR TITLE
LPS-66906

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1262,10 +1262,6 @@ rerun your task.
 					<propertyref name="liferay.releng.supported" />
 					<propertyref name="microsoft.translator.client.id" />
 					<propertyref name="microsoft.translator.client.secret" />
-					<propertyref name="nodejs.npm.ci.registry" />
-					<propertyref name="nodejs.npm.email" />
-					<propertyref name="nodejs.npm.password" />
-					<propertyref name="nodejs.npm.user" />
 					<propertyref name="sass.compiler.class.name" />
 					<propertyref name="sass.generate.source.map" />
 					<propertyref name="sass.precision" />
@@ -1273,6 +1269,7 @@ rerun your task.
 					<propertyref name="source.formatter.processor.thread.count" />
 					<propertyref name="timeout.app.server.wait" />
 					<propertyref prefix="ivy.pom." />
+					<propertyref prefix="nodejs.npm." />
 					<propertyref prefix="sonatype." />
 					<propertyref regex="^\s*app\.server\.(?:glassfish|jboss|jetty|jonas|resin|tcat|tcserver|tomcat|weblogic|websphere|wildfly).*" />
 				</propertyset>

--- a/build-common.xml
+++ b/build-common.xml
@@ -1262,6 +1262,7 @@ rerun your task.
 					<propertyref name="liferay.releng.supported" />
 					<propertyref name="microsoft.translator.client.id" />
 					<propertyref name="microsoft.translator.client.secret" />
+					<propertyref name="nodejs.npm.ci.registry" />
 					<propertyref name="nodejs.npm.email" />
 					<propertyref name="nodejs.npm.password" />
 					<propertyref name="nodejs.npm.user" />

--- a/build.properties
+++ b/build.properties
@@ -186,6 +186,8 @@
     nodejs.npm.ci.registry=http://lrdcom-vm-110.lax.liferay.com:4873
     nodejs.npm.email=
     nodejs.npm.password=
+    nodejs.npm.registry=
+    nodejs.npm.remove.shrinkwrapped.urls=
     nodejs.npm.user=
 
 ##

--- a/build.properties
+++ b/build.properties
@@ -183,6 +183,7 @@
 ## NodeJS
 ##
 
+    nodejs.npm.ci.registry=http://lrdcom-vm-110.lax.liferay.com:4873
     nodejs.npm.email=
     nodejs.npm.password=
     nodejs.npm.user=

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -143,8 +143,12 @@ gradle.beforeProject {
 				}
 			}
 
-			tasks.withType(ExecuteNpmTask) {
-				registry = "http://lrdcom-vm-110.lax.liferay.com:4873"
+			String ciRegistry = project.properties["nodejs.npm.ci.registry"]
+
+			if (ciRegistry) {
+				tasks.withType(ExecuteNpmTask) {
+					registry = ciRegistry
+				}
 			}
 		}
 	}


### PR DESCRIPTION
@mdelapenya: you can add an empty line to your `build.*.properties` in CI to prevent using the NPM registry we have here:

``` properties
nodejs.npm.ci.registry=
```

@dantewang: you can now set the NPM properties for China in your `build.*.properties`, then run `ant setup-sdk` to have them applied (`ant all` already calls `ant setup-sdk`):

``` properties
nodejs.npm.registry=https://registry.npm.taobao.org/
nodejs.npm.remove.shrinkwrapped.urls=true
```
