### PR TITLE
LPS-67406 Exception thrown when deleted a global webcontent structure…

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -109,7 +109,12 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		List<KeyValuePair> subtypesLeftList = new ArrayList<KeyValuePair>();
 
 		for (long subtypeId : assetSelectedClassTypeIds) {
-			subtypesLeftList.add(new KeyValuePair(String.valueOf(subtypeId), HtmlUtil.escape(classTypeReader.getClassType(subtypeId, locale).getName())));
+			try {
+				ClassType classType = classTypeReader.getClassType(subtypeId, locale);
+				subtypesLeftList.add(new KeyValuePair(String.valueOf(subtypeId), HtmlUtil.escape(classType.getName())));
+			}
+			catch (NoSuchModelException nsme) {
+			}
 		}
 
 		Arrays.sort(assetSelectedClassTypeIds);


### PR DESCRIPTION
Fixed a code to add catch block around the code in order to successfully handle the exception scenario so that functionality works seamlessly without any exception.

Test Env : 
tomcat-8.0.32
MySQL 5.7
Chrome/FF/IE

Issue exist for Structure and Document Type. Added try/catch for NoSuchModelException in JSP.
