### PR TITLE
LPS-66483

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -1293,6 +1293,7 @@ rerun your task.
 				<entry key="database.jdbc.drivers.url" value="${test.jdbc.drivers.url}" />
 				<entry key="database.jdbc.oracle.driver" value="${jdbc.oracle.driver}" />
 				<entry key="database.oracle.version" value="${database.oracle.version}" />
+				<entry key="systemProp.build.bnd.print.enabled" value="${build.bnd.print.enabled}" />
 				<entry key="systemProp.build.performance.logger.enabled" value="${build.performance.logger.enabled}" />
 				<entry key="systemProp.repository.private.password" value="${build.repository.private.password}" />
 				<entry key="systemProp.repository.private.url" value="${build.repository.private.url}" />

--- a/build.properties
+++ b/build.properties
@@ -63,7 +63,7 @@
 ## Build
 ##
 
-    build.bnd.print.enabled=true
+    build.bnd.print.enabled=false
     build.marketplace.apps.enabled=true
     build.performance.logger.enabled=false
     build.repository.private.password=

--- a/build.properties
+++ b/build.properties
@@ -63,6 +63,7 @@
 ## Build
 ##
 
+    build.bnd.print.enabled=true
     build.marketplace.apps.enabled=true
     build.performance.logger.enabled=false
     build.repository.private.password=

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 Set<File> bndPrintJarFiles = null
 
-if (System.getenv("JENKINS_HOME")) {
+if (Boolean.getBoolean("build.bnd.print.enabled") && System.getenv("JENKINS_HOME")) {
 	configurations {
 		bnd
 	}


### PR DESCRIPTION
Hi!
Do we still need to show the output of `bnd print` in the CI log? It makes the logs **very** verbose :sweat_smile:
