### PR TITLE
master-LRQA-26525

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1359,7 +1359,7 @@
     test.skip.tear.down=false
     #test.url=http://localhost:8080
     timeout.app.server.wait=900
-    timeout.explicit.wait=60
+    timeout.explicit.wait=120
     #unzip.executable=
 
 ##


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-26525

This is a resend of https://github.com/brianchandotcom/liferay-portal/pull/42074. Updating the explicit timeout value to be 2 minutes to mitigate sporadic SPA related failures on the test-3 upstream jobs. 

cc-ing @brianchiu @jpince @michaelhashimoto @pyoo47
