### PR TITLE
LPS-66906 Update NPM registry mirror URL

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -188,7 +188,7 @@
     # Set the registry URL to use when invoking NPM via Gradle in a Jenkins
     # environment. Leave the property empty to use the default NPM registry.
     #
-    nodejs.npm.ci.registry=http://lrdcom-vm-110.lax.liferay.com:4873
+    nodejs.npm.ci.registry=http://mirrors.lax.liferay.com:4873
 
     #
     # Set the credentials to use when publishing NPM modules via Gradle.


### PR DESCRIPTION
cc @stsquared99

@lesliewong92: after this pull is merged, we should be ready to use the NPM mirror again, so I guess you can remove the nodes without cache from the blacklist.

Thank you!
