### PR TITLE
LRQA-27062 Add a 30 minute timeout to 'junitreport' to avoid stale jobs

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -4905,24 +4905,26 @@ go]]></replacevalue>
 	<target name="merge-test-results">
 		<mkdir dir="test-results" />
 
-		<junitreport todir="test-results">
-			<fileset dir="modules" erroronmissingdir="false">
-				<include name="**/TEST-*.xml" />
-			</fileset>
-			<fileset dir="portal-impl/test-results" erroronmissingdir="false">
-				<include name="**/TEST-*.xml" />
-			</fileset>
-			<fileset dir="portal-kernel/test-results" erroronmissingdir="false">
-				<include name="**/TEST-*.xml" />
-			</fileset>
-			<fileset dir="portal-web/test-results" erroronmissingdir="false">
-				<include name="**/TEST-*.xml" />
-			</fileset>
-			<fileset dir="util-java/test-results" erroronmissingdir="false">
-				<include name="**/TEST-*.xml" />
-			</fileset>
-			<report format="frames" todir="test-results/html" />
-		</junitreport>
+		<parallel timeout="1800000">
+			<junitreport todir="test-results">
+				<fileset dir="modules" erroronmissingdir="false">
+					<include name="**/TEST-*.xml" />
+				</fileset>
+				<fileset dir="portal-impl/test-results" erroronmissingdir="false">
+					<include name="**/TEST-*.xml" />
+				</fileset>
+				<fileset dir="portal-kernel/test-results" erroronmissingdir="false">
+					<include name="**/TEST-*.xml" />
+				</fileset>
+				<fileset dir="portal-web/test-results" erroronmissingdir="false">
+					<include name="**/TEST-*.xml" />
+				</fileset>
+				<fileset dir="util-java/test-results" erroronmissingdir="false">
+					<include name="**/TEST-*.xml" />
+				</fileset>
+				<report format="frames" todir="test-results/html" />
+			</junitreport>
+		</parallel>
 
 		<replaceregexp
 			file="test-results/TESTS-TestSuites.xml"

--- a/modules/apps/foundation/portal-background-task/.gitrepo
+++ b/modules/apps/foundation/portal-background-task/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = e74d9db5905cbc4ce98a4a29c1e11a6941e01e62
+	commit = 16fc186ab84ab003876cef4757ca2cff005ecaf6
 	mode = push
-	parent = 71c908aa517f9aa9b0d00d6ec5c6fb0a5fbe533a
+	parent = d50771e792fb25e51aec679a1ffaf55242b4cbd9
 	remote = git@github.com:liferay/com-liferay-portal-background-task.git


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-27062
