### PR TITLE
LPS-60487 Skip CacheFilter for /webdav/*

### DIFF
--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 22029220a9b1490d1399fad6464046370a93dcbb
+	commit = fa5713b1158139cee693b7a4e3b09c5b6062d1e9
 	mode = push
-	parent = 7d8f2a47cb59e8045fa950f46033c870aeed4fbf
+	parent = 7dc5bac4cd42d433e46bb34ebec62d8750648b82
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ca18ed25153ae53119b001185c7706f464d2cbdf
+	commit = c878291740d63369deba9c4642a168dd7acfb642
 	mode = push
-	parent = dd5ca27dcba36061740e2c92b1ab6a323922128b
+	parent = d37238b7d8996089ab8ca06779ebab3c7ce24a7f
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 89083d429f6422e8e50c5a7f10d972f13ab14bf4
+	commit = 4dfdcad2f09ef9f3545a3ac639ae80c6d5e351fe
 	mode = push
-	parent = 5a9f13473a32d8cf2cd9ec9acdc1909abb5ba083
+	parent = de5e894bb3e13722a04b2b6cce5abf8db1333938
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 45616739d29f505f8b77e65e2f5c8fdabd47f4d1
+	commit = fa5030bdcf361faf8e882f40b60b391d1183a272
 	mode = push
-	parent = c0b597fd544494ba73f7443eee256e9d75d755a3
+	parent = e0684390eae651f7a31c8f278907cf7aa2be7332
 	remote = git@github.com:liferay/com-liferay-dynamic-data-mapping.git

--- a/modules/apps/foundation/frontend-theme/.gitrepo
+++ b/modules/apps/foundation/frontend-theme/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 31da2a6b8c36e302dbc8d84c15e99f4ae5564110
+	commit = 426b5836cbf8cae89e191e5cf8ee6f84f81a1fa1
 	mode = push
-	parent = 7560731458f0193d38562f50e1f9bd87018ce403
+	parent = 4e2772be899a2bba513bf514facc4899899fd0a6
 	remote = git@github.com:liferay/com-liferay-frontend-theme.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 44cf42d13d4030e74830d23d2cd5e391dca123ca
+	commit = 7423b17787b2fffd94362b92f009c4456478b7ef
 	mode = push
-	parent = 629067e0c611ae5df699461a9249ff80d64a9950
+	parent = c61035b15b58f9631ba8d7090af1d47139ab0e58
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security-sso/.gitrepo
+++ b/modules/apps/foundation/portal-security-sso/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7aa31a8f340ad0233416e710889ee016c363e4eb
+	commit = a0987fd5b721f7743af2be18cbaa71f1fd86ebcb
 	mode = push
-	parent = 41cd4dc2e0a1455276937d61af9fcf201b18aaaa
+	parent = c7b49af1f229d22e954e9c6e062fce92914c43a9
 	remote = git@github.com:liferay/com-liferay-portal-security-sso.git

--- a/modules/apps/foundation/portal-template/.gitrepo
+++ b/modules/apps/foundation/portal-template/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5d2036db65f5ed6b9bbb151ccb2dd59baa5d5dcc
+	commit = bf695dd45253e0e92e6f70f3d80db429e35458b5
 	mode = push
-	parent = bbfc8bfc29633ff745846083d3028bd3e2108f09
+	parent = 0ed3d3f4c7d0a3e982c35ad1a2e4d7761a88cfee
 	remote = git@github.com:liferay/com-liferay-portal-template.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b37ee196b810bee45ad61cfe590f0f726f9bad28
+	commit = 52b26c86767293c5dabd20c60d5a6eb284dfab1d
 	mode = push
-	parent = f8dd85be2d57f2bc6aa93e525799f777c6587642
+	parent = 401072128b16608d9e5f80762ce85fc9a05c232f
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 24fbf04dba8f1b63ed69931a1d632ddfb00e7460
+	commit = 0a0fb048946975c0f5836fa4867f5f0fc89652b8
 	mode = push
-	parent = 7f8d008328195424b64b86ae8c39e18e82b419d7
+	parent = 65332fdaf68eca919efcf1653c8bc1c9d339e05f
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 17b320b3f1eee29e79c0dd356a27a493c5bad803
+	commit = b5f444d16e800a890b69a65f70ad6f87ad342627
 	mode = push
-	parent = d83f1796860e66ecac8674711a46f806d3ff25c2
+	parent = 8fd592169388d42dd100541e2404dbd385682c39
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9342612741a429809baec78405b882cad2a1bbc5
+	commit = b50e971562e2ea28393bc087372c340690e4cf70
 	mode = push
-	parent = af2ab88b3756cd9fd3bd2d90924e6f3e552e8dde
+	parent = b0c8fafb81e9326abda8bc326e2eae30d9d804df
 	remote = git@github.com:liferay/com-liferay-journal.git

--- a/modules/apps/web-experience/site-navigation/.gitrepo
+++ b/modules/apps/web-experience/site-navigation/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = c99628d456271d4eed5d3a836beb4d952410ac4f
+	commit = 29036399a3cbf68ac7cf9f6c23389d0bfe56dc53
 	mode = push
-	parent = 421b57427554b1e3a7b1c12f476e2938d854fb48
+	parent = 8969e46784f8b1fc6853916f45e2c964eef4435e
 	remote = git@github.com:liferay/com-liferay-site-navigation.git

--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -66,7 +66,7 @@
 		<filter-class>com.liferay.portal.servlet.filters.cache.CacheFilter</filter-class>
 		<init-param>
 			<param-name>url-regex-ignore-pattern</param-name>
-			<param-value>.+/-/.+</param-value>
+			<param-value>(/webdav/.*|.+/-/.+)</param-value>
 		</init-param>
 		<init-param>
 			<param-name>pattern</param-name>


### PR DESCRIPTION
Hi Brian,

We made this change beacuse all /webdav/\* requests (not just /webdav/_.js and /webdav/_.css) are always dynamic and should never be cached.

cc @ChrisKian @holatuwol  @shuyangzhou

Thanks.
Tina.
