### PR TITLE
LPS-67209 GroupLocalServiceUtil.addRoleGroup calls do not clear permission cache

### DIFF
--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d0a862b8187cb10587482a88145a7e5aac2cb045
+	commit = fb926f03d771b593c28a03077eba13b9088d712c
 	mode = push
-	parent = 5e87992b74b3ea4b3ec4aa8fbc5ab6285887ff0b
+	parent = 56746a7abc3c04a663ab06059cd6dd9ba2fd9272
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Bnd-LastModified: 1468904359940
+Bnd-LastModified: 1470905705125
 Bundle-ManifestVersion: 2
 Bundle-Name: system.packages.extra
 Bundle-SymbolicName: system.packages.extra
@@ -2830,7 +2830,7 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  el.util",com.liferay.portal.kernel.security.pacl;version="6.2.0",com.
  liferay.portal.kernel.security.pacl.permission;version="7.0.0";uses:=
  "com.liferay.portal.kernel.util",com.liferay.portal.kernel.security.p
- ermission;version="1.1.0";uses:="com.liferay.portal.kernel.exception,
+ ermission;version="1.2.0";uses:="com.liferay.portal.kernel.exception,
  com.liferay.portal.kernel.model,javax.portlet,javax.servlet.http",com
  .liferay.portal.kernel.security.permission.comparator;version="1.0.0"
  ,com.liferay.portal.kernel.security.pwd;version="1.0.0";uses:="com.li

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -9,6 +9,11 @@
 >
 	<bean class="com.liferay.portal.security.permission.ResourceBlockModelListener" id="com.liferay.portal.kernel.model.ResourceBlock" />
 	<bean class="com.liferay.portal.security.permission.ResourcePermissionModelListener" id="com.liferay.portal.kernel.model.ResourcePermission" />
+	<bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.kernel.model.Group" />
+	<bean class="com.liferay.portal.security.permission.TeamModelListener" id="com.liferay.portal.kernel.model.Team" />
+	<bean class="com.liferay.portal.security.permission.UserModelListener" id="com.liferay.portal.kernel.model.Role" />
+	<bean class="com.liferay.portal.security.permission.UserGroupGroupRoleModelListener" id="com.liferay.portal.kernel.model.UserGroupGroupRole" />
+	<bean class="com.liferay.portal.security.permission.UserGroupRoleModelListener" id="com.liferay.portal.kernel.model.UserGroupRole" />
 	<bean class="com.liferay.portal.model.LayoutModelListener" id="com.liferay.portal.model.LayoutModelListener" />
 	<bean class="com.liferay.portal.model.LayoutSetModelListener" id="com.liferay.portal.model.LayoutSetModelListener" />
 	<bean class="com.liferay.portal.model.PortletPreferencesModelListener" id="com.liferay.portal.model.PortletPreferencesModelListener" />

--- a/portal-impl/src/com/liferay/portal/security/permission/GroupModelListener.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/GroupModelListener.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+
+/**
+ * @author Preston Crary
+ */
+public class GroupModelListener extends BaseModelListener<Group> {
+
+	@Override
+	public void onAfterAddAssociation(
+		Object classPK, String associationClassName,
+		Object associationClassPK) {
+
+		if (!associationClassName.equals(User.class.getName())) {
+			PermissionCacheUtil.clearCache();
+		}
+	}
+
+	@Override
+	public void onAfterRemove(Group group) {
+		PermissionCacheUtil.clearCache();
+	}
+
+	@Override
+	public void onAfterRemoveAssociation(
+		Object classPK, String associationClassName,
+		Object associationClassPK) {
+
+		if (!associationClassName.equals(User.class.getName())) {
+			PermissionCacheUtil.clearCache();
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/security/permission/TeamModelListener.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/TeamModelListener.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Team;
+import com.liferay.portal.kernel.model.User;
+
+/**
+ * @author Preston Crary
+ */
+public class TeamModelListener extends BaseModelListener<Team> {
+
+	@Override
+	public void onAfterAddAssociation(
+		Object classPK, String associationClassName,
+		Object associationClassPK) {
+
+		if (!associationClassName.equals(User.class.getName())) {
+			PermissionCacheUtil.clearCache();
+		}
+	}
+
+	@Override
+	public void onAfterRemove(Team group) {
+		PermissionCacheUtil.clearCache();
+	}
+
+	@Override
+	public void onAfterRemoveAssociation(
+		Object classPK, String associationClassName,
+		Object associationClassPK) {
+
+		if (!associationClassName.equals(User.class.getName())) {
+			PermissionCacheUtil.clearCache();
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
@@ -18,11 +18,13 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.security.permission.UserBagFactory;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PropsValues;
 
@@ -58,19 +60,27 @@ public class UserBagFactoryImpl implements UserBagFactory {
 				userOrgGroups.add(organization.getGroup());
 			}
 
+			List<UserGroup> userUserGroups =
+				UserGroupLocalServiceUtil.getUserUserGroups(userId);
+
+			List<Group> userUserGroupGroups =
+				GroupLocalServiceUtil.getUserGroupsGroups(userUserGroups);
+
 			if (userGroups.isEmpty()) {
 				long[] userRoleIds = UserLocalServiceUtil.getRolePrimaryKeys(
 					userId);
 
 				userBag = new UserBagImpl(
-					userId, userGroups, userOrgs, userOrgGroups, userRoleIds);
+					userId, userGroups, userOrgs, userOrgGroups,
+					userUserGroupGroups, userRoleIds);
 			}
 			else {
 				List<Role> userRoles = RoleLocalServiceUtil.getUserRelatedRoles(
 					userId, userGroups);
 
 				userBag = new UserBagImpl(
-					userId, userGroups, userOrgs, userOrgGroups, userRoles);
+					userId, userGroups, userOrgs, userOrgGroups,
+					userUserGroupGroups, userRoles);
 			}
 
 			PermissionCacheUtil.putUserBag(userId, userBag);

--- a/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserBagFactoryImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.util.PropsValues;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -66,7 +67,13 @@ public class UserBagFactoryImpl implements UserBagFactory {
 			List<Group> userUserGroupGroups =
 				GroupLocalServiceUtil.getUserGroupsGroups(userUserGroups);
 
-			if (userGroups.isEmpty()) {
+			List<Group> allUserGroups = new ArrayList<>();
+
+			allUserGroups.addAll(userGroups);
+			allUserGroups.addAll(userOrgGroups);
+			allUserGroups.addAll(userUserGroupGroups);
+
+			if (allUserGroups.isEmpty()) {
 				long[] userRoleIds = UserLocalServiceUtil.getRolePrimaryKeys(
 					userId);
 
@@ -76,7 +83,7 @@ public class UserBagFactoryImpl implements UserBagFactory {
 			}
 			else {
 				List<Role> userRoles = RoleLocalServiceUtil.getUserRelatedRoles(
-					userId, userGroups);
+					userId, allUserGroups);
 
 				userBag = new UserBagImpl(
 					userId, userGroups, userOrgs, userOrgGroups,

--- a/portal-impl/src/com/liferay/portal/security/permission/UserBagImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserBagImpl.java
@@ -39,24 +39,26 @@ public class UserBagImpl implements UserBag {
 	public UserBagImpl(
 		long userId, Collection<Group> userGroups,
 		Collection<Organization> userOrgs, Collection<Group> userOrgGroups,
-		Collection<Role> userRoles) {
+		Collection<Group> userUserGroupGroups, Collection<Role> userRoles) {
 
 		_userId = userId;
 		_userGroupIds = _toSortedLongArray(userGroups);
 		_userOrgIds = _toSortedLongArray(userOrgs);
 		_userOrgGroupIds = _toSortedLongArray(userOrgGroups);
 		_userRoleIds = _toSortedLongArray(userRoles);
+		_userUserGroupGroupsIds = _toSortedLongArray(userUserGroupGroups);
 	}
 
 	public UserBagImpl(
 		long userId, Collection<Group> userGroups,
 		Collection<Organization> userOrgs, Collection<Group> userOrgGroups,
-		long[] userRoleIds) {
+		Collection<Group> userUserGroupGroups, long[] userRoleIds) {
 
 		_userId = userId;
 		_userGroupIds = _toSortedLongArray(userGroups);
 		_userOrgIds = _toSortedLongArray(userOrgs);
 		_userOrgGroupIds = _toSortedLongArray(userOrgGroups);
+		_userUserGroupGroupsIds = _toSortedLongArray(userUserGroupGroups);
 
 		Arrays.sort(userRoleIds);
 
@@ -68,6 +70,7 @@ public class UserBagImpl implements UserBag {
 		Set<Group> groups = new HashSet<>(getUserGroups());
 
 		groups.addAll(getUserOrgGroups());
+		groups.addAll(getUserUserGroupGroups());
 
 		return groups;
 	}
@@ -115,6 +118,11 @@ public class UserBagImpl implements UserBag {
 	@Override
 	public List<Organization> getUserOrgs() throws PortalException {
 		return OrganizationLocalServiceUtil.getOrganizations(_userOrgIds);
+	}
+
+	@Override
+	public List<Group> getUserUserGroupGroups() throws PortalException {
+		return GroupLocalServiceUtil.getGroups(_userUserGroupGroupsIds);
 	}
 
 	@Override
@@ -170,5 +178,6 @@ public class UserBagImpl implements UserBag {
 	private final long[] _userOrgGroupIds;
 	private final long[] _userOrgIds;
 	private final long[] _userRoleIds;
+	private final long[] _userUserGroupGroupsIds;
 
 }

--- a/portal-impl/src/com/liferay/portal/security/permission/UserGroupGroupRoleModelListener.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserGroupGroupRoleModelListener.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.UserGroupGroupRole;
+
+/**
+ * @author Preston Crary
+ */
+public class UserGroupGroupRoleModelListener
+	extends BaseModelListener<UserGroupGroupRole> {
+
+	@Override
+	public void onAfterCreate(UserGroupGroupRole userGroupGroupRole) {
+		PermissionCacheUtil.clearCache();
+	}
+
+	@Override
+	public void onAfterRemove(UserGroupGroupRole userGroupGroupRole) {
+		PermissionCacheUtil.clearCache();
+	}
+
+	@Override
+	public void onAfterUpdate(UserGroupGroupRole userGroupGroupRole) {
+		PermissionCacheUtil.clearCache();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/security/permission/UserGroupRoleModelListener.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserGroupRoleModelListener.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.UserGroupRole;
+import com.liferay.portal.model.impl.UserGroupRoleModelImpl;
+
+/**
+ * @author Preston Crary
+ */
+public class UserGroupRoleModelListener
+	extends BaseModelListener<UserGroupRole> {
+
+	@Override
+	public void onAfterCreate(UserGroupRole userGroupRole) {
+		_clearCache(userGroupRole);
+	}
+
+	@Override
+	public void onAfterRemove(UserGroupRole userGroupRole) {
+		_clearCache(userGroupRole);
+	}
+
+	@Override
+	public void onAfterUpdate(UserGroupRole userGroupRole) {
+		_clearCache(userGroupRole);
+	}
+
+	@Override
+	public void onBeforeUpdate(UserGroupRole userGroupRole) {
+		UserGroupRoleModelImpl userGroupRoleModelImpl =
+			(UserGroupRoleModelImpl)userGroupRole;
+
+		long originalUserId = userGroupRoleModelImpl.getOriginalUserId();
+
+		if (originalUserId != userGroupRoleModelImpl.getUserId()) {
+			PermissionCacheUtil.clearCache(originalUserId);
+		}
+	}
+
+	private void _clearCache(UserGroupRole userGroupRole) {
+		if (userGroupRole != null) {
+			PermissionCacheUtil.clearCache(userGroupRole.getUserId());
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/security/permission/UserModelListener.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/UserModelListener.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.User;
+
+/**
+ * @author Preston Crary
+ */
+public class UserModelListener extends BaseModelListener<User> {
+
+	@Override
+	public void onAfterAddAssociation(
+		Object classPK, String associationClassName,
+		Object associationClassPK) {
+
+		PermissionCacheUtil.clearCache((long)classPK);
+	}
+
+	@Override
+	public void onAfterRemove(User user) {
+		if (user != null) {
+			PermissionCacheUtil.clearCache(user.getUserId());
+		}
+	}
+
+	@Override
+	public void onAfterRemoveAssociation(
+		Object classPK, String associationClassName,
+		Object associationClassPK) {
+
+		PermissionCacheUtil.clearCache((long)classPK);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -471,28 +471,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	}
 
 	/**
-	 * Adds the groups to the role.
-	 *
-	 * @param roleId the primary key of the role
-	 * @param groupIds the primary keys of the groups
-	 */
-	@Override
-	public void addRoleGroups(long roleId, long[] groupIds) {
-		rolePersistence.addGroups(roleId, groupIds);
-	}
-
-	/**
-	 * Adds the user to the groups.
-	 *
-	 * @param userId the primary key of the user
-	 * @param groupIds the primary keys of the groups
-	 */
-	@Override
-	public void addUserGroups(long userId, long[] groupIds) {
-		userPersistence.addGroups(userId, groupIds);
-	}
-
-	/**
 	 * Adds a company group if it does not exist. This method is typically used
 	 * when a virtual host is added.
 	 *
@@ -3006,18 +2984,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		return searchCount(
 			companyId, getClassNameIds(), GroupConstants.ANY_PARENT_GROUP_ID,
 			name, description, params, andOperator);
-	}
-
-	/**
-	 * Sets the groups associated with the role, removing and adding
-	 * associations as necessary.
-	 *
-	 * @param roleId the primary key of the role
-	 * @param groupIds the primary keys of the groups
-	 */
-	@Override
-	public void setRoleGroups(long roleId, long[] groupIds) {
-		rolePersistence.setGroups(roleId, groupIds);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -104,7 +104,6 @@ import com.liferay.portal.kernel.util.comparator.GroupNameComparator;
 import com.liferay.portal.kernel.workflow.WorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.model.impl.LayoutImpl;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.GroupLocalServiceBaseImpl;
 import com.liferay.portal.theme.ThemeLoader;
 import com.liferay.portal.theme.ThemeLoaderFactory;
@@ -480,8 +479,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	@Override
 	public void addRoleGroups(long roleId, long[] groupIds) {
 		rolePersistence.addGroups(roleId, groupIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -493,8 +490,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	@Override
 	public void addUserGroups(long userId, long[] groupIds) {
 		userPersistence.addGroups(userId, groupIds);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -893,10 +888,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 				groupPersistence.remove(group);
 			}
-
-			// Permission cache
-
-			PermissionCacheUtil.clearCache();
 
 			return group;
 		}
@@ -3027,8 +3018,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	@Override
 	public void setRoleGroups(long roleId, long[] groupIds) {
 		rolePersistence.setGroups(roleId, groupIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -3040,8 +3029,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	@Override
 	public void unsetRoleGroups(long roleId, long[] groupIds) {
 		rolePersistence.removeGroups(roleId, groupIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -3055,8 +3042,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 		userGroupRoleLocalService.deleteUserGroupRoles(userId, groupIds);
 
 		userPersistence.removeGroups(userId, groupIds);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutPrototypeLocalServiceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.LayoutPrototypeLocalServiceBaseImpl;
 
 import java.util.Date;
@@ -163,10 +162,6 @@ public class LayoutPrototypeLocalServiceImpl
 		// Layout Prototype
 
 		layoutPrototypePersistence.remove(layoutPrototype);
-
-		// Permission cache
-
-		PermissionCacheUtil.clearCache();
 
 		return layoutPrototype;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.LayoutSetPrototypeLocalServiceBaseImpl;
 
 import java.util.Date;
@@ -167,10 +166,6 @@ public class LayoutSetPrototypeLocalServiceImpl
 		// Layout set prototype
 
 		layoutSetPrototypePersistence.remove(layoutSetPrototype);
-
-		// Permission cache
-
-		PermissionCacheUtil.clearCache();
 
 		return layoutSetPrototype;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -65,7 +65,6 @@ import com.liferay.portal.kernel.util.comparator.OrganizationIdComparator;
 import com.liferay.portal.kernel.util.comparator.OrganizationNameComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.impl.OrganizationImpl;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.OrganizationLocalServiceBaseImpl;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsUtil;
@@ -107,8 +106,6 @@ public class OrganizationLocalServiceImpl
 	@Override
 	public void addGroupOrganizations(long groupId, long[] organizationIds) {
 		groupPersistence.addOrganizations(groupId, organizationIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -415,10 +412,6 @@ public class OrganizationLocalServiceImpl
 		// Organization
 
 		organizationPersistence.remove(organization);
-
-		// Permission cache
-
-		PermissionCacheUtil.clearCache();
 
 		return organization;
 	}
@@ -1563,8 +1556,6 @@ public class OrganizationLocalServiceImpl
 	@Override
 	public void setGroupOrganizations(long groupId, long[] organizationIds) {
 		groupPersistence.setOrganizations(groupId, organizationIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -1576,8 +1567,6 @@ public class OrganizationLocalServiceImpl
 	@Override
 	public void unsetGroupOrganizations(long groupId, long[] organizationIds) {
 		groupPersistence.removeOrganizations(groupId, organizationIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -98,17 +98,6 @@ public class OrganizationLocalServiceImpl
 	extends OrganizationLocalServiceBaseImpl {
 
 	/**
-	 * Adds the organizations to the group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param organizationIds the primary keys of the organizations
-	 */
-	@Override
-	public void addGroupOrganizations(long groupId, long[] organizationIds) {
-		groupPersistence.addOrganizations(groupId, organizationIds);
-	}
-
-	/**
 	 * Adds an organization.
 	 *
 	 * <p>
@@ -1544,18 +1533,6 @@ public class OrganizationLocalServiceImpl
 
 		throw new SearchException(
 			"Unable to fix the search index after 10 attempts");
-	}
-
-	/**
-	 * Sets the organizations in the group, removing and adding organizations to
-	 * the group as necessary.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param organizationIds the primary keys of the organizations
-	 */
-	@Override
-	public void setGroupOrganizations(long groupId, long[] organizationIds) {
-		groupPersistence.setOrganizations(groupId, organizationIds);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java
@@ -958,8 +958,6 @@ public class ResourcePermissionLocalServiceImpl
 		}
 
 		roleLocalService.deleteRole(fromRoleId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -1008,8 +1006,6 @@ public class ResourcePermissionLocalServiceImpl
 		if (resourcePermissions.isEmpty()) {
 			roleLocalService.deleteRole(fromRoleId);
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -189,8 +189,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.addRole(userId, roleId);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -206,8 +204,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.addRole(userId, role);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -226,8 +222,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.addRoles(userId, roles);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -246,8 +240,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.addRoles(userId, roleIds);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -394,8 +386,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.clearRoles(userId);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -484,10 +474,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 
 		expandoRowLocalService.deleteRows(role.getRoleId());
 
-		// Permission cache
-
-		PermissionCacheUtil.clearCache();
-
 		return role;
 	}
 
@@ -507,8 +493,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.removeRole(userId, roleId);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -525,8 +509,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.removeRole(userId, role);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -545,8 +527,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.removeRoles(userId, roles);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -565,8 +545,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.removeRoles(userId, roleIds);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -1388,8 +1366,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.setRoles(userId, roleIds);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -1408,8 +1384,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.removeRoles(userId, roleIds);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.TeamLocalServiceBaseImpl;
 
 import java.util.LinkedHashMap;
@@ -96,71 +95,51 @@ public class TeamLocalServiceImpl extends TeamLocalServiceBaseImpl {
 	@Override
 	public void addUserGroupTeam(long userGroupId, long teamId) {
 		super.addUserGroupTeam(userGroupId, teamId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void addUserGroupTeam(long userGroupId, Team team) {
 		super.addUserGroupTeam(userGroupId, team);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void addUserGroupTeams(long userGroupId, List<Team> teams) {
 		super.addUserGroupTeams(userGroupId, teams);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void addUserGroupTeams(long userGroupId, long[] teamIds) {
 		super.addUserGroupTeams(userGroupId, teamIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void addUserTeam(long userId, long teamId) {
 		super.addUserTeam(userId, teamId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
 	public void addUserTeam(long userId, Team team) {
 		super.addUserTeam(userId, team);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
 	public void addUserTeams(long userId, List<Team> teams) {
 		super.addUserTeams(userId, teams);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
 	public void addUserTeams(long userId, long[] teamIds) {
 		super.addUserTeams(userId, teamIds);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
 	public void clearUserGroupTeams(long userGroupId) {
 		super.clearUserGroupTeams(userGroupId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void clearUserTeams(long userId) {
 		super.clearUserTeams(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
@@ -204,57 +183,41 @@ public class TeamLocalServiceImpl extends TeamLocalServiceBaseImpl {
 	@Override
 	public void deleteUserGroupTeam(long userGroupId, long teamId) {
 		super.deleteUserGroupTeam(userGroupId, teamId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupTeam(long userGroupId, Team team) {
 		super.deleteUserGroupTeam(userGroupId, team);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupTeams(long userGroupId, List<Team> teams) {
 		super.deleteUserGroupTeams(userGroupId, teams);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupTeams(long userGroupId, long[] teamIds) {
 		super.deleteUserGroupTeams(userGroupId, teamIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserTeam(long userId, long teamId) {
 		super.deleteUserTeam(userId, teamId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
 	public void deleteUserTeam(long userId, Team team) {
 		super.deleteUserTeam(userId, team);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
 	public void deleteUserTeams(long userId, List<Team> teams) {
 		super.deleteUserTeams(userId, teams);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
 	public void deleteUserTeams(long userId, long[] teamIds) {
 		super.deleteUserTeams(userId, teamIds);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/TeamLocalServiceImpl.java
@@ -93,56 +93,6 @@ public class TeamLocalServiceImpl extends TeamLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void addUserGroupTeam(long userGroupId, long teamId) {
-		super.addUserGroupTeam(userGroupId, teamId);
-	}
-
-	@Override
-	public void addUserGroupTeam(long userGroupId, Team team) {
-		super.addUserGroupTeam(userGroupId, team);
-	}
-
-	@Override
-	public void addUserGroupTeams(long userGroupId, List<Team> teams) {
-		super.addUserGroupTeams(userGroupId, teams);
-	}
-
-	@Override
-	public void addUserGroupTeams(long userGroupId, long[] teamIds) {
-		super.addUserGroupTeams(userGroupId, teamIds);
-	}
-
-	@Override
-	public void addUserTeam(long userId, long teamId) {
-		super.addUserTeam(userId, teamId);
-	}
-
-	@Override
-	public void addUserTeam(long userId, Team team) {
-		super.addUserTeam(userId, team);
-	}
-
-	@Override
-	public void addUserTeams(long userId, List<Team> teams) {
-		super.addUserTeams(userId, teams);
-	}
-
-	@Override
-	public void addUserTeams(long userId, long[] teamIds) {
-		super.addUserTeams(userId, teamIds);
-	}
-
-	@Override
-	public void clearUserGroupTeams(long userGroupId) {
-		super.clearUserGroupTeams(userGroupId);
-	}
-
-	@Override
-	public void clearUserTeams(long userId) {
-		super.clearUserTeams(userId);
-	}
-
-	@Override
 	public Team deleteTeam(long teamId) throws PortalException {
 		Team team = teamPersistence.findByPrimaryKey(teamId);
 
@@ -178,46 +128,6 @@ public class TeamLocalServiceImpl extends TeamLocalServiceBaseImpl {
 		for (Team team : teams) {
 			deleteTeam(team.getTeamId());
 		}
-	}
-
-	@Override
-	public void deleteUserGroupTeam(long userGroupId, long teamId) {
-		super.deleteUserGroupTeam(userGroupId, teamId);
-	}
-
-	@Override
-	public void deleteUserGroupTeam(long userGroupId, Team team) {
-		super.deleteUserGroupTeam(userGroupId, team);
-	}
-
-	@Override
-	public void deleteUserGroupTeams(long userGroupId, List<Team> teams) {
-		super.deleteUserGroupTeams(userGroupId, teams);
-	}
-
-	@Override
-	public void deleteUserGroupTeams(long userGroupId, long[] teamIds) {
-		super.deleteUserGroupTeams(userGroupId, teamIds);
-	}
-
-	@Override
-	public void deleteUserTeam(long userId, long teamId) {
-		super.deleteUserTeam(userId, teamId);
-	}
-
-	@Override
-	public void deleteUserTeam(long userId, Team team) {
-		super.deleteUserTeam(userId, team);
-	}
-
-	@Override
-	public void deleteUserTeams(long userId, List<Team> teams) {
-		super.deleteUserTeams(userId, teams);
-	}
-
-	@Override
-	public void deleteUserTeams(long userId, long[] teamIds) {
-		super.deleteUserTeams(userId, teamIds);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupGroupRoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupGroupRoleLocalServiceImpl.java
@@ -69,15 +69,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 	}
 
 	@Override
-	public UserGroupGroupRole deleteUserGroupGroupRole(
-		UserGroupGroupRole userGroupGroupRole) {
-
-		userGroupGroupRolePersistence.remove(userGroupGroupRole);
-
-		return userGroupGroupRole;
-	}
-
-	@Override
 	public void deleteUserGroupGroupRoles(long groupId, int roleType) {
 		List<UserGroupGroupRole> userGroupGroupRoles =
 			userGroupGroupRoleFinder.findByGroupRoleType(groupId, roleType);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupGroupRoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupGroupRoleLocalServiceImpl.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.UserGroupGroupRole;
 import com.liferay.portal.kernel.service.persistence.UserGroupGroupRolePK;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.UserGroupGroupRoleLocalServiceBaseImpl;
 
 import java.util.List;
@@ -48,8 +47,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 				userGroupGroupRolePersistence.update(userGroupGroupRole);
 			}
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
@@ -69,8 +66,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 				userGroupGroupRolePersistence.update(userGroupGroupRole);
 			}
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
@@ -78,8 +73,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 		UserGroupGroupRole userGroupGroupRole) {
 
 		userGroupGroupRolePersistence.remove(userGroupGroupRole);
-
-		PermissionCacheUtil.clearCache();
 
 		return userGroupGroupRole;
 	}
@@ -93,8 +86,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 			userGroupGroupRolePersistence.removeByG_R(
 				groupId, userGroupGroupRole.getRoleId());
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
@@ -111,8 +102,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 			catch (NoSuchUserGroupGroupRoleException nsuggre) {
 			}
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
@@ -120,8 +109,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 		for (long groupId : groupIds) {
 			userGroupGroupRolePersistence.removeByU_G(userGroupId, groupId);
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
@@ -129,8 +116,6 @@ public class UserGroupGroupRoleLocalServiceImpl
 		for (long userGroupId : userGroupIds) {
 			userGroupGroupRolePersistence.removeByU_G(userGroupId, groupId);
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
@@ -147,29 +132,21 @@ public class UserGroupGroupRoleLocalServiceImpl
 			catch (NoSuchUserGroupGroupRoleException nsuggre) {
 			}
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupGroupRolesByGroupId(long groupId) {
 		userGroupGroupRolePersistence.removeByGroupId(groupId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupGroupRolesByRoleId(long roleId) {
 		userGroupGroupRolePersistence.removeByRoleId(roleId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupGroupRolesByUserGroupId(long userGroupId) {
 		userGroupGroupRolePersistence.removeByUserGroupId(userGroupId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -57,7 +57,6 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.UserGroupLocalServiceBaseImpl;
 import com.liferay.portal.service.persistence.constants.UserGroupFinderConstants;
 import com.liferay.portal.util.PropsValues;
@@ -91,8 +90,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	@Override
 	public void addGroupUserGroups(long groupId, long[] userGroupIds) {
 		groupPersistence.addUserGroups(groupId, userGroupIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -104,8 +101,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	@Override
 	public void addTeamUserGroups(long teamId, long[] userGroupIds) {
 		teamPersistence.addUserGroups(teamId, userGroupIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -222,8 +217,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	@Override
 	public void clearUserUserGroups(long userId) {
 		userPersistence.clearUserGroups(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -371,10 +364,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		// User group
 
 		userGroupPersistence.remove(userGroup);
-
-		// Permission cache
-
-		PermissionCacheUtil.clearCache();
 
 		return userGroup;
 	}
@@ -867,8 +856,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		User user = userLocalService.fetchUser(userId);
 
 		indexer.reindex(user);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -889,8 +876,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 			userGroupIds, groupId);
 
 		groupPersistence.removeUserGroups(groupId, userGroupIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -902,8 +887,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 	@Override
 	public void unsetTeamUserGroups(long teamId, long[] userGroupIds) {
 		teamPersistence.removeUserGroups(teamId, userGroupIds);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupLocalServiceImpl.java
@@ -82,28 +82,6 @@ import java.util.Set;
 public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 
 	/**
-	 * Adds the user groups to the group.
-	 *
-	 * @param groupId the primary key of the group
-	 * @param userGroupIds the primary keys of the user groups
-	 */
-	@Override
-	public void addGroupUserGroups(long groupId, long[] userGroupIds) {
-		groupPersistence.addUserGroups(groupId, userGroupIds);
-	}
-
-	/**
-	 * Adds the user groups to the team.
-	 *
-	 * @param teamId the primary key of the team
-	 * @param userGroupIds the primary keys of the user groups
-	 */
-	@Override
-	public void addTeamUserGroups(long teamId, long[] userGroupIds) {
-		teamPersistence.addUserGroups(teamId, userGroupIds);
-	}
-
-	/**
 	 * Adds a user group.
 	 *
 	 * <p>
@@ -206,17 +184,6 @@ public class UserGroupLocalServiceImpl extends UserGroupLocalServiceBaseImpl {
 		indexer.reindex(userGroup);
 
 		return userGroup;
-	}
-
-	/**
-	 * Clears all associations between the user and its user groups and clears
-	 * the permissions cache.
-	 *
-	 * @param userId the primary key of the user
-	 */
-	@Override
-	public void clearUserUserGroups(long userId) {
-		userPersistence.clearUserGroups(userId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupRoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupRoleLocalServiceImpl.java
@@ -78,13 +78,6 @@ public class UserGroupRoleLocalServiceImpl
 	}
 
 	@Override
-	public UserGroupRole deleteUserGroupRole(UserGroupRole userGroupRole) {
-		userGroupRolePersistence.remove(userGroupRole);
-
-		return userGroupRole;
-	}
-
-	@Override
 	public void deleteUserGroupRoles(long groupId, int roleType) {
 		List<UserGroupRole> userGroupRoles =
 			userGroupRoleFinder.findByGroupRoleType(groupId, roleType);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserGroupRoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserGroupRoleLocalServiceImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.service.persistence.UserGroupRolePK;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.UserGroupRoleLocalServiceBaseImpl;
 
 import java.util.ArrayList;
@@ -53,8 +52,6 @@ public class UserGroupRoleLocalServiceImpl
 			groupPersistence.addUser(groupId, userId);
 		}
 
-		PermissionCacheUtil.clearCache(userId);
-
 		return userGroupRoles;
 	}
 
@@ -77,16 +74,12 @@ public class UserGroupRoleLocalServiceImpl
 			groupPersistence.addUsers(groupId, userIds);
 		}
 
-		PermissionCacheUtil.clearCache(userIds);
-
 		return userGroupRoles;
 	}
 
 	@Override
 	public UserGroupRole deleteUserGroupRole(UserGroupRole userGroupRole) {
 		userGroupRolePersistence.remove(userGroupRole);
-
-		PermissionCacheUtil.clearCache(userGroupRole.getUserId());
 
 		return userGroupRole;
 	}
@@ -100,8 +93,6 @@ public class UserGroupRoleLocalServiceImpl
 			userGroupRolePersistence.removeByG_R(
 				groupId, userGroupRole.getRoleId());
 		}
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
@@ -118,8 +109,6 @@ public class UserGroupRoleLocalServiceImpl
 			catch (NoSuchUserGroupRoleException nsugre) {
 			}
 		}
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
@@ -127,8 +116,6 @@ public class UserGroupRoleLocalServiceImpl
 		for (long groupId : groupIds) {
 			userGroupRolePersistence.removeByU_G(userId, groupId);
 		}
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override
@@ -136,8 +123,6 @@ public class UserGroupRoleLocalServiceImpl
 		for (long userId : userIds) {
 			userGroupRolePersistence.removeByU_G(userId, groupId);
 		}
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	@Override
@@ -159,8 +144,6 @@ public class UserGroupRoleLocalServiceImpl
 				}
 			}
 		}
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	@Override
@@ -176,29 +159,21 @@ public class UserGroupRoleLocalServiceImpl
 			catch (NoSuchUserGroupRoleException nsugre) {
 			}
 		}
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	@Override
 	public void deleteUserGroupRolesByGroupId(long groupId) {
 		userGroupRolePersistence.removeByGroupId(groupId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupRolesByRoleId(long roleId) {
 		userGroupRolePersistence.removeByRoleId(roleId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	@Override
 	public void deleteUserGroupRolesByUserId(long userId) {
 		userGroupRolePersistence.removeByUserId(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1469,26 +1469,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	/**
-	 * Removes all the users from the organization.
-	 *
-	 * @param organizationId the primary key of the organization
-	 */
-	@Override
-	public void clearOrganizationUsers(long organizationId) {
-		organizationPersistence.clearUsers(organizationId);
-	}
-
-	/**
-	 * Removes all the users from the user group.
-	 *
-	 * @param userGroupId the primary key of the user group
-	 */
-	@Override
-	public void clearUserGroupUsers(long userGroupId) {
-		userGroupPersistence.clearUsers(userGroupId);
-	}
-
-	/**
 	 * Completes the user's registration by generating a password and sending
 	 * the confirmation email.
 	 *

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -134,7 +134,6 @@ import com.liferay.portal.security.auth.EmailAddressValidatorFactory;
 import com.liferay.portal.security.auth.FullNameValidatorFactory;
 import com.liferay.portal.security.auth.ScreenNameGeneratorFactory;
 import com.liferay.portal.security.auth.ScreenNameValidatorFactory;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.security.pwd.PwdAuthenticator;
 import com.liferay.portal.security.pwd.PwdToolkitUtil;
 import com.liferay.portal.security.pwd.RegExpToolkit;
@@ -427,8 +426,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		reindex(userIds);
 
-		PermissionCacheUtil.clearCache(userIds);
-
 		addDefaultRolesAndTeams(groupId, userIds);
 	}
 
@@ -445,8 +442,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		organizationPersistence.addUsers(organizationId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -475,8 +470,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		rolePersistence.addUsers(roleId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -492,8 +485,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		teamPersistence.addUsers(teamId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -602,8 +593,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		userGroupPersistence.addUsers(userGroupId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -1487,8 +1476,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	@Override
 	public void clearOrganizationUsers(long organizationId) {
 		organizationPersistence.clearUsers(organizationId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -1499,8 +1486,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	@Override
 	public void clearUserGroupUsers(long userGroupId) {
 		userGroupPersistence.clearUsers(userGroupId);
-
-		PermissionCacheUtil.clearCache();
 	}
 
 	/**
@@ -1665,8 +1650,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		rolePersistence.removeUser(roleId, userId);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -1814,10 +1797,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		userPersistence.remove(user);
 
-		// Permission cache
-
-		PermissionCacheUtil.clearCache(user.getUserId());
-
 		// Workflow
 
 		workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
@@ -1839,8 +1818,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		userGroupPersistence.removeUser(userGroupId, userId);
 
 		reindex(userId);
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	/**
@@ -3744,8 +3721,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		rolePersistence.setUsers(roleId, userIds);
 
 		reindex(updateUserIds);
-
-		PermissionCacheUtil.clearCache(updateUserIds);
 	}
 
 	/**
@@ -3775,8 +3750,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		userGroupPersistence.setUsers(userGroupId, userIds);
 
 		reindex(updateUserIds);
-
-		PermissionCacheUtil.clearCache(updateUserIds);
 	}
 
 	/**
@@ -3794,8 +3767,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		for (Team team : teams) {
 			unsetTeamUsers(team.getTeamId(), userIds);
 		}
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -3820,8 +3791,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		groupPersistence.removeUsers(groupId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 
 		Callable<Void> callable = new Callable<Void>() {
 
@@ -3865,8 +3834,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		organizationPersistence.removeUsers(organizationId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 
 		Callable<Void> callable = new Callable<Void>() {
 
@@ -3929,16 +3896,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			User.class);
 
 		indexer.reindex(users);
-
-		long[] userIds = new long[users.size()];
-
-		for (int i = 0; i < users.size(); i++) {
-			User user = users.get(i);
-
-			userIds[i] = user.getUserId();
-		}
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -3965,8 +3922,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		rolePersistence.removeUsers(roleId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -3982,8 +3937,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		teamPersistence.removeUsers(teamId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -3999,8 +3952,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		userGroupPersistence.removeUsers(userGroupId, userIds);
 
 		reindex(userIds);
-
-		PermissionCacheUtil.clearCache(userIds);
 	}
 
 	/**
@@ -5288,10 +5239,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			sendEmailAddressVerification(user, emailAddress, serviceContext);
 		}
 
-		// Permission cache
-
-		PermissionCacheUtil.clearCache(userId);
-
 		return user;
 	}
 
@@ -6189,8 +6136,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		if (indexingEnabled) {
 			reindex(userId);
 		}
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	protected void updateOrganizations(
@@ -6218,8 +6163,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		if (indexingEnabled) {
 			reindex(userId);
 		}
-
-		PermissionCacheUtil.clearCache(userId);
 	}
 
 	protected void updateUserGroupRoles(

--- a/portal-impl/src/com/liferay/portal/verify/VerifyPermission.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyPermission.java
@@ -50,7 +50,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.impl.ResourcePermissionLocalServiceImpl;
 import com.liferay.portal.util.PortalInstances;
 
@@ -264,8 +263,6 @@ public class VerifyPermission extends VerifyProcess {
 					_log.error(e, e);
 				}
 			}
-
-			PermissionCacheUtil.clearResourceCache();
 		}
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/PermissionCheckerTest.java
@@ -940,8 +940,6 @@ public class PermissionCheckerTest {
 	private PermissionChecker _getPermissionChecker(User user)
 		throws Exception {
 
-		PermissionCacheUtil.clearCache(user.getUserId());
-
 		return PermissionCheckerFactoryUtil.create(user);
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/UserBagFactoryTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/UserBagFactoryTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Assert;
@@ -77,17 +78,32 @@ public class UserBagFactoryTest {
 
 	@Test
 	public void testGetGroups() throws Exception {
-		UserBag userBag = getUserBag();
+		Collection<Group> groups = getGroups();
 
-		Collection<Group> groups = userBag.getGroups();
+		Assert.assertEquals(1, groups.size());
 
 		Collection<Group> userGroups = getUserGroups();
+
+		Assert.assertTrue(userGroups.containsAll(groups));
+
 		Collection<Group> userOrgGroups = getUserOrgGroups();
 		Collection<Group> userUserGroupGroups = getUserUserGroupGroups();
 
-		Assert.assertTrue(groups.containsAll(userGroups));
-		Assert.assertTrue(groups.containsAll(userOrgGroups));
-		Assert.assertTrue(groups.containsAll(userUserGroupGroups));
+		groups = getGroups();
+
+		Assert.assertEquals(5, groups.size());
+		Assert.assertEquals(2, userGroups.size());
+		Assert.assertEquals(2, userOrgGroups.size());
+		Assert.assertEquals(1, userUserGroupGroups.size());
+
+		groups = new HashSet<>(groups);
+		userGroups = new HashSet<>(userGroups);
+		userOrgGroups = new HashSet<>(userOrgGroups);
+
+		Assert.assertEquals(5, groups.size());
+		Assert.assertEquals(2, userGroups.size());
+		Assert.assertEquals(2, userOrgGroups.size());
+		Assert.assertEquals(1, userUserGroupGroups.size());
 	}
 
 	@Test
@@ -111,6 +127,7 @@ public class UserBagFactoryTest {
 
 		long[] roleIds = ListUtil.toLongArray(roles, Role.ROLE_ID_ACCESSOR);
 
+		Assert.assertEquals(4, roleIds.length);
 		Assert.assertTrue(ArrayUtil.contains(roleIds, regularRole.getRoleId()));
 		Assert.assertTrue(ArrayUtil.contains(roleIds, groupRoleId));
 		Assert.assertTrue(ArrayUtil.contains(roleIds, organizationRoleId));
@@ -120,6 +137,7 @@ public class UserBagFactoryTest {
 	public void testGetUserGroups() throws Exception {
 		Collection<Group> userGroups = getUserGroups();
 
+		Assert.assertEquals(2, userGroups.size());
 		Assert.assertTrue(userGroups.contains(_childGroup));
 		Assert.assertFalse(userGroups.contains(_parentGroup));
 	}
@@ -135,6 +153,7 @@ public class UserBagFactoryTest {
 	public void testGetUserOrgGroups() throws Exception {
 		Collection<Group> groups = getUserOrgGroups();
 
+		Assert.assertEquals(2, groups.size());
 		Assert.assertTrue(groups.contains(_childOrganization.getGroup()));
 		Assert.assertTrue(groups.contains(_parentOrganization.getGroup()));
 	}
@@ -143,6 +162,7 @@ public class UserBagFactoryTest {
 	public void testGetUserOrgs() throws Exception {
 		Collection<Organization> organizations = getUserOrgs();
 
+		Assert.assertEquals(2, organizations.size());
 		Assert.assertTrue(organizations.contains(_childOrganization));
 		Assert.assertTrue(organizations.contains(_parentOrganization));
 	}
@@ -154,7 +174,15 @@ public class UserBagFactoryTest {
 		Assert.assertTrue(groups.contains(_userGroup.getGroup()));
 	}
 
+	protected Collection<Group> getGroups() throws Exception {
+		UserBag userBag = getUserBag();
+
+		return userBag.getGroups();
+	}
+
 	protected UserBag getUserBag() throws Exception {
+		PermissionCacheUtil.removeUserBag(_user.getUserId());
+
 		return UserBagFactoryUtil.create(_user.getUserId());
 	}
 

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/UserBagFactoryTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/UserBagFactoryTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.security.permission.UserBagFactoryUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -68,6 +70,8 @@ public class UserBagFactoryTest {
 			_parentOrganization.getOrganizationId(),
 			RandomTestUtil.randomString(), true);
 
+		_userGroup = UserGroupTestUtil.addUserGroup(_childGroup.getGroupId());
+
 		_user = UserTestUtil.addUser();
 	}
 
@@ -79,9 +83,11 @@ public class UserBagFactoryTest {
 
 		Collection<Group> userGroups = getUserGroups();
 		Collection<Group> userOrgGroups = getUserOrgGroups();
+		Collection<Group> userUserGroupGroups = getUserUserGroupGroups();
 
 		Assert.assertTrue(groups.containsAll(userGroups));
 		Assert.assertTrue(groups.containsAll(userOrgGroups));
+		Assert.assertTrue(groups.containsAll(userUserGroupGroups));
 	}
 
 	@Test
@@ -141,6 +147,13 @@ public class UserBagFactoryTest {
 		Assert.assertTrue(organizations.contains(_parentOrganization));
 	}
 
+	@Test
+	public void testGetUserUserGroupGroups() throws Exception {
+		Collection<Group> groups = getUserUserGroupGroups();
+
+		Assert.assertTrue(groups.contains(_userGroup.getGroup()));
+	}
+
 	protected UserBag getUserBag() throws Exception {
 		return UserBagFactoryUtil.create(_user.getUserId());
 	}
@@ -171,6 +184,15 @@ public class UserBagFactoryTest {
 		return userBag.getUserOrgs();
 	}
 
+	protected Collection<Group> getUserUserGroupGroups() throws Exception {
+		UserLocalServiceUtil.addUserGroupUser(
+			_userGroup.getUserGroupId(), _user.getUserId());
+
+		UserBag userBag = getUserBag();
+
+		return userBag.getUserUserGroupGroups();
+	}
+
 	@DeleteAfterTestRun
 	private Group _childGroup;
 
@@ -185,5 +207,8 @@ public class UserBagFactoryTest {
 
 	@DeleteAfterTestRun
 	private User _user;
+
+	@DeleteAfterTestRun
+	private UserGroup _userGroup;
 
 }

--- a/portal-impl/test/integration/com/liferay/portal/security/permission/UserBagFactoryTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/permission/UserBagFactoryTest.java
@@ -181,8 +181,6 @@ public class UserBagFactoryTest {
 	}
 
 	protected UserBag getUserBag() throws Exception {
-		PermissionCacheUtil.removeUserBag(_user.getUserId());
-
 		return UserBagFactoryUtil.create(_user.getUserId());
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/UserBag.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/UserBag.java
@@ -52,6 +52,8 @@ public interface UserBag extends Serializable {
 
 	public Collection<Organization> getUserOrgs() throws PortalException;
 
+	public Collection<Group> getUserUserGroupGroups() throws PortalException;
+
 	public boolean hasRole(Role role);
 
 	public boolean hasUserGroup(Group group);

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-67209

Depends on https://github.com/brianchandotcom/liferay-portal/pull/42249 (LPS-61319)

/cc @Preston-Crary: 
- I included your test in the previous PR related to UserBag, the test didn't work correctly without it,
- Here I only removed PermissionCacheUtil.clear() from UserBagFactoryTest and PermissionCheckerTest to test this particular issue,
- Btw. good job on this, I like it more then the previous way, it's more consistent.

Thank you.
