### PR TITLE
LRQA-27121 Fix chrome failures on environment tester

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -3240,12 +3240,12 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 			<if>
 				<os family="unix" />
 				<then>
-					<execute>
+					<execute failonerror="false">
 						killall chromedriver
 					</execute>
 				</then>
 				<else>
-					<execute>
+					<execute failonerror="false">
 						taskkill.exe /F /IM chromedriver.exe
 					</execute>
 				</else>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-27121

@kiyoshilee, @pyoo47, this will fix the Chrome failures on the environment tester. It happened due to the execute macrodef update that sets the failonerror attribute to true by default. Let me know if there's any questions, thanks!
