### PR TITLE
master-qa-27168 Fix failing Poshi validation unit tests

### DIFF
--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,7 +4,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 6bddeb803d4e984f600682f66fd0893b57e663ff
+	commit = 096529276edab385cae1716c8825557293dc4740
 	mode = push
-	parent = d6b8c6a1a8e6fbe169ebf545855764883663ee1e
+	parent = 98ee8e4a773738c86b1a60af5dbb8cefad27f509
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/test/poshi-runner/src/main/resources/poshi-runner.properties
+++ b/modules/test/poshi-runner/src/main/resources/poshi-runner.properties
@@ -88,7 +88,7 @@ test.batch.group.ignore.regex=portal\.(acceptance|smoke|release).*|testray.*
 #test.batch.run.type=sequential
 test.batch.run.type=single
 
-test.case.available.property.names=portal.smoke,component.names
+test.case.available.property.names=component.names,portal.smoke,testray.main.component.name
 #test.case.required.property.names=
 #test.console.log.file.name=
 #test.console.shut.down.file.name=


### PR DESCRIPTION
http://issues.liferay.com/browse/LRQA-27168

@brianchandotcom The pull is to fix the failing poshi unit tests in 'modules-unit-jdk8'. A property value required for the unit tests was removed from poshi-runner.properties.

cc @michaelhashimoto @pyoo47
