### PR TITLE
LPS-67611 Sybase indexes can only be 1250 bytes, so this unique index…

### DIFF
--- a/modules/apps/opensocial/opensocial-portlet/docroot/WEB-INF/sql/indexes.sql
+++ b/modules/apps/opensocial/opensocial-portlet/docroot/WEB-INF/sql/indexes.sql
@@ -1,4 +1,3 @@
-create unique index IX_A6A89EB1 on OpenSocial_Gadget (companyId, url[$COLUMN_LENGTH:4000$]);
 create index IX_3C79316E on OpenSocial_Gadget (uuid_[$COLUMN_LENGTH:75$], companyId);
 
 create index IX_8E715BF8 on OpenSocial_OAuthConsumer (gadgetKey[$COLUMN_LENGTH:75$], serviceName[$COLUMN_LENGTH:75$]);


### PR DESCRIPTION
… can't work on sybase

This fixes the module-integration-sybase test failures
