### PR TITLE
LPS-67635 Fix random DynamicQueryTest failures on CI

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/dao/orm/hibernate/DynamicQueryTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/dao/orm/hibernate/DynamicQueryTest.java
@@ -16,12 +16,16 @@ package com.liferay.portal.dao.orm.hibernate;
 
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.OrderFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -45,6 +49,24 @@ public class DynamicQueryTest {
 	public void setUp() {
 		_allClassNames = ClassNameLocalServiceUtil.getClassNames(
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+	}
+
+	@Test
+	public void testCriterion() {
+		DynamicQuery dynamicQuery = ClassNameLocalServiceUtil.dynamicQuery();
+
+		Property classNameIdProperty = PropertyFactoryUtil.forName(
+			"classNameId");
+
+		ClassName className = _allClassNames.get(10);
+
+		dynamicQuery.add(classNameIdProperty.eq(className.getClassNameId()));
+
+		List<ClassName> classNames = ClassNameLocalServiceUtil.dynamicQuery(
+			dynamicQuery);
+
+		Assert.assertEquals(1, classNames.size());
+		Assert.assertEquals(className, classNames.get(0));
 	}
 
 	@Test
@@ -133,6 +155,22 @@ public class DynamicQueryTest {
 			ClassNameLocalServiceUtil.dynamicQuery(dynamicQuery);
 
 		Assert.assertTrue(dynamicQueryClassNames.isEmpty());
+	}
+
+	@Test
+	public void testOrderBy() {
+		DynamicQuery dynamicQuery = ClassNameLocalServiceUtil.dynamicQuery();
+
+		dynamicQuery.addOrder(OrderFactoryUtil.desc("classNameId"));
+		dynamicQuery.setLimit(QueryUtil.ALL_POS, _allClassNames.size());
+
+		_allClassNames = new ArrayList<>(_allClassNames);
+
+		Collections.reverse(_allClassNames);
+
+		Assert.assertEquals(
+			_allClassNames,
+			ClassNameLocalServiceUtil.<ClassName>dynamicQuery(dynamicQuery));
 	}
 
 	@Test

--- a/portal-impl/test/integration/com/liferay/portal/dao/orm/hibernate/DynamicQueryTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/dao/orm/hibernate/DynamicQueryTest.java
@@ -19,13 +19,9 @@ import com.liferay.portal.kernel.dao.orm.OrderFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
-import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -47,21 +43,8 @@ public class DynamicQueryTest {
 
 	@Before
 	public void setUp() {
-		_allClassNames = new ArrayList<>(
-			ClassNameLocalServiceUtil.getClassNames(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS));
-
-		_oldClassNameCount = _allClassNames.size();
-
-		for (int i = 0; i < _BATCH_SIZE; i++) {
-			ClassName className = ClassNameLocalServiceUtil.addClassName(
-				RandomTestUtil.randomString(
-					UniqueStringRandomizerBumper.INSTANCE));
-
-			_newClassNames.add(className);
-
-			_allClassNames.add(className);
-		}
+		_allClassNames = ClassNameLocalServiceUtil.getClassNames(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 	}
 
 	@Test
@@ -69,10 +52,10 @@ public class DynamicQueryTest {
 		DynamicQuery dynamicQuery = ClassNameLocalServiceUtil.dynamicQuery();
 
 		dynamicQuery.addOrder(OrderFactoryUtil.asc("classNameId"));
-		dynamicQuery.setLimit(_oldClassNameCount, QueryUtil.ALL_POS);
+		dynamicQuery.setLimit(10, _allClassNames.size());
 
 		Assert.assertEquals(
-			_newClassNames,
+			_allClassNames.subList(10, _allClassNames.size()),
 			ClassNameLocalServiceUtil.<ClassName>dynamicQuery(dynamicQuery));
 	}
 
@@ -81,11 +64,10 @@ public class DynamicQueryTest {
 		DynamicQuery dynamicQuery = ClassNameLocalServiceUtil.dynamicQuery();
 
 		dynamicQuery.addOrder(OrderFactoryUtil.asc("classNameId"));
-		dynamicQuery.setLimit(
-			_oldClassNameCount, _oldClassNameCount + _BATCH_SIZE);
+		dynamicQuery.setLimit(10, _allClassNames.size());
 
 		Assert.assertEquals(
-			_newClassNames,
+			_allClassNames.subList(10, _allClassNames.size()),
 			ClassNameLocalServiceUtil.<ClassName>dynamicQuery(dynamicQuery));
 	}
 
@@ -106,7 +88,7 @@ public class DynamicQueryTest {
 		DynamicQuery dynamicQuery = ClassNameLocalServiceUtil.dynamicQuery();
 
 		dynamicQuery.addOrder(OrderFactoryUtil.asc("classNameId"));
-		dynamicQuery.setLimit(-50, QueryUtil.ALL_POS);
+		dynamicQuery.setLimit(-50, _allClassNames.size());
 
 		Assert.assertEquals(
 			_allClassNames,
@@ -131,9 +113,14 @@ public class DynamicQueryTest {
 
 		dynamicQuery.addOrder(OrderFactoryUtil.asc("classNameId"));
 
-		Assert.assertEquals(
-			_allClassNames,
-			ClassNameLocalServiceUtil.<ClassName>dynamicQuery(dynamicQuery));
+		List<ClassName> classNames = ClassNameLocalServiceUtil.dynamicQuery(
+			dynamicQuery);
+
+		for (ClassName className : _allClassNames) {
+			if (!classNames.contains(className)) {
+				Assert.fail("ClassNames did not contain " + className);
+			}
+		}
 	}
 
 	@Test
@@ -180,20 +167,13 @@ public class DynamicQueryTest {
 		DynamicQuery dynamicQuery = ClassNameLocalServiceUtil.dynamicQuery();
 
 		dynamicQuery.addOrder(OrderFactoryUtil.asc("classNameId"));
-		dynamicQuery.setLimit(QueryUtil.ALL_POS, _BATCH_SIZE);
+		dynamicQuery.setLimit(QueryUtil.ALL_POS, 10);
 
 		Assert.assertEquals(
-			_allClassNames.subList(0, _BATCH_SIZE),
+			_allClassNames.subList(0, 10),
 			ClassNameLocalServiceUtil.<ClassName>dynamicQuery(dynamicQuery));
 	}
 
-	private static final int _BATCH_SIZE = 50;
-
 	private List<ClassName> _allClassNames;
-
-	@DeleteAfterTestRun
-	private final List<ClassName> _newClassNames = new ArrayList<>();
-
-	private int _oldClassNameCount;
 
 }


### PR DESCRIPTION
Hey Brian,

this change only effects random test failure for the DynamicQueryTest.  Any other test failures are unrelated.  We're tracking over 20 random test failures currently, some of which are startup issues that break random tests.
