### PR TITLE
LPS-67568

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/test/SocketTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/test/SocketTest.java
@@ -26,7 +26,6 @@ import java.net.SocketException;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 


### PR DESCRIPTION
[LPS-67568](https://issues.liferay.com/browse/LPS-67643) @brianchandotcom @mhan810 I noticed that the changes in 4498bdd when Brian deactivated SocketTest.java did not match those in 4585314 when Mike reactivated it, so I am assuming this will fix the source formatter error occurring in every pull ([example](https://test-1-1.liferay.com/job/test-portal-acceptance-pullrequest-batch%28master%29/AXIS_VARIABLE=0,label_exp=!master/29039/testReport/com.liferay.source.formatter/SourceFormatterTest/testSourceFormatter/)).
