### PR TITLE
LRQA-27271 | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -778,7 +778,6 @@
         apps/foundation/mobile-device-rules/mobile-device-rules-recognition-provider-wurfl,\
         apps/foundation/portal-cache/portal-cache-ehcache-ee-provider,\
         apps/foundation/portal-cache/portal-cache-multiple,\
-        apps/foundation/portal-scheduler/portal-scheduler-multiple,\
         apps/foundation/portal-search/portal-search-elasticsearch-shield,\
         apps/foundation/portal-search/portal-search-elasticsearch-shield-fragment,\
         apps/foundation/portal-security-audit/portal-security-audit-event-generators,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-27271

@alee8888 @brianchandotcom 

This pull removes portal-scheduler-multiple from the CE PR tester. We should also use this pull to see if there are any other failures that are hidden by the portal-scheduler-multiple failure.

Currently all pulls are failing with this:

```
     [exec] 17:27:10,746 WARN  [fileinstall-/opt/dev/projects/github/liferay-portal/bundles/osgi/portal][org_apache_felix_fileinstall:103] Error while starting bundle: file:/opt/dev/projects/github/liferay-portal/bundles/osgi/portal/com.liferay.portal.scheduler.multiple.jar 
     [exec] org.osgi.framework.BundleException: Could not resolve module: com.liferay.portal.scheduler.multiple [77]
     [exec]   Unresolved requirement: Import-Package: com.liferay.portal.kernel.scheduler; version="[7.0.0,7.1.0)"
```
