### PR TITLE
LPS-67824 Use writeObject instead of writeUTF to handle entries that …

### DIFF
--- a/portal-impl/src/com/liferay/portal/json/JSONArrayImpl.java
+++ b/portal-impl/src/com/liferay/portal/json/JSONArrayImpl.java
@@ -209,7 +209,8 @@ public class JSONArrayImpl implements JSONArray {
 	@Override
 	public void readExternal(ObjectInput objectInput) throws IOException {
 		try {
-			_jsonArray = new org.json.JSONArray(objectInput.readUTF());
+			_jsonArray = new org.json.JSONArray(
+				(String)objectInput.readObject());
 		}
 		catch (Exception e) {
 			throw new IOException(e);
@@ -248,7 +249,7 @@ public class JSONArrayImpl implements JSONArray {
 
 	@Override
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
-		objectOutput.writeUTF(toString());
+		objectOutput.writeObject(toString());
 	}
 
 	private static final String _NULL_JSON = "[]";

--- a/portal-impl/src/com/liferay/portal/json/JSONObjectImpl.java
+++ b/portal-impl/src/com/liferay/portal/json/JSONObjectImpl.java
@@ -343,7 +343,8 @@ public class JSONObjectImpl implements JSONObject {
 	@Override
 	public void readExternal(ObjectInput objectInput) throws IOException {
 		try {
-			_jsonObject = new org.json.JSONObject(objectInput.readUTF());
+			_jsonObject = new org.json.JSONObject(
+				(String)objectInput.readObject());
 		}
 		catch (Exception e) {
 			throw new IOException(e);
@@ -387,7 +388,7 @@ public class JSONObjectImpl implements JSONObject {
 
 	@Override
 	public void writeExternal(ObjectOutput objectOutput) throws IOException {
-		objectOutput.writeUTF(toString());
+		objectOutput.writeObject(toString());
 	}
 
 	private static final String _NULL_JSON = "{}";


### PR DESCRIPTION
…are longer than 65535 bytes
