### PR TITLE
LRQA-27384 | 7.0.x

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5327,7 +5327,9 @@ sprite.root.dir=/tmp/sprite
 
 axis.servlet.hosts.allowed=
 
-tunnel.servlet.hosts.allowed=</echo>
+tunnel.servlet.hosts.allowed=
+
+javascript.single.page.application.timeout=300000</echo>
 
 		<get-testcase-property property.name="captcha.max.challenges" />
 


### PR DESCRIPTION
@brianchandotcom, we actually have to revert https://github.com/brianchandotcom/liferay-portal/pull/42926 from the 7.0 branches. The behavior is different between master and the 7.0's because of https://issues.liferay.com/browse/LPS-66990, which was only applied to master. Let me know if you have any questions. Thanks! 

cc-ing: @anthony-chu
