### PR TITLE
LPS-68096 explicitly support the full range of current journal apis (…

### DIFF
--- a/modules/apps/screens/screens-service/bnd.bnd
+++ b/modules/apps/screens/screens-service/bnd.bnd
@@ -5,3 +5,4 @@ Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title:
 Liferay-Require-SchemaVersion: 1.0.8
 Liferay-Service: true
+Import-Package: com.liferay.journal.*;version="[1.0,3.0]",*


### PR DESCRIPTION
…from GA1 to GA3) to release only a plugin version compatible with all GAs.

The journal API has evolved through the different GAs and the compatibility plugin supports all the versions. Specifying manually the supported versions we can release only a plugin for all those versions.

/ @ahdezma

Let's try again (brianchandotcom#43077)
