### PR TITLE
LPS-68162 Using unambiguous message for upgrade:check command

### DIFF
--- a/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerOSGiCommands.java
+++ b/modules/apps/foundation/portal/portal-upgrade/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerOSGiCommands.java
@@ -96,9 +96,9 @@ public class ReleaseManagerOSGiCommands {
 				continue;
 			}
 
-			StringBundler sb = new StringBundler(7);
+			StringBundler sb = new StringBundler(6);
 
-			sb.append("Check upgrade ");
+			sb.append("There is an upgrade process available for ");
 			sb.append(bundleSymbolicName);
 			sb.append(" from ");
 			sb.append(schemaVersionString);
@@ -110,8 +110,6 @@ public class ReleaseManagerOSGiCommands {
 				upgradeInfos.size() - 1);
 
 			sb.append(lastUpgradeInfo.getToSchemaVersionString());
-
-			sb.append(" and its dependent modules");
 
 			System.out.println(sb.toString());
 		}


### PR DESCRIPTION
Hi @brianchandotcom,

The upgrade:check command shows available upgrade processes so the current message is a bit ambiguous.

Thanks.

PS: the name of the command was agreed by @david-truong and I and also reviewed by @csierra after a long discussion. We can't modify the command name now when Liferay 7 has been released.
