### PR TITLE
LRQA-27793 Remove modules/.gitignore from liferay-portal-source.zip

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -456,6 +456,8 @@ app.server.type=@{app.server.type}]]></echo>
 							git add -A
 
 							git diff --cached --name-only | grep -v '^bundles/' | xargs -n 1000 zip liferay-portal-source.zip
+
+							zip -d liferay-portal-source.zip modules/.gitignore
 						]]>
 					</execute>
 				</then>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-27793

@Ithildir
This pull request fixes the junit ModulesStructureTest.
