### PR TITLE
LRQA-27793 Do not include modules/.gitignore in liferay-portal-source.zip

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -455,7 +455,7 @@ app.server.type=@{app.server.type}]]></echo>
 						<![CDATA[
 							git add -A
 
-							git diff --cached --name-only | grep -v '^bundles/' | xargs -n 1000 zip liferay-portal-source.zip
+							git diff --cached --name-only | grep -v -E '^bundles/|^modules/\.gitignore' | xargs -n 1000 zip liferay-portal-source.zip
 						]]>
 					</execute>
 				</then>


### PR DESCRIPTION
Resend of https://github.com/brianchandotcom/liferay-portal/pull/43199

https://issues.liferay.com/browse/LRQA-27793

@Ithildir
This pull request fixes the junit ModulesStructureTest.
