### PR TITLE
LPS-68289 Avoid duplicated company checking caused race condition.

### DIFF
--- a/portal-test-integration/src/com/liferay/portal/service/test/ServiceTestUtil.java
+++ b/portal-test-integration/src/com/liferay/portal/service/test/ServiceTestUtil.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.model.impl.PortletImpl;
@@ -267,12 +268,16 @@ public class ServiceTestUtil {
 
 		// Company
 
-		try {
-			CompanyLocalServiceUtil.checkCompany(
-				TestPropsValues.COMPANY_WEB_ID);
-		}
-		catch (Exception e) {
-			_log.error(e, e);
+		if (!ArrayUtil.contains(
+				PortalInstances.getWebIds(), TestPropsValues.COMPANY_WEB_ID)) {
+
+			try {
+				CompanyLocalServiceUtil.checkCompany(
+					TestPropsValues.COMPANY_WEB_ID);
+			}
+			catch (Exception e) {
+				_log.error(e, e);
+			}
 		}
 	}
 


### PR DESCRIPTION
@brianchandotcom this would fix many integration tests random failures, most likely there will be other causes too, we will recapture the latest failures once this is in.

CC @tomwang2011
