### PR TITLE
LPS-66024 Manually revert "Replicate the bug with unit tests" at 4e30…

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/kernel/upgrade/BaseUpgradePortletIdTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/upgrade/BaseUpgradePortletIdTest.java
@@ -17,7 +17,6 @@ package com.liferay.portal.kernel.upgrade;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -28,7 +27,6 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
-import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
@@ -38,7 +36,6 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -91,8 +88,6 @@ public class BaseUpgradePortletIdTest extends BaseUpgradePortletId {
 		}
 
 		_portlets.clear();
-
-		assertFurtherTestsInTheSameJVMCanAddCompanies();
 	}
 
 	@After
@@ -146,14 +141,6 @@ public class BaseUpgradePortletIdTest extends BaseUpgradePortletId {
 		finally {
 			_testInstanceable = true;
 		}
-	}
-
-	protected static void assertFurtherTestsInTheSameJVMCanAddCompanies()
-		throws Exception {
-
-		Company company = CompanyTestUtil.addCompany();
-
-		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
 	protected Layout addLayout() throws Exception {


### PR DESCRIPTION
…8338102c3c3c989f502fd678ced70fc01f87 . There is no point to reproduce something that has already been fixed. And the reproducing logic is causing new issues. Integration test is almost like real portal which is a very dynamic env. In this case, while BaseUpgradePortletIdTest is running, we maybe deploy opensocial-portlet-7.0.0.6.war in the background. Which calls CompanyLocalServiceUtil.getCompanies() in many locations, then loop through to process each company. In case CompanyLocalServiceUtil.getCompanies() is called after the test company is created, before it is removed, it will see this test company. But the loop is running after it is removed, there will be tons of unpredictable side effects casued by the missing company in DB.

@brianchandotcom this issue was added by https://github.com/brianchandotcom/liferay-portal/pull/40657

CC @arboliveira
