### PR TITLE
LPS-68289 Avoid reflection, the PropsValues were getting their 'tempo…

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/ActionRequestPortletContainerTest.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/ActionRequestPortletContainerTest.java
@@ -15,17 +15,19 @@
 package com.liferay.portal.osgi.web.portlet.container.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.encryptor.Encryptor;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
+import com.liferay.portal.kernel.security.auth.AuthToken;
+import com.liferay.portal.kernel.security.auth.AuthTokenWhitelist;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.security.auth.AuthTokenWhitelistImpl;
+import com.liferay.portal.security.auth.SessionAuthToken;
 import com.liferay.portal.test.log.CaptureAppender;
 import com.liferay.portal.test.log.Log4JLoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.test.PortletContainerTestUtil;
 import com.liferay.portal.util.test.PortletContainerTestUtil.Response;
 import com.liferay.portlet.PortletURLImpl;
@@ -70,33 +72,31 @@ public class ActionRequestPortletContainerTest
 
 	@Test
 	public void testAuthTokenCheckEnabled() throws Exception {
-		Boolean authTokenCheckEnabled = ReflectionTestUtil.getAndSetFieldValue(
-			PropsValues.class, "AUTH_TOKEN_CHECK_ENABLED", Boolean.FALSE);
+		HashMapDictionary<String, Object> properties =
+			new HashMapDictionary<>();
 
-		try {
-			setUpPortlet(
-				testPortlet, new HashMapDictionary<String, Object>(),
-				TEST_PORTLET_ID);
+		properties.put("service.ranking", Integer.MAX_VALUE);
 
-			HttpServletRequest httpServletRequest =
-				PortletContainerTestUtil.getHttpServletRequest(group, layout);
+		registerService(
+			AuthToken.class, new DisabledSessionAuthToken(), properties);
 
-			PortletURL portletURL = new PortletURLImpl(
-				httpServletRequest, TEST_PORTLET_ID, layout.getPlid(),
-				PortletRequest.ACTION_PHASE);
+		setUpPortlet(
+			testPortlet, new HashMapDictionary<String, Object>(),
+			TEST_PORTLET_ID);
 
-			Response response = PortletContainerTestUtil.request(
-				portletURL.toString());
+		HttpServletRequest httpServletRequest =
+			PortletContainerTestUtil.getHttpServletRequest(group, layout);
 
-			Assert.assertEquals(200, response.getCode());
+		PortletURL portletURL = new PortletURLImpl(
+			httpServletRequest, TEST_PORTLET_ID, layout.getPlid(),
+			PortletRequest.ACTION_PHASE);
 
-			Assert.assertTrue(testPortlet.isCalledAction());
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				PropsValues.class, "AUTH_TOKEN_CHECK_ENABLED",
-				authTokenCheckEnabled);
-		}
+		Response response = PortletContainerTestUtil.request(
+			portletURL.toString());
+
+		Assert.assertEquals(200, response.getCode());
+
+		Assert.assertTrue(testPortlet.isCalledAction());
 	}
 
 	@Test
@@ -256,35 +256,34 @@ public class ActionRequestPortletContainerTest
 
 	@Test
 	public void testPortalAuthenticationTokenSecret() throws Exception {
-		String authTokenSharedSecret = ReflectionTestUtil.getAndSetFieldValue(
-			PropsValues.class, "AUTH_TOKEN_SHARED_SECRET", "test");
+		HashMapDictionary<String, Object> properties =
+			new HashMapDictionary<>();
 
-		try {
-			setUpPortlet(
-				testPortlet, new HashMapDictionary<String, Object>(),
-				TEST_PORTLET_ID);
+		properties.put("service.ranking", Integer.MAX_VALUE);
 
-			HttpServletRequest httpServletRequest =
-				PortletContainerTestUtil.getHttpServletRequest(group, layout);
+		registerService(
+			AuthTokenWhitelist.class, new TestSharedSecretTokenWhitelist(),
+			properties);
 
-			PortletURL portletURL = new PortletURLImpl(
-				httpServletRequest, TEST_PORTLET_ID, layout.getPlid(),
-				PortletRequest.ACTION_PHASE);
+		setUpPortlet(
+			testPortlet, new HashMapDictionary<String, Object>(),
+			TEST_PORTLET_ID);
 
-			portletURL.setParameter("p_auth_secret", Encryptor.digest("test"));
+		HttpServletRequest httpServletRequest =
+			PortletContainerTestUtil.getHttpServletRequest(group, layout);
 
-			Response response = PortletContainerTestUtil.request(
-				portletURL.toString());
+		PortletURL portletURL = new PortletURLImpl(
+			httpServletRequest, TEST_PORTLET_ID, layout.getPlid(),
+			PortletRequest.ACTION_PHASE);
 
-			Assert.assertEquals(200, response.getCode());
+		portletURL.setParameter("p_auth_secret", _SHARED_SECRET);
 
-			Assert.assertTrue(testPortlet.isCalledAction());
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				PropsValues.class, "AUTH_TOKEN_SHARED_SECRET",
-				authTokenSharedSecret);
-		}
+		Response response = PortletContainerTestUtil.request(
+			portletURL.toString());
+
+		Assert.assertEquals(200, response.getCode());
+
+		Assert.assertTrue(testPortlet.isCalledAction());
 	}
 
 	@Test
@@ -352,6 +351,8 @@ public class ActionRequestPortletContainerTest
 		Assert.assertTrue(testPortlet.isCalledAction());
 	}
 
+	private static final String _SHARED_SECRET = "test";
+
 	private static class ActionRequestTestPortlet extends TestPortlet {
 
 		@Override
@@ -373,6 +374,33 @@ public class ActionRequestPortletContainerTest
 				parameterMap, "p_auth");
 
 			printWriter.write(portalAuthenticationToken);
+		}
+
+	}
+
+	private static class DisabledSessionAuthToken extends SessionAuthToken {
+
+		@Override
+		public void addCSRFToken(
+			HttpServletRequest request, LiferayPortletURL liferayPortletURL) {
+		}
+
+		@Override
+		public void checkCSRFToken(HttpServletRequest request, String origin) {
+		}
+
+	}
+
+	private static class TestSharedSecretTokenWhitelist
+		extends AuthTokenWhitelistImpl {
+
+		@Override
+		public boolean isValidSharedSecret(String sharedSecret) {
+			if (_SHARED_SECRET.equals(sharedSecret)) {
+				return true;
+			}
+
+			return false;
 		}
 
 	}


### PR DESCRIPTION
…rary' values set before SessionAuthToken was initalized.  This meant that the simple types were getting inlined with the altered value before setting them back to the original value.

@brianchandotcom this fixes all the random failures in ActionRequestPortletContainerTest.
