### PR TITLE
LPS-67772

### DIFF
--- a/modules/apps/collaboration/announcements/.gitattributes
+++ b/modules/apps/collaboration/announcements/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/blogs/.gitattributes
+++ b/modules/apps/collaboration/blogs/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = c75fd9833f1704c8c3c9b22f7db39247ef12db63
+	commit = 649f392e1c9d8fd94a2ee31d4586eafb1cdca5d6
 	mode = push
-	parent = c6498f7139cd3978282f624bc5e15e7d368131e2
+	parent = 3272c3087cd6342effccd481c1853a946b6f055d
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/bookmarks/.gitattributes
+++ b/modules/apps/collaboration/bookmarks/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/comment/.gitattributes
+++ b/modules/apps/collaboration/comment/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/directory/.gitattributes
+++ b/modules/apps/collaboration/directory/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/document-library/.gitattributes
+++ b/modules/apps/collaboration/document-library/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = aacc5f23dee73662daa4d562bc147c0833a46625
+	commit = f0a915205f68612551fdb2ef7313da18f6cfa1ba
 	mode = push
-	parent = 99de17f269fb6be106e6aece54acf6d55582e20a
+	parent = 87721d12765bb48a97eef4c5b6a5e0fceba06a15
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/flags/.gitattributes
+++ b/modules/apps/collaboration/flags/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/image-uploader/.gitattributes
+++ b/modules/apps/collaboration/image-uploader/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/invitation/.gitattributes
+++ b/modules/apps/collaboration/invitation/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/invitation/.gitrepo
+++ b/modules/apps/collaboration/invitation/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = e2e9e6eb1975a3891418da3eeaedfac52e5e52d1
+	commit = 7de79ed788dc726c052af8af5d9873ad3418b9a6
 	mode = push
-	parent = 58b73abe30b02c030b62ba45a1ed3d865db018d2
+	parent = b3b984cb7f5d18868c811855214a36414169c24f
 	remote = git@github.com:liferay/com-liferay-invitation.git

--- a/modules/apps/collaboration/item-selector/.gitattributes
+++ b/modules/apps/collaboration/item-selector/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/mentions/.gitattributes
+++ b/modules/apps/collaboration/mentions/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/message-boards/.gitattributes
+++ b/modules/apps/collaboration/message-boards/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 46d1f299e1de7df6bb07d49fc0177f6c0fb9644a
+	commit = 8a3f0d6bb710392af926619bea1f2841e86d6e79
 	mode = push
-	parent = 91aeb48c225f406f0d467825d23eb9cd170ac34f
+	parent = 75d6eef08e25a646da234a2adeb7d6e20ec243cf
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/microblogs/.gitattributes
+++ b/modules/apps/collaboration/microblogs/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/notifications/.gitattributes
+++ b/modules/apps/collaboration/notifications/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/quick-note/.gitattributes
+++ b/modules/apps/collaboration/quick-note/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/ratings/.gitattributes
+++ b/modules/apps/collaboration/ratings/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/recent-documents/.gitattributes
+++ b/modules/apps/collaboration/recent-documents/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/social/.gitattributes
+++ b/modules/apps/collaboration/social/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/wiki/.gitattributes
+++ b/modules/apps/collaboration/wiki/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 81ec24c96f52b9f67b4047174f6ab31a4813d366
+	commit = 08d0c551f207d348cba2b10ed2395c2a25a8c2dd
 	mode = push
-	parent = fbb4c21868f9c4c53220a98eb9b3ef79ac568c82
+	parent = bcbbb8744b924acd808713862d5cac5b6f92d7c2
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/calendar/.gitattributes
+++ b/modules/apps/forms-and-workflow/calendar/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = db878e6350f0b5d5abf7e6bb399f0db7e62681bf
+	commit = cdfaed110f0798518cc2a977627cdde5f1fe7e97
 	mode = push
-	parent = 50f410580c370f5c68e4f656815c664b8587b7b0
+	parent = 4dbd2a3881185728e718be83afa1d0bfc93040d1
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b50e7bf195024553768fb2f88cb0c36af71399fd
+	commit = b1e225689a968c0bd44d794c551d0d0b4c15b288
 	mode = push
-	parent = a922e8c2bd59281b2e1c8f1547c5ddfdd2ee7752
+	parent = a464fe177a199c4a6d731f8988b917d51526acb3
 	remote = git@github.com:liferay/com-liferay-dynamic-data-mapping.git

--- a/modules/apps/forms-and-workflow/polls/.gitattributes
+++ b/modules/apps/forms-and-workflow/polls/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/forms-and-workflow/portal-reports-engine/.gitattributes
+++ b/modules/apps/forms-and-workflow/portal-reports-engine/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/forms-and-workflow/portal-rules-engine/.gitattributes
+++ b/modules/apps/forms-and-workflow/portal-rules-engine/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/forms-and-workflow/portal-workflow/.gitattributes
+++ b/modules/apps/forms-and-workflow/portal-workflow/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/configuration-admin/.gitattributes
+++ b/modules/apps/foundation/configuration-admin/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/contacts/.gitattributes
+++ b/modules/apps/foundation/contacts/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/expando/.gitattributes
+++ b/modules/apps/foundation/expando/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/frontend-css/.gitattributes
+++ b/modules/apps/foundation/frontend-css/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/frontend-editor/.gitattributes
+++ b/modules/apps/foundation/frontend-editor/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/frontend-js/.gitattributes
+++ b/modules/apps/foundation/frontend-js/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/frontend-taglib/.gitattributes
+++ b/modules/apps/foundation/frontend-taglib/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/frontend-theme/.gitattributes
+++ b/modules/apps/foundation/frontend-theme/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/hello-velocity/.gitattributes
+++ b/modules/apps/foundation/hello-velocity/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/hello-world/.gitattributes
+++ b/modules/apps/foundation/hello-world/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/license-manager/.gitattributes
+++ b/modules/apps/foundation/license-manager/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/login/.gitattributes
+++ b/modules/apps/foundation/login/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/map/.gitattributes
+++ b/modules/apps/foundation/map/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/mobile-device-rules/.gitattributes
+++ b/modules/apps/foundation/mobile-device-rules/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/monitoring/.gitattributes
+++ b/modules/apps/foundation/monitoring/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/my-account/.gitattributes
+++ b/modules/apps/foundation/my-account/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/password-policies-admin/.gitattributes
+++ b/modules/apps/foundation/password-policies-admin/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/petra/.gitattributes
+++ b/modules/apps/foundation/petra/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/plugins-admin/.gitattributes
+++ b/modules/apps/foundation/plugins-admin/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-background-task/.gitattributes
+++ b/modules/apps/foundation/portal-background-task/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-cache/.gitattributes
+++ b/modules/apps/foundation/portal-cache/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-configuration/.gitattributes
+++ b/modules/apps/foundation/portal-configuration/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-instances/.gitattributes
+++ b/modules/apps/foundation/portal-instances/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-language/.gitattributes
+++ b/modules/apps/foundation/portal-language/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-lock/.gitattributes
+++ b/modules/apps/foundation/portal-lock/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-portlet-bridge/.gitattributes
+++ b/modules/apps/foundation/portal-portlet-bridge/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-remote/.gitattributes
+++ b/modules/apps/foundation/portal-remote/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-scheduler/.gitattributes
+++ b/modules/apps/foundation/portal-scheduler/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-scripting/.gitattributes
+++ b/modules/apps/foundation/portal-scripting/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-search/.gitattributes
+++ b/modules/apps/foundation/portal-search/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-security-audit/.gitattributes
+++ b/modules/apps/foundation/portal-security-audit/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-security-sso/.gitattributes
+++ b/modules/apps/foundation/portal-security-sso/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-security/.gitattributes
+++ b/modules/apps/foundation/portal-security/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-settings/.gitattributes
+++ b/modules/apps/foundation/portal-settings/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-store/.gitattributes
+++ b/modules/apps/foundation/portal-store/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal-template/.gitattributes
+++ b/modules/apps/foundation/portal-template/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/portal/.gitattributes
+++ b/modules/apps/foundation/portal/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/roles/.gitattributes
+++ b/modules/apps/foundation/roles/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/server/.gitattributes
+++ b/modules/apps/foundation/server/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/user-groups-admin/.gitattributes
+++ b/modules/apps/foundation/user-groups-admin/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/users-admin/.gitattributes
+++ b/modules/apps/foundation/users-admin/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/web-proxy/.gitattributes
+++ b/modules/apps/foundation/web-proxy/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/foundation/xstream/.gitattributes
+++ b/modules/apps/foundation/xstream/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/ip-geocoder/.gitattributes
+++ b/modules/apps/ip-geocoder/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/marketplace/.gitattributes
+++ b/modules/apps/marketplace/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/screens/.gitattributes
+++ b/modules/apps/screens/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/static/osgi/.gitattributes
+++ b/modules/apps/static/osgi/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/static/portal-osgi-web/.gitattributes
+++ b/modules/apps/static/portal-osgi-web/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/sync/.gitattributes
+++ b/modules/apps/sync/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/application-list/.gitattributes
+++ b/modules/apps/web-experience/application-list/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/asset/.gitattributes
+++ b/modules/apps/web-experience/asset/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/export-import/.gitattributes
+++ b/modules/apps/web-experience/export-import/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/iframe/.gitattributes
+++ b/modules/apps/web-experience/iframe/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/layout/.gitattributes
+++ b/modules/apps/web-experience/layout/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/nested-portlets/.gitattributes
+++ b/modules/apps/web-experience/nested-portlets/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/portlet-configuration/.gitattributes
+++ b/modules/apps/web-experience/portlet-configuration/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/portlet-display-template/.gitattributes
+++ b/modules/apps/web-experience/portlet-display-template/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/product-navigation/.gitattributes
+++ b/modules/apps/web-experience/product-navigation/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/rss/.gitattributes
+++ b/modules/apps/web-experience/rss/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/site-navigation/.gitattributes
+++ b/modules/apps/web-experience/site-navigation/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/site/.gitattributes
+++ b/modules/apps/web-experience/site/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/staging/.gitattributes
+++ b/modules/apps/web-experience/staging/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/trash/.gitattributes
+++ b/modules/apps/web-experience/trash/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/modules/apps/web-experience/xsl-content/.gitattributes
+++ b/modules/apps/web-experience/xsl-content/.gitattributes
@@ -1,0 +1,1 @@
+*.soy	text eol=lf

--- a/portal-kernel/test/unit/com/liferay/portal/modules/dependencies/git_repo_gitattributes.tmpl
+++ b/portal-kernel/test/unit/com/liferay/portal/modules/dependencies/git_repo_gitattributes.tmpl
@@ -1,0 +1,1 @@
+*.soy	text eol=lf


### PR DESCRIPTION
Hi @brianchandotcom!

I'm sending you this pull (which is the same as https://github.com/brianchandotcom/liferay-portal/pull/43396) because @jpince told me `ModulesStructureTest` is constantly failing on `ee-7.0.x`. The reason is that the Journal subrepo has a `.gitattributes` file, but not `.soy` files. We need `.gitattributes` in order to force Unix line endings on Soy files because of a [bug](https://issues.liferay.com/browse/LPS-67772) in the Soy compiler that AFAIK hasn't been solved yet.

This pull simplifies the test so that every subrepo has to have the same `.gitattributes`. Do you think it's okay or we should manually delete the `.gitattributes` file of Journal in `ee-7.0.x`?

Thank you!
