### PR TITLE
master-qa-28061

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/mongodb/OSGiMongodbhook.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/mongodb/OSGiMongodbhook.testcase
@@ -9,7 +9,7 @@
 
 	<command name="MongoDBHookSmoke" priority="5">
 		<property name="hook.plugins.includes" value="mongodb-hook" />
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<var name="appName" value="MongoDB Expando Adapter" />
 		<var name="portletName" value="mongodb-hook" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-28061

See corresponding 7.0.x pull [here](https://github.com/brianchandotcom/liferay-portal/pull/43521).

@jpince @brianchiu @alee8888 This pull quarantines `OSGiMongodbhook#MongoDBHookSmoke` which is failing due to [LPS-68375](https://issues.liferay.com/browse/LPS-68375).
