### PR TITLE
[READ DESCRIPTION] LPS-67914 Creates the META-INF folder if not present

### DIFF
--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9946d0182c31f0eb7e73bae0d29ca3c5baa8ef41
+	commit = 99726ab37c50b34b539f675b53558b184a7719af
 	mode = push
-	parent = 84f6d97847a4072ca1d509befafb7573ea935311
+	parent = 95e1778f9a9c9c99c32311c70cb0cdad235544b7
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/frontend-theme-porygon/.gitignore
+++ b/modules/apps/frontend-theme-porygon/.gitignore
@@ -1,0 +1,4 @@
+*.lar
+/*/build_gradle
+/*/dist
+/*/liferay-theme.json

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/gulpfile.js
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/gulpfile.js
@@ -1,32 +1,45 @@
 'use strict';
 
 var ConfigGenerator = require('liferay-module-config-generator/lib/config-generator');
+var fs = require('fs');
 var gulp = require('gulp');
 var liferayThemeTasks = require('liferay-theme-tasks');
 var metal = require('gulp-metal');
 var path = require('path');
 var runSequence = require('run-sequence').use(gulp);
 
+var outputFolder = path.join(__dirname, 'build', 'META-INF');
+
+var configModules = function(done) {
+	var configGenerator = new ConfigGenerator(
+		{
+			args: [path.join(__dirname, 'build', 'js')],
+			config: '',
+			extension: '',
+			filePattern: '**/*.es.js',
+			format: ['/-/g', '_'],
+			ignorePath: true,
+			moduleConfig: path.join(__dirname, 'package.json'),
+			moduleRoot: path.join(__dirname, 'build'),
+			output: path.join(outputFolder, 'config.json')
+		}
+	);
+};
+
 gulp.task(
 	'configModules',
 	function(done) {
-		var configGenerator = new ConfigGenerator(
-			{
-				args: [path.join(__dirname, 'build', 'js')],
-				config: '',
-				extension: '',
-				filePattern: '**/*.es.js',
-				format: ['/-/g', '_'],
-				ignorePath: true,
-				moduleConfig: path.join(__dirname, 'package.json'),
-				moduleRoot: path.join(__dirname, 'build'),
-				output: path.join(__dirname, 'build', 'META-INF', 'config.json')
-			}
-		);
+		console.log('holakease');
+		fs.open(
+			outputFolder,
+			'wx',
+			function(error, fd) {
+				console.log(error);
+				if (error && error.code !== 'EEXIST') {
+					throw error;
+				}
 
-		configGenerator.process().then(
-			function() {
-				done();
+				configModules(done);
 			}
 		);
 	}


### PR DESCRIPTION
Hey @brianchandotcom, several of the changes you did upstream broke the build.
- All the marketplace themes have the `.gitignore` file: [westeros](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/.gitignore), [fjord](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme-fjord/frontend-theme-fjord/.gitignore)
- The `META-INF` folder is needed for the build process. I've tweaked the build to create it if it doesn't exist, but having a `META-INF/.touch` seemed easier at the time.
- The changes in `liferay-plugin-package.properties` were indeed intentional.
  - The `WabExtender` will get headers such as `Liferay-JS-Config` from there and not from a `bnd.bnd` file
  - The `Provide-Capability` is usually automatically added by our `NpmAnalyzer`, but themes don't go through that process, so we need to manually mark it as a webresource.

Could you please Backport it automatically?

Thanks!
