### PR TITLE
LPS-67914 Theme is broken on Windows, exclude it for now

### DIFF
--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9946d0182c31f0eb7e73bae0d29ca3c5baa8ef41
+	commit = 99726ab37c50b34b539f675b53558b184a7719af
 	mode = push
-	parent = 84f6d97847a4072ca1d509befafb7573ea935311
+	parent = 95e1778f9a9c9c99c32311c70cb0cdad235544b7
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/.lfrbuild-portal
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/.lfrbuild-portal
@@ -1,1 +1,0 @@
-.lfrbuild-portal


### PR DESCRIPTION
Hi Brian,
The new `frontend-theme-porygon` cannot be built on Windows because of a problem in the autogenerated `npm-shrinkwrap.json`. Instead of fixing the file manually, I'm going to write a Gradle task people can call to generate it correctly.

Thank you!

cc @jbalsas and @marcoscv-work

**_This pull will no longer automatically close if this comment is available. If you believe this is a mistake please re-open this pull by entering the following command as a comment.**_
