### PR TITLE
LRQA-28279 & LRQA-28261 Customize GitHub message to highlight FF/VNC errors.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseRule.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/AutoCloseRule.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Peter Yoo
+ */
+public class AutoCloseRule {
+
+	public AutoCloseRule(String ruleData) {
+		this.ruleData = ruleData;
+
+		String[] ruleDataArray = ruleData.split("\\|");
+
+		rulePattern = Pattern.compile(ruleDataArray[0]);
+
+		if (ruleDataArray[1].endsWith("%")) {
+			String percentageRule = ruleDataArray[1];
+
+			maxFailPercentage = Integer.parseInt(
+				percentageRule.substring(0, percentageRule.length() - 1)) / 100;
+		}
+		else {
+			maxFailCount = Integer.parseInt(ruleDataArray[1]);
+		}
+	}
+
+	public List<Build> evaluate(List<Build> downstreamBuilds) {
+		downstreamBuilds = getMatchingBuilds(downstreamBuilds);
+
+		if (downstreamBuilds.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		List<Build> failedDownstreamBuilds = new ArrayList<>(
+			downstreamBuilds.size());
+
+		int failLimit = 0;
+
+		if (maxFailPercentage != -1) {
+			failLimit = (int)(maxFailPercentage * downstreamBuilds.size());
+		}
+		else {
+			failLimit = maxFailCount;
+		}
+
+		for (Build downstreamBuild : downstreamBuilds) {
+			String status = downstreamBuild.getStatus();
+
+			if (!status.equals("completed")) {
+				continue;
+			}
+
+			String result = downstreamBuild.getResult();
+
+			if ((result != null) && !result.equals("SUCCESS")) {
+				failedDownstreamBuilds.add(downstreamBuild);
+			}
+		}
+
+		if (failedDownstreamBuilds.size() > failLimit) {
+			return failedDownstreamBuilds;
+		}
+
+		return Collections.emptyList();
+	}
+
+	public String toString() {
+		return ruleData;
+	}
+
+	protected String getBatchName(Build build) {
+		String batchName = build.getParameterValue("JOB_VARIANT");
+
+		if ((batchName == null) || batchName.isEmpty()) {
+			batchName = build.getParameterValue("JENKINS_JOB_VARIANT");
+		}
+
+		return batchName;
+	}
+
+	protected List<Build> getMatchingBuilds(List<Build> downstreamBuilds) {
+		List<Build> filteredDownstreamBuilds = new ArrayList<>(
+			downstreamBuilds.size());
+
+		for (Build downstreamBuild : downstreamBuilds) {
+			String batchName = getBatchName(downstreamBuild);
+
+			if ((batchName == null) || batchName.isEmpty()) {
+				continue;
+			}
+
+			Matcher matcher = rulePattern.matcher(
+				getBatchName(downstreamBuild));
+
+			if (matcher.matches()) {
+				filteredDownstreamBuilds.add(downstreamBuild);
+			}
+		}
+
+		return filteredDownstreamBuilds;
+	}
+
+	protected int maxFailCount = -1;
+	protected float maxFailPercentage = -1;
+	protected String ruleData;
+	protected Pattern rulePattern;
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -23,11 +23,13 @@ import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.Writer;
 
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
+import java.net.UnknownHostException;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -347,6 +349,17 @@ public class JenkinsResultsParserUtil {
 		properties.load(new StringReader(toString(getLocalURL(url))));
 
 		return properties;
+	}
+
+	public static String getHostName(String defaultHostName) {
+		try {
+			InetAddress address = InetAddress.getLocalHost();
+
+			return address.getHostName();
+		}
+		catch (UnknownHostException uhe) {
+			return defaultHostName;
+		}
 	}
 
 	public static String getJobVariant(JSONObject jsonObject) throws Exception {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
@@ -383,11 +383,11 @@ public class UnstableMessageUtil {
 
 			StringBuilder toSB = new StringBuilder();
 
-			toSB.append("peter.yoo@liferay.com,");
-			toSB.append("michael.hashimoto@liferay.com,");
-			toSB.append("leslie.wong@liferay.com,");
 			toSB.append("kevin.yen@liferay.com,");
-			toSB.append("kiyoshi.lee@liferay.com");
+			toSB.append("kiyoshi.lee@liferay.com,");
+			toSB.append("leslie.wong@liferay.com,");
+			toSB.append("michael.hashimoto@liferay.com,");
+			toSB.append("peter.yoo@liferay.com");
 
 			String message = hostName + " VNC Failure";
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
@@ -383,10 +383,10 @@ public class UnstableMessageUtil {
 
 			StringBuilder toSB = new StringBuilder();
 
-			toSB.append("kevin.yen@liferay.com,");
-			toSB.append("kiyoshi.lee@liferay.com,");
-			toSB.append("leslie.wong@liferay.com,");
-			toSB.append("michael.hashimoto@liferay.com,");
+			toSB.append("kevin.yen@liferay.com, ");
+			toSB.append("kiyoshi.lee@liferay.com, ");
+			toSB.append("leslie.wong@liferay.com, ");
+			toSB.append("michael.hashimoto@liferay.com, ");
 			toSB.append("peter.yoo@liferay.com");
 
 			String message = hostName + " VNC Failure";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
@@ -256,111 +256,109 @@ public class UnstableMessageUtil {
 						failureCount++;
 
 						sb.append("<li>...</li>");
+
+						continue;
 					}
 
-					if (failureCount < 3) {
-						sb.append("<li><a href=\"");
+					if (failureCount > 3) {
+						continue;
+					}
 
-						String runBuildHREF = runBuildURL;
+					sb.append("<li><a href=\"");
 
-						runBuildHREF = runBuildHREF.replace("[", "_");
-						runBuildHREF = runBuildHREF.replace("]", "_");
-						runBuildHREF = runBuildHREF.replace("#", "_");
+					String runBuildHREF = runBuildURL;
 
-						sb.append(runBuildHREF);
+					runBuildHREF = runBuildHREF.replace("[", "_");
+					runBuildHREF = runBuildHREF.replace("]", "_");
+					runBuildHREF = runBuildHREF.replace("#", "_");
 
-						sb.append("/testReport/");
+					sb.append(runBuildHREF);
 
-						String testClassName = caseJSONObject.getString(
-							"className");
+					sb.append("/testReport/");
 
-						int x = testClassName.lastIndexOf(".");
+					String testClassName = caseJSONObject.getString(
+						"className");
 
-						String testPackageName = testClassName.substring(0, x);
+					int x = testClassName.lastIndexOf(".");
 
-						sb.append(testPackageName);
+					String testPackageName = testClassName.substring(0, x);
+
+					sb.append(testPackageName);
+
+					sb.append("/");
+
+					String testSimpleClassName = testClassName.substring(x + 1);
+
+					sb.append(testSimpleClassName);
+
+					sb.append("/");
+
+					String testMethodName = caseJSONObject.getString("name");
+
+					String testMethodNameURL = testMethodName;
+
+					testMethodNameURL = testMethodNameURL.replace("[", "_");
+					testMethodNameURL = testMethodNameURL.replace("]", "_");
+					testMethodNameURL = testMethodNameURL.replace("#", "_");
+
+					if (testPackageName.equals("junit.framework")) {
+						testMethodNameURL = testMethodNameURL.replace(".", "_");
+					}
+
+					sb.append(testMethodNameURL);
+
+					sb.append("\">");
+
+					String jobVariant = JenkinsResultsParserUtil.getJobVariant(
+						runBuildURLJSONObject);
+
+					if (jobVariant.contains("functional")) {
+						String testName = testMethodName.substring(
+							5, testMethodName.length() - 1);
+
+						sb.append(testName);
+
+						sb.append("</a> - ");
+						sb.append("<a href=\"");
+
+						String logURL = _getLogURL(
+							jobVariant, project, runBuildURLJSONObject);
+
+						sb.append(logURL);
 
 						sb.append("/");
+						sb.append(testName.replace("#", "_"));
+						sb.append("/index.html.gz\">Poshi Report</a> - ");
+						sb.append("<a href=\"");
+						sb.append(logURL);
+						sb.append("/");
+						sb.append(testName.replace("#", "_"));
+						sb.append("/summary.html.gz\">Poshi Summary</a> - ");
+						sb.append("<a href=\"");
+						sb.append(logURL);
+						sb.append(
+							"/jenkins-console.txt.gz\">Console Output</a>");
 
-						String testSimpleClassName = testClassName.substring(
-							x + 1);
+						if (Boolean.parseBoolean(
+								project.getProperty(
+									"record.liferay.log"))) {
 
+							sb.append(" - ");
+							sb.append("<a href=\"");
+							sb.append(logURL);
+							sb.append("/liferay-log.txt.gz\">Liferay Log</a>");
+						}
+					}
+					else {
 						sb.append(testSimpleClassName);
-
-						sb.append("/");
-
-						String testMethodName = caseJSONObject.getString(
-							"name");
-
-						String testMethodNameURL = testMethodName;
-
-						testMethodNameURL = testMethodNameURL.replace("[", "_");
-						testMethodNameURL = testMethodNameURL.replace("]", "_");
-						testMethodNameURL = testMethodNameURL.replace("#", "_");
-
-						if (testPackageName.equals("junit.framework")) {
-							testMethodNameURL = testMethodNameURL.replace(
-								".", "_");
-						}
-
-						sb.append(testMethodNameURL);
-
-						sb.append("\">");
-
-						String jobVariant =
-							JenkinsResultsParserUtil.getJobVariant(
-								runBuildURLJSONObject);
-
-						if (jobVariant.contains("functional")) {
-							String testName = testMethodName.substring(
-								5, testMethodName.length() - 1);
-
-							sb.append(testName);
-
-							sb.append("</a> - ");
-							sb.append("<a href=\"");
-
-							String logURL = _getLogURL(
-								jobVariant, project, runBuildURLJSONObject);
-
-							sb.append(logURL);
-
-							sb.append("/");
-							sb.append(testName.replace("#", "_"));
-							sb.append("/index.html.gz\">Poshi Report</a> - ");
-							sb.append("<a href=\"");
-							sb.append(logURL);
-							sb.append("/");
-							sb.append(testName.replace("#", "_"));
-							sb.append(
-								"/summary.html.gz\">Poshi Summary</a> - ");
-							sb.append("<a href=\"");
-							sb.append(logURL);
-							sb.append(
-								"/jenkins-console.txt.gz\">Console Output</a>");
-
-							if (Boolean.parseBoolean(
-									project.getProperty(
-										"record.liferay.log"))) {
-
-								sb.append(" - ");
-								sb.append("<a href=\"");
-								sb.append(logURL);
-								sb.append(
-									"/liferay-log.txt.gz\">Liferay Log</a>");
-							}
-						}
-						else {
-							sb.append(testSimpleClassName);
-							sb.append(".");
-							sb.append(testMethodName);
-							sb.append("</a>");
-						}
-
-						sb.append("</li>");
-
-						failureCount++;
+						sb.append(".");
+						sb.append(testMethodName);
+						sb.append("</a>");
 					}
+
+					sb.append("</li>");
+
+					failureCount++;
 				}
 			}
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UnstableMessageUtil.java
@@ -107,7 +107,7 @@ public class UnstableMessageUtil {
 			runBuildURLs.add(buildURL);
 		}
 
-		int failureCount = _getUnstableMessage(project, runBuildURLs, sb);
+		int failureCount = _getFailureCount(project, runBuildURLs, sb);
 
 		sb.append("</ol>");
 
@@ -177,7 +177,7 @@ public class UnstableMessageUtil {
 		return sb.toString();
 	}
 
-	private static int _getUnstableMessage(
+	private static int _getFailureCount(
 			Project project, List<String> runBuildURLs, StringBuilder sb)
 		throws Exception {
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitHubMessageUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/GitHubMessageUtilTest.java
@@ -40,6 +40,9 @@ public class GitHubMessageUtilTest extends BaseJenkinsResultsParserTestCase {
 	@Before
 	public void setUp() throws Exception {
 		downloadSample(
+			"ff-vnc-1", "37", "test-portal-acceptance-pullrequest(master)",
+			"test-1-12");
+		downloadSample(
 			"generic-1", "1609", "test-portal-acceptance-pullrequest(master)",
 			"test-1-1");
 		downloadSample(

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/0-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/0-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-9/job/test-portal-acceptance-pullrequest-source(master)/578/">test-portal-acceptance-pullrequest-source(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/1-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/1-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-13/job/test-portal-acceptance-pullrequest-dist(master)/133/">test-portal-acceptance-pullrequest-dist(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/10-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/10-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45276/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/11-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/11-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44990/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/12-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/12-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45277/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/13-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/13-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1634/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/14-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/14-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1412/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/15-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/15-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1330/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/16-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/16-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44991/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/17-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/17-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-10/job/test-portal-acceptance-pullrequest-batch(master)/39808/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/18-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/18-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46278/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/19-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/19-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1331/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/2-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/2-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44983/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/20-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/20-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-6/job/test-portal-acceptance-pullrequest-batch(master)/26018/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/21-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/21-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47108/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/22-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/22-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1414/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/23-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/23-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1332/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/24-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/24-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1415/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/25-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/25-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="UNSTABLE"><a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1333/">test-portal-acceptance-pullrequest-batch(master)</a></h5><h6>Job Results:</h6><p>29 Tests Passed.<br />3 Tests Failed.</p><ol>All tests failed due to the Firefox VNC error. See <a href="https://issues.liferay.com/browse/LRQA-28169">LRQA-28169</a> for more details.</ol>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/26-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/26-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46162/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/27-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/27-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-13/job/test-portal-acceptance-pullrequest-batch(master)/42311/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/28-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/28-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29493/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/29-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/29-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41601/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/3-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/3-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45154/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/30-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/30-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45056/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/31-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/31-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46281/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/32-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/32-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44995/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/33-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/33-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45157/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/34-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/34-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47114/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/35-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/35-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1421/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/36-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/36-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45280/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/37-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/37-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-20/job/test-portal-acceptance-pullrequest-batch(master)/43916/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/38-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/38-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-20/job/test-portal-acceptance-pullrequest-batch(master)/43917/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/39-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/39-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44772/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/4-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/4-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1325/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/40-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/40-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1424/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/41-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/41-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-10/job/test-portal-acceptance-pullrequest-batch(master)/39811/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/42-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/42-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1643/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/43-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/43-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-19/job/test-portal-acceptance-pullrequest-batch(master)/41027/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/44-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/44-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29494/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/45-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/45-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29496/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/46-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/46-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41603/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/47-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/47-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1426/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/48-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/48-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1644/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/49-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/49-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45158/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/5-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/5-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41592/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/50-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/50-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-7/job/test-portal-acceptance-pullrequest-batch(master)/29110/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/51-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/51-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44996/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/52-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/52-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47118/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/53-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/53-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29501/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/54-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/54-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46165/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/55-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/55-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-10/job/test-portal-acceptance-pullrequest-batch(master)/39815/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/56-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/56-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1651/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/57-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/57-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1339/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/58-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/58-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45057/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/59-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/59-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1652/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/6-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/6-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46160/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/60-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/60-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45283/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/61-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/61-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45058/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/62-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/62-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-6/job/test-portal-acceptance-pullrequest-batch(master)/26023/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/63-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/63-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-13/job/test-portal-acceptance-pullrequest-batch(master)/42315/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/64-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/64-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44779/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/65-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/65-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47124/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/66-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/66-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41607/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/67-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/67-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46287/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/68-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/68-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-19/job/test-portal-acceptance-pullrequest-batch(master)/41030/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/69-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/69-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45162/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/7-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/7-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44767/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/70-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/70-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46167/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/71-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/71-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1653/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/72-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/72-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1341/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/73-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/73-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-7/job/test-portal-acceptance-pullrequest-batch(master)/29112/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/74-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/74-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45061/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/75-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/75-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-19/job/test-portal-acceptance-pullrequest-batch(master)/41032/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/76-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/76-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47127/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/77-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/77-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29505/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/78-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/78-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46291/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/79-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/79-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46293/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/8-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/8-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44768/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/80-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/80-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1654/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/81-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/81-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45285/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/82-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/82-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46168/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/83-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/83-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45164/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/9-report.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/9-report.html
@@ -1,0 +1,1 @@
+<h5 job-result="SUCCESS"><a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41595/">test-portal-acceptance-pullrequest-batch(master)</a></h5>

--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/expected_message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageUtilTest/ff-vnc-1/expected_message.html
@@ -1,0 +1,306 @@
+
+<html>
+  <h1>junit-top-level-result-message</h1>
+  <p>Build Time: junit-top-level-build-time</p>
+  <h4>Base Branch:</h4>
+  <p>Branch Name:
+    <a href="https://github.com/liferay/junit-repository/tree/junit-branch-name">junit-branch-name</a>
+    <br/>Branch GIT ID:
+    <a href="https://github.com/liferay/junit-repository/commit/rebase-branch-git-commit">rebase-branch-git-commit</a>
+  </p>
+  <h4>Job Summary:</h4>
+  <ul>
+    <li>
+      <strike>
+        <strong>
+          <a href="${dependencies.url}/GitHubMessageUtilTest/ff-vnc-1/">junit-top-level-build-name</a>
+        </strong>
+      </strike>
+    </li>
+    <li>
+      <a href="http://test-1-9/job/test-portal-acceptance-pullrequest-source(master)/578/">test-portal-acceptance-pullrequest-source(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-13/job/test-portal-acceptance-pullrequest-dist(master)/133/">test-portal-acceptance-pullrequest-dist(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44983/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45154/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1325/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41592/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46160/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44767/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44768/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41595/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45276/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44990/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45277/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1634/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1412/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1330/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44991/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-10/job/test-portal-acceptance-pullrequest-batch(master)/39808/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46278/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1331/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-6/job/test-portal-acceptance-pullrequest-batch(master)/26018/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47108/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1414/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1332/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1415/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <strike>
+        <strong>
+          <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1333/">test-portal-acceptance-pullrequest-batch(master)</a>
+        </strong>
+      </strike>
+    </li>
+    <li>
+      <a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46162/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-13/job/test-portal-acceptance-pullrequest-batch(master)/42311/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29493/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41601/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45056/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46281/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44995/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45157/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47114/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1421/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45280/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-20/job/test-portal-acceptance-pullrequest-batch(master)/43916/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-20/job/test-portal-acceptance-pullrequest-batch(master)/43917/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44772/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1424/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-10/job/test-portal-acceptance-pullrequest-batch(master)/39811/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1643/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-19/job/test-portal-acceptance-pullrequest-batch(master)/41027/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29494/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29496/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41603/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-15/job/test-portal-acceptance-pullrequest-batch(master)/1426/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1644/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45158/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-7/job/test-portal-acceptance-pullrequest-batch(master)/29110/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-11/job/test-portal-acceptance-pullrequest-batch(master)/44996/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47118/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29501/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46165/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-10/job/test-portal-acceptance-pullrequest-batch(master)/39815/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1651/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1339/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45057/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1652/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45283/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45058/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-6/job/test-portal-acceptance-pullrequest-batch(master)/26023/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-13/job/test-portal-acceptance-pullrequest-batch(master)/42315/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-17/job/test-portal-acceptance-pullrequest-batch(master)/44779/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47124/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-9/job/test-portal-acceptance-pullrequest-batch(master)/41607/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46287/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-19/job/test-portal-acceptance-pullrequest-batch(master)/41030/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45162/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46167/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1653/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1341/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-7/job/test-portal-acceptance-pullrequest-batch(master)/29112/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-2/job/test-portal-acceptance-pullrequest-batch(master)/45061/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-19/job/test-portal-acceptance-pullrequest-batch(master)/41032/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-3/job/test-portal-acceptance-pullrequest-batch(master)/47127/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-5/job/test-portal-acceptance-pullrequest-batch(master)/29505/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46291/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-4/job/test-portal-acceptance-pullrequest-batch(master)/46293/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-12/job/test-portal-acceptance-pullrequest-batch(master)/1654/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-18/job/test-portal-acceptance-pullrequest-batch(master)/45285/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-14/job/test-portal-acceptance-pullrequest-batch(master)/46168/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+    <li>
+      <a href="http://test-1-16/job/test-portal-acceptance-pullrequest-batch(master)/45164/">test-portal-acceptance-pullrequest-batch(master)</a>
+    </li>
+  </ul>
+  <h5>For more details click
+    <a href="junit-top-level-shared-dir-url/jenkins-report.html">here</a>.
+  </h5>
+  <hr/>
+  <h4>Failed Jobs:</h4>
+  <ol>
+    <li>
+      <h5>
+        <a href="${dependencies.url}/GitHubMessageUtilTest/ff-vnc-1/">junit-top-level-build-name</a>
+      </h5>
+      <h6>Job Results:</h6>
+      <p>83 Jobs Passed.
+        <br/>2 Jobs Failed.
+      </p>
+      <pre><code>Completed with the status of FAILURE.</code></pre>
+    </li>
+    <li>
+      <h5 job-result="UNSTABLE">
+        <a href="http://test-1-8/job/test-portal-acceptance-pullrequest-batch(master)/1333/">test-portal-acceptance-pullrequest-batch(master)</a>
+      </h5>
+      <h6>Job Results:</h6>
+      <p>29 Tests Passed.
+        <br/>3 Tests Failed.
+      </p>
+      <ol>All tests failed due to the Firefox VNC error. See
+        <a href="https://issues.liferay.com/browse/LRQA-28169">LRQA-28169</a> for more details.
+      </ol>
+    </li>
+  </ol>
+</html>


### PR DESCRIPTION
Re-send of https://github.com/brianchandotcom/liferay-portal/pull/43832

The sb variable is actually passed in to the method so the changes that are made to it are a side-effect and don't have to be returned directly. I normally don't like side-effect-y stuff but it was the most efficient way and since it is in a private method, I didn't think it would be a problem.

I renamed the method from _getUnstableMessage() to _getFailureCount() since it actually returns the failureCount while the message part of it is side-effect. I thought this may make things a little clearer.

---

This pull modifies the GitHub message that is displayed when functional tests that have failed because of the Firefox/VNC problem. This pull also contains the new class, AutoCloseRule that was originally written in beanshell. (brianchandotcom/liferay-jenkins-ee#1851)

https://issues.liferay.com/browse/LRQA-28261
https://issues.liferay.com/browse/LRQA-28279
