### PR TITLE
LPS-68781 Add registry-api to workaround gradle bug for buildWSDD mis…

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-service/build.gradle
+++ b/modules/apps/collaboration/blogs/blogs-service/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	provided project(":apps:foundation:friendly-url:friendly-url-api")
 	provided project(":apps:web-experience:export-import:export-import-api")
 	provided project(":apps:web-experience:export-import:export-import-service")
+	provided project(":core:registry-api")
 
 	testCompile group: "com.liferay", name: "com.liferay.blogs.web", version: "1.0.0"
 	testCompile project(":apps:collaboration:blogs:blogs-test-util")


### PR DESCRIPTION
…sing registry-api jar on the classpath.

@Ithildir please take a look at this. The fix should really go into gradle classpath generation for buildWSDD. We should not force all xyz-service with remote services to declare dependency to registry-api. I am only doing this as a workaround to unblock my blogs service builder extraction. Once you fix it in the right way, please revert this commit. You can get reproduce steps from https://issues.liferay.com/browse/LPS-68781, thanks!

CC @sergiogonzalez @mhan810
