### PR TITLE
LPS-68554 Disable disk allocation decider - pointless in embedded mode, and breaks CI

### DIFF
--- a/modules/apps/foundation/portal-configuration/.gitrepo
+++ b/modules/apps/foundation/portal-configuration/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3e8a0590d22e2fb8685e3e94228e6b6f6f0f93b7
+	commit = 1ecec0d5c0c45c51088c15f62fdde0e17b782f0f
 	mode = push
-	parent = ea83cb48c5e319326a257fbc6b80692d4a533113
+	parent = ebad9afd2de5039ab188ff20bf72dff84cd33eb4
 	remote = git@github.com:liferay/com-liferay-portal-configuration.git

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
@@ -113,6 +113,8 @@ public class EmbeddedElasticsearchConnection
 	protected void configureClustering() {
 		settingsBuilder.put(
 			"cluster.name", elasticsearchConfiguration.clusterName());
+		settingsBuilder.put(
+			"cluster.routing.allocation.disk.threshold_enabled", false);
 		settingsBuilder.put("discovery.zen.ping.multicast.enabled", false);
 	}
 


### PR DESCRIPTION
Author: @alee8888 
Reviewer: @arboliveira

@peterfellwock @shuyangzhou This should fix https://github.com/brianchandotcom/liferay-portal/pull/44014#issuecomment-254633781 (random test failures due to Elasticsearch being really conservative by default and thinking 15% free disk space is too low to allocate shards, even in embedded mode in a developer or CI environment.)
