### PR TITLE
LPS-68814

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2375,4 +2375,24 @@ ${output.content}</echo>
 	<target name="upstream-functional-tomcat8-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
+
+	<target name="wsdd-builder-jdk8">
+		<run-batch-test>
+			<test-action>
+				<ant dir="portal-impl" target="build-wsdds" />
+			</test-action>
+
+			<test-set-up>
+				<if>
+					<isset property="env.DIST_PATH" />
+					<then>
+						<prepare-test-environment />
+					</then>
+					<else>
+						<prepare-test-build />
+					</else>
+				</if>
+			</test-set-up>
+		</run-batch-test>
+	</target>
 </project>

--- a/git-commit-portal-ee
+++ b/git-commit-portal-ee
@@ -1,1 +1,1 @@
-ebc720b31349f7932820fdc358cf5502b9aff5eb
+https://github.com/brianchandotcom/liferay-portal-ee/pull/14778

--- a/modules/apps/collaboration/blogs/blogs-service/build.gradle
+++ b/modules/apps/collaboration/blogs/blogs-service/build.gradle
@@ -28,6 +28,5 @@ dependencies {
 	provided project(":core:registry-api")
 
 	testCompile group: "com.liferay", name: "com.liferay.blogs.web", version: "1.0.0"
-	testCompile group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	testCompile project(":apps:collaboration:blogs:blogs-test-util")
 }

--- a/modules/apps/collaboration/blogs/blogs-service/build.gradle
+++ b/modules/apps/collaboration/blogs/blogs-service/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.dao.orm.custom.sql", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.rss.util", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
@@ -25,7 +26,6 @@ dependencies {
 	provided project(":apps:foundation:friendly-url:friendly-url-api")
 	provided project(":apps:web-experience:export-import:export-import-api")
 	provided project(":apps:web-experience:export-import:export-import-service")
-	provided project(":core:registry-api")
 
 	testCompile group: "com.liferay", name: "com.liferay.blogs.web", version: "1.0.0"
 	testCompile project(":apps:collaboration:blogs:blogs-test-util")

--- a/modules/apps/collaboration/bookmarks/bookmarks-service/build.gradle
+++ b/modules/apps/collaboration/bookmarks/bookmarks-service/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.dao.orm.custom.sql", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"

--- a/modules/apps/collaboration/flags/flags-service/build.gradle
+++ b/modules/apps/collaboration/flags/flags-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.petra.content", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"

--- a/modules/apps/collaboration/microblogs/microblogs-service/build.gradle
+++ b/modules/apps/collaboration/microblogs/microblogs-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.dao.orm.custom.sql", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"

--- a/modules/apps/collaboration/wiki/wiki-service/build.gradle
+++ b/modules/apps/collaboration/wiki/wiki-service/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portlet.display.template", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.rss.util", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.wiki.api", version: "2.2.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/build.gradle
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.security.service.access.policy.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.rss.util", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay", name: "net.fortuna.ical4j", version: "1.0"

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/build.gradle
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"

--- a/modules/apps/forms-and-workflow/polls/polls-service/build.gradle
+++ b/modules/apps/forms-and-workflow/polls/polls-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.dao.orm.custom.sql", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/build.gradle
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.dao.orm.custom.sql", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"

--- a/modules/apps/foundation/portal-security/portal-security-service-access-policy-service/build.gradle
+++ b/modules/apps/foundation/portal-security/portal-security-service-access-policy-service/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.security.service.access.policy.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"

--- a/modules/apps/shopping/shopping-service/build.gradle
+++ b/modules/apps/shopping/shopping-service/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.dao.orm.custom.sql", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.shopping.api", version: "3.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"

--- a/modules/apps/sync/sync-service/build.gradle
+++ b/modules/apps/sync/sync-service/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.instance.lifecycle", version: "3.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.sync.api", version: "2.2.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"

--- a/test.properties
+++ b/test.properties
@@ -1000,7 +1000,8 @@
         semantic-versioning-jdk8,\
         service-builder-jdk8,\
         tck-jdk8,\
-        unit-jdk8
+        unit-jdk8,\
+        wsdd-builder-jdk8
 
     test.batch.names[auto-close]=\
         functional-smoke-.*,\


### PR DESCRIPTION
@shuyangzhou: I did some research, it seems that `registry-api` is required if a remote service has a method with `ServiceContext` as argument. That's because: `ServiceContext` -> `ThemeDisplay` -> `PortletDisplay` -> `PortletToolbar` -> `ServiceTrackerCustomizer`.

[LPS-66697](https://issues.liferay.com/browse/LPS-66697) is the one that removed `registry-api` from these modules.
