### PR TITLE
LPS-68814 Add missing test property

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1085,6 +1085,7 @@
     test.batch.size[service-builder-jdk8]=1
     test.batch.size[tck-jdk8]=10
     test.batch.size[unit-jdk8]=1
+    test.batch.size[wsdd-builder-jdk8]=1
 
 ##
 ## Test Case


### PR DESCRIPTION
Hi,
Sorry, I didn't know about this property. With this pull, we have a new test batch that tries to run `build-wsdds`.
