### PR TITLE
LPS-68289 Fix NotSerializableException: org.hamcrest.core.Is, when ru…

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/test/ReflectionTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/test/ReflectionTest.java
@@ -44,7 +44,7 @@ public class ReflectionTest {
 
 	@BeforeClass
 	public static void setUpClass() {
-		Assume.assumeTrue(JavaDetector.isJDK7());
+		Assume.assumeTrue("JDK is not 7", JavaDetector.isJDK7());
 	}
 
 	@Test


### PR DESCRIPTION
…nning PACLTestSuite with JDK other than 7. The problem is that the default method creates a non-serializable Matcher which is a field of the AssumptionViolatedException.
