### PR TITLE
Lps 68289 32

### DIFF
--- a/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorCriterionHandlerTest.java
+++ b/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorCriterionHandlerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.item.selector.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
@@ -25,9 +26,6 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 
@@ -48,7 +47,10 @@ public class ItemSelectorCriterionHandlerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = bundle.getBundleContext();
+		_bundle = FrameworkUtil.getBundle(
+			ItemSelectorCriterionHandlerTest.class);
+
+		_bundleContext = _bundle.getBundleContext();
 
 		_serviceReference = _bundleContext.getServiceReference(
 			TestItemSelectorCriterionHandler.class);
@@ -116,9 +118,6 @@ public class ItemSelectorCriterionHandlerTest {
 		}
 	}
 
-	@ArquillianResource
-	public Bundle bundle;
-
 	protected ServiceRegistration<ItemSelectorView> registerItemSelectorView(
 		ItemSelectorView itemSelectorView, String itemSelectorViewKey) {
 
@@ -149,6 +148,7 @@ public class ItemSelectorCriterionHandlerTest {
 		serviceRegistrations.forEach(ServiceRegistration::unregister);
 	}
 
+	private Bundle _bundle;
 	private BundleContext _bundleContext;
 	private TestItemSelectorCriterionHandler _itemSelectorCriterionHandler;
 	private ServiceReference<TestItemSelectorCriterionHandler>

--- a/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorCriterionSerializerTest.java
+++ b/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorCriterionSerializerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.item.selector.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
@@ -26,9 +27,6 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 
@@ -49,7 +48,10 @@ public class ItemSelectorCriterionSerializerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = bundle.getBundleContext();
+		_bundle = FrameworkUtil.getBundle(
+			ItemSelectorCriterionSerializerTest.class);
+
+		_bundleContext = _bundle.getBundleContext();
 
 		_serviceReference = _bundleContext.getServiceReference(
 			ItemSelectorCriterionSerializer.class);
@@ -128,9 +130,6 @@ public class ItemSelectorCriterionSerializerTest {
 		}
 	}
 
-	@ArquillianResource
-	public Bundle bundle;
-
 	protected ServiceRegistration<ItemSelectorView> registerItemSelectorView(
 		ItemSelectorView itemSelectorView, String itemSelectorViewKey) {
 
@@ -161,6 +160,7 @@ public class ItemSelectorCriterionSerializerTest {
 		serviceRegistrations.forEach(ServiceRegistration::unregister);
 	}
 
+	private Bundle _bundle;
 	private BundleContext _bundleContext;
 	private ItemSelectorCriterionSerializer _itemSelectorCriterionSerializer;
 	private ServiceReference<ItemSelectorCriterionSerializer> _serviceReference;

--- a/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorReturnTypeResolverHandlerTest.java
+++ b/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorReturnTypeResolverHandlerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.item.selector.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.item.selector.ItemSelectorReturnTypeResolver;
 import com.liferay.item.selector.ItemSelectorReturnTypeResolverHandler;
 import com.liferay.item.selector.ItemSelectorView;
@@ -27,9 +28,6 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,6 +37,7 @@ import org.junit.runner.RunWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 
@@ -50,7 +49,10 @@ public class ItemSelectorReturnTypeResolverHandlerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = bundle.getBundleContext();
+		_bundle = FrameworkUtil.getBundle(
+			ItemSelectorReturnTypeResolverHandlerTest.class);
+
+		_bundleContext = _bundle.getBundleContext();
 
 		_serviceReference = _bundleContext.getServiceReference(
 			ItemSelectorReturnTypeResolverHandler.class);
@@ -222,9 +224,6 @@ public class ItemSelectorReturnTypeResolverHandlerTest {
 		}
 	}
 
-	@ArquillianResource
-	public Bundle bundle;
-
 	protected ServiceRegistration<ItemSelectorReturnTypeResolver>
 		registerItemSelectorReturnTypeResolver(
 			ItemSelectorReturnTypeResolver itemSelectorReturnTypeResolver,
@@ -269,6 +268,7 @@ public class ItemSelectorReturnTypeResolverHandlerTest {
 		serviceRegistrations.forEach(ServiceRegistration::unregister);
 	}
 
+	private Bundle _bundle;
 	private BundleContext _bundleContext;
 	private ItemSelectorReturnTypeResolverHandler
 		_itemSelectorReturnTypeResolverHandler;

--- a/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorViewReturnTypeProviderHandlerTest.java
+++ b/modules/apps/collaboration/item-selector/item-selector-test/src/testIntegration/java/com/liferay/item/selector/test/ItemSelectorViewReturnTypeProviderHandlerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.item.selector.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewReturnTypeProvider;
@@ -24,9 +25,6 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 
@@ -47,7 +46,10 @@ public class ItemSelectorViewReturnTypeProviderHandlerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_bundleContext = bundle.getBundleContext();
+		_bundle = FrameworkUtil.getBundle(
+			ItemSelectorViewReturnTypeProviderHandlerTest.class);
+
+		_bundleContext = _bundle.getBundleContext();
 
 		_serviceReference = _bundleContext.getServiceReference(
 			ItemSelectorViewReturnTypeProviderHandler.class);
@@ -98,9 +100,6 @@ public class ItemSelectorViewReturnTypeProviderHandlerTest {
 		}
 	}
 
-	@ArquillianResource
-	public Bundle bundle;
-
 	protected ServiceRegistration<ItemSelectorView> registerItemSelectorView(
 		ItemSelectorView itemSelectorView, String itemSelectorViewKey) {
 
@@ -131,6 +130,7 @@ public class ItemSelectorViewReturnTypeProviderHandlerTest {
 		serviceRegistrations.forEach(ServiceRegistration::unregister);
 	}
 
+	private Bundle _bundle;
 	private BundleContext _bundleContext;
 	private ItemSelectorViewReturnTypeProviderHandler
 		_itemSelectorViewReturnTypeProviderHandler;

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/test/ConfigurationPersistenceManagerTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/test/ConfigurationPersistenceManagerTest.java
@@ -14,9 +14,9 @@
 
 package com.liferay.portal.configuration.persistence.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.portal.configuration.persistence.ConfigurationPersistenceManager;
-import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.util.StringPool;
 
 import java.io.IOException;
@@ -25,8 +25,6 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 
 import org.apache.felix.cm.PersistenceManager;
-
-import org.jboss.arquillian.junit.Arquillian;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -44,7 +42,6 @@ import org.osgi.util.tracker.ServiceTracker;
  * @author Raymond Augé
  */
 @RunWith(Arquillian.class)
-@Sync
 public class ConfigurationPersistenceManagerTest {
 
 	@Before


### PR DESCRIPTION
@hhuijser we need a SF check to regulate this. Here is the rule:
1) Select out all tests that use "org.jboss.arquillian.junit.Arquillian"
2) If the test class has usage to "org.jboss.arquillian.container.test.api.RunAsClient" don't need to do anything.
3) If the test class has "testIntegration/resources/arquillian.xml" in its module don't need to do anything.
4) For any test class from 1) that does not match 2) or 3), replace it to be "com.liferay.arquillian.extension.junit.bridge.junit.Arquillian"

Please let me know if you run into any issues, thanks!

CC @peterfellwock
