### PR TITLE
LPS-68542 Autogenerated

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 2c302e9efdc8afe5eb4dcf058410dad1536588c6
+	commit = 932371847603403f723f90a19cff99de0be006c8
 	mode = push
-	parent = ddce213231261e23c75c7fe51500637973518c44
+	parent = 10a83004451b632b9e8c694b75369bf389f98966
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleService.java
@@ -74,6 +74,14 @@ public interface KBArticleService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle fetchFirstChildKBArticle(long groupId,
+		long parentResourcePrimKey);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBArticle fetchKBArticleByUrlTitle(long groupId, long kbFolderId,
+		java.lang.String urlTitle) throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBArticle fetchLatestKBArticle(long resourcePrimKey, int status)
 		throws PortalException;
 

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceUtil.java
@@ -61,6 +61,19 @@ public class KBArticleServiceUtil {
 		return getService().deleteKBArticle(resourcePrimKey);
 	}
 
+	public static com.liferay.knowledge.base.model.KBArticle fetchFirstChildKBArticle(
+		long groupId, long parentResourcePrimKey) {
+		return getService()
+				   .fetchFirstChildKBArticle(groupId, parentResourcePrimKey);
+	}
+
+	public static com.liferay.knowledge.base.model.KBArticle fetchKBArticleByUrlTitle(
+		long groupId, long kbFolderId, java.lang.String urlTitle)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .fetchKBArticleByUrlTitle(groupId, kbFolderId, urlTitle);
+	}
+
 	public static com.liferay.knowledge.base.model.KBArticle fetchLatestKBArticle(
 		long resourcePrimKey, int status)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBArticleServiceWrapper.java
@@ -55,6 +55,21 @@ public class KBArticleServiceWrapper implements KBArticleService,
 	}
 
 	@Override
+	public com.liferay.knowledge.base.model.KBArticle fetchFirstChildKBArticle(
+		long groupId, long parentResourcePrimKey) {
+		return _kbArticleService.fetchFirstChildKBArticle(groupId,
+			parentResourcePrimKey);
+	}
+
+	@Override
+	public com.liferay.knowledge.base.model.KBArticle fetchKBArticleByUrlTitle(
+		long groupId, long kbFolderId, java.lang.String urlTitle)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _kbArticleService.fetchKBArticleByUrlTitle(groupId, kbFolderId,
+			urlTitle);
+	}
+
+	@Override
 	public com.liferay.knowledge.base.model.KBArticle fetchLatestKBArticle(
 		long resourcePrimKey, int status)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderService.java
@@ -64,6 +64,10 @@ public interface KBFolderService extends BaseService {
 	public KBFolder deleteKBFolder(long kbFolderId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBFolder fetchFirstChildKBFolder(long groupId, long kbFolderId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder fetchKBFolder(long kbFolderId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceUtil.java
@@ -58,6 +58,12 @@ public class KBFolderServiceUtil {
 		return getService().deleteKBFolder(kbFolderId);
 	}
 
+	public static com.liferay.knowledge.base.model.KBFolder fetchFirstChildKBFolder(
+		long groupId, long kbFolderId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().fetchFirstChildKBFolder(groupId, kbFolderId);
+	}
+
 	public static com.liferay.knowledge.base.model.KBFolder fetchKBFolder(
 		long kbFolderId)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceWrapper.java
@@ -50,6 +50,13 @@ public class KBFolderServiceWrapper implements KBFolderService,
 	}
 
 	@Override
+	public com.liferay.knowledge.base.model.KBFolder fetchFirstChildKBFolder(
+		long groupId, long kbFolderId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _kbFolderService.fetchFirstChildKBFolder(groupId, kbFolderId);
+	}
+
+	@Override
 	public com.liferay.knowledge.base.model.KBFolder fetchKBFolder(
 		long kbFolderId)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceHttp.java
@@ -252,12 +252,74 @@ public class KBArticleServiceHttp {
 		}
 	}
 
+	public static com.liferay.knowledge.base.model.KBArticle fetchFirstChildKBArticle(
+		HttpPrincipal httpPrincipal, long groupId, long parentResourcePrimKey) {
+		try {
+			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
+					"fetchFirstChildKBArticle",
+					_fetchFirstChildKBArticleParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					parentResourcePrimKey);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.knowledge.base.model.KBArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBArticle fetchKBArticleByUrlTitle(
+		HttpPrincipal httpPrincipal, long groupId, long kbFolderId,
+		java.lang.String urlTitle)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
+					"fetchKBArticleByUrlTitle",
+					_fetchKBArticleByUrlTitleParameterTypes7);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					kbFolderId, urlTitle);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.knowledge.base.model.KBArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static com.liferay.knowledge.base.model.KBArticle fetchLatestKBArticle(
 		HttpPrincipal httpPrincipal, long resourcePrimKey, int status)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"fetchLatestKBArticle", _fetchLatestKBArticleParameterTypes6);
+					"fetchLatestKBArticle", _fetchLatestKBArticleParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, status);
@@ -291,7 +353,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getAllDescendantKBArticles",
-					_getAllDescendantKBArticlesParameterTypes7);
+					_getAllDescendantKBArticlesParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, status, orderByComparator);
@@ -326,7 +388,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getAllDescendantKBArticles",
-					_getAllDescendantKBArticlesParameterTypes8);
+					_getAllDescendantKBArticlesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKey, status, orderByComparator);
@@ -359,7 +421,7 @@ public class KBArticleServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.knowledge.base.model.KBArticle> orderByComparator) {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getGroupKBArticles", _getGroupKBArticlesParameterTypes9);
+					"getGroupKBArticles", _getGroupKBArticlesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, start, end, orderByComparator);
@@ -387,7 +449,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getGroupKBArticlesCount",
-					_getGroupKBArticlesCountParameterTypes10);
+					_getGroupKBArticlesCountParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status);
@@ -418,7 +480,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getGroupKBArticlesRSS",
-					_getGroupKBArticlesRSSParameterTypes11);
+					_getGroupKBArticlesRSSParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, status,
 					rssDelta, rssDisplayStyle, rssFormat, themeDisplay);
@@ -450,7 +512,7 @@ public class KBArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getKBArticle", _getKBArticleParameterTypes12);
+					"getKBArticle", _getKBArticleParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, version);
@@ -484,7 +546,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getKBArticleAndAllDescendantKBArticles",
-					_getKBArticleAndAllDescendantKBArticlesParameterTypes13);
+					_getKBArticleAndAllDescendantKBArticlesParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, status, orderByComparator);
@@ -518,7 +580,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getKBArticleAndAllDescendants",
-					_getKBArticleAndAllDescendantsParameterTypes14);
+					_getKBArticleAndAllDescendantsParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKey, status, orderByComparator);
@@ -549,7 +611,7 @@ public class KBArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getKBArticleRSS", _getKBArticleRSSParameterTypes15);
+					"getKBArticleRSS", _getKBArticleRSSParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, status, rssDelta, rssDisplayStyle,
@@ -583,7 +645,7 @@ public class KBArticleServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.knowledge.base.model.KBArticle> orderByComparator) {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getKBArticles", _getKBArticlesParameterTypes16);
+					"getKBArticles", _getKBArticlesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentResourcePrimKey, status, start, end, orderByComparator);
@@ -612,7 +674,7 @@ public class KBArticleServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.knowledge.base.model.KBArticle> orderByComparator) {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getKBArticles", _getKBArticlesParameterTypes17);
+					"getKBArticles", _getKBArticlesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKeys, status, start, end, orderByComparator);
@@ -641,7 +703,7 @@ public class KBArticleServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.knowledge.base.model.KBArticle> orderByComparator) {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getKBArticles", _getKBArticlesParameterTypes18);
+					"getKBArticles", _getKBArticlesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKeys, status, orderByComparator);
@@ -668,7 +730,7 @@ public class KBArticleServiceHttp {
 		long groupId, long parentResourcePrimKey, int status) {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getKBArticlesCount", _getKBArticlesCountParameterTypes19);
+					"getKBArticlesCount", _getKBArticlesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentResourcePrimKey, status);
@@ -695,7 +757,7 @@ public class KBArticleServiceHttp {
 		long groupId, long[] resourcePrimKeys, int status) {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getKBArticlesCount", _getKBArticlesCountParameterTypes20);
+					"getKBArticlesCount", _getKBArticlesCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKeys, status);
@@ -728,7 +790,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getKBArticleSearchDisplay",
-					_getKBArticleSearchDisplayParameterTypes21);
+					_getKBArticleSearchDisplayParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					title, content, status, startDate, endDate, andOperator,
@@ -763,7 +825,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getKBArticleVersions",
-					_getKBArticleVersionsParameterTypes22);
+					_getKBArticleVersionsParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKey, status, start, end, orderByComparator);
@@ -791,7 +853,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getKBArticleVersionsCount",
-					_getKBArticleVersionsCountParameterTypes23);
+					_getKBArticleVersionsCountParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKey, status);
@@ -819,7 +881,7 @@ public class KBArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"getLatestKBArticle", _getLatestKBArticleParameterTypes24);
+					"getLatestKBArticle", _getLatestKBArticleParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, status);
@@ -853,7 +915,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getSectionsKBArticles",
-					_getSectionsKBArticlesParameterTypes25);
+					_getSectionsKBArticlesParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					sections, status, start, end, orderByComparator);
@@ -881,7 +943,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getSectionsKBArticlesCount",
-					_getSectionsKBArticlesCountParameterTypes26);
+					_getSectionsKBArticlesCountParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					sections, status);
@@ -911,7 +973,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getSiblingKBArticles",
-					_getSiblingKBArticlesParameterTypes27);
+					_getSiblingKBArticlesParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentResourcePrimKey, status, start, end, orderByComparator);
@@ -939,7 +1001,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getSiblingKBArticlesCount",
-					_getSiblingKBArticlesCountParameterTypes28);
+					_getSiblingKBArticlesCountParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentResourcePrimKey, status);
@@ -969,7 +1031,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"getTempAttachmentNames",
-					_getTempAttachmentNamesParameterTypes29);
+					_getTempAttachmentNamesParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					tempFolderName);
@@ -1002,7 +1064,7 @@ public class KBArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"moveKBArticle", _moveKBArticleParameterTypes30);
+					"moveKBArticle", _moveKBArticleParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, parentResourceClassNameId,
@@ -1032,7 +1094,7 @@ public class KBArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"revertKBArticle", _revertKBArticleParameterTypes31);
+					"revertKBArticle", _revertKBArticleParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, version, serviceContext);
@@ -1065,7 +1127,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"subscribeGroupKBArticles",
-					_subscribeGroupKBArticlesParameterTypes32);
+					_subscribeGroupKBArticlesParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					portletId);
@@ -1093,7 +1155,7 @@ public class KBArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"subscribeKBArticle", _subscribeKBArticleParameterTypes33);
+					"subscribeKBArticle", _subscribeKBArticleParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKey);
@@ -1122,7 +1184,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"unsubscribeGroupKBArticles",
-					_unsubscribeGroupKBArticlesParameterTypes34);
+					_unsubscribeGroupKBArticlesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					portletId);
@@ -1151,7 +1213,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"unsubscribeKBArticle",
-					_unsubscribeKBArticleParameterTypes35);
+					_unsubscribeKBArticleParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey);
@@ -1184,7 +1246,7 @@ public class KBArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
-					"updateKBArticle", _updateKBArticleParameterTypes36);
+					"updateKBArticle", _updateKBArticleParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey, title, content, description, sourceURL,
@@ -1220,7 +1282,7 @@ public class KBArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBArticleServiceUtil.class,
 					"updateKBArticlesPriorities",
-					_updateKBArticlesPrioritiesParameterTypes37);
+					_updateKBArticlesPrioritiesParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKeyToPriorityMap);
@@ -1272,123 +1334,129 @@ public class KBArticleServiceHttp {
 			long.class, long.class, java.lang.String.class,
 			java.lang.String.class
 		};
-	private static final Class<?>[] _fetchLatestKBArticleParameterTypes6 = new Class[] {
+	private static final Class<?>[] _fetchFirstChildKBArticleParameterTypes6 = new Class[] {
+			long.class, long.class
+		};
+	private static final Class<?>[] _fetchKBArticleByUrlTitleParameterTypes7 = new Class[] {
+			long.class, long.class, java.lang.String.class
+		};
+	private static final Class<?>[] _fetchLatestKBArticleParameterTypes8 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getAllDescendantKBArticlesParameterTypes7 = new Class[] {
+	private static final Class<?>[] _getAllDescendantKBArticlesParameterTypes9 = new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getAllDescendantKBArticlesParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getAllDescendantKBArticlesParameterTypes10 = new Class[] {
 			long.class, long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupKBArticlesParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getGroupKBArticlesParameterTypes11 = new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupKBArticlesCountParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getGroupKBArticlesCountParameterTypes12 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupKBArticlesRSSParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getGroupKBArticlesRSSParameterTypes13 = new Class[] {
 			int.class, int.class, java.lang.String.class, java.lang.String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getKBArticleParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getKBArticleParameterTypes14 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getKBArticleAndAllDescendantKBArticlesParameterTypes13 =
+	private static final Class<?>[] _getKBArticleAndAllDescendantKBArticlesParameterTypes15 =
 		new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleAndAllDescendantsParameterTypes14 =
+	private static final Class<?>[] _getKBArticleAndAllDescendantsParameterTypes16 =
 		new Class[] {
 			long.class, long.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleRSSParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getKBArticleRSSParameterTypes17 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			java.lang.String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getKBArticlesParameterTypes18 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getKBArticlesParameterTypes19 = new Class[] {
 			long.class, long[].class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getKBArticlesParameterTypes20 = new Class[] {
 			long.class, long[].class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticlesCountParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getKBArticlesCountParameterTypes21 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getKBArticlesCountParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getKBArticlesCountParameterTypes22 = new Class[] {
 			long.class, long[].class, int.class
 		};
-	private static final Class<?>[] _getKBArticleSearchDisplayParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getKBArticleSearchDisplayParameterTypes23 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			int.class, java.util.Date.class, java.util.Date.class, boolean.class,
 			int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleVersionsParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getKBArticleVersionsParameterTypes24 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBArticleVersionsCountParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getKBArticleVersionsCountParameterTypes25 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getLatestKBArticleParameterTypes24 = new Class[] {
+	private static final Class<?>[] _getLatestKBArticleParameterTypes26 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getSectionsKBArticlesParameterTypes25 = new Class[] {
+	private static final Class<?>[] _getSectionsKBArticlesParameterTypes27 = new Class[] {
 			long.class, java.lang.String[].class, int.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getSectionsKBArticlesCountParameterTypes26 = new Class[] {
+	private static final Class<?>[] _getSectionsKBArticlesCountParameterTypes28 = new Class[] {
 			long.class, java.lang.String[].class, int.class
 		};
-	private static final Class<?>[] _getSiblingKBArticlesParameterTypes27 = new Class[] {
+	private static final Class<?>[] _getSiblingKBArticlesParameterTypes29 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getSiblingKBArticlesCountParameterTypes28 = new Class[] {
+	private static final Class<?>[] _getSiblingKBArticlesCountParameterTypes30 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getTempAttachmentNamesParameterTypes29 = new Class[] {
+	private static final Class<?>[] _getTempAttachmentNamesParameterTypes31 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _moveKBArticleParameterTypes30 = new Class[] {
+	private static final Class<?>[] _moveKBArticleParameterTypes32 = new Class[] {
 			long.class, long.class, long.class, double.class
 		};
-	private static final Class<?>[] _revertKBArticleParameterTypes31 = new Class[] {
+	private static final Class<?>[] _revertKBArticleParameterTypes33 = new Class[] {
 			long.class, int.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes32 = new Class[] {
+	private static final Class<?>[] _subscribeGroupKBArticlesParameterTypes34 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _subscribeKBArticleParameterTypes33 = new Class[] {
+	private static final Class<?>[] _subscribeKBArticleParameterTypes35 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _unsubscribeGroupKBArticlesParameterTypes34 = new Class[] {
+	private static final Class<?>[] _unsubscribeGroupKBArticlesParameterTypes36 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _unsubscribeKBArticleParameterTypes35 = new Class[] {
+	private static final Class<?>[] _unsubscribeKBArticleParameterTypes37 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateKBArticleParameterTypes36 = new Class[] {
+	private static final Class<?>[] _updateKBArticleParameterTypes38 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, java.lang.String.class,
 			java.lang.String[].class, java.lang.String[].class, long[].class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateKBArticlesPrioritiesParameterTypes37 = new Class[] {
+	private static final Class<?>[] _updateKBArticlesPrioritiesParameterTypes39 = new Class[] {
 			long.class, java.util.Map.class
 		};
 }

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceSoap.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBArticleServiceSoap.java
@@ -128,6 +128,37 @@ public class KBArticleServiceSoap {
 		}
 	}
 
+	public static com.liferay.knowledge.base.model.KBArticleSoap fetchFirstChildKBArticle(
+		long groupId, long parentResourcePrimKey) throws RemoteException {
+		try {
+			com.liferay.knowledge.base.model.KBArticle returnValue = KBArticleServiceUtil.fetchFirstChildKBArticle(groupId,
+					parentResourcePrimKey);
+
+			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBArticleSoap fetchKBArticleByUrlTitle(
+		long groupId, long kbFolderId, java.lang.String urlTitle)
+		throws RemoteException {
+		try {
+			com.liferay.knowledge.base.model.KBArticle returnValue = KBArticleServiceUtil.fetchKBArticleByUrlTitle(groupId,
+					kbFolderId, urlTitle);
+
+			return com.liferay.knowledge.base.model.KBArticleSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.knowledge.base.model.KBArticleSoap fetchLatestKBArticle(
 		long resourcePrimKey, int status) throws RemoteException {
 		try {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceHttp.java
@@ -123,12 +123,45 @@ public class KBFolderServiceHttp {
 		}
 	}
 
+	public static com.liferay.knowledge.base.model.KBFolder fetchFirstChildKBFolder(
+		HttpPrincipal httpPrincipal, long groupId, long kbFolderId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
+					"fetchFirstChildKBFolder",
+					_fetchFirstChildKBFolderParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					kbFolderId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.knowledge.base.model.KBFolder)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static com.liferay.knowledge.base.model.KBFolder fetchKBFolder(
 		HttpPrincipal httpPrincipal, long kbFolderId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
-					"fetchKBFolder", _fetchKBFolderParameterTypes2);
+					"fetchKBFolder", _fetchKBFolderParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					kbFolderId);
@@ -162,7 +195,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
 					"fetchKBFolderByUrlTitle",
-					_fetchKBFolderByUrlTitleParameterTypes3);
+					_fetchKBFolderByUrlTitleParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentKbFolderId, urlTitle);
@@ -194,7 +227,7 @@ public class KBFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
-					"getKBFolder", _getKBFolderParameterTypes4);
+					"getKBFolder", _getKBFolderParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					kbFolderId);
@@ -228,7 +261,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
 					"getKBFolderByUrlTitle",
-					_getKBFolderByUrlTitleParameterTypes5);
+					_getKBFolderByUrlTitleParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentKbFolderId, urlTitle);
@@ -261,7 +294,7 @@ public class KBFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
-					"getKBFolders", _getKBFoldersParameterTypes6);
+					"getKBFolders", _getKBFoldersParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentKBFolderId, start, end);
@@ -295,7 +328,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
 					"getKBFoldersAndKBArticles",
-					_getKBFoldersAndKBArticlesParameterTypes7);
+					_getKBFoldersAndKBArticlesParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentResourcePrimKey, status, start, end, orderByComparator);
@@ -324,7 +357,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
 					"getKBFoldersAndKBArticlesCount",
-					_getKBFoldersAndKBArticlesCountParameterTypes8);
+					_getKBFoldersAndKBArticlesCountParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentResourcePrimKey, status);
@@ -352,7 +385,7 @@ public class KBFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
-					"getKBFoldersCount", _getKBFoldersCountParameterTypes9);
+					"getKBFoldersCount", _getKBFoldersCountParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					parentKBFolderId);
@@ -384,7 +417,7 @@ public class KBFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
-					"moveKBFolder", _moveKBFolderParameterTypes10);
+					"moveKBFolder", _moveKBFolderParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					kbFolderId, parentKBFolderId);
@@ -414,7 +447,7 @@ public class KBFolderServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(KBFolderServiceUtil.class,
-					"updateKBFolder", _updateKBFolderParameterTypes11);
+					"updateKBFolder", _updateKBFolderParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					parentResourceClassNameId, parentResourcePrimKey,
@@ -451,34 +484,37 @@ public class KBFolderServiceHttp {
 	private static final Class<?>[] _deleteKBFolderParameterTypes1 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _fetchKBFolderParameterTypes2 = new Class[] {
+	private static final Class<?>[] _fetchFirstChildKBFolderParameterTypes2 = new Class[] {
+			long.class, long.class
+		};
+	private static final Class<?>[] _fetchKBFolderParameterTypes3 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _fetchKBFolderByUrlTitleParameterTypes3 = new Class[] {
+	private static final Class<?>[] _fetchKBFolderByUrlTitleParameterTypes4 = new Class[] {
 			long.class, long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getKBFolderParameterTypes4 = new Class[] {
+	private static final Class<?>[] _getKBFolderParameterTypes5 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getKBFolderByUrlTitleParameterTypes5 = new Class[] {
+	private static final Class<?>[] _getKBFolderByUrlTitleParameterTypes6 = new Class[] {
 			long.class, long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getKBFoldersParameterTypes6 = new Class[] {
+	private static final Class<?>[] _getKBFoldersParameterTypes7 = new Class[] {
 			long.class, long.class, int.class, int.class
 		};
-	private static final Class<?>[] _getKBFoldersAndKBArticlesParameterTypes7 = new Class[] {
+	private static final Class<?>[] _getKBFoldersAndKBArticlesParameterTypes8 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getKBFoldersAndKBArticlesCountParameterTypes8 =
+	private static final Class<?>[] _getKBFoldersAndKBArticlesCountParameterTypes9 =
 		new Class[] { long.class, long.class, int.class };
-	private static final Class<?>[] _getKBFoldersCountParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getKBFoldersCountParameterTypes10 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _moveKBFolderParameterTypes10 = new Class[] {
+	private static final Class<?>[] _moveKBFolderParameterTypes11 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _updateKBFolderParameterTypes11 = new Class[] {
+	private static final Class<?>[] _updateKBFolderParameterTypes12 = new Class[] {
 			long.class, long.class, long.class, java.lang.String.class,
 			java.lang.String.class
 		};

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceSoap.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceSoap.java
@@ -99,6 +99,21 @@ public class KBFolderServiceSoap {
 		}
 	}
 
+	public static com.liferay.knowledge.base.model.KBFolderSoap fetchFirstChildKBFolder(
+		long groupId, long kbFolderId) throws RemoteException {
+		try {
+			com.liferay.knowledge.base.model.KBFolder returnValue = KBFolderServiceUtil.fetchFirstChildKBFolder(groupId,
+					kbFolderId);
+
+			return com.liferay.knowledge.base.model.KBFolderSoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.knowledge.base.model.KBFolderSoap fetchKBFolder(
 		long kbFolderId) throws RemoteException {
 		try {

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBArticleServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.knowledge.base.service.permission.KBArticlePermission;
 import com.liferay.knowledge.base.service.util.AdminUtil;
 import com.liferay.knowledge.base.util.KnowledgeBaseUtil;
 import com.liferay.knowledge.base.util.comparator.KBArticleModifiedDateComparator;
+import com.liferay.knowledge.base.util.comparator.KBArticlePriorityComparator;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -39,6 +40,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -163,6 +165,42 @@ public class KBArticleServiceImpl extends KBArticleServiceBaseImpl {
 
 		kbArticleLocalService.deleteTempAttachment(
 			groupId, getUserId(), fileName, tempFolderName);
+	}
+
+	@Override
+	public KBArticle fetchFirstChildKBArticle(
+		long groupId, long parentResourcePrimKey) {
+
+		List<KBArticle> kbArticles = kbArticlePersistence.filterFindByG_P_L(
+			groupId, parentResourcePrimKey, true, 0, 1,
+			new KBArticlePriorityComparator(true));
+
+		if (kbArticles.isEmpty()) {
+			return null;
+		}
+
+		return kbArticles.get(0);
+	}
+
+	@Override
+	public KBArticle fetchKBArticleByUrlTitle(
+			long groupId, long kbFolderId, String urlTitle)
+		throws PortalException {
+
+		KBArticle kbArticle = kbArticleLocalService.fetchKBArticleByUrlTitle(
+			groupId, kbFolderId, urlTitle);
+
+		if (kbArticle == null) {
+			return null;
+		}
+
+		if (KBArticlePermission.contains(
+				getPermissionChecker(), kbArticle, ActionKeys.VIEW)) {
+
+			return kbArticle;
+		}
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
@@ -57,6 +57,20 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 	}
 
 	@Override
+	public KBFolder fetchFirstChildKBFolder(long groupId, long kbFolderId)
+		throws PortalException {
+
+		List<KBFolder> kbFolders = kbFolderPersistence.filterFindByG_P(
+			groupId, kbFolderId, 0, 1, null);
+
+		if (kbFolders.isEmpty()) {
+			return null;
+		}
+
+		return kbFolders.get(0);
+	}
+
+	@Override
 	public KBFolder fetchKBFolder(long kbFolderId) throws PortalException {
 		KBFolder kbFolder = kbFolderLocalService.fetchKBFolder(kbFolderId);
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/selector/KBFolderKBArticleSelector.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/selector/KBFolderKBArticleSelector.java
@@ -18,8 +18,8 @@ import com.liferay.knowledge.base.constants.KBFolderConstants;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.model.KBFolder;
 import com.liferay.knowledge.base.model.impl.KBFolderImpl;
-import com.liferay.knowledge.base.service.KBArticleLocalService;
-import com.liferay.knowledge.base.service.KBFolderLocalService;
+import com.liferay.knowledge.base.service.KBArticleService;
+import com.liferay.knowledge.base.service.KBFolderService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -51,7 +51,7 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 		if (ancestorResourcePrimKey !=
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
-			ancestorKBFolder = _kbFolderLocalService.fetchKBFolder(
+			ancestorKBFolder = _kbFolderService.fetchKBFolder(
 				ancestorResourcePrimKey);
 
 			if (ancestorKBFolder == null) {
@@ -59,7 +59,7 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 			}
 		}
 
-		KBArticle kbArticle = _kbArticleLocalService.fetchLatestKBArticle(
+		KBArticle kbArticle = _kbArticleService.fetchLatestKBArticle(
 			resourcePrimKey, WorkflowConstants.STATUS_APPROVED);
 
 		if ((kbArticle == null) || !isDescendant(kbArticle, ancestorKBFolder)) {
@@ -88,7 +88,7 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 		if (ancestorResourcePrimKey !=
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 
-			ancestorKBFolder = _kbFolderLocalService.fetchKBFolder(
+			ancestorKBFolder = _kbFolderService.fetchKBFolder(
 				ancestorResourcePrimKey);
 
 			if (ancestorKBFolder == null) {
@@ -103,13 +103,13 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 				kbFolder = ancestorKBFolder;
 			}
 			else {
-				kbFolder = _kbFolderLocalService.fetchKBFolderByUrlTitle(
+				kbFolder = _kbFolderService.fetchKBFolderByUrlTitle(
 					groupId, ancestorKBFolder.getKbFolderId(),
 					kbFolderUrlTitle);
 			}
 		}
 
-		KBArticle kbArticle = _kbArticleLocalService.fetchKBArticleByUrlTitle(
+		KBArticle kbArticle = _kbArticleService.fetchKBArticleByUrlTitle(
 			groupId, kbFolder.getKbFolderId(), urlTitle);
 
 		if ((kbArticle == null) || !isDescendant(kbArticle, ancestorKBFolder)) {
@@ -131,14 +131,14 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 			groupId, preferredKBFolderUrlTitle, ancestorKBFolder,
 			kbFolderUrlTitle);
 
-		KBArticle kbArticle = _kbArticleLocalService.fetchKBArticleByUrlTitle(
+		KBArticle kbArticle = _kbArticleService.fetchKBArticleByUrlTitle(
 			groupId, kbFolder.getKbFolderId(), urlTitle);
 
 		if (kbArticle != null) {
 			return new KBArticleSelection(kbArticle, false);
 		}
 
-		kbArticle = _kbArticleLocalService.fetchFirstChildKBArticle(
+		kbArticle = _kbArticleService.fetchFirstChildKBArticle(
 			groupId, kbFolder.getKbFolderId());
 
 		String[] keywords = StringUtil.split(urlTitle, '-');
@@ -153,20 +153,20 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 
 		KBFolder kbFolder = null;
 
-		int kbArticlesCount = _kbArticleLocalService.getKBArticlesCount(
+		int kbArticlesCount = _kbArticleService.getKBArticlesCount(
 			groupId, ancestorKBFolder.getKbFolderId(),
 			WorkflowConstants.STATUS_APPROVED);
 
 		if (Validator.isNotNull(preferredKBFolderUrlTitle) &&
 			(kbArticlesCount == 0)) {
 
-			kbFolder = _kbFolderLocalService.fetchKBFolderByUrlTitle(
+			kbFolder = _kbFolderService.fetchKBFolderByUrlTitle(
 				groupId, ancestorKBFolder.getKbFolderId(),
 				preferredKBFolderUrlTitle);
 		}
 
 		if ((kbFolder == null) && (kbArticlesCount == 0)) {
-			kbFolder = _kbFolderLocalService.fetchFirstChildKBFolder(
+			kbFolder = _kbFolderService.fetchFirstChildKBFolder(
 				groupId, ancestorKBFolder.getKbFolderId());
 		}
 
@@ -174,7 +174,7 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 			kbFolder = ancestorKBFolder;
 		}
 
-		KBArticle kbArticle = _kbArticleLocalService.fetchFirstChildKBArticle(
+		KBArticle kbArticle = _kbArticleService.fetchFirstChildKBArticle(
 			groupId, kbFolder.getKbFolderId());
 
 		return new KBArticleSelection(kbArticle, true);
@@ -188,24 +188,24 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 		KBFolder kbFolder = null;
 
 		if (Validator.isNotNull(kbFolderUrlTitle)) {
-			kbFolder = _kbFolderLocalService.fetchKBFolderByUrlTitle(
+			kbFolder = _kbFolderService.fetchKBFolderByUrlTitle(
 				groupId, ancestorKBFolder.getKbFolderId(), kbFolderUrlTitle);
 		}
 
 		if ((kbFolder == null) &&
 			Validator.isNotNull(preferredKBFolderUrlTitle)) {
 
-			kbFolder = _kbFolderLocalService.fetchKBFolderByUrlTitle(
+			kbFolder = _kbFolderService.fetchKBFolderByUrlTitle(
 				groupId, ancestorKBFolder.getKbFolderId(),
 				preferredKBFolderUrlTitle);
 		}
 
-		int kbArticlesCount = _kbArticleLocalService.getKBArticlesCount(
+		int kbArticlesCount = _kbArticleService.getKBArticlesCount(
 			groupId, ancestorKBFolder.getKbFolderId(),
 			WorkflowConstants.STATUS_APPROVED);
 
 		if ((kbFolder == null) && (kbArticlesCount == 0)) {
-			kbFolder = _kbFolderLocalService.fetchFirstChildKBFolder(
+			kbFolder = _kbFolderService.fetchFirstChildKBFolder(
 				groupId, ancestorKBFolder.getKbFolderId());
 		}
 
@@ -225,7 +225,7 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 			return true;
 		}
 
-		KBFolder parentKBFolder = _kbFolderLocalService.getKBFolder(
+		KBFolder parentKBFolder = _kbFolderService.getKBFolder(
 			kbArticle.getKbFolderId());
 
 		List<Long> ancestorKBFolderIds =
@@ -239,17 +239,13 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 	}
 
 	@Reference(unbind = "-")
-	protected void setKBArticleLocalService(
-		KBArticleLocalService kbArticleLocalService) {
-
-		_kbArticleLocalService = kbArticleLocalService;
+	protected void setKBArticleLocalService(KBArticleService kbArticleService) {
+		_kbArticleService = kbArticleService;
 	}
 
 	@Reference(unbind = "-")
-	protected void setKBFolderLocalService(
-		KBFolderLocalService kbFolderLocalService) {
-
-		_kbFolderLocalService = kbFolderLocalService;
+	protected void setKBFolderLocalService(KBFolderService kbFolderService) {
+		_kbFolderService = kbFolderService;
 	}
 
 	private static final KBFolder _rootKBFolder;
@@ -260,7 +256,7 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 		_rootKBFolder.setKbFolderId(KBFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 	}
 
-	private KBArticleLocalService _kbArticleLocalService;
-	private KBFolderLocalService _kbFolderLocalService;
+	private KBArticleService _kbArticleService;
+	private KBFolderService _kbFolderService;
 
 }


### PR DESCRIPTION
Hey @brianchandotcom,

This is the same pull I sent you a couple of days ago. In that PR you commented the following:

```
can you resend? Remote service should call local service implementation whenever there is some logic.

the fetchFirstChildKBFolder has 2 different implementations between remote and local, that should not be the case. The remote should only add security logic.
```

The thing is that the local implementation cannot be used by the remote service because the behaviour is slightly different:
- the local service will always return the one with the lowest priority
- on the other hand, given the list of child articles, the remote service will return the one with lowest priority for which the user has view permissions (that may or may not be the article with the actual lowest priority)

So that's why the remote service needs to fetch the list of children filtered by permissions. If I tried to use the local impl in the remote one, and the user happened to not have view permissions on that article, I would need to get the whole list and filter it anyway to get the correct result or return null (which would be incorrect).

Hope this helps to clarify the issue.

Thanks!
