### PR TITLE
LPS-68944 portal-search-elasticsearch: Add tests for the Japanese language analyzer and queries

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/document/SingleFieldFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/document/SingleFieldFixture.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.document;
+
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
+import com.liferay.portal.search.elasticsearch.internal.query.QueryBuilderFactory;
+import com.liferay.portal.search.elasticsearch.internal.query.SearchAssert;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryBuilder;
+
+/**
+ * @author André de Oliveira
+ */
+public class SingleFieldFixture {
+
+	public SingleFieldFixture(Client client, IndexName indexName, String type) {
+		_client = client;
+		_index = indexName.getName();
+		_type = type;
+	}
+
+	public void assertNoHits(String text) throws Exception {
+		SearchAssert.assertNoHits(_client, _field, _createQueryBuilder(text));
+	}
+
+	public void assertSearch(String text, String... expected) throws Exception {
+		SearchAssert.assertSearch(
+			_client, _field, _createQueryBuilder(text), expected);
+	}
+
+	public void indexDocument(String value) {
+		IndexRequestBuilder indexRequestBuilder = _client.prepareIndex(
+			_index, _type);
+
+		indexRequestBuilder.setSource(_field, value);
+
+		indexRequestBuilder.get();
+	}
+
+	public void setField(String field) {
+		_field = field;
+	}
+
+	public void setQueryBuilderFactory(
+		QueryBuilderFactory queryBuilderFactory) {
+
+		_queryBuilderFactory = queryBuilderFactory;
+	}
+
+	private QueryBuilder _createQueryBuilder(String text) {
+		return _queryBuilderFactory.create(_field, text);
+	}
+
+	private final Client _client;
+	private String _field;
+	private final String _index;
+	private QueryBuilderFactory _queryBuilderFactory;
+	private final String _type;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayIndexFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayIndexFixture.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.index;
+
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.Index;
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
+import com.liferay.portal.search.elasticsearch.internal.connection.LiferayIndexCreationHelper;
+
+import org.elasticsearch.client.Client;
+
+/**
+ * @author André de Oliveira
+ */
+public class LiferayIndexFixture {
+
+	public LiferayIndexFixture(String subdirName, IndexName indexName) {
+		_elasticsearchFixture = new ElasticsearchFixture(subdirName);
+		_indexName = indexName;
+	}
+
+	public Client getClient() {
+		return _elasticsearchFixture.getClient();
+	}
+
+	public ElasticsearchFixture getElasticsearchFixture() {
+		return _elasticsearchFixture;
+	}
+
+	public Index getIndex() {
+		return _index;
+	}
+
+	public void setUp() throws Exception {
+		_elasticsearchFixture.setUp();
+
+		_index = createIndex();
+	}
+
+	public void tearDown() throws Exception {
+		_elasticsearchFixture.tearDown();
+	}
+
+	protected Index createIndex() {
+		return _elasticsearchFixture.createIndex(
+			_indexName,
+			new LiferayIndexCreationHelper(
+				_elasticsearchFixture.getIndicesAdminClient()));
+	}
+
+	private final ElasticsearchFixture _elasticsearchFixture;
+	private Index _index;
+	private final IndexName _indexName;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsJapaneseTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsJapaneseTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.index;
+
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
+import com.liferay.portal.search.elasticsearch.internal.document.SingleFieldFixture;
+import com.liferay.portal.search.elasticsearch.internal.query.QueryBuilderFactories;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * @author André de Oliveira
+ */
+public class LiferayTypeMappingsJapaneseTest {
+
+	@Before
+	public void setUp() throws Exception {
+		IndexName indexName = new IndexName(testName.getMethodName());
+
+		_liferayIndexFixture = new LiferayIndexFixture(_PREFIX, indexName);
+
+		_liferayIndexFixture.setUp();
+
+		_singleFieldFixture = new SingleFieldFixture(
+			_liferayIndexFixture.getClient(), indexName,
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+
+		_singleFieldFixture.setField(_PREFIX + "_ja");
+		_singleFieldFixture.setQueryBuilderFactory(QueryBuilderFactories.MATCH);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_liferayIndexFixture.tearDown();
+	}
+
+	@Test
+	public void testSearch1() throws Exception {
+		String content1 = "作戦大成功";
+		String content2 = "新規作戦";
+		String content3 = "映像製作会社";
+		String content4 = "作文を書いた";
+
+		index(content1, content2, content3, content4);
+
+		assertSearch("作戦", content1, content2);
+
+		assertSearch("製作", content3);
+
+		assertSearch("作文", content4);
+
+		assertNoHits("作");
+	}
+
+	@Test
+	public void testSearch2() throws Exception {
+		String content1 = "作戦大成功";
+		String content2 = "新規作戦";
+		String content3 = "映像製作会社";
+		String content4 = "作文を書いた";
+		String content5 = "新しい作戦";
+		String content6 = "新規作成";
+		String content7 = "新世界";
+		String content8 = "新着情報";
+
+		index(
+			content1, content2, content3, content4, content5, content6,
+			content7, content8);
+
+		assertSearch("作戦", content1, content2, content5);
+
+		assertSearch("新規", content2, content6);
+
+		assertSearch("新", content7);
+	}
+
+	@Test
+	public void testSearch3() throws Exception {
+		String content1 = "作戦大成功";
+		String content2 = "新規作戦";
+		String content3 = "映像製作会社";
+		String content4 = "作文を書いた";
+		String content5 = "新しい作戦";
+		String content6 = "新規作成";
+		String content7 = "新世界";
+		String content8 = "新着情報";
+		String content9 = "新規作戦";
+
+		index(
+			content1, content2, content3, content4, content5, content6,
+			content7, content8, content9);
+
+		assertSearch("新規", content2, content6, content9);
+
+		assertSearch("新", content7);
+	}
+
+	@Test
+	public void testSearch4() throws Exception {
+		String content1 = "作戦大成功";
+		String content2 = "新大阪";
+		String content3 = "新規作成";
+		String content4 = "東京特許許可局局長";
+		String content5 = "京都";
+
+		index(content1, content2, content3, content4, content5);
+
+		assertSearch("新規", content3);
+
+		assertSearch("作成", content3);
+	}
+
+	@Rule
+	public TestName testName = new TestName();
+
+	protected void assertNoHits(String query) throws Exception {
+		_singleFieldFixture.assertNoHits(query);
+	}
+
+	protected void assertSearch(String query, String... expected)
+		throws Exception {
+
+		_singleFieldFixture.assertSearch(query, expected);
+	}
+
+	protected void index(String... strings) {
+		for (String string : strings) {
+			_singleFieldFixture.indexDocument(string);
+		}
+	}
+
+	private static final String _PREFIX =
+		LiferayTypeMappingsJapaneseTest.class.getSimpleName();
+
+	private LiferayIndexFixture _liferayIndexFixture;
+	private SingleFieldFixture _singleFieldFixture;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsPrefixPerLanguageTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsPrefixPerLanguageTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.index;
+
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
+import com.liferay.portal.search.elasticsearch.internal.document.SingleFieldFixture;
+import com.liferay.portal.search.elasticsearch.internal.query.QueryBuilderFactories;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * @author André de Oliveira
+ */
+public class LiferayTypeMappingsPrefixPerLanguageTest {
+
+	@Before
+	public void setUp() throws Exception {
+		IndexName indexName = new IndexName(testName.getMethodName());
+
+		_liferayIndexFixture = new LiferayIndexFixture(_PREFIX, indexName);
+
+		_liferayIndexFixture.setUp();
+
+		_singleFieldFixture = new SingleFieldFixture(
+			_liferayIndexFixture.getClient(), indexName,
+			LiferayTypeMappingsConstants.LIFERAY_DOCUMENT_TYPE);
+
+		_singleFieldFixture.setQueryBuilderFactory(
+			QueryBuilderFactories.MATCH_PHRASE_PREFIX);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_liferayIndexFixture.tearDown();
+	}
+
+	@Test
+	public void testPrefixEnglish() throws Exception {
+		_singleFieldFixture.setField(_PREFIX + "_en");
+
+		String content1 = "terrible";
+		String content2 = "terrific";
+
+		index(content1, content2);
+
+		assertSearch("terr", content1, content2);
+
+		assertSearch("terrib", content1);
+
+		assertSearch("terrif", content2);
+
+		assertNoHits("terrier");
+	}
+
+	@Test
+	public void testPrefixJapanese() throws Exception {
+		_singleFieldFixture.setField(_PREFIX + "_ja");
+
+		String content1 = "作戦大成功";
+		String content2 = "新規作戦";
+		String content3 = "映像製作会社";
+		String content4 = "作文を書いた";
+		String content5 = "新しい作戦";
+		String content6 = "新規作成";
+		String content7 = "新世界";
+		String content8 = "新着情報";
+
+		index(
+			content1, content2, content3, content4, content5, content6,
+			content7, content8);
+
+		assertSearch("新", content2, content5, content6, content7, content8);
+
+		assertSearch("作", content1, content2, content4, content5, content6);
+
+		assertNoHits("し");
+	}
+
+	@Rule
+	public TestName testName = new TestName();
+
+	protected void assertNoHits(String query) throws Exception {
+		_singleFieldFixture.assertNoHits(query);
+	}
+
+	protected void assertSearch(String query, String... expected)
+		throws Exception {
+
+		_singleFieldFixture.assertSearch(query, expected);
+	}
+
+	protected void index(String... strings) {
+		for (String string : strings) {
+			_singleFieldFixture.indexDocument(string);
+		}
+	}
+
+	private static final String _PREFIX =
+		LiferayTypeMappingsPrefixPerLanguageTest.class.getSimpleName();
+
+	private LiferayIndexFixture _liferayIndexFixture;
+	private SingleFieldFixture _singleFieldFixture;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/index/LiferayTypeMappingsTest.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.Index;
 import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture.IndexName;
-import com.liferay.portal.search.elasticsearch.internal.connection.LiferayIndexCreationHelper;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Client;
@@ -36,17 +35,20 @@ public class LiferayTypeMappingsTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_elasticsearchFixture = new ElasticsearchFixture(
-			LiferayTypeMappingsTest.class.getSimpleName());
+		_liferayIndexFixture = new LiferayIndexFixture(
+			LiferayTypeMappingsTest.class.getSimpleName(),
+			new IndexName(testName.getMethodName()));
 
-		_elasticsearchFixture.setUp();
+		_liferayIndexFixture.setUp();
 
-		_index = createIndex();
+		_index = _liferayIndexFixture.getIndex();
+
+		_elasticsearchFixture = _liferayIndexFixture.getElasticsearchFixture();
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		_elasticsearchFixture.tearDown();
+		_liferayIndexFixture.tearDown();
 	}
 
 	@Test
@@ -86,14 +88,8 @@ public class LiferayTypeMappingsTest {
 			_index.getName(), _elasticsearchFixture.getIndicesAdminClient());
 	}
 
-	protected Index createIndex() {
-		return _elasticsearchFixture.createIndex(
-			new IndexName(testName.getMethodName()),
-			new LiferayIndexCreationHelper(
-				_elasticsearchFixture.getIndicesAdminClient()));
-	}
-
 	private ElasticsearchFixture _elasticsearchFixture;
 	private Index _index;
+	private LiferayIndexFixture _liferayIndexFixture;
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/QueryBuilderFactories.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/QueryBuilderFactories.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.query;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+
+/**
+ * @author André de Oliveira
+ */
+public class QueryBuilderFactories {
+
+	public static final QueryBuilderFactory MATCH = new QueryBuilderFactory() {
+
+		@Override
+		public QueryBuilder create(String field, String text) {
+			return QueryBuilders.matchQuery(field, text);
+		}
+
+	};
+
+	public static final QueryBuilderFactory MATCH_PHRASE_PREFIX =
+		new QueryBuilderFactory() {
+
+			@Override
+			public QueryBuilder create(String name, String text) {
+				return QueryBuilders.matchPhrasePrefixQuery(name, text);
+			}
+
+		};
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/QueryBuilderFactory.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/QueryBuilderFactory.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.query;
+
+import org.elasticsearch.index.query.QueryBuilder;
+
+/**
+ * @author André de Oliveira
+ */
+public interface QueryBuilderFactory {
+
+	public QueryBuilder create(String name, String text);
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/SearchAssert.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/SearchAssert.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.query;
+
+import com.liferay.portal.kernel.test.IdempotentRetryAssert;
+import com.liferay.portal.kernel.util.StringPool;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHitField;
+import org.elasticsearch.search.SearchHits;
+
+import org.junit.Assert;
+
+/**
+ * @author André de Oliveira
+ */
+public class SearchAssert {
+
+	public static void assertNoHits(
+			Client client, String field, QueryBuilder queryBuilder)
+		throws Exception {
+
+		assertSearch(client, field, queryBuilder, new String[0]);
+	}
+
+	public static void assertSearch(
+			final Client client, final String field,
+			final QueryBuilder queryBuilder, final String... expectedValues)
+		throws Exception {
+
+		IdempotentRetryAssert.retryAssert(
+			10, TimeUnit.SECONDS,
+			new Callable<Void>() {
+
+				@Override
+				public Void call() throws Exception {
+					Assert.assertEquals(
+						sort(Arrays.asList(expectedValues)),
+						sort(getValues(search(client, queryBuilder), field)));
+
+					return null;
+				}
+
+			});
+	}
+
+	protected static List<String> getValues(
+		SearchHits searchHits, String field) {
+
+		ArrayList<String> values = new ArrayList<>();
+
+		for (SearchHit searchHit : searchHits.hits()) {
+			SearchHitField searchHitField = searchHit.field(field);
+
+			String value = searchHitField.value();
+
+			values.add(value);
+		}
+
+		return values;
+	}
+
+	protected static SearchHits search(
+		Client client, QueryBuilder queryBuilder) {
+
+		SearchRequestBuilder searchRequestBuilder = client.prepareSearch();
+
+		searchRequestBuilder.addField(StringPool.STAR);
+
+		searchRequestBuilder.setQuery(queryBuilder);
+
+		SearchResponse searchResponse = searchRequestBuilder.get();
+
+		return searchResponse.getHits();
+	}
+
+	protected static String sort(Collection<String> collection) {
+		List<String> list = new ArrayList<>(collection);
+
+		Collections.sort(list);
+
+		return list.toString();
+	}
+
+}


### PR DESCRIPTION
cc @jordirodo @lipusz

Tests document and prove that `kuromoji` analyzer works correctly on `*_ja` fields - fix for `JournalArticleIndexer` will follow in a separate PR.

https://issues.liferay.com/browse/LPS-68944
