### PR TITLE
LRQA-28693 Redownload any invalid .zip file.

### DIFF
--- a/build-common-ivy.xml
+++ b/build-common-ivy.xml
@@ -93,9 +93,42 @@
 				replace="\1"
 			/>
 
+			<local name="unzip.error.output" />
+			<local name="unzip.test.result" />
+
+			<var name="unzip.test.result" value="0" />
+
 			<if>
 				<and>
-					<equals arg1="@{force}" arg2="true" />
+					<matches pattern=".*\.zip" string="${mirrors.cache.artifact.file.name}" />
+					<available file="${mirrors.cache.artifact.dir}/${mirrors.cache.artifact.file.name}" />
+				</and>
+				<then>
+					<echo>unzip -t ${mirrors.cache.artifact.dir}/${mirrors.cache.artifact.file.name}</echo>
+
+					<exec errorproperty="unzip.error.output" executable="unzip" resultproperty="unzip.test.result">
+						<arg line="-t ${mirrors.cache.artifact.dir}/${mirrors.cache.artifact.file.name}" />
+					</exec>
+
+					<if>
+						<not>
+							<equals arg1="${unzip.test.result}" arg2="0" />
+						</not>
+						<then>
+							<echo>Invalid zip file ${mirrors.cache.artifact.dir}/${mirrors.cache.artifact.file.name}: ${unzip.error.output}. This file will be redownloaded from mirrors.</echo>
+						</then>
+					</if>
+				</then>
+			</if>
+
+			<if>
+				<and>
+					<or>
+						<equals arg1="@{force}" arg2="true" />
+						<not>
+							<equals arg1="${unzip.test.result}" arg2="0" />
+						</not>
+					</or>
 					<available file="${mirrors.cache.artifact.dir}/${mirrors.cache.artifact.file.name}" />
 				</and>
 				<then>

--- a/build-test.xml
+++ b/build-test.xml
@@ -7136,28 +7136,10 @@ ANT_OPTS=${env.ANT_OPTS}</echo>
 					src="${test.build.bundle.zip.url}"
 				/>
 
-				<trycatch property="error.message">
-					<try>
-						<unzip dest="${app.server.parent.dir}" src="${tstamp.value}.zip">
-							<patternset includes="liferay-*/**" />
-							<mapper from="[^/]+/(.*)" to="\1" type="regexp" />
-						</unzip>
-					</try>
-					<catch>
-						<echo>Error occurred while unzipping ${tstamp.value.zip}. ${error.message} Re-fetching zip file. </echo>
-
-						<mirrors-get
-							clear.local.cache="true"
-							dest="${tstamp.value}.zip"
-							src="${test.build.bundle.zip.url}"
-						/>
-
-						<unzip dest="${app.server.parent.dir}" src="${tstamp.value}.zip">
-							<patternset includes="liferay-*/**" />
-							<mapper from="[^/]+/(.*)" to="\1" type="regexp" />
-						</unzip>
-					</catch>
-				</trycatch>
+				<unzip dest="${app.server.parent.dir}" src="${tstamp.value}.zip">
+					<patternset includes="liferay-*/**" />
+					<mapper from="[^/]+/(.*)" to="\1" type="regexp" />
+				</unzip>
 
 				<delete file="${tstamp.value}.zip" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -7144,7 +7144,7 @@ ANT_OPTS=${env.ANT_OPTS}</echo>
 						</unzip>
 					</try>
 					<catch>
-						<echo>Unable to unzip ${tstamp.value.zip}: ${error.message}. Redownloading ${test.build.bundle.zip.url}.</echo>
+						<echo>Error occurred while unzipping ${tstamp.value.zip}. ${error.message} Re-fetching zip file. </echo>
 
 						<mirrors-get
 							dest="${tstamp.value}.zip"

--- a/build-test.xml
+++ b/build-test.xml
@@ -7147,8 +7147,8 @@ ANT_OPTS=${env.ANT_OPTS}</echo>
 						<echo>Error occurred while unzipping ${tstamp.value.zip}. ${error.message} Re-fetching zip file. </echo>
 
 						<mirrors-get
+							clear.local.cache="true"
 							dest="${tstamp.value}.zip"
-							force="true"
 							src="${test.build.bundle.zip.url}"
 						/>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-28693

This pull reverts all the previous changes that only tested certain zip files in favor of new changes that will automatically test all .zip files that are downloaded via mirrors-get.
