### PR TITLE
LRQA-28736 Allow for 'test.batch.group.ignore.regex' to be null

### DIFF
--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -509,13 +509,16 @@ public class PoshiRunnerContext {
 			properties.putAll(
 				_classCommandNamePropertiesMap.get(classCommandName));
 
-			Set<String> propertyNames = properties.stringPropertyNames();
+			String testBatchGroupIgnoreRegex =
+				PropsValues.TEST_BATCH_GROUP_IGNORE_REGEX;
 
-			for (String propertyName : propertyNames) {
-				if (propertyName.matches(
-						PropsValues.TEST_BATCH_GROUP_IGNORE_REGEX)) {
+			if (Validator.isNotNull(testBatchGroupIgnoreRegex)) {
+				Set<String> propertyNames = properties.stringPropertyNames();
 
-					properties.remove(propertyName);
+				for (String propertyName : propertyNames) {
+					if (propertyName.matches(testBatchGroupIgnoreRegex)) {
+						properties.remove(propertyName);
+					}
 				}
 			}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-28736
