### PR TITLE
LPS-68995 Fix QDox ClassLibrary thread safety issue, to avoid SourceF…

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/JSPSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/JSPSourceProcessor.java
@@ -29,7 +29,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.ImportsFormatter;
 import com.liferay.source.formatter.util.FileUtil;
 
+import com.liferay.source.formatter.util.ThreadSafeClassLibrary;
 import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.DefaultDocletTagFactory;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaMethod;
 import com.thoughtworks.qdox.model.Type;
@@ -1978,7 +1980,9 @@ public class JSPSourceProcessor extends BaseSourceProcessor {
 					continue;
 				}
 
-				JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+				JavaDocBuilder javaDocBuilder = new JavaDocBuilder(
+					new DefaultDocletTagFactory(),
+					new ThreadSafeClassLibrary());
 
 				javaDocBuilder.addSource(tagJavaFile);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/JavaClass.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/JavaClass.java
@@ -28,7 +28,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.ToolsUtil;
 import com.liferay.source.formatter.util.FileUtil;
 
+import com.liferay.source.formatter.util.ThreadSafeClassLibrary;
 import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.DefaultDocletTagFactory;
 import com.thoughtworks.qdox.model.JavaMethod;
 
 import java.io.File;
@@ -327,7 +329,8 @@ public class JavaClass {
 			return;
 		}
 
-		JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+		JavaDocBuilder javaDocBuilder = new JavaDocBuilder(
+				new DefaultDocletTagFactory(), new ThreadSafeClassLibrary());
 
 		javaDocBuilder.addSource(_file);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UnprocessedExceptionCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UnprocessedExceptionCheck.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.checkstyle.util.DetailASTUtil;
+import com.liferay.source.formatter.util.ThreadSafeClassLibrary;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -28,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 import com.thoughtworks.qdox.JavaDocBuilder;
+import com.thoughtworks.qdox.model.DefaultDocletTagFactory;
 import com.thoughtworks.qdox.model.JavaClass;
 import com.thoughtworks.qdox.model.JavaPackage;
 import com.thoughtworks.qdox.model.JavaSource;
@@ -213,7 +215,8 @@ public class UnprocessedExceptionCheck extends AbstractCheck {
 	}
 
 	private JavaDocBuilder _getJavaDocBuilder() {
-		JavaDocBuilder javaDocBuilder = new JavaDocBuilder();
+		JavaDocBuilder javaDocBuilder = new JavaDocBuilder(
+			new DefaultDocletTagFactory(), new ThreadSafeClassLibrary());
 
 		FileContents fileContents = getFileContents();
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/ThreadSafeClassLibrary.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/ThreadSafeClassLibrary.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.util;
+
+import com.thoughtworks.qdox.model.ClassLibrary;
+
+import java.util.Collection;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ThreadSafeClassLibrary extends ClassLibrary {
+
+	public ThreadSafeClassLibrary() {
+		addDefaultLoader();
+	}
+
+	@Override
+	public void add(String className) {
+		synchronized (_classNamesLock) {
+			super.add(className);
+		}
+	}
+
+	@Override
+	public Collection<?> all() {
+		synchronized (_classNamesLock) {
+			return super.all();
+		}
+	}
+
+	@Override
+	public boolean contains(String className) {
+		synchronized (_classNamesLock) {
+			return super.contains(className);
+		}
+	}
+
+	@Override
+	public Class<?> getClass(String className) {
+		synchronized (_classNameToClassMapLock) {
+			return super.getClass(className);
+		}
+	}
+
+	private final Object _classNamesLock = new Object();
+	private final Object _classNameToClassMapLock = new Object();
+
+}


### PR DESCRIPTION
…ormatter randomly runs into infinite loops

@brianchandotcom @hhuijser this is the fix to SourceFormatterTest "deadlock" timeout, it turns out to be a hashmap infinite loop thread safety issue, and it is not only for the test. People could run into it when running SF normally too.

I only "hack" fix the QDox code, as it is the simplest solution. At some point we need to re-discuss about the plans for SF. As QDox is an ugly lib, it is buggy and does not perform well. And as I far as I know there is no good exist java source parser at all. Eventually we will have to create something by ourselves, it is just a matter of time.

But anyway, this is caught with the help of the new TimeoutTestRule :) This may not be the only issue we have, so if you see timeout failures again for SF test, let me know, we may have to keep patching it.

CC @pyoo47
