### PR TITLE
LPS-69036 Create a test to make a point that unregister a service(tra…

### DIFF
--- a/modules/test/service-tracker-test/bnd.bnd
+++ b/modules/test/service-tracker-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Service Tracker Test
+Bundle-SymbolicName: com.liferay.service.tracker.test
+Bundle-Version: 1.0.0

--- a/modules/test/service-tracker-test/build.gradle
+++ b/modules/test/service-tracker-test/build.gradle
@@ -1,0 +1,6 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+dependencies {
+	testIntegrationCompile group: "com.liferay", name: "com.liferay.arquillian.extension.junit.bridge", version: "1.0.5"
+}

--- a/modules/test/service-tracker-test/src/testIntegration/java/com/liferay/service/tracker/test/ServiceTrackerTest.java
+++ b/modules/test/service-tracker-test/src/testIntegration/java/com/liferay/service/tracker/test/ServiceTrackerTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.service.tracker.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class ServiceTrackerTest {
+
+	@Test
+	public void testUnregisterServiceDuringServiceTrackerClosing() {
+		Bundle bundle = FrameworkUtil.getBundle(ServiceTrackerTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		TestService testService1 = new TestService();
+
+		ServiceRegistration<TestService> serviceRegistration1 =
+			bundleContext.registerService(
+				TestService.class, testService1, null);
+
+		ServiceReference<TestService> serviceReference1 =
+			serviceRegistration1.getReference();
+
+		TestService testService2 = new TestService();
+
+		ServiceRegistration<TestService> serviceRegistration2 =
+			bundleContext.registerService(
+				TestService.class, testService2, null);
+
+		ServiceReference<TestService> serviceReference2 =
+			serviceRegistration2.getReference();
+
+		testService1._serviceRegistration = serviceRegistration2;
+
+		testService2._serviceRegistration = serviceRegistration1;
+
+		List<ObjectValuePair<ServiceReference<TestService>, Bundle>>
+			objectValuePairs = new ArrayList<>();
+
+		ServiceTracker<TestService, TestService> serviceTracker =
+			new ServiceTracker<TestService, TestService>(
+				bundleContext, TestService.class, null) {
+
+				@Override
+				public void removedService(
+					ServiceReference<TestService> serviceReference,
+					TestService testService) {
+
+					objectValuePairs.add(
+						new ObjectValuePair<>(
+							serviceReference, serviceReference.getBundle()));
+
+					ServiceRegistration<TestService> serviceRegistration =
+						testService._serviceRegistration;
+
+					serviceRegistration.unregister();
+
+					super.removedService(serviceReference, testService);
+				}
+
+			};
+
+		serviceTracker.open();
+
+		serviceTracker.close();
+
+		Assert.assertEquals(2, objectValuePairs.size());
+
+		ObjectValuePair<ServiceReference<TestService>, Bundle> objectValuePair =
+			objectValuePairs.get(0);
+
+		if (serviceReference1 == objectValuePair.getKey()) {
+			Assert.assertSame(bundle, objectValuePair.getValue());
+
+			objectValuePair = objectValuePairs.get(1);
+
+			Assert.assertSame(serviceReference2, objectValuePair.getKey());
+			Assert.assertNull(objectValuePair.getValue());
+		}
+		else {
+			Assert.assertSame(serviceReference2, objectValuePair.getKey());
+			Assert.assertSame(bundle, objectValuePair.getValue());
+
+			objectValuePair = objectValuePairs.get(1);
+
+			Assert.assertSame(serviceReference1, objectValuePair.getKey());
+			Assert.assertNull(objectValuePair.getValue());
+		}
+	}
+
+	private class TestService {
+
+		private ServiceRegistration<TestService> _serviceRegistration;
+
+	}
+
+}


### PR DESCRIPTION
…cked by the same ServiceTracker) during ServiceTracker closing is going to cause the unregstered ServiceReference disconnecting from the bundle. (This exposes the root cause of the WSRP/PortletTracker issue)

@brianchandotcom this is a documenting purpose test, to make a point that unregister a service during service tracker closing creates an issue. And this is exactly the reason why wsrp shutdown throws NPE. This is not fixing the WSRP problem, that will come as a separated pull with changes go into PortletTracker, as PortletTracker is unregistering service during its closing which is causing the NPE.