### PR TITLE
LPS-69089 Create a test to assert all Spring extender DM dependencies…

### DIFF
--- a/modules/test/dependency-manager-integrity-test/bnd.bnd
+++ b/modules/test/dependency-manager-integrity-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Dependency Manager Integrity Test
+Bundle-SymbolicName: com.liferay.dependency.manager.integrity.test
+Bundle-Version: 1.0.0

--- a/modules/test/dependency-manager-integrity-test/build.gradle
+++ b/modules/test/dependency-manager-integrity-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	provided group: "org.apache.felix", name: "org.apache.felix.dependencymanager", version: "3.2.0"
+
+	testIntegrationCompile group: "com.liferay", name: "com.liferay.arquillian.extension.junit.bridge", version: "1.0.5"
+}

--- a/modules/test/dependency-manager-integrity-test/src/testIntegration/java/com/liferay/dependency/manager/integrity/test/DependencyManagerIntegrityTest.java
+++ b/modules/test/dependency-manager-integrity-test/src/testIntegration/java/com/liferay/dependency/manager/integrity/test/DependencyManagerIntegrityTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dependency.manager.integrity.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.felix.dm.ComponentDeclaration;
+import org.apache.felix.dm.ComponentDependencyDeclaration;
+import org.apache.felix.dm.DependencyManager;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Shuyang Zhou
+ */
+@RunWith(Arquillian.class)
+public class DependencyManagerIntegrityTest {
+
+	@Test
+	public void testDependencyManagerIntegrity() throws IOException {
+		List<ComponentDependencyDeclaration>
+			missingComponentDependencyDeclarations = new ArrayList<>();
+
+		for (DependencyManager dependencyManager :
+				(List<DependencyManager>)
+					DependencyManager.getDependencyManagers()) {
+
+			for (ComponentDeclaration componentDeclaration :
+					(List<ComponentDeclaration>)
+						dependencyManager.getComponents()) {
+
+				if (componentDeclaration.getState() !=
+						ComponentDeclaration.STATE_UNREGISTERED) {
+
+					continue;
+				}
+
+				for (ComponentDependencyDeclaration
+						componentDependencyDeclaration :
+							componentDeclaration.getComponentDependencies()) {
+
+					if (componentDependencyDeclaration.getState() ==
+							ComponentDependencyDeclaration.
+								STATE_UNAVAILABLE_REQUIRED) {
+
+						missingComponentDependencyDeclarations.add(
+							componentDependencyDeclaration);
+					}
+				}
+			}
+		}
+
+		Assert.assertTrue(
+			"Missing dependencies " + missingComponentDependencyDeclarations,
+			missingComponentDependencyDeclarations.isEmpty());
+	}
+
+}


### PR DESCRIPTION
… are satisfied

This is to make sure CI can catch issues like https://github.com/brianchandotcom/liferay-portal/pull/44495

CC @rotty3000 @peterfellwock @mhan810

And @hhuijser please check my comment on https://github.com/brianchandotcom/liferay-portal/pull/44495#issuecomment-258349125, we must make sure that SF is in place for that check. I remember you did something for it, just don't remember whether it is finished or disabled?