### PR TITLE
7.0.x-qa-28861

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationjahook.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationjahook.testcase
@@ -13,19 +13,9 @@
 		<var name="appName" value="Japanese Localization" />
 		<var name="portletName" value="localization-ja-hook" />
 
-		<execute macro="Page#gotoContentCP">
-			<var name="portletName" value="Categories" />
-		</execute>
-
-		<!-- LPS-63777 -->
-
-		<!-- <execute macro="OSGiSmoke#Smoke">
+		<execute macro="OSGiSmoke#Smoke">
 			<var name="appName" value="${portletName}" />
 			<var name="portletName" value="${portletName}" />
-		</execute> -->
-
-		<execute macro="Page#gotoContentCP">
-			<var name="portletName" value="Web Content" />
 		</execute>
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationzhhook.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationzhhook.testcase
@@ -13,19 +13,9 @@
 		<var name="appName" value="Chinese Localization" />
 		<var name="portletName" value="localization-zh-hook" />
 
-		<execute macro="Page#gotoContentCP">
-			<var name="portletName" value="Categories" />
-		</execute>
-
-		<!-- LPS-63777 -->
-
-		<!-- <execute macro="OSGiSmoke#Smoke">
+		<execute macro="OSGiSmoke#Smoke">
 			<var name="appName" value="${portletName}" />
 			<var name="portletName" value="${portletName}" />
-		</execute> -->
-
-		<execute macro="Page#gotoContentCP">
-			<var name="portletName" value="Web Content" />
 		</execute>
 	</command>
 </definition>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-28861

@brianchandotcom this fixes the poshi compile issue that happens on **7.0.x only**.

@brianwulbern Page#gotoContentCP is a macro that no longer exists in master/7.0.x (but it does in 6.2). can you take a look at it when you get the chance? thanks!