### PR TITLE
LPS-65350 API method naming

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/BaseIndexedSAQImpressionProvider.java
+++ b/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/BaseIndexedSAQImpressionProvider.java
@@ -29,7 +29,7 @@ public abstract class BaseIndexedSAQImpressionProvider
 		long companyId, String metricName);
 
 	@Override
-	public void findSAQImpressions(
+	public void feedSAQImpressions(
 		long companyId, final SAQContextMatcher saqContextMatcher,
 		SAQImpressionConsumer saqImpressionConsumer) {
 
@@ -49,7 +49,7 @@ public abstract class BaseIndexedSAQImpressionProvider
 		}
 	}
 
-	public abstract void findSAQImpressions(
+	public abstract void feedSAQImpressions(
 		long companyId, SAQImpressionConsumer saqImpressionConsumer);
 
 	public abstract void findSAQImpressionsMatchingMetric(

--- a/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/SAQImpressionProvider.java
+++ b/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/SAQImpressionProvider.java
@@ -29,11 +29,11 @@ public interface SAQImpressionProvider {
 	public void createSAQImpression(
 		long companyId, Map<String, String> metrics, long expiryIntervalMillis);
 
-	public void findSAQImpressions(
+	public void feedSAQImpressions(
 		long companyId, SAQContextMatcher saqContextMatcher,
 		SAQImpressionConsumer saqImpressionConsumer);
 
-	public void findSAQImpressions(
+	public void feedSAQImpressions(
 		long companyId, SAQImpressionConsumer saqImpressionConsumer);
 
 	public int getSAQImpressionsCount(

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a3bf99209e8fa7186596f3cb661f394defba443e
+	commit = 7f8970e5ddecc59f513d7c144f0409031a368bfd
 	mode = push
-	parent = d7ff89b8f6817b1698015caf32652e6a6c7d4462
+	parent = a04568a39c434d46c182b5654b8451606b84dfa7
 	remote = git@github.com:liferay/com-liferay-asset.git


### PR DESCRIPTION
Follow up to brianchandotcom/liferay-portal/pull/44545

Hi Brian. How about naming the methods "feed"? This avoids find/get methods with void return type, and makes an association with the "consumer" object parameter.

We decided to use a "consumer" object parameter instead of returning a List for these reasons:

1. The API client (service module) should encapsulate all logic matching SAQImpressions with configured Service Access Quotas, reporting breaches

1. The API impl module should not return more SAQImpressions than necessary (which only the API client can determine)

1. The API impl module must be given opportunity to gracefully free up any used resources

We explored using List with pagination (to achieve 2.). However since everything happens in one process, this was inefficient because of needing to free resources after each page (to achieve 3.). Also you had to very carefully track pages because new SAQImpressions are added concurrently by other user requests, making the API more complex to implement.