### PR TITLE
LPS-65350 API method naming - ii

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/BaseIndexedSAQImpressionProvider.java
+++ b/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/BaseIndexedSAQImpressionProvider.java
@@ -17,16 +17,11 @@ package com.liferay.portal.security.service.access.quota.persistence;
 import com.liferay.portal.security.service.access.quota.metric.SAQContextMatcher;
 import com.liferay.portal.security.service.access.quota.metric.SAQMetricMatcher;
 
-import java.util.Iterator;
-
 /**
  * @author Stian Sigvartsen
  */
 public abstract class BaseIndexedSAQImpressionProvider
 	implements SAQImpressionProvider {
-
-	public abstract Iterator<String> findMetricValues(
-		long companyId, String metricName);
 
 	@Override
 	public void feedSAQImpressions(

--- a/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/BaseIndexedSAQImpressionProvider.java
+++ b/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/BaseIndexedSAQImpressionProvider.java
@@ -29,12 +29,12 @@ public abstract class BaseIndexedSAQImpressionProvider
 		long companyId, String metricName);
 
 	@Override
-	public void findSAQImpressions(
+	public void feedSAQImpressions(
 		long companyId, final SAQContextMatcher saqContextMatcher,
 		SAQImpressionConsumer saqImpressionConsumer) {
 
 		for (final String metricName : saqContextMatcher.getMetricNames()) {
-			findSAQImpressionsMatchingMetric(
+			feedSAQImpressionsMatchingMetric(
 				companyId, metricName,
 				new SAQMetricMatcher() {
 
@@ -49,10 +49,10 @@ public abstract class BaseIndexedSAQImpressionProvider
 		}
 	}
 
-	public abstract void findSAQImpressions(
+	public abstract void feedSAQImpressions(
 		long companyId, SAQImpressionConsumer saqImpressionConsumer);
 
-	public abstract void findSAQImpressionsMatchingMetric(
+	public abstract void feedSAQImpressionsMatchingMetric(
 		long companyId, String metric, SAQMetricMatcher saqMetricMatcher,
 		SAQImpressionConsumer saqImpressionConsumer);
 

--- a/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/SAQImpressionProvider.java
+++ b/modules/apps/foundation/portal-security/portal-security-service-access-quota-api/src/main/java/com/liferay/portal/security/service/access/quota/persistence/SAQImpressionProvider.java
@@ -29,11 +29,11 @@ public interface SAQImpressionProvider {
 	public void createSAQImpression(
 		long companyId, Map<String, String> metrics, long expiryIntervalMillis);
 
-	public void findSAQImpressions(
+	public void feedSAQImpressions(
 		long companyId, SAQContextMatcher saqContextMatcher,
 		SAQImpressionConsumer saqImpressionConsumer);
 
-	public void findSAQImpressions(
+	public void feedSAQImpressions(
 		long companyId, SAQImpressionConsumer saqImpressionConsumer);
 
 	public int getSAQImpressionsCount(


### PR DESCRIPTION
**Resending due to SF issue... (apologies)**

Follow up to brianchandotcom/liferay-portal#44545

Hi Brian. How about naming the methods "feed"? This avoids find/get methods with void return type, and makes an association with the "consumer" object parameter.

We decided to use a "consumer" object parameter instead of returning a List for these reasons:

1. The API client (service module) should encapsulate all logic matching SAQImpressions with configured Service Access Quotas, reporting breaches

1. The API impl module should not return more SAQImpressions than necessary (which only the API client can determine)

1. The API impl module must be given opportunity to gracefully free up any used resources

We explored using List with pagination (to achieve 2.). However since everything happens in one synchronous process, this was inefficient because of needing to free resources after each page (to achieve 3.). Also you had to very carefully track pages because new SAQImpressions are added concurrently by other user requests, making the API more complex to implement.

/cc @jpince @hhuijser