### PR TITLE
Lps 68289 36

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -791,9 +791,9 @@ Error-Prone was automatically installed. Please rerun your task.
 				<jvmarg value="-Djava.net.preferIPv4Stack=true" />
 				<jvmarg value="-Dliferay.log.dir=${liferay.home}/logs" />
 				<jvmarg value="-Dliferay.mode=test" />
-				<jvmarg value="-Dsun.zip.disableMemoryMapping=true" />
 				<jvmarg value="-Dosgi.state.dir=${liferay.home}/osgi/state" />
 				<jvmarg value="-Drelease.versions.test.other.dir=${release.versions.test.other.dir}" />
+				<jvmarg value="-Dsun.zip.disableMemoryMapping=true" />
 				<misc />
 				<jvmarg value="-Duser.timezone=GMT" />
 				<classpath location="test-coverage" />

--- a/build-common.xml
+++ b/build-common.xml
@@ -791,6 +791,7 @@ Error-Prone was automatically installed. Please rerun your task.
 				<jvmarg value="-Djava.net.preferIPv4Stack=true" />
 				<jvmarg value="-Dliferay.log.dir=${liferay.home}/logs" />
 				<jvmarg value="-Dliferay.mode=test" />
+				<jvmarg value="-Dsun.zip.disableMemoryMapping=true" />
 				<jvmarg value="-Dosgi.state.dir=${liferay.home}/osgi/state" />
 				<jvmarg value="-Drelease.versions.test.other.dir=${release.versions.test.other.dir}" />
 				<misc />

--- a/build-test.xml
+++ b/build-test.xml
@@ -2770,7 +2770,7 @@ go</echo>
 						<![CDATA[
 							JMX_OPTS="${testable.tomcat.jmx.opts}"
 
-							CATALINA_OPTS="${CATALINA_OPTS} ${JMX_OPTS}"
+							CATALINA_OPTS="${CATALINA_OPTS} ${JMX_OPTS} -Dsun.zip.disableMemoryMapping=true"
 						]]>
 					</echo>
 				</then>

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -81,8 +81,6 @@ public class InitUtil {
 				Field field = ReflectionUtil.getDeclaredField(
 					ZipFile.class, "usemmap");
 
-				field.setAccessible(true);
-
 				if ((boolean)field.get(null)) {
 					field.setBoolean(null, false);
 				}

--- a/portal-impl/src/com/liferay/portal/util/InitUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/InitUtil.java
@@ -32,9 +32,11 @@ import com.liferay.portal.kernel.util.ClassLoaderUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.OSDetector;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.PortalLifecycle;
 import com.liferay.portal.kernel.util.PortalLifecycleUtil;
+import com.liferay.portal.kernel.util.ReflectionUtil;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.SystemProperties;
@@ -52,9 +54,12 @@ import com.liferay.util.log4j.Log4JUtil;
 
 import com.sun.syndication.io.XmlReader;
 
+import java.lang.reflect.Field;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipFile;
 
 import org.apache.commons.lang.time.StopWatch;
 
@@ -69,6 +74,22 @@ public class InitUtil {
 	public static synchronized void init() {
 		if (_initialized) {
 			return;
+		}
+
+		try {
+			if (!OSDetector.isWindows()) {
+				Field field = ReflectionUtil.getDeclaredField(
+					ZipFile.class, "usemmap");
+
+				field.setAccessible(true);
+
+				if ((boolean)field.get(null)) {
+					field.setBoolean(null, false);
+				}
+			}
+		}
+		catch (Exception e) {
+			e.printStackTrace();
 		}
 
 		StopWatch stopWatch = new StopWatch();

--- a/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/counter/service/CounterLocalServiceTest.java
@@ -130,6 +130,7 @@ public class CounterLocalServiceTest {
 		List<String> arguments = new ArrayList<>();
 
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		for (String property :
 				HypersonicServerTestRule.INSTANCE.getJdbcProperties()) {

--- a/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/security/pacl/PACLAggregateTest.java
@@ -125,6 +125,7 @@ public class PACLAggregateTest extends AutoBalanceTestCase {
 		arguments.add("-Djava.security.policy==" + url.getFile());
 
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		String aspectjAgent = System.getProperty("aspectj.agent");
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/process/local/LocalProcessExecutorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/process/local/LocalProcessExecutorTest.java
@@ -1481,6 +1481,7 @@ public class LocalProcessExecutorTest {
 		arguments.add(
 			"-D" + SystemProperties.SYSTEM_PROPERTIES_QUIET + "=true");
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		if (Boolean.getBoolean("jvm.debug")) {
 			arguments.add(jpdaOptions);

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/NewEnvTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/NewEnvTestRule.java
@@ -173,6 +173,7 @@ public class NewEnvTestRule implements TestRule {
 		}
 
 		arguments.add("-Dliferay.mode=test");
+		arguments.add("-Dsun.zip.disableMemoryMapping=true");
 
 		String whipAgentLine = System.getProperty("whip.agent");
 


### PR DESCRIPTION
@brianchandotcom this should fix all sort of random JVM crashing on reading zip files, most break cases we saw are when felix fileinstall scanning/loading osgi jars.

Just in case you are curious, the failure looks like this on CI, https://test-1-20.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=4,label_exp=!master/53165/testReport/com.liferay.portal.security.pacl/PACLAggregateTest/testPACLTests/

But due to it is a jvm crashing, we don't get any missingful report from CI/Junit. The actual failure can only be gathered by login into the CI machine to get the crash report, something like this:
```

# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGBUS (0x7) at pc=0xb65eb220, pid=26256, tid=1561279344
#
# JRE version: Java(TM) SE Runtime Environment (8.0_51-b16) (build 1.8.0_51-b16)
# Java VM: Java HotSpot(TM) Server VM (25.51-b03 mixed mode linux-x86 )
# Problematic frame:
# C  [libzip.so+0x13220]  readCEN+0x7b0
#
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /opt/dev/projects/github/liferay-portal/hs_err_pid26256.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
```