### PR TITLE
LPS-69120 ConfigurationModelListeners won't trigger for factory configurations

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence/src/main/java/com/liferay/portal/configuration/persistence/ConfigurationPersistenceManager.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence/src/main/java/com/liferay/portal/configuration/persistence/ConfigurationPersistenceManager.java
@@ -53,6 +53,8 @@ import org.apache.felix.cm.NotCachablePersistenceManager;
 import org.apache.felix.cm.PersistenceManager;
 import org.apache.felix.cm.file.ConfigurationHandler;
 
+import org.osgi.service.cm.ConfigurationAdmin;
+
 /**
  * @author Raymond Augé
  * @author Sampsa Sohlman
@@ -320,10 +322,19 @@ public class ConfigurationPersistenceManager
 
 		ConfigurationModelListener configurationModelListener = null;
 
-		if (hasPid(pid)) {
+		if (!pid.endsWith("factory") &&
+			(dictionary.get("_felix_.cm.newConfiguration") == null)) {
+
+			String pidKey = (String)dictionary.get(
+				ConfigurationAdmin.SERVICE_FACTORYPID);
+
+			if (pidKey == null) {
+				pidKey = pid;
+			}
+
 			configurationModelListener =
 				ConfigurationModelListenerProvider.
-					getConfigurationModelListener(pid);
+					getConfigurationModelListener(pidKey);
 		}
 
 		if (configurationModelListener != null) {


### PR DESCRIPTION
This is an update for [LPS-69120](https://issues.liferay.com/browse/LPS-69120).<br><br>/cc @pei-jung @jorgeferrer