### PR TITLE
7.0.x-al-385

### DIFF
--- a/build-test-elasticsearch.xml
+++ b/build-test-elasticsearch.xml
@@ -550,11 +550,6 @@ username=liferay</echo>
 			<replacevalue><![CDATA[cluster.name: LiferayElasticsearchCluster]]></replacevalue>
 		</replace>
 
-		<replace file="${elasticsearch.dir}/config/elasticsearch.yml">
-			<replacetoken><![CDATA[# bootstrap.mlockall: true]]></replacetoken>
-			<replacevalue><![CDATA[bootstrap.mlockall: true]]></replacevalue>
-		</replace>
-
 		<antcall target="configure-elasticsearch-osgi-bundle-properties" />
 
 		<get-testcase-property property.name="elastic.shield.enabled" />

--- a/build-test-elasticsearch.xml
+++ b/build-test-elasticsearch.xml
@@ -572,7 +572,7 @@ username=liferay</echo>
 			<then>
 				<exec dir="${elasticsearch.dir}/bin" executable="/bin/bash">
 					<arg value="-c" />
-					<arg value="ES_HEAP_SIZE=512m ./elasticsearch -Des.insecure.allow.root=true -d -p pid-elasticsearch" />
+					<arg value="./elasticsearch -Des.insecure.allow.root=true -d -p pid-elasticsearch" />
 				</exec>
 			</then>
 			<elseif>
@@ -580,7 +580,7 @@ username=liferay</echo>
 				<then>
 					<exec dir="${elasticsearch.dir}/bin" executable="cmd" spawn="true">
 						<arg value="/c" />
-						<arg value="ES_HEAP_SIZE=512m elasticsearch -d -p pid-elasticsearch" />
+						<arg value="elasticsearch -d -p pid-elasticsearch" />
 					</exec>
 				</then>
 			</elseif>

--- a/build-test-elasticsearch.xml
+++ b/build-test-elasticsearch.xml
@@ -104,7 +104,7 @@ subjectKeyIdentifier = hash</echo>
 			<exec dir="${elastic.shield.ca.dir}" executable="keytool" failonerror="true">
 				<arg value="-importcert" />
 				<arg value="-alias" />
-				<arg value="es-ssl" />
+				<arg value="ca_cert" />
 				<arg value="-file" />
 				<arg value="certs/cacert.pem" />
 				<arg value="-keystore" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -8872,6 +8872,13 @@ jdbc.default.password=${database.mysql.password}</echo>
 			<then>
 				<print-file file.name="${elasticsearch.dir}/logs/LiferayElasticsearchCluster.log" />
 
+				<get
+					dest="${elasticsearch.dir}/logs/LiferayElasticsearchClusterMappings.log"
+					src="http://localhost:9200/_all/_mapping?pretty"
+				/>
+
+				<print-file file.name="${elasticsearch.dir}/logs/LiferayElasticsearchClusterMappings.log" />
+
 				<ant antfile="build-test-elasticsearch.xml" target="stop-elasticsearch" />
 			</then>
 		</if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-28860
https://issues.liferay.com/browse/LRQA-28865

About the revert:
"I reverted changes from LRQA-28799 since they didn't appear to make a difference in the Elasticsearch shard failures for ClusteringEE#AddAndDeleteBlogEntriesOnSeparateNodes and ElasticsearchEE#ElasticsearchRemoteClusterSmokeTest."