### PR TITLE
LPS-69140 ConfigurationModelListeners won't trigger when configuration is deleted

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence/src/main/java/com/liferay/portal/configuration/persistence/listener/ConfigurationModelListener.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence/src/main/java/com/liferay/portal/configuration/persistence/listener/ConfigurationModelListener.java
@@ -21,8 +21,16 @@ import java.util.Dictionary;
  */
 public interface ConfigurationModelListener {
 
+	public default void onAfterDelete(String pid)
+		throws ConfigurationModelListenerException {
+	}
+
 	public default void onAfterSave(
 			String pid, Dictionary<String, Object> properties)
+		throws ConfigurationModelListenerException {
+	}
+
+	public default void onBeforeDelete(String pid)
 		throws ConfigurationModelListenerException {
 	}
 

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 8d691fee2433b721fab028db02a3e7047fbfbd99
+	commit = ba8dcff37f869436419262ee6383d0672e3f3c03
 	mode = push
-	parent = 24c857e90262a970d4b6f0d72a9ce30fd4d9358b
+	parent = 1c3bc287611dc396443cc11dd91d615a8ec6fd54
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git


### PR DESCRIPTION
This is an update for [LPS-69140](https://issues.liferay.com/browse/LPS-69140).<br><br>/cc @pei-jung @jorgeferrer