### PR TITLE
LPS-68289 net.sf.ehcache.CacheManager.clearAll() is not thread safe, …

### DIFF
--- a/modules/apps/foundation/portal-cache/portal-cache-ehcache/src/main/java/com/liferay/portal/cache/ehcache/internal/EhcachePortalCacheManager.java
+++ b/modules/apps/foundation/portal-cache/portal-cache-ehcache/src/main/java/com/liferay/portal/cache/ehcache/internal/EhcachePortalCacheManager.java
@@ -157,7 +157,13 @@ public class EhcachePortalCacheManager<K extends Serializable, V>
 
 	@Override
 	protected void doClearAll() {
-		_cacheManager.clearAll();
+		for (String cacheName : _cacheManager.getCacheNames()) {
+			Cache cache = _cacheManager.getCache(cacheName);
+
+			if (cache != null) {
+				cache.removeAll();
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
…in case of concurrent cache removal, it could trigger NPE.

CC @tinatian 
The failure happens on shutdown in osgi log, something like this:
```
Portal log assert failure, OSGi log found: /opt/dev/projects/github/liferay-portal/bundles/osgi/state/1478584161661.log:
!SESSION 2016-11-08 05:52:46.682 -----------------------------------------------
eclipse.buildId=unknown
java.version=1.8.0_51
java.vendor=Oracle Corporation
BootLoader constants: OS=linux, ARCH=x86, WS=gtk, NL=en_US

!ENTRY com.liferay.portal.cache 4 0 2016-11-08 05:52:46.683
!MESSAGE [com.liferay.portal.cache.internal.MultiVMPoolImpl(1394)] The deactivate method has thrown an exception
!STACK 0
java.lang.NullPointerException
	at net.sf.ehcache.CacheManager.clearAll(CacheManager.java:1609)
	at com.liferay.portal.cache.ehcache.internal.EhcachePortalCacheManager.doClearAll(EhcachePortalCacheManager.java:160)
	at com.liferay.portal.cache.BasePortalCacheManager.clearAll(BasePortalCacheManager.java:48)
	at com.liferay.portal.cache.internal.MultiVMPoolImpl.deactivate(MultiVMPoolImpl.java:142)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.felix.scr.impl.helper.BaseMethod.invokeMethod(BaseMethod.java:222)
	at org.apache.felix.scr.impl.helper.BaseMethod.access$500(BaseMethod.java:37)
	at org.apache.felix.scr.impl.helper.BaseMethod$Resolved.invoke(BaseMethod.java:615)
	at org.apache.felix.scr.impl.helper.BaseMethod.invoke(BaseMethod.java:499)
	at org.apache.felix.scr.impl.helper.ActivateMethod.invoke(ActivateMethod.java:295)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.disposeImplementationObject(SingleComponentManager.java:342)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.deleteComponent(SingleComponentManager.java:157)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.doDeactivate(AbstractComponentManager.java:783)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.deactivateInternal(AbstractComponentManager.java:757)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleStaticCustomizer.removedService(DependencyManager.java:1014)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleStaticCustomizer.removedService(DependencyManager.java:915)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:1241)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:1136)
	at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.untrack(ServiceTracker.java:996)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:1175)
	at org.apache.felix.scr.impl.BundleComponentActivator$ListenerInfo.serviceChanged(BundleComponentActivator.java:120)
	at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:109)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:917)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:862)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:801)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.unregister(ServiceRegistrationImpl.java:222)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.unregister(AbstractComponentManager.java:883)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.unregister(AbstractComponentManager.java:857)
	at org.apache.felix.scr.impl.manager.RegistrationManager.changeRegistration(RegistrationManager.java:140)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.unregisterService(AbstractComponentManager.java:925)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.doDeactivate(AbstractComponentManager.java:774)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.deactivateInternal(AbstractComponentManager.java:757)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.dispose(AbstractComponentManager.java:550)
	at org.apache.felix.scr.impl.config.ConfigurableComponentHolder.disposeComponents(ConfigurableComponentHolder.java:725)
	at org.apache.felix.scr.impl.BundleComponentActivator.dispose(BundleComponentActivator.java:530)
	at org.apache.felix.scr.impl.Activator.disposeComponents(Activator.java:414)
	at org.apache.felix.scr.impl.Activator.access$300(Activator.java:53)
	at org.apache.felix.scr.impl.Activator$ScrExtension.destroy(Activator.java:273)
	at org.apache.felix.utils.extender.AbstractExtender$2.run(AbstractExtender.java:290)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.apache.felix.utils.extender.AbstractExtender.destroyExtension(AbstractExtender.java:312)
	at org.apache.felix.utils.extender.AbstractExtender.bundleChanged(AbstractExtender.java:186)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:905)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEventPrivileged(EquinoxEventPublisher.java:165)
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:75)
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:67)
	at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor.publishModuleEvent(EquinoxContainerAdaptor.java:102)
	at org.eclipse.osgi.container.Module.publishEvent(Module.java:461)
	at org.eclipse.osgi.container.Module.doStop(Module.java:619)
	at org.eclipse.osgi.container.Module.stop(Module.java:483)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.decStartLevel(ModuleContainer.java:1623)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1542)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1476)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:340)
```

@tomwang2011 backport please.