### PR TITLE
LPS-68289 Increase heap size for integration tests

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -152,7 +152,7 @@
     junit.cobertura.report.format=html
     junit.code.coverage=false
     junit.halt.on.failure=false
-    junit.java.integration.gc=-Xms768m -Xmx768m -XX:MaxMetaspaceSize=200m -XX:MaxNewSize=32m -XX:MaxTenuringThreshold=0 -XX:MetaspaceSize=200m -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:SurvivorRatio=65536 -XX:TargetSurvivorRatio=0 -XX:-UseAdaptiveSizePolicy -XX:+UseParallelOldGC
+    junit.java.integration.gc=-Xms1024m -Xmx1024m -XX:MaxMetaspaceSize=256m -XX:MaxNewSize=32m -XX:MaxTenuringThreshold=0 -XX:MetaspaceSize=256m -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:SurvivorRatio=65536 -XX:TargetSurvivorRatio=0 -XX:-UseAdaptiveSizePolicy -XX:+UseParallelOldGC
     junit.java.unit.gc=-Xms256m -Xmx256m -XX:MaxMetaspaceSize=64m -XX:MaxNewSize=32m -XX:MaxTenuringThreshold=0 -XX:MetaspaceSize=64m -XX:NewSize=32m -XX:ParallelGCThreads=2 -XX:SurvivorRatio=65536 -XX:TargetSurvivorRatio=0 -XX:-UseAdaptiveSizePolicy -XX:+UseParallelOldGC
     junit.java.unit.gc.logging=off
     junit.jvm=java


### PR DESCRIPTION
With more and more modules, the test jvm is getting a lot fatter. CI machine is really running low on memory. Do we have any plan for upgrading the machines or rebuild the VMs to put less VMs on the same box to increase each VM's resources? Soon we will hit the swap space badly.