### PR TITLE
LPS-69046 Administrator is unable to disable propagation from Site Template if a user's Profile or Dashboard is set to a Site Template and propagation is enabled

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -136,7 +136,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:when test="<%= publicLayoutSetPrototype != null %>">
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:when>

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -133,12 +133,16 @@ if (selUser != null) {
 						<c:if test="<%= PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED && (publicLayoutSetPrototype != null) %>">
 							<aui:input name="publicLayoutSetPrototypeId" type="hidden" value="<%= publicLayoutSetPrototype.getLayoutSetPrototypeId() %>" />
 
+							<%
+							String publicLayoutSetPrototypeName = HtmlUtil.escape(publicLayoutSetPrototype.getName(locale));
+							%>
+
 							<c:choose>
 								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
-									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
+									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", publicLayoutSetPrototypeName, false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= new Object[] {publicLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>
@@ -205,12 +209,16 @@ if (selUser != null) {
 						<c:if test="<%= PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED && (privateLayoutSetPrototype != null) %>">
 							<aui:input name="privateLayoutSetPrototypeId" type="hidden" value="<%= privateLayoutSetPrototype.getLayoutSetPrototypeId() %>" />
 
+							<%
+							String privateLayoutSetPrototypeName = HtmlUtil.escape(privateLayoutSetPrototype.getName(locale));
+							%>
+
 							<c:choose>
 								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
-									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(locale)), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
+									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", privateLayoutSetPrototypeName, false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= new Object[] {privateLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -130,16 +130,18 @@ if (selUser != null) {
 							</c:otherwise>
 						</c:choose>
 
-						<c:if test="<%= PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED %>">
+						<c:if test="<%= PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED && (publicLayoutSetPrototype != null) %>">
+							<aui:input name="publicLayoutSetPrototypeId" type="hidden" value="<%= publicLayoutSetPrototype.getLayoutSetPrototypeId() %>" />
+
 							<c:choose>
-								<c:when test="<%= (publicLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
+								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
-								<c:when test="<%= publicLayoutSetPrototype != null %>">
+								<c:otherwise>
 									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
-								</c:when>
+								</c:otherwise>
 							</c:choose>
 						</c:if>
 					</c:when>
@@ -200,16 +202,18 @@ if (selUser != null) {
 							</c:otherwise>
 						</c:choose>
 
-						<c:if test="<%= PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED %>">
+						<c:if test="<%= PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED && (privateLayoutSetPrototype != null) %>">
+							<aui:input name="privateLayoutSetPrototypeId" type="hidden" value="<%= privateLayoutSetPrototype.getLayoutSetPrototypeId() %>" />
+
 							<c:choose>
-								<c:when test="<%= (privateLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
+								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(locale)), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
-								<c:when test="<%= privateLayoutSetPrototype != null %>">
+								<c:otherwise>
 									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
-								</c:when>
+								</c:otherwise>
 							</c:choose>
 						</c:if>
 					</c:when>

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -142,7 +142,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", publicLayoutSetPrototypeName, false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {publicLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= publicLayoutSetPrototypeName %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>
@@ -218,7 +218,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", privateLayoutSetPrototypeName, false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {privateLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= privateLayoutSetPrototypeName %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>


### PR DESCRIPTION
This is an update for [LPS-69046](https://issues.liferay.com/browse/LPS-69046).<br><br>Hey Brian, an interesting side-effect of this issue being fixed is that the form save is now very slow whenever a user has a Site Template enabled.  This is because we're actually running `SitesUtil.updateLayoutSetPrototypesLinks` in `SEditUserMVCActionCommand#updateUser` when we're supposed to.  It seems like `SitesUtil.updateLayoutSetPrototypesLinks` is running a significant operation, even when no values have changed.  Just FYI.<br><br>/cc @yuhai @hhuijser @daledotshan @pei-jung