### PR TITLE
Lps 68289 45

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -235,6 +235,15 @@ jdbc.counter.minIdle=0
 
 counter.jdbc.prefix=jdbc.counter.]]></echo>
 
+			<if>
+				<equals arg1="${database.type}" arg2="oracle" />
+				<then>
+					<echo append="true" file="@{properties.file}"><![CDATA[
+jdbc.default.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_TIMEOUT=0
+jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_TIMEOUT=0]]></echo>
+				</then>
+			</if>
+
 			<post-action />
 		</sequential>
 	</macrodef>
@@ -5629,6 +5638,14 @@ sprite.root.dir=/tmp/sprite
 axis.servlet.hosts.allowed=
 
 tunnel.servlet.hosts.allowed=</echo>
+
+		<if>
+			<equals arg1="${database.type}" arg2="oracle" />
+			<then>
+				<echo append="true" file="portal-impl/src/portal-ext.properties"><![CDATA[
+jdbc.default.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_TIMEOUT=0]]></echo>
+			</then>
+		</if>
 
 		<get-testcase-property property.name="captcha.max.challenges" />
 

--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.jndi.JNDIUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
+import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.ClassLoaderUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -226,6 +227,18 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 
 		comboPooledDataSource.setIdentityToken(identityToken);
 
+		String connectionPropertiesString = (String)properties.remove(
+			"connectionProperties");
+
+		if (connectionPropertiesString != null) {
+			Properties connectionProperties = PropertiesUtil.load(
+				StringUtil.replace(
+					connectionPropertiesString, CharPool.SEMICOLON,
+					CharPool.NEW_LINE));
+
+			comboPooledDataSource.setProperties(connectionProperties);
+		}
+
 		Enumeration<String> enu =
 			(Enumeration<String>)properties.propertyNames();
 
@@ -314,6 +327,19 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 			_HIKARICP_DATASOURCE_CLASS_NAME);
 
 		Object hikariDataSource = hikariDataSourceClazz.newInstance();
+
+		String connectionPropertiesString = (String)properties.remove(
+			"connectionProperties");
+
+		if (connectionPropertiesString != null) {
+			Properties connectionProperties = PropertiesUtil.load(
+				StringUtil.replace(
+					connectionPropertiesString, CharPool.SEMICOLON,
+					CharPool.NEW_LINE));
+
+			BeanUtil.setProperty(
+				hikariDataSource, "dataSourceProperties", connectionProperties);
+		}
 
 		for (Map.Entry<Object, Object> entry : properties.entrySet()) {
 			String key = (String)entry.getKey();


### PR DESCRIPTION
@brianchandotcom
This is the follow up fix pull to https://github.com/brianchandotcom/liferay-portal/pull/44671

We got a hit on the aspect, and it has confirmed to be a real socket read timeout, basically CI is too slow for Oracle.

To fix this I have to disable connect and read timeout for Oracle Driver. And I realized we never had an unified way to configure jdbc Driver properties for connection creation. Due to we support 4 different connection pools which use 3 different ways to configure this. Tomcat pool and DBCP are sister projects, they share the same configuration. HikariCP and C3P0 have their own ways. I adapted HikariCP and C3P0 to use the same way as Tomcat pool and DBCP do, so that we have an unified way now.

And I disabled the timeouts for Oracle on CI. I am keeping the oracle debug aspect active for a couple more days, just to be safe. If everything works out fine for oracle, I will disable the debug aspect later.

@tomwang2011 backport please

CC @mhan810