### PR TITLE
LPS-69046 Administrator is unable to disable propagation from Site Template if a user's Profile or Dashboard is set to a Site Template and propagation is enabled

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
@@ -751,13 +751,13 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 			PortalMyAccountApplicationType.MyAccount.CLASS_NAME,
 			PortletProvider.Action.VIEW);
 
-		if (!portletId.equals(myAccountPortletId)) {
-			Group group = user.getGroup();
+		Group group = user.getGroup();
 
-			boolean hasGroupUpdatePermission = GroupPermissionUtil.contains(
-				themeDisplay.getPermissionChecker(), group.getGroupId(),
-				ActionKeys.UPDATE);
+		boolean hasGroupUpdatePermission = GroupPermissionUtil.contains(
+			themeDisplay.getPermissionChecker(), group.getGroupId(),
+			ActionKeys.UPDATE);
 
+		if (!portletId.equals(myAccountPortletId) && hasGroupUpdatePermission) {
 			long publicLayoutSetPrototypeId = ParamUtil.getLong(
 				actionRequest, "publicLayoutSetPrototypeId");
 			long privateLayoutSetPrototypeId = ParamUtil.getLong(
@@ -775,8 +775,7 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 			String privateLayoutSetPrototypeUuid =
 				privateLayoutSet.getLayoutSetPrototypeUuid();
 
-			if (hasGroupUpdatePermission &&
-				((publicLayoutSetPrototypeId > 0) ||
+			if (((publicLayoutSetPrototypeId > 0) ||
 				 (privateLayoutSetPrototypeId > 0) ||
 				 Validator.isNotNull(publicLayoutSetPrototypeUuid) ||
 				 Validator.isNotNull(privateLayoutSetPrototypeUuid))) {

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
@@ -66,7 +66,6 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.membershippolicy.MembershipPolicyException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
@@ -550,13 +549,6 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	@Reference(unbind = "-")
-	protected void setLayoutSetLocalService(
-		LayoutSetLocalService layoutSetLocalService) {
-
-		_layoutSetLocalService = layoutSetLocalService;
-	}
-
-	@Reference(unbind = "-")
 	protected void setListTypeLocalService(
 		ListTypeLocalService listTypeLocalService) {
 
@@ -781,10 +773,8 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 			boolean privateLayoutSetPrototypeLinkEnabled = ParamUtil.getBoolean(
 				actionRequest, "privateLayoutSetPrototypeLinkEnabled");
 
-			LayoutSet publicLayoutSet = _layoutSetLocalService.getLayoutSet(
-				group.getGroupId(), false);
-			LayoutSet privateLayoutSet = _layoutSetLocalService.getLayoutSet(
-				group.getGroupId(), true);
+			LayoutSet publicLayoutSet = group.getPublicLayoutSet();
+			LayoutSet privateLayoutSet = group.getPrivateLayoutSet();
 
 			String publicLayoutSetPrototypeUuid =
 				publicLayoutSet.getLayoutSetPrototypeUuid();
@@ -822,7 +812,6 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 	private AnnouncementsDeliveryLocalService
 		_announcementsDeliveryLocalService;
 	private DLAppLocalService _dlAppLocalService;
-	private LayoutSetLocalService _layoutSetLocalService;
 	private ListTypeLocalService _listTypeLocalService;
 	private UserService _userService;
 

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
@@ -770,15 +770,12 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 			LayoutSet publicLayoutSet = group.getPublicLayoutSet();
 			LayoutSet privateLayoutSet = group.getPrivateLayoutSet();
 
-			String publicLayoutSetPrototypeUuid =
-				publicLayoutSet.getLayoutSetPrototypeUuid();
-			String privateLayoutSetPrototypeUuid =
-				privateLayoutSet.getLayoutSetPrototypeUuid();
-
-			if (((publicLayoutSetPrototypeId > 0) ||
-				 (privateLayoutSetPrototypeId > 0) ||
-				 Validator.isNotNull(publicLayoutSetPrototypeUuid) ||
-				 Validator.isNotNull(privateLayoutSetPrototypeUuid))) {
+			if ((publicLayoutSetPrototypeId > 0) ||
+				(privateLayoutSetPrototypeId > 0) ||
+				(publicLayoutSetPrototypeLinkEnabled !=
+					publicLayoutSet.isLayoutSetPrototypeLinkEnabled()) ||
+				(privateLayoutSetPrototypeLinkEnabled !=
+					privateLayoutSet.isLayoutSetPrototypeLinkEnabled())) {
 
 				SitesUtil.updateLayoutSetPrototypesLinks(
 					group, publicLayoutSetPrototypeId,

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
@@ -72,7 +72,6 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -759,11 +758,6 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 				themeDisplay.getPermissionChecker(), group.getGroupId(),
 				ActionKeys.UPDATE);
 
-			boolean hasUnlinkLayoutSetPrototypePermission =
-				PortalPermissionUtil.contains(
-					themeDisplay.getPermissionChecker(),
-					ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);
-
 			long publicLayoutSetPrototypeId = ParamUtil.getLong(
 				actionRequest, "publicLayoutSetPrototypeId");
 			long privateLayoutSetPrototypeId = ParamUtil.getLong(
@@ -782,7 +776,6 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 				privateLayoutSet.getLayoutSetPrototypeUuid();
 
 			if (hasGroupUpdatePermission &&
-				hasUnlinkLayoutSetPrototypePermission &&
 				((publicLayoutSetPrototypeId > 0) ||
 				 (privateLayoutSetPrototypeId > 0) ||
 				 Validator.isNotNull(publicLayoutSetPrototypeUuid) ||

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -130,16 +130,16 @@ if (selUser != null) {
 							</c:otherwise>
 						</c:choose>
 
-						<c:if test="<%= PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED %>">
+						<c:if test="<%= PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED && (publicLayoutSetPrototype != null) %>">
 							<c:choose>
-								<c:when test="<%= (publicLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
+								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
-								<c:when test="<%= publicLayoutSetPrototype != null %>">
+								<c:otherwise>
 									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
-								</c:when>
+								</c:otherwise>
 							</c:choose>
 						</c:if>
 					</c:when>
@@ -200,16 +200,16 @@ if (selUser != null) {
 							</c:otherwise>
 						</c:choose>
 
-						<c:if test="<%= PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED %>">
+						<c:if test="<%= PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED && (privateLayoutSetPrototype != null) %>">
 							<c:choose>
-								<c:when test="<%= (privateLayoutSetPrototype != null) && hasUnlinkLayoutSetPrototypePermission %>">
+								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(locale)), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
-								<c:when test="<%= privateLayoutSetPrototype != null %>">
+								<c:otherwise>
 									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
-								</c:when>
+								</c:otherwise>
 							</c:choose>
 						</c:if>
 					</c:when>

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -141,7 +141,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", publicLayoutSetPrototypeName, false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {publicLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= publicLayoutSetPrototypeName %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>
@@ -216,7 +216,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", privateLayoutSetPrototypeName, false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {privateLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= privateLayoutSetPrototypeName %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -136,7 +136,7 @@ if (selUser != null) {
 									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:when test="<%= publicLayoutSetPrototype != null %>">
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:when>

--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/personal_site.jsp
@@ -131,12 +131,17 @@ if (selUser != null) {
 						</c:choose>
 
 						<c:if test="<%= PropsValues.LAYOUT_USER_PUBLIC_LAYOUTS_ENABLED && (publicLayoutSetPrototype != null) %>">
+
+							<%
+							String publicLayoutSetPrototypeName = HtmlUtil.escape(publicLayoutSetPrototype.getName(locale));
+							%>
+
 							<c:choose>
 								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
-									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
+									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", publicLayoutSetPrototypeName, false) %>' name="publicLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(publicLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= new Object[] {publicLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>
@@ -201,12 +206,17 @@ if (selUser != null) {
 						</c:choose>
 
 						<c:if test="<%= PropsValues.LAYOUT_USER_PRIVATE_LAYOUTS_ENABLED && (privateLayoutSetPrototype != null) %>">
+
+							<%
+							String privateLayoutSetPrototypeName = HtmlUtil.escape(privateLayoutSetPrototype.getName(locale));
+							%>
+
 							<c:choose>
 								<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
-									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(locale)), false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
+									<aui:input label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", privateLayoutSetPrototypeName, false) %>' name="privateLayoutSetPrototypeLinkEnabled" type="checkbox" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
 								</c:when>
 								<c:otherwise>
-									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(privateLayoutSetPrototype.getName(locale))} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
+									<liferay-ui:message arguments="<%= new Object[] {privateLayoutSetPrototypeName} %>" key="these-pages-are-linked-to-site-template-x" translateArguments="<%= false %>" />
 
 									<aui:input name="layoutSetPrototypeLinkEnabled" type="hidden" value="<%= true %>" />
 								</c:otherwise>


### PR DESCRIPTION
This is an update for [LPS-69046](https://issues.liferay.com/browse/LPS-69046).

@brianchandotcom: using @yuhai's method of solving the issue maintains good performance when saving the form.  It will only copy content on the first link. I added a commit (c4c545a) that will only call `SitesUtil.updateLayoutSetPrototypeLinks` when the checkbox value changes.  Even without c4c545a, the performance remains pretty good.

Since I had a chance to look at the ActionCommand class and the personal site JSP pretty closely, I took this opportunity for some refactoring/source formatting.

/cc @yuhai @hhuijser @daledotshan @pei-jung