### PR TITLE
LPS-69241 Elasticsearch test failures: excess index shards due to outsiders connecting to unit test cluster

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/cluster/TestCluster.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/cluster/TestCluster.java
@@ -30,14 +30,14 @@ import org.mockito.Mockito;
 public class TestCluster {
 
 	public TestCluster(int size, Object object) {
+		String prefix = getPrefix(object);
+
 		_elasticsearchConfigurationProperties =
-			createElasticsearchConfigurationProperties(size);
+			createElasticsearchConfigurationProperties(prefix, size);
 
 		_elasticsearchFixtures = new ElasticsearchFixture[size];
 
-		Class<?> clazz = object.getClass();
-
-		_prefix = clazz.getSimpleName();
+		_prefix = prefix;
 	}
 
 	public ElasticsearchFixture createNode(int index) throws Exception {
@@ -87,7 +87,7 @@ public class TestCluster {
 	}
 
 	protected HashMap<String, Object>
-		createElasticsearchConfigurationProperties(int size) {
+		createElasticsearchConfigurationProperties(String prefix, int size) {
 
 		HashMap<String, Object> properties = new HashMap<>();
 
@@ -101,10 +101,17 @@ public class TestCluster {
 			range = range + StringPool.MINUS + endingPort;
 		}
 
+		properties.put("clusterName", prefix + "-Cluster");
 		properties.put("discoveryZenPingUnicastHostsPort", range);
 		properties.put("transportTcpPort", range);
 
 		return properties;
+	}
+
+	protected String getPrefix(Object object) {
+		Class<?> clazz = object.getClass();
+
+		return clazz.getSimpleName();
 	}
 
 	private final HashMap<String, Object> _elasticsearchConfigurationProperties;


### PR DESCRIPTION
This fix prevents one random CI failure from Elasticsearch tests.

cc @preston-crary

https://issues.liferay.com/browse/LPS-69241