### PR TITLE
LRQA-28693 trim /'s from end of _path.

### DIFF
--- a/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
+++ b/modules/sdk/ant-mirrors-get/src/main/java/com/liferay/ant/mirrors/get/MirrorsGetTask.java
@@ -75,6 +75,10 @@ public class MirrorsGetTask extends Task {
 		if (_path.startsWith("mirrors/")) {
 			_path = _path.replace("mirrors/", _HOSTNAME);
 		}
+
+		while (_path.endsWith("/")) {
+			_path = _path.substring(0, _path.length() - 1);
+		}
 	}
 
 	public void setTryLocalNetwork(boolean tryLocalNetwork) {


### PR DESCRIPTION
I discovered that some of the URLs that we use with mirrors-get don't tolerate extra /'s. This change will ensure that extra /'s are not inserted between the path and the filename.

Please publish com.liferay.ant.mirrors.get.jar again after merging.