### PR TITLE
LRQA-28741 Update the ant script logic for the gatekeeper blacklist | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5768,14 +5768,34 @@ javascript.fast.load=false</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="blacklist.portal.profile.names" />
+		<get-testcase-property property.name="blacklist.portal.profile.names.remove" />
 
 		<if>
-			<not>
-				<isset property="blacklist.portal.profile.names" />
-			</not>
+			<isset property="blacklist.portal.profile.names.remove" />
 			<then>
-				<property name="blacklist.portal.profile.names" value="com.liferay.chat.service,com.liferay.chat.web" />
+				<beanshell>
+					<![CDATA[
+						String blacklistPortalProfileNamesRemoveString = project.getProperty("blacklist.portal.profile.names.remove");
+						String blacklistPortalProfileNamesString = project.getProperty("blacklist.portal.profile.names");
+
+						List blacklistPortalProfileNames = new ArrayList(Arrays.asList(blacklistPortalProfileNamesString.split(",")));
+						List blacklistPortalProfileNamesRemove = new ArrayList(Arrays.asList(blacklistPortalProfileNamesRemoveString.split(",")));
+
+						blacklistPortalProfileNames.removeAll(blacklistPortalProfileNamesRemove);
+
+						StringBuilder sb = new StringBuilder();
+
+						for (int i = 0; i < blacklistPortalProfileNames.size(); i++) {
+							sb.append(blacklistPortalProfileNames.get(i));
+
+							if (i != (blacklistPortalProfileNames.size() - 1)) {
+								sb.append(",");
+							}
+						}
+
+						project.setProperty("blacklist.portal.profile.names", sb.toString());
+					]]>
+				</beanshell>
 			</then>
 		</if>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/uiinfrastructure/chat/Chat.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/uiinfrastructure/chat/Chat.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-interface">
-	<property name="blacklist.portal.profile.names" value="" />
+	<property name="blacklist.portal.profile.names.remove" value="com.liferay.chat.service,com.liferay.chat.web" />
 	<property name="portal.release" value="true" />
 	<property name="testray.main.component.name" value="User Interface" />
 

--- a/test.properties
+++ b/test.properties
@@ -1114,7 +1114,7 @@
         apacheds.blank.user.password.enabled,\
         apacheds.enabled,\
         app.server.bundles.size,\
-        blacklist.portal.profile.names,\
+        blacklist.portal.profile.names.remove,\
         browser.type,\
         captcha.max.challenges,\
         cluster.enabled,\

--- a/test.properties
+++ b/test.properties
@@ -1409,6 +1409,10 @@
 ## Utilities
 ##
 
+    blacklist.portal.profile.names=\
+        com.liferay.chat.service,\
+        com.liferay.chat.web
+
     build.test.results.xml=true
     #ip.address=
     patching.tool.latest.txt=LATEST-2.0.txt


### PR DESCRIPTION
@brianchandotcom, this is a follow up to the gatekeeper blacklist pull from yesterday: https://github.com/brianchandotcom/liferay-portal/pull/44795. Basically, we'll use two lists. The default list in test.properties, and a 'remove' list in the testcase for modules we want to 'unblacklist'. Let me know if you have any questions/concerns. Thanks\!