### PR TITLE
LRQA-28741 Update the ant script logic for the gatekeeper blacklist | 7.0.x

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5770,14 +5770,34 @@ javascript.fast.load=false</echo>
 			</then>
 		</if>
 
-		<get-testcase-property property.name="blacklist.portal.profile.names" />
+		<get-testcase-property property.name="blacklist.portal.profile.names.remove" />
 
 		<if>
-			<not>
-				<isset property="blacklist.portal.profile.names" />
-			</not>
+			<isset property="blacklist.portal.profile.names.remove" />
 			<then>
-				<property name="blacklist.portal.profile.names" value="com.liferay.chat.service,com.liferay.chat.web" />
+				<beanshell>
+					<![CDATA[
+						String blacklistPortalProfileNamesRemoveString = project.getProperty("blacklist.portal.profile.names.remove");
+						String blacklistPortalProfileNamesString = project.getProperty("blacklist.portal.profile.names");
+
+						List blacklistPortalProfileNames = new ArrayList(Arrays.asList(blacklistPortalProfileNamesString.split(",")));
+						List blacklistPortalProfileNamesRemove = new ArrayList(Arrays.asList(blacklistPortalProfileNamesRemoveString.split(",")));
+
+						blacklistPortalProfileNames.removeAll(blacklistPortalProfileNamesRemove);
+
+						StringBuilder sb = new StringBuilder();
+
+						for (int i = 0; i < blacklistPortalProfileNames.size(); i++) {
+							sb.append(blacklistPortalProfileNames.get(i));
+
+							if (i != (blacklistPortalProfileNames.size() - 1)) {
+								sb.append(",");
+							}
+						}
+
+						project.setProperty("blacklist.portal.profile.names", sb.toString());
+					]]>
+				</beanshell>
 			</then>
 		</if>
 

--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 667e1357793176fc749a5e9636f8c5d88545adac
+	commit = 8de67149b948a3ae5cc3d361d7d120459381e86d
 	mode = push
-	parent = e2bedf25f2faeb248d09533063db94033e85b7c7
+	parent = 903cbf5ba4b33c93aceccd1e36960e888795ebcd
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/comment/.gitrepo
+++ b/modules/apps/collaboration/comment/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = bd787d749aa442f59b1935d820e8329e7b28b951
+	commit = 93fb0edc0738f5a5330ab5f8943eb83f2b93d58d
 	mode = push
-	parent = 54b061cd9faa102495da84668f2036c8f6751d3a
+	parent = bb0d59fb0a66eeed864dd03b9e443903b0f9a6b0
 	remote = git@github.com:liferay/com-liferay-comment.git

--- a/modules/apps/collaboration/mentions/.gitrepo
+++ b/modules/apps/collaboration/mentions/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 7b1383ad6a091c5603b2aea81d2de9c95b07dc2b
+	commit = 76390bcccb612c97688f4fe4010e6b9ee2651290
 	mode = push
-	parent = 9c6b18c78d40fd5e2915e9723af51dc155e428bf
+	parent = ca4944aed5edc82dc183644aca2087e6ae0bbe4f
 	remote = git@github.com:liferay/com-liferay-mentions.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b80025680212e3ec30a2b87d6643be84d5daa638
+	commit = 0bdf9251a27555632200ae2005807e52cfcd61a3
 	mode = push
-	parent = e8d515310860f79bd713569780bd7d59c2a585a6
+	parent = e4497c265fd2c3b2e8ef76c9f6d664c0192f4e04
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/microblogs/.gitrepo
+++ b/modules/apps/collaboration/microblogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9e73726656a9bce5d4bc41f6429454a470bc3a6f
+	commit = fe0bf9886b69ec619845a6260cb1a48aa82ca10c
 	mode = push
-	parent = 18359c04c373d0dc773156a0dc2dd960f9308091
+	parent = 7e88180ccdd88c242a222b22bae00b4a29629551
 	remote = git@github.com:liferay/com-liferay-microblogs.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a00552c389e073afbf161070e410775f77ed550a
+	commit = 14513dc03d9db15abc1eed154e653e93908ab55d
 	mode = push
-	parent = 3a7be86ade0c561b9aa9f1b925d3a572e6541086
+	parent = f4cee6e1f528d805f014556d978c923bbab505cb
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/uiinfrastructure/chat/Chat.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/uiinfrastructure/chat/Chat.testcase
@@ -1,5 +1,5 @@
 <definition component-name="portal-user-interface">
-	<property name="blacklist.portal.profile.names" value="" />
+	<property name="blacklist.portal.profile.names.remove" value="com.liferay.chat.service,com.liferay.chat.web" />
 	<property name="portal.release" value="true" />
 	<property name="testray.main.component.name" value="User Interface" />
 

--- a/test.properties
+++ b/test.properties
@@ -1116,7 +1116,7 @@
         apacheds.blank.user.password.enabled,\
         apacheds.enabled,\
         app.server.bundles.size,\
-        blacklist.portal.profile.names,\
+        blacklist.portal.profile.names.remove,\
         browser.type,\
         captcha.max.challenges,\
         cluster.enabled,\

--- a/test.properties
+++ b/test.properties
@@ -1411,6 +1411,10 @@
 ## Utilities
 ##
 
+    blacklist.portal.profile.names=\
+        com.liferay.chat.service,\
+        com.liferay.chat.web
+
     build.test.results.xml=true
     #ip.address=
     patching.tool.latest.txt=LATEST-2.0.txt


### PR DESCRIPTION
@brianchandotcom, this is a follow up to the gatekeeper blacklist pull from yesterday: https://github.com/brianchandotcom/liferay-portal/pull/44795. Basically, we'll use two lists. The default list in test.properties, and a 'remove' list in the testcase for modules we want to 'unblacklist'. Let me know if you have any questions/concerns. Thanks\!