### PR TITLE
LRQA-29060 Fix race condition

### DIFF
--- a/modules/apps/foundation/frontend-theme/.gitrepo
+++ b/modules/apps/foundation/frontend-theme/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0c2a1030673ec4247e5ec6459869cc4e7af8c2f6
+	commit = bbcbdfb92bdcefc360e271b23c5ad81ea9efd977
 	mode = push
-	parent = 3b3a6bdcf1712be9c32a7e413598954d851ab5e0
+	parent = 6dac0d8f679a63b59cde50d10698e4562a857d54
 	remote = git@github.com:liferay/com-liferay-frontend-theme.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3279b1dd313b0e2c096231224982dbc44d9d8507
+	commit = 9c7a46d164d4681aa1db19b5c3b5760be8473987
 	mode = push
-	parent = 6f767debc3466611a451f08ba09efcae727cf6e6
+	parent = a81c1ca94193ee806017808a11aaa890efa954f6
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseErrorTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseErrorTopLevelBuild.java
@@ -72,10 +72,24 @@ public class RebaseErrorTopLevelBuild extends TopLevelBuild {
 				return result;
 			}
 
+			long start = System.currentTimeMillis();
+
 			Map<String, String> stopPropertiesMap = getStopPropertiesMap();
 
-			if (!stopPropertiesMap.containsKey("TOP_LEVEL_GITHUB_COMMENT_ID")) {
-				return result;
+			while (!stopPropertiesMap.containsKey(
+						"TOP_LEVEL_GITHUB_COMMENT_ID")) {
+
+				if ((System.currentTimeMillis() - start) > (5 * 60 * 1000)) {
+					System.out.println(
+						"rebase-error build did not generate a " +
+							"TOP_LEVEL_GITHUB_COMMENT_ID");
+
+					return result;
+				}
+
+				JenkinsResultsParserUtil.sleep(10 * 1000);
+
+				stopPropertiesMap = getStopPropertiesMap();
 			}
 
 			StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
This pull request addresses a race condition between the liferay-jenkins-ee top-level build and the rebase-error liferay-portal-ee pull request test. The recent changes in RebaseErrorTopLevelBuild made an incorrect assumption that when the rebase-error build returned a result, the build was complete and the stop.properties temp map had been uploaded. Unfortunately, the stop.properties temp map is uploaded in the post-build section of the job. This means that the github comment id for the github comment that is posted at the end of the rebase-error build, may or may not be found in the stop.properties temp map. It depends on whether or not the post-build logic has executed or not by the time the jenkins-ee top-level build is ready to compare the rebase-error message with the template.

I've fixed this race condition by adding code that will allow the jenkins-ee top-level build to wait for up to 5 minutes for the github comment id to be added to the stop.properties temp map. If the post build of the rebase-error build does not complete in 5 minutes, then the jenkins-ee top-level build will report the rebase-error build as a failure because it was unable to get the comment id.