### PR TITLE
LPS-68289 Print timestamp when Gradle build finishes

### DIFF
--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -10,6 +10,12 @@ if (System.properties["http.proxyHost"] == "squid.lax.liferay.com") {
 }
 
 gradle.buildFinished {
+	if (System.getenv("JENKINS_HOME")) {
+		Date now = new Date()
+
+		println "Gradle build finished at " + now.format("yyyy-MM-dd HH:mm:ss.SSS", TimeZone.getTimeZone("UTC"))
+	}
+
 	ByteArrayOutputStream errorByteArrayOutputStream = new ByteArrayOutputStream()
 	ByteArrayOutputStream outputByteArrayOutputStream = new ByteArrayOutputStream()
 


### PR DESCRIPTION
Hi,
This should help diagnose a timeout problem that happens randomly during test integrations.

Thank you!

cc @shuyangzhou