### PR TITLE
LPS-69219 look-and-feel property order fix

### DIFF
--- a/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/src/WEB-INF/liferay-look-and-feel.xml
+++ b/modules/apps/frontend-theme-westeros-bank/frontend-theme-westeros-bank/src/WEB-INF/liferay-look-and-feel.xml
@@ -12,6 +12,14 @@
 			<setting configurable="true" key="show-main-search" options="all-screens,big-screens,small-screen,no-screen" type="select" value="all-screens" />
 			<setting configurable="true" key="show-recursive-menu-on" options="all-screens,big-screens,small-screen,no-screen" type="select" value="big-screens" />
 		</settings>
+		<layout-templates>
+			<custom>
+				<layout-template id="westeros_2_width_limited" name="Westeros 2 columns (90/10) width limited">
+					<template-path>/layoutttpl/custom/westeros_2_width_limited.tpl</template-path>
+					<thumbnail-path>/layoutttpl/custom/westeros_2_width_limited.png</thumbnail-path>
+				</layout-template>
+			</custom>
+		</layout-templates>
 		<portlet-decorator id="barebone" name="Barebone">
 			<portlet-decorator-css-class>portlet-barebone</portlet-decorator-css-class>
 		</portlet-decorator>
@@ -22,13 +30,5 @@
 		<portlet-decorator id="solid" name="Solid">
 			<portlet-decorator-css-class>portlet-solid</portlet-decorator-css-class>
 		</portlet-decorator>
-		<layout-templates>
-			<custom>
-				<layout-template id="westeros_2_width_limited" name="Westeros 2 columns (90/10) width limited">
-					<template-path>/layoutttpl/custom/westeros_2_width_limited.tpl</template-path>
-					<thumbnail-path>/layoutttpl/custom/westeros_2_width_limited.png</thumbnail-path>
-				</layout-template>
-			</custom>
-		</layout-templates>
 	</theme>
 </look-and-feel>


### PR DESCRIPTION
Brian, this is a fix so the `liferay-look-and-feel.xml` for the `Westeros Bank Theme` validates against the `liferay-look-and-feel_7_0_0.dtd`.

We'll be sending a separate one for the one in the `Porygon Theme` which also fails to validate, and we'll send backports as well.

Thanks!