### PR TITLE
LRQA-29177 & LRQA-29188

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FailureMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FailureMessageUtil.java
@@ -44,6 +44,7 @@ public class FailureMessageUtil {
 	}
 
 	private static final FailureMessageGenerator[] _failureMessageGenerators = {
+		new IntegrationTestTimeoutFailureMessageGenerator(),
 		new LocalGitMirrorFailureMessageGenerator(),
 		new PluginFailureMessageGenerator(),
 		new PluginGitIDFailureMessageGenerator(),

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/IntegrationTestTimeoutFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/IntegrationTestTimeoutFailureMessageGenerator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.tools.ant.Project;
+
+/**
+ * @author Peter Yoo
+ */
+public class IntegrationTestTimeoutFailureMessageGenerator
+	extends BaseFailureMessageGenerator {
+
+	@Override
+	public String getMessage(
+			String buildURL, String consoleOutput, Project project)
+		throws Exception {
+
+		Matcher matcher = _pattern.matcher(consoleOutput);
+
+		if (!matcher.find()) {
+			return null;
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("<p><strong>");
+		sb.append(matcher.group("testName"));
+		sb.append("</strong> was aborted because it exceeded ");
+		sb.append("the timeout period.</p>");
+
+		String snippet = matcher.group(0);
+
+		sb.append(getConsoleOutputSnippet(snippet, false, 0, snippet.length()));
+
+		return sb.toString();
+	}
+
+	private static final Pattern _pattern;
+
+	static {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("Execution failed for task '(?<testName>[^']*)'\\.\\s*");
+		sb.append("\\[exec\\] > Process 'Gradle Test Executor \\d+' finished ");
+		sb.append("with non-zero exit value 200");
+
+		_pattern = Pattern.compile(sb.toString());
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ModulesIntegrationBatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ModulesIntegrationBatchBuild.java
@@ -44,7 +44,7 @@ public class ModulesIntegrationBatchBuild extends BatchBuild {
 	public void update() {
 		super.update();
 
-		if (_notificationSent) {
+		if (_notificationsComplete) {
 			return;
 		}
 
@@ -110,6 +110,8 @@ public class ModulesIntegrationBatchBuild extends BatchBuild {
 				sb.append(reinvokeErrorMarker);
 
 				System.out.println(sb);
+
+				_notificationsComplete = true;
 			}
 
 			try {
@@ -117,8 +119,6 @@ public class ModulesIntegrationBatchBuild extends BatchBuild {
 					sb.toString(),
 					"root@" + JenkinsResultsParserUtil.getHostName("UNKNOWN"),
 					subject, "peter.yoo@liferay.com, shuyang.zhou@liferay.com");
-
-				_notificationSent = true;
 			}
 			catch (Exception e) {
 				System.out.println(
@@ -149,6 +149,6 @@ public class ModulesIntegrationBatchBuild extends BatchBuild {
 	private static final String _REINVOKE_ERROR_MARKER_TEMPLATE =
 		"reinvoke.error.marker[modules-integration-?]";
 
-	private boolean _notificationSent;
+	private boolean _notificationsComplete;
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteExecutor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteExecutor.java
@@ -171,7 +171,8 @@ public class RemoteExecutor {
 		private int _executeBashCommands()
 			throws InterruptedException, IOException {
 
-			StringBuffer sb = new StringBuffer("ssh ");
+			StringBuffer sb = new StringBuffer(
+				"ssh -o PasswordAuthentication=no ");
 
 			sb.append(_targetSlave);
 			sb.append(" '");


### PR DESCRIPTION
- [LRQA-29177](https://issues.liferay.com/browse/LRQA-29177) Create a custom GitHub message to explain when an integration test has timed out.
- [LRQA-29188](https://issues.liferay.com/browse/LRQA-29188) RemoteExecutor hangs when token authentication is not working.

Please publish a new com.liferay.jenkins.results.parser.jar after merging.

You can see an example of the custom GitHub message here: https://github.com/pyoo47/liferay-portal/pull/217