### PR TITLE
LRQA-28538 Update poshi theme test ant script logic

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7182,6 +7182,31 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 			</then>
 		</if>
 
+		<get-testcase-property property.name="theme.file.name" />
+
+		<if>
+			<and>
+				<available file="${liferay.home}/deploy/${theme.file.name}" />
+				<isset property="theme.file.name" />
+			</and>
+			<then>
+				<if>
+					<resourcecount when="greater" count="0">
+						<zipfileset src="${liferay.home}/deploy/${theme.file.name}">
+							<patternset>
+								<include name="**/private.lar" />
+							</patternset>
+						</zipfileset>
+					</resourcecount>
+					<then>
+						<echo append="true" file="${test.ext.properties.file}">
+							theme.contains.resources=true
+						</echo>
+					</then>
+				</if>
+			</then>
+		</if>
+
 		<get-testcase-property property.name="timeout.explicit.wait" />
 
 		<if>

--- a/build-test.xml
+++ b/build-test.xml
@@ -8802,15 +8802,15 @@ jdbc.default.password=${database.mysql.password}</echo>
 				<equals arg1="${skip.start-app-server}" arg2="true" />
 			</not>
 			<then>
-				<get-testcase-property property.name="themes.delayed.deployment" />
+				<get-testcase-property property.name="theme.file.name" />
 
 				<if>
-					<isset property="themes.delayed.deployment" />
+					<isset property="theme.file.name" />
 					<then>
 						<mkdir dir="${liferay.home}/tmp" />
 
 						<move todir="${liferay.home}/tmp">
-							<fileset dir="${liferay.home}/deploy" includes="${themes.delayed.deployment}" />
+							<fileset dir="${liferay.home}/deploy" includes="${theme.file.name}" />
 						</move>
 					</then>
 				</if>
@@ -8856,10 +8856,10 @@ jdbc.default.password=${database.mysql.password}</echo>
 				</if>
 
 				<if>
-					<isset property="themes.delayed.deployment" />
+					<isset property="theme.file.name" />
 					<then>
 						<move todir="${liferay.home}/deploy">
-							<fileset dir="${liferay.home}/tmp" includes="${themes.delayed.deployment}" />
+							<fileset dir="${liferay.home}/tmp" includes="${theme.file.name}" />
 						</move>
 
 						<delete dir="${liferay.home}/tmp" failonerror="false" />

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/util/PropsValues.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/util/PropsValues.java
@@ -257,6 +257,9 @@ public class PropsValues {
 	public static final String[] THEME_IDS = StringUtil.split(
 		PropsUtil.get("theme.ids"));
 
+	public static final boolean THEME_CONTAINS_RESOURCES =
+		GetterUtil.getBoolean(PropsUtil.get("theme.contains.resources"));
+
 	public static final int TIMEOUT_EXPLICIT_WAIT = GetterUtil.getInteger(
 		PropsUtil.get("timeout.explicit.wait"));
 

--- a/modules/test/poshi-runner/src/main/resources/poshi-runner.properties
+++ b/modules/test/poshi-runner/src/main/resources/poshi-runner.properties
@@ -108,6 +108,7 @@ test.toggle.file.names=poshi.toggle
 testing.class.method=false
 
 theme.ids=classic,controlpanel
+theme.contains.resources=false
 
 timeout.explicit.wait=60
 timeout.implicit.wait=3

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/themesinfrastructure/FjordTheme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/themesinfrastructure/FjordTheme.testcase
@@ -21,7 +21,7 @@
 
 	<command name="AddThemeSite" priority="1">
 		<property name="test.name.skip.portal.instance" value="FjordTheme#AddThemeSite" />
-		<property name="themes.delayed.deployment" value="fjord-theme.war" />
+		<property name="theme.file.name" value="fjord-theme.war" />
 
 		<execute macro="ProductMenu#gotoControlPanelSites">
 			<var name="portlet" value="Sites" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/themesinfrastructure/PorygonTheme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/themesinfrastructure/PorygonTheme.testcase
@@ -21,7 +21,7 @@
 
 	<command name="AddThemeSite" priority="1">
 		<property name="test.name.skip.portal.instance" value="PorygonTheme#AddThemeSite" />
-		<property name="themes.delayed.deployment" value="porygon-theme.war" />
+		<property name="theme.file.name" value="porygon-theme.war" />
 
 		<execute macro="ProductMenu#gotoControlPanelSites">
 			<var name="portlet" value="Sites" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/themesinfrastructure/WesterosTheme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/uiinfrastructure/themesinfrastructure/WesterosTheme.testcase
@@ -21,7 +21,7 @@
 
 	<command name="AddThemeSite" priority="1">
 		<property name="test.name.skip.portal.instance" value="WesterosTheme#AddThemeSite" />
-		<property name="themes.delayed.deployment" value="westeros-bank-theme.war" />
+		<property name="theme.file.name" value="westeros-bank-theme.war" />
 
 		<execute macro="ProductMenu#gotoControlPanelSites">
 			<var name="portlet" value="Sites" />

--- a/test.properties
+++ b/test.properties
@@ -1179,7 +1179,7 @@
         testcase.url,\
         testray.component.names,\
         testray.testcase.product.edition,\
-        themes.delayed.deployment,\
+        theme.file.name,\
         theme.plugins.includes,\
         timeout.explicit.wait,\
         web.plugins.includes,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-28538

@brianchandotcom, this is a follow up pull from a conversation from last month. You had a question about https://github.com/liferay/liferay-portal/commit/580a3077ad9306de10f84a88a2119efb72e3d636, and suggested that we make the tests on 7.0 and master the same but have logic to check for available resources within the theme (since master doesn't have any resources). I added a conditional to our ant scripts to check for the private.lar (which is only in 7.0) file within the theme war and a corresponding property to pass up to poshi. Let me know if you have any questions, thanks\!