### PR TITLE
LPS-64624 testWhileIdle does not work without validationQuery or vali…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1122,6 +1122,7 @@
     #jdbc.default.removeAbandonedTimeout=3600
     jdbc.default.testWhileIdle=true
     jdbc.default.timeBetweenEvictionRunsMillis=30000
+    jdbc.default.validationQuery=SELECT releaseId FROM Release_
 
     #
     # The following properties will be read by Tomcat JDBC Connection Pool if


### PR DESCRIPTION
…datorClassName. Without a mean to do the validation, testWhileIdle=true basically means killing all idle connections, due to the validation query fails with NPE.

@mhan810 this is caused by https://github.com/brianchandotcom/liferay-portal/pull/38569
This issue is discovered by randomly failing DocumentLibraryConvertProcessTest. The test failure was exposed by https://github.com/brianchandotcom/liferay-portal/pull/38569, not caused by it.

But the change in https://github.com/brianchandotcom/liferay-portal/pull/38569 has its own problem. With testWhileIdle=true, tomcat pool will periodically check idle connection for liveness, but it needs a way to do the validation, it must be provided to the pool via validationQuery or validatorClassName. If none of them is configured, the pool will try to run a validation query with "null" sql, which will for sure to fail with NPE. Causing the pool to kill the idle connection, even it is still alive.

I think this fix may bring back the issue in https://issues.liferay.com/browse/LPS-64624. Because in https://github.com/brianchandotcom/liferay-portal/pull/38569, it basically disabled the pool(by killing pooled connections right away), with this fix, we will start to allow alive idle connection to stay, I don't know how this would affect the original ticket.

@brianchiu can you reverify the https://issues.liferay.com/browse/LPS-64624 after this is merged? If the problem shows up again, let me know. We should fix it by promotely recycling the connections or shrink the pool side, rather than killing alive idle connections.

@brianchandotcom I will fix the DocumentLibraryConvertProcessTest random failures separately to keep the issues isolated.
