### PR TITLE
LPS-68369 Use the local service so the advice can wrap the layout

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ExceptionRetryAcceptor;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.spring.aop.Property;
@@ -481,7 +482,7 @@ public class PortletPreferencesLocalServiceImpl
 			return layoutRevision;
 		}
 
-		Layout layout = layoutPersistence.fetchByPrimaryKey(plid);
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(plid);
 
 		if (layout == null) {
 			return null;


### PR DESCRIPTION
cc @shuyangzhou a regression caused by a refactor. We need to call the local service instead of the persistence as there is an advice class hooked on it, handling the page versioning

 @pavel-savinov the bug was this regression, the advice was not called for the layout. The advice always wraps the layout object this is how the page versioning is handled