### PR TITLE
LPS-68289 For the threadEnabled && (referenceType == ReferenceType.PH…

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/memory/FinalizeManagerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/memory/FinalizeManagerTest.java
@@ -284,7 +284,9 @@ public class FinalizeManagerTest {
 			Assert.assertNull(markFinalizeAction.getId());
 		}
 
-		Assert.assertNull(_getReferent(reference));
+		if (!threadEnabled || (referenceType != ReferenceType.PHANTOM)) {
+			Assert.assertNull(_getReferent(reference));
+		}
 
 		if (threadEnabled) {
 			_checkThreadState();


### PR DESCRIPTION
…ANTOM), the Reference.clear() happens in the background thread, and the Reference.referent is not volatile, therefore there is no guarantee that the main thread can see the change right away. It is not easy to add in another CPU cache line flush here. Let's simply not to assert this race condition.