### PR TITLE
LPS-69392

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -145,7 +145,9 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 			}
 			catch (Exception e) {
 				if (_log.isDebugEnabled()) {
-					_log.debug("Unable to get resource primary key", e);
+					_log.debug(
+						"Unable to get resource primary key for class " +
+							className + " with primary key " + classPK);
 				}
 			}
 


### PR DESCRIPTION
I sent this pull to @mhan810 (see https://github.com/mhan810/liferay-portal/pull/1280) and he said I can forward it to you https://github.com/mhan810/liferay-portal/pull/1280#issuecomment-263335108

> https://issues.liferay.com/browse/LPS-69392
> 
> In case of activating debug traces for index buffer (com.liferay.portal.search.internal.buffer) we are having a lot of exceptions.
> That debug traces were added in [LPS-67703](https://issues.liferay.com/browse/LPS-67703) but they are not necessary because it is a controlled error:
> 1. In order to avoid duplicated reindex operations for ResourcedModel, in [LPS-67703](https://issues.liferay.com/browse/LPS-67703) we search the object using classPK and call resourcedModel.getResourcePrimKey()
>  2. But sometimes for JournalArticle, classPK parameter is already the resourcePrimKey, so we get a NoSuchModelException but it is ok, we can ignore it because JournalArticleIndexer handles both id fields
> 
> So I am removing the exception but maintaining the log.debug, see: https://github.com/mhan810/liferay-portal/pull/1280/commits/3753552261f4f5fb42c38e2bf7a6ebb83a2f6a9c