### PR TITLE
LRQA-28348 Remove unused PR tester batch | 7.0.x

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1002,7 +1002,6 @@
         functional-upgrade-tomcat8-mysql56-jdk8,\
         functional-upgrade-tomcat8-oracle12-jdk8,\
         functional-upgrade-tomcat8-postgresql94-jdk8,\
-        functional-upgrade-tomcat8-postgresql94-jdk8-quarantine,\
         functional-upgrade-tomcat8-sybase16-jdk8,\
         integration-db2105-jdk8,\
         integration-hypersonic20-jdk8,\
@@ -1074,7 +1073,6 @@
     test.batch.run.property.query[functional-upgrade-tomcat8-mysql56-jdk8]=portal.upgrades == true
     test.batch.run.property.query[functional-upgrade-tomcat8-oracle12-jdk8]=portal.upgrades == true
     test.batch.run.property.query[functional-upgrade-tomcat8-postgresql94-jdk8]=portal.upgrades == true
-    test.batch.run.property.query[functional-upgrade-tomcat8-postgresql94-jdk8-quarantine]=portal.upgrades == quarantine
     #test.batch.run.property.query[functional-upgrade-tomcat8-sybase16-jdk8]=portal.upgrades == true
 
     #test.batch.run.type=sequential


### PR DESCRIPTION
@brianchandotcom, this quarantine batch is no longer used/ needed. Furthermore, this will keep these properties in parallel with master, so there's no pull for master necessary