### PR TITLE
LRQA-29468 Make batch names consistent

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1470,23 +1470,23 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-functional-test app.server.type="tcserver" database.type="mysql" />
 	</target>
 
-	<target name="functional-smoke-tomcat8-mariadb100-jdk8">
+	<target name="functional-smoke-tomcat80-mariadb100-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mariadb" />
 	</target>
 
-	<target name="functional-smoke-tomcat8-mysql56-jdk8">
+	<target name="functional-smoke-tomcat80-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 
-	<target name="functional-smoke-tomcat8-oracle12-jdk8">
+	<target name="functional-smoke-tomcat80-oracle121-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="oracle" />
 	</target>
 
-	<target name="functional-smoke-tomcat8-postgresql94-jdk8">
+	<target name="functional-smoke-tomcat80-postgresql94-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="postgresql" />
 	</target>
 
-	<target name="functional-smoke-tomcat8-sybase160-jdk8">
+	<target name="functional-smoke-tomcat80-sybase160-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="sybase" />
 	</target>
 
@@ -1498,47 +1498,47 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-functional-test app.server.type="websphere" database.type="mysql" />
 	</target>
 
-	<target name="functional-smoke-wildfly10-mariadb100-jdk8">
+	<target name="functional-smoke-wildfly100-mariadb100-jdk8">
 		<run-functional-test app.server.type="wildfly" database.type="mariadb" />
 	</target>
 
-	<target name="functional-tomcat8-hypersonic20-jdk8">
+	<target name="functional-tomcat80-hypersonic20-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="hypersonic" />
 	</target>
 
-	<target name="functional-tomcat8-mysql55-jdk8">
+	<target name="functional-tomcat80-mysql55-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" database.version="5.5" />
 	</target>
 
-	<target name="functional-tomcat8-mysql56-jdk8">
+	<target name="functional-tomcat80-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 
-	<target name="functional-tomcat8-mysql56-jdk8-quarantine">
-		<antcall target="functional-tomcat8-mysql56-jdk8" />
+	<target name="functional-tomcat80-mysql56-jdk8-quarantine">
+		<antcall target="functional-tomcat80-mysql56-jdk8" />
 	</target>
 
-	<target name="functional-upgrade-tomcat8-mariadb100-jdk8">
+	<target name="functional-upgrade-tomcat80-mariadb100-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mariadb" />
 	</target>
 
-	<target name="functional-upgrade-tomcat8-mysql56-jdk8">
+	<target name="functional-upgrade-tomcat80-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 
-	<target name="functional-upgrade-tomcat8-oracle12-jdk8">
+	<target name="functional-upgrade-tomcat80-oracle121-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="oracle" />
 	</target>
 
-	<target name="functional-upgrade-tomcat8-postgresql94-jdk8">
+	<target name="functional-upgrade-tomcat80-postgresql94-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="postgresql" />
 	</target>
 
-	<target name="functional-upgrade-tomcat8-postgresql94-jdk8-quarantine">
-		<antcall target="functional-upgrade-tomcat8-postgresql94-jdk8" />
+	<target name="functional-upgrade-tomcat80-postgresql94-jdk8-quarantine">
+		<antcall target="functional-upgrade-tomcat80-postgresql94-jdk8" />
 	</target>
 
-	<target name="functional-upgrade-tomcat8-sybase160-jdk8">
+	<target name="functional-upgrade-tomcat80-sybase160-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="sybase" />
 	</target>
 
@@ -1554,7 +1554,7 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-integration-test database.type="mysql" />
 	</target>
 
-	<target name="integration-oracle12-jdk8">
+	<target name="integration-oracle121-jdk8">
 		<run-integration-test database.type="oracle" />
 	</target>
 
@@ -1578,7 +1578,7 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-legacy-database-dump database.type="mysql" database.version="5.5" />
 	</target>
 
-	<target name="legacy-functional-bundle-tomcat-oracle12-jdk7">
+	<target name="legacy-functional-bundle-tomcat-oracle121-jdk7">
 		<run-legacy-database-dump database.type="oracle" />
 	</target>
 
@@ -1640,7 +1640,7 @@ app.server.type=@{app.server.type}]]></echo>
 		</run-batch-test>
 	</target>
 
-	<target name="modules-functional-tomcat8-mysql56-jdk8">
+	<target name="modules-functional-tomcat80-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 
@@ -1656,7 +1656,7 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-modules-integration-test database.type="mysql" />
 	</target>
 
-	<target name="modules-integration-oracle12-jdk8">
+	<target name="modules-integration-oracle121-jdk8">
 		<run-modules-integration-test database.type="oracle" />
 	</target>
 
@@ -1773,7 +1773,7 @@ ${output.content}</echo>
 		/>
 	</target>
 
-	<target name="plugins-functional-tomcat8-mysql56-jdk8">
+	<target name="plugins-functional-tomcat80-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 
@@ -2168,7 +2168,7 @@ information. Make sure to commit in all build services results.
 		</trycatch>
 	</target>
 
-	<target name="subrepository-functional-tomcat8-mysql56-jdk8">
+	<target name="subrepository-functional-tomcat80-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 
@@ -2478,7 +2478,7 @@ ${output.content}</echo>
 		</run-batch-test>
 	</target>
 
-	<target name="upstream-functional-tomcat8-mysql56-jdk8">
+	<target name="upstream-functional-tomcat80-mysql56-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="mysql" />
 	</target>
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1486,7 +1486,7 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-functional-test app.server.type="tomcat" database.type="postgresql" />
 	</target>
 
-	<target name="functional-smoke-tomcat8-sybase16-jdk8">
+	<target name="functional-smoke-tomcat8-sybase160-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="sybase" />
 	</target>
 
@@ -1538,7 +1538,7 @@ app.server.type=@{app.server.type}]]></echo>
 		<antcall target="functional-upgrade-tomcat8-postgresql94-jdk8" />
 	</target>
 
-	<target name="functional-upgrade-tomcat8-sybase16-jdk8">
+	<target name="functional-upgrade-tomcat8-sybase160-jdk8">
 		<run-functional-test app.server.type="tomcat" database.type="sybase" />
 	</target>
 
@@ -1586,7 +1586,7 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-legacy-database-dump database.type="postgresql" />
 	</target>
 
-	<target name="legacy-functional-bundle-tomcat-sybase16-jdk7">
+	<target name="legacy-functional-bundle-tomcat-sybase160-jdk7">
 		<run-legacy-database-dump database.type="sybase" />
 	</target>
 

--- a/test.properties
+++ b/test.properties
@@ -987,26 +987,26 @@
         functional-smoke-jboss70-mysql56-jdk8,\
         #functional-smoke-resin40-mysql56-jdk8,\
         #functional-smoke-tcserver26-mysql56-jdk8,\
-        functional-smoke-tomcat8-mariadb100-jdk8,\
-        functional-smoke-tomcat8-mysql56-jdk8,\
-        functional-smoke-tomcat8-oracle12-jdk8,\
-        functional-smoke-tomcat8-postgresql94-jdk8,\
-        functional-smoke-tomcat8-sybase160-jdk8,\
+        functional-smoke-tomcat80-mariadb100-jdk8,\
+        functional-smoke-tomcat80-mysql56-jdk8,\
+        functional-smoke-tomcat80-oracle121-jdk8,\
+        functional-smoke-tomcat80-postgresql94-jdk8,\
+        functional-smoke-tomcat80-sybase160-jdk8,\
         functional-smoke-weblogic121-mysql56-jdk8,\
         #functional-smoke-websphere85-mysql56-jdk8,\
-        functional-smoke-wildfly10-mariadb100-jdk8,\
-        functional-tomcat8-hypersonic20-jdk8,\
-        functional-tomcat8-mysql56-jdk8,\
-        functional-tomcat8-mysql56-jdk8-quarantine,\
-        functional-upgrade-tomcat8-mariadb100-jdk8,\
-        functional-upgrade-tomcat8-mysql56-jdk8,\
-        functional-upgrade-tomcat8-oracle12-jdk8,\
-        functional-upgrade-tomcat8-postgresql94-jdk8,\
-        functional-upgrade-tomcat8-sybase160-jdk8,\
+        functional-smoke-wildfly100-mariadb100-jdk8,\
+        functional-tomcat80-hypersonic20-jdk8,\
+        functional-tomcat80-mysql56-jdk8,\
+        functional-tomcat80-mysql56-jdk8-quarantine,\
+        functional-upgrade-tomcat80-mariadb100-jdk8,\
+        functional-upgrade-tomcat80-mysql56-jdk8,\
+        functional-upgrade-tomcat80-oracle121-jdk8,\
+        functional-upgrade-tomcat80-postgresql94-jdk8,\
+        functional-upgrade-tomcat80-sybase160-jdk8,\
         integration-db2105-jdk8,\
         integration-hypersonic20-jdk8,\
         integration-mysql56-jdk8,\
-        integration-oracle12-jdk8,\
+        integration-oracle121-jdk8,\
         integration-postgresql94-jdk8,\
         integration-sybase160-jdk8,\
         lpkg-override-jdk8,\
@@ -1015,17 +1015,17 @@
         lpkg-startup-jdk8,\
         modules-compile-jdk8,\
         modules-functional-jdk8,\
-        modules-functional-tomcat8-mysql56-jdk8,\
+        modules-functional-tomcat80-mysql56-jdk8,\
         modules-integration-db2105-jdk8,\
         modules-integration-hypersonic20-jdk8,\
         modules-integration-mysql56-jdk8,\
-        modules-integration-oracle12-jdk8,\
+        modules-integration-oracle121-jdk8,\
         modules-integration-postgresql94-jdk8,\
         modules-integration-sybase160-jdk8,\
         modules-unit-jdk8,\
         plugins-compile-jdk8,\
         plugins-functional-bundle-tomcat-mysql56-jdk8,\
-        plugins-functional-tomcat8-mysql56-jdk8,\
+        plugins-functional-tomcat80-mysql56-jdk8,\
         portal-frontend-js-jdk8,\
         portal-web-jdk8,\
         release-functional-bundle-tomcat-mysql56-jdk8,\
@@ -1051,29 +1051,29 @@
     test.batch.run.property.query[functional-smoke-jboss70-mysql56-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-resin40-mysql56-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-tcserver26-mysql56-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-tomcat8-mysql56-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-tomcat8-mariadb100-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-tomcat8-oracle12-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-tomcat8-postgresql94-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-tomcat8-sybase160-jdk8]=portal.smoke == true
-    #test.batch.run.property.query[functional-smoke-tomcat8-sybase160-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-smoke-tomcat80-mysql56-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-smoke-tomcat80-mariadb100-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-smoke-tomcat80-oracle121-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-smoke-tomcat80-postgresql94-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-smoke-tomcat80-sybase160-jdk8]=portal.smoke == true
+    #test.batch.run.property.query[functional-smoke-tomcat80-sybase160-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-weblogic121-mysql56-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-websphere85-mysql56-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-wildfly100mariadb100-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-tomcat8-hypersonic20-jdk8]=portal.acceptance.tomcat.hypersonic == true
-    test.batch.run.property.query[functional-tomcat8-mysql56-jdk8]=(portal.acceptance == true) OR (portal.acceptance.tomcat.mysql == true)
-    test.batch.run.property.query[functional-tomcat8-mysql56-jdk8-quarantine]=(portal.acceptance == pending) OR (portal.acceptance == quarantine)
+    test.batch.run.property.query[functional-smoke-wildfly100-mariadb100-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-tomcat80-hypersonic20-jdk8]=portal.acceptance.tomcat.hypersonic == true
+    test.batch.run.property.query[functional-tomcat80-mysql56-jdk8]=(portal.acceptance == true) OR (portal.acceptance.tomcat.mysql == true)
+    test.batch.run.property.query[functional-tomcat80-mysql56-jdk8-quarantine]=(portal.acceptance == pending) OR (portal.acceptance == quarantine)
     test.batch.run.property.query[legacy-functional-bundle-tomcat-db2105-jdk7]=legacy.database.dump == true
     test.batch.run.property.query[legacy-functional-bundle-tomcat-mariadb100-jdk7]=legacy.database.dump == true
     test.batch.run.property.query[legacy-functional-bundle-tomcat-mysql55-jdk7]=legacy.database.dump == true
-    test.batch.run.property.query[legacy-functional-bundle-tomcat-oracle12-jdk7]=legacy.database.dump == true
+    test.batch.run.property.query[legacy-functional-bundle-tomcat-oracle121-jdk7]=legacy.database.dump == true
     test.batch.run.property.query[legacy-functional-bundle-tomcat-postgresql94-jdk7]=legacy.database.dump == true
     test.batch.run.property.query[legacy-functional-bundle-tomcat-sybase160-jdk7]=legacy.database.dump == true
-    test.batch.run.property.query[functional-upgrade-tomcat8-mariadb100-jdk8]=portal.upgrades == true
-    test.batch.run.property.query[functional-upgrade-tomcat8-mysql56-jdk8]=portal.upgrades == true
-    test.batch.run.property.query[functional-upgrade-tomcat8-oracle12-jdk8]=portal.upgrades == true
-    test.batch.run.property.query[functional-upgrade-tomcat8-postgresql94-jdk8]=portal.upgrades == true
-    #test.batch.run.property.query[functional-upgrade-tomcat8-sybase160-jdk8]=portal.upgrades == true
+    test.batch.run.property.query[functional-upgrade-tomcat80-mariadb100-jdk8]=portal.upgrades == true
+    test.batch.run.property.query[functional-upgrade-tomcat80-mysql56-jdk8]=portal.upgrades == true
+    test.batch.run.property.query[functional-upgrade-tomcat80-oracle121-jdk8]=portal.upgrades == true
+    test.batch.run.property.query[functional-upgrade-tomcat80-postgresql94-jdk8]=portal.upgrades == true
+    #test.batch.run.property.query[functional-upgrade-tomcat80-sybase160-jdk8]=portal.upgrades == true
 
     #test.batch.run.type=sequential
     test.batch.run.type=single
@@ -1082,7 +1082,7 @@
     test.batch.size[integration-db2105-jdk8]=5
     test.batch.size[integration-hypersonic20-jdk8]=5
     test.batch.size[integration-mysql56-jdk8]=5
-    test.batch.size[integration-oracle12-jdk8]=5
+    test.batch.size[integration-oracle121-jdk8]=5
     test.batch.size[integration-postgresql94-jdk8]=5
     test.batch.size[integration-sybase160-jdk8]=5
     test.batch.size[lpkg-override-jdk8]=1
@@ -1093,7 +1093,7 @@
     test.batch.size[modules-integration-db2105-jdk8]=15
     test.batch.size[modules-integration-hypersonic20-jdk8]=15
     test.batch.size[modules-integration-mysql56-jdk8]=15
-    test.batch.size[modules-integration-oracle12-jdk8]=15
+    test.batch.size[modules-integration-oracle121-jdk8]=15
     test.batch.size[modules-integration-postgresql94-jdk8]=15
     test.batch.size[modules-integration-sybase160-jdk8]=15
     test.batch.size[modules-unit-jdk8]=5

--- a/test.properties
+++ b/test.properties
@@ -991,7 +991,7 @@
         functional-smoke-tomcat8-mysql56-jdk8,\
         functional-smoke-tomcat8-oracle12-jdk8,\
         functional-smoke-tomcat8-postgresql94-jdk8,\
-        functional-smoke-tomcat8-sybase16-jdk8,\
+        functional-smoke-tomcat8-sybase160-jdk8,\
         functional-smoke-weblogic121-mysql56-jdk8,\
         #functional-smoke-websphere85-mysql56-jdk8,\
         functional-smoke-wildfly10-mariadb100-jdk8,\
@@ -1002,7 +1002,7 @@
         functional-upgrade-tomcat8-mysql56-jdk8,\
         functional-upgrade-tomcat8-oracle12-jdk8,\
         functional-upgrade-tomcat8-postgresql94-jdk8,\
-        functional-upgrade-tomcat8-sybase16-jdk8,\
+        functional-upgrade-tomcat8-sybase160-jdk8,\
         integration-db2105-jdk8,\
         integration-hypersonic20-jdk8,\
         integration-mysql56-jdk8,\
@@ -1055,11 +1055,11 @@
     test.batch.run.property.query[functional-smoke-tomcat8-mariadb100-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-tomcat8-oracle12-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-tomcat8-postgresql94-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-tomcat8-sybase16-jdk8]=portal.smoke == true
-    #test.batch.run.property.query[functional-smoke-tomcat8-sybase16-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-smoke-tomcat8-sybase160-jdk8]=portal.smoke == true
+    #test.batch.run.property.query[functional-smoke-tomcat8-sybase160-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-weblogic121-mysql56-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-smoke-websphere85-mysql56-jdk8]=portal.smoke == true
-    test.batch.run.property.query[functional-smoke-wildfly10-mariadb100-jdk8]=portal.smoke == true
+    test.batch.run.property.query[functional-smoke-wildfly100mariadb100-jdk8]=portal.smoke == true
     test.batch.run.property.query[functional-tomcat8-hypersonic20-jdk8]=portal.acceptance.tomcat.hypersonic == true
     test.batch.run.property.query[functional-tomcat8-mysql56-jdk8]=(portal.acceptance == true) OR (portal.acceptance.tomcat.mysql == true)
     test.batch.run.property.query[functional-tomcat8-mysql56-jdk8-quarantine]=(portal.acceptance == pending) OR (portal.acceptance == quarantine)
@@ -1068,12 +1068,12 @@
     test.batch.run.property.query[legacy-functional-bundle-tomcat-mysql55-jdk7]=legacy.database.dump == true
     test.batch.run.property.query[legacy-functional-bundle-tomcat-oracle12-jdk7]=legacy.database.dump == true
     test.batch.run.property.query[legacy-functional-bundle-tomcat-postgresql94-jdk7]=legacy.database.dump == true
-    test.batch.run.property.query[legacy-functional-bundle-tomcat-sybase16-jdk7]=legacy.database.dump == true
+    test.batch.run.property.query[legacy-functional-bundle-tomcat-sybase160-jdk7]=legacy.database.dump == true
     test.batch.run.property.query[functional-upgrade-tomcat8-mariadb100-jdk8]=portal.upgrades == true
     test.batch.run.property.query[functional-upgrade-tomcat8-mysql56-jdk8]=portal.upgrades == true
     test.batch.run.property.query[functional-upgrade-tomcat8-oracle12-jdk8]=portal.upgrades == true
     test.batch.run.property.query[functional-upgrade-tomcat8-postgresql94-jdk8]=portal.upgrades == true
-    #test.batch.run.property.query[functional-upgrade-tomcat8-sybase16-jdk8]=portal.upgrades == true
+    #test.batch.run.property.query[functional-upgrade-tomcat8-sybase160-jdk8]=portal.upgrades == true
 
     #test.batch.run.type=sequential
     test.batch.run.type=single


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-29468

The format of a batch environment component should be:
(environment name)(environment major version)(environment minor version)

To keep with this convention, the following environments will be renamed in the batch names:
Tomcat 8.0 - will be renamed from tomcat8 to tomcat80
Wildfly 10.0 - will be renamed from wildfly10 to wildfly100
Oracle 12.1 - will be renamed from oracle12 to oracle121