### PR TITLE
Lps 69520

### DIFF
--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = cd0fdb73286599571342f514b5a31e25cb72879c
+	commit = 93120b8c4e3763c0334eb9a1711b5d5a26cb12e1
 	mode = push
-	parent = 7734d05ddb23acfa0fbd07ecc1a2389cb85464ba
+	parent = fe1ebe9e8d164600c32df807aa1697a135dacf1c
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/collaboration/wiki/wiki-web/build.gradle
+++ b/modules/apps/collaboration/wiki/wiki-web/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portlet.display.template", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
 	provided group: "com.liferay", name: "com.liferay.trash.taglib", version: "2.0.0"
-	provided group: "com.liferay", name: "com.liferay.wiki.service", version: "1.2.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.7.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
@@ -24,5 +23,6 @@ dependencies {
 	provided project(":apps:collaboration:item-selector:item-selector-api")
 	provided project(":apps:collaboration:item-selector:item-selector-taglib")
 	provided project(":apps:collaboration:wiki:wiki-api")
+	provided project(":apps:collaboration:wiki:wiki-service")
 	provided project(":apps:web-experience:asset:asset-taglib")
 }

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 6a686465255ac3dbdaf1a2cd06e3c939557cb7cf
+	commit = 0e747171b063e966d9a82d3f0dad9baa848f7b58
 	mode = push
-	parent = 1f2536a3f50e7fb2cfb396471e61c2fc423ac8c7
+	parent = 09886a809416983a3f22f24692c932dc3d3b08ee
 	remote = git@github.com:liferay/com-liferay-dynamic-data-mapping.git

--- a/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
+++ b/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f380cb979fb78692645b5aea1931331bc7d0fd61
+	commit = 134f5143edef66f04cba9f0637750bf187b800e1
 	mode = push
-	parent = 3ba8d75a28267f39c110a6f49a1f10772d2fbbe7
+	parent = ef7f59db67ded811b7a7643d118d22d6c2e5c227
 	remote = git@github.com:liferay/com-liferay-portal-workflow.git

--- a/modules/apps/foundation/frontend-editor/.gitrepo
+++ b/modules/apps/foundation/frontend-editor/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 233372d472cdcdbffd43f2de7cbcef089674e094
+	commit = 56f4f443c82d01fad4c15a8d15f79d6b99667c05
 	mode = push
-	parent = 3954432a77d1292c7d5de0b9f4779c74520f8dae
+	parent = acc612b9403d5297559f07d4151b051468a5419f
 	remote = git@github.com:liferay/com-liferay-frontend-editor.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = e4fe242a6e399f9f1a38b2d68262d94dbfbbf81a
+	commit = 4d1dc0e2ed6911907d0ed9706b952dbd37e75d0f
 	mode = push
-	parent = cab2414f9edbaf070dee7a9ebc3f7cdff0bbe038
+	parent = 642d8ec2b373d98fa593f4d1d97481679c00884f
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 036213a406b303cb9c9a25b003cd87ec7cb9c8e2
+	commit = 8137a1ecdd86cbbfe27a23400cbdd493d9378f45
 	mode = push
-	parent = 15e32dd7a94751fdc5768c4e0c9895993714b6c2
+	parent = 76d9e5bcc6f5977a31a354cad204dd0435f20a9f
 	remote = git@github.com:liferay/com-liferay-site.git

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -156,7 +156,12 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		try {
 			super.contextDestroyed(servletContextEvent);
 
-			ModuleFrameworkUtilAdapter.stopRuntime();
+			try {
+				ModuleFrameworkUtilAdapter.stopRuntime();
+			}
+			catch (Exception e) {
+				_log.error(e, e);
+			}
 
 			try {
 				ModuleFrameworkUtilAdapter.stopFramework(
@@ -170,9 +175,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 				_arrayApplicationContext);
 
 			_arrayApplicationContext.close();
-		}
-		catch (Exception e) {
-			_log.error(e, e);
 		}
 		finally {
 			PortalContextLoaderLifecycleThreadLocal.setDestroying(false);

--- a/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
+++ b/portal-impl/src/com/liferay/portal/spring/context/PortalContextLoaderListener.java
@@ -143,13 +143,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		}
 
 		try {
-			ModuleFrameworkUtilAdapter.stopRuntime();
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-		}
-
-		try {
 			PortalLifecycleUtil.reset();
 		}
 		catch (Exception e) {
@@ -163,6 +156,8 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 		try {
 			super.contextDestroyed(servletContextEvent);
 
+			ModuleFrameworkUtilAdapter.stopRuntime();
+
 			try {
 				ModuleFrameworkUtilAdapter.stopFramework(
 					PropsValues.MODULE_FRAMEWORK_STOP_WAIT_TIMEOUT);
@@ -175,6 +170,9 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 				_arrayApplicationContext);
 
 			_arrayApplicationContext.close();
+		}
+		catch (Exception e) {
+			_log.error(e, e);
 		}
 		finally {
 			PortalContextLoaderLifecycleThreadLocal.setDestroying(false);
@@ -251,6 +249,8 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 				_arrayApplicationContext);
 
 			ModuleFrameworkUtilAdapter.startFramework();
+
+			ModuleFrameworkUtilAdapter.startRuntime();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
@@ -344,8 +344,6 @@ public class PortalContextLoaderListener extends ContextLoaderListener {
 
 		try {
 			ModuleFrameworkUtilAdapter.registerContext(applicationContext);
-
-			ModuleFrameworkUtilAdapter.startRuntime();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
Hey @rotty3000, @migue and @mhan810

This is a simple but important change, that I think it should draw some attention.
In this pull we changed the system's startup/shutdown ordering.
It used to be:
1) For startup, Framework -> Spring -> Runtime
2) For shutdown, Runtime -> Spring -> Framework

The new order is:
1) For startup, Framework -> Runtime -> Spring
2) For shutdown, Spring -> Runtime -> Framework.

The reason for this change is, we got random shutdown deadlock all the time, it is rare, but showing enough times on CI. And will eventually happen to real production system too.

The issue is, Portal relies on some Modules provided service impls. You must all remember the messy busy waiting stuff we did just to solve the startup NPEs or deadlocks. This was because Portal's code is inside Spring, Modules services are started by Runtime, we started Spring before Runtime, so portal must wait. This kind of waiting is ugly, but at least it works. So no problem for startup.

The pain is at shutdown. For shutdown, we must do the reverse order of start, therefore Runtime -> Spring. So the module's services go offline before portal. And some portal code has shutdown logic, like clearing some cache, by that time, the cache impl was long gone. 

Why this problem was random? Because the Runtime shutdown is an async operation and it is slower comparing to portal spring shutdown. Therefore even we shutodwn runtime first, spring second. In most cases, spring actually shutdown first in physical time, saved us from those NPE/deadlocks. But this is highly unreliable, sooner or later, we will run into cases that runtime actually stops first, then spring shutdown will break. And it happened to CI a lot, causing all those 2 hours shutdown timeout.

The order switching can work, because all Runtime bundles are dynamic ready, which means if they need something from portal spring, and spring is not ready yet, they will simply not activate. By the moment spring context is published, they will activate themselves. As for shutdown, we shutdown spring first, causing some Runtime bundles dependencies missing, they will automatically taking themselves offline while spring is shutting down, then we proceed to the actual runtime shutdown. Therefore no more shutdown time race condition.

Let me know if you think this could cause any issue, we tested it, at least everything is still working on CI.
