### PR TITLE
LRQA-29490 Remove unused Selenium RC methods

### DIFF
--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseMobileDriverImpl.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseMobileDriverImpl.java
@@ -115,11 +115,6 @@ public abstract class BaseMobileDriverImpl
 		throw new UnsupportedOperationException();
 	}
 
-	@Override
-	public void dragdrop(String locator, String movementsString) {
-		throw new UnsupportedOperationException();
-	}
-
 	public Response execute(String driverCommand, Map<String, ?> parameters) {
 		return _mobileDriver.execute(driverCommand, parameters);
 	}
@@ -593,11 +588,6 @@ public abstract class BaseMobileDriverImpl
 
 	@Override
 	public void waitForPopUp(String windowID, String timeout) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void windowMaximizeAndWait() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -546,7 +546,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		WebDriverHelper.check(this, locator);
 	}
 
-
 	@Override
 	public void click(String locator) {
 		if (locator.contains("x:")) {

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -2846,12 +2846,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		}
 	}
 
-	@Override
-	public void windowMaximizeAndWait() {
-		windowMaximize();
-		waitForPageToLoad("30000");
-	}
-
 	protected void acceptConfirmation() {
 		WebDriver.TargetLocator targetLocator = switchTo();
 

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java
@@ -156,45 +156,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void addCustomRequestHeader(String key, String value) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void addLocationStrategy(
-		String strategyName, String functionDefinition) {
-
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void addScript(String script, String scriptTagId) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void addSelection(String locator, String optionLocator) {
 		WebDriverHelper.addSelection(this, locator, optionLocator);
-	}
-
-	@Override
-	public void allowNativeXpath(String allow) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void altKeyDown() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void altKeyUp() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void answerOnNextPrompt(String answer) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -579,54 +542,10 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void assignId(String locator, String identifier) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void attachFile(String fieldLocator, String fileLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void captureEntirePageScreenshot(String fileName, String kwargs) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String captureEntirePageScreenshotToString(String kwargs) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String captureNetworkTraffic(String type) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void captureScreenshot(String fileName) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String captureScreenshotToString() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void check(String locator) {
 		WebDriverHelper.check(this, locator);
 	}
 
-	@Override
-	public void chooseCancelOnNextConfirmation() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void chooseOkOnNextConfirmation() {
-		throw new UnsupportedOperationException();
-	}
 
 	@Override
 	public void click(String locator) {
@@ -748,26 +667,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void contextMenu(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void contextMenuAt(String locator, String coordString) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void controlKeyDown() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void controlKeyUp() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void copyText(String locator) throws Exception {
 		_clipBoard = getText(locator);
 	}
@@ -778,28 +677,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void createCookie(String nameValuePair, String optionsString) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void deleteAllEmails() throws Exception {
 		LiferaySeleniumHelper.deleteAllEmails();
-	}
-
-	@Override
-	public void deleteAllVisibleCookies() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void deleteCookie(String name, String optionsString) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void deselectPopUp() {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -915,11 +794,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void dragdrop(String locator, String movementsString) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void echo(String message) {
 		LiferaySeleniumHelper.echo(message);
 	}
@@ -940,16 +814,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void fireEvent(String locator, String eventName) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void focus(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void get(String url) {
 		_webDriver.get(url);
 	}
@@ -966,43 +830,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public String[] getAllButtons() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getAllFields() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getAllLinks() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getAllWindowIds() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getAllWindowNames() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getAllWindowTitles() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public String getAttribute(String attributeLocator) {
 		return WebDriverHelper.getAttribute(this, attributeLocator);
-	}
-
-	@Override
-	public String[] getAttributeFromAllWindows(String attributeName) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1015,21 +844,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	@Override
 	public String getConfirmation() {
 		return WebDriverHelper.getConfirmation(this);
-	}
-
-	@Override
-	public String getCookie() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getCookieByName(String name) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Number getCssCount(String css) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1075,28 +889,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public Number getCursorPosition(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public int getElementHeight(String locator) {
 		return WebDriverHelper.getElementHeight(this, locator);
-	}
-
-	@Override
-	public Number getElementIndex(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Number getElementPositionLeft(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Number getElementPositionTop(String locator) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1137,11 +931,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	@Override
 	public String getEval(String script) {
 		return WebDriverHelper.getEval(this, script);
-	}
-
-	@Override
-	public String getExpression(String expression) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1257,16 +1046,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public String getLog() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Number getMouseSpeed() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public String getNumberDecrement(String value) {
 		return LiferaySeleniumHelper.getNumberDecrement(value);
 	}
@@ -1292,31 +1071,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public String getPrompt() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getSelectedId(String selectLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getSelectedIds(String selectLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getSelectedIndex(String selectLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getSelectedIndexes(String selectLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public String getSelectedLabel(String selectLocator) {
 		return getSelectedLabel(selectLocator, null);
 	}
@@ -1331,33 +1085,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public String getSelectedValue(String selectLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getSelectedValues(String selectLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String[] getSelectOptions(String selectLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public String getSikuliImagesDirName() {
 		return _sikuliImagesDirName;
-	}
-
-	@Override
-	public String getSpeed() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public String getTable(String tableCellAddress) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1420,25 +1149,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public String getValue(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public boolean getWhetherThisFrameMatchFrameExpression(
-		String currentFrameString, String target) {
-
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public boolean getWhetherThisWindowMatchWindowExpression(
-		String currentWindowString, String target) {
-
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public String getWindowHandle() {
 		return _webDriver.getWindowHandle();
 	}
@@ -1453,11 +1163,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public Number getXpathCount(String xPath) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void goBack() {
 		WebDriverHelper.goBack(this);
 	}
@@ -1466,16 +1171,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	public void goBackAndWait() {
 		goBack();
 		waitForPageToLoad("30000");
-	}
-
-	@Override
-	public void highlight(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void ignoreAttributesWithoutValue(String ignore) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1512,16 +1207,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		String confirmation = getConfirmation();
 
 		return pattern.equals(confirmation);
-	}
-
-	@Override
-	public boolean isConfirmationPresent() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public boolean isCookiePresent(String name) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1627,11 +1312,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public boolean isOrdered(String locator1, String locator2) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public boolean isPartialText(String locator, String value) {
 		return WebDriverHelper.isPartialText(this, locator, value);
 	}
@@ -1639,11 +1319,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	@Override
 	public boolean isPartialTextAceEditor(String locator, String value) {
 		return WebDriverHelper.isPartialTextAceEditor(this, locator, value);
-	}
-
-	@Override
-	public boolean isPromptPresent() {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1662,11 +1337,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		}
 
 		return false;
-	}
-
-	@Override
-	public boolean isSomethingSelected(String selectLocator) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1762,11 +1432,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void keyDownNative(String keycode) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void keyPress(String locator, String keySequence) {
 		WebElement webElement = getWebElement(locator);
 
@@ -1809,11 +1474,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void keyPressNative(String keycode) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void keyUp(String locator, String keySequence) {
 		WebElement webElement = getWebElement(locator);
 
@@ -1841,11 +1501,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void keyUpNative(String keycode) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void makeVisible(String locator) {
 		WebDriverHelper.makeVisible(this, locator);
 	}
@@ -1853,16 +1508,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	@Override
 	public Options manage() {
 		return _webDriver.manage();
-	}
-
-	@Override
-	public void metaKeyDown() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void metaKeyUp() {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -1917,16 +1562,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		Action action = actions.build();
 
 		action.perform();
-	}
-
-	@Override
-	public void mouseDownRight(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void mouseDownRightAt(String locator, String coordString) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -2085,16 +1720,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void mouseUpRight(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void mouseUpRightAt(String locator, String coordString) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public Navigation navigate() {
 		return _webDriver.navigate();
 	}
@@ -2102,11 +1727,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	@Override
 	public void open(String url) {
 		WebDriverHelper.open(this, url);
-	}
-
-	@Override
-	public void open(String url, String ignoreResponseCode) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -2145,35 +1765,10 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void removeAllSelections(String locator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void removeScript(String scriptTagId) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void removeSelection(String locator, String optionLocator) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void replyToEmail(String to, String body) throws Exception {
 		EmailCommands.replyToEmail(to, body);
 
 		pause("3000");
-	}
-
-	@Override
-	public String retrieveLastRemoteControlLogs() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void rollup(String rollupName, String kwargs) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -2354,21 +1949,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void setBrowserLogLevel(String logLevel) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void setContext(String context) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void setCursorPosition(String locator, String position) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void setDefaultTimeout() {
 	}
 
@@ -2378,23 +1958,8 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void setExtensionJs(String extensionJs) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void setMouseSpeed(String pixels) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void setPrimaryTestSuiteName(String primaryTestSuiteName) {
 		_primaryTestSuiteName = primaryTestSuiteName;
-	}
-
-	@Override
-	public void setSpeed(String value) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -2424,31 +1989,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 		int y = GetterUtil.getInteger(screenResolution[1]);
 
 		window.setSize(new Dimension(x, y));
-	}
-
-	@Override
-	public void shiftKeyDown() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void shiftKeyUp() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void showContextualBanner() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void showContextualBanner(String className, String methodName) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void shutDownSeleniumServer() {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -2719,21 +2259,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void start() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void start(Object optionsObject) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void start(String optionsString) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void startLogger() {
 	}
 
@@ -2744,11 +2269,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 	@Override
 	public void stopLogger() {
-	}
-
-	@Override
-	public void submit(String formLocator) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -2931,16 +2451,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 	}
 
 	@Override
-	public void useXpathLibrary(String libraryName) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void waitForCondition(String script, String timeout) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public void waitForConfirmation(String pattern) throws Exception {
 		int timeout =
 			PropsValues.TIMEOUT_EXPLICIT_WAIT /
@@ -2997,11 +2507,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 			Thread.sleep(1000);
 		}
-	}
-
-	@Override
-	public void waitForFrameToLoad(String frameAddress, String timeout) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -3339,16 +2844,6 @@ public abstract class BaseWebDriverImpl implements LiferaySelenium, WebDriver {
 
 			Thread.sleep(1000);
 		}
-	}
-
-	@Override
-	public void windowFocus() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void windowMaximize() {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySelenium.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySelenium.java
@@ -473,6 +473,4 @@ public interface LiferaySelenium {
 
 	public void waitForVisible(String locator) throws Exception;
 
-	public void windowMaximizeAndWait();
-
 }

--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySelenium.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySelenium.java
@@ -20,22 +20,7 @@ package com.liferay.poshi.runner.selenium;
 @SuppressWarnings("deprecation")
 public interface LiferaySelenium {
 
-	public void addCustomRequestHeader(String key, String value);
-
-	public void addLocationStrategy(
-		String strategyName, String functionDefinition);
-
-	public void addScript(String scriptContent, String scriptTagId);
-
 	public void addSelection(String locator, String optionLocator);
-
-	public void allowNativeXpath(String allow);
-
-	public void altKeyDown();
-
-	public void altKeyUp();
-
-	public void answerOnNextPrompt(String answer);
 
 	public void antCommand(String fileName, String target) throws Exception;
 
@@ -126,25 +111,7 @@ public interface LiferaySelenium {
 
 	public void assertVisible(String locator) throws Exception;
 
-	public void assignId(String locator, String identifier);
-
-	public void attachFile(String fieldLocator, String fileLocator);
-
-	public void captureEntirePageScreenshot(String filename, String kwargs);
-
-	public String captureEntirePageScreenshotToString(String kwargs);
-
-	public String captureNetworkTraffic(String type);
-
-	public void captureScreenshot(String filename);
-
-	public String captureScreenshotToString();
-
 	public void check(String locator);
-
-	public void chooseCancelOnNextConfirmation();
-
-	public void chooseOkOnNextConfirmation();
 
 	public void click(String locator) throws Exception;
 
@@ -159,27 +126,11 @@ public interface LiferaySelenium {
 	public void connectToEmailAccount(String emailAddress, String emailPassword)
 		throws Exception;
 
-	public void contextMenu(String locator);
-
-	public void contextMenuAt(String locator, String coordString);
-
-	public void controlKeyDown();
-
-	public void controlKeyUp();
-
 	public void copyText(String locator) throws Exception;
 
 	public void copyValue(String locator) throws Exception;
 
-	public void createCookie(String nameValuePair, String optionsString);
-
 	public void deleteAllEmails() throws Exception;
-
-	public void deleteAllVisibleCookies();
-
-	public void deleteCookie(String name, String optionsString);
-
-	public void deselectPopUp();
 
 	public void doubleClick(String locator);
 
@@ -191,43 +142,17 @@ public interface LiferaySelenium {
 		String locatorOfObjectToBeDragged,
 		String locatorOfDragDestinationObject);
 
-	public void dragdrop(String locator, String movementsString);
-
 	public void echo(String message);
 
 	public void fail(String message);
 
-	public void fireEvent(String locator, String eventName);
-
-	public void focus(String locator);
-
 	public String getAlert();
 
-	public String[] getAllButtons();
-
-	public String[] getAllFields();
-
-	public String[] getAllLinks();
-
-	public String[] getAllWindowIds();
-
-	public String[] getAllWindowNames();
-
-	public String[] getAllWindowTitles();
-
 	public String getAttribute(String attributeLocator);
-
-	public String[] getAttributeFromAllWindows(String attributeName);
 
 	public String getBodyText();
 
 	public String getConfirmation();
-
-	public String getCookie();
-
-	public String getCookieByName(String name);
-
-	public Number getCssCount(String css);
 
 	public String getCurrentDay();
 
@@ -239,15 +164,7 @@ public interface LiferaySelenium {
 
 	public String getCurrentYear();
 
-	public Number getCursorPosition(String locator);
-
 	public int getElementHeight(String locator);
-
-	public Number getElementIndex(String locator);
-
-	public Number getElementPositionLeft(String locator);
-
-	public Number getElementPositionTop(String locator);
 
 	public String getElementValue(String locator) throws Exception;
 
@@ -259,8 +176,6 @@ public interface LiferaySelenium {
 
 	public String getEval(String script);
 
-	public String getExpression(String expression);
-
 	public String getFirstNumber(String locator);
 
 	public String getFirstNumberIncrement(String locator);
@@ -268,10 +183,6 @@ public interface LiferaySelenium {
 	public String getHtmlSource();
 
 	public String getLocation() throws Exception;
-
-	public String getLog();
-
-	public Number getMouseSpeed();
 
 	public String getNumberDecrement(String value);
 
@@ -281,31 +192,11 @@ public interface LiferaySelenium {
 
 	public String getPrimaryTestSuiteName();
 
-	public String getPrompt();
-
-	public String getSelectedId(String selectLocator);
-
-	public String[] getSelectedIds(String selectLocator);
-
-	public String getSelectedIndex(String selectLocator);
-
-	public String[] getSelectedIndexes(String selectLocator);
-
 	public String getSelectedLabel(String selectLocator);
 
 	public String[] getSelectedLabels(String selectLocator);
 
-	public String getSelectedValue(String selectLocator);
-
-	public String[] getSelectedValues(String selectLocator);
-
-	public String[] getSelectOptions(String selectLocator);
-
 	public String getSikuliImagesDirName();
-
-	public String getSpeed();
-
-	public String getTable(String tableCellAddress);
 
 	public String getTestDependenciesDirName();
 
@@ -313,33 +204,15 @@ public interface LiferaySelenium {
 
 	public String getTitle();
 
-	public String getValue(String locator);
-
-	public boolean getWhetherThisFrameMatchFrameExpression(
-		String currentFrameString, String target);
-
-	public boolean getWhetherThisWindowMatchWindowExpression(
-		String currentWindowString, String target);
-
-	public Number getXpathCount(String xpath);
-
 	public void goBack();
 
 	public void goBackAndWait();
-
-	public void highlight(String locator);
-
-	public void ignoreAttributesWithoutValue(String ignore);
 
 	public boolean isAlertPresent();
 
 	public boolean isChecked(String locator);
 
 	public boolean isConfirmation(String pattern);
-
-	public boolean isConfirmationPresent();
-
-	public boolean isCookiePresent(String name);
 
 	public boolean isEditable(String locator);
 
@@ -367,19 +240,13 @@ public interface LiferaySelenium {
 
 	public boolean isNotVisible(String locator);
 
-	public boolean isOrdered(String locator1, String locator2);
-
 	public boolean isPartialText(String locator, String value);
 
 	public boolean isPartialTextAceEditor(String locator, String value);
 
-	public boolean isPromptPresent();
-
 	public boolean isSelectedLabel(String selectLocator, String pattern);
 
 	public boolean isSikuliImagePresent(String image) throws Exception;
-
-	public boolean isSomethingSelected(String selectLocator);
 
 	public boolean isTCatEnabled();
 
@@ -405,33 +272,19 @@ public interface LiferaySelenium {
 
 	public void keyDownAndWait(String locator, String keySequence);
 
-	public void keyDownNative(String keycode);
-
 	public void keyPress(String locator, String keySequence);
 
 	public void keyPressAndWait(String locator, String keySequence);
-
-	public void keyPressNative(String keycode);
 
 	public void keyUp(String locator, String keySequence);
 
 	public void keyUpAndWait(String locator, String keySequence);
 
-	public void keyUpNative(String keycode);
-
 	public void makeVisible(String locator);
-
-	public void metaKeyDown();
-
-	public void metaKeyUp();
 
 	public void mouseDown(String locator);
 
 	public void mouseDownAt(String locator, String coordString);
-
-	public void mouseDownRight(String locator);
-
-	public void mouseDownRightAt(String locator, String coordString);
 
 	public void mouseMove(String locator);
 
@@ -447,13 +300,7 @@ public interface LiferaySelenium {
 
 	public void mouseUpAt(String locator, String coordString);
 
-	public void mouseUpRight(String locator);
-
-	public void mouseUpRightAt(String locator, String coordString);
-
 	public void open(String url) throws Exception;
-
-	public void open(String url, String ignoreResponseCode);
 
 	public void openWindow(String url, String windowID) throws Exception;
 
@@ -467,17 +314,7 @@ public interface LiferaySelenium {
 
 	public void refreshAndWait();
 
-	public void removeAllSelections(String locator);
-
-	public void removeScript(String scriptTagId);
-
-	public void removeSelection(String locator, String optionLocator);
-
 	public void replyToEmail(String to, String body) throws Exception;
-
-	public String retrieveLastRemoteControlLogs();
-
-	public void rollup(String rollupName, String kwargs);
 
 	public void runScript(String script);
 
@@ -523,39 +360,17 @@ public interface LiferaySelenium {
 
 	public void sendTestCaseHeaderLogger(String command);
 
-	public void setBrowserLogLevel(String logLevel);
-
-	public void setContext(String context);
-
-	public void setCursorPosition(String locator, String position);
-
 	public void setDefaultTimeout();
 
 	public void setDefaultTimeoutImplicit();
 
-	public void setExtensionJs(String extensionJs);
-
-	public void setMouseSpeed(String pixels);
-
 	public void setPrimaryTestSuiteName(String primaryTestSuiteName);
-
-	public void setSpeed(String value);
 
 	public void setTimeout(String timeout);
 
 	public void setTimeoutImplicit(String timeout);
 
 	public void setWindowSize(String coordString);
-
-	public void shiftKeyDown();
-
-	public void shiftKeyUp();
-
-	public void showContextualBanner();
-
-	public void showContextualBanner(String className, String methodName);
-
-	public void shutDownSeleniumServer();
 
 	public void sikuliAssertElementNotPresent(String image) throws Exception;
 
@@ -589,19 +404,11 @@ public interface LiferaySelenium {
 	public void sikuliUploadTempFile(String image, String value)
 		throws Exception;
 
-	public void start();
-
-	public void start(Object optionsObject);
-
-	public void start(String optionsString);
-
 	public void startLogger();
 
 	public void stop();
 
 	public void stopLogger();
-
-	public void submit(String formLocator);
 
 	public void type(String locator, String value);
 
@@ -625,17 +432,11 @@ public interface LiferaySelenium {
 
 	public void uploadTempFile(String locator, String value);
 
-	public void useXpathLibrary(String libraryName);
-
-	public void waitForCondition(String script, String timeout);
-
 	public void waitForConfirmation(String pattern) throws Exception;
 
 	public void waitForElementNotPresent(String locator) throws Exception;
 
 	public void waitForElementPresent(String locator) throws Exception;
-
-	public void waitForFrameToLoad(String frameAddress, String timeout);
 
 	public void waitForNotPartialText(String locator, String value)
 		throws Exception;
@@ -671,10 +472,6 @@ public interface LiferaySelenium {
 	public void waitForValue(String locator, String value) throws Exception;
 
 	public void waitForVisible(String locator) throws Exception;
-
-	public void windowFocus();
-
-	public void windowMaximize();
 
 	public void windowMaximizeAndWait();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-29490

kenjiheigel:
> Most of these methods exist because our Selenium implementation used both WebDriver and Selenium RC at one point. We have since removed Selenium RC capabilities in poshi though, so all those methods are not used. Further more, they only throw UnsupportedOperationException's, so they're not even usable methods.