### PR TITLE
LRQA-29581 | 7.0.x

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -119,7 +119,7 @@
 ## Git
 ##
 
-    git.working.branch.name=master
+    git.working.branch.name=7.0.x
 
 ##
 ## JDBC Drivers

--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 00c62c098442785156bee7bcebf33420f899d771
+	commit = f1ae5ef7de86528a82c8d5372d0f1aaed950c258
 	mode = push
-	parent = 88a5a5c8bc0c08e0d0b5d090ee823664a8bd471a
+	parent = d9da0c3bda6f6065869faf4dcf457d30bc14b7d6
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/foundation/frontend-taglib/.gitrepo
+++ b/modules/apps/foundation/frontend-taglib/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 50d390fde461b345cee92e5af55c561ea681e53e
+	commit = 80fd3808125df2f1160adbefce25cbb873f5024f
 	mode = push
-	parent = 2e5de78422b379e020203919306382d05e342c25
+	parent = 44f055a9e991c0c4c2c32a8c3f498faa7fa99c37
 	remote = git@github.com:liferay/com-liferay-frontend-taglib.git

--- a/modules/apps/foundation/map/.gitrepo
+++ b/modules/apps/foundation/map/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 670970ac6b6398289b6466b474cf35582d9813d5
+	commit = 6b8c620a8fe9f52c97291a66aeb20a91eecac8ee
 	mode = push
-	parent = 0b50c8bfe576fdf0410cc264c8b5886cef0068e6
+	parent = 7a8499b3546e5e221ea71688fcad53489c752af4
 	remote = git@github.com:liferay/com-liferay-map.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b8e0490e93daa6e91ff725b1fde236617826714d
+	commit = 81ac3a487dfd995da470f6d422e0d6c4fec4423b
 	mode = push
-	parent = 8f314da30846926659e67dd5fb20d08ec7303916
+	parent = d737bbf707d8a124e2733ebdec1f77e544da953e
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/web-proxy/.gitrepo
+++ b/modules/apps/foundation/web-proxy/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b1f0174cd31b1b668223872d95528af926fa2cc3
+	commit = 5512303941b98eba682c0cd1b8a0901672ef4761
 	mode = push
-	parent = 81122c6f19289da8b15b8d34542b1effa34535de
+	parent = 7a7c0696ac84387f7116a374ba03f61756951c73
 	remote = git@github.com:liferay/com-liferay-web-proxy.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0279a362ff4de4cc52c092280cb0d44d0b6e7698
+	commit = 84057f0adf0bb7458e285766f41ae5584b8e892f
 	mode = push
-	parent = 0b485d3aaf11cb5c3fde7787ff96605d312ad98f
+	parent = a30c450e54ea04eff3e3a30b68db2898a6be1958
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/journal/.gitrepo
+++ b/modules/apps/web-experience/journal/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = bb6c4c11837ede49ea291e30fe9b51cc9b382dc6
+	commit = 5a1f2926142540a1842eb3627ac0351fa95450c1
 	mode = push
-	parent = 8d1dfc87de58588877ba5f902f9b295027986be6
+	parent = 8275d9bf3a575ad0bce48654b776d81928520769
 	remote = git@github.com:liferay/com-liferay-journal.git


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-29581

**This is 7.0 only**

@brianchandotcom this commit shouldn't be synced with ee-7.0.x, as there the setting should be set equal to "ee-7.0.x".  So I've sent you another pull on ee-7.0.x here: https://github.com/brianchandotcom/liferay-portal-ee/pull/15327

Using the appropriate branch name for this setting increases the speed of `ant format-source-current-branch` nearly 20-fold on Windows.

Thanks! @hhuijser 

CC @vicnate5