### PR TITLE
LPS-69270

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/ServletContextHelperRegistration.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/ServletContextHelperRegistration.java
@@ -36,10 +36,6 @@ public interface ServletContextHelperRegistration {
 
 	public boolean isWabShapedBundle();
 
-	/**
-	 * @deprecated As of 2.1.0, with no direct replacement
-	 */
-	@Deprecated
 	public void setProperties(Map<String, String> contextParameters);
 
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
@@ -38,6 +39,7 @@ import org.apache.felix.utils.log.Logger;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.http.context.ServletContextHelper;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
@@ -140,12 +142,32 @@ public class ServletContextHelperRegistrationImpl
 		return _wabShapedBundle;
 	}
 
-	/**
-	 * @deprecated As of 2.1.0, with no direct replacement
-	 */
-	@Deprecated
 	@Override
 	public void setProperties(Map<String, String> contextParameters) {
+		if (contextParameters.isEmpty()) {
+			return;
+		}
+
+		ServiceReference<ServletContextHelper> serviceReference =
+			_servletContextHelperServiceRegistration.getReference();
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		for (String key : serviceReference.getPropertyKeys()) {
+			properties.put(key, serviceReference.getProperty(key));
+		}
+
+		for (Entry<String, String> entry : contextParameters.entrySet()) {
+			String key = entry.getKey();
+			String value = entry.getValue();
+
+			properties.put(
+				HttpWhiteboardConstants.
+					HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + key,
+				value);
+		}
+
+		_servletContextHelperServiceRegistration.setProperties(properties);
 	}
 
 	protected String createContextSelectFilterString() {

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -28,6 +28,8 @@ import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ModifiableServl
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ModifiableServletContextAdapter;
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ServletContextListenerExceptionAdapter;
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ServletExceptionAdapter;
+import com.liferay.portal.osgi.web.wab.extender.internal.registration.FilterRegistrationImpl;
+import com.liferay.portal.osgi.web.wab.extender.internal.registration.ServletRegistrationImpl;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -164,10 +164,10 @@ public class WabBundleProcessor {
 					modifiableServletContext.getListenerDefinitions();
 
 				Map<String, FilterRegistrationImpl> filterRegistrationImpls =
-					modifiableServletContext.getFilterRegistrationsImpl();
+					modifiableServletContext.getFilterRegistrationImpls();
 
 				Map<String, ServletRegistrationImpl> servletRegistrationImpls =
-					modifiableServletContext.getServletRegistrationsImpl();
+					modifiableServletContext.getServletRegistrationImpls();
 
 				Enumeration<String> attributeNames =
 					servletContext.getAttributeNames();

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -160,18 +160,16 @@ public class WabBundleProcessor {
 			if ((unregisteredInitParameters != null) &&
 				!unregisteredInitParameters.isEmpty()) {
 
-				List<ListenerDefinition> listenerDefinitions =
-					modifiableServletContext.getListenerDefinitions();
+				servletContextHelperRegistration.setProperties(
+					unregisteredInitParameters);
 
-				Map<String, FilterRegistrationImpl> filterRegistrationImpls =
-					modifiableServletContext.getFilterRegistrationImpls();
+				ServletContext newServletContext =
+					servletContextHelperRegistration.getServletContext();
 
-				Map<String, ServletRegistrationImpl> servletRegistrationImpls =
-					modifiableServletContext.getServletRegistrationImpls();
+				Map<String, Object> attributes = new HashMap<>();
 
 				Enumeration<String> attributeNames =
 					servletContext.getAttributeNames();
-				Map<String, Object> attributes = new HashMap<>();
 
 				while (attributeNames.hasMoreElements()) {
 					String attributeName = attributeNames.nextElement();
@@ -181,15 +179,11 @@ public class WabBundleProcessor {
 						servletContext.getAttribute(attributeName));
 				}
 
-				servletContextHelperRegistration.setProperties(
-					unregisteredInitParameters);
-
-				ServletContext newServletContext =
-					servletContextHelperRegistration.getServletContext();
-
 				servletContext = ModifiableServletContextAdapter.createInstance(
-					newServletContext, attributes, listenerDefinitions,
-					filterRegistrationImpls, servletRegistrationImpls,
+					newServletContext, attributes,
+					modifiableServletContext.getListenerDefinitions(),
+					modifiableServletContext.getFilterRegistrationImpls(),
+					modifiableServletContext.getServletRegistrationImpls(),
 					_bundle.getBundleContext(), webXMLDefinition, _logger);
 			}
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -28,8 +28,6 @@ import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ModifiableServl
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ModifiableServletContextAdapter;
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ServletContextListenerExceptionAdapter;
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ServletExceptionAdapter;
-import com.liferay.portal.osgi.web.wab.extender.internal.registration.FilterRegistrationImpl;
-import com.liferay.portal.osgi.web.wab.extender.internal.registration.ServletRegistrationImpl;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -191,6 +191,9 @@ public class WabBundleProcessor {
 					newServletContext, attributes, listenerDefinitions,
 					filterRegistrationImpls, servletRegistrationImpls,
 					_bundle.getBundleContext(), webXMLDefinition, _logger);
+
+				modifiableServletContext =
+					(ModifiableServletContext)servletContext;
 			}
 
 			scanTLDsForListeners(webXMLDefinition, servletContext);

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -158,16 +158,18 @@ public class WabBundleProcessor {
 			if ((unregisteredInitParameters != null) &&
 				!unregisteredInitParameters.isEmpty()) {
 
-				servletContextHelperRegistration.setProperties(
-					unregisteredInitParameters);
+				List<ListenerDefinition> listenerDefinitions =
+					modifiableServletContext.getListenerDefinitions();
 
-				ServletContext newServletContext =
-					servletContextHelperRegistration.getServletContext();
+				Map<String, FilterRegistrationImpl> filterRegistrationImpls =
+					modifiableServletContext.getFilterRegistrationImpls();
 
-				Map<String, Object> attributes = new HashMap<>();
+				Map<String, ServletRegistrationImpl> servletRegistrationImpls =
+					modifiableServletContext.getServletRegistrationImpls();
 
 				Enumeration<String> attributeNames =
 					servletContext.getAttributeNames();
+				Map<String, Object> attributes = new HashMap<>();
 
 				while (attributeNames.hasMoreElements()) {
 					String attributeName = attributeNames.nextElement();
@@ -177,11 +179,15 @@ public class WabBundleProcessor {
 						servletContext.getAttribute(attributeName));
 				}
 
+				servletContextHelperRegistration.setProperties(
+					unregisteredInitParameters);
+
+				ServletContext newServletContext =
+					servletContextHelperRegistration.getServletContext();
+
 				servletContext = ModifiableServletContextAdapter.createInstance(
-					newServletContext, attributes,
-					modifiableServletContext.getListenerDefinitions(),
-					modifiableServletContext.getFilterRegistrationImpls(),
-					modifiableServletContext.getServletRegistrationImpls(),
+					newServletContext, attributes, listenerDefinitions,
+					filterRegistrationImpls, servletRegistrationImpls,
 					_bundle.getBundleContext(), webXMLDefinition, _logger);
 			}
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabBundleProcessor.java
@@ -28,6 +28,8 @@ import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ModifiableServl
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ModifiableServletContextAdapter;
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ServletContextListenerExceptionAdapter;
 import com.liferay.portal.osgi.web.wab.extender.internal.adapter.ServletExceptionAdapter;
+import com.liferay.portal.osgi.web.wab.extender.internal.registration.FilterRegistrationImpl;
+import com.liferay.portal.osgi.web.wab.extender.internal.registration.ServletRegistrationImpl;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,6 +46,7 @@ import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.EventListener;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
@@ -148,13 +151,52 @@ public class WabBundleProcessor {
 
 			initServletContainerInitializers(_bundle, servletContext);
 
+			ModifiableServletContext modifiableServletContext =
+				(ModifiableServletContext)servletContext;
+
+			Map<String, String> unregisteredInitParameters =
+				modifiableServletContext.getUnregisteredInitParameters();
+
+			if ((unregisteredInitParameters != null) &&
+				!unregisteredInitParameters.isEmpty()) {
+
+				List<ListenerDefinition> listenerDefinitions =
+					modifiableServletContext.getListenerDefinitions();
+
+				Map<String, FilterRegistrationImpl> filterRegistrationImpls =
+					modifiableServletContext.getFilterRegistrationsImpl();
+
+				Map<String, ServletRegistrationImpl> servletRegistrationImpls =
+					modifiableServletContext.getServletRegistrationsImpl();
+
+				Enumeration<String> attributeNames =
+					servletContext.getAttributeNames();
+				Map<String, Object> attributes = new HashMap<>();
+
+				while (attributeNames.hasMoreElements()) {
+					String attributeName = attributeNames.nextElement();
+
+					attributes.put(
+						attributeName,
+						servletContext.getAttribute(attributeName));
+				}
+
+				servletContextHelperRegistration.setProperties(
+					unregisteredInitParameters);
+
+				ServletContext newServletContext =
+					servletContextHelperRegistration.getServletContext();
+
+				servletContext = ModifiableServletContextAdapter.createInstance(
+					newServletContext, attributes, listenerDefinitions,
+					filterRegistrationImpls, servletRegistrationImpls,
+					_bundle.getBundleContext(), webXMLDefinition, _logger);
+			}
+
 			scanTLDsForListeners(webXMLDefinition, servletContext);
 
 			initListeners(
 				webXMLDefinition.getListenerDefinitions(), servletContext);
-
-			ModifiableServletContext modifiableServletContext =
-				(ModifiableServletContext)servletContext;
 
 			initListeners(
 				modifiableServletContext.getListenerDefinitions(),

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContext.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContext.java
@@ -15,8 +15,11 @@
 package com.liferay.portal.osgi.web.wab.extender.internal.adapter;
 
 import com.liferay.portal.osgi.web.servlet.context.helper.definition.ListenerDefinition;
+import com.liferay.portal.osgi.web.wab.extender.internal.registration.FilterRegistrationImpl;
+import com.liferay.portal.osgi.web.wab.extender.internal.registration.ServletRegistrationImpl;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.ServletContext;
 
@@ -29,7 +32,13 @@ public interface ModifiableServletContext {
 
 	public Bundle getBundle();
 
+	public Map<String, FilterRegistrationImpl> getFilterRegistrationsImpl();
+
 	public List<ListenerDefinition> getListenerDefinitions();
+
+	public Map<String, ServletRegistrationImpl> getServletRegistrationsImpl();
+
+	public Map<String, String> getUnregisteredInitParameters();
 
 	public ServletContext getWrappedServletContext();
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContext.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContext.java
@@ -32,11 +32,11 @@ public interface ModifiableServletContext {
 
 	public Bundle getBundle();
 
-	public Map<String, FilterRegistrationImpl> getFilterRegistrationsImpl();
+	public Map<String, FilterRegistrationImpl> getFilterRegistrationImpls();
 
 	public List<ListenerDefinition> getListenerDefinitions();
 
-	public Map<String, ServletRegistrationImpl> getServletRegistrationsImpl();
+	public Map<String, ServletRegistrationImpl> getServletRegistrationImpls();
 
 	public Map<String, String> getUnregisteredInitParameters();
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
@@ -345,24 +345,22 @@ public class ModifiableServletContextAdapter
 	}
 
 	public String getInitParameter(String name) {
-		String parameter = _servletContext.getInitParameter(name);
+		String value = _servletContext.getInitParameter(name);
 
-		if (parameter == null) {
+		if (value == null) {
 			return _initParameters.get(name);
 		}
 
-		return parameter;
+		return value;
 	}
 
 	public Enumeration<String> getInitParameterNames() {
-		List<String> parameterNames = new ArrayList<>();
+		List<String> names = new ArrayList<>();
 
-		parameterNames.addAll(
-			Collections.list(_servletContext.getInitParameterNames()));
+		names.addAll(Collections.list(_servletContext.getInitParameterNames()));
+		names.addAll(_initParameters.keySet());
 
-		parameterNames.addAll(_initParameters.keySet());
-
-		return Collections.enumeration(parameterNames);
+		return Collections.enumeration(names);
 	}
 
 	@Override

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Proxy;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -281,6 +282,27 @@ public class ModifiableServletContextAdapter
 		return _filterRegistrations;
 	}
 
+	public String getInitParameter(String name) {
+		String parameter = _servletContext.getInitParameter(name);
+
+		if (parameter == null) {
+			return _initParameters.get(name);
+		}
+
+		return parameter;
+	}
+
+	public Enumeration<String> getInitParameterNames() {
+		List<String> parameterNames = new ArrayList<>();
+
+		parameterNames.addAll(
+			Collections.list(_servletContext.getInitParameterNames()));
+
+		parameterNames.addAll(_initParameters.keySet());
+
+		return Collections.enumeration(parameterNames);
+	}
+
 	@Override
 	public List<ListenerDefinition> getListenerDefinitions() {
 		List<ListenerDefinition> listenerDefinitions = new ArrayList<>();
@@ -483,6 +505,22 @@ public class ModifiableServletContextAdapter
 		}
 	}
 
+	public boolean setInitParameter(String name, String value)
+		throws IllegalStateException, UnsupportedOperationException {
+
+		boolean exists = _initParameters.containsKey(name);
+
+		if (!exists && (_servletContext.getInitParameter(name) != null)) {
+			exists = true;
+		}
+
+		if (!exists) {
+			_initParameters.put(name, value);
+		}
+
+		return !exists;
+	}
+
 	private static Map<Method, Method> _createContextAdapterMethods() {
 		Map<Method, Method> methods = new HashMap<>();
 
@@ -552,6 +590,7 @@ public class ModifiableServletContextAdapter
 		_eventListeners = new LinkedHashMap<>();
 	private final LinkedHashMap<String, FilterRegistrationImpl>
 		_filterRegistrations = new LinkedHashMap<>();
+	private final Map<String, String> _initParameters = new HashMap<>();
 	private final Logger _logger;
 	private final ServletContext _servletContext;
 	private final LinkedHashMap<String, ServletRegistrationImpl>

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
@@ -335,13 +335,13 @@ public class ModifiableServletContextAdapter
 		return _filterRegistrations.get(filterName);
 	}
 
-	public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
-		return getFilterRegistrationImpls();
-	}
-
 	@Override
 	public Map<String, FilterRegistrationImpl> getFilterRegistrationImpls() {
 		return _filterRegistrations;
+	}
+
+	public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+		return getFilterRegistrationImpls();
 	}
 
 	public String getInitParameter(String name) {
@@ -415,15 +415,15 @@ public class ModifiableServletContextAdapter
 		return _servletRegistrations.get(servletName);
 	}
 
+	@Override
+	public Map<String, ServletRegistrationImpl> getServletRegistrationImpls() {
+		return _servletRegistrations;
+	}
+
 	public Map<String, ? extends ServletRegistration>
 		getServletRegistrations() {
 
 		return getServletRegistrationImpls();
-	}
-
-	@Override
-	public Map<String, ServletRegistrationImpl> getServletRegistrationImpls() {
-		return _servletRegistrations;
 	}
 
 	@Override

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/adapter/ModifiableServletContextAdapter.java
@@ -101,7 +101,7 @@ public class ModifiableServletContextAdapter
 		/* Filters */
 		if (filterRegistrations != null) {
 			Map<String, FilterRegistrationImpl> newFilterRegistrationsImpl =
-				modifiableServletContext.getFilterRegistrationsImpl();
+				modifiableServletContext.getFilterRegistrationImpls();
 
 			for (String filterName : filterRegistrations.keySet()) {
 				FilterRegistrationImpl filterRegistrationImpl =
@@ -115,7 +115,7 @@ public class ModifiableServletContextAdapter
 		/* Servlets */
 		if (servletRegistrations != null) {
 			Map<String, ServletRegistrationImpl> newServletRegistrationsImpl =
-				modifiableServletContext.getServletRegistrationsImpl();
+				modifiableServletContext.getServletRegistrationImpls();
 
 			for (String servletName : servletRegistrations.keySet()) {
 				ServletRegistrationImpl servletRegistrationImpl =
@@ -336,11 +336,11 @@ public class ModifiableServletContextAdapter
 	}
 
 	public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
-		return getFilterRegistrationsImpl();
+		return getFilterRegistrationImpls();
 	}
 
 	@Override
-	public Map<String, FilterRegistrationImpl> getFilterRegistrationsImpl() {
+	public Map<String, FilterRegistrationImpl> getFilterRegistrationImpls() {
 		return _filterRegistrations;
 	}
 
@@ -418,11 +418,11 @@ public class ModifiableServletContextAdapter
 	public Map<String, ? extends ServletRegistration>
 		getServletRegistrations() {
 
-		return getServletRegistrationsImpl();
+		return getServletRegistrationImpls();
 	}
 
 	@Override
-	public Map<String, ServletRegistrationImpl> getServletRegistrationsImpl() {
+	public Map<String, ServletRegistrationImpl> getServletRegistrationImpls() {
 		return _servletRegistrations;
 	}
 


### PR DESCRIPTION
Hi @brianchandotcom. Thanks for realizing about un-deprecate the method in the interface.

I reverted one of the SF commits, as all filters, attributes etc won't be available anymore after setProperties invocation, that's why they were assigned in variables before that. If not, it won't work and will throw an exception.

I additionally added a line to refresh modifiableServletContext. Although it doesn't affect the current behavior (filters, listeners etc aren't modified when executing setProperties) but it makes sense and could prevent some future errors.

/cc @rotty3000