### PR TITLE
LRQA-27552 Check archive-marker content to determine if it is valid.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -647,9 +647,11 @@ public abstract class BaseBuild implements Build {
 		_parentBuild = parentBuild;
 
 		try {
-			JenkinsResultsParserUtil.toString(
+			String archiveMarkerContent = JenkinsResultsParserUtil.toString(
 				url + "/archive-marker", false, 0, 0, 0);
-			fromArchive = true;
+
+			fromArchive =
+				archiveMarkerContent != null && !archiveMarkerContent.isEmpty();
 		}
 		catch (IOException ioe) {
 			fromArchive = false;


### PR DESCRIPTION
This corrects a bug caused by an incorrect assumption that toString() will throw an IOException when attempting to read an archive-marker file that does not exist.