### PR TITLE
[See Description] LPS-69718 Regenerate npm-shrinkwrap.json (autogenerated)

### DIFF
--- a/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/npm-shrinkwrap.json
+++ b/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/npm-shrinkwrap.json
@@ -92,8 +92,8 @@
 		},
 		"autoprefixer": {
 			"from": "autoprefixer@>=6.0.0 <7.0.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.5.3.tgz",
-			"version": "6.5.3"
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.5.4.tgz",
+			"version": "6.5.4"
 		},
 		"aws-sign2": {
 			"from": "aws-sign2@>=0.6.0 <0.7.0",
@@ -183,9 +183,9 @@
 			"version": "2.1.0"
 		},
 		"caniuse-db": {
-			"from": "caniuse-db@>=1.0.30000578 <2.0.0",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000587.tgz",
-			"version": "1.0.30000587"
+			"from": "caniuse-db@>=1.0.30000597 <2.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000597.tgz",
+			"version": "1.0.30000597"
 		},
 		"capture-stack-trace": {
 			"from": "capture-stack-trace@>=1.0.0 <2.0.0",
@@ -283,8 +283,8 @@
 			"dependencies": {
 				"lru-cache": {
 					"from": "lru-cache@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-					"version": "4.0.1"
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+					"version": "4.0.2"
 				}
 			},
 			"from": "cross-spawn@>=3.0.0 <4.0.0",
@@ -325,8 +325,8 @@
 		},
 		"debug": {
 			"from": "debug@>=2.2.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-			"version": "2.3.3"
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.4.3.tgz",
+			"version": "2.4.3"
 		},
 		"decamelize": {
 			"from": "decamelize@>=1.1.2 <2.0.0",
@@ -653,8 +653,8 @@
 		},
 		"global-prefix": {
 			"from": "global-prefix@>=0.1.4 <0.2.0",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz",
-			"version": "0.1.4"
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"version": "0.1.5"
 		},
 		"globule": {
 			"dependencies": {
@@ -992,8 +992,8 @@
 						}
 					},
 					"from": "babel-generator@>=6.18.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.18.0.tgz",
-					"version": "6.18.0"
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -1104,8 +1104,8 @@
 				},
 				"babel-plugin-transform-es2015-destructuring": {
 					"from": "babel-plugin-transform-es2015-destructuring@>=6.18.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.18.0.tgz",
-					"version": "6.18.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
 					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
@@ -1139,8 +1139,8 @@
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
 					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.18.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.18.0.tgz",
-					"version": "6.18.0"
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
 					"from": "babel-plugin-transform-es2015-modules-umd@>=6.18.0 <7.0.0",
@@ -1228,18 +1228,18 @@
 				},
 				"babel-traverse": {
 					"from": "babel-traverse@>=6.18.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.18.0.tgz",
-					"version": "6.18.0"
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-types": {
 					"from": "babel-types@>=6.18.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.18.0.tgz",
-					"version": "6.18.0"
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babylon": {
 					"from": "babylon@>=6.11.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.13.1.tgz",
-					"version": "6.13.1"
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+					"version": "6.14.1"
 				},
 				"backo2": {
 					"from": "backo2@1.0.2",
@@ -1268,8 +1268,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"benchmark": {
 					"from": "benchmark@1.0.0",
@@ -1320,6 +1320,16 @@
 				},
 				"body-parser": {
 					"dependencies": {
+						"debug": {
+							"from": "debug@>=2.2.0 <2.3.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						},
 						"qs": {
 							"from": "qs@6.2.0",
 							"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
@@ -1352,8 +1362,8 @@
 				},
 				"buffer-crc32": {
 					"from": "buffer-crc32@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
-					"version": "0.2.5"
+					"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+					"version": "0.2.13"
 				},
 				"buffer-shims": {
 					"from": "buffer-shims@>=1.0.0 <2.0.0",
@@ -1430,10 +1440,20 @@
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
 					"version": "1.0.2"
 				},
+				"clone-buffer": {
+					"from": "clone-buffer@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+					"version": "1.0.0"
+				},
 				"clone-stats": {
 					"from": "clone-stats@>=0.0.1 <0.0.2",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
 					"version": "0.0.1"
+				},
+				"cloneable-readable": {
+					"from": "cloneable-readable@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+					"version": "1.0.0"
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
@@ -1515,6 +1535,18 @@
 					"version": "1.0.4"
 				},
 				"connect": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@>=2.2.0 <2.3.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "connect@>=3.3.5 <4.0.0",
 					"resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
 					"version": "3.5.0"
@@ -1565,8 +1597,8 @@
 					"dependencies": {
 						"lru-cache": {
 							"from": "lru-cache@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-							"version": "4.0.1"
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+							"version": "4.0.2"
 						}
 					},
 					"from": "cross-spawn@>=3.0.0 <4.0.0",
@@ -1619,8 +1651,8 @@
 						}
 					},
 					"from": "dashdash@>=1.12.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-					"version": "1.14.0"
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"version": "1.14.1"
 				},
 				"date-now": {
 					"from": "date-now@>=0.1.4 <0.2.0",
@@ -1639,8 +1671,8 @@
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+					"version": "2.3.3"
 				},
 				"debug-fabulous": {
 					"from": "debug-fabulous@>=0.0.0 <0.1.0",
@@ -1773,8 +1805,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "duplexify@>=3.5.0 <4.0.0",
@@ -1792,11 +1824,35 @@
 					"version": "1.1.1"
 				},
 				"engine.io": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "engine.io@1.6.10",
 					"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
 					"version": "1.6.10"
 				},
 				"engine.io-client": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "engine.io-client@1.6.9",
 					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
 					"version": "1.6.9"
@@ -2004,6 +2060,18 @@
 					"version": "2.2.3"
 				},
 				"finalhandler": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@>=2.2.0 <2.3.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "finalhandler@0.5.0",
 					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
 					"version": "0.5.0"
@@ -2040,8 +2108,8 @@
 				},
 				"form-data": {
 					"from": "form-data@>=2.1.1 <2.2.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.1.tgz",
-					"version": "2.1.1"
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+					"version": "2.1.2"
 				},
 				"formatio": {
 					"from": "formatio@1.1.1",
@@ -2139,8 +2207,8 @@
 				},
 				"globals": {
 					"from": "globals@>=9.0.0 <10.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-9.12.0.tgz",
-					"version": "9.12.0"
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
+					"version": "9.14.0"
 				},
 				"globby": {
 					"from": "globby@>=5.0.0 <6.0.0",
@@ -2154,8 +2222,8 @@
 				},
 				"graceful-fs": {
 					"from": "graceful-fs@>=4.1.2 <5.0.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz",
-					"version": "4.1.10"
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"version": "4.1.11"
 				},
 				"graceful-readlink": {
 					"from": "graceful-readlink@>=1.0.0",
@@ -2179,20 +2247,25 @@
 				},
 				"gulp-concat": {
 					"dependencies": {
-						"readable-stream": {
-							"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-							"version": "1.0.34"
+						"clone-stats": {
+							"from": "clone-stats@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+							"version": "1.0.0"
 						},
-						"through2": {
-							"from": "through2@>=0.6.3 <0.7.0",
-							"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-							"version": "0.6.5"
+						"replace-ext": {
+							"from": "replace-ext@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+							"version": "1.0.0"
+						},
+						"vinyl": {
+							"from": "vinyl@>=2.0.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.1.tgz",
+							"version": "2.0.1"
 						}
 					},
 					"from": "gulp-concat@>=2.5.2 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
-					"version": "2.6.0"
+					"resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+					"version": "2.6.1"
 				},
 				"gulp-esformatter": {
 					"from": "gulp-esformatter@>=5.0.0 <6.0.0",
@@ -2210,21 +2283,9 @@
 					"version": "2.0.2"
 				},
 				"gulp-jshint": {
-					"dependencies": {
-						"readable-stream": {
-							"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-							"version": "1.0.34"
-						},
-						"through2": {
-							"from": "through2@>=0.6.1 <0.7.0",
-							"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-							"version": "0.6.5"
-						}
-					},
 					"from": "gulp-jshint@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.2.tgz",
-					"version": "2.0.2"
+					"resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.4.tgz",
+					"version": "2.0.4"
 				},
 				"gulp-match": {
 					"from": "gulp-match@>=1.0.3 <2.0.0",
@@ -2250,8 +2311,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -2277,8 +2338,8 @@
 						}
 					},
 					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.9.0.tgz",
-					"version": "1.9.0"
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.9.1.tgz",
+					"version": "1.9.1"
 				},
 				"gulp-uglify": {
 					"from": "gulp-uglify@>=1.2.0 <2.0.0",
@@ -2338,8 +2399,8 @@
 						}
 					},
 					"from": "handlebars@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-					"version": "4.0.5"
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+					"version": "4.0.6"
 				},
 				"har-validator": {
 					"from": "har-validator@>=2.0.6 <2.1.0",
@@ -2407,16 +2468,9 @@
 					"version": "3.8.3"
 				},
 				"http-errors": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@2.0.1",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
 					"from": "http-errors@>=1.5.0 <1.6.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-					"version": "1.5.0"
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+					"version": "1.5.1"
 				},
 				"http-proxy": {
 					"from": "http-proxy@>=1.13.0 <2.0.0",
@@ -2487,8 +2541,8 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
@@ -2596,7 +2650,7 @@
 					"version": "1.0.2"
 				},
 				"is-stream": {
-					"from": "is-stream@>=1.0.1 <2.0.0",
+					"from": "is-stream@>=1.1.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 					"version": "1.1.0"
 				},
@@ -2729,8 +2783,8 @@
 						}
 					},
 					"from": "js-yaml@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-					"version": "3.6.1"
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+					"version": "3.7.0"
 				},
 				"js2xmlparser": {
 					"from": "js2xmlparser@>=1.0.0 <1.1.0",
@@ -2756,8 +2810,8 @@
 						}
 					},
 					"from": "jsdoc@>=3.4.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.2.tgz",
-					"version": "3.4.2"
+					"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.3.tgz",
+					"version": "3.4.3"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -2808,8 +2862,8 @@
 				},
 				"json5": {
 					"from": "json5@>=0.5.0 <0.6.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
-					"version": "0.5.0"
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -2971,8 +3025,8 @@
 				},
 				"lodash": {
 					"from": "lodash@>=4.2.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
-					"version": "4.16.6"
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
+					"version": "4.17.2"
 				},
 				"lodash._basecopy": {
 					"from": "lodash._basecopy@>=3.0.0 <4.0.0",
@@ -3049,10 +3103,20 @@
 					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
 					"version": "4.4.0"
 				},
+				"lodash.isobject": {
+					"from": "lodash.isobject@>=3.0.2 <4.0.0",
+					"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+					"version": "3.0.2"
+				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 					"version": "3.1.2"
+				},
+				"lodash.merge": {
+					"from": "lodash.merge@>=4.6.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+					"version": "4.6.0"
 				},
 				"lodash.restparam": {
 					"from": "lodash.restparam@>=3.0.0 <4.0.0",
@@ -3152,13 +3216,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -3230,8 +3294,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3319,8 +3383,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3409,8 +3473,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3504,8 +3568,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3538,14 +3602,14 @@
 					"version": "1.3.4"
 				},
 				"mime-db": {
-					"from": "mime-db@>=1.24.0 <1.25.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-					"version": "1.24.0"
+					"from": "mime-db@>=1.25.0 <1.26.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+					"version": "1.25.0"
 				},
 				"mime-types": {
 					"from": "mime-types@>=2.1.7 <2.2.0",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-					"version": "2.1.12"
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+					"version": "2.1.13"
 				},
 				"minimatch": {
 					"from": "minimatch@>=3.0.2 <4.0.0",
@@ -3569,6 +3633,11 @@
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
 							"version": "2.3.0"
 						},
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
 						"escape-string-regexp": {
 							"from": "escape-string-regexp@1.0.2",
 							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
@@ -3583,6 +3652,11 @@
 							"from": "minimatch@>=0.3.0 <0.4.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
 							"version": "0.3.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
 						},
 						"supports-color": {
 							"from": "supports-color@1.2.0",
@@ -3605,9 +3679,9 @@
 					"version": "1.0.0"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -3657,16 +3731,16 @@
 							"from": "globule@>=1.0.0 <2.0.0",
 							"resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
 							"version": "1.1.0"
+						},
+						"lodash": {
+							"from": "lodash@>=4.16.4 <4.17.0",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+							"version": "4.16.6"
 						}
 					},
 					"from": "node-sass@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.11.2.tgz",
-					"version": "3.11.2"
-				},
-				"node-uuid": {
-					"from": "node-uuid@>=1.4.7 <1.5.0",
-					"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-					"version": "1.4.7"
+					"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.0.tgz",
+					"version": "3.13.0"
 				},
 				"nomnomnomnom": {
 					"dependencies": {
@@ -3733,9 +3807,16 @@
 					"version": "2.0.0"
 				},
 				"npmlog": {
+					"dependencies": {
+						"gauge": {
+							"from": "gauge@>=2.7.1 <2.8.0",
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.1.tgz",
+							"version": "2.7.1"
+						}
+					},
 					"from": "npmlog@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
-					"version": "4.0.0"
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.1.tgz",
+					"version": "4.0.1"
 				},
 				"null-check": {
 					"from": "null-check@>=1.0.0 <2.0.0",
@@ -3825,7 +3906,7 @@
 					"version": "1.0.2"
 				},
 				"osenv": {
-					"from": "osenv@>=0.1.3 <0.2.0",
+					"from": "osenv@>=0.0.0 <1.0.0",
 					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
 					"version": "0.1.3"
 				},
@@ -3961,8 +4042,8 @@
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"range-parser": {
 					"from": "range-parser@>=1.2.0 <2.0.0",
@@ -3980,16 +4061,9 @@
 					"version": "0.1.9"
 				},
 				"rcloader": {
-					"dependencies": {
-						"lodash": {
-							"from": "lodash@>=2.4.1 <2.5.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-							"version": "2.4.2"
-						}
-					},
-					"from": "rcloader@0.1.2",
-					"resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
-					"version": "0.1.2"
+					"from": "rcloader@>=0.2.2 <0.3.0",
+					"resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.2.2.tgz",
+					"version": "0.2.2"
 				},
 				"read-pkg": {
 					"from": "read-pkg@>=1.0.0 <2.0.0",
@@ -4015,8 +4089,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "readdirp@>=2.0.0 <3.0.0",
@@ -4030,8 +4104,8 @@
 				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
 					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
@@ -4057,6 +4131,11 @@
 					"from": "regjsparser@>=0.1.4 <0.2.0",
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
+				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
@@ -4087,8 +4166,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -4097,8 +4176,8 @@
 				},
 				"request": {
 					"from": "request@>=2.61.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
-					"version": "2.78.0"
+					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+					"version": "2.79.0"
 				},
 				"require-directory": {
 					"from": "require-directory@>=2.1.1 <3.0.0",
@@ -4264,9 +4343,9 @@
 					"version": "1.0.1"
 				},
 				"setprototypeof": {
-					"from": "setprototypeof@1.0.1",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
-					"version": "1.0.1"
+					"from": "setprototypeof@1.0.2",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"shelljs": {
 					"from": "shelljs@>=0.3.0 <0.4.0",
@@ -4299,12 +4378,34 @@
 					"version": "1.0.9"
 				},
 				"socket.io": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "socket.io@1.4.7",
 					"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.7.tgz",
 					"version": "1.4.7"
 				},
 				"socket.io-adapter": {
 					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						},
 						"socket.io-parser": {
 							"dependencies": {
 								"debug": {
@@ -4328,6 +4429,16 @@
 							"from": "component-emitter@1.2.0",
 							"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
 							"version": "1.2.0"
+						},
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
 						}
 					},
 					"from": "socket.io-client@1.4.6",
@@ -4336,10 +4447,20 @@
 				},
 				"socket.io-parser": {
 					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
 						"json3": {
 							"from": "json3@3.3.2",
 							"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
 							"version": "3.3.2"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
 						}
 					},
 					"from": "socket.io-parser@2.2.6",
@@ -4414,9 +4535,9 @@
 					"version": "1.10.1"
 				},
 				"statuses": {
-					"from": "statuses@>=1.3.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-					"version": "1.3.0"
+					"from": "statuses@>=1.3.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"stdin": {
 					"from": "stdin@*",
@@ -4565,14 +4686,14 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -4653,8 +4774,8 @@
 				},
 				"type-is": {
 					"from": "type-is@>=1.6.13 <1.7.0",
-					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-					"version": "1.6.13"
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+					"version": "1.6.14"
 				},
 				"typedarray": {
 					"from": "typedarray@>=0.0.5 <0.1.0",
@@ -4773,6 +4894,11 @@
 					"from": "utils-merge@1.0.0",
 					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
 					"version": "1.0.0"
+				},
+				"uuid": {
+					"from": "uuid@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"vali-date": {
 					"from": "vali-date@>=1.0.0 <2.0.0",
@@ -4893,6 +5019,11 @@
 							"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
 							"version": "2.0.14"
 						},
+						"node-uuid": {
+							"from": "node-uuid@>=1.4.0 <1.5.0",
+							"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+							"version": "1.4.7"
+						},
 						"oauth-sign": {
 							"from": "oauth-sign@>=0.6.0 <0.7.0",
 							"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
@@ -4919,9 +5050,9 @@
 					"version": "0.3.12"
 				},
 				"which": {
-					"from": "which@>=1.2.10 <2.0.0",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-					"version": "1.2.11"
+					"from": "which@>=1.2.12 <2.0.0",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+					"version": "1.2.12"
 				},
 				"which-module": {
 					"from": "which-module@>=1.0.0 <2.0.0",
@@ -4945,8 +5076,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -4964,7 +5095,7 @@
 					"version": "1.5.1"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -5019,8 +5150,8 @@
 				}
 			},
 			"from": "gulp-metal@>=1.9.12 <2.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.9.12.tgz",
-			"version": "1.9.12"
+			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.9.13.tgz",
+			"version": "1.9.13"
 		},
 		"gulp-sass": {
 			"from": "gulp-sass@>=2.1.1 <3.0.0",
@@ -5076,6 +5207,11 @@
 			"from": "hoek@>=2.0.0 <3.0.0",
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
 			"version": "2.16.3"
+		},
+		"homedir-polyfill": {
+			"from": "homedir-polyfill@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"version": "1.0.1"
 		},
 		"hosted-git-info": {
 			"from": "hosted-git-info@>=2.1.4 <3.0.0",
@@ -5244,8 +5380,8 @@
 		},
 		"is-unc-path": {
 			"from": "is-unc-path@>=0.1.1 <0.2.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz",
-			"version": "0.1.1"
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+			"version": "0.1.2"
 		},
 		"is-utf8": {
 			"from": "is-utf8@>=0.2.0 <0.3.0",
@@ -5336,8 +5472,8 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-			"version": "3.0.4"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+			"version": "3.1.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
@@ -5371,13 +5507,13 @@
 		},
 		"liferay-frontend-theme-styled": {
 			"from": "liferay-frontend-theme-styled@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.16.tgz",
-			"version": "2.0.16"
+			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.18.tgz",
+			"version": "2.0.18"
 		},
 		"liferay-frontend-theme-unstyled": {
 			"from": "liferay-frontend-theme-unstyled@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.0.16.tgz",
-			"version": "2.0.16"
+			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.0.18.tgz",
+			"version": "2.0.18"
 		},
 		"liferay-module-config-generator": {
 			"dependencies": {
@@ -5407,9 +5543,9 @@
 			"version": "1.0.0"
 		},
 		"liferay-theme-es2015-hook": {
-			"from": "liferay-theme-es2015-hook@>=0.0.1 <0.0.2",
-			"resolved": "https://registry.npmjs.org/liferay-theme-es2015-hook/-/liferay-theme-es2015-hook-0.0.1.tgz",
-			"version": "0.0.1"
+			"from": "liferay-theme-es2015-hook@>=0.1.0 <0.2.0",
+			"resolved": "https://registry.npmjs.org/liferay-theme-es2015-hook/-/liferay-theme-es2015-hook-0.1.0.tgz",
+			"version": "0.1.0"
 		},
 		"liferay-theme-tasks": {
 			"dependencies": {
@@ -8263,23 +8399,23 @@
 		},
 		"metal": {
 			"from": "metal@>=2.2.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal/-/metal-2.5.2.tgz",
-			"version": "2.5.2"
+			"resolved": "https://registry.npmjs.org/metal/-/metal-2.5.12.tgz",
+			"version": "2.5.12"
 		},
 		"metal-dom": {
 			"from": "metal-dom@>=2.4.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.5.3.tgz",
-			"version": "2.5.3"
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.5.16.tgz",
+			"version": "2.5.16"
 		},
 		"metal-events": {
-			"from": "metal-events@>=2.5.3 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-2.5.3.tgz",
-			"version": "2.5.3"
+			"from": "metal-events@>=2.5.16 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-2.5.16.tgz",
+			"version": "2.5.16"
 		},
 		"metal-state": {
 			"from": "metal-state@>=2.3.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.5.3.tgz",
-			"version": "2.5.3"
+			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.5.16.tgz",
+			"version": "2.5.16"
 		},
 		"micromatch": {
 			"from": "micromatch@>=2.3.7 <3.0.0",
@@ -8389,8 +8525,8 @@
 				}
 			},
 			"from": "node-sass@>=3.4.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.0.tgz",
-			"version": "3.13.0"
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
+			"version": "3.13.1"
 		},
 		"node-status-codes": {
 			"from": "node-status-codes@>=1.0.0 <2.0.0",
@@ -8421,18 +8557,23 @@
 			"dependencies": {
 				"gauge": {
 					"from": "gauge@>=2.7.1 <2.8.0",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.1.tgz",
-					"version": "2.7.1"
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+					"version": "2.7.2"
 				},
 				"object-assign": {
 					"from": "object-assign@>=4.1.0 <5.0.0",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
 					"version": "4.1.0"
+				},
+				"supports-color": {
+					"from": "supports-color@>=0.2.0 <0.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+					"version": "0.2.0"
 				}
 			},
 			"from": "npmlog@>=4.0.0 <5.0.0",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.1.tgz",
-			"version": "4.0.1"
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+			"version": "4.0.2"
 		},
 		"num2fraction": {
 			"from": "num2fraction@>=1.2.2 <2.0.0",
@@ -8490,9 +8631,9 @@
 			"version": "1.0.2"
 		},
 		"osenv": {
-			"from": "osenv@>=0.1.3 <0.2.0",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-			"version": "0.1.3"
+			"from": "osenv@>=0.0.0 <1.0.0",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+			"version": "0.1.4"
 		},
 		"package-json": {
 			"dependencies": {
@@ -8525,6 +8666,11 @@
 			"from": "parse-json@>=2.2.0 <3.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"version": "2.2.0"
+		},
+		"parse-passwd": {
+			"from": "parse-passwd@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"version": "1.0.0"
 		},
 		"path-array": {
 			"from": "path-array@>=1.0.0 <2.0.0",
@@ -8635,8 +8781,8 @@
 		},
 		"randomatic": {
 			"from": "randomatic@>=1.1.3 <2.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-			"version": "1.1.5"
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+			"version": "1.1.6"
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
@@ -8749,8 +8895,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
+			"version": "1.2.0"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -8835,8 +8981,8 @@
 		},
 		"signal-exit": {
 			"from": "signal-exit@>=3.0.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-			"version": "3.0.1"
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"version": "3.0.2"
 		},
 		"slide": {
 			"from": "slide@>=1.1.5 <2.0.0",
@@ -8943,14 +9089,14 @@
 					"version": "1.0.0"
 				},
 				"readable-stream": {
-					"from": "readable-stream@>=2.0.0 <2.1.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-					"version": "2.0.6"
+					"from": "readable-stream@>=2.1.5 <3.0.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+					"version": "2.2.2"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"version": "2.0.3"
 		},
 		"tildify": {
 			"from": "tildify@>=1.0.0 <2.0.0",
@@ -8964,8 +9110,8 @@
 		},
 		"timed-out": {
 			"from": "timed-out@>=3.0.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.0.0.tgz",
-			"version": "3.0.0"
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.0.tgz",
+			"version": "3.1.0"
 		},
 		"tough-cookie": {
 			"from": "tough-cookie@>=2.3.0 <2.4.0",
@@ -8984,8 +9130,8 @@
 		},
 		"tweetnacl": {
 			"from": "tweetnacl@>=0.14.0 <0.15.0",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-			"version": "0.14.3"
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"version": "0.14.5"
 		},
 		"unc-path-regex": {
 			"from": "unc-path-regex@>=0.1.0 <0.2.0",
@@ -9046,8 +9192,8 @@
 		},
 		"uuid": {
 			"from": "uuid@>=3.0.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-			"version": "3.0.0"
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+			"version": "3.0.1"
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
@@ -9122,7 +9268,7 @@
 			"version": "0.0.10"
 		},
 		"which": {
-			"from": "which@>=1.2.10 <2.0.0",
+			"from": "which@>=1.2.12 <2.0.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
 			"version": "1.2.12"
 		},
@@ -9148,8 +9294,8 @@
 		},
 		"wrap-ansi": {
 			"from": "wrap-ansi@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"version": "2.1.0"
 		},
 		"wrappy": {
 			"from": "wrappy@>=1.0.0 <2.0.0",
@@ -9167,7 +9313,7 @@
 			"version": "2.0.0"
 		},
 		"xtend": {
-			"from": "xtend@>=4.0.0 <4.1.0",
+			"from": "xtend@>=4.0.1 <4.1.0",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"version": "4.0.1"
 		},

--- a/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/package.json
+++ b/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/package.json
@@ -12,7 +12,7 @@
 		"gulp": "^3.8.10",
 		"gulp-metal": "^1.9.12",
 		"liferay-theme-deps-7.0": "*",
-		"liferay-theme-es2015-hook": "^0.0.1",
+		"liferay-theme-es2015-hook": "^0.1.0",
 		"liferay-theme-tasks": "*"
 	},
 	"keywords": [

--- a/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/src/WEB-INF/liferay-plugin-package.properties
+++ b/modules/apps/frontend-theme-1975-london/frontend-theme-1975-london/src/WEB-INF/liferay-plugin-package.properties
@@ -7,6 +7,5 @@ module-group-id=liferay
 module-incremental-version=1
 name=1975 London
 page-url=http://www.liferay.com
-Provide-Capability=osgi.webresource;osgi.webresource=1975-london-theme
 short-description=
 tags=

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/npm-shrinkwrap.json
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/npm-shrinkwrap.json
@@ -92,8 +92,8 @@
 		},
 		"autoprefixer": {
 			"from": "autoprefixer@>=6.0.0 <7.0.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.5.0.tgz",
-			"version": "6.5.0"
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.5.4.tgz",
+			"version": "6.5.4"
 		},
 		"aws-sign2": {
 			"from": "aws-sign2@>=0.6.0 <0.7.0",
@@ -102,8 +102,8 @@
 		},
 		"aws4": {
 			"from": "aws4@>=1.2.1 <2.0.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-			"version": "1.4.1"
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+			"version": "1.5.0"
 		},
 		"balanced-match": {
 			"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -117,25 +117,8 @@
 		},
 		"beeper": {
 			"from": "beeper@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-			"version": "1.1.0"
-		},
-		"bl": {
-			"dependencies": {
-				"isarray": {
-					"from": "isarray@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"version": "1.0.0"
-				},
-				"readable-stream": {
-					"from": "readable-stream@>=2.0.5 <2.1.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-					"version": "2.0.6"
-				}
-			},
-			"from": "bl@>=1.1.2 <1.2.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-			"version": "1.1.2"
+			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+			"version": "1.1.1"
 		},
 		"block-stream": {
 			"from": "block-stream@*",
@@ -200,9 +183,9 @@
 			"version": "2.1.0"
 		},
 		"caniuse-db": {
-			"from": "caniuse-db@>=1.0.30000540 <2.0.0",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000547.tgz",
-			"version": "1.0.30000547"
+			"from": "caniuse-db@>=1.0.30000597 <2.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000597.tgz",
+			"version": "1.0.30000597"
 		},
 		"capture-stack-trace": {
 			"from": "capture-stack-trace@>=1.0.0 <2.0.0",
@@ -236,8 +219,8 @@
 		},
 		"code-point-at": {
 			"from": "code-point-at@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-			"version": "1.0.1"
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"version": "1.1.0"
 		},
 		"combined-stream": {
 			"from": "combined-stream@>=1.0.5 <1.1.0",
@@ -270,6 +253,11 @@
 					"from": "object-assign@>=4.0.1 <5.0.0",
 					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
 					"version": "4.1.0"
+				},
+				"uuid": {
+					"from": "uuid@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+					"version": "2.0.3"
 				}
 			},
 			"from": "configstore@>=2.0.0 <3.0.0",
@@ -295,8 +283,8 @@
 			"dependencies": {
 				"lru-cache": {
 					"from": "lru-cache@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-					"version": "4.0.1"
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+					"version": "4.0.2"
 				}
 			},
 			"from": "cross-spawn@>=3.0.0 <4.0.0",
@@ -327,8 +315,8 @@
 				}
 			},
 			"from": "dashdash@>=1.12.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-			"version": "1.14.0"
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"version": "1.14.1"
 		},
 		"dateformat": {
 			"from": "dateformat@>=1.0.11 <2.0.0",
@@ -337,8 +325,8 @@
 		},
 		"debug": {
 			"from": "debug@>=2.2.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-			"version": "2.2.0"
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.4.3.tgz",
+			"version": "2.4.3"
 		},
 		"decamelize": {
 			"from": "decamelize@>=1.1.2 <2.0.0",
@@ -504,8 +492,8 @@
 		},
 		"findup-sync": {
 			"from": "findup-sync@>=0.4.2 <0.5.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
-			"version": "0.4.2"
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+			"version": "0.4.3"
 		},
 		"fined": {
 			"from": "fined@>=1.0.1 <2.0.0",
@@ -528,7 +516,7 @@
 			"version": "0.1.6"
 		},
 		"for-own": {
-			"from": "for-own@>=0.1.3 <0.2.0",
+			"from": "for-own@>=0.1.4 <0.2.0",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
 			"version": "0.1.4"
 		},
@@ -543,9 +531,9 @@
 			"version": "0.6.1"
 		},
 		"form-data": {
-			"from": "form-data@>=2.0.0 <2.1.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
-			"version": "2.0.0"
+			"from": "form-data@>=2.1.1 <2.2.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+			"version": "2.1.2"
 		},
 		"fs-exists-sync": {
 			"from": "fs-exists-sync@>=0.1.0 <0.2.0",
@@ -665,8 +653,8 @@
 		},
 		"global-prefix": {
 			"from": "global-prefix@>=0.1.4 <0.2.0",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.4.tgz",
-			"version": "0.1.4"
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"version": "0.1.5"
 		},
 		"globule": {
 			"dependencies": {
@@ -719,18 +707,18 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.5 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-					"version": "2.1.5"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+					"version": "2.2.2"
 				}
 			},
 			"from": "got@>=5.0.0 <6.0.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
-			"version": "5.6.0"
+			"resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+			"version": "5.7.1"
 		},
 		"graceful-fs": {
 			"from": "graceful-fs@>=4.1.2 <5.0.0",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-			"version": "4.1.9"
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"version": "4.1.11"
 		},
 		"graceful-readlink": {
 			"from": "graceful-readlink@>=1.0.0",
@@ -771,6 +759,16 @@
 					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
 					"version": "1.1.4"
 				},
+				"acorn": {
+					"from": "acorn@>=3.3.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+					"version": "3.3.0"
+				},
+				"acorn-jsx": {
+					"from": "acorn-jsx@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+					"version": "3.0.1"
+				},
 				"adm-zip": {
 					"from": "adm-zip@>=0.4.3 <0.5.0",
 					"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
@@ -800,8 +798,8 @@
 				},
 				"amdefine": {
 					"from": "amdefine@>=0.0.4",
-					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"ansi-regex": {
 					"from": "ansi-regex@>=2.0.0 <3.0.0",
@@ -955,6 +953,11 @@
 					"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 					"version": "0.4.0"
 				},
+				"atob": {
+					"from": "atob@>=1.1.0 <1.2.0",
+					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+					"version": "1.1.3"
+				},
 				"aws-sign2": {
 					"from": "aws-sign2@>=0.6.0 <0.7.0",
 					"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -962,8 +965,8 @@
 				},
 				"aws4": {
 					"from": "aws4@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-					"version": "1.4.1"
+					"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+					"version": "1.5.0"
 				},
 				"babel-code-frame": {
 					"from": "babel-code-frame@>=6.16.0 <7.0.0",
@@ -971,9 +974,9 @@
 					"version": "6.16.0"
 				},
 				"babel-core": {
-					"from": "babel-core@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-core@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
+					"version": "6.18.2"
 				},
 				"babel-deps": {
 					"from": "babel-deps@>=2.0.0 <3.0.0",
@@ -988,9 +991,9 @@
 							"version": "1.3.0"
 						}
 					},
-					"from": "babel-generator@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-generator@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-globals": {
 					"from": "babel-globals@>=2.0.0 <3.0.0",
@@ -998,44 +1001,44 @@
 					"version": "2.0.1"
 				},
 				"babel-helper-call-delegate": {
-					"from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-call-delegate@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helper-define-map": {
-					"from": "babel-helper-define-map@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz",
-					"version": "6.9.0"
+					"from": "babel-helper-define-map@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helper-function-name": {
-					"from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-function-name@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helper-get-function-arity": {
-					"from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-get-function-arity@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helper-hoist-variables": {
-					"from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-hoist-variables@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helper-optimise-call-expression": {
-					"from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-helper-optimise-call-expression@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helper-regex": {
 					"from": "babel-helper-regex@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
-					"version": "6.9.0"
+					"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helper-replace-supers": {
-					"from": "babel-helper-replace-supers@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-helper-replace-supers@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-helpers": {
 					"from": "babel-helpers@>=6.16.0 <7.0.0",
@@ -1085,14 +1088,14 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-block-scoping": {
-					"from": "babel-plugin-transform-es2015-block-scoping@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
-					"version": "6.15.0"
+					"from": "babel-plugin-transform-es2015-block-scoping@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-classes": {
-					"from": "babel-plugin-transform-es2015-classes@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-classes@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-computed-properties": {
 					"from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
@@ -1100,9 +1103,9 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-destructuring": {
-					"from": "babel-plugin-transform-es2015-destructuring@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-destructuring@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-plugin-transform-es2015-duplicate-keys": {
 					"from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
@@ -1110,9 +1113,9 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-for-of": {
-					"from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-for-of@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-function-name": {
 					"from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
@@ -1125,24 +1128,24 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-modules-amd": {
-					"from": "babel-plugin-transform-es2015-modules-amd@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-modules-amd@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-modules-commonjs": {
-					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-modules-commonjs@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-modules-systemjs": {
-					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.14.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.14.0.tgz",
-					"version": "6.14.0"
+					"from": "babel-plugin-transform-es2015-modules-systemjs@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-plugin-transform-es2015-modules-umd": {
-					"from": "babel-plugin-transform-es2015-modules-umd@>=6.12.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.12.0.tgz",
-					"version": "6.12.0"
+					"from": "babel-plugin-transform-es2015-modules-umd@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-object-super": {
 					"from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
@@ -1150,14 +1153,14 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-parameters": {
-					"from": "babel-plugin-transform-es2015-parameters@>=6.16.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-plugin-transform-es2015-parameters@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-shorthand-properties": {
-					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-shorthand-properties@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-spread": {
 					"from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
@@ -1175,9 +1178,9 @@
 					"version": "6.8.0"
 				},
 				"babel-plugin-transform-es2015-typeof-symbol": {
-					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz",
-					"version": "6.8.0"
+					"from": "babel-plugin-transform-es2015-typeof-symbol@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-plugin-transform-es2015-unicode-regex": {
 					"from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
@@ -1190,14 +1193,14 @@
 					"version": "6.16.1"
 				},
 				"babel-plugin-transform-strict-mode": {
-					"from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.11.3.tgz",
-					"version": "6.11.3"
+					"from": "babel-plugin-transform-strict-mode@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-preset-es2015": {
 					"from": "babel-preset-es2015@>=6.3.13 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz",
-					"version": "6.16.0"
+					"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-preset-metal": {
 					"from": "babel-preset-metal@>=3.0.0 <4.0.0",
@@ -1206,18 +1209,17 @@
 				},
 				"babel-preset-metal-resolve-source": {
 					"from": "babel-preset-metal-resolve-source@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-metal-resolve-source/-/babel-preset-metal-resolve-source-1.0.0.tgz",
-					"version": "1.0.0"
+					"version": "1.0.1"
 				},
 				"babel-register": {
 					"from": "babel-register@>=6.4.3 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.16.3.tgz",
-					"version": "6.16.3"
+					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-runtime": {
 					"from": "babel-runtime@>=6.0.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.11.6.tgz",
-					"version": "6.11.6"
+					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
+					"version": "6.18.0"
 				},
 				"babel-template": {
 					"from": "babel-template@>=6.15.0 <7.0.0",
@@ -1225,19 +1227,19 @@
 					"version": "6.16.0"
 				},
 				"babel-traverse": {
-					"from": "babel-traverse@>=6.15.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-traverse@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babel-types": {
-					"from": "babel-types@>=6.15.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.16.0.tgz",
-					"version": "6.16.0"
+					"from": "babel-types@>=6.18.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+					"version": "6.19.0"
 				},
 				"babylon": {
-					"from": "babylon@>=6.9.0 <7.0.0",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.11.2.tgz",
-					"version": "6.11.2"
+					"from": "babylon@>=6.11.0 <7.0.0",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+					"version": "6.14.1"
 				},
 				"backo2": {
 					"from": "backo2@1.0.2",
@@ -1266,8 +1268,8 @@
 				},
 				"beeper": {
 					"from": "beeper@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-					"version": "1.1.0"
+					"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+					"version": "1.1.1"
 				},
 				"benchmark": {
 					"from": "benchmark@1.0.0",
@@ -1281,8 +1283,8 @@
 				},
 				"binary-extensions": {
 					"from": "binary-extensions@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz",
+					"version": "1.7.0"
 				},
 				"binaryextensions": {
 					"from": "binaryextensions@>=1.0.0 <1.1.0",
@@ -1291,20 +1293,15 @@
 				},
 				"bl": {
 					"dependencies": {
-						"isarray": {
-							"from": "isarray@>=1.0.0 <1.1.0",
-							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-							"version": "1.0.0"
-						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.5 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=1.0.26 <1.1.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+							"version": "1.0.34"
 						}
 					},
-					"from": "bl@>=1.1.2 <1.2.0",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-					"version": "1.1.2"
+					"from": "bl@>=0.9.0 <0.10.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"version": "0.9.5"
 				},
 				"blob": {
 					"from": "blob@0.0.4",
@@ -1323,6 +1320,16 @@
 				},
 				"body-parser": {
 					"dependencies": {
+						"debug": {
+							"from": "debug@>=2.2.0 <2.3.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						},
 						"qs": {
 							"from": "qs@6.2.0",
 							"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
@@ -1340,8 +1347,8 @@
 				},
 				"bower": {
 					"from": "bower@>=1.7.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
-					"version": "1.7.9"
+					"resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+					"version": "1.8.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
@@ -1355,8 +1362,8 @@
 				},
 				"buffer-crc32": {
 					"from": "buffer-crc32@>=0.2.1 <0.3.0",
-					"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
-					"version": "0.2.5"
+					"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+					"version": "0.2.13"
 				},
 				"buffer-shims": {
 					"from": "buffer-shims@>=1.0.0 <2.0.0",
@@ -1415,13 +1422,13 @@
 				},
 				"chokidar": {
 					"from": "chokidar@>=1.4.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"cli": {
 					"from": "cli@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"cliui": {
 					"from": "cliui@>=3.2.0 <4.0.0",
@@ -1433,15 +1440,25 @@
 					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
 					"version": "1.0.2"
 				},
+				"clone-buffer": {
+					"from": "clone-buffer@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+					"version": "1.0.0"
+				},
 				"clone-stats": {
 					"from": "clone-stats@>=0.0.1 <0.0.2",
 					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
 					"version": "0.0.1"
 				},
+				"cloneable-readable": {
+					"from": "cloneable-readable@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+					"version": "1.0.0"
+				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"colors": {
 					"from": "colors@>=1.1.0 <2.0.0",
@@ -1518,6 +1535,18 @@
 					"version": "1.0.4"
 				},
 				"connect": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@>=2.2.0 <2.3.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "connect@>=3.3.5 <4.0.0",
 					"resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
 					"version": "3.5.0"
@@ -1568,8 +1597,8 @@
 					"dependencies": {
 						"lru-cache": {
 							"from": "lru-cache@>=4.0.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-							"version": "4.0.1"
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+							"version": "4.0.2"
 						}
 					},
 					"from": "cross-spawn@>=3.0.0 <4.0.0",
@@ -1580,6 +1609,18 @@
 					"from": "cryptiles@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"version": "2.0.5"
+				},
+				"css": {
+					"dependencies": {
+						"source-map": {
+							"from": "source-map@>=0.1.38 <0.2.0",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+							"version": "0.1.43"
+						}
+					},
+					"from": "css@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+					"version": "2.2.1"
 				},
 				"ctype": {
 					"from": "ctype@0.5.3",
@@ -1593,8 +1634,8 @@
 				},
 				"custom-event": {
 					"from": "custom-event@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"d": {
 					"from": "d@>=0.1.1 <0.2.0",
@@ -1610,8 +1651,8 @@
 						}
 					},
 					"from": "dashdash@>=1.12.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-					"version": "1.14.0"
+					"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+					"version": "1.14.1"
 				},
 				"date-now": {
 					"from": "date-now@>=0.1.4 <0.2.0",
@@ -1630,8 +1671,13 @@
 				},
 				"debug": {
 					"from": "debug@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"version": "2.2.0"
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+					"version": "2.3.3"
+				},
+				"debug-fabulous": {
+					"from": "debug-fabulous@>=0.0.0 <0.1.0",
+					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+					"version": "0.0.4"
 				},
 				"decamelize": {
 					"from": "decamelize@>=1.1.2 <2.0.0",
@@ -1669,9 +1715,14 @@
 					"version": "1.1.0"
 				},
 				"detect-indent": {
-					"from": "detect-indent@>=3.0.1 <4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-					"version": "3.0.1"
+					"from": "detect-indent@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+					"version": "4.0.0"
+				},
+				"detect-newline": {
+					"from": "detect-newline@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"di": {
 					"from": "di@>=0.0.1 <0.0.2",
@@ -1754,13 +1805,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
-					"from": "duplexify@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"from": "duplexify@>=3.5.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+					"version": "3.5.0"
 				},
 				"ecc-jsbn": {
 					"from": "ecc-jsbn@>=0.1.1 <0.2.0",
@@ -1773,11 +1824,35 @@
 					"version": "1.1.1"
 				},
 				"engine.io": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "engine.io@1.6.10",
 					"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
 					"version": "1.6.10"
 				},
 				"engine.io-client": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "engine.io-client@1.6.9",
 					"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
 					"version": "1.6.9"
@@ -1837,8 +1912,7 @@
 				"escodegen": {
 					"dependencies": {
 						"esprima": {
-							"from": "esprima@^2.7.1",
-							"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+							"from": "esprima@>=2.7.1 <3.0.0",
 							"version": "2.7.3"
 						},
 						"source-map": {
@@ -1862,6 +1936,11 @@
 							"from": "glob@>=5.0.3 <6.0.0",
 							"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 							"version": "5.0.15"
+						},
+						"minimist": {
+							"from": "minimist@>=1.1.1 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
 						},
 						"supports-color": {
 							"from": "supports-color@>=1.3.1 <2.0.0",
@@ -1981,18 +2060,23 @@
 					"version": "2.2.3"
 				},
 				"finalhandler": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@>=2.2.0 <2.3.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "finalhandler@0.5.0",
 					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
 					"version": "0.5.0"
 				},
 				"find-up": {
-					"dependencies": {
-						"path-exists": {
-							"from": "path-exists@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-							"version": "2.1.0"
-						}
-					},
 					"from": "find-up@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 					"version": "1.1.2"
@@ -2008,7 +2092,7 @@
 					"version": "0.1.6"
 				},
 				"for-own": {
-					"from": "for-own@>=0.1.3 <0.2.0",
+					"from": "for-own@>=0.1.4 <0.2.0",
 					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
 					"version": "0.1.4"
 				},
@@ -2023,9 +2107,9 @@
 					"version": "0.0.4"
 				},
 				"form-data": {
-					"from": "form-data@>=2.0.0 <2.1.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "form-data@>=2.1.1 <2.2.0",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+					"version": "2.1.2"
 				},
 				"formatio": {
 					"from": "formatio@1.1.1",
@@ -2036,11 +2120,6 @@
 					"from": "fs-access@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
 					"version": "1.0.1"
-				},
-				"fs-extra": {
-					"from": "fs-extra@>=0.30.0 <0.31.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-					"version": "0.30.0"
 				},
 				"fs.realpath": {
 					"from": "fs.realpath@>=1.0.0 <2.0.0",
@@ -2091,8 +2170,8 @@
 				},
 				"glob": {
 					"from": "glob@>=7.0.3 <8.0.0",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-					"version": "7.1.0"
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"version": "7.1.1"
 				},
 				"glob-base": {
 					"from": "glob-base@>=0.3.0 <0.4.0",
@@ -2127,9 +2206,9 @@
 					"version": "2.0.0"
 				},
 				"globals": {
-					"from": "globals@>=8.3.0 <9.0.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
-					"version": "8.18.0"
+					"from": "globals@>=9.0.0 <10.0.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
+					"version": "9.14.0"
 				},
 				"globby": {
 					"from": "globby@>=5.0.0 <6.0.0",
@@ -2143,8 +2222,8 @@
 				},
 				"graceful-fs": {
 					"from": "graceful-fs@>=4.1.2 <5.0.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
-					"version": "4.1.9"
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"version": "4.1.11"
 				},
 				"graceful-readlink": {
 					"from": "graceful-readlink@>=1.0.0",
@@ -2168,20 +2247,25 @@
 				},
 				"gulp-concat": {
 					"dependencies": {
-						"readable-stream": {
-							"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-							"version": "1.0.34"
+						"clone-stats": {
+							"from": "clone-stats@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+							"version": "1.0.0"
 						},
-						"through2": {
-							"from": "through2@>=0.6.3 <0.7.0",
-							"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-							"version": "0.6.5"
+						"replace-ext": {
+							"from": "replace-ext@>=1.0.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+							"version": "1.0.0"
+						},
+						"vinyl": {
+							"from": "vinyl@>=2.0.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.1.tgz",
+							"version": "2.0.1"
 						}
 					},
 					"from": "gulp-concat@>=2.5.2 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
-					"version": "2.6.0"
+					"resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+					"version": "2.6.1"
 				},
 				"gulp-esformatter": {
 					"from": "gulp-esformatter@>=5.0.0 <6.0.0",
@@ -2190,40 +2274,23 @@
 				},
 				"gulp-if": {
 					"from": "gulp-if@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-ignore": {
 					"from": "gulp-ignore@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-ignore/-/gulp-ignore-2.0.2.tgz",
+					"version": "2.0.2"
 				},
 				"gulp-jshint": {
-					"dependencies": {
-						"minimatch": {
-							"from": "minimatch@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-							"version": "2.0.10"
-						},
-						"readable-stream": {
-							"from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-							"version": "1.0.34"
-						},
-						"through2": {
-							"from": "through2@>=0.6.1 <0.7.0",
-							"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-							"version": "0.6.5"
-						}
-					},
 					"from": "gulp-jshint@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-2.0.4.tgz",
+					"version": "2.0.4"
 				},
 				"gulp-match": {
-					"from": "gulp-match@>=1.0.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.2.tgz",
-					"version": "1.0.2"
+					"from": "gulp-match@>=1.0.3 <2.0.0",
+					"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+					"version": "1.0.3"
 				},
 				"gulp-mocha": {
 					"from": "gulp-mocha@>=2.2.0 <3.0.0",
@@ -2244,8 +2311,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "gulp-replace@>=0.5.4 <0.6.0",
@@ -2259,6 +2326,11 @@
 				},
 				"gulp-sourcemaps": {
 					"dependencies": {
+						"acorn": {
+							"from": "acorn@>=4.0.0 <5.0.0",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
+							"version": "4.0.3"
+						},
 						"vinyl": {
 							"from": "vinyl@>=1.0.0 <2.0.0",
 							"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
@@ -2266,8 +2338,8 @@
 						}
 					},
 					"from": "gulp-sourcemaps@>=1.6.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.9.1.tgz",
+					"version": "1.9.1"
 				},
 				"gulp-uglify": {
 					"from": "gulp-uglify@>=1.2.0 <2.0.0",
@@ -2276,6 +2348,11 @@
 				},
 				"gulp-util": {
 					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.0 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						},
 						"object-assign": {
 							"from": "object-assign@>=3.0.0 <4.0.0",
 							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -2322,8 +2399,8 @@
 						}
 					},
 					"from": "handlebars@>=4.0.1 <5.0.0",
-					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
-					"version": "4.0.5"
+					"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+					"version": "4.0.6"
 				},
 				"har-validator": {
 					"from": "har-validator@>=2.0.6 <2.1.0",
@@ -2376,9 +2453,9 @@
 					"version": "2.16.3"
 				},
 				"home-or-tmp": {
-					"from": "home-or-tmp@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "home-or-tmp@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+					"version": "2.0.0"
 				},
 				"hosted-git-info": {
 					"from": "hosted-git-info@>=2.1.4 <3.0.0",
@@ -2391,21 +2468,14 @@
 					"version": "3.8.3"
 				},
 				"http-errors": {
-					"dependencies": {
-						"inherits": {
-							"from": "inherits@2.0.1",
-							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
 					"from": "http-errors@>=1.5.0 <1.6.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-					"version": "1.5.0"
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+					"version": "1.5.1"
 				},
 				"http-proxy": {
 					"from": "http-proxy@>=1.13.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.1.tgz",
-					"version": "1.15.1"
+					"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+					"version": "1.15.2"
 				},
 				"http-signature": {
 					"from": "http-signature@>=1.1.0 <1.2.0",
@@ -2450,13 +2520,6 @@
 					"version": "2.0.0"
 				},
 				"indent-string": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-							"version": "2.0.1"
-						}
-					},
 					"from": "indent-string@>=2.1.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 					"version": "2.1.0"
@@ -2468,8 +2531,8 @@
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-					"version": "1.0.5"
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"version": "1.0.6"
 				},
 				"inherits": {
 					"from": "inherits@>=2.0.0 <3.0.0",
@@ -2478,8 +2541,8 @@
 				},
 				"invariant": {
 					"from": "invariant@>=2.2.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
-					"version": "2.2.1"
+					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+					"version": "2.2.2"
 				},
 				"invert-kv": {
 					"from": "invert-kv@>=1.0.0 <2.0.0",
@@ -2548,8 +2611,8 @@
 				},
 				"is-my-json-valid": {
 					"from": "is-my-json-valid@>=2.12.4 <3.0.0",
-					"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.14.0.tgz",
-					"version": "2.14.0"
+					"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+					"version": "2.15.0"
 				},
 				"is-number": {
 					"from": "is-number@>=2.1.0 <3.0.0",
@@ -2587,7 +2650,7 @@
 					"version": "1.0.2"
 				},
 				"is-stream": {
-					"from": "is-stream@>=1.0.1 <2.0.0",
+					"from": "is-stream@>=1.1.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 					"version": "1.1.0"
 				},
@@ -2636,8 +2699,7 @@
 				"isparta": {
 					"dependencies": {
 						"esprima": {
-							"from": "esprima@^2.1.0",
-							"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+							"from": "esprima@>=2.1.0 <3.0.0",
 							"version": "2.7.3"
 						}
 					},
@@ -2658,8 +2720,7 @@
 							"version": "1.5.2"
 						},
 						"esprima": {
-							"from": "esprima@2.7.x",
-							"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+							"from": "esprima@>=2.7.0 <2.8.0",
 							"version": "2.7.3"
 						},
 						"glob": {
@@ -2717,14 +2778,13 @@
 				"js-yaml": {
 					"dependencies": {
 						"esprima": {
-							"from": "esprima@^2.6.0",
-							"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+							"from": "esprima@>=2.6.0 <3.0.0",
 							"version": "2.7.3"
 						}
 					},
 					"from": "js-yaml@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-					"version": "3.6.1"
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+					"version": "3.7.0"
 				},
 				"js2xmlparser": {
 					"from": "js2xmlparser@>=1.0.0 <1.1.0",
@@ -2738,6 +2798,11 @@
 				},
 				"jsdoc": {
 					"dependencies": {
+						"espree": {
+							"from": "espree@>=3.1.7 <3.2.0",
+							"resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
+							"version": "3.1.7"
+						},
 						"strip-json-comments": {
 							"from": "strip-json-comments@>=2.0.1 <2.1.0",
 							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2745,8 +2810,8 @@
 						}
 					},
 					"from": "jsdoc@>=3.4.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.1.tgz",
-					"version": "3.4.1"
+					"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.3.tgz",
+					"version": "3.4.3"
 				},
 				"jsesc": {
 					"from": "jsesc@>=0.5.0 <0.6.0",
@@ -2767,8 +2832,8 @@
 						}
 					},
 					"from": "jshint@>=2.9.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.3.tgz",
-					"version": "2.9.3"
+					"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
+					"version": "2.9.4"
 				},
 				"jshint-stylish": {
 					"from": "jshint-stylish@>=2.0.0 <3.0.0",
@@ -2796,14 +2861,9 @@
 					"version": "3.2.6"
 				},
 				"json5": {
-					"from": "json5@>=0.4.0 <0.5.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"version": "0.4.0"
-				},
-				"jsonfile": {
-					"from": "jsonfile@>=2.1.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-					"version": "2.4.0"
+					"from": "json5@>=0.5.0 <0.6.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+					"version": "0.5.1"
 				},
 				"jsonify": {
 					"from": "jsonify@>=0.0.0 <0.1.0",
@@ -2811,9 +2871,9 @@
 					"version": "0.0.0"
 				},
 				"jsonpointer": {
-					"from": "jsonpointer@2.0.0",
-					"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "jsonpointer@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+					"version": "4.0.0"
 				},
 				"jsprim": {
 					"from": "jsprim@>=1.2.2 <2.0.0",
@@ -2922,14 +2982,19 @@
 					"version": "3.0.4"
 				},
 				"klaw": {
-					"from": "klaw@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-					"version": "1.3.0"
+					"from": "klaw@>=1.3.0 <1.4.0",
+					"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"lazy-cache": {
 					"from": "lazy-cache@>=1.0.3 <2.0.0",
 					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
 					"version": "1.0.4"
+				},
+				"lazy-debug-legacy": {
+					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
+					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+					"version": "0.0.1"
 				},
 				"lazystream": {
 					"dependencies": {
@@ -2960,8 +3025,8 @@
 				},
 				"lodash": {
 					"from": "lodash@>=4.2.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz",
-					"version": "4.16.2"
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
+					"version": "4.17.2"
 				},
 				"lodash._basecopy": {
 					"from": "lodash._basecopy@>=3.0.0 <4.0.0",
@@ -3038,10 +3103,20 @@
 					"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.4.0.tgz",
 					"version": "4.4.0"
 				},
+				"lodash.isobject": {
+					"from": "lodash.isobject@>=3.0.2 <4.0.0",
+					"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+					"version": "3.0.2"
+				},
 				"lodash.keys": {
 					"from": "lodash.keys@>=3.0.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 					"version": "3.1.2"
+				},
+				"lodash.merge": {
+					"from": "lodash.merge@>=4.6.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+					"version": "4.6.0"
 				},
 				"lodash.restparam": {
 					"from": "lodash.restparam@>=3.0.0 <4.0.0",
@@ -3086,16 +3161,9 @@
 					"version": "1.0.1"
 				},
 				"loose-envify": {
-					"dependencies": {
-						"js-tokens": {
-							"from": "js-tokens@>=1.0.1 <2.0.0",
-							"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.3.tgz",
-							"version": "1.0.3"
-						}
-					},
 					"from": "loose-envify@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.2.0.tgz",
-					"version": "1.2.0"
+					"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
+					"version": "1.3.0"
 				},
 				"loud-rejection": {
 					"from": "loud-rejection@>=1.0.0 <2.0.0",
@@ -3123,6 +3191,13 @@
 					"version": "0.3.0"
 				},
 				"meow": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.3 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "meow@>=3.3.0 <4.0.0",
 					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 					"version": "3.7.0"
@@ -3141,13 +3216,13 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "merge-stream@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"metal-jquery-adapter": {
 					"from": "metal-jquery-adapter@>=1.0.0-rc.1 <2.0.0",
@@ -3168,14 +3243,13 @@
 						},
 						"glob-parent": {
 							"from": "glob-parent@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-							"version": "3.0.0"
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.1.tgz",
+							"version": "3.0.1"
 						},
 						"glob-stream": {
 							"dependencies": {
 								"isarray": {
 									"from": "isarray@0.0.1",
-									"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 									"version": "0.0.1"
 								},
 								"readable-stream": {
@@ -3194,14 +3268,14 @@
 							"version": "5.3.5"
 						},
 						"is-extglob": {
-							"from": "is-extglob@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.0.0.tgz",
-							"version": "2.0.0"
+							"from": "is-extglob@>=2.1.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
+							"version": "2.1.0"
 						},
 						"is-glob": {
-							"from": "is-glob@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.0.0.tgz",
-							"version": "3.0.0"
+							"from": "is-glob@>=3.1.0 <4.0.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"version": "3.1.0"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -3220,8 +3294,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3234,14 +3308,20 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
+							"dependencies": {
+								"gulp-sourcemaps": {
+									"from": "gulp-sourcemaps@1.6.0",
+									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+									"version": "1.6.0"
+								}
+							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-							"version": "2.4.3"
+							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-amd@>=3.0.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/metal-tools-build-amd/-/metal-tools-build-amd-3.0.1.tgz",
-					"version": "3.0.1"
+					"version": "3.0.2"
 				},
 				"metal-tools-build-globals": {
 					"dependencies": {
@@ -3252,14 +3332,13 @@
 						},
 						"glob-parent": {
 							"from": "glob-parent@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-							"version": "3.0.0"
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.1.tgz",
+							"version": "3.0.1"
 						},
 						"glob-stream": {
 							"dependencies": {
 								"isarray": {
 									"from": "isarray@0.0.1",
-									"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 									"version": "0.0.1"
 								},
 								"readable-stream": {
@@ -3278,14 +3357,14 @@
 							"version": "5.3.5"
 						},
 						"is-extglob": {
-							"from": "is-extglob@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.0.0.tgz",
-							"version": "2.0.0"
+							"from": "is-extglob@>=2.1.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
+							"version": "2.1.0"
 						},
 						"is-glob": {
-							"from": "is-glob@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.0.0.tgz",
-							"version": "3.0.0"
+							"from": "is-glob@>=3.1.0 <4.0.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"version": "3.1.0"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -3304,8 +3383,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3318,9 +3397,16 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
+							"dependencies": {
+								"gulp-sourcemaps": {
+									"from": "gulp-sourcemaps@1.6.0",
+									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+									"version": "1.6.0"
+								}
+							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-							"version": "2.4.3"
+							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-globals@>=2.0.0 <3.0.0",
@@ -3336,14 +3422,13 @@
 						},
 						"glob-parent": {
 							"from": "glob-parent@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-							"version": "3.0.0"
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.1.tgz",
+							"version": "3.0.1"
 						},
 						"glob-stream": {
 							"dependencies": {
 								"isarray": {
 									"from": "isarray@0.0.1",
-									"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 									"version": "0.0.1"
 								},
 								"readable-stream": {
@@ -3362,14 +3447,14 @@
 							"version": "5.3.5"
 						},
 						"is-extglob": {
-							"from": "is-extglob@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.0.0.tgz",
-							"version": "2.0.0"
+							"from": "is-extglob@>=2.1.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
+							"version": "2.1.0"
 						},
 						"is-glob": {
-							"from": "is-glob@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.0.0.tgz",
-							"version": "3.0.0"
+							"from": "is-glob@>=3.1.0 <4.0.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"version": "3.1.0"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -3388,8 +3473,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3402,9 +3487,16 @@
 							"version": "1.2.0"
 						},
 						"vinyl-fs": {
+							"dependencies": {
+								"gulp-sourcemaps": {
+									"from": "gulp-sourcemaps@1.6.0",
+									"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+									"version": "1.6.0"
+								}
+							},
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-							"version": "2.4.3"
+							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-build-jquery@>=2.0.0 <3.0.0",
@@ -3420,14 +3512,13 @@
 						},
 						"glob-parent": {
 							"from": "glob-parent@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.0.tgz",
-							"version": "3.0.0"
+							"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.0.1.tgz",
+							"version": "3.0.1"
 						},
 						"glob-stream": {
 							"dependencies": {
 								"isarray": {
 									"from": "isarray@0.0.1",
-									"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
 									"version": "0.0.1"
 								},
 								"readable-stream": {
@@ -3445,15 +3536,20 @@
 							"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
 							"version": "5.3.5"
 						},
+						"gulp-sourcemaps": {
+							"from": "gulp-sourcemaps@1.6.0",
+							"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+							"version": "1.6.0"
+						},
 						"is-extglob": {
-							"from": "is-extglob@>=2.0.0 <3.0.0",
-							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.0.0.tgz",
-							"version": "2.0.0"
+							"from": "is-extglob@>=2.1.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.0.tgz",
+							"version": "2.1.0"
 						},
 						"is-glob": {
-							"from": "is-glob@>=3.0.0 <4.0.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.0.0.tgz",
-							"version": "3.0.0"
+							"from": "is-glob@>=3.1.0 <4.0.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"version": "3.1.0"
 						},
 						"isarray": {
 							"from": "isarray@>=1.0.0 <1.1.0",
@@ -3472,8 +3568,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.4 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						},
 						"unique-stream": {
 							"from": "unique-stream@>=2.0.2 <3.0.0",
@@ -3487,8 +3583,8 @@
 						},
 						"vinyl-fs": {
 							"from": "vinyl-fs@>=2.2.1 <3.0.0",
-							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.3.tgz",
-							"version": "2.4.3"
+							"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+							"version": "2.4.4"
 						}
 					},
 					"from": "metal-tools-soy@>=3.0.0 <4.0.0",
@@ -3506,14 +3602,14 @@
 					"version": "1.3.4"
 				},
 				"mime-db": {
-					"from": "mime-db@>=1.24.0 <1.25.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-					"version": "1.24.0"
+					"from": "mime-db@>=1.25.0 <1.26.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+					"version": "1.25.0"
 				},
 				"mime-types": {
 					"from": "mime-types@>=2.1.7 <2.2.0",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-					"version": "2.1.12"
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+					"version": "2.1.13"
 				},
 				"minimatch": {
 					"from": "minimatch@>=3.0.2 <4.0.0",
@@ -3521,18 +3617,11 @@
 					"version": "3.0.3"
 				},
 				"minimist": {
-					"from": "minimist@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"version": "1.2.0"
+					"from": "minimist@0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"version": "0.0.8"
 				},
 				"mkdirp": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@0.0.8",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-							"version": "0.0.8"
-						}
-					},
 					"from": "mkdirp@>=0.5.1 <0.6.0",
 					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"version": "0.5.1"
@@ -3543,6 +3632,11 @@
 							"from": "commander@2.3.0",
 							"resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
 							"version": "2.3.0"
+						},
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
 						},
 						"escape-string-regexp": {
 							"from": "escape-string-regexp@1.0.2",
@@ -3558,6 +3652,11 @@
 							"from": "minimatch@>=0.3.0 <0.4.0",
 							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
 							"version": "0.3.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
 						},
 						"supports-color": {
 							"from": "supports-color@1.2.0",
@@ -3580,9 +3679,9 @@
 					"version": "1.0.0"
 				},
 				"ms": {
-					"from": "ms@0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"version": "0.7.1"
+					"from": "ms@0.7.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+					"version": "0.7.2"
 				},
 				"mtil": {
 					"from": "mtil@>=0.1.3 <0.2.0",
@@ -3629,31 +3728,19 @@
 							"version": "1.1.2"
 						},
 						"globule": {
-							"dependencies": {
-								"glob": {
-									"from": "glob@>=7.0.3 <7.1.0",
-									"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-									"version": "7.0.6"
-								}
-							},
 							"from": "globule@>=1.0.0 <2.0.0",
-							"resolved": "https://registry.npmjs.org/globule/-/globule-1.0.0.tgz",
-							"version": "1.0.0"
+							"resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
+							"version": "1.1.0"
 						},
 						"lodash": {
-							"from": "lodash@>=4.9.0 <4.10.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz",
-							"version": "4.9.0"
+							"from": "lodash@>=4.16.4 <4.17.0",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+							"version": "4.16.6"
 						}
 					},
 					"from": "node-sass@>=3.4.2 <4.0.0",
-					"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.10.1.tgz",
-					"version": "3.10.1"
-				},
-				"node-uuid": {
-					"from": "node-uuid@>=1.4.7 <1.5.0",
-					"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-					"version": "1.4.7"
+					"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.0.tgz",
+					"version": "3.13.0"
 				},
 				"nomnomnomnom": {
 					"dependencies": {
@@ -3703,6 +3790,13 @@
 					"version": "1.1.0"
 				},
 				"npm-run": {
+					"dependencies": {
+						"minimist": {
+							"from": "minimist@>=1.1.1 <2.0.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"version": "1.2.0"
+						}
+					},
 					"from": "npm-run@>=2.0.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/npm-run/-/npm-run-2.0.0.tgz",
 					"version": "2.0.0"
@@ -3713,9 +3807,16 @@
 					"version": "2.0.0"
 				},
 				"npmlog": {
+					"dependencies": {
+						"gauge": {
+							"from": "gauge@>=2.7.1 <2.8.0",
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.1.tgz",
+							"version": "2.7.1"
+						}
+					},
 					"from": "npmlog@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
-					"version": "4.0.0"
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.1.tgz",
+					"version": "4.0.1"
 				},
 				"null-check": {
 					"from": "null-check@>=1.0.0 <2.0.0",
@@ -3744,8 +3845,8 @@
 				},
 				"object.omit": {
 					"from": "object.omit@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"on-finished": {
 					"from": "on-finished@>=2.3.0 <2.4.0",
@@ -3763,13 +3864,6 @@
 					"version": "0.0.5"
 				},
 				"optimist": {
-					"dependencies": {
-						"minimist": {
-							"from": "minimist@>=0.0.1 <0.1.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-							"version": "0.0.10"
-						}
-					},
 					"from": "optimist@>=0.6.1 <0.7.0",
 					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 					"version": "0.6.1"
@@ -3792,7 +3886,7 @@
 					"version": "0.0.6"
 				},
 				"os-homedir": {
-					"from": "os-homedir@>=1.0.1 <2.0.0",
+					"from": "os-homedir@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"version": "1.0.2"
 				},
@@ -3812,7 +3906,7 @@
 					"version": "1.0.2"
 				},
 				"osenv": {
-					"from": "osenv@>=0.1.3 <0.2.0",
+					"from": "osenv@>=0.0.0 <1.0.0",
 					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
 					"version": "0.1.3"
 				},
@@ -3851,10 +3945,15 @@
 					"resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
 					"version": "1.0.1"
 				},
+				"path-dirname": {
+					"from": "path-dirname@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+					"version": "1.0.2"
+				},
 				"path-exists": {
-					"from": "path-exists@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "path-exists@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
@@ -3921,6 +4020,11 @@
 					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 					"version": "1.0.2"
 				},
+				"punycode": {
+					"from": "punycode@>=1.4.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"version": "1.4.1"
+				},
 				"q": {
 					"from": "q@>=0.9.6 <0.10.0",
 					"resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
@@ -3932,14 +4036,14 @@
 					"version": "1.1.5"
 				},
 				"qs": {
-					"from": "qs@>=6.2.0 <6.3.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-					"version": "6.2.1"
+					"from": "qs@>=6.3.0 <6.4.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+					"version": "6.3.0"
 				},
 				"randomatic": {
 					"from": "randomatic@>=1.1.3 <2.0.0",
-					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-					"version": "1.1.5"
+					"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+					"version": "1.1.6"
 				},
 				"range-parser": {
 					"from": "range-parser@>=1.2.0 <2.0.0",
@@ -3957,16 +4061,9 @@
 					"version": "0.1.9"
 				},
 				"rcloader": {
-					"dependencies": {
-						"lodash": {
-							"from": "lodash@>=2.4.1 <2.5.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-							"version": "2.4.2"
-						}
-					},
-					"from": "rcloader@0.1.2",
-					"resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
-					"version": "0.1.2"
+					"from": "rcloader@>=0.2.2 <0.3.0",
+					"resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.2.2.tgz",
+					"version": "0.2.2"
 				},
 				"read-pkg": {
 					"from": "read-pkg@>=1.0.0 <2.0.0",
@@ -3992,8 +4089,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "readdirp@>=2.0.0 <3.0.0",
@@ -4007,13 +4104,13 @@
 				},
 				"regenerate": {
 					"from": "regenerate@>=1.2.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.1.tgz",
-					"version": "1.3.1"
+					"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+					"version": "1.3.2"
 				},
 				"regenerator-runtime": {
 					"from": "regenerator-runtime@>=0.9.5 <0.10.0",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-					"version": "0.9.5"
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+					"version": "0.9.6"
 				},
 				"regex-cache": {
 					"from": "regex-cache@>=0.4.2 <0.5.0",
@@ -4035,6 +4132,11 @@
 					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 					"version": "0.1.5"
 				},
+				"remove-trailing-separator": {
+					"from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+					"version": "1.0.1"
+				},
 				"repeat-element": {
 					"from": "repeat-element@>=1.1.2 <2.0.0",
 					"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
@@ -4042,13 +4144,13 @@
 				},
 				"repeat-string": {
 					"from": "repeat-string@>=1.5.2 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-					"version": "1.5.4"
+					"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+					"version": "1.6.1"
 				},
 				"repeating": {
-					"from": "repeating@>=1.1.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-					"version": "1.1.3"
+					"from": "repeating@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"replace-ext": {
 					"from": "replace-ext@0.0.1",
@@ -4064,8 +4166,8 @@
 						},
 						"readable-stream": {
 							"from": "readable-stream@>=2.0.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-							"version": "2.1.5"
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "replacestream@>=4.0.0 <5.0.0",
@@ -4074,8 +4176,8 @@
 				},
 				"request": {
 					"from": "request@>=2.61.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
-					"version": "2.75.0"
+					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+					"version": "2.79.0"
 				},
 				"require-directory": {
 					"from": "require-directory@>=2.1.1 <3.0.0",
@@ -4113,6 +4215,11 @@
 					"from": "resolve-from@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
 					"version": "1.0.1"
+				},
+				"resolve-url": {
+					"from": "resolve-url@>=0.2.1 <0.3.0",
+					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+					"version": "0.2.1"
 				},
 				"right-align": {
 					"from": "right-align@>=0.1.1 <0.2.0",
@@ -4236,14 +4343,9 @@
 					"version": "1.0.1"
 				},
 				"setprototypeof": {
-					"from": "setprototypeof@1.0.1",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
-					"version": "1.0.1"
-				},
-				"shebang-regex": {
-					"from": "shebang-regex@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-					"version": "1.0.0"
+					"from": "setprototypeof@1.0.2",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"shelljs": {
 					"from": "shelljs@>=0.3.0 <0.4.0",
@@ -4276,12 +4378,34 @@
 					"version": "1.0.9"
 				},
 				"socket.io": {
+					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						}
+					},
 					"from": "socket.io@1.4.7",
 					"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.7.tgz",
 					"version": "1.4.7"
 				},
 				"socket.io-adapter": {
 					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
+						},
 						"socket.io-parser": {
 							"dependencies": {
 								"debug": {
@@ -4305,6 +4429,16 @@
 							"from": "component-emitter@1.2.0",
 							"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
 							"version": "1.2.0"
+						},
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
 						}
 					},
 					"from": "socket.io-client@1.4.6",
@@ -4313,10 +4447,20 @@
 				},
 				"socket.io-parser": {
 					"dependencies": {
+						"debug": {
+							"from": "debug@2.2.0",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+							"version": "2.2.0"
+						},
 						"json3": {
 							"from": "json3@3.3.2",
 							"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
 							"version": "3.3.2"
+						},
+						"ms": {
+							"from": "ms@0.7.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+							"version": "0.7.1"
 						}
 					},
 					"from": "socket.io-parser@2.2.6",
@@ -4328,10 +4472,20 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
 					"version": "0.5.6"
 				},
+				"source-map-resolve": {
+					"from": "source-map-resolve@>=0.3.0 <0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+					"version": "0.3.1"
+				},
 				"source-map-support": {
 					"from": "source-map-support@>=0.4.2 <0.5.0",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.3.tgz",
-					"version": "0.4.3"
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
+					"version": "0.4.6"
+				},
+				"source-map-url": {
+					"from": "source-map-url@>=0.3.0 <0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+					"version": "0.3.0"
 				},
 				"soyparser": {
 					"from": "soyparser@>=0.2.2 <0.3.0",
@@ -4355,8 +4509,8 @@
 				},
 				"spdx-expression-parse": {
 					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
-					"version": "1.0.3"
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+					"version": "1.0.4"
 				},
 				"spdx-license-ids": {
 					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
@@ -4381,9 +4535,9 @@
 					"version": "1.10.1"
 				},
 				"statuses": {
-					"from": "statuses@>=1.3.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-					"version": "1.3.0"
+					"from": "statuses@>=1.3.1 <2.0.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+					"version": "1.3.1"
 				},
 				"stdin": {
 					"from": "stdin@*",
@@ -4472,11 +4626,6 @@
 				},
 				"tar-stream": {
 					"dependencies": {
-						"bl": {
-							"from": "bl@>=0.9.0 <0.10.0",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-							"version": "0.9.5"
-						},
 						"end-of-stream": {
 							"from": "end-of-stream@>=1.0.0 <2.0.0",
 							"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
@@ -4510,9 +4659,9 @@
 					"version": "0.8.3"
 				},
 				"ternary-stream": {
-					"from": "ternary-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-					"version": "2.0.0"
+					"from": "ternary-stream@>=2.0.1 <3.0.0",
+					"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+					"version": "2.0.1"
 				},
 				"text-table": {
 					"from": "text-table@>=0.2.0 <0.3.0",
@@ -4537,14 +4686,14 @@
 							"version": "1.0.0"
 						},
 						"readable-stream": {
-							"from": "readable-stream@>=2.0.0 <2.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-							"version": "2.0.6"
+							"from": "readable-stream@>=2.1.5 <3.0.0",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+							"version": "2.2.2"
 						}
 					},
 					"from": "through2@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-					"version": "2.0.1"
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"through2-filter": {
 					"from": "through2-filter@>=2.0.0 <3.0.0",
@@ -4583,8 +4732,8 @@
 				},
 				"tough-cookie": {
 					"from": "tough-cookie@>=2.3.0 <2.4.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-					"version": "2.3.1"
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+					"version": "2.3.2"
 				},
 				"trim-newlines": {
 					"from": "trim-newlines@>=1.0.0 <2.0.0",
@@ -4625,8 +4774,8 @@
 				},
 				"type-is": {
 					"from": "type-is@>=1.6.13 <1.7.0",
-					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-					"version": "1.6.13"
+					"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+					"version": "1.6.14"
 				},
 				"typedarray": {
 					"from": "typedarray@>=0.0.5 <0.1.0",
@@ -4702,10 +4851,10 @@
 					"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 					"version": "1.0.0"
 				},
-				"user-home": {
-					"from": "user-home@>=1.1.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-					"version": "1.1.1"
+				"urix": {
+					"from": "urix@>=0.1.0 <0.2.0",
+					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+					"version": "0.1.0"
 				},
 				"useragent": {
 					"dependencies": {
@@ -4745,6 +4894,11 @@
 					"from": "utils-merge@1.0.0",
 					"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
 					"version": "1.0.0"
+				},
+				"uuid": {
+					"from": "uuid@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"version": "3.0.1"
 				},
 				"vali-date": {
 					"from": "vali-date@>=1.0.0 <2.0.0",
@@ -4802,11 +4956,6 @@
 							"from": "aws-sign2@>=0.5.0 <0.6.0",
 							"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
 							"version": "0.5.0"
-						},
-						"bl": {
-							"from": "bl@>=0.9.0 <0.10.0",
-							"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-							"version": "0.9.5"
 						},
 						"bluebird": {
 							"from": "bluebird@>=2.9.30 <3.0.0",
@@ -4870,6 +5019,11 @@
 							"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
 							"version": "2.0.14"
 						},
+						"node-uuid": {
+							"from": "node-uuid@>=1.4.0 <1.5.0",
+							"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+							"version": "1.4.7"
+						},
 						"oauth-sign": {
 							"from": "oauth-sign@>=0.6.0 <0.7.0",
 							"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
@@ -4885,11 +5039,6 @@
 							"resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
 							"version": "2.4.2"
 						},
-						"readable-stream": {
-							"from": "readable-stream@>=1.0.26 <1.1.0",
-							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-							"version": "1.0.34"
-						},
 						"request": {
 							"from": "request@>=2.55.0 <2.56.0",
 							"resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
@@ -4901,9 +5050,9 @@
 					"version": "0.3.12"
 				},
 				"which": {
-					"from": "which@>=1.2.10 <2.0.0",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-					"version": "1.2.11"
+					"from": "which@>=1.2.12 <2.0.0",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+					"version": "1.2.12"
 				},
 				"which-module": {
 					"from": "which-module@>=1.0.0 <2.0.0",
@@ -4927,8 +5076,8 @@
 				},
 				"wrap-ansi": {
 					"from": "wrap-ansi@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-					"version": "2.0.0"
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"wrappy": {
 					"from": "wrappy@>=1.0.0 <2.0.0",
@@ -4946,7 +5095,7 @@
 					"version": "1.5.1"
 				},
 				"xtend": {
-					"from": "xtend@>=4.0.0 <4.1.0",
+					"from": "xtend@>=4.0.1 <4.1.0",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 					"version": "4.0.1"
 				},
@@ -5001,8 +5150,8 @@
 				}
 			},
 			"from": "gulp-metal@>=1.9.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.9.8.tgz",
-			"version": "1.9.8"
+			"resolved": "https://registry.npmjs.org/gulp-metal/-/gulp-metal-1.9.13.tgz",
+			"version": "1.9.13"
 		},
 		"gulp-sass": {
 			"from": "gulp-sass@>=2.1.1 <3.0.0",
@@ -5059,6 +5208,11 @@
 			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
 			"version": "2.16.3"
 		},
+		"homedir-polyfill": {
+			"from": "homedir-polyfill@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+			"version": "1.0.1"
+		},
 		"hosted-git-info": {
 			"from": "hosted-git-info@>=2.1.4 <3.0.0",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
@@ -5086,8 +5240,8 @@
 		},
 		"inflight": {
 			"from": "inflight@>=1.0.4 <2.0.0",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-			"version": "1.0.5"
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"version": "1.0.6"
 		},
 		"inherits": {
 			"from": "inherits@>=2.0.1 <2.1.0",
@@ -5110,16 +5264,9 @@
 			"version": "1.0.0"
 		},
 		"is-absolute": {
-			"dependencies": {
-				"is-windows": {
-					"from": "is-windows@>=0.1.1 <0.2.0",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
-					"version": "0.1.1"
-				}
-			},
 			"from": "is-absolute@>=0.2.3 <0.3.0",
-			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
-			"version": "0.2.5"
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+			"version": "0.2.6"
 		},
 		"is-arrayish": {
 			"from": "is-arrayish@>=0.2.1 <0.3.0",
@@ -5191,11 +5338,6 @@
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"version": "1.0.1"
 		},
-		"is-plain-obj": {
-			"from": "is-plain-obj@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"version": "1.1.0"
-		},
 		"is-posix-bracket": {
 			"from": "is-posix-bracket@>=0.1.0 <0.2.0",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -5238,8 +5380,8 @@
 		},
 		"is-unc-path": {
 			"from": "is-unc-path@>=0.1.1 <0.2.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.1.tgz",
-			"version": "0.1.1"
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+			"version": "0.1.2"
 		},
 		"is-utf8": {
 			"from": "is-utf8@>=0.2.0 <0.3.0",
@@ -5330,13 +5472,13 @@
 		},
 		"kind-of": {
 			"from": "kind-of@>=3.0.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-			"version": "3.0.4"
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+			"version": "3.1.0"
 		},
 		"klaw": {
 			"from": "klaw@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
-			"version": "1.3.0"
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"version": "1.3.1"
 		},
 		"latest-version": {
 			"from": "latest-version@>=2.0.0 <3.0.0",
@@ -5365,13 +5507,13 @@
 		},
 		"liferay-frontend-theme-styled": {
 			"from": "liferay-frontend-theme-styled@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.13.tgz",
-			"version": "2.0.13"
+			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.18.tgz",
+			"version": "2.0.18"
 		},
 		"liferay-frontend-theme-unstyled": {
 			"from": "liferay-frontend-theme-unstyled@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.0.13.tgz",
-			"version": "2.0.13"
+			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.0.18.tgz",
+			"version": "2.0.18"
 		},
 		"liferay-module-config-generator": {
 			"dependencies": {
@@ -5401,16 +5543,26 @@
 			"version": "1.0.0"
 		},
 		"liferay-theme-es2015-hook": {
-			"from": "liferay-theme-es2015-hook@>=0.0.1 <0.0.2",
-			"resolved": "https://registry.npmjs.org/liferay-theme-es2015-hook/-/liferay-theme-es2015-hook-0.0.1.tgz",
-			"version": "0.0.1"
+			"from": "liferay-theme-es2015-hook@>=0.1.0 <0.2.0",
+			"resolved": "https://registry.npmjs.org/liferay-theme-es2015-hook/-/liferay-theme-es2015-hook-0.1.0.tgz",
+			"version": "0.1.0"
 		},
 		"liferay-theme-tasks": {
 			"dependencies": {
+				"acorn": {
+					"from": "acorn@>=4.0.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
+					"version": "4.0.3"
+				},
 				"amdefine": {
 					"from": "amdefine@>=0.0.4",
 					"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
 					"version": "1.0.0"
+				},
+				"ansi-align": {
+					"from": "ansi-align@>=1.1.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"ansi-escapes": {
 					"from": "ansi-escapes@>=1.1.0 <2.0.0",
@@ -5439,8 +5591,8 @@
 				},
 				"argparse": {
 					"from": "argparse@>=1.0.7 <2.0.0",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-					"version": "1.0.7"
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+					"version": "1.0.9"
 				},
 				"arr-diff": {
 					"from": "arr-diff@>=2.0.0 <3.0.0",
@@ -5459,8 +5611,8 @@
 				},
 				"array-find-index": {
 					"from": "array-find-index@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"array-union": {
 					"from": "array-union@>=1.0.1 <2.0.0",
@@ -5486,6 +5638,11 @@
 					"from": "async@>=0.9.0 <0.10.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
 					"version": "0.9.2"
+				},
+				"atob": {
+					"from": "atob@>=1.1.0 <1.2.0",
+					"resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+					"version": "1.1.3"
 				},
 				"balanced-match": {
 					"from": "balanced-match@>=0.4.1 <0.5.0",
@@ -5518,6 +5675,18 @@
 					"from": "bourbon@4.2.3",
 					"resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.3.tgz",
 					"version": "4.2.3"
+				},
+				"boxen": {
+					"dependencies": {
+						"object-assign": {
+							"from": "object-assign@>=4.0.1 <5.0.0",
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+							"version": "4.1.0"
+						}
+					},
+					"from": "boxen@>=0.6.0 <0.7.0",
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+					"version": "0.6.0"
 				},
 				"brace-expansion": {
 					"from": "brace-expansion@>=1.0.0 <2.0.0",
@@ -5569,6 +5738,11 @@
 					"resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
 					"version": "0.4.5"
 				},
+				"cli-boxes": {
+					"from": "cli-boxes@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+					"version": "1.0.0"
+				},
 				"cli-color": {
 					"from": "cli-color@>=0.2.2 <0.3.0",
 					"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
@@ -5601,13 +5775,13 @@
 				},
 				"code-point-at": {
 					"from": "code-point-at@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"coffee-script": {
 					"from": "coffee-script@>=1.10.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-					"version": "1.10.0"
+					"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+					"version": "1.11.1"
 				},
 				"compass-mixins": {
 					"from": "compass-mixins@>=0.12.8 <0.13.0",
@@ -5644,9 +5818,9 @@
 							"version": "4.1.0"
 						}
 					},
-					"from": "configstore@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-					"version": "1.4.0"
+					"from": "configstore@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+					"version": "2.1.0"
 				},
 				"content-formatter": {
 					"from": "content-formatter@>=1.1.0 <2.0.0",
@@ -5681,7 +5855,7 @@
 					"version": "1.0.3"
 				},
 				"convert-source-map": {
-					"from": "convert-source-map@>=1.1.1 <2.0.0",
+					"from": "convert-source-map@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
 					"version": "1.3.0"
 				},
@@ -5707,8 +5881,13 @@
 				},
 				"cson-parser": {
 					"from": "cson-parser@>=1.0.9 <2.0.0",
-					"resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.3.tgz",
-					"version": "1.3.3"
+					"resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.4.tgz",
+					"version": "1.3.4"
+				},
+				"css": {
+					"from": "css@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+					"version": "2.2.1"
 				},
 				"css-stringify": {
 					"from": "css-stringify@>=1.4.0 <1.5.0",
@@ -5729,6 +5908,18 @@
 					"from": "debug@>=2.1.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
 					"version": "2.2.0"
+				},
+				"debug-fabulous": {
+					"dependencies": {
+						"object-assign": {
+							"from": "object-assign@4.1.0",
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+							"version": "4.1.0"
+						}
+					},
+					"from": "debug-fabulous@>=0.0.0 <0.1.0",
+					"resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+					"version": "0.0.4"
 				},
 				"decamelize": {
 					"from": "decamelize@>=1.1.2 <2.0.0",
@@ -5782,10 +5973,20 @@
 					"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
 					"version": "0.1.0"
 				},
+				"detect-newline": {
+					"from": "detect-newline@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+					"version": "2.1.0"
+				},
 				"diff": {
 					"from": "diff@>=1.4.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
 					"version": "1.4.0"
+				},
+				"dot-prop": {
+					"from": "dot-prop@>=3.0.0 <4.0.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+					"version": "3.0.0"
 				},
 				"drip": {
 					"from": "drip@>=1.4.0 <2.0.0",
@@ -5828,8 +6029,8 @@
 						}
 					},
 					"from": "duplexify@>=3.2.0 <4.0.0",
-					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz",
-					"version": "3.4.5"
+					"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.6.tgz",
+					"version": "3.4.6"
 				},
 				"each-async": {
 					"from": "each-async@>=1.0.0 <2.0.0",
@@ -5945,6 +6146,11 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 					"version": "2.2.3"
 				},
+				"filled-array": {
+					"from": "filled-array@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+					"version": "1.1.0"
+				},
 				"find-index": {
 					"from": "find-index@>=0.1.1 <0.2.0",
 					"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
@@ -5973,16 +6179,9 @@
 					"version": "0.2.1"
 				},
 				"fined": {
-					"dependencies": {
-						"lodash.isarray": {
-							"from": "lodash.isarray@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-							"version": "4.0.0"
-						}
-					},
 					"from": "fined@>=1.0.1 <2.0.0",
-					"resolved": "https://registry.npmjs.org/fined/-/fined-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/fined/-/fined-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"first-chunk-stream": {
 					"from": "first-chunk-stream@>=1.0.0 <2.0.0",
@@ -6036,8 +6235,8 @@
 				},
 				"glob": {
 					"from": "glob@>=3.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-					"version": "7.0.6"
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"version": "7.1.1"
 				},
 				"glob-base": {
 					"from": "glob-base@>=0.3.0 <0.4.0",
@@ -6164,8 +6363,8 @@
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.6.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-							"version": "4.15.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
 					"from": "gogo-shell@*",
@@ -6191,8 +6390,8 @@
 				},
 				"graceful-fs": {
 					"from": "graceful-fs@>=4.1.2 <5.0.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-					"version": "4.1.6"
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+					"version": "4.1.9"
 				},
 				"gulp": {
 					"dependencies": {
@@ -6409,8 +6608,8 @@
 						}
 					},
 					"from": "gulp-sourcemaps@>=1.2.8 <2.0.0",
-					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-					"version": "1.6.0"
+					"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.8.1.tgz",
+					"version": "1.8.1"
 				},
 				"gulp-storage": {
 					"dependencies": {
@@ -6578,8 +6777,8 @@
 				},
 				"inflight": {
 					"from": "inflight@>=1.0.4 <2.0.0",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-					"version": "1.0.5"
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"version": "1.0.6"
 				},
 				"inherits": {
 					"from": "inherits@>=2.0.0 <3.0.0",
@@ -6595,8 +6794,8 @@
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.3.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-							"version": "4.15.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
 					"from": "inquirer@>=0.12.0 <0.13.0",
@@ -6614,16 +6813,9 @@
 					"version": "1.2.0"
 				},
 				"is-absolute": {
-					"dependencies": {
-						"is-windows": {
-							"from": "is-windows@>=0.1.1 <0.2.0",
-							"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
-							"version": "0.1.1"
-						}
-					},
 					"from": "is-absolute@>=0.2.3 <0.3.0",
-					"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.5.tgz",
-					"version": "0.2.5"
+					"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+					"version": "0.2.6"
 				},
 				"is-arrayish": {
 					"from": "is-arrayish@>=0.2.1 <0.3.0",
@@ -6662,8 +6854,8 @@
 				},
 				"is-finite": {
 					"from": "is-finite@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"is-fullwidth-code-point": {
 					"from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
@@ -6684,6 +6876,11 @@
 					"from": "is-number@>=2.1.0 <3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 					"version": "2.1.0"
+				},
+				"is-obj": {
+					"from": "is-obj@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"is-path-cwd": {
 					"from": "is-path-cwd@>=1.0.0 <2.0.0",
@@ -6786,9 +6983,26 @@
 					"version": "3.0.4"
 				},
 				"latest-version": {
-					"from": "latest-version@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
-					"version": "1.0.1"
+					"dependencies": {
+						"package-json": {
+							"from": "package-json@>=2.0.0 <3.0.0",
+							"resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+							"version": "2.4.0"
+						}
+					},
+					"from": "latest-version@>=2.0.0 <3.0.0",
+					"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+					"version": "2.0.0"
+				},
+				"lazy-debug-legacy": {
+					"from": "lazy-debug-legacy@>=0.0.0 <0.1.0",
+					"resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+					"version": "0.0.1"
+				},
+				"lazy-req": {
+					"from": "lazy-req@>=1.1.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"liferay-css-parse": {
 					"from": "liferay-css-parse@>=1.7.1 <1.8.0",
@@ -6799,13 +7013,13 @@
 					"dependencies": {
 						"async": {
 							"from": "async@>=2.0.0-rc.2 <3.0.0",
-							"resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-							"version": "2.0.1"
+							"resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
+							"version": "2.1.2"
 						},
 						"lodash": {
 							"from": "lodash@>=4.6.1 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-							"version": "4.15.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
 					"from": "liferay-plugin-node-tasks@>=1.0.9 <2.0.0",
@@ -6821,8 +7035,8 @@
 					"dependencies": {
 						"findup-sync": {
 							"from": "findup-sync@>=0.4.2 <0.5.0",
-							"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.2.tgz",
-							"version": "0.4.2"
+							"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+							"version": "0.4.3"
 						}
 					},
 					"from": "liftoff@>=2.1.0 <3.0.0",
@@ -7125,14 +7339,14 @@
 					"version": "2.3.11"
 				},
 				"mime-db": {
-					"from": "mime-db@>=1.23.0 <1.24.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-					"version": "1.23.0"
+					"from": "mime-db@>=1.24.0 <1.25.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+					"version": "1.24.0"
 				},
 				"mime-types": {
 					"from": "mime-types@>=2.1.11 <2.2.0",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-					"version": "2.1.11"
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+					"version": "2.1.12"
 				},
 				"mini-lr": {
 					"from": "mini-lr@>=0.1.8 <0.2.0",
@@ -7230,8 +7444,8 @@
 				},
 				"number-is-nan": {
 					"from": "number-is-nan@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"object-assign": {
 					"from": "object-assign@>=3.0.0 <4.0.0",
@@ -7282,8 +7496,8 @@
 				},
 				"os-homedir": {
 					"from": "os-homedir@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"os-shim": {
 					"from": "os-shim@>=0.1.2 <0.2.0",
@@ -7292,8 +7506,8 @@
 				},
 				"os-tmpdir": {
 					"from": "os-tmpdir@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-					"version": "1.0.1"
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"version": "1.0.2"
 				},
 				"osenv": {
 					"from": "osenv@>=0.1.3 <0.2.0",
@@ -7339,8 +7553,8 @@
 				},
 				"path-is-absolute": {
 					"from": "path-is-absolute@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"version": "1.0.1"
 				},
 				"path-is-inside": {
 					"from": "path-is-inside@>=1.0.1 <2.0.0",
@@ -7503,6 +7717,11 @@
 					"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 					"version": "0.4.3"
 				},
+				"registry-auth-token": {
+					"from": "registry-auth-token@>=3.0.1 <4.0.0",
+					"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.0.1.tgz",
+					"version": "3.0.1"
+				},
 				"registry-url": {
 					"from": "registry-url@>=3.0.3 <4.0.0",
 					"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
@@ -7542,6 +7761,11 @@
 					"from": "resolve-dir@>=0.1.0 <0.2.0",
 					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
 					"version": "0.1.1"
+				},
+				"resolve-url": {
+					"from": "resolve-url@>=0.2.1 <0.3.0",
+					"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+					"version": "0.2.1"
 				},
 				"restore-cursor": {
 					"from": "restore-cursor@>=1.0.1 <2.0.0",
@@ -7618,6 +7842,16 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
 					"version": "0.1.43"
 				},
+				"source-map-resolve": {
+					"from": "source-map-resolve@>=0.3.0 <0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+					"version": "0.3.1"
+				},
+				"source-map-url": {
+					"from": "source-map-url@>=0.3.0 <0.4.0",
+					"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+					"version": "0.3.0"
+				},
 				"sparkles": {
 					"from": "sparkles@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
@@ -7635,8 +7869,8 @@
 				},
 				"spdx-expression-parse": {
 					"from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.3.tgz",
-					"version": "1.0.3"
+					"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+					"version": "1.0.4"
 				},
 				"spdx-license-ids": {
 					"from": "spdx-license-ids@>=1.0.2 <2.0.0",
@@ -7672,11 +7906,6 @@
 					"from": "stream-shift@>=1.0.0 <2.0.0",
 					"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
 					"version": "1.0.0"
-				},
-				"string-length": {
-					"from": "string-length@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-					"version": "1.0.1"
 				},
 				"string-sub": {
 					"from": "string-sub@0.0.1",
@@ -7811,16 +8040,14 @@
 					"version": "1.0.1"
 				},
 				"update-notifier": {
-					"dependencies": {
-						"repeating": {
-							"from": "repeating@>=1.1.2 <2.0.0",
-							"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-							"version": "1.1.3"
-						}
-					},
-					"from": "update-notifier@>=0.5.0 <0.6.0",
-					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
-					"version": "0.5.0"
+					"from": "update-notifier@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.2.tgz",
+					"version": "1.0.2"
+				},
+				"urix": {
+					"from": "urix@>=0.1.0 <0.2.0",
+					"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+					"version": "0.1.0"
 				},
 				"url-parse-lax": {
 					"from": "url-parse-lax@>=1.0.0 <2.0.0",
@@ -7839,8 +8066,8 @@
 				},
 				"uuid": {
 					"from": "uuid@>=2.0.1 <3.0.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.2.tgz",
-					"version": "2.0.2"
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+					"version": "2.0.3"
 				},
 				"v8flags": {
 					"from": "v8flags@>=2.0.2 <3.0.0",
@@ -7936,6 +8163,11 @@
 					"resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
 					"version": "1.2.11"
 				},
+				"widest-line": {
+					"from": "widest-line@>=1.0.0 <2.0.0",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+					"version": "1.0.0"
+				},
 				"wordwrap": {
 					"from": "wordwrap@>=0.0.2 <0.1.0",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -7965,8 +8197,8 @@
 					"dependencies": {
 						"lodash": {
 							"from": "lodash@>=4.0.0 <5.0.0",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-							"version": "4.15.0"
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+							"version": "4.16.4"
 						}
 					},
 					"from": "xmlbuilder@>=4.1.0 <5.0.0",
@@ -7990,8 +8222,8 @@
 				}
 			},
 			"from": "liferay-theme-tasks@*",
-			"resolved": "https://registry.npmjs.org/liferay-theme-tasks/-/liferay-theme-tasks-1.3.9.tgz",
-			"version": "1.3.9"
+			"resolved": "https://registry.npmjs.org/liferay-theme-tasks/-/liferay-theme-tasks-1.3.10.tgz",
+			"version": "1.3.10"
 		},
 		"liftoff": {
 			"from": "liftoff@>=2.1.0 <3.0.0",
@@ -8167,23 +8399,23 @@
 		},
 		"metal": {
 			"from": "metal@>=2.2.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal/-/metal-2.4.7.tgz",
-			"version": "2.4.7"
+			"resolved": "https://registry.npmjs.org/metal/-/metal-2.5.12.tgz",
+			"version": "2.5.12"
 		},
 		"metal-dom": {
 			"from": "metal-dom@>=2.4.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.4.7.tgz",
-			"version": "2.4.7"
+			"resolved": "https://registry.npmjs.org/metal-dom/-/metal-dom-2.5.16.tgz",
+			"version": "2.5.16"
 		},
 		"metal-events": {
-			"from": "metal-events@>=2.4.7 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-2.4.7.tgz",
-			"version": "2.4.7"
+			"from": "metal-events@>=2.5.16 <3.0.0",
+			"resolved": "https://registry.npmjs.org/metal-events/-/metal-events-2.5.16.tgz",
+			"version": "2.5.16"
 		},
 		"metal-state": {
 			"from": "metal-state@>=2.3.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.4.7.tgz",
-			"version": "2.4.7"
+			"resolved": "https://registry.npmjs.org/metal-state/-/metal-state-2.5.16.tgz",
+			"version": "2.5.16"
 		},
 		"micromatch": {
 			"from": "micromatch@>=2.3.7 <3.0.0",
@@ -8191,14 +8423,14 @@
 			"version": "2.3.11"
 		},
 		"mime-db": {
-			"from": "mime-db@>=1.24.0 <1.25.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-			"version": "1.24.0"
+			"from": "mime-db@>=1.25.0 <1.26.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+			"version": "1.25.0"
 		},
 		"mime-types": {
 			"from": "mime-types@>=2.1.7 <2.2.0",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-			"version": "2.1.12"
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+			"version": "2.1.13"
 		},
 		"minimatch": {
 			"from": "minimatch@>=2.0.1 <3.0.0",
@@ -8223,9 +8455,9 @@
 			"version": "0.5.1"
 		},
 		"ms": {
-			"from": "ms@0.7.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-			"version": "0.7.1"
+			"from": "ms@0.7.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+			"version": "0.7.2"
 		},
 		"multipipe": {
 			"from": "multipipe@>=0.1.2 <0.2.0",
@@ -8246,8 +8478,8 @@
 			"dependencies": {
 				"glob": {
 					"from": "glob@>=7.0.3 <8.0.0",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-					"version": "7.1.0"
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"version": "7.1.1"
 				},
 				"minimatch": {
 					"from": "minimatch@>=3.0.2 <4.0.0",
@@ -8273,45 +8505,33 @@
 				},
 				"glob": {
 					"from": "glob@>=7.0.3 <8.0.0",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-					"version": "7.1.0"
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"version": "7.1.1"
 				},
 				"globule": {
-					"dependencies": {
-						"glob": {
-							"from": "glob@>=7.0.3 <7.1.0",
-							"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-							"version": "7.0.6"
-						}
-					},
 					"from": "globule@>=1.0.0 <2.0.0",
-					"resolved": "https://registry.npmjs.org/globule/-/globule-1.0.0.tgz",
-					"version": "1.0.0"
+					"resolved": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
+					"version": "1.1.0"
 				},
 				"lodash": {
-					"from": "lodash@>=4.9.0 <4.10.0",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.9.0.tgz",
-					"version": "4.9.0"
+					"from": "lodash@>=4.16.4 <4.17.0",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+					"version": "4.16.6"
 				},
 				"minimatch": {
-					"from": "minimatch@>=3.0.0 <3.1.0",
+					"from": "minimatch@>=3.0.2 <3.1.0",
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 					"version": "3.0.3"
 				}
 			},
 			"from": "node-sass@>=3.4.2 <4.0.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.10.1.tgz",
-			"version": "3.10.1"
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
+			"version": "3.13.1"
 		},
 		"node-status-codes": {
 			"from": "node-status-codes@>=1.0.0 <2.0.0",
 			"resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
 			"version": "1.0.0"
-		},
-		"node-uuid": {
-			"from": "node-uuid@>=1.4.7 <1.5.0",
-			"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-			"version": "1.4.7"
 		},
 		"nopt": {
 			"from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
@@ -8334,9 +8554,26 @@
 			"version": "0.1.2"
 		},
 		"npmlog": {
+			"dependencies": {
+				"gauge": {
+					"from": "gauge@>=2.7.1 <2.8.0",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
+					"version": "2.7.2"
+				},
+				"object-assign": {
+					"from": "object-assign@>=4.1.0 <5.0.0",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+					"version": "4.1.0"
+				},
+				"supports-color": {
+					"from": "supports-color@>=0.2.0 <0.3.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+					"version": "0.2.0"
+				}
+			},
 			"from": "npmlog@>=4.0.0 <5.0.0",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
-			"version": "4.0.0"
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+			"version": "4.0.2"
 		},
 		"num2fraction": {
 			"from": "num2fraction@>=1.2.2 <2.0.0",
@@ -8360,8 +8597,8 @@
 		},
 		"object.omit": {
 			"from": "object.omit@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"version": "2.0.1"
 		},
 		"once": {
 			"from": "once@>=1.3.0 <1.4.0",
@@ -8370,8 +8607,8 @@
 		},
 		"orchestrator": {
 			"from": "orchestrator@>=0.3.0 <0.4.0",
-			"resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-			"version": "0.3.7"
+			"resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+			"version": "0.3.8"
 		},
 		"ordered-read-streams": {
 			"from": "ordered-read-streams@>=0.1.0 <0.2.0",
@@ -8394,9 +8631,9 @@
 			"version": "1.0.2"
 		},
 		"osenv": {
-			"from": "osenv@>=0.1.3 <0.2.0",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-			"version": "0.1.3"
+			"from": "osenv@>=0.0.0 <1.0.0",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+			"version": "0.1.4"
 		},
 		"package-json": {
 			"dependencies": {
@@ -8429,6 +8666,11 @@
 			"from": "parse-json@>=2.2.0 <3.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"version": "2.2.0"
+		},
+		"parse-passwd": {
+			"from": "parse-passwd@>=1.0.0 <2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"version": "1.0.0"
 		},
 		"path-array": {
 			"from": "path-array@>=1.0.0 <2.0.0",
@@ -8484,8 +8726,8 @@
 				}
 			},
 			"from": "postcss@>=5.0.4 <6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.4.tgz",
-			"version": "5.2.4"
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.6.tgz",
+			"version": "5.2.6"
 		},
 		"postcss-value-parser": {
 			"from": "postcss-value-parser@>=3.2.3 <4.0.0",
@@ -8504,8 +8746,8 @@
 		},
 		"pretty-hrtime": {
 			"from": "pretty-hrtime@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
-			"version": "1.0.2"
+			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+			"version": "1.0.3"
 		},
 		"private": {
 			"from": "private@>=0.1.5 <0.2.0",
@@ -8527,15 +8769,20 @@
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 			"version": "1.0.2"
 		},
+		"punycode": {
+			"from": "punycode@>=1.4.1 <2.0.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+			"version": "1.4.1"
+		},
 		"qs": {
-			"from": "qs@>=6.2.0 <6.3.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-			"version": "6.2.1"
+			"from": "qs@>=6.3.0 <6.4.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+			"version": "6.3.0"
 		},
 		"randomatic": {
 			"from": "randomatic@>=1.1.3 <2.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-			"version": "1.1.5"
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+			"version": "1.1.6"
 		},
 		"rc": {
 			"from": "rc@>=1.1.6 <2.0.0",
@@ -8551,8 +8798,8 @@
 				},
 				"readable-stream": {
 					"from": "readable-stream@>=2.0.0 <3.0.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-					"version": "2.1.5"
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+					"version": "2.2.2"
 				}
 			},
 			"from": "read-all-stream@>=3.0.0 <4.0.0",
@@ -8603,8 +8850,8 @@
 		},
 		"registry-auth-token": {
 			"from": "registry-auth-token@>=3.0.1 <4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.0.1.tgz",
-			"version": "3.0.1"
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
+			"version": "3.1.0"
 		},
 		"registry-url": {
 			"from": "registry-url@>=3.0.3 <4.0.0",
@@ -8618,8 +8865,8 @@
 		},
 		"repeat-string": {
 			"from": "repeat-string@>=1.5.2 <2.0.0",
-			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-			"version": "1.5.4"
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"version": "1.6.1"
 		},
 		"repeating": {
 			"from": "repeating@>=2.0.0 <3.0.0",
@@ -8633,8 +8880,8 @@
 		},
 		"request": {
 			"from": "request@>=2.61.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
-			"version": "2.75.0"
+			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+			"version": "2.79.0"
 		},
 		"require-directory": {
 			"from": "require-directory@>=2.1.1 <3.0.0",
@@ -8648,8 +8895,8 @@
 		},
 		"resolve": {
 			"from": "resolve@>=1.1.7 <2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"version": "1.1.7"
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
+			"version": "1.2.0"
 		},
 		"resolve-dir": {
 			"from": "resolve-dir@>=0.1.0 <0.2.0",
@@ -8660,8 +8907,8 @@
 			"dependencies": {
 				"glob": {
 					"from": "glob@>=7.0.5 <8.0.0",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-					"version": "7.1.0"
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"version": "7.1.1"
 				},
 				"minimatch": {
 					"from": "minimatch@>=3.0.2 <4.0.0",
@@ -8682,13 +8929,13 @@
 			"dependencies": {
 				"glob": {
 					"from": "glob@>=7.0.0 <8.0.0",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
-					"version": "7.1.0"
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+					"version": "7.1.1"
 				},
 				"lodash": {
 					"from": "lodash@>=4.0.0 <5.0.0",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
-					"version": "4.16.4"
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
+					"version": "4.17.2"
 				},
 				"minimatch": {
 					"from": "minimatch@>=3.0.2 <4.0.0",
@@ -8734,8 +8981,8 @@
 		},
 		"signal-exit": {
 			"from": "signal-exit@>=3.0.0 <4.0.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
-			"version": "3.0.1"
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"version": "3.0.2"
 		},
 		"slide": {
 			"from": "slide@>=1.1.5 <2.0.0",
@@ -8842,14 +9089,14 @@
 					"version": "1.0.0"
 				},
 				"readable-stream": {
-					"from": "readable-stream@>=2.0.0 <2.1.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-					"version": "2.0.6"
+					"from": "readable-stream@>=2.1.5 <3.0.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+					"version": "2.2.2"
 				}
 			},
 			"from": "through2@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-			"version": "2.0.1"
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"version": "2.0.3"
 		},
 		"tildify": {
 			"from": "tildify@>=1.0.0 <2.0.0",
@@ -8862,14 +9109,14 @@
 			"version": "1.0.1"
 		},
 		"timed-out": {
-			"from": "timed-out@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-			"version": "2.0.0"
+			"from": "timed-out@>=3.0.0 <4.0.0",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.0.tgz",
+			"version": "3.1.0"
 		},
 		"tough-cookie": {
 			"from": "tough-cookie@>=2.3.0 <2.4.0",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-			"version": "2.3.1"
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+			"version": "2.3.2"
 		},
 		"trim-newlines": {
 			"from": "trim-newlines@>=1.0.0 <2.0.0",
@@ -8883,8 +9130,8 @@
 		},
 		"tweetnacl": {
 			"from": "tweetnacl@>=0.14.0 <0.15.0",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-			"version": "0.14.3"
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"version": "0.14.5"
 		},
 		"unc-path-regex": {
 			"from": "unc-path-regex@>=0.1.0 <0.2.0",
@@ -8907,9 +9154,9 @@
 			"version": "1.0.0"
 		},
 		"unzip-response": {
-			"from": "unzip-response@>=1.0.0 <2.0.0",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz",
-			"version": "1.0.1"
+			"from": "unzip-response@>=1.0.2 <2.0.0",
+			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+			"version": "1.0.2"
 		},
 		"upath": {
 			"dependencies": {
@@ -8944,9 +9191,9 @@
 			"version": "1.0.2"
 		},
 		"uuid": {
-			"from": "uuid@>=2.0.1 <3.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-			"version": "2.0.3"
+			"from": "uuid@>=3.0.0 <4.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+			"version": "3.0.1"
 		},
 		"v8flags": {
 			"from": "v8flags@>=2.0.2 <3.0.0",
@@ -9021,9 +9268,9 @@
 			"version": "0.0.10"
 		},
 		"which": {
-			"from": "which@>=1.2.10 <2.0.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-			"version": "1.2.11"
+			"from": "which@>=1.2.12 <2.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+			"version": "1.2.12"
 		},
 		"which-module": {
 			"from": "which-module@>=1.0.0 <2.0.0",
@@ -9047,8 +9294,8 @@
 		},
 		"wrap-ansi": {
 			"from": "wrap-ansi@>=2.0.0 <3.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.0.0.tgz",
-			"version": "2.0.0"
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"version": "2.1.0"
 		},
 		"wrappy": {
 			"from": "wrappy@>=1.0.0 <2.0.0",
@@ -9066,7 +9313,7 @@
 			"version": "2.0.0"
 		},
 		"xtend": {
-			"from": "xtend@>=4.0.0 <4.1.0",
+			"from": "xtend@>=4.0.1 <4.1.0",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"version": "4.0.1"
 		},

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/package.json
@@ -12,7 +12,7 @@
 		"metal-state": "^2.3.0"
 	},
 	"devDependencies": {
-		"liferay-theme-es2015-hook": "^0.0.1"
+		"liferay-theme-es2015-hook": "^0.1.0"
 	},
 	"keywords": [
 		"liferay-theme"

--- a/modules/apps/frontend-theme-porygon/frontend-theme-porygon/src/WEB-INF/liferay-plugin-package.properties
+++ b/modules/apps/frontend-theme-porygon/frontend-theme-porygon/src/WEB-INF/liferay-plugin-package.properties
@@ -8,6 +8,5 @@ module-group-id=liferay
 module-incremental-version=1
 name=Porygon
 page-url=http://www.liferay.com
-Provide-Capability=osgi.webresource;osgi.webresource=porygon-theme
 short-description=
 tags=


### PR DESCRIPTION
Hey Brian,

This removes the need for developers to add the `Provide-Capability` to the `plugin-package.properties` file in order to get modules working.

After discussing it with @Robert-Frampton, we decided to go with this since it better matches the gradle build process and it hides the implementation-specific details from the rest of the code.

Let me know if you still think we should do something else.

Thanks!