### PR TITLE
LPS-68471 Partially revert dee25ffad12f719c7f07158634dc73d586c6df49, …

### DIFF
--- a/util-taglib/src/com/liferay/taglib/util/ParamTag.java
+++ b/util-taglib/src/com/liferay/taglib/util/ParamTag.java
@@ -20,9 +20,7 @@ import javax.servlet.jsp.JspException;
 
 /**
  * @author     Brian Wing Shun Chan
- * @deprecated As of 7.0.0, with no direct replacement
  */
-@Deprecated
 public class ParamTag extends TagSupport {
 
 	@Override


### PR DESCRIPTION
…can not deprecated ParamTag, it is still used by <portlet:param>

CC @jonmak08