### PR TITLE
[See desc] LPS-69861 Blogs JAX-RS API - Initial Commit

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-rest/bnd.bnd
+++ b/modules/apps/collaboration/blogs/blogs-rest/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Blogs REST
+Bundle-SymbolicName: com.liferay.blogs.rest
+Bundle-Version: 1.0.0

--- a/modules/apps/collaboration/blogs/blogs-rest/build.gradle
+++ b/modules/apps/collaboration/blogs/blogs-rest/build.gradle
@@ -1,0 +1,5 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+dependencies {
+}

--- a/modules/apps/collaboration/blogs/blogs-rest/build.gradle
+++ b/modules/apps/collaboration/blogs/blogs-rest/build.gradle
@@ -2,4 +2,6 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
+	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
+	provided group: "org.apache.cxf", name: "cxf-rt-rs-extension-providers", version: "3.0.3"
 }

--- a/modules/apps/collaboration/blogs/blogs-rest/build.gradle
+++ b/modules/apps/collaboration/blogs/blogs-rest/build.gradle
@@ -3,5 +3,6 @@ targetCompatibility = "1.8"
 
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.2.0"
 	provided group: "org.apache.cxf", name: "cxf-rt-rs-extension-providers", version: "3.0.3"
 }

--- a/modules/apps/collaboration/blogs/blogs-rest/build.gradle
+++ b/modules/apps/collaboration/blogs/blogs-rest/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.2.0"
 	provided group: "org.apache.cxf", name: "cxf-rt-rs-extension-providers", version: "3.0.3"
+	provided project(":apps:collaboration:blogs:blogs-api")
 }

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/BlogsJaxRsApplication.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/BlogsJaxRsApplication.java
@@ -29,7 +29,8 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alejandro Hernández
  */
-@ApplicationPath("/") @Component(immediate = true, service = Application.class)
+@ApplicationPath("/")
+@Component(immediate = true, service = Application.class)
 public class BlogsJaxRsApplication extends Application {
 
 	@Override

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/BlogsJaxRsApplication.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/BlogsJaxRsApplication.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.rest.internal;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Alejandro Hernández
+ */
+@ApplicationPath("/") @Component(immediate = true, service = Application.class)
+public class BlogsJaxRsApplication extends Application {
+}

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/BlogsJaxRsApplication.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/BlogsJaxRsApplication.java
@@ -14,7 +14,7 @@
 
 package com.liferay.blogs.rest.internal;
 
-import com.liferay.blogs.rest.internal.resources.BlogsRestRootResource;
+import com.liferay.blogs.rest.internal.resources.BlogsRootResource;
 import com.liferay.portal.kernel.util.SetUtil;
 
 import java.util.Collections;
@@ -36,10 +36,10 @@ public class BlogsJaxRsApplication extends Application {
 	@Override
 	public Set<Object> getSingletons() {
 		return SetUtil.fromCollection(
-			Collections.singletonList(_blogsRestRootResource));
+			Collections.singletonList(_blogsRootResource));
 	}
 
 	@Reference
-	private BlogsRestRootResource _blogsRestRootResource;
+	private BlogsRootResource _blogsRootResource;
 
 }

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/repr/BlogsEntryRepr.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/repr/BlogsEntryRepr.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.blogs.rest.internal.repr;
+
+import com.liferay.blogs.model.BlogsEntry;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Alejandro Hernández
+ */
+@XmlRootElement
+public class BlogsEntryRepr {
+
+	public BlogsEntryRepr() {
+	}
+
+	public BlogsEntryRepr(BlogsEntry blogsEntry) {
+		_title = blogsEntry.getTitle();
+		_content = blogsEntry.getContent();
+		_entryId = blogsEntry.getEntryId();
+	}
+
+	public String getContent() {
+		return _content;
+	}
+
+	@XmlElement(name = "id")
+	public long getEntryId() {
+		return _entryId;
+	}
+
+	public String getTitle() {
+		return _title;
+	}
+
+	public void setContent(String content) {
+		_content = content;
+	}
+
+	public void setEntryId(long entryId) {
+		_entryId = entryId;
+	}
+
+	public void setTitle(String title) {
+		_title = title;
+	}
+
+	private String _content;
+	private long _entryId;
+	private String _title;
+
+}

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/repr/BlogsEntryRepr.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/repr/BlogsEntryRepr.java
@@ -16,7 +16,6 @@ package com.liferay.blogs.rest.internal.repr;
 
 import com.liferay.blogs.model.BlogsEntry;
 
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -28,17 +27,16 @@ public class BlogsEntryRepr {
 	public BlogsEntryRepr() {
 	}
 
-	public BlogsEntryRepr(BlogsEntry blogsEntry) {
-		_title = blogsEntry.getTitle();
-		_content = blogsEntry.getContent();
-		_entryId = blogsEntry.getEntryId();
+	public BlogsEntryRepr(BlogsEntry entry) {
+		_content = entry.getContent();
+		_entryId = entry.getEntryId();
+		_title = entry.getTitle();
 	}
 
 	public String getContent() {
 		return _content;
 	}
 
-	@XmlElement(name = "id")
 	public long getEntryId() {
 		return _entryId;
 	}

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsEntryResource.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsEntryResource.java
@@ -26,17 +26,17 @@ import javax.ws.rs.Produces;
  */
 public class BlogsEntryResource {
 
-	public BlogsEntryResource(BlogsEntry blogsEntry) {
-		_blogsEntry = blogsEntry;
+	public BlogsEntryResource(BlogsEntry entry) {
+		_entry = entry;
 	}
 
 	@GET
 	@Path("/")
 	@Produces("application/json")
-	public BlogsEntryRepr getBlogsEntry() {
-		return new BlogsEntryRepr(_blogsEntry);
+	public BlogsEntryRepr getEntry() {
+		return new BlogsEntryRepr(_entry);
 	}
 
-	private final BlogsEntry _blogsEntry;
+	private final BlogsEntry _entry;
 
 }

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsEntryResource.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsEntryResource.java
@@ -15,33 +15,16 @@
 package com.liferay.blogs.rest.internal.resources;
 
 import com.liferay.blogs.model.BlogsEntry;
-import com.liferay.blogs.service.BlogsEntryService;
-import com.liferay.portal.kernel.exception.PortalException;
-
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Hernández
  */
-@Component(immediate = true, service = BlogsRestRootResource.class)
-@Path("/")
-public class BlogsRestRootResource {
+public class BlogsEntryResource {
 
-	@Path("/{entryId}")
-	public BlogsEntryResource getEntryResource(
-			@PathParam("entryId") long entryId)
-		throws PortalException {
-
-		BlogsEntry blogsEntry = _blogsEntryService.getEntry(entryId);
-
-		return new BlogsEntryResource(blogsEntry);
+	public BlogsEntryResource(BlogsEntry blogsEntry) {
+		_blogsEntry = blogsEntry;
 	}
 
-	@Reference
-	private BlogsEntryService _blogsEntryService;
+	private final BlogsEntry _blogsEntry;
 
 }

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsEntryResource.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsEntryResource.java
@@ -15,6 +15,11 @@
 package com.liferay.blogs.rest.internal.resources;
 
 import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.blogs.rest.internal.repr.BlogsEntryRepr;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 /**
  * @author Alejandro Hernández
@@ -23,6 +28,13 @@ public class BlogsEntryResource {
 
 	public BlogsEntryResource(BlogsEntry blogsEntry) {
 		_blogsEntry = blogsEntry;
+	}
+
+	@GET
+	@Path("/")
+	@Produces("application/json")
+	public BlogsEntryRepr getBlogsEntry() {
+		return new BlogsEntryRepr(_blogsEntry);
 	}
 
 	private final BlogsEntry _blogsEntry;

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRestRootResource.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRestRootResource.java
@@ -38,16 +38,16 @@ public class BlogsRestRootResource {
 			@PathParam("entryId") long entryId)
 		throws PortalException {
 
-		BlogsEntry blogsEntry = null;
+		BlogsEntry entry = null;
 
 		try {
-			blogsEntry = _blogsEntryService.getEntry(entryId);
+			entry = _blogsEntryService.getEntry(entryId);
 		}
 		catch (NoSuchEntryException nsee) {
 			throw new NotFoundException();
 		}
 
-		return new BlogsEntryResource(blogsEntry);
+		return new BlogsEntryResource(entry);
 	}
 
 	@Reference

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRestRootResource.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRestRootResource.java
@@ -12,33 +12,16 @@
  * details.
  */
 
-package com.liferay.blogs.rest.internal;
+package com.liferay.blogs.rest.internal.resources;
 
-import com.liferay.blogs.rest.internal.resources.BlogsRestRootResource;
-import com.liferay.portal.kernel.util.SetUtil;
-
-import java.util.Collections;
-import java.util.Set;
-
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import javax.ws.rs.Path;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Hernández
  */
-@ApplicationPath("/") @Component(immediate = true, service = Application.class)
-public class BlogsJaxRsApplication extends Application {
-
-	@Override
-	public Set<Object> getSingletons() {
-		return SetUtil.fromCollection(
-			Collections.singletonList(_blogsRestRootResource));
-	}
-
-	@Reference
-	private BlogsRestRootResource _blogsRestRootResource;
-
+@Component(immediate = true, service = BlogsRestRootResource.class)
+@Path("/")
+public class BlogsRestRootResource {
 }

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRestRootResource.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRestRootResource.java
@@ -14,10 +14,12 @@
 
 package com.liferay.blogs.rest.internal.resources;
 
+import com.liferay.blogs.exception.NoSuchEntryException;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
@@ -36,7 +38,14 @@ public class BlogsRestRootResource {
 			@PathParam("entryId") long entryId)
 		throws PortalException {
 
-		BlogsEntry blogsEntry = _blogsEntryService.getEntry(entryId);
+		BlogsEntry blogsEntry = null;
+
+		try {
+			blogsEntry = _blogsEntryService.getEntry(entryId);
+		}
+		catch (NoSuchEntryException nsee) {
+			throw new NotFoundException();
+		}
 
 		return new BlogsEntryResource(blogsEntry);
 	}

--- a/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRootResource.java
+++ b/modules/apps/collaboration/blogs/blogs-rest/src/main/java/com/liferay/blogs/rest/internal/resources/BlogsRootResource.java
@@ -29,9 +29,9 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Alejandro Hernández
  */
-@Component(immediate = true, service = BlogsRestRootResource.class)
+@Component(immediate = true, service = BlogsRootResource.class)
 @Path("/")
-public class BlogsRestRootResource {
+public class BlogsRootResource {
 
 	@Path("/{entryId}")
 	public BlogsEntryResource getEntryResource(


### PR DESCRIPTION
Hey Brian,

This is the fist pull we send you to create a REST JAX-RS Api for Blogs. Let us know if there's anything you'd like us to clarify. 
There's a brief explanation about this pull next from @ahdezma:

Creation of a REST API for Liferay Blogs using JAX-RS as the main Framework.
Code has been separated in three layers:

- Application:  core of the module. This class holds the providers, writers, readers and resources used in the API -> **BlogsJaxRsApplication.java**

- Resources: the different endpoints are defined in this classes. There is always a "root" resource which defines partial paths to all the different sub-resources. This sub-resources are modular pieces that can be used anywhere across our module. A good example of this concept is a "blog-entry" sub-resource, which receives a blog entry and holds all its operation endpoints -> **BlogsRootResource.java, BlogsEntryResource.java**

- Representations: the data layer, this classes serve as a proxy for the model classes. Use annotation such as JAXB or Jackson in order to transform models into its JSON representation -> **BlogsEntryRepr.java**