### PR TITLE
LPS-64631 Blogs -  Error messages on maximum cover image size are inconsistent

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/BlogsItemSelectorHelper.java
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/BlogsItemSelectorHelper.java
@@ -24,6 +24,7 @@ import com.liferay.item.selector.criteria.upload.criterion.UploadItemSelectorCri
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,7 +85,9 @@ public class BlogsItemSelectorHelper {
 		UploadItemSelectorCriterion uploadItemSelectorCriterion =
 			new UploadItemSelectorCriterion(
 				uploadURL.toString(),
-				LanguageUtil.get(themeDisplay.getLocale(), "blog-images"));
+				LanguageUtil.get(themeDisplay.getLocale(), "blog-images"),
+				PropsValues.BLOGS_IMAGE_MAX_SIZE);
+		
 
 		uploadItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			uploadCriterionDesiredItemSelectorReturnTypes);


### PR DESCRIPTION
Fixed to reflect correct/consistent Message

Test Environment:
Tomcat : 8.x
MySql : 5.7
IE/Mozilla Firefox/Google Chrome

