### PR TITLE
LPS-60894 Make string representation of Query instances more informative for debugging purposes

### DIFF
--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 988c1a97ddb4b3a8ed02ef878db70a47a961e934
+	commit = 633631437f438b80737d6590b22cf28272c782e0
 	mode = push
-	parent = c983311996c0f505ab88d92368d614c6647dd6e9
+	parent = f54aed66b42c0d39f78a021a30b02180f51e34cd
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4fbb95b4b1653e8be50d4b095898b25621ec0aab
+	commit = d5755c008265b1a1f48c3166bbeaccdf3e4d5944
 	mode = push
-	parent = be4453af6b1a175c742fc1a2043567f4909742a9
+	parent = 9aa5c366bd409119f0fa585f1bc650e4a2c95382
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/BooleanQueryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/BooleanQueryImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.query.FieldQueryFactoryUtil;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -364,7 +365,19 @@ public class BooleanQueryImpl extends BaseBooleanQueryImpl {
 
 	@Override
 	public String toString() {
-		return "{booleanClauses=" + _booleanClauses + "}";
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("{booleanClauses=");
+		sb.append(_booleanClauses);
+		sb.append(", className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final List<BooleanClause<Query>> _booleanClauses =

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/BooleanQueryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/BooleanQueryImpl.java
@@ -362,6 +362,11 @@ public class BooleanQueryImpl extends BaseBooleanQueryImpl {
 		return !_booleanClauses.isEmpty();
 	}
 
+	@Override
+	public String toString() {
+		return "{booleanClauses=" + _booleanClauses + "}";
+	}
+
 	private final List<BooleanClause<Query>> _booleanClauses =
 		new ArrayList<>();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/DisMaxQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/DisMaxQuery.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.search.generic;
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -55,6 +56,19 @@ public class DisMaxQuery extends BaseQueryImpl {
 
 	public void setTieBreaker(Float tieBreaker) {
 		_tieBreaker = tieBreaker;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("{tieBreaker=");
+		sb.append(_tieBreaker);
+		sb.append(", queries=");
+		sb.append(_queries);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final Set<Query> _queries = new HashSet<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/DisMaxQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/DisMaxQuery.java
@@ -60,12 +60,18 @@ public class DisMaxQuery extends BaseQueryImpl {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(7);
 
-		sb.append("{tieBreaker=");
-		sb.append(_tieBreaker);
+		sb.append("{className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
 		sb.append(", queries=");
 		sb.append(_queries);
+		sb.append(", tieBreaker=");
+		sb.append(_tieBreaker);
 		sb.append("}");
 
 		return sb.toString();

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/FuzzyQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/FuzzyQuery.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.search.generic;
 
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 /**
  * @author Michael C. Han
@@ -70,6 +71,21 @@ public class FuzzyQuery extends BaseQueryImpl {
 
 	public void setPrefixLength(Integer prefixLength) {
 		_prefixLength = prefixLength;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(7);
+
+		sb.append("{field=");
+		sb.append(_field);
+		sb.append(", fuzziness=");
+		sb.append(_fuzziness);
+		sb.append(", value=");
+		sb.append(_value);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final String _field;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/FuzzyQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/FuzzyQuery.java
@@ -75,12 +75,24 @@ public class FuzzyQuery extends BaseQueryImpl {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(7);
+		StringBundler sb = new StringBundler(15);
 
-		sb.append("{field=");
+		sb.append("{className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", field=");
 		sb.append(_field);
 		sb.append(", fuzziness=");
 		sb.append(_fuzziness);
+		sb.append(", maxEdits=");
+		sb.append(_maxEdits);
+		sb.append(", maxExpansions=");
+		sb.append(_maxExpansions);
+		sb.append(", prefixLength=");
+		sb.append(_prefixLength);
 		sb.append(", value=");
 		sb.append(_value);
 		sb.append("}");

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MatchAllQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MatchAllQuery.java
@@ -27,4 +27,11 @@ public class MatchAllQuery extends BaseQueryImpl {
 		return queryVisitor.visitQuery(this);
 	}
 
+	@Override
+	public String toString() {
+		Class<?> clazz = getClass();
+
+		return "{className=" + clazz.getSimpleName() + "}";
+	}
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MatchQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MatchQuery.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.search.generic;
 
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 /**
  * @author Michael C. Han
@@ -142,6 +143,25 @@ public class MatchQuery extends BaseQueryImpl {
 
 	public void setZeroTermsQuery(ZeroTermsQuery zeroTermsQuery) {
 		_zeroTermsQuery = zeroTermsQuery;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(11);
+
+		sb.append("{analyzer=");
+		sb.append(_analyzer);
+		sb.append(", field=");
+		sb.append(_field);
+		sb.append(", operator=");
+		sb.append(_operator);
+		sb.append(", type=");
+		sb.append(_type);
+		sb.append(", value=");
+		sb.append(_value);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	public enum Operator {

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MatchQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MatchQuery.java
@@ -147,14 +147,36 @@ public class MatchQuery extends BaseQueryImpl {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(11);
+		StringBundler sb = new StringBundler(29);
 
 		sb.append("{analyzer=");
 		sb.append(_analyzer);
+		sb.append(", className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", cutOffFrequency=");
+		sb.append(_cutOffFrequency);
 		sb.append(", field=");
 		sb.append(_field);
+		sb.append(", fuzziness=");
+		sb.append(_fuzziness);
+		sb.append(", fuzzyTranspositions=");
+		sb.append(_fuzzyTranspositions);
+		sb.append(", lenient=");
+		sb.append(_lenient);
+		sb.append(", maxExpansions=");
+		sb.append(_maxExpansions);
+		sb.append(", minShouldMatch=");
+		sb.append(_minShouldMatch);
 		sb.append(", operator=");
 		sb.append(_operator);
+		sb.append(", prefixLength=");
+		sb.append(_prefixLength);
+		sb.append(", slop=");
+		sb.append(_slop);
 		sb.append(", type=");
 		sb.append(_type);
 		sb.append(", value=");

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MoreLikeThisQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MoreLikeThisQuery.java
@@ -198,18 +198,44 @@ public class MoreLikeThisQuery extends BaseQueryImpl {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(13);
+		StringBundler sb = new StringBundler(35);
 
 		sb.append("{analyzer=");
 		sb.append(_analyzer);
+		sb.append(", className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", companyId=");
+		sb.append(_companyId);
 		sb.append(", documentUIDs=");
 		sb.append(_documentUIDs);
 		sb.append(", fields=");
 		sb.append(_fields);
+		sb.append(", includeInput=");
+		sb.append(_includeInput);
 		sb.append(", likeText=");
 		sb.append(_likeText);
+		sb.append(", maxDocFrequency=");
+		sb.append(_maxDocFrequency);
+		sb.append(", maxQueryTerms=");
+		sb.append(_maxQueryTerms);
+		sb.append(", maxWordLength=");
+		sb.append(_maxWordLength);
+		sb.append(", minDocFrequency=");
+		sb.append(_minDocFrequency);
+		sb.append(", minShouldMatch=");
+		sb.append(_minShouldMatch);
+		sb.append(", minTermFrequency=");
+		sb.append(_minTermFrequency);
+		sb.append(", minWordLength=");
+		sb.append(_minWordLength);
 		sb.append(", stopWords=");
 		sb.append(_stopWords);
+		sb.append(", termBoost=");
+		sb.append(_termBoost);
 		sb.append(", type=");
 		sb.append(_type);
 		sb.append("}");

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MoreLikeThisQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MoreLikeThisQuery.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.search.generic;
 
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -193,6 +194,27 @@ public class MoreLikeThisQuery extends BaseQueryImpl {
 
 	public void setType(String type) {
 		_type = type;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(13);
+
+		sb.append("{analyzer=");
+		sb.append(_analyzer);
+		sb.append(", documentUIDs=");
+		sb.append(_documentUIDs);
+		sb.append(", fields=");
+		sb.append(_fields);
+		sb.append(", likeText=");
+		sb.append(_likeText);
+		sb.append(", stopWords=");
+		sb.append(_stopWords);
+		sb.append(", type=");
+		sb.append(_type);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private String _analyzer;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MultiMatchQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MultiMatchQuery.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.search.generic;
 
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -174,6 +175,25 @@ public class MultiMatchQuery extends BaseQueryImpl {
 
 	public void setZeroTermsQuery(MatchQuery.ZeroTermsQuery zeroTermsQuery) {
 		_zeroTermsQuery = zeroTermsQuery;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(11);
+
+		sb.append("{analyzer=");
+		sb.append(_analyzer);
+		sb.append(", fields=");
+		sb.append(_fields);
+		sb.append(", operator=");
+		sb.append(_operator);
+		sb.append(", type=");
+		sb.append(_type);
+		sb.append(", value=");
+		sb.append(_value);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	public enum Type {

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/MultiMatchQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/MultiMatchQuery.java
@@ -179,14 +179,36 @@ public class MultiMatchQuery extends BaseQueryImpl {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(11);
+		StringBundler sb = new StringBundler(29);
 
 		sb.append("{analyzer=");
 		sb.append(_analyzer);
+		sb.append(", className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", cutOffFrequency=");
+		sb.append(_cutOffFrequency);
 		sb.append(", fields=");
 		sb.append(_fields);
+		sb.append(", fuzziness=");
+		sb.append(_fuzziness);
+		sb.append(", lenient=");
+		sb.append(_lenient);
+		sb.append(", maxExpansions=");
+		sb.append(_maxExpansions);
+		sb.append(", minShouldMatch=");
+		sb.append(_minShouldMatch);
 		sb.append(", operator=");
 		sb.append(_operator);
+		sb.append(", prefixLength=");
+		sb.append(_prefixLength);
+		sb.append(", slop=");
+		sb.append(_slop);
+		sb.append(", tieBreaker=");
+		sb.append(_tieBreaker);
 		sb.append(", type=");
 		sb.append(_type);
 		sb.append(", value=");

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/NestedQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/NestedQuery.java
@@ -53,9 +53,15 @@ public class NestedQuery extends BaseQueryImpl {
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(5);
+		StringBundler sb = new StringBundler(7);
 
-		sb.append("{path=");
+		sb.append("{className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", path=");
 		sb.append(_path);
 		sb.append(", query=");
 		sb.append(_query);

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/NestedQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/NestedQuery.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.search.generic;
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 /**
  * @author Michael C. Han
@@ -48,6 +49,19 @@ public class NestedQuery extends BaseQueryImpl {
 		}
 
 		return false;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("{path=");
+		sb.append(_path);
+		sb.append(", query=");
+		sb.append(_query);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final String _path;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/QueryTermImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/QueryTermImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.search.generic;
 
 import com.liferay.portal.kernel.search.QueryTerm;
+import com.liferay.portal.kernel.util.StringBundler;
 
 /**
  * @author Michael C. Han
@@ -34,6 +35,19 @@ public class QueryTermImpl implements QueryTerm {
 	@Override
 	public String getValue() {
 		return _value;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("{field=");
+		sb.append(_field);
+		sb.append(", value=");
+		sb.append(_value);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final String _field;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/StringQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/StringQuery.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.search.generic;
 
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.util.StringBundler;
 
 /**
  * @author Bruno Farache
@@ -32,7 +33,19 @@ public class StringQuery extends BaseQueryImpl implements Query {
 
 	@Override
 	public String toString() {
-		return _query;
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("{className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", query=");
+		sb.append(_query);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final String _query;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/TermQueryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/TermQueryImpl.java
@@ -42,6 +42,11 @@ public class TermQueryImpl extends BaseQueryImpl implements TermQuery {
 		return _queryTerm;
 	}
 
+	@Override
+	public String toString() {
+		return "{queryTerm=" + _queryTerm + "}";
+	}
+
 	private final QueryTerm _queryTerm;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/TermQueryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/TermQueryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.TermQuery;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 /**
  * @author Michael C. Han
@@ -44,7 +45,19 @@ public class TermQueryImpl extends BaseQueryImpl implements TermQuery {
 
 	@Override
 	public String toString() {
-		return "{queryTerm=" + _queryTerm + "}";
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("{className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", queryTerm=");
+		sb.append(_queryTerm);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final QueryTerm _queryTerm;

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/TermRangeQueryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/TermRangeQueryImpl.java
@@ -69,10 +69,17 @@ public class TermRangeQueryImpl
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(7);
+		StringBundler sb = new StringBundler(15);
 
+		sb.append("{className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", field=");
 		sb.append(_field);
-		sb.append(CharPool.COLON);
+		sb.append(", range=");
 
 		if (_includesLower) {
 			sb.append(CharPool.OPEN_BRACKET);
@@ -103,6 +110,8 @@ public class TermRangeQueryImpl
 		else {
 			sb.append(CharPool.CLOSE_CURLY_BRACE);
 		}
+
+		sb.append("}");
 
 		return sb.toString();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/WildcardQueryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/WildcardQueryImpl.java
@@ -42,6 +42,11 @@ public class WildcardQueryImpl extends BaseQueryImpl implements WildcardQuery {
 		return _queryTerm;
 	}
 
+	@Override
+	public String toString() {
+		return "{queryTerm=" + _queryTerm + "}";
+	}
+
 	private final QueryTerm _queryTerm;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/WildcardQueryImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/WildcardQueryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.QueryTerm;
 import com.liferay.portal.kernel.search.WildcardQuery;
 import com.liferay.portal.kernel.search.query.QueryVisitor;
+import com.liferay.portal.kernel.util.StringBundler;
 
 /**
  * @author Michael C. Han
@@ -44,7 +45,19 @@ public class WildcardQueryImpl extends BaseQueryImpl implements WildcardQuery {
 
 	@Override
 	public String toString() {
-		return "{queryTerm=" + _queryTerm + "}";
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("{className=");
+
+		Class<?> clazz = getClass();
+
+		sb.append(clazz.getSimpleName());
+
+		sb.append(", queryTerm=");
+		sb.append(_queryTerm);
+		sb.append("}");
+
+		return sb.toString();
 	}
 
 	private final QueryTerm _queryTerm;


### PR DESCRIPTION
Re-sending, addressing https://github.com/brianchandotcom/liferay-portal/pull/45861#issuecomment-269733495. Sorted all keys in toString methods, adding the className as a key like the others. Thanks!

(Curious.... any reason there isn't a simple, concise `StringUtil.concat` varargs method?)

`return StringUtil.concat("{className=", className, ", queryTerm=", _queryTerm, "}");`

Author: @Preston-Crary 
Reviewer: @arboliveira

cc @brandizzi

https://issues.liferay.com/browse/LPS-60894
