### PR TITLE
LPS-69294 Use externally accessible URLs 

### DIFF
--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d5755c008265b1a1f48c3166bbeaccdf3e4d5944
+	commit = d73f9a00f4c154bcbf14b33865e2fe9fa7fcabc4
 	mode = push
-	parent = 9aa5c366bd409119f0fa585f1bc650e4a2c95382
+	parent = 8206b5686e9ccd3db1cb6434140538b40a24b6fc
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/build-buildscript.gradle
+++ b/modules/build-buildscript.gradle
@@ -3,6 +3,7 @@ dependencies {
 	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.lang.merger", version: "1.0.3"
 	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.maven.plugin.builder", version: "1.0.12"
 	classpath group: "com.liferay", name: "org.ysb33r.gradle.gradletest", version: "1.0-beta3"
+	classpath group: "de.undercouch", name: "gradle-download-task", version: "3.1.1"
 	classpath group: "xalan", name: "xalan", version: "2.7.2"
 }
 

--- a/modules/sdk/gradle-plugins-workspace/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/build.gradle
@@ -1,20 +1,36 @@
-import com.liferay.gradle.util.FileUtil
 import com.liferay.gradle.util.copy.StripPathSegmentsAction
+import de.undercouch.gradle.tasks.download.Download
 
+apply plugin: "de.undercouch.download"
 apply plugin: "org.ysb33r.gradletest"
 
 task copyDistBundleZipPluginsSdk(type: Copy)
+task downloadPluginsSdk(type: Download)
 task copyGradleTestDependencies(type: Copy)
 
+String bundleUrl = "https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.2%20GA3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip"
+String pluginsSdkUrl = "https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.0.2%20GA3/com.liferay.portal.plugins.sdk-7.0-ga3-20160804222206210.zip"
+
+if (System.properties["http.proxyHost"] == "squid.lax.liferay.com") {
+	bundleUrl = "http://mirrors.liferay.com/releases.liferay.com/portal/7.0.2-ga3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip"
+	pluginsSdkUrl = "http://mirrors.liferay.com/releases.liferay.com/portal/7.0.2-ga3/com.liferay.portal.plugins.sdk-7.0-ga3-20160804222206210.zip"
+}
+
 copyDistBundleZipPluginsSdk {
+	dependsOn downloadPluginsSdk
 	eachFile new StripPathSegmentsAction(1)
 
 	from {
-		zipTree(FileUtil.get(project, "http://mirrors.liferay.com/releases.liferay.com/portal/7.0.2-ga3/com.liferay.portal.plugins.sdk-7.0-ga3-20160804222206210.zip"))
+		zipTree(downloadPluginsSdk.dest)
 	}
 
 	includeEmptyDirs = false
 	into "src/gradleTest/distBundleZip/plugins-sdk"
+}
+
+downloadPluginsSdk {
+	dest new File(buildDir, "plugins-sdk.zip")
+	src pluginsSdkUrl
 }
 
 copyGradleTestDependencies {
@@ -35,7 +51,7 @@ gradleTest {
 	dependsOn copyGradleTestDependencies
 	dependsOn jar
 
-	gradleArguments "--project-prop", "liferay.workspace.bundle.url=http://mirrors.liferay.com/releases.liferay.com/portal/7.0.2-ga3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip"
+	gradleArguments "--project-prop", "liferay.workspace.bundle.url=${bundleUrl}"
 	gradleArguments "--project-prop", "pluginClasspathDir=${uri(jar.destinationDir)}"
 
 	versions "2.14.1", "3.0", "3.1", "3.2.1"


### PR DESCRIPTION
Hi,
This commit is a workaround until [LRQA-28338](https://issues.liferay.com/browse/LRQA-28338) is done: I asked QA a way to run the Gradle tests (simple smoke tests on all supported Gradle versions) on our infrastructure, but in the meantime I'm trying to run them on [Codeship](https://codeship.com/).