### PR TITLE
LPS-69383 Extract Captcha to OSGi module

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/build.gradle
+++ b/modules/apps/collaboration/message-boards/message-boards-web/build.gradle
@@ -17,5 +17,6 @@ dependencies {
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:captcha:captcha-taglib")
 	provided project(":apps:foundation:expando:expando-taglib")
 }

--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_category.jsp
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_category.jsp
@@ -207,7 +207,7 @@ if (portletTitleBasedNavigation) {
 				<c:if test="<%= (category == null) && PropsValues.CAPTCHA_CHECK_PORTLET_MESSAGE_BOARDS_EDIT_CATEGORY %>">
 					<portlet:resourceURL id="/message_boards/captcha" var="captchaURL" />
 
-					<liferay-ui:captcha url="<%= captchaURL %>" />
+					<liferay-captcha:captcha url="<%= captchaURL %>" />
 				</c:if>
 			</aui:fieldset>
 

--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -432,7 +432,7 @@ if (portletTitleBasedNavigation) {
 			<c:if test="<%= (message == null) && PropsValues.CAPTCHA_CHECK_PORTLET_MESSAGE_BOARDS_EDIT_MESSAGE %>">
 				<portlet:resourceURL id="/message_boards/captcha" var="captchaURL" />
 
-				<liferay-ui:captcha url="<%= captchaURL %>" />
+				<liferay-captcha:captcha url="<%= captchaURL %>" />
 			</c:if>
 		</aui:fieldset-group>
 

--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/captcha" prefix="liferay-captcha" %><%@
 taglib uri="http://liferay.com/tld/expando" prefix="liferay-expando" %><%@
 taglib uri="http://liferay.com/tld/flags" prefix="liferay-flags" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-captcha/build.gradle
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-captcha/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:forms-and-workflow:dynamic-data-mapping:dynamic-data-mapping-form-field-type")
+	provided project(":apps:foundation:captcha:captcha-taglib")
 }
 
 task wrapSoyTemplates

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-captcha/src/main/java/com/liferay/dynamic/data/mapping/type/captcha/internal/CaptchaDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-type-captcha/src/main/java/com/liferay/dynamic/data/mapping/type/captcha/internal/CaptchaDDMFormFieldTemplateContextContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dynamic.data.mapping.type.captcha.internal;
 
+import com.liferay.captcha.taglib.servlet.taglib.CaptchaTag;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTemplateContextContributor;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
@@ -23,7 +24,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.taglib.servlet.PipingPageContext;
-import com.liferay.taglib.ui.CaptchaTag;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/modules/apps/foundation/captcha/build.gradle
+++ b/modules/apps/foundation/captcha/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+	}
+
+	repositories {
+		mavenLocal()
+
+		maven {
+			url "https://cdn.lfrs.sl/repository.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+configure(subprojects.findAll {!it.childProjects}) {
+	apply plugin: "com.liferay.defaults.plugin"
+}

--- a/modules/apps/foundation/captcha/captcha-api/bnd.bnd
+++ b/modules/apps/foundation/captcha/captcha-api/bnd.bnd
@@ -3,3 +3,6 @@ Bundle-SymbolicName: com.liferay.captcha.api
 Bundle-Version: 1.0.0
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title:
+-includeresource:\
+	@../../../../../lib/portal/jhlabs-filters.jar,\
+	@../../../../../lib/portal/simplecaptcha.jar

--- a/modules/apps/foundation/captcha/captcha-api/bnd.bnd
+++ b/modules/apps/foundation/captcha/captcha-api/bnd.bnd
@@ -1,6 +1,9 @@
 Bundle-Name: Liferay Captcha API
 Bundle-SymbolicName: com.liferay.captcha.api
 Bundle-Version: 1.0.0
+Export-Package:\
+	com.liferay.captcha.recaptcha,\
+	com.liferay.captcha.simplecaptcha
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title:
 -includeresource:\

--- a/modules/apps/foundation/captcha/captcha-api/bnd.bnd
+++ b/modules/apps/foundation/captcha/captcha-api/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Liferay Captcha API
+Bundle-SymbolicName: com.liferay.captcha.api
+Bundle-Version: 1.0.0
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title:

--- a/modules/apps/foundation/captcha/captcha-api/build.gradle
+++ b/modules/apps/foundation/captcha/captcha-api/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+	provided fileTree(dir: "../../../../../lib/portal", includes: ["jhlabs-filters.jar", "simplecaptcha.jar"])
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.4.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.4.0"
+	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
+	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+}

--- a/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/recaptcha/ReCaptchaImpl.java
+++ b/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/recaptcha/ReCaptchaImpl.java
@@ -12,9 +12,10 @@
  * details.
  */
 
-package com.liferay.portal.captcha.recaptcha;
+package com.liferay.captcha.recaptcha;
 
-import com.liferay.portal.captcha.simplecaptcha.SimpleCaptchaImpl;
+import com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl;
+import com.liferay.portal.kernel.captcha.Captcha;
 import com.liferay.portal.kernel.captcha.CaptchaConfigurationException;
 import com.liferay.portal.kernel.captcha.CaptchaException;
 import com.liferay.portal.kernel.captcha.CaptchaTextException;
@@ -47,12 +48,21 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.service.component.annotations.Component;
+
 /**
  * @author Tagnaouti Boubker
  * @author Jorge Ferrer
  * @author Brian Wing Shun Chan
  * @author Daniel Sanz
  */
+@Component(
+	immediate = true,
+	property = {
+		"captcha.engine.impl=com.liferay.captcha.recaptcha.ReCaptchaImpl"
+	},
+	service = Captcha.class
+)
 public class ReCaptchaImpl extends SimpleCaptchaImpl {
 
 	@Override

--- a/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/recaptcha/ReCaptchaImpl.java
+++ b/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/recaptcha/ReCaptchaImpl.java
@@ -196,8 +196,7 @@ public class ReCaptchaImpl extends SimpleCaptchaImpl {
 		return validateChallenge(request);
 	}
 
-	private static final String _TAGLIB_PATH =
-		"/html/taglib/ui/captcha/recaptcha.jsp";
+	private static final String _TAGLIB_PATH = "/captcha/recaptcha.jsp";
 
 	private static final Log _log = LogFactoryUtil.getLog(ReCaptchaImpl.class);
 

--- a/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/DictionaryWordTextProducer.java
+++ b/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/DictionaryWordTextProducer.java
@@ -12,20 +12,20 @@
  * details.
  */
 
-package com.liferay.portal.captcha.simplecaptcha;
+package com.liferay.captcha.simplecaptcha;
 
-import com.liferay.portal.kernel.util.PwdGenerator;
+import com.liferay.portal.kernel.words.WordsUtil;
 
 import nl.captcha.text.producer.TextProducer;
 
 /**
  * @author Brian Wing Shun Chan
  */
-public class PinNumberTextProducer implements TextProducer {
+public class DictionaryWordTextProducer implements TextProducer {
 
 	@Override
 	public String getText() {
-		return PwdGenerator.getPinNumber();
+		return WordsUtil.getRandomWord();
 	}
 
 }

--- a/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/PinNumberTextProducer.java
+++ b/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/PinNumberTextProducer.java
@@ -12,20 +12,20 @@
  * details.
  */
 
-package com.liferay.portal.captcha.simplecaptcha;
+package com.liferay.captcha.simplecaptcha;
 
-import com.liferay.portal.kernel.words.WordsUtil;
+import com.liferay.portal.kernel.util.PwdGenerator;
 
 import nl.captcha.text.producer.TextProducer;
 
 /**
  * @author Brian Wing Shun Chan
  */
-public class DictionaryWordTextProducer implements TextProducer {
+public class PinNumberTextProducer implements TextProducer {
 
 	@Override
 	public String getText() {
-		return WordsUtil.getRandomWord();
+		return PwdGenerator.getPinNumber();
 	}
 
 }

--- a/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
+++ b/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
@@ -503,8 +503,7 @@ public class SimpleCaptchaImpl implements Captcha {
 		return classLoader.loadClass(className);
 	}
 
-	private static final String _TAGLIB_PATH =
-		"/html/taglib/ui/captcha/simplecaptcha.jsp";
+	private static final String _TAGLIB_PATH = "/captcha/simplecaptcha.jsp";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SimpleCaptchaImpl.class);

--- a/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
+++ b/modules/apps/foundation/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.captcha.simplecaptcha;
+package com.liferay.captcha.simplecaptcha;
 
 import com.liferay.portal.kernel.captcha.Captcha;
 import com.liferay.portal.kernel.captcha.CaptchaException;

--- a/modules/apps/foundation/captcha/captcha-taglib/bnd.bnd
+++ b/modules/apps/foundation/captcha/captcha-taglib/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Liferay Captcha Taglib
+Bundle-SymbolicName: com.liferay.captcha.taglib
+Bundle-Version: 1.0.0
+Export-Package: com.liferay.captcha.taglib.servlet.taglib
+Provide-Capability: osgi.extender;osgi.extender="jsp.taglib";uri="http://liferay.com/tld/captcha";version:Version="${Bundle-Version}"
+Web-ContextPath: /captcha-taglib

--- a/modules/apps/foundation/captcha/captcha-taglib/build.gradle
+++ b/modules/apps/foundation/captcha/captcha-taglib/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
+	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
+	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:captcha:captcha-api")
+}

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/internal/servlet/ServletContextUtil.java
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/internal/servlet/ServletContextUtil.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.captcha.taglib.internal.servlet;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Component(immediate = true)
+public class ServletContextUtil {
+
+	public static final ServletContext getServletContext() {
+		return _instance._getServletContext();
+	}
+
+	@Activate
+	protected void activate() {
+		_instance = this;
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_instance = null;
+	}
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.captcha.taglib)",
+		unbind = "-"
+	)
+	protected void setServletContext(ServletContext servletContext) {
+		_servletContext = servletContext;
+	}
+
+	private ServletContext _getServletContext() {
+		return _servletContext;
+	}
+
+	private static ServletContextUtil _instance;
+
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.taglib.ui;
+
+import com.liferay.taglib.util.IncludeTag;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class CaptchaTag extends IncludeTag {
+
+	public void setUrl(String url) {
+		_url = url;
+	}
+
+	@Override
+	protected void cleanUp() {
+		_url = null;
+	}
+
+	@Override
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	@Override
+	protected void setAttributes(HttpServletRequest request) {
+		request.setAttribute("liferay-ui:captcha:url", _url);
+	}
+
+	private static final String _PAGE = "/html/taglib/ui/captcha/page.jsp";
+
+	private String _url;
+
+}

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
@@ -42,7 +42,7 @@ public class CaptchaTag extends IncludeTag {
 		request.setAttribute("liferay-captcha:captcha:url", _url);
 	}
 
-	private static final String _PAGE = "/html/taglib/ui/captcha/page.jsp";
+	private static final String _PAGE = "/captcha/page.jsp";
 
 	private String _url;
 

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.taglib.ui;
+package com.liferay.captcha.taglib.servlet.taglib;
 
 import com.liferay.taglib.util.IncludeTag;
 
@@ -39,7 +39,7 @@ public class CaptchaTag extends IncludeTag {
 
 	@Override
 	protected void setAttributes(HttpServletRequest request) {
-		request.setAttribute("liferay-ui:captcha:url", _url);
+		request.setAttribute("liferay-captcha:captcha:url", _url);
 	}
 
 	private static final String _PAGE = "/html/taglib/ui/captcha/page.jsp";

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/java/com/liferay/captcha/taglib/servlet/taglib/CaptchaTag.java
@@ -14,14 +14,23 @@
 
 package com.liferay.captcha.taglib.servlet.taglib;
 
+import com.liferay.captcha.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.taglib.util.IncludeTag;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.PageContext;
 
 /**
  * @author Brian Wing Shun Chan
  */
 public class CaptchaTag extends IncludeTag {
+
+	@Override
+	public void setPageContext(PageContext pageContext) {
+		super.setPageContext(pageContext);
+
+		setServletContext(ServletContextUtil.getServletContext());
+	}
 
 	public void setUrl(String url) {
 		_url = url;

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/liferay-captcha.tld
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/liferay-captcha.tld
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+
+<taglib
+	version="2.1"
+	xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+>
+	<tlib-version>1.0</tlib-version>
+	<short-name>liferay-captcha</short-name>
+	<uri>http://liferay.com/tld/captcha</uri>
+	<tag>
+		<description>Creates an image CAPTCHA with a corresponding verification input.</description>
+		<name>captcha</name>
+		<tag-class>com.liferay.captcha.taglib.servlet.taglib.CaptchaTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description>The source URL for the image CAPTCHA.</description>
+			<name>url</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+</taglib>

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/init.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/init.jsp
@@ -1,0 +1,30 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/taglib/init.jsp" %>
+
+<%@ page import="com.liferay.portal.kernel.captcha.CaptchaUtil" %>
+
+<%
+boolean captchaEnabled = false;
+
+if (portletRequest != null) {
+	captchaEnabled = CaptchaUtil.isEnabled(portletRequest);
+}
+else {
+	captchaEnabled = CaptchaUtil.isEnabled(request);
+}
+%>

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/init.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/init.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/taglib/init.jsp" %>
+<%@ include file="/init.jsp" %>
 
 <%@ page import="com.liferay.portal.kernel.captcha.CaptchaUtil" %>
 

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/page.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/page.jsp
@@ -1,0 +1,19 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/taglib/ui/captcha/init.jsp" %>
+
+<liferay-util:include page="<%= CaptchaUtil.getTaglibPath() %>" />

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/page.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/page.jsp
@@ -14,6 +14,6 @@
  */
 --%>
 
-<%@ include file="/html/taglib/ui/captcha/init.jsp" %>
+<%@ include file="/captcha/init.jsp" %>
 
 <liferay-util:include page="<%= CaptchaUtil.getTaglibPath() %>" />

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/page.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/page.jsp
@@ -16,4 +16,4 @@
 
 <%@ include file="/captcha/init.jsp" %>
 
-<liferay-util:include page="<%= CaptchaUtil.getTaglibPath() %>" />
+<liferay-util:include page="<%= CaptchaUtil.getTaglibPath() %>" servletContext="<%= application %>" />

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/recaptcha.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/recaptcha.jsp
@@ -1,0 +1,37 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/taglib/ui/captcha/init.jsp" %>
+
+<c:if test="<%= captchaEnabled %>">
+	<script src="<%= PropsValues.CAPTCHA_ENGINE_RECAPTCHA_URL_SCRIPT %>?hl=<%= locale.getLanguage() %>" type="text/javascript"></script>
+
+	<div class="g-recaptcha" data-sitekey="<%= PrefsPropsUtil.getString(PropsKeys.CAPTCHA_ENGINE_RECAPTCHA_KEY_PUBLIC, PropsValues.CAPTCHA_ENGINE_RECAPTCHA_KEY_PUBLIC) %>"></div>
+
+	<noscript>
+		<div style="height: 525px; width: 302px;">
+			<div style="height: 525px; position: relative; width: 302px;">
+				<div style="height: 525px; position: absolute; width: 302px;">
+					<iframe frameborder="0" scrolling="no" src="<%= PropsValues.CAPTCHA_ENGINE_RECAPTCHA_URL_NOSCRIPT %><%= PrefsPropsUtil.getString(PropsKeys.CAPTCHA_ENGINE_RECAPTCHA_KEY_PUBLIC, PropsValues.CAPTCHA_ENGINE_RECAPTCHA_KEY_PUBLIC) %>" style="border-style: none; height: 525px; width: 302px;"></iframe>
+				</div>
+
+				<div style="background: #F9F9F9; border-radius: 3px; border: 1px solid #C1C1C1; bottom: 25px; height: 60px; left: 0; margin: 0; padding: 0; position: absolute; right: 25px; width: 300px;">
+					<textarea class="g-recaptcha-response" id="g-recaptcha-response" name="g-recaptcha-response" style="border: 1px solid #C1C1C1; height: 40px; margin: 10px 25px; padding: 0; resize: none; width: 250px;"></textarea>
+				</div>
+			</div>
+		</div>
+	</noscript>
+</c:if>

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/recaptcha.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/recaptcha.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/taglib/ui/captcha/init.jsp" %>
+<%@ include file="/captcha/init.jsp" %>
 
 <c:if test="<%= captchaEnabled %>">
 	<script src="<%= PropsValues.CAPTCHA_ENGINE_RECAPTCHA_URL_SCRIPT %>?hl=<%= locale.getLanguage() %>" type="text/javascript"></script>

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/taglib/ui/captcha/init.jsp" %>
+<%@ include file="/captcha/init.jsp" %>
 
 <%
 String url = (String)request.getAttribute("liferay-captcha:captcha:url");

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/html/taglib/ui/captcha/init.jsp" %>
 
 <%
-String url = (String)request.getAttribute("liferay-ui:captcha:url");
+String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 %>
 
 <c:if test="<%= captchaEnabled %>">

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -1,0 +1,44 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/taglib/ui/captcha/init.jsp" %>
+
+<%
+String url = (String)request.getAttribute("liferay-ui:captcha:url");
+%>
+
+<c:if test="<%= captchaEnabled %>">
+	<div class="taglib-captcha">
+		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha" id="<portlet:namespace />captcha" src="<%= HttpUtil.addParameter(url, "t", String.valueOf(System.currentTimeMillis())) %>" />
+
+		<liferay-ui:icon cssClass="refresh" iconCssClass="icon-refresh" id="refreshCaptcha" label="<%= false %>" localizeMessage="<%= true %>" message="refresh-captcha" url="javascript:;" />
+
+		<aui:input ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" size="10" type="text" value="">
+			<aui:validator name="required" />
+		</aui:input>
+	</div>
+
+	<aui:script sandbox="<%= true %>">
+		$('#<portlet:namespace />refreshCaptcha').on(
+			'click',
+			function() {
+				var url = Liferay.Util.addParams('t=' + $.now(), '<%= url %>');
+
+				$('#<portlet:namespace />captcha').attr('src', url);
+			}
+		);
+	</aui:script>
+</c:if>

--- a/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/captcha/captcha-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,40 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
+taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+
+<%@ page import="com.liferay.portal.kernel.util.HttpUtil" %><%@
+page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
+page import="com.liferay.portal.kernel.util.PrefsPropsUtil" %><%@
+page import="com.liferay.portal.kernel.util.PropsKeys" %><%@
+page import="com.liferay.portal.util.PropsValues" %>
+
+<%@ page import="javax.portlet.PortletRequest" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />
+
+<%
+PortletRequest portletRequest = (PortletRequest)request.getAttribute(JavaConstants.JAVAX_PORTLET_REQUEST);
+%>

--- a/modules/apps/foundation/captcha/gradle.properties
+++ b/modules/apps/foundation/captcha/gradle.properties
@@ -1,0 +1,1 @@
+project.path.prefix=:apps:foundation:captcha

--- a/modules/apps/foundation/captcha/settings.gradle
+++ b/modules/apps/foundation/captcha/settings.gradle
@@ -1,0 +1,15 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+	}
+
+	repositories {
+		mavenLocal()
+
+		maven {
+			url "https://cdn.lfrs.sl/repository.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+apply plugin: "com.liferay.settings.plugin"

--- a/modules/apps/foundation/login/login-web/build.gradle
+++ b/modules/apps/foundation/login/login-web/build.gradle
@@ -9,4 +9,5 @@ dependencies {
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:captcha:captcha-taglib")
 }

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
@@ -193,7 +193,7 @@ birthdayCalendar.set(Calendar.YEAR, 1970);
 			<c:if test="<%= PropsValues.CAPTCHA_CHECK_PORTAL_CREATE_ACCOUNT %>">
 				<portlet:resourceURL id="/login/captcha" var="captchaURL" />
 
-				<liferay-ui:captcha url="<%= captchaURL %>" />
+				<liferay-captcha:captcha url="<%= captchaURL %>" />
 			</c:if>
 		</aui:col>
 	</aui:fieldset>

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/create_anonymous_account.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/create_anonymous_account.jsp
@@ -76,7 +76,7 @@
 			<c:if test="<%= PropsValues.CAPTCHA_CHECK_PORTAL_CREATE_ACCOUNT %>">
 				<portlet:resourceURL id="/login/captcha" var="captchaURL" />
 
-				<liferay-ui:captcha url="<%= captchaURL %>" />
+				<liferay-captcha:captcha url="<%= captchaURL %>" />
 			</c:if>
 		</aui:col>
 	</aui:fieldset>

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
@@ -99,7 +99,7 @@ if (reminderAttempts == null) {
 				<c:if test="<%= PropsValues.CAPTCHA_CHECK_PORTAL_SEND_PASSWORD %>">
 					<portlet:resourceURL id="/login/captcha" var="captchaURL" />
 
-					<liferay-ui:captcha url="<%= captchaURL %>" />
+					<liferay-captcha:captcha url="<%= captchaURL %>" />
 				</c:if>
 
 				<aui:button-row>
@@ -149,7 +149,7 @@ if (reminderAttempts == null) {
 						<c:if test="<%= reminderAttempts >= 3 %>">
 							<portlet:resourceURL id="/login/captcha" var="captchaURL" />
 
-							<liferay-ui:captcha url="<%= captchaURL %>" />
+							<liferay-captcha:captcha url="<%= captchaURL %>" />
 						</c:if>
 
 						<aui:button-row>

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/captcha" prefix="liferay-captcha" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/foundation/server/server-admin-web/build.gradle
+++ b/modules/apps/foundation/server/server-admin-web/build.gradle
@@ -16,5 +16,6 @@ dependencies {
 	provided group: "jfree", name: "jfreechart", version: "1.0.13"
 	provided group: "log4j", name: "log4j", version: "1.2.17"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:captcha:captcha-api")
 	provided project(":apps:foundation:portal-instances:portal-instances-api")
 }

--- a/modules/apps/foundation/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/server/server-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,13 +24,13 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.document.library.kernel.model.DLFileEntry" %><%@
+<%@ page import="com.liferay.captcha.recaptcha.ReCaptchaImpl" %><%@
+page import="com.liferay.document.library.kernel.model.DLFileEntry" %><%@
 page import="com.liferay.document.library.kernel.model.DLFileVersion" %><%@
 page import="com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil" %><%@
 page import="com.liferay.expando.kernel.model.ExpandoBridge" %><%@
 page import="com.liferay.expando.kernel.model.ExpandoColumnConstants" %><%@
 page import="com.liferay.petra.log4j.Levels" %><%@
-page import="com.liferay.portal.captcha.recaptcha.ReCaptchaImpl" %><%@
 page import="com.liferay.portal.convert.ConvertProcess" %><%@
 page import="com.liferay.portal.convert.ConvertProcessUtil" %><%@
 page import="com.liferay.portal.convert.documentlibrary.FileSystemStoreRootDirException" %><%@

--- a/modules/apps/web-form/web-form-web/build.gradle
+++ b/modules/apps/web-form/web-form-web/build.gradle
@@ -11,4 +11,5 @@ dependencies {
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.mozilla", name: "rhino", version: "1.7R4"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:foundation:captcha:captcha-taglib")
 }

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/captcha" prefix="liferay-captcha" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -138,7 +138,7 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				<portlet:param name="<%= Constants.CMD %>" value="captcha" />
 			</portlet:resourceURL>
 
-			<liferay-ui:captcha url="<%= captchaURL %>" />
+			<liferay-captcha:captcha url="<%= captchaURL %>" />
 		</c:if>
 
 		<aui:button onClick="" type="submit" value="send" />

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -61,11 +61,6 @@
 			<bean class="com.liferay.portal.cache.key.SimpleCacheKeyGenerator" />
 		</property>
 	</bean>
-	<bean class="com.liferay.portal.kernel.captcha.CaptchaUtil" id="com.liferay.portal.kernel.captcha.CaptchaUtil">
-		<property name="captcha">
-			<bean class="com.liferay.portal.captcha.CaptchaImpl" />
-		</property>
-	</bean>
 	<bean class="com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil">
 		<property name="currentConnection">
 			<bean class="com.liferay.portal.dao.jdbc.CurrentConnectionImpl" />

--- a/portal-impl/src/com/liferay/portal/captcha/CaptchaImpl.java
+++ b/portal-impl/src/com/liferay/portal/captcha/CaptchaImpl.java
@@ -37,7 +37,9 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author Brian Wing Shun Chan
- */
+ * @deprecated As of 7.0.0, with no direct replacement
+*/
+@Deprecated
 @DoPrivileged
 public class CaptchaImpl implements Captcha {
 

--- a/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/HookHotDeployListener.java
@@ -19,13 +19,10 @@ import com.liferay.document.library.kernel.antivirus.AntivirusScannerUtil;
 import com.liferay.document.library.kernel.antivirus.AntivirusScannerWrapper;
 import com.liferay.document.library.kernel.util.DLProcessor;
 import com.liferay.document.library.kernel.util.DLProcessorRegistryUtil;
-import com.liferay.portal.captcha.CaptchaImpl;
 import com.liferay.portal.kernel.bean.BeanLocatorException;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
 import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 import com.liferay.portal.kernel.bean.PortletBeanLocatorUtil;
-import com.liferay.portal.kernel.captcha.Captcha;
-import com.liferay.portal.kernel.captcha.CaptchaUtil;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
 import com.liferay.portal.kernel.deploy.DeployManagerUtil;
@@ -118,7 +115,6 @@ import com.liferay.portal.repository.registry.RepositoryClassDefinitionCatalogUt
 import com.liferay.portal.repository.util.ExternalRepositoryFactory;
 import com.liferay.portal.repository.util.ExternalRepositoryFactoryImpl;
 import com.liferay.portal.security.auth.AuthVerifierPipeline;
-import com.liferay.portal.security.lang.DoPrivilegedBean;
 import com.liferay.portal.servlet.filters.cache.CacheUtil;
 import com.liferay.portal.servlet.taglib.ui.DeprecatedFormNavigatorEntry;
 import com.liferay.portal.spring.aop.ServiceBeanAopProxy;
@@ -183,9 +179,8 @@ public class HookHotDeployListener
 		"auth.token.ignore.actions", "auth.token.ignore.origins",
 		"auth.token.ignore.portlets", "auth.token.impl", "auth.pipeline.post",
 		"auth.pipeline.pre", "auto.login.hooks",
-		"captcha.check.portal.create_account", "captcha.engine.impl",
-		"company.default.locale", "company.default.time.zone",
-		"company.settings.form.authentication",
+		"captcha.check.portal.create_account", "company.default.locale",
+		"company.default.time.zone", "company.settings.form.authentication",
 		"company.settings.form.configuration",
 		"company.settings.form.identification",
 		"company.settings.form.miscellaneous", "company.settings.form.social",
@@ -390,23 +385,6 @@ public class HookHotDeployListener
 		}
 
 		resetPortalProperties(servletContextName, portalProperties, false);
-
-		if (portalProperties.containsKey(PropsKeys.CAPTCHA_ENGINE_IMPL)) {
-			CaptchaImpl captchaImpl = null;
-
-			Captcha captcha = CaptchaUtil.getCaptcha();
-
-			if (captcha instanceof DoPrivilegedBean) {
-				DoPrivilegedBean doPrivilegedBean = (DoPrivilegedBean)captcha;
-
-				captchaImpl = (CaptchaImpl)doPrivilegedBean.getActualBean();
-			}
-			else {
-				captchaImpl = (CaptchaImpl)captcha;
-			}
-
-			captchaImpl.setCaptcha(null);
-		}
 
 		if (portalProperties.containsKey(PropsKeys.DL_FILE_ENTRY_PROCESSORS)) {
 			DLFileEntryProcessorContainer dlFileEntryProcessorContainer =
@@ -1407,30 +1385,6 @@ public class HookHotDeployListener
 			registerService(
 				servletContextName, authTokenClassName, AuthToken.class,
 				authToken);
-		}
-
-		if (portalProperties.containsKey(PropsKeys.CAPTCHA_ENGINE_IMPL)) {
-			String captchaClassName = portalProperties.getProperty(
-				PropsKeys.CAPTCHA_ENGINE_IMPL);
-
-			Captcha captcha = (Captcha)newInstance(
-				portletClassLoader, Captcha.class, captchaClassName);
-
-			CaptchaImpl captchaImpl = null;
-
-			Captcha currentCaptcha = CaptchaUtil.getCaptcha();
-
-			if (currentCaptcha instanceof DoPrivilegedBean) {
-				DoPrivilegedBean doPrivilegedBean =
-					(DoPrivilegedBean)currentCaptcha;
-
-				captchaImpl = (CaptchaImpl)doPrivilegedBean.getActualBean();
-			}
-			else {
-				captchaImpl = (CaptchaImpl)currentCaptcha;
-			}
-
-			captchaImpl.setCaptcha(captcha);
 		}
 
 		if (portalProperties.containsKey(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3720,7 +3720,7 @@
     # alternative which makes the captcha accessible to the visually impaired.
     # See https://www.google.com/recaptcha/admin/create for details.
     #
-    #captcha.engine.impl=com.liferay.portal.captcha.recaptcha.ReCaptchaImpl
+    #captcha.engine.impl=com.liferay.captcha.recaptcha.ReCaptchaImpl
     captcha.engine.impl=com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl
 
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3721,7 +3721,7 @@
     # See https://www.google.com/recaptcha/admin/create for details.
     #
     #captcha.engine.impl=com.liferay.portal.captcha.recaptcha.ReCaptchaImpl
-    captcha.engine.impl=com.liferay.portal.captcha.simplecaptcha.SimpleCaptchaImpl
+    captcha.engine.impl=com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl
 
     #
     # reCAPTCHA
@@ -3770,8 +3770,8 @@
     # nl.captcha.text.producer.TextProducer. These classes will be randomly
     # used by SimpleCaptcha to generate text for a captcha image.
     #
-    captcha.engine.simplecaptcha.text.producers=com.liferay.portal.captcha.simplecaptcha.PinNumberTextProducer
-    #captcha.engine.simplecaptcha.text.producers=com.liferay.portal.captcha.simplecaptcha.DictionaryWordTextProducer,com.liferay.portal.captcha.simplecaptcha.PinNumberTextProducer,nl.captcha.text.producer.DefaultTextProducer,nl.captcha.text.producer.FiveLetterFirstNameTextProducer
+    captcha.engine.simplecaptcha.text.producers=com.liferay.captcha.simplecaptcha.PinNumberTextProducer
+    #captcha.engine.simplecaptcha.text.producers=com.liferay.captcha.simplecaptcha.DictionaryWordTextProducer,com.liferay.captcha.simplecaptcha.PinNumberTextProducer,nl.captcha.text.producer.DefaultTextProducer,nl.captcha.text.producer.FiveLetterFirstNameTextProducer
 
     #
     # Input a list of comma delimited class names that implement

--- a/readme/7.0/BREAKING_CHANGES.markdown
+++ b/readme/7.0/BREAKING_CHANGES.markdown
@@ -4170,7 +4170,6 @@ This change was made as part of modularization efforts to ease portlet
 configuration changes.
 
 ---------------------------------------
-
 ### Moved the liferay-ui:journal-article Tag to Journal
 - **Date:** 2016-Nov-24
 - **JIRA Ticket:** LPS-69321
@@ -4213,6 +4212,31 @@ Content application.
 
 ---------------------------------------
 
+### Deprecated the liferay-ui:captcha Tag and Replaced with liferay-captcha:captcha
+- **Date:** 2016-Nov-29
+- **JIRA Ticket:** LPS-69383
+
+#### What changed?
+
+The `liferay-ui:captcha` tag has been deprecated and replaced with the
+`liferay-captcha:captcha` tag.
+
+#### Who is affected?
+
+Plugins or templates that are using the `liferay-ui:captcha` tag need to update
+their usage of the tag.
+
+#### How should I update my code?
+
+You should import the `liferay-captcha` tag library (if necessary) and update the
+tag namespace from `liferay-ui:captcha` to `liferay-captcha:captcha`.
+
+#### Why was this change made?
+
+This change was made as a part of the ongoing strategy to modularize Liferay
+Portal by means of an OSGi container.
+
+---------------------------------------
 ### Moved Shopping File Uploads Portlet Properties to OSGi Configuration
 - **Date:** 2016-Dec-08
 - **JIRA Ticket:** LPS-69210

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1115,7 +1115,7 @@
 		</attribute>
 	</tag>
 	<tag>
-		<description>Creates an image CAPTCHA with a corresponding verification input.</description>
+		<description>Deprecated as of 7.0.0, replaced by <![CDATA[<code>liferay-captcha:captcha</code>]]>. Creates an image CAPTCHA with a corresponding verification input.</description>
 		<name>captcha</name>
 		<tag-class>com.liferay.taglib.ui.CaptchaTag</tag-class>
 		<body-content>JSP</body-content>

--- a/util-taglib/src/com/liferay/taglib/ui/CaptchaTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/CaptchaTag.java
@@ -20,7 +20,10 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Brian Wing Shun Chan
+ * @deprecated As of 7.0.0, replaced by {@link
+ *             com.liferay.captcha.taglib.servlet.taglib.CaptchaTag}
  */
+@Deprecated
 public class CaptchaTag extends IncludeTag {
 
 	public void setUrl(String url) {


### PR DESCRIPTION
This is an update for [LPS-69383](https://issues.liferay.com/browse/LPS-69383).

Hey Brian, this is part 1 a prerequisite pull extracting Captcha into a module (https://issues.liferay.com/browse/LPS-67830).

The only question I have is how to effectively deprecate CaptchaUtil (see e7147c9).  That commit is done to maintain backwards-compatibility, but ideally we want to create a class called CaptchaProvider to do what CaptchaUtil is now doing, since we are using it to retrieve service-tracked instances of Captcha.  That's on the roadmap for the next half, but is there an example of this kind of deprecation/transition?  Thanks!

/cc @pei-jung @jorgeferrer

PS: There were a couple of SF failures when I checked before sending, but they were in `ClpSerializer.java` and `JournalArticleLocalServiceImpl.java`.  This pull doesn't touch either of those.