### PR TITLE
LPS-69919 For foreign datasources, create plain PlatformTransactionMa…

### DIFF
--- a/modules/apps/foundation/portal/portal-spring-extender/src/main/resources/META-INF/spring/parent/hibernate-spring.xml
+++ b/modules/apps/foundation/portal/portal-spring-extender/src/main/resources/META-INF/spring/parent/hibernate-spring.xml
@@ -22,7 +22,8 @@
 			</bean>
 		</constructor-arg>
 	</bean>
-	<bean class="com.liferay.portal.spring.hibernate.PortletTransactionManager" id="liferayTransactionManager">
+	<bean class="com.liferay.portal.spring.hibernate.PortletTransactionManagerFactory" factory-method="create" id="liferayTransactionManager">
+		<constructor-arg ref="liferayDataSource" />
 		<constructor-arg ref="originalLiferayTransactionManager" />
 		<constructor-arg ref="liferayHibernateSessionFactory" />
 	</bean>

--- a/portal-impl/src/com/liferay/portal/spring/context/xml/hibernate-spring.xml
+++ b/portal-impl/src/com/liferay/portal/spring/context/xml/hibernate-spring.xml
@@ -28,7 +28,8 @@
 			</bean>
 		</constructor-arg>
 	</bean>
-	<bean class="com.liferay.portal.spring.hibernate.PortletTransactionManager" id="liferayTransactionManager">
+	<bean class="com.liferay.portal.spring.hibernate.PortletTransactionManagerFactory" factory-method="create" id="liferayTransactionManager">
+		<constructor-arg ref="liferayDataSource" />
 		<constructor-arg ref="originalLiferayTransactionManager" />
 		<constructor-arg ref="liferayHibernateSessionFactory" />
 	</bean>

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/PortletTransactionManagerFactory.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/PortletTransactionManagerFactory.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.spring.hibernate;
+
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.spring.transaction.TransactionManagerFactory;
+
+import javax.sql.DataSource;
+
+import org.hibernate.SessionFactory;
+
+import org.springframework.orm.hibernate3.HibernateTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class PortletTransactionManagerFactory {
+
+	public static PlatformTransactionManager create(
+			DataSource dataSource,
+			HibernateTransactionManager portalHibernateTransactionManager,
+			SessionFactory portletSessionFactory)
+		throws Exception {
+
+		if (InfrastructureUtil.getDataSource() == dataSource) {
+			return new PortletTransactionManager(
+				portalHibernateTransactionManager, portletSessionFactory);
+		}
+
+		return TransactionManagerFactory.createTransactionManager(
+			dataSource, portletSessionFactory);
+	}
+
+}


### PR DESCRIPTION
…nager.

@mhan810 this is the fix for SB supporting external DataSource. Technically this is not a bug, as you can simply redefine "liferayTransactionManager" in the ext-spring.xml to any impl, just by the same way we are swapping to the external DataSource. This pull is just automating the redefine to free developers from manually doing it.