### PR TITLE
LPS-69954 RefreshURL doesn't include p_p_auth token

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletURLUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletURLUtil.java
@@ -271,6 +271,13 @@ public class PortletURLUtil {
 			return sb.toString();
 		}
 
+		String p_p_auth = ParamUtil.getString(request, "p_p_auth");
+
+		if (!Validator.isBlank(p_p_auth)) {
+			sb.append("&p_p_auth=");
+			sb.append(HttpUtil.encodeURL(p_p_auth));
+		}
+
 		String settingsScope = (String)request.getAttribute(
 			WebKeys.SETTINGS_SCOPE);
 


### PR DESCRIPTION
Hi Brian,

resending https://github.com/brianchandotcom/liferay-portal/pull/45899 again, tests were green.

Related to https://github.com/brianchandotcom/liferay-portal/pull/45899#issuecomment-270188576: the code is at the proper place. Current p_p_auth is related only and always to current rendered portlet so it should be **after** the `if` to avoid adding invalid p_p_auth to other portlets' refreshURL.

Thanks.

/cc @IstvanD 

https://issues.liferay.com/browse/LPS-69954