### PR TITLE
LPS-69967 Use official IE11 user agent

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -2081,8 +2081,7 @@ public class HttpImpl implements Http {
 	}
 
 	private static final String _DEFAULT_USER_AGENT =
-		"Mozilla/5.0 (X11; U; Linux x86_64; rv:1.9.0.5) Gecko/2008121623 " +
-			"Ubuntu/8.10 (intrepid) Firefox/3.0.5";
+		"Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko";
 
 	private static final int _MAX_BYTE_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 

--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -2081,7 +2081,8 @@ public class HttpImpl implements Http {
 	}
 
 	private static final String _DEFAULT_USER_AGENT =
-		"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)";
+		"Mozilla/5.0 (X11; U; Linux x86_64; rv:1.9.0.5) Gecko/2008121623 " +
+			"Ubuntu/8.10 (intrepid) Firefox/3.0.5";
 
 	private static final int _MAX_BYTE_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 


### PR DESCRIPTION
HttpUtil.URLtoInputStream used the user-agent of IE6 (Mozilla/4.0 (Windows; MSIE 6.0; Windows NT 5.2). This user-agent is not accepted in some pages, as described in LPS-69967. In this change we propose updating this agent to the latest IE version [(Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko)](https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx).