### PR TITLE
LRQA-29640-B Support dom4j-based failure messages

### DIFF
--- a/build-common-java.xml
+++ b/build-common-java.xml
@@ -68,7 +68,11 @@
 					<then>
 						<echo append="true" file="${project.dir}/javac.output.txt" message="${line.separator}${ant.project.name}${line.separator}" />
 						<echo append="true" file="${project.dir}/javac.output.txt" message="${javac.output.txt.content}" />
+						<echo>Deprecation warning found in javac.output.txt</echo>
 					</then>
+					<else>
+						<echo>No deprecation warnings found in javac.output.txt</echo>
+					</else>
 				</if>
 			</then>
 		</if>

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = dffe3b46464bde79aa68b164185cd19f7a6307e7
+	commit = f5403160570752dd17463a33c52ff761a98b6623
 	mode = push
-	parent = c4e3254370b5231d1ad87828d640240bd1a2aea3
+	parent = e5a3cffc0c046b2b52095142c63fa5f9f77abf32
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 30f4bd9bc8c247ae9b37cef1adbf0de7e144e92c
+	commit = 52232d68e0860f2e5317853c83c768c8c3ad9577
 	mode = push
-	parent = fadd915a8256389b300b51444db7ab9dd6c991ed
+	parent = ecc658196f4475398efe0dec3726cefb8319b283
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -408,6 +408,41 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
+	public String getRepositoryName() {
+		if (repositoryName == null) {
+			StringBuilder sb = new StringBuilder();
+
+			sb.append("repository[");
+
+			TopLevelBuild topLevelBuild = getTopLevelBuild();
+
+			sb.append(topLevelBuild.getJobName());
+
+			sb.append("]");
+
+			Properties buildProperties = null;
+
+			try {
+				buildProperties = JenkinsResultsParserUtil.getBuildProperties();
+			}
+			catch (IOException ioe) {
+				throw new RuntimeException(
+					"Unable to get build.properties.", ioe);
+			}
+
+			repositoryName = buildProperties.getProperty(sb.toString());
+
+			if (repositoryName == null) {
+				throw new RuntimeException(
+					"Unable to find repository name for job " +
+						topLevelBuild.getJobName());
+			}
+		}
+
+		return repositoryName;
+	}
+
+	@Override
 	public String getResult() {
 		String buildURL = getBuildURL();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -661,6 +661,18 @@ public abstract class BaseBuild implements Build {
 	public void reinvoke() {
 		String hostName = JenkinsResultsParserUtil.getHostName("");
 
+		Build parentBuild = getParentBuild();
+
+		String parentBuildStatus = parentBuild.getStatus();
+
+		if (!parentBuildStatus.equals("running")) {
+			System.out.println(
+				"Parent build is no longer running. Reinvocation has been " +
+					"aborted.");
+
+			return;
+		}
+
 		if (!hostName.startsWith("cloud-10-0")) {
 			System.out.println("A build may not be reinvoked by " + hostName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -233,6 +233,15 @@ public abstract class BaseBuild implements Build {
 
 	@Override
 	public String getConsoleText() {
+		String status = getStatus();
+
+		if (status.equals("running")) {
+			JenkinsConsoleTextLoader jenkinsConsoleTextLoader =
+				new JenkinsConsoleTextLoader(getBuildURL());
+
+			return jenkinsConsoleTextLoader.getConsoleText();
+		}
+
 		try {
 			return JenkinsResultsParserUtil.toString(
 				JenkinsResultsParserUtil.getLocalURL(
@@ -990,6 +999,11 @@ public abstract class BaseBuild implements Build {
 			while (downstreamBuildURLMatcher.find()) {
 				String url = downstreamBuildURLMatcher.group("url");
 
+				if (url.contains("<a href")) {
+					throw new RuntimeException(
+						"PDY2 " + downstreamBuildURLMatcher.group(0));
+				}
+
 				String reinvocationMarker = url + " restarted at ";
 
 				int reinvocationIndex = consoleText.indexOf(reinvocationMarker);
@@ -1000,6 +1014,10 @@ public abstract class BaseBuild implements Build {
 						consoleText.indexOf(
 							".\n",
 							reinvocationIndex + reinvocationMarker.length()));
+
+					if (url.contains("<a href")) {
+						throw new RuntimeException("PDY3");
+					}
 				}
 
 				if (!foundDownstreamBuildURLs.contains(url)) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -999,11 +999,6 @@ public abstract class BaseBuild implements Build {
 			while (downstreamBuildURLMatcher.find()) {
 				String url = downstreamBuildURLMatcher.group("url");
 
-				if (url.contains("<a href")) {
-					throw new RuntimeException(
-						"PDY2 " + downstreamBuildURLMatcher.group(0));
-				}
-
 				String reinvocationMarker = url + " restarted at ";
 
 				int reinvocationIndex = consoleText.indexOf(reinvocationMarker);
@@ -1014,10 +1009,6 @@ public abstract class BaseBuild implements Build {
 						consoleText.indexOf(
 							".\n",
 							reinvocationIndex + reinvocationMarker.length()));
-
-					if (url.contains("<a href")) {
-						throw new RuntimeException("PDY3");
-					}
 				}
 
 				if (!foundDownstreamBuildURLs.contains(url)) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseFailureMessageGenerator.java
@@ -14,10 +14,13 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.Hashtable;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.tools.ant.Project;
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
 
 /**
  * @author Peter Yoo
@@ -26,9 +29,39 @@ public abstract class BaseFailureMessageGenerator
 	implements FailureMessageGenerator {
 
 	@Override
+	public abstract Element getMessage(Build build);
+
+	@Override
 	public abstract String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception;
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties);
+
+	protected Element getBaseBranchAnchorElement(TopLevelBuild topLevelBuild) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("https://github.com/");
+
+		String baseRepositoryName = topLevelBuild.getRepositoryName();
+
+		Map<String, String> baseRepositoryGitDetailMap =
+			topLevelBuild.getGitRepositoryDetailsTempMap(baseRepositoryName);
+
+		sb.append(baseRepositoryGitDetailMap.get("github.origin.name"));
+
+		sb.append("/");
+		sb.append(baseRepositoryName);
+		sb.append("/tree/");
+		sb.append(baseRepositoryGitDetailMap.get("github.sender.branch.name"));
+
+		String url = sb.toString();
+
+		sb = new StringBuilder();
+
+		sb.append(baseRepositoryGitDetailMap.get("github.origin.name"));
+		sb.append("/");
+		sb.append(baseRepositoryGitDetailMap.get("github.sender.branch.name"));
+
+		return Dom4JUtil.getNewAnchorElement(url, sb.toString());
+	}
 
 	protected String getConsoleOutputSnippet(
 		String consoleOutput, boolean truncateTop, int end) {
@@ -43,6 +76,86 @@ public abstract class BaseFailureMessageGenerator
 	}
 
 	protected String getConsoleOutputSnippet(
+		String consoleOutput, boolean truncateTop, int start, int end) {
+
+		return "<pre><code>" +
+			_getConsoleOutputSnippet(consoleOutput, truncateTop, start, end) +
+				"</code></pre>";
+	}
+
+	protected Element getConsoleOutputSnippetElement(
+		String consoleOutput, boolean truncateTop, int end) {
+
+		if (end == -1) {
+			end = consoleOutput.length();
+		}
+
+		int start = getSnippetStart(consoleOutput, end);
+
+		return getConsoleOutputSnippetElement(
+			consoleOutput, truncateTop, start, end);
+	}
+
+	protected Element getConsoleOutputSnippetElement(
+		String consoleOutput, boolean truncateTop, int start, int end) {
+
+		return Dom4JUtil.toCodeSnippetElement(
+			_getConsoleOutputSnippet(consoleOutput, truncateTop, start, end));
+	}
+
+	protected Element getGitCommitPluginsAnchorElement(
+		TopLevelBuild topLevelBuild) {
+
+		String repositoryName = topLevelBuild.getRepositoryName();
+
+		String portalRepositoryName = "liferay-portal";
+
+		if (repositoryName.endsWith("-ee")) {
+			portalRepositoryName += "-ee";
+		}
+
+		Map<String, String> portalRepositoryGitDetailsMap =
+			topLevelBuild.getGitRepositoryDetailsTempMap(portalRepositoryName);
+
+		Element gitCommitPluginsAnchorElement = new DefaultElement("a");
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("https://github.com/");
+		sb.append(portalRepositoryGitDetailsMap.get("github.origin.name"));
+		sb.append("/");
+		sb.append(portalRepositoryName);
+		sb.append("/blob/");
+		sb.append(
+			portalRepositoryGitDetailsMap.get("github.sender.branch.name"));
+		sb.append("/git-commit-plugins");
+
+		gitCommitPluginsAnchorElement.addAttribute("href", sb.toString());
+
+		gitCommitPluginsAnchorElement.addText("git-commit-plugins");
+
+		return gitCommitPluginsAnchorElement;
+	}
+
+	protected int getSnippetStart(String consoleOutput, int end) {
+		int start = 0;
+
+		Matcher matcher = _pattern.matcher(consoleOutput);
+
+		while (matcher.find()) {
+			int x = matcher.start() + 1;
+
+			if (x >= end) {
+				return start;
+			}
+
+			start = x;
+		}
+
+		return start;
+	}
+
+	private String _getConsoleOutputSnippet(
 		String consoleOutput, boolean truncateTop, int start, int end) {
 
 		if ((end - start) > 2500) {
@@ -63,25 +176,7 @@ public abstract class BaseFailureMessageGenerator
 		consoleOutput = consoleOutput.replaceFirst("^\\s*\\n", "");
 		consoleOutput = consoleOutput.replaceFirst("\\n\\s*$", "");
 
-		return "<pre><code>" + consoleOutput + "</code></pre>";
-	}
-
-	protected int getSnippetStart(String consoleOutput, int end) {
-		int start = 0;
-
-		Matcher matcher = _pattern.matcher(consoleOutput);
-
-		while (matcher.find()) {
-			int x = matcher.start() + 1;
-
-			if (x >= end) {
-				return start;
-			}
-
-			start = x;
-		}
-
-		return start;
+		return consoleOutput;
 	}
 
 	private static final Pattern _pattern = Pattern.compile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -78,6 +78,8 @@ public interface Build {
 
 	public Build getParentBuild();
 
+	public String getRepositoryName();
+
 	public String getResult();
 
 	public Map<String, String> getStartPropertiesMap();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Dom4JUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Dom4JUtil.java
@@ -16,15 +16,19 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.CharArrayWriter;
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.Writer;
 
 import java.util.Iterator;
 
 import org.dom4j.Attribute;
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
 import org.dom4j.Element;
 import org.dom4j.Node;
 import org.dom4j.Text;
 import org.dom4j.io.OutputFormat;
+import org.dom4j.io.SAXReader;
 import org.dom4j.io.XMLWriter;
 import org.dom4j.tree.DefaultElement;
 
@@ -110,6 +114,12 @@ public class Dom4JUtil {
 		}
 
 		return childElement;
+	}
+
+	public static Document parse(String xmlString) throws DocumentException {
+		SAXReader saxReader = new SAXReader();
+
+		return saxReader.read(new StringReader(xmlString));
 	}
 
 	public static void replace(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DownstreamFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DownstreamFailureMessageGenerator.java
@@ -14,7 +14,9 @@
 
 package com.liferay.jenkins.results.parser;
 
-import org.apache.tools.ant.Project;
+import java.util.Hashtable;
+
+import org.dom4j.Element;
 
 /**
  * @author Kevin Yen
@@ -23,9 +25,19 @@ public class DownstreamFailureMessageGenerator
 	extends BaseFailureMessageGenerator {
 
 	@Override
+	public Element getMessage(Build build) {
+		String consoleOutput = build.getConsoleText();
+
+		if (consoleOutput.contains("Downstream jobs FAILED.")) {
+			return Dom4JUtil.toCodeSnippetElement("Downstream jobs FAILED.");
+		}
+
+		return null;
+	}
+
+	@Override
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception {
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties) {
 
 		if (consoleOutput.contains("Downstream jobs FAILED.")) {
 			return "<pre><code>Downstream jobs FAILED</code></pre>";

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FailureMessageGenerator.java
@@ -14,15 +14,18 @@
 
 package com.liferay.jenkins.results.parser;
 
-import org.apache.tools.ant.Project;
+import java.util.Hashtable;
+
+import org.dom4j.Element;
 
 /**
  * @author Peter Yoo
  */
 public interface FailureMessageGenerator {
 
+	public Element getMessage(Build build);
+
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception;
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties);
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FailureMessageUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FailureMessageUtil.java
@@ -33,7 +33,7 @@ public class FailureMessageUtil {
 				_failureMessageGenerators) {
 
 			String message = failureMessageGenerator.getMessage(
-				buildURL, consoleOutput, project);
+				buildURL, consoleOutput, project.getProperties());
 
 			if (message != null) {
 				return message;
@@ -41,7 +41,7 @@ public class FailureMessageUtil {
 		}
 
 		return _genericFailureMessageGenerator.getMessage(
-			buildURL, consoleOutput, project);
+			buildURL, consoleOutput, project.getProperties());
 	}
 
 	private static final FailureMessageGenerator[] _failureMessageGenerators = {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/IntegrationTestTimeoutFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/IntegrationTestTimeoutFailureMessageGenerator.java
@@ -14,10 +14,12 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.Hashtable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.tools.ant.Project;
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
 
 /**
  * @author Peter Yoo
@@ -26,9 +28,34 @@ public class IntegrationTestTimeoutFailureMessageGenerator
 	extends BaseFailureMessageGenerator {
 
 	@Override
+	public Element getMessage(Build build) {
+		String consoleText = build.getConsoleText();
+
+		Matcher matcher = _pattern.matcher(consoleText);
+
+		if (!matcher.find()) {
+			return null;
+		}
+
+		Element messageElement = new DefaultElement("div");
+
+		Dom4JUtil.addToElement(
+			Dom4JUtil.getNewElement("p", messageElement),
+			Dom4JUtil.wrapWithNewElement(matcher.group("testName"), "strong"),
+			" was aborted because it exceeded the timeout period.");
+
+		String snippet = matcher.group(0);
+
+		messageElement.add(
+			getConsoleOutputSnippetElement(
+				snippet, false, 0, snippet.length()));
+
+		return messageElement;
+	}
+
+	@Override
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception {
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties) {
 
 		Matcher matcher = _pattern.matcher(consoleOutput);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConsoleTextLoader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsConsoleTextLoader.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Peter Yoo
+ */
+public class JenkinsConsoleTextLoader {
+
+	public JenkinsConsoleTextLoader(String buildURL) {
+		this.buildURL = buildURL;
+
+		logStringBuilder = new StringBuilder();
+		serverLogSize = 0;
+	}
+
+	public String getConsoleText() {
+		update();
+
+		return logStringBuilder.toString();
+	}
+
+	public int getLineCount() {
+		String consoleLog = logStringBuilder.toString();
+
+		String[] consoleLogLines = consoleLog.split("\n");
+
+		return consoleLogLines.length;
+	}
+
+	public boolean hasMoreData() {
+		return hasMoreData;
+	}
+
+	protected void update() {
+		StringBuilder sb = new StringBuilder();
+
+		boolean behindLatest = true;
+
+		while (behindLatest) {
+			String url =
+				buildURL + "/logText/progressiveHtml?start=" + serverLogSize;
+
+			try {
+				URL urlObject = new URL(url);
+
+				HttpURLConnection httpURLConnection =
+					(HttpURLConnection)urlObject.openConnection();
+
+				long latestServerLogSize = httpURLConnection.getHeaderFieldLong(
+					"X-Text-Size", serverLogSize);
+
+				if (latestServerLogSize > serverLogSize) {
+					try (BufferedReader bufferedReader = new BufferedReader(
+							new InputStreamReader(
+								httpURLConnection.getInputStream()))) {
+
+						String line = bufferedReader.readLine();
+
+						while (line != null) {
+							Matcher matcher = _anchorPattern.matcher(line);
+
+							line = matcher.replaceAll("$1");
+
+							sb.append(line);
+
+							sb.append("\n");
+
+							line = bufferedReader.readLine();
+						}
+					}
+				}
+
+				hasMoreData = Boolean.parseBoolean(
+					httpURLConnection.getHeaderField("X-More-Data"));
+
+				if (((latestServerLogSize - serverLogSize) < 5000) ||
+					!hasMoreData) {
+
+					behindLatest = false;
+				}
+
+				serverLogSize = latestServerLogSize;
+			}
+			catch (MalformedURLException murle) {
+				throw new IllegalArgumentException(
+					"Invalid buildURL " + buildURL, murle);
+			}
+			catch (IOException ioe) {
+				throw new RuntimeException(
+					"IOException occurred while updating console log.", ioe);
+			}
+		}
+
+		if (sb.length() > 0) {
+			logStringBuilder.append(sb);
+		}
+	}
+
+	protected String buildURL;
+	protected boolean hasMoreData = true;
+	protected StringBuilder logStringBuilder;
+	protected long serverLogSize;
+
+	private static final Pattern _anchorPattern = Pattern.compile(
+		"\\<a[^>]*\\>(?<text>[^<]*)\\</a\\>");
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitMirrorFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitMirrorFailureMessageGenerator.java
@@ -14,7 +14,10 @@
 
 package com.liferay.jenkins.results.parser;
 
-import org.apache.tools.ant.Project;
+import java.util.Hashtable;
+
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
 
 /**
  * @author Peter Yoo
@@ -23,9 +26,60 @@ public class LocalGitMirrorFailureMessageGenerator
 	extends BaseFailureMessageGenerator {
 
 	@Override
+	public Element getMessage(Build build) {
+		String consoleText = build.getConsoleText();
+
+		if (!consoleText.contains(_LOCAL_GIT_FAILURE_END_STRING) ||
+			!consoleText.contains(_LOCAL_GIT_FAILURE_START_STRING)) {
+
+			return null;
+		}
+
+		Element messageElement = new DefaultElement("div");
+
+		Dom4JUtil.addToElement(
+			Dom4JUtil.getNewElement("p", messageElement),
+			"Unable to synchronize with ",
+			Dom4JUtil.wrapWithNewElement("local Git mirror", "strong"), ".");
+
+		int end = consoleText.indexOf(_LOCAL_GIT_FAILURE_END_STRING);
+
+		int start = consoleText.lastIndexOf(
+			_LOCAL_GIT_FAILURE_START_STRING, end);
+
+		consoleText = consoleText.substring(start, end);
+
+		int minIndex = consoleText.length();
+
+		for (String string : new String[] {"error: ", "fatal: "}) {
+			int index = consoleText.indexOf(string);
+
+			if (index != -1) {
+				if (index < minIndex) {
+					minIndex = index;
+				}
+			}
+		}
+
+		int gitCommandIndex = consoleText.lastIndexOf("+ git", minIndex);
+
+		if (gitCommandIndex != -1) {
+			start = gitCommandIndex;
+		}
+
+		start = consoleText.lastIndexOf("\n", start);
+
+		end = consoleText.lastIndexOf("\n");
+
+		messageElement.add(
+			getConsoleOutputSnippetElement(consoleText, false, start, end));
+
+		return messageElement;
+	}
+
+	@Override
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception {
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties) {
 
 		if (!consoleOutput.contains(_LOCAL_GIT_FAILURE_END_STRING) ||
 			!consoleOutput.contains(_LOCAL_GIT_FAILURE_START_STRING)) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiValidationFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiValidationFailureMessageGenerator.java
@@ -14,10 +14,12 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.util.Hashtable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.tools.ant.Project;
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
 
 /**
  * @author Kevin Yen
@@ -26,9 +28,30 @@ public class PoshiValidationFailureMessageGenerator
 	extends BaseFailureMessageGenerator {
 
 	@Override
+	public Element getMessage(Build build) {
+		String consoleText = build.getConsoleText();
+
+		Matcher poshiFailureMatcher = _poshiFailurePattern.matcher(consoleText);
+
+		if (!poshiFailureMatcher.find()) {
+			return null;
+		}
+
+		Element messageElement = new DefaultElement("div");
+
+		Element paragraphElement = Dom4JUtil.getNewElement("p", messageElement);
+
+		paragraphElement.addText("POSHI Validation Failure");
+
+		messageElement.add(
+			Dom4JUtil.toCodeSnippetElement(poshiFailureMatcher.group(1)));
+
+		return messageElement;
+	}
+
+	@Override
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception {
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties) {
 
 		Matcher poshiFailureMatcher = _poshiFailurePattern.matcher(
 			consoleOutput);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseErrorTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseErrorTopLevelBuild.java
@@ -15,7 +15,6 @@
 package com.liferay.jenkins.results.parser;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
@@ -31,8 +30,8 @@ import java.util.regex.Pattern;
 
 import org.dom4j.Attribute;
 import org.dom4j.Document;
+import org.dom4j.DocumentException;
 import org.dom4j.Element;
-import org.dom4j.io.SAXReader;
 
 import org.json.JSONObject;
 
@@ -188,23 +187,21 @@ public class RebaseErrorTopLevelBuild extends TopLevelBuild {
 		return tokens;
 	}
 
-	protected Element getElement(String content) throws Exception {
-		SAXReader saxReader = new SAXReader();
-
+	protected Element getElement(String content) {
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("<div>");
 		sb.append(content);
 		sb.append("</div>");
 
-		content = sb.toString();
+		try {
+			Document document = Dom4JUtil.parse(sb.toString());
 
-		InputStream inputStream = new ByteArrayInputStream(
-			content.getBytes("UTF-8"));
-
-		Document document = saxReader.read(inputStream);
-
-		return document.getRootElement();
+			return document.getRootElement();
+		}
+		catch (DocumentException de) {
+			throw new RuntimeException("Unable to parse xml", de);
+		}
 	}
 
 	protected JSONObject getJSONObjectFromURL(String url) throws Exception {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseErrorTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseErrorTopLevelBuild.java
@@ -172,15 +172,17 @@ public class RebaseErrorTopLevelBuild extends TopLevelBuild {
 
 		tokens.add("text: " + removeWhitespace(element.getText()));
 
-		List<Element> elements = element.elements();
+		List<?> elementObjects = element.elements();
 
-		for (Element childElement : elements) {
-			tokens.addAll(getCommentTokens(childElement));
+		for (Object childElementObject : elementObjects) {
+			tokens.addAll(getCommentTokens((Element)childElementObject));
 		}
 
-		List<Attribute> attributes = element.attributes();
+		List<?> attributeObjects = element.attributes();
 
-		for (Attribute attribute : attributes) {
+		for (Object attributeObject : attributeObjects) {
+			Attribute attribute = (Attribute)attributeObject;
+
 			tokens.add("attribute: " + removeWhitespace(attribute.getValue()));
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RebaseFailureMessageGenerator.java
@@ -14,7 +14,10 @@
 
 package com.liferay.jenkins.results.parser;
 
-import org.apache.tools.ant.Project;
+import java.util.Hashtable;
+
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
 
 /**
  * @author Peter Yoo
@@ -22,9 +25,42 @@ import org.apache.tools.ant.Project;
 public class RebaseFailureMessageGenerator extends BaseFailureMessageGenerator {
 
 	@Override
+	public Element getMessage(Build build) {
+		String consoleText = build.getConsoleText();
+
+		if (!consoleText.contains(_REBASE_END_STRING) ||
+			!consoleText.contains(_REBASE_START_STRING) ||
+			!consoleText.contains("CONFLICT")) {
+
+			return null;
+		}
+
+		Element messageElement = new DefaultElement("div");
+
+		Dom4JUtil.addToElement(
+			Dom4JUtil.getNewElement("p", messageElement), "Please fix ",
+			Dom4JUtil.wrapWithNewElement("rebase errors", "strong"), " on ",
+			Dom4JUtil.wrapWithNewElement(
+				getBaseBranchAnchorElement(build.getTopLevelBuild()),
+				"strong"));
+
+		int end = consoleText.indexOf(_REBASE_END_STRING);
+
+		end = consoleText.lastIndexOf("\n", end);
+
+		int start = consoleText.lastIndexOf(_REBASE_START_STRING, end);
+
+		start = consoleText.lastIndexOf("\n", start);
+
+		messageElement.add(
+			getConsoleOutputSnippetElement(consoleText, true, start, end));
+
+		return messageElement;
+	}
+
+	@Override
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception {
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties) {
 
 		if (!consoleOutput.contains(_REBASE_END_STRING) ||
 			!consoleOutput.contains(_REBASE_START_STRING) ||
@@ -37,15 +73,15 @@ public class RebaseFailureMessageGenerator extends BaseFailureMessageGenerator {
 
 		sb.append("<p>Please fix <strong>rebase errors</strong> on <strong>");
 		sb.append("<a href=\"https://github.com/");
-		sb.append(project.getProperty("github.origin.name"));
+		sb.append(properties.get("github.origin.name"));
 		sb.append("/");
-		sb.append(project.getProperty("repository"));
+		sb.append(properties.get("repository"));
 		sb.append("/tree/");
-		sb.append(project.getProperty("github.sender.branch.name"));
+		sb.append(properties.get("github.sender.branch.name"));
 		sb.append("\">");
-		sb.append(project.getProperty("github.origin.name"));
+		sb.append(properties.get("github.origin.name"));
 		sb.append("/");
-		sb.append(project.getProperty("github.sender.branch.name"));
+		sb.append(properties.get("github.sender.branch.name"));
 		sb.append("</a></strong>.</p>");
 
 		int end = consoleOutput.indexOf(_REBASE_END_STRING);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SemanticVersioningFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SemanticVersioningFailureMessageGenerator.java
@@ -14,7 +14,10 @@
 
 package com.liferay.jenkins.results.parser;
 
-import org.apache.tools.ant.Project;
+import java.util.Hashtable;
+
+import org.dom4j.Element;
+import org.dom4j.tree.DefaultElement;
 
 /**
  * @author Peter Yoo
@@ -24,9 +27,42 @@ public class SemanticVersioningFailureMessageGenerator
 	extends BaseFailureMessageGenerator {
 
 	@Override
+	public Element getMessage(Build build) {
+		String consoleText = build.getConsoleText();
+
+		if (!consoleText.contains(_SEMVER_END_STRING) ||
+			!consoleText.contains(_SEMVER_START_STRING)) {
+
+			return null;
+		}
+
+		Element messageElement = new DefaultElement("div");
+
+		Dom4JUtil.addToElement(
+			Dom4JUtil.getNewElement("p", messageElement), "Please fix ",
+			Dom4JUtil.wrapWithNewElement("semantic versioning", "strong"),
+			" on ",
+			Dom4JUtil.wrapWithNewElement(
+				getBaseBranchAnchorElement(build.getTopLevelBuild()),
+				"strong"));
+
+		int end = consoleText.indexOf(_SEMVER_END_STRING);
+
+		end = consoleText.indexOf("\n", end);
+
+		int start = consoleText.lastIndexOf(_SEMVER_START_STRING, end);
+
+		start = consoleText.lastIndexOf("\n", start);
+
+		messageElement.add(
+			getConsoleOutputSnippetElement(consoleText, true, start, end));
+
+		return messageElement;
+	}
+
+	@Override
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception {
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties) {
 
 		if (!consoleOutput.contains(_SEMVER_END_STRING) ||
 			!consoleOutput.contains(_SEMVER_START_STRING)) {
@@ -38,15 +74,15 @@ public class SemanticVersioningFailureMessageGenerator
 
 		sb.append("<p>Please fix <strong>semantic versioning</strong> on ");
 		sb.append("<strong><a href=\"https://github.com/");
-		sb.append(project.getProperty("github.origin.name"));
+		sb.append(properties.get("github.origin.name"));
 		sb.append("/");
-		sb.append(project.getProperty("repository"));
+		sb.append(properties.get("repository"));
 		sb.append("/tree/");
-		sb.append(project.getProperty("github.sender.branch.name"));
+		sb.append(properties.get("github.sender.branch.name"));
 		sb.append("\">");
-		sb.append(project.getProperty("github.origin.name"));
+		sb.append(properties.get("github.origin.name"));
 		sb.append("/");
-		sb.append(project.getProperty("github.sender.branch.name"));
+		sb.append(properties.get("github.sender.branch.name"));
 		sb.append("</a></strong>.</p>");
 
 		int end = consoleOutput.indexOf(_SEMVER_END_STRING);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceFormatFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SourceFormatFailureMessageGenerator.java
@@ -14,7 +14,9 @@
 
 package com.liferay.jenkins.results.parser;
 
-import org.apache.tools.ant.Project;
+import java.util.Hashtable;
+
+import org.dom4j.Element;
 
 /**
  * @author Peter Yoo
@@ -23,23 +25,38 @@ public class SourceFormatFailureMessageGenerator
 	extends BaseFailureMessageGenerator {
 
 	@Override
+	public Element getMessage(Build build) {
+		String consoleText = build.getConsoleText();
+
+		if (!consoleText.contains(_SOURCE_FORMAT_STRING)) {
+			return null;
+		}
+
+		consoleText = consoleText.substring(
+			consoleText.lastIndexOf("format-source:"));
+
+		int end = consoleText.indexOf("merge-test-results:");
+
+		return getConsoleOutputSnippetElement(consoleText, true, end);
+	}
+
+	@Override
 	public String getMessage(
-			String buildURL, String consoleOutput, Project project)
-		throws Exception {
+		String buildURL, String consoleOutput, Hashtable<?, ?> properties) {
 
 		if (!consoleOutput.contains(_SOURCE_FORMAT_STRING)) {
 			return null;
 		}
 
-		int end = consoleOutput.indexOf(_SOURCE_FORMAT_STRING);
+		consoleOutput = consoleOutput.substring(
+			consoleOutput.lastIndexOf("format-source:"));
 
-		end = consoleOutput.indexOf("[exec] :", end);
+		int end = consoleOutput.indexOf("merge-test-results:");
 
 		return getConsoleOutputSnippet(consoleOutput, true, end);
 	}
 
 	private static final String _SOURCE_FORMAT_STRING =
-		"[exec] com.liferay.source.formatter.SourceFormatterTest > " +
-			"testSourceFormatter FAILED";
+		"at com.liferay.source.formatter.SourceFormatter.format";
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-29640

I'm leaving in the old failure message logic for now alongside the new, dom4j-based failure message logic. The old logic will be removed in a later pull request.