### PR TITLE
LPS-70031 Entries on the Organization_ table do not always have full tree paths

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -2119,11 +2120,16 @@ public class OrganizationLocalServiceImpl
 	protected long[] getReindexOrganizationIds(Organization organization)
 		throws PortalException {
 
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(StringPool.FORWARD_SLASH);
+		sb.append(organization.getOrganizationId());
+		sb.append(StringPool.FORWARD_SLASH);
+
 		List<Organization> organizations = organizationPersistence.findByC_T(
 			organization.getCompanyId(),
-			CustomSQLUtil.keywords(organization.getTreePath())[0],
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-			new OrganizationNameComparator(true));
+			CustomSQLUtil.keywords(sb.toString())[0], QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, new OrganizationNameComparator(true));
 
 		long[] organizationIds = new long[organizations.size()];
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -2173,8 +2173,8 @@ public class OrganizationLocalServiceImpl
 			long parentOrganizationId, long organizationId)
 		throws PortalException {
 
-		// Return true if parentOrganizationId is among the parent/ancestor
-		// organizatons of organizationId
+		// Return true if parentOrganizationId is among the parent organizatons
+		// of organizationId
 
 		if (organizationId ==
 				OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID) {
@@ -2193,8 +2193,7 @@ public class OrganizationLocalServiceImpl
 			return true;
 		}
 		else {
-			return isParentOrganization(
-				parentOrganizationId, organization.getParentOrganizationId());
+			return false;
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -2173,8 +2173,8 @@ public class OrganizationLocalServiceImpl
 			long parentOrganizationId, long organizationId)
 		throws PortalException {
 
-		// Return true if parentOrganizationId is among the parent or ancestor
-		// organizations of organizationId
+		// Return true if parentOrganizationId is among the parent/ancestor
+		// organizatons of organizationId
 
 		if (organizationId ==
 				OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID) {

--- a/portal-impl/test/integration/com/liferay/portal/service/OrganizationLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/OrganizationLocalServiceTest.java
@@ -611,6 +611,61 @@ public class OrganizationLocalServiceTest {
 	}
 
 	@Test
+	public void testParentOrganizationUpdatesAllTreePaths() throws Exception {
+		Organization organizationA = OrganizationTestUtil.addOrganization(
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			"Organization A", false);
+
+		Organization organizationB = OrganizationTestUtil.addOrganization(
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			"Organization B", false);
+
+		Organization organizationBB = OrganizationTestUtil.addOrganization(
+			organizationB.getOrganizationId(), "Organization BB", false);
+
+		Organization organizationBBB = OrganizationTestUtil.addOrganization(
+			organizationBB.getOrganizationId(), "Organization BBB", false);
+
+		_organizations.add(organizationBBB);
+
+		_organizations.add(organizationBB);
+		_organizations.add(organizationB);
+		_organizations.add(organizationA);
+
+		String shallowTreePath = OrganizationTestUtil.constructTreePath(
+			new Organization[] {
+				organizationB, organizationBB, organizationBBB
+			});
+
+		Assert.assertEquals(shallowTreePath, organizationBBB.getTreePath());
+
+		organizationB.setParentOrganizationId(
+			organizationA.getOrganizationId());
+
+		OrganizationTestUtil.updateOrganization(organizationB);
+
+		organizationBBB = OrganizationLocalServiceUtil.fetchOrganization(
+			organizationBBB.getOrganizationId());
+
+		String deepTreePath = OrganizationTestUtil.constructTreePath(
+			new Organization[] {
+				organizationA, organizationB, organizationBB, organizationBBB
+			});
+
+		Assert.assertEquals(deepTreePath, organizationBBB.getTreePath());
+
+		organizationB.setParentOrganizationId(
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
+
+		OrganizationTestUtil.updateOrganization(organizationB);
+
+		organizationBBB = OrganizationLocalServiceUtil.fetchOrganization(
+			organizationBBB.getOrganizationId());
+
+		Assert.assertEquals(shallowTreePath, organizationBBB.getTreePath());
+	}
+
+	@Test
 	public void testSearchOrganizationsAndUsers() throws Exception {
 		Organization organization = OrganizationTestUtil.addOrganization();
 

--- a/portal-impl/test/integration/com/liferay/portal/service/OrganizationLocalServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/OrganizationLocalServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.service;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.OrganizationParentException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ListTypeConstants;
@@ -608,6 +609,33 @@ public class OrganizationLocalServiceTest {
 
 		Assert.assertEquals(
 			organizationB.getGroupId(), groupAA.getParentGroupId());
+	}
+
+	@Test(expected = OrganizationParentException.class)
+	public void testNoCircularParentOrganization() throws Exception {
+		Organization organizationA = OrganizationTestUtil.addOrganization(
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID,
+			"Organization A", false);
+
+		Organization organizationAA = OrganizationTestUtil.addOrganization(
+			organizationA.getOrganizationId(), "Organization AA", false);
+
+		Organization organizationAAA = OrganizationTestUtil.addOrganization(
+			organizationAA.getOrganizationId(), "Organization AAA", false);
+
+		Organization organizationAAAA = OrganizationTestUtil.addOrganization(
+			organizationAAA.getOrganizationId(), "Organization AAAA", false);
+
+		_organizations.add(organizationAAAA);
+
+		_organizations.add(organizationAAA);
+		_organizations.add(organizationAA);
+		_organizations.add(organizationA);
+
+		organizationA.setParentOrganizationId(
+			organizationAAAA.getOrganizationId());
+
+		OrganizationTestUtil.updateOrganization(organizationA);
 	}
 
 	@Test

--- a/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/OrganizationTestUtil.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.test.util;
 
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.EmailAddress;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.model.ListTypeConstants;
 import com.liferay.portal.kernel.model.OrgLabor;
@@ -34,6 +35,8 @@ import com.liferay.portal.kernel.service.PasswordPolicyRelLocalServiceUtil;
 import com.liferay.portal.kernel.service.PhoneLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WebsiteLocalServiceUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portlet.passwordpoliciesadmin.util.test.PasswordPolicyTestUtil;
 
 import java.util.List;
@@ -144,6 +147,33 @@ public class OrganizationTestUtil {
 			organization.getOrganizationId(), "http://www.test.com",
 			_getListTypeId(ListTypeConstants.ORGANIZATION_WEBSITE), false,
 			new ServiceContext());
+	}
+
+	public static String constructTreePath(Organization[] organizations) {
+		StringBundler sb = new StringBundler();
+
+		sb.append(StringPool.FORWARD_SLASH);
+
+		for (Organization organization : organizations) {
+			sb.append(organization.getOrganizationId());
+			sb.append(StringPool.FORWARD_SLASH);
+		}
+
+		return sb.toString();
+	}
+
+	public static Organization updateOrganization(Organization organization)
+		throws Exception {
+
+		Group organizationGroup = organization.getGroup();
+
+		return OrganizationLocalServiceUtil.updateOrganization(
+			organization.getCompanyId(), organization.getOrganizationId(),
+			organization.getParentOrganizationId(), organization.getName(),
+			organization.getType(), organization.getRegionId(),
+			organization.getCountryId(), organization.getStatusId(),
+			organization.getComments(), false, null, organizationGroup.isSite(),
+			null);
 	}
 
 	private static long _getListTypeId(String type) throws Exception {


### PR DESCRIPTION
This is an update for [LPS-70031](https://issues.liferay.com/browse/LPS-70031).

Hey @brianchandotcom, do we need to put any special guards into place for the test at 0a469b7? If it throws the exception then we're good (it's expecting an exception).  However, if the test "fails" then the application will just hang (see the "Actual Result" of [LPS-69881](https://issues.liferay.com/browse/LPS-69881)).  I just don't want to cause CI to hang when it doesn't have to :).

/cc @pei-jung @jorgeferrer @shinnlok @SpencerWoo @jonathanmccann