### PR TITLE
[See desc] LPS-69589 LPS-69971 Remove dependency with kernel by removing the dependency on the new method of SocialActivity and do it with a Dynamic Query that is already available in previous versions.

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = aa072cff338dd728c6be0339c7f36d8cefb92d35
+	commit = 702450431c5ed532784d5eb8d434997b85ba7f50
 	mode = push
-	parent = 7f3a695fc15e5c97895fa8261a4ce9b350bad059
+	parent = 60ddce0474076c77488697f72e55e084b6faccba
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a83b1c5735b908c791cc7c8380d9d22294d77539
+	commit = 39125d9969646c6295df04f80d7e8963c0404e5a
 	mode = push
-	parent = 5908ca221d01c83c3829569803ec1f6a4cc240d4
+	parent = 6eaf5a0bba69cffa87ce36c2942ddf5e56705ce0
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/collaboration/comment/.gitrepo
+++ b/modules/apps/collaboration/comment/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3d52a15ae5a291eee2260f8bb33c08356a32d46c
+	commit = c587edc86d7607f51322895e5dcf60d6323ace21
 	mode = push
-	parent = 5ad47b928daf67e824fc05d911cff57bd950affb
+	parent = 0d5dd1454ae4b4d2e66d72cbe764d72baded4b1a
 	remote = git@github.com:liferay/com-liferay-comment.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = dda9535643c565d51d2df1e8c02c4c7b23573f47
+	commit = 2f22c08ea784fa9376962ed4b5d4f2d116c0c0c8
 	mode = push
-	parent = 806a20f64f9c19ea2eb4b9ffaeff98d7b186583b
+	parent = d048ded11bbd4eb5153aded10a81880046cf5f24
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/image-uploader/.gitrepo
+++ b/modules/apps/collaboration/image-uploader/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4b7c15d0c2e68e2a32bfb487d9321c2798fa9bf1
+	commit = 2a00ec98f6728eff3986a89d97ba78b8d47c0445
 	mode = push
-	parent = a67c2d6feb5ef65f42a4864ebaf821819909b1ae
+	parent = 720b28ba177be9a0fc7a71288bce352cba54223a
 	remote = git@github.com:liferay/com-liferay-image-uploader.git

--- a/modules/apps/collaboration/invitation/.gitrepo
+++ b/modules/apps/collaboration/invitation/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = a63e9544398cbd03faa166bdc473b93011127b2b
+	commit = adca188ce95a9f7d0a9c7aa4886eaab1a085be37
 	mode = push
-	parent = fe77f617ccaea7327cb9b51347fa7bd3bb78cc5a
+	parent = 49dd4d45ae7b6ebbefe51755482c8f84e11300ca
 	remote = git@github.com:liferay/com-liferay-invitation.git

--- a/modules/apps/collaboration/item-selector/.gitrepo
+++ b/modules/apps/collaboration/item-selector/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 171d9fe5ab2582991f8bddb4cd1ec9d94ffd4e23
+	commit = 0dc934fc68130bc8fefe909351cc88ed9ff5bd26
 	mode = push
-	parent = c3e8dcfd067e106b2c88b3c47ad9eceeb3dcb6e3
+	parent = 4a4d37b47d7d619a417777ad00989f81d6140997
 	remote = git@github.com:liferay/com-liferay-item-selector.git

--- a/modules/apps/collaboration/mentions/.gitrepo
+++ b/modules/apps/collaboration/mentions/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = cb1ede408189f9f2bb9973b865fbc37913d8f5c7
+	commit = 7c73057ca79facecabdbc5d6a1dd13cfa93b30fb
 	mode = push
-	parent = a6b8152f759b4af92fffeb063a5518749ce906c6
+	parent = 7cae5a8b10b3645f729f365b229e9bc5a382b18b
 	remote = git@github.com:liferay/com-liferay-mentions.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f5403160570752dd17463a33c52ff761a98b6623
+	commit = 5e217b12744f539730725154d8111a0099d96ce4
 	mode = push
-	parent = e5a3cffc0c046b2b52095142c63fa5f9f77abf32
+	parent = 5ca9d7d00f939fd8635e5ac2955fc5c80939ed4b
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/microblogs/.gitrepo
+++ b/modules/apps/collaboration/microblogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = c9280e9305f54e7e8224ff0c076b463c6bdd6ad5
+	commit = 2d326d9a3c2c07f32226d068cfeb6e773ac78e0a
 	mode = push
-	parent = 44f2d1b4c645e82aa1ca96e81fd6b84097528fbf
+	parent = 4a7f4dddc08ed2d8f1f43d0582fc929272aeb36c
 	remote = git@github.com:liferay/com-liferay-microblogs.git

--- a/modules/apps/collaboration/social/.gitrepo
+++ b/modules/apps/collaboration/social/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4efff79e1e955a415f00211aa30fec413aa76b71
+	commit = 0dd9d18b5d0300f131864be34582adfffc988cb0
 	mode = push
-	parent = c5551bf7ae90603290b7fe9fd1a7db1b60dbe5c2
+	parent = 8ba5da66dcc4f635fae7f3557da2d6d022ab14ed
 	remote = git@github.com:liferay/com-liferay-social.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 52232d68e0860f2e5317853c83c768c8c3ad9577
+	commit = 30e4728c233d7400f82da8e6353413ce4254323c
 	mode = push
-	parent = ecc658196f4475398efe0dec3726cefb8319b283
+	parent = 2c2bdd82f34be8df75a221ba8bf049f70b2ee1fd
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5f4cfa6061cd8efe619ca182e3c5a5ba749900ec
+	commit = 95e37fc170de2a4ea4944634c22d1ef3315b9dba
 	mode = push
-	parent = b40f06694af3eae1c5b89043a18f85d53ed07d3c
+	parent = 7cbc1de7be37f98d62e92328c4f00ed9e8a8363e
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 772517ac892f25204047a13edaa712703619ab51
+	commit = b97c433ec91c3ac40165ced297809f6101d87caa
 	mode = push
-	parent = f7980c3aa88aa6124a68138f2920595d280eb16b
+	parent = 4f10e60041382fdb81c570bb6bfb232643ad98c6
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 048ff1e252ded7d56d80b57437bad388b62c5ba9
+	commit = 8f4b5af12b279338b405dff7153a5118f126491c
 	mode = push
-	parent = 181fc2f2a2056d43d7326f1176e01ffae9825ef1
+	parent = 417a75736afa71b45ea8229619aada35f086cfe5
 	remote = git@github.com:liferay/com-liferay-dynamic-data-mapping.git

--- a/modules/apps/forms-and-workflow/polls/.gitrepo
+++ b/modules/apps/forms-and-workflow/polls/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 77ce08e97632adcca8afce3d6f2f3078d38e414a
+	commit = c6387ef33dafb66ca0346f04ca6fc76bee21c2a0
 	mode = push
-	parent = 5cd22e2072ff5ef859d3eb73c2f05d36038e82c1
+	parent = 8255a6167538a6f20d0240c832906c499d74e26f
 	remote = git@github.com:liferay/com-liferay-polls.git

--- a/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
+++ b/modules/apps/forms-and-workflow/portal-workflow/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0c89f0ff800b6309f0cec9c6e57ec70dabad13bc
+	commit = 26752a1a2f8b8e752a67fe4728cde4a2a8516db1
 	mode = push
-	parent = 138722f484bd2cee37f4da8f76fcfca2cef71ea5
+	parent = f51f74b69d7065a17ecc500fc6f3bfa2197efc6d
 	remote = git@github.com:liferay/com-liferay-portal-workflow.git

--- a/modules/apps/foundation/configuration-admin/.gitrepo
+++ b/modules/apps/foundation/configuration-admin/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 4d59a07d002839d0c2c973b5754fe6e10f6806dc
+	commit = 43215836ca9c88bc1cc5d9686e77264bf2111d6f
 	mode = push
-	parent = 970b625af5f5913bb21df3bd0c15551be81a8d09
+	parent = 952f2e96e7803d49bd1e6988b206b09b3f6163bb
 	remote = git@github.com:liferay/com-liferay-configuration-admin.git

--- a/modules/apps/foundation/contacts/.gitrepo
+++ b/modules/apps/foundation/contacts/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 54e684d82dced80a914c2cc18544c9be7d4b9f47
+	commit = 617e20eaef20587f0bd79b3d846996636a885411
 	mode = push
-	parent = 20dfa02d34590187e419d6b62063255dd07c1d82
+	parent = fcdd68efc31024ee434b1b86e49d5e7eae4eb4b6
 	remote = git@github.com:liferay/com-liferay-contacts.git

--- a/modules/apps/foundation/expando/.gitrepo
+++ b/modules/apps/foundation/expando/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0ae555bf34ffeff1aa874799460786ba04ad6060
+	commit = c8d6302f87932302c983b2d1922dc528517e44cf
 	mode = push
-	parent = ee4ce86b0a70dc82b7460d466cc053aef943b96a
+	parent = f7e577fbe79bba1b0638e699713e5bfaeb3d253b
 	remote = git@github.com:liferay/com-liferay-expando.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 914ba312be3079de190bd136d20ae83ec5a09ce8
+	commit = 545695aaae0dc2e80a81e73f0f04a20228f1fb0a
 	mode = push
-	parent = 272ee580e2881e75286aca89a6b9f92e16c85c5e
+	parent = 52c2a231cf00564b06ef41883bcca657d3302385
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/frontend-taglib/.gitrepo
+++ b/modules/apps/foundation/frontend-taglib/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = e52f47d45e901a4bdc5bc84d211711fd8cc0d672
+	commit = 2ae4c84c2576e450752d62965b2df33bea3fcc57
 	mode = push
-	parent = 6c29204949285af3b2acde038f57635552dccd1d
+	parent = 9ec37fc3118d76c11251271a17911d2073978f1f
 	remote = git@github.com:liferay/com-liferay-frontend-taglib.git

--- a/modules/apps/foundation/login/.gitrepo
+++ b/modules/apps/foundation/login/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b6c13dfba028c66a1094c9fcfdaf9c5a46c05243
+	commit = 272b14fd831a9b82b9cf0635a78de446e0c0b8fe
 	mode = push
-	parent = 2ea8fca27cd54a06f7e0aab236086ebd6e473185
+	parent = 830f07ab548903da38fa9fa8ffe19d5264e0931a
 	remote = git@github.com:liferay/com-liferay-login.git

--- a/modules/apps/foundation/mobile-device-rules/.gitrepo
+++ b/modules/apps/foundation/mobile-device-rules/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3085e862b5a4262ac003b9adecf70f45790f765b
+	commit = 8c14e14db902ffc35e4f9408da0fdc4ac43a08fb
 	mode = push
-	parent = c0b8ae8194d87140ad466ca3e915180770eaa747
+	parent = 31add131b6eb8585be5d8cf8c3bf460fd6f11cff
 	remote = git@github.com:liferay/com-liferay-mobile-device-rules.git

--- a/modules/apps/foundation/my-account/.gitrepo
+++ b/modules/apps/foundation/my-account/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 94a1dac8cfdf9f79bb651890d3d660c48b3016f1
+	commit = 5cb8d5dabe29ee35fdcd4ce31ed638dc84bff0e1
 	mode = push
-	parent = 78b392eca8c2af94df52575adec188844f95a9b5
+	parent = 4342b66bc915a7f8ba136cee80801027a7acd9be
 	remote = git@github.com:liferay/com-liferay-my-account.git

--- a/modules/apps/foundation/password-policies-admin/.gitrepo
+++ b/modules/apps/foundation/password-policies-admin/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 9f8701875d838632695b950b0b8a2c844da187b8
+	commit = 7044ea0fa113ff812ffc984f180ee655ddab0927
 	mode = push
-	parent = aa955de2ae58c49bc58bc55d8495b348020c37a0
+	parent = 483ea22abc223751732ab03af1f0bf56ff6632e5
 	remote = git@github.com:liferay/com-liferay-password-policies-admin.git

--- a/modules/apps/foundation/plugins-admin/.gitrepo
+++ b/modules/apps/foundation/plugins-admin/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 53d9de840064b544170468bf9c498e691a9aeb96
+	commit = 8ee7b9742a2559c8610d1b632102045ecea6b1b9
 	mode = push
-	parent = 06e229ec9869161113c752b64207524971a16ad6
+	parent = cf6d6cf5f9c31f91116c86f579a94c5a7fd8d17c
 	remote = git@github.com:liferay/com-liferay-plugins-admin.git

--- a/modules/apps/foundation/portal-scheduler/.gitrepo
+++ b/modules/apps/foundation/portal-scheduler/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 6d180028cb5fac67cef5c1903e6b2f278c6d5fcc
+	commit = e3109a7499a0140e0788d701faf17e7770140b23
 	mode = push
-	parent = e7b05925773e80116c58f1a9a0f6e60145f551ae
+	parent = f431d0a7cff39ab6579dddc742384ab44c14f86d
 	remote = git@github.com:liferay/com-liferay-portal-scheduler.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = cd4f2c07dd20b9f8234abbd292e67e3facd80cff
+	commit = 8e5df9ded9385e5f816c4ff0eebcf35ec98f3e61
 	mode = push
-	parent = ca0c3f827c0694b5b882127e5d1d41c55c4f2f47
+	parent = 240600f5a151027e73176bba5e368438617cc47c
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security-sso/.gitrepo
+++ b/modules/apps/foundation/portal-security-sso/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 6fbf0c062db66f7944041d5395d55d74809eb2ba
+	commit = e9713957cc0828b556f2482efad3f855a3de00e0
 	mode = push
-	parent = ee0263a60435d101344c498b6798679c50084eaf
+	parent = 61197d503d4719cadea12b45a18922650df05747
 	remote = git@github.com:liferay/com-liferay-portal-security-sso.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5484767bf50119705e802f91cd2614edcce13be0
+	commit = ef8562373cae583312b9cdf2f157dae242c28457
 	mode = push
-	parent = f3c0388defb38059f8f9de1aef31a558268f5208
+	parent = fab4ee2fe1a3c79b2ca22f255bf742a95d653c5c
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 46f540c12f463e0b60269f9e1dace2fc52d8b04c
+	commit = 8343fc20bd42387a45ff8d96b7b974521fdd5866
 	mode = push
-	parent = d76de4f6d850cbc2e96af264fae44278f100dfe3
+	parent = 2cacb0c290af6abd7cd4007181ff6c3454294ba8
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/twitter/twitter-service/build.gradle
+++ b/modules/apps/twitter/twitter-service/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.4.0"
 	provided group: "com.liferay", name: "com.liferay.twitter.api", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.18.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 }


### PR DESCRIPTION
Hey Brian,

This is a weird issue that took me a lot of time to figure it out, and I know that it's very weird. 

http://stackoverflow.com/questions/18349131/why-org-json-jsonobject-getlong-and-getstring-not-equal

Basically, if you eval this expression:

`JSONFactoryUtil.createJSONObject().put("test", 3341020181694750713L).getLong("test")` it will return `3341020181694750720` which is different than the value you stored `3341020181694750713L`. 

However, if the number is not that big it will work: 
`JSONFactoryUtil.createJSONObject().put("test", 181694750713).getLong("test")` it will return the correct value `181694750713`.

I found a thread that explains that it happens because json uses internally doubles and that's lossy. 

Therefore, I needed to use GetterUtil.getLong() and obtain the json value as a string.

Thanks!