### PR TITLE
LRQA-30142 Comment out notification logic for Arquillian broken connection failure.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ModulesIntegrationBatchBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/ModulesIntegrationBatchBuild.java
@@ -120,6 +120,7 @@ public class ModulesIntegrationBatchBuild extends BatchBuild {
 				_notificationsComplete = true;
 			}
 
+			/*
 			try {
 				JenkinsResultsParserUtil.sendEmail(
 					sb.toString(),
@@ -130,6 +131,7 @@ public class ModulesIntegrationBatchBuild extends BatchBuild {
 				System.out.println(
 					"Unable to send email notification: " + e.getMessage());
 			}
+			*/
 		}
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-30142

@shuyangzhou doesn't think there will be any work done on this issue for a while so he would like to stop receiving notifications until then. For now, I have commented out the notification logic so can easily turn it back on when the time comes.

@brianchandotcom Please publish com.liferay.jenkins.results.parser.jar after merging this pull.