### PR TITLE
Revert "opensocial/.gitignore not needed"

### DIFF
--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 5e830c06291a525e857f9fa9043c9ee92c83a9d7
+	commit = 43116bee6e5f77f18c6f22af63c5552fcef6b90a
 	mode = push
-	parent = ebfa2fbef0a713cc40fd2e607fbf4ba5bb8e54f2
+	parent = 0e542387309e57c9b1ea5b5394fe8b8c3f9c0518
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b17542a8f36b045b8df1ec6eeb374c910dc18558
+	commit = ba84317ab3e04c4c74a1ab28237bbeacfa8b0697
 	mode = push
-	parent = 3bec09301a5e7610b1ddfade873c18e38e8c2637
+	parent = ae9eec3b59501e875142c34dc3c5ebe2f77ffd95
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0ae1567d94f3ff623ec06bb568f1b79b1b6789de
+	commit = 3efc28ee557e5367307c70fa7cf449c34dda1188
 	mode = push
-	parent = 83eef872977bdf3fdab0c4d19f1fac5190a3d826
+	parent = 35fa98953e9c77b725a32b455bfa2cd92ea56242
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/opensocial/.gitignore
+++ b/modules/apps/opensocial/.gitignore
@@ -1,0 +1,1 @@
+!/opensocial-portlet/docroot/WEB-INF/lib


### PR DESCRIPTION
Hi Brian!

`opensocial/.gitignore` is needed because:

- All `lib` subdirectories are ignored in [`modules/.gitignore`](https://github.com/liferay/liferay-portal/blob/master/modules/.gitignore#L12)
- `opensocial-portlet` has a `service.xml`, and so we have to commit the service JAR in its `WEB-INF/lib` directory