### PR TITLE
LPS-70422

### DIFF
--- a/modules/apps/foundation/portal-lock/.gitrepo
+++ b/modules/apps/foundation/portal-lock/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 6dfec8fc40aa6671655df7ffa5e52017ee3317fa
+	commit = 7fc0304e25b4a116633341273cf9bbdeacb151ad
 	mode = push
-	parent = f205cedd9229a00b817e8ddbfd306336b1bb397d
+	parent = 3f33bb319acf09363d8fcc351585d442bb604d2e
 	remote = git@github.com:liferay/com-liferay-portal-lock.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 3f0d86cd772b407efe6a45256230761adf284119
+	commit = 275eda3f162dcecbdde5158c4b78b7abc4bacae2
 	mode = push
-	parent = 9f4d4229611496fe3d88744a1364427458aa3948
+	parent = ce5fb17408140c5fe003947620f3135a18bee497
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal-template/.gitrepo
+++ b/modules/apps/foundation/portal-template/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = ea352467760564cbe763ca48f80e16cfe64db2a5
+	commit = fd58133ffe9358ec7344cad268824e5be74598ad
 	mode = push
-	parent = c1b944f538e2f21f184a327eba448a4a54099375
+	parent = ed2a8f41a927eca4bfc3cea7cb2d78afd9e3dd3a
 	remote = git@github.com:liferay/com-liferay-portal-template.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d50bd8bf333d4ba867017c89e3685bef5fb23c6e
+	commit = d9f1acb8424031e6bd761f5ba01fdfc5877077d7
 	mode = push
-	parent = 961490029f3b8dbb1665806c0c57602ddb3e7a7b
+	parent = c9ef3b56bc97fcf72e93551f72f94595364c3643
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/aui/ToolTag.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/aui/ToolTag.java
@@ -16,7 +16,9 @@ package com.liferay.portal.kernel.servlet.taglib.aui;
 
 /**
  * @author Brian Wing Shun Chan
+ * @deprecated As of 7.0.0, with no direct replacement
  */
+@Deprecated
 public interface ToolTag {
 
 	public void cleanUp();

--- a/readme/7.0/BREAKING_CHANGES.markdown
+++ b/readme/7.0/BREAKING_CHANGES.markdown
@@ -4343,3 +4343,28 @@ This change was made as part of the modularization efforts to ease portal
 configuration changes.
 
 ---------------------------------------
+
+### Deprecated the aui:tool Tag with No Direct Replacement
+- **Date:** 2017-Feb-02
+- **JIRA Ticket:** LPS-70422
+
+#### What changed?
+
+The `aui:tool` tag has been deprecated with no direct
+replacement.
+
+#### Who is affected?
+
+Plugins or templates that are using the `aui:tool` tag must
+remove their usage of the tag.
+
+#### How should I update my code?
+
+There is no direct replacement. You should remove all usages of the
+`aui:tool` tag.
+
+#### Why was this change made?
+
+This change was made as a part of the ongoing strategy to deprecate unused tags.
+
+---------------------------------------

--- a/util-taglib/src/com/liferay/taglib/aui/ToolTagImpl.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ToolTagImpl.java
@@ -20,7 +20,9 @@ import com.liferay.taglib.aui.base.BaseToolTagImpl;
 /**
  * @author Julio Camarero
  * @author Brian Wing Shun Chan
+ * @deprecated As of 7.0.0, with no direct replacement
  */
+@Deprecated
 public class ToolTagImpl extends BaseToolTagImpl implements ToolTag {
 
 	@Override

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseToolTagImpl.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseToolTagImpl.java
@@ -22,7 +22,9 @@ import javax.servlet.jsp.JspException;
  * @author Nathan Cavanaugh
  * @author Julio Camarero
  * @generated
+ * @deprecated As of 7.0.0, with no direct replacement
  */
+@Deprecated
 public class BaseToolTagImpl extends javax.servlet.jsp.tagext.TagSupport {
 
 	@Override


### PR DESCRIPTION
Hey @brianchandotcom,

Attached is an update for http://issues.liferay.com/browse/LPS-70422.  I spoke with @Preston-Crary about this deprecation and because one of the java files is in ```portal-kernel```, we would have to release a version of the updated ```portal-kernel``` with the deprecation notes otherwise if we move it directly into the jar that @Preston-Crary made, the user would never get any notice about the deprecation.

Once we release this updated ```portal-kernel``` jar, we can proceed with moving this taglib to the new comapt jar that @Preston-Crary made.  

Please let me know if you have any questions. Thanks!