### PR TITLE
[See description] LPS-68616 Add missing indexes during the upgrade

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 802d6cfa111ced8b224a3c8e433dbdd4864c969a
+	commit = 6a7248421adddb648f27e0fbc5234f33b537ead2
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 8849eca79c4e92274fad674a5af8f1e3d13b8e9f
+	parent = f62791e9fc9cb8855873b7d1062436d77637392c
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4ec3192b6be6322fa96e0df44703c9bd6e640969
+	commit = 38d88657a92310827ad46e5bd9c4fde2ea2442e4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a627676a889fd66b7ed180a9259aa6eeb139f68a
+	parent = 9cb424ec1a73f8b04e8ab7516ba66a17381cbff8
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e96ea958e87f73de3fd320170ab1e2f9d8d28e28
+	commit = d23abd5f4236463e0bb6edb506bcc66aaa9db76b
 	mergebuttonmergecommits = false
 	mode = push
-	parent = abbd8dea4d22db80b89bcba6f9369f76b2903db4
+	parent = 5c5a6070b6e7baabe0e31c8155d0bc7b9981dd08
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/invitation/.gitrepo
+++ b/modules/apps/collaboration/invitation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 306efd616ee1558f79a59be46fe439e04941af6d
+	commit = 6a01a916f13c70b3c84a81ef5cc66a0a312a8826
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 169fc004d803576f67e5abb32cbdcc9724c3ffb6
+	parent = fbce4d8e6e9ccc4e56782a04c25873e75c5cd429
 	remote = git@github.com:liferay/com-liferay-invitation.git

--- a/modules/apps/collaboration/mentions/.gitrepo
+++ b/modules/apps/collaboration/mentions/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 55a040e6755e541f20d1e3a10e0e2b78806dcebe
+	commit = e3d2eff2c8d9f52026300416790530e93faaeb5c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9b58d335d73fbd513936482850bc2c26c7b159fc
+	parent = 45934f9b5ce394f665a3ea742b9e8e7b9333bf43
 	remote = git@github.com:liferay/com-liferay-mentions.git

--- a/modules/apps/collaboration/microblogs/.gitrepo
+++ b/modules/apps/collaboration/microblogs/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c9a34bdf086047d81196aae5a77851c2965bfa7b
+	commit = 916a884c1b4c694fc9c4a5db60abe13980d6e658
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5568119ed62b22ced07014cecc8bd127edd39583
+	parent = a434faa05d2d62644543a06afa539a6fec6db4f4
 	remote = git@github.com:liferay/com-liferay-microblogs.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e58bdd1a37982082defe88586e7712a613bf2543
+	commit = ffb72f1a269948e3827061c1b16d91ef0a512cd6
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ccd6ed893dbae2a6272c938fee3bbc5a2f37ecca
+	parent = 4ddeab0195afb93912c1c80edda8d2d9518f6988
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/collaboration/wiki/wiki-service/build.gradle
+++ b/modules/apps/collaboration/wiki/wiki-service/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.wiki.api", version: "2.2.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "commons-lang", name: "commons-lang", version: "2.6"

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v1_0_0/UpgradeCompanyId.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/upgrade/v1_0_0/UpgradeCompanyId.java
@@ -22,6 +22,15 @@ import com.liferay.portal.kernel.upgrade.BaseUpgradeCompanyId;
 public class UpgradeCompanyId extends BaseUpgradeCompanyId {
 
 	@Override
+	protected void doUpgrade() throws Exception {
+		super.doUpgrade();
+
+		runIndexSQL(
+			"create index IX_13319367 on WikiPageResource " +
+				"(uuid_[$COLUMN_LENGTH:75$], companyId)");
+	}
+
+	@Override
 	protected TableUpdater[] getTableUpdaters() {
 		return new TableUpdater[] {
 			new TableUpdater("WikiPageResource", "WikiNode", "nodeId")

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/resources/com/liferay/wiki/internal/upgrade/v1_0_0/dependencies/update.sql
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/resources/com/liferay/wiki/internal/upgrade/v1_0_0/dependencies/update.sql
@@ -1,3 +1,5 @@
 alter table WikiPageResource add groupId LONG;
 
+create unique index IX_F705C7A9 on WikiPageResource (uuid_[$COLUMN_LENGTH:75$], groupId);
+
 COMMIT_TRANSACTION;

--- a/modules/apps/forms-and-workflow/polls/.gitrepo
+++ b/modules/apps/forms-and-workflow/polls/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0b829580884439fda8eee25746e44e2024194d6b
+	commit = 92c6dc45ff14a0affc751a373201db626265ccfb
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 25c2c204af098ce5333479bb13d750107dbdd1df
+	parent = 2a9bfe316f2ea4cd580b72cd0b4c1b1a5d411a66
 	remote = git@github.com:liferay/com-liferay-polls.git

--- a/modules/apps/foundation/contacts/.gitrepo
+++ b/modules/apps/foundation/contacts/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 8cb44ac4f582d604e905802162ea87aa90779a36
+	commit = 89eeea62c46680a664d4c5a29f3e189c69eba9a3
 	mergebuttonmergecommits = false
 	mode = push
-	parent = dada92a8bb1f256d4404f2088c8851dc71bbec30
+	parent = 619f02b140a1d43093ec781f636b93a52f437125
 	remote = git@github.com:liferay/com-liferay-contacts.git

--- a/modules/apps/foundation/frontend-editor/.gitrepo
+++ b/modules/apps/foundation/frontend-editor/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 377b6dc07745a437599678f494935882923b06f6
+	commit = 0ca2e5ee1be2303c42108657120bdd1c74d94e21
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 6a6e6929e4ca16d249b54561b3f02ec5879bb3b7
+	parent = 5db54d5e5318788b0a72bbe7a10f3ccf6cf2d1f4
 	remote = git@github.com:liferay/com-liferay-frontend-editor.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c04ec62e81f5029d5a9e896d6fd1754e028796e9
+	commit = 4dcbfc8c2c18340104518a450be82a175b048b39
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9921a547d75ad381a5a073d02a18e623b8d4b5a4
+	parent = cdc3e3f05da251b5e73f2a8221c993c0ae1dd5dc
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/frontend-theme/.gitrepo
+++ b/modules/apps/foundation/frontend-theme/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 904f90dbdc857006363fa9a4389377833c666f4c
+	commit = bcadc23a09abd7cf2310aabf70d18247edb01bda
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ec5a24a662843a13dd5ab4662d72d1ba10ee318d
+	parent = 16237997129ec1068bf2e36387345935636cbad0
 	remote = git@github.com:liferay/com-liferay-frontend-theme.git

--- a/modules/apps/foundation/mobile-device-rules/.gitrepo
+++ b/modules/apps/foundation/mobile-device-rules/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = da67d0839bce1615794655ebeb7e4780b8059805
+	commit = 06f11e823c64a7370f518d1350d9a28f1457c0f1
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 320dc992ebf47b4b7ffd25a06646e4a124d784f5
+	parent = fddcc4f6233f12e542fee21c7614751f000b895b
 	remote = git@github.com:liferay/com-liferay-mobile-device-rules.git

--- a/modules/apps/foundation/portal-background-task/.gitrepo
+++ b/modules/apps/foundation/portal-background-task/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = bf5a11243478d03ab5edea3f34ebe8e52d3de581
+	commit = 74520bb40eab7fd4eca71e77e7c0fe96e91f8872
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 408823b11595cd311bbcf1e2c6281e6118241f36
+	parent = d775b7360822747d619603a277450019eec3af9b
 	remote = git@github.com:liferay/com-liferay-portal-background-task.git

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v1_0_0/UpgradeSchema.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v1_0_0/UpgradeSchema.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Miguel Pastor
+ */
+public class UpgradeSchema extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			String template = StringUtil.read(
+				UpgradeSchema.class.getResourceAsStream(
+					"dependencies/update.sql"));
+
+			runSQLTemplateString(template, false, false);
+		}
+	}
+
+}

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/upgrade/BackgroundTaskServiceUpgrade.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/upgrade/BackgroundTaskServiceUpgrade.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.background.task.upgrade;
 
 import com.liferay.portal.background.task.internal.upgrade.v1_0_0.UpgradeBackgroundTask;
+import com.liferay.portal.background.task.internal.upgrade.v1_0_0.UpgradeSchema;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -28,7 +29,11 @@ public class BackgroundTaskServiceUpgrade implements UpgradeStepRegistrator {
 	@Override
 	public void register(Registry registry) {
 		registry.register(
-			"com.liferay.portal.background.task.service", "0.0.1", "1.0.0",
+			"com.liferay.portal.background.task.service", "0.0.1", "0.0.2",
+			new UpgradeSchema());
+
+		registry.register(
+			"com.liferay.portal.background.task.service", "0.0.2", "1.0.0",
 			new UpgradeBackgroundTask());
 	}
 

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/resources/com/liferay/portal/background/task/internal/upgrade/v1_0_0/dependencies/update.sql
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/resources/com/liferay/portal/background/task/internal/upgrade/v1_0_0/dependencies/update.sql
@@ -1,0 +1,3 @@
+create index IX_FBF5FAA2 on BackgroundTask (completed);
+
+COMMIT_TRANSACTION;

--- a/modules/apps/foundation/portal-lock/.gitrepo
+++ b/modules/apps/foundation/portal-lock/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e6717c0b290345f5d803740c6db7d8c7f6d1e982
+	commit = d6bd318e80bc355bbb16e3ab96cceaba6b525403
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0dd47ed35bc17b9a132fb4bf0f51fcc439ed7429
+	parent = 11b8446a3ded729c086f33fc619ae0de478b873e
 	remote = git@github.com:liferay/com-liferay-portal-lock.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 5108fda32d680a950e584eeb7056dfddb431d29f
+	commit = 042cc4c30a1c863c675c4fd1efe537c906e1dbc5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 83ef3b8e2e3106fc245fa108f5ed3705e5444d1f
+	parent = b6a0c8609fb619e6f4a276e3f3f8e6b52511f734
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 903eca86700a274c5c54302d896a92b221a8aa42
+	commit = c86bb084871e14e69f8783188d58a37d355f2e02
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c30e3b11594778ff916d01f50f25556e2b8dd310
+	parent = 4c7ebf91d0343f2ecba6f7498890135cb56e1847
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -2486,7 +2486,7 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  om.liferay.portal.kernel.concurrent;version="7.0.0";uses:="com.lifera
  y.portal.kernel.memory,com.liferay.portal.kernel.util",com.liferay.po
  rtal.kernel.configuration;version="6.2.0",com.liferay.portal.kernel.d
- ao.db;version="7.2.0",com.liferay.portal.kernel.dao.jdbc;version="7.1
+ ao.db;version="7.3.0",com.liferay.portal.kernel.dao.jdbc;version="7.1
  .0",com.liferay.portal.kernel.dao.jdbc.aop;version="6.3.0",com.lifera
  y.portal.kernel.dao.jdbc.pool.metrics;version="1.0.0",com.liferay.por
  tal.kernel.dao.orm;version="7.2.0";uses:="com.liferay.exportimport.ke
@@ -2925,14 +2925,14 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  ce,com.liferay.portal.kernel.util,com.liferay.trash.kernel.model,java
  x.portlet,javax.servlet,javax.servlet.http",com.liferay.portal.kernel
  .tree;version="2.1.0";uses:="com.liferay.portal.kernel.exception",com
- .liferay.portal.kernel.upgrade;version="7.3.0";uses:="com.liferay.por
+ .liferay.portal.kernel.upgrade;version="7.4.0";uses:="com.liferay.por
  tal.kernel.dao.db,com.liferay.portal.kernel.exception,com.liferay.por
  tal.kernel.upgrade.util,com.liferay.portal.kernel.util,com.liferay.po
  rtal.kernel.xml,javax.portlet",com.liferay.portal.kernel.upgrade.dao.
  orm;version="7.0.0";uses:="com.liferay.portal.kernel.dao.db",com.life
  ray.portal.kernel.upgrade.util;version="7.0.0";uses:="com.liferay.por
  tal.kernel.model,com.liferay.portal.kernel.upgrade",com.liferay.porta
- l.kernel.upgrade.v6_2_0;version="7.2.0";uses:="com.liferay.portal.ker
+ l.kernel.upgrade.v6_2_0;version="7.3.0";uses:="com.liferay.portal.ker
  nel.upgrade",com.liferay.portal.kernel.upload;version="6.3.0";uses:="
  com.liferay.portal.kernel.exception,com.liferay.portal.kernel.json,co
  m.liferay.portal.kernel.repository.model,com.liferay.portal.kernel.se

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -256,6 +256,24 @@ public abstract class BaseDB implements DB {
 	}
 
 	@Override
+	public void runIndexSQL(Connection con, String sql)
+		throws IOException, SQLException {
+
+		sql = applyMaxStringIndexLengthLimitation(
+			_columnLengthPattern.matcher(sql));
+
+		runSQL(con, new String[] {sql});
+	}
+
+	@Override
+	public void runIndexSQL(String sql) throws IOException, SQLException {
+		sql = applyMaxStringIndexLengthLimitation(
+			_columnLengthPattern.matcher(sql));
+
+		runSQL(new String[] {sql});
+	}
+
+	@Override
 	public void runSQL(Connection con, String sql)
 		throws IOException, SQLException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -32,6 +32,17 @@ public abstract class BaseDBProcess implements DBProcess {
 	public BaseDBProcess() {
 	}
 
+	public void runIndexSQL(String template) throws IOException, SQLException {
+		DB db = DBManagerUtil.getDB();
+
+		if (connection == null) {
+			db.runIndexSQL(template);
+		}
+		else {
+			db.runIndexSQL(connection, template);
+		}
+	}
+
 	@Override
 	public void runSQL(Connection connection, String template)
 		throws IOException, SQLException {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -87,6 +87,11 @@ public interface DB {
 
 	public boolean isSupportsUpdateWithInnerJoin();
 
+	public void runIndexSQL(Connection con, String sql)
+		throws IOException, SQLException;
+
+	public void runIndexSQL(String sql) throws IOException, SQLException;
+
 	public default void runSQL(Connection con, DBTypeToSQLMap dbTypeToSQLMap)
 		throws IOException, SQLException {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBProcess.java
@@ -27,6 +27,12 @@ import javax.naming.NamingException;
  */
 public interface DBProcess {
 
+	public default void runIndexSQL(String template)
+		throws IOException, SQLException {
+
+		throw new UnsupportedOperationException();
+	}
+
 	public void runSQL(Connection connection, String template)
 		throws IOException, SQLException;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.0
+version 7.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/packageinfo
@@ -1,1 +1,1 @@
-version 7.3.0
+version 7.4.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/v6_2_0/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/v6_2_0/packageinfo
@@ -1,1 +1,1 @@
-version 7.2.0
+version 7.3.0


### PR DESCRIPTION
From: #46825 (comment)

Hi @brianchandotcom,

Here you can see an example of using runIndexSQL:
https://github.com/brianchandotcom/liferay-portal/pull/46907/commits/488fb684bd4d4247f08b513cf37d60f89cf4d955

We think that it's better not to add the call to applyMaxStringIndexLengthLimitation to runSQL() for two main reasons:
- Here https://github.com/brianchandotcom/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java#L365 we would call applyMaxStringIndexLengthLimitation 1+n (n=number of lines in SQL file) without needing it instead of just once as right now.
- This check is just valid for indexes so we would add an impact in the peformance since in most of the cases we don't need this check.

Let me know what you think about this.

Thanks.

@migue