### PR TITLE
LPS-70662 Misleading tooltip in Source column when viewing a portal property that has been obfuscated

### DIFF
--- a/modules/apps/foundation/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
+++ b/modules/apps/foundation/server/server-admin-web/src/main/resources/META-INF/resources/properties.jsp
@@ -84,20 +84,16 @@ serverURL.setParameter("tabs2", tabs2);
 		String property = (String)entry.getKey();
 		String value = StringPool.BLANK;
 
-		boolean overriddenPropertyValue = false;
+		boolean overriddenPropertyValue = portalPropertiesTab && (serverPortletPreferencesMap.containsKey(property) || companyPortletPreferencesMap.containsKey(property));
 
 		if (ArrayUtil.contains(PropsValues.ADMIN_OBFUSCATED_PROPERTIES, property)) {
 			value = StringPool.EIGHT_STARS;
 		}
 		else if (portalPropertiesTab && serverPortletPreferencesMap.containsKey(property)) {
 			value = serverPortletPreferences.getValue(property, StringPool.BLANK);
-
-			overriddenPropertyValue = true;
 		}
 		else if (portalPropertiesTab && companyPortletPreferencesMap.containsKey(property)) {
 			value = companyPortletPreferences.getValue(property, StringPool.BLANK);
-
-			overriddenPropertyValue = true;
 		}
 		else {
 			value = (String)entry.getValue();


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-70662

Thanks.

/cc @mbowerman Thanks for the regression fix! (And sorry for the delay in response, I'm sick.)