### PR TITLE
LPS-70519 portal-kernel 2.11.0 apply

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-test-util/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "[2.2.0,3.0.0)"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.11.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.test", version: "1.0.0"
 	provided group: "junit", name: "junit", version: "4.12"
 	provided group: "org.mockito", name: "mockito-core", version: "1.10.8"


### PR DESCRIPTION
2.11.0 should also be safe enough to cherry backport.