### PR TITLE
LPS-70684 : Portlet's Look and Feel generates incorrect portlet id

### DIFF
--- a/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/look_and_feel.js
+++ b/modules/apps/web-experience/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/js/look_and_feel.js
@@ -584,7 +584,7 @@ AUI.add(
 				var portletClasses = instance._getCSSClasses(portletBoundary, portlet);
 
 				var portletInfoText = Liferay.Language.get('your-current-portlet-information-is-as-follows') + '<br />' +
-					Liferay.Language.get('portlet-id') + ': <strong>#' + portletId + '</strong><br />' +
+					Liferay.Language.get('portlet-id') + ': <strong>#portlet_' + portletId + '</strong><br />' +
 					Liferay.Language.get('portlet-classes') + ': <strong>' + portletClasses + '</strong>';
 
 				var customNote = A.one('#lfr-refresh-styles');


### PR DESCRIPTION
Fixed to generate correct portlet ID with correct prefix added.
Tested on : JDK 8, Tomcat 8, MySQl 5.7, Chrome, FF, IE
