### PR TITLE
Revert "LPS-70754 Optimize BaseValidatorTagSupport to use findAncesto…

### DIFF
--- a/util-taglib/src/com/liferay/taglib/BaseValidatorTagSupport.java
+++ b/util-taglib/src/com/liferay/taglib/BaseValidatorTagSupport.java
@@ -16,13 +16,14 @@ package com.liferay.taglib;
 
 import com.liferay.portal.kernel.servlet.taglib.aui.ValidatorTag;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.taglib.aui.FormTag;
 import com.liferay.taglib.aui.ValidatorTagImpl;
 import com.liferay.taglib.util.IncludeTag;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
 
 /**
@@ -74,11 +75,18 @@ public abstract class BaseValidatorTagSupport extends IncludeTag {
 			return;
 		}
 
-		FormTag formTag = (FormTag)findAncestorWithClass(this, FormTag.class);
+		HttpServletRequest request =
+			(HttpServletRequest)pageContext.getRequest();
 
-		if (formTag != null) {
-			formTag.addValidatorTags(
-				getInputName(), ListUtil.fromMapValues(_validatorTags));
+		Map<String, List<ValidatorTag>> validatorTagsMap =
+			(Map<String, List<ValidatorTag>>)request.getAttribute(
+				"aui:form:validatorTagsMap");
+
+		if (validatorTagsMap != null) {
+			List<ValidatorTag> validatorTags = ListUtil.fromMapValues(
+				_validatorTags);
+
+			validatorTagsMap.put(getInputName(), validatorTags);
 		}
 	}
 

--- a/util-taglib/src/com/liferay/taglib/aui/FormTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/FormTag.java
@@ -34,16 +34,6 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class FormTag extends BaseFormTag {
 
-	public void addValidatorTags(
-		String name, List<ValidatorTag> validatorTags) {
-
-		if (_validatorTagsMap == null) {
-			_validatorTagsMap = new HashMap<>();
-		}
-
-		_validatorTagsMap.put(name, validatorTags);
-	}
-
 	@Override
 	public String getAction() {
 		return super.getAction();
@@ -70,7 +60,7 @@ public class FormTag extends BaseFormTag {
 				}
 			}
 
-			_validatorTagsMap = null;
+			_validatorTagsMap.clear();
 		}
 	}
 
@@ -89,11 +79,7 @@ public class FormTag extends BaseFormTag {
 			super.setAction(HtmlUtil.escape(action));
 		}
 
-		if (_validatorTagsMap != null) {
-			request.setAttribute(
-				"aui:form:validatorTagsMap", _validatorTagsMap);
-		}
-
+		request.setAttribute("aui:form:validatorTagsMap", _validatorTagsMap);
 		request.setAttribute(
 			"LIFERAY_SHARED_aui:form:checkboxNames", _checkboxNames);
 	}
@@ -101,6 +87,7 @@ public class FormTag extends BaseFormTag {
 	private static final boolean _CLEAN_UP_SET_ATTRIBUTES = true;
 
 	private final List<String> _checkboxNames = new ArrayList<>();
-	private Map<String, List<ValidatorTag>> _validatorTagsMap;
+	private final Map<String, List<ValidatorTag>> _validatorTagsMap =
+		new HashMap<>();
 
 }


### PR DESCRIPTION
…rWithClass() to find FormTag to populate ValidatorTags"

This reverts commit 17f477292ba0fec57d9c61be35b1cd41a604a94b.

Sorry, this one does not work when the form tag has nested tag/jsp that does the validator populating.