### PR TITLE
LPS-63213 Incorrect parameter namespace handling in Portal Settings

### DIFF
--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/action/PortalSettingsCASFormMVCActionCommand.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/action/PortalSettingsCASFormMVCActionCommand.java
@@ -97,4 +97,5 @@ public class PortalSettingsCASFormMVCActionCommand
 	protected String getSettingsId() {
 		return CASConstants.SERVICE_NAME;
 	}
+
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/action/PortalSettingsCASFormMVCActionCommand.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/action/PortalSettingsCASFormMVCActionCommand.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.cas.constants.CASConstants;
+import com.liferay.portal.settings.authentication.cas.web.internal.portlet.constants.PortalSettingsCASConstants;
 import com.liferay.portal.settings.portlet.action.BasePortalSettingsFormMVCActionCommand;
 import com.liferay.portal.settings.web.constants.PortalSettingsPortletKeys;
 
@@ -89,7 +90,7 @@ public class PortalSettingsCASFormMVCActionCommand
 
 	@Override
 	protected String getParameterNamespace() {
-		return "cas--";
+		return PortalSettingsCASConstants.PARAMETER_NAMESPACE;
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/constants/PortalSettingsCASConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/constants/PortalSettingsCASConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.settings.authentication.cas.web.internal.portlet.constants;
+
+/**
+ * @author Jose A. Jimenez
+ */
+public class PortalSettingsCASConstants {
+
+	public static String PARAMETER_NAMESPACE = "cas_";
+
+}

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/constants/PortalSettingsCASConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/java/com/liferay/portal/settings/authentication/cas/web/internal/portlet/constants/PortalSettingsCASConstants.java
@@ -19,6 +19,6 @@ package com.liferay.portal.settings.authentication.cas.web.internal.portlet.cons
  */
 public class PortalSettingsCASConstants {
 
-	public static String PARAMETER_NAMESPACE = "cas_";
+	public static final String PARAMETER_NAMESPACE = "cas_";
 
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/cas.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/cas.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-CASConfiguration casConfiguration = ConfigurationProviderUtil.getConfiguration(CASConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), "cas--", new CompanyServiceSettingsLocator(company.getCompanyId(), CASConstants.SERVICE_NAME)));
+CASConfiguration casConfiguration = ConfigurationProviderUtil.getConfiguration(CASConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), PortalSettingsCASConstants.PARAMETER_NAMESPACE, new CompanyServiceSettingsLocator(company.getCompanyId(), CASConstants.SERVICE_NAME)));
 
 boolean enabled = casConfiguration.enabled();
 boolean importFromLDAP = casConfiguration.importFromLDAP();
@@ -40,23 +40,23 @@ String noSuchUserRedirectURL = casConfiguration.noSuchUserRedirectURL();
 
 	<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/portal_settings/cas" />
 
-	<aui:input label="enabled" name="cas--enabled" type="checkbox" value="<%= enabled %>" />
+	<aui:input label="enabled" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "enabled" %>' type="checkbox" value="<%= enabled %>" />
 
-	<aui:input helpMessage="import-cas-users-from-ldap-help" label="import-cas-users-from-ldap" name="cas--importFromLDAP" type="checkbox" value="<%= importFromLDAP %>" />
+	<aui:input helpMessage="import-cas-users-from-ldap-help" label="import-cas-users-from-ldap" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "importFromLDAP" %>' type="checkbox" value="<%= importFromLDAP %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-login-url-help" label="login-url" name="cas--loginURL" type="text" value="<%= loginURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-login-url-help" label="login-url" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "loginURL" %>' type="text" value="<%= loginURL %>" />
 
-	<aui:input helpMessage="cas-logout-on-session-expiration-help" label="cas-logout-on-session-expiration" name="cas--logoutOnSessionExpiration" type="checkbox" value="<%= logoutOnSessionExpiration %>" />
+	<aui:input helpMessage="cas-logout-on-session-expiration-help" label="cas-logout-on-session-expiration" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "logoutOnSessionExpiration" %>' type="checkbox" value="<%= logoutOnSessionExpiration %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-logout-url-help" label="logout-url" name="cas--logoutURL" type="text" value="<%= logoutURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-logout-url-help" label="logout-url" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "logoutURL" %>' type="text" value="<%= logoutURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-server-name-help" label="server-name" name="cas--serverName" type="text" value="<%= serverName %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-server-name-help" label="server-name" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "serverName" %>' type="text" value="<%= serverName %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-server-url-help" label="server-url" name="cas--serverURL" type="text" value="<%= serverURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-server-url-help" label="server-url" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "serverURL" %>' type="text" value="<%= serverURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-service-url-help" label="service-url" name="cas--serviceURL" type="text" value="<%= serviceURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-service-url-help" label="service-url" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "serviceURL" %>' type="text" value="<%= serviceURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-no-such-user-redirect-url-help" label="no-such-user-redirect-url" name="cas--noSuchUserRedirectURL" type="text" value="<%= noSuchUserRedirectURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-no-such-user-redirect-url-help" label="no-such-user-redirect-url" name='<%= PortalSettingsCASConstants.PARAMETER_NAMESPACE + "noSuchUserRedirectURL" %>' type="text" value="<%= noSuchUserRedirectURL %>" />
 
 	<aui:button-row>
 		<aui:button cssClass="btn-lg" onClick='<%= renderResponse.getNamespace() + "testCasSettings();" %>' value="test-cas-configuration" />
@@ -72,10 +72,10 @@ String noSuchUserRedirectURL = casConfiguration.noSuchUserRedirectURL();
 
 			var data = {};
 
-			data.<portlet:namespace />casLoginURL = document.<portlet:namespace />fm['<portlet:namespace />cas--loginURL'].value;
-			data.<portlet:namespace />casLogoutURL = document.<portlet:namespace />fm['<portlet:namespace />cas--logoutURL'].value;
-			data.<portlet:namespace />casServerURL = document.<portlet:namespace />fm['<portlet:namespace />cas--serverURL'].value;
-			data.<portlet:namespace />casServiceURL = document.<portlet:namespace />fm['<portlet:namespace />cas--serviceURL'].value;
+			data.<portlet:namespace />casLoginURL = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsCASConstants.PARAMETER_NAMESPACE %>loginURL'].value;
+			data.<portlet:namespace />casLogoutURL = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsCASConstants.PARAMETER_NAMESPACE %>logoutURL'].value;
+			data.<portlet:namespace />casServerURL = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsCASConstants.PARAMETER_NAMESPACE %>serverURL'].value;
+			data.<portlet:namespace />casServiceURL = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsCASConstants.PARAMETER_NAMESPACE %>serviceURL'].value;
 
 			var url = '<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_cas" /></portlet:renderURL>';
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/init.jsp
@@ -30,7 +30,8 @@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.cas.configuration.CASConfiguration" %><%@
-page import="com.liferay.portal.security.sso.cas.constants.CASConstants" %>
+page import="com.liferay.portal.security.sso.cas.constants.CASConstants" %><%@
+page import="com.liferay.portal.settings.authentication.cas.web.internal.portlet.constants.PortalSettingsCASConstants"%>
 
 <%@ page import="java.net.HttpURLConnection" %><%@
 page import="java.net.MalformedURLException" %><%@

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/init.jsp
@@ -31,7 +31,7 @@ page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.cas.configuration.CASConfiguration" %><%@
 page import="com.liferay.portal.security.sso.cas.constants.CASConstants" %><%@
-page import="com.liferay.portal.settings.authentication.cas.web.internal.portlet.constants.PortalSettingsCASConstants"%>
+page import="com.liferay.portal.settings.authentication.cas.web.internal.portlet.constants.PortalSettingsCASConstants" %>
 
 <%@ page import="java.net.HttpURLConnection" %><%@
 page import="java.net.MalformedURLException" %><%@

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/action/PortalSettingsFacebookConnectFormMVCActionCommand.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/action/PortalSettingsFacebookConnectFormMVCActionCommand.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants;
+import com.liferay.portal.settings.authentication.facebook.connect.web.internal.portlet.constants.PortalSettingsFacebookConnectConstants;
 import com.liferay.portal.settings.portlet.action.BasePortalSettingsFormMVCActionCommand;
 import com.liferay.portal.settings.web.constants.PortalSettingsPortletKeys;
 
@@ -88,7 +89,7 @@ public class PortalSettingsFacebookConnectFormMVCActionCommand
 
 	@Override
 	protected String getParameterNamespace() {
-		return "facebook--";
+		return PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE;
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/constants/PortalSettingsFacebookConnectConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/constants/PortalSettingsFacebookConnectConstants.java
@@ -19,6 +19,6 @@ package com.liferay.portal.settings.authentication.facebook.connect.web.internal
  */
 public class PortalSettingsFacebookConnectConstants {
 
-	public static String PARAMETER_NAMESPACE = "facebook_";
+	public static final String PARAMETER_NAMESPACE = "facebook_";
 
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/constants/PortalSettingsFacebookConnectConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/constants/PortalSettingsFacebookConnectConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.settings.authentication.facebook.connect.web.internal.portlet.constants;
+
+/**
+ * @author Jose A. Jimenez
+ */
+public class PortalSettingsFacebookConnectConstants {
+
+	public static String PARAMETER_NAMESPACE = "facebook_";
+
+}

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/facebook.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/facebook.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/com.liferay.portal.settings.web/init.jsp" %>
 
 <%
-FacebookConnectConfiguration facebookConnectConfiguration = ConfigurationProviderUtil.getConfiguration(FacebookConnectConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), "facebook--", new CompanyServiceSettingsLocator(company.getCompanyId(), FacebookConnectConstants.SERVICE_NAME)));
+FacebookConnectConfiguration facebookConnectConfiguration = ConfigurationProviderUtil.getConfiguration(FacebookConnectConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE, new CompanyServiceSettingsLocator(company.getCompanyId(), FacebookConnectConstants.SERVICE_NAME)));
 
 boolean authEnabled = facebookConnectConfiguration.enabled();
 boolean verifiedAccountRequired = facebookConnectConfiguration.verifiedAccountRequired();
@@ -43,19 +43,19 @@ String oauthRedirectURL = facebookConnectConfiguration.oauthRedirectURL();
 <aui:fieldset>
 	<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/portal_settings/facebook_connect" />
 
-	<aui:input label="enabled" name="facebook--enabled" type="checkbox" value="<%= authEnabled %>" />
+	<aui:input label="enabled" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "enabled" %>' type="checkbox" value="<%= authEnabled %>" />
 
-	<aui:input label="require-verified-account" name="facebook--verifiedAccountRequired" type="checkbox" value="<%= verifiedAccountRequired %>" />
+	<aui:input label="require-verified-account" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "verifiedAccountRequired" %>' type="checkbox" value="<%= verifiedAccountRequired %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="application-id" name="facebook--appId" type="text" value="<%= appId %>" />
+	<aui:input cssClass="lfr-input-text-container" label="application-id" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "appId" %>' type="text" value="<%= appId %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="application-secret" name="facebook--appSecret" type="password" value="<%= appSecret %>" />
+	<aui:input cssClass="lfr-input-text-container" label="application-secret" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "appSecret" %>' type="password" value="<%= appSecret %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="graph-url" name="facebook--graphURL" type="text" value="<%= graphURL %>" />
+	<aui:input cssClass="lfr-input-text-container" label="graph-url" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "graphURL" %>' type="text" value="<%= graphURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="oauth-authentication-url" name="facebook--oauthAuthURL" type="text" value="<%= oauthAuthURL %>" />
+	<aui:input cssClass="lfr-input-text-container" label="oauth-authentication-url" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "oauthAuthURL" %>' type="text" value="<%= oauthAuthURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="oauth-token-url" name="facebook--oauthTokenURL" type="text" value="<%= oauthTokenURL %>" />
+	<aui:input cssClass="lfr-input-text-container" label="oauth-token-url" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "oauthTokenURL" %>' type="text" value="<%= oauthTokenURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="oauth-redirect-url" name="facebook--oauthRedirectURL" type="text" value="<%= oauthRedirectURL %>" />
+	<aui:input cssClass="lfr-input-text-container" label="oauth-redirect-url" name='<%= PortalSettingsFacebookConnectConstants.PARAMETER_NAMESPACE + "oauthRedirectURL" %>' type="text" value="<%= oauthRedirectURL %>" />
 </aui:fieldset>

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -25,7 +25,8 @@ page import="com.liferay.portal.kernel.settings.ParameterMapSettingsLocator" %><
 page import="com.liferay.portal.kernel.util.Portal" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.facebook.connect.configuration.FacebookConnectConfiguration" %><%@
-page import="com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants" %>
+page import="com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants" %><%@
+page import="com.liferay.portal.settings.authentication.facebook.connect.web.internal.portlet.constants.PortalSettingsFacebookConnectConstants"%>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -26,7 +26,7 @@ page import="com.liferay.portal.kernel.util.Portal" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.facebook.connect.configuration.FacebookConnectConfiguration" %><%@
 page import="com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnectConstants" %><%@
-page import="com.liferay.portal.settings.authentication.facebook.connect.web.internal.portlet.constants.PortalSettingsFacebookConnectConstants"%>
+page import="com.liferay.portal.settings.authentication.facebook.connect.web.internal.portlet.constants.PortalSettingsFacebookConnectConstants" %>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/java/com/liferay/portal/settings/authentication/google/web/internal/portlet/action/PortalSettingsGoogleFormMVCActionCommand.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/java/com/liferay/portal/settings/authentication/google/web/internal/portlet/action/PortalSettingsGoogleFormMVCActionCommand.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.google.constants.GoogleConstants;
+import com.liferay.portal.settings.authentication.google.web.internal.portlet.constants.PortalSettingsGoogleConstants;
 import com.liferay.portal.settings.portlet.action.BasePortalSettingsFormMVCActionCommand;
 import com.liferay.portal.settings.web.constants.PortalSettingsPortletKeys;
 
@@ -64,7 +65,7 @@ public class PortalSettingsGoogleFormMVCActionCommand
 
 	@Override
 	protected String getParameterNamespace() {
-		return "google--";
+		return PortalSettingsGoogleConstants.PARAMETER_NAMESPACE;
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/java/com/liferay/portal/settings/authentication/google/web/internal/portlet/constants/PortalSettingsGoogleConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/java/com/liferay/portal/settings/authentication/google/web/internal/portlet/constants/PortalSettingsGoogleConstants.java
@@ -19,6 +19,6 @@ package com.liferay.portal.settings.authentication.google.web.internal.portlet.c
  */
 public class PortalSettingsGoogleConstants {
 
-	public static String PARAMETER_NAMESPACE = "google_";
+	public static final String PARAMETER_NAMESPACE = "google_";
 
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/java/com/liferay/portal/settings/authentication/google/web/internal/portlet/constants/PortalSettingsGoogleConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/java/com/liferay/portal/settings/authentication/google/web/internal/portlet/constants/PortalSettingsGoogleConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.settings.authentication.google.web.internal.portlet.constants;
+
+/**
+ * @author Jose A. Jimenez
+ */
+public class PortalSettingsGoogleConstants {
+
+	public static String PARAMETER_NAMESPACE = "google_";
+
+}

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/google.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/google.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/com.liferay.portal.settings.web/init.jsp" %>
 
 <%
-GoogleAuthorizationConfiguration googleAuthorizationConfiguration = ConfigurationProviderUtil.getConfiguration(GoogleAuthorizationConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), "google--", new CompanyServiceSettingsLocator(company.getCompanyId(), GoogleConstants.SERVICE_NAME)));
+GoogleAuthorizationConfiguration googleAuthorizationConfiguration = ConfigurationProviderUtil.getConfiguration(GoogleAuthorizationConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), PortalSettingsGoogleConstants.PARAMETER_NAMESPACE, new CompanyServiceSettingsLocator(company.getCompanyId(), GoogleConstants.SERVICE_NAME)));
 
 boolean googleAuthEnabled = googleAuthorizationConfiguration.enabled();
 String googleClientId = googleAuthorizationConfiguration.clientId();
@@ -30,9 +30,9 @@ String googleClientSecret = googleAuthorizationConfiguration.clientSecret();
 <aui:fieldset>
 	<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/portal_settings/google" />
 
-	<aui:input label="enabled" name="google--enabled" type="checkbox" value="<%= googleAuthEnabled %>" />
+	<aui:input label="enabled" name='<%= PortalSettingsGoogleConstants.PARAMETER_NAMESPACE + "enabled" %>' type="checkbox" value="<%= googleAuthEnabled %>" />
 
-	<aui:input label="google-client-id" name="google--clientId" type="text" value="<%= googleClientId %>" wrapperCssClass="lfr-input-text-container" />
+	<aui:input label="google-client-id" name='<%= PortalSettingsGoogleConstants.PARAMETER_NAMESPACE + "clientId" %>' type="text" value="<%= googleClientId %>" wrapperCssClass="lfr-input-text-container" />
 
-	<aui:input label="google-client-secret" name="google--clientSecret" type="text" value="<%= googleClientSecret %>" wrapperCssClass="lfr-input-text-container" />
+	<aui:input label="google-client-secret" name='<%= PortalSettingsGoogleConstants.PARAMETER_NAMESPACE + "clientSecret" %>' type="text" value="<%= googleClientSecret %>" wrapperCssClass="lfr-input-text-container" />
 </aui:fieldset>

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -24,7 +24,8 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator" %><%@
 page import="com.liferay.portal.kernel.settings.ParameterMapSettingsLocator" %><%@
 page import="com.liferay.portal.security.sso.google.configuration.GoogleAuthorizationConfiguration" %><%@
-page import="com.liferay.portal.security.sso.google.constants.GoogleConstants" %>
+page import="com.liferay.portal.security.sso.google.constants.GoogleConstants" %><%@
+page import="com.liferay.portal.settings.authentication.google.web.internal.portlet.constants.PortalSettingsGoogleConstants"%>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-google-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -25,7 +25,7 @@ page import="com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator" %
 page import="com.liferay.portal.kernel.settings.ParameterMapSettingsLocator" %><%@
 page import="com.liferay.portal.security.sso.google.configuration.GoogleAuthorizationConfiguration" %><%@
 page import="com.liferay.portal.security.sso.google.constants.GoogleConstants" %><%@
-page import="com.liferay.portal.settings.authentication.google.web.internal.portlet.constants.PortalSettingsGoogleConstants"%>
+page import="com.liferay.portal.settings.authentication.google.web.internal.portlet.constants.PortalSettingsGoogleConstants" %>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/java/com/liferay/portal/settings/authentication/ntlm/web/internal/portlet/action/PortalSettingsNtlmFormMVCActionCommand.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/java/com/liferay/portal/settings/authentication/ntlm/web/internal/portlet/action/PortalSettingsNtlmFormMVCActionCommand.java
@@ -16,6 +16,7 @@ package com.liferay.portal.settings.authentication.ntlm.web.internal.portlet.act
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.security.sso.ntlm.constants.NtlmConstants;
+import com.liferay.portal.settings.authentication.ntlm.web.internal.portlet.constants.PortalSettingsNtlmConstants;
 import com.liferay.portal.settings.portlet.action.BasePortalSettingsFormMVCActionCommand;
 import com.liferay.portal.settings.web.constants.PortalSettingsPortletKeys;
 
@@ -44,7 +45,7 @@ public class PortalSettingsNtlmFormMVCActionCommand
 
 	@Override
 	protected String getParameterNamespace() {
-		return "ntlm--";
+		return PortalSettingsNtlmConstants.PARAMETER_NAMESPACE;
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/java/com/liferay/portal/settings/authentication/ntlm/web/internal/portlet/constants/PortalSettingsNtlmConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/java/com/liferay/portal/settings/authentication/ntlm/web/internal/portlet/constants/PortalSettingsNtlmConstants.java
@@ -19,6 +19,6 @@ package com.liferay.portal.settings.authentication.ntlm.web.internal.portlet.con
  */
 public class PortalSettingsNtlmConstants {
 
-	public static String PARAMETER_NAMESPACE = "ntlm_";
+	public static final String PARAMETER_NAMESPACE = "ntlm_";
 
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/java/com/liferay/portal/settings/authentication/ntlm/web/internal/portlet/constants/PortalSettingsNtlmConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/java/com/liferay/portal/settings/authentication/ntlm/web/internal/portlet/constants/PortalSettingsNtlmConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.settings.authentication.ntlm.web.internal.portlet.constants;
+
+/**
+ * @author Jose A. Jimenez
+ */
+public class PortalSettingsNtlmConstants {
+
+	public static String PARAMETER_NAMESPACE = "ntlm_";
+
+}

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -24,7 +24,7 @@ page import="com.liferay.portal.kernel.util.Portal" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.ntlm.configuration.NtlmConfiguration" %><%@
 page import="com.liferay.portal.security.sso.ntlm.constants.NtlmConstants" %><%@
-page import="com.liferay.portal.settings.authentication.ntlm.web.internal.portlet.constants.PortalSettingsNtlmConstants"%>
+page import="com.liferay.portal.settings.authentication.ntlm.web.internal.portlet.constants.PortalSettingsNtlmConstants" %>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -23,7 +23,8 @@ page import="com.liferay.portal.kernel.settings.ParameterMapSettingsLocator" %><
 page import="com.liferay.portal.kernel.util.Portal" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.ntlm.configuration.NtlmConfiguration" %><%@
-page import="com.liferay.portal.security.sso.ntlm.constants.NtlmConstants" %>
+page import="com.liferay.portal.security.sso.ntlm.constants.NtlmConstants" %><%@
+page import="com.liferay.portal.settings.authentication.ntlm.web.internal.portlet.constants.PortalSettingsNtlmConstants"%>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/ntlm.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-ntlm-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/ntlm.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/com.liferay.portal.settings.web/init.jsp" %>
 
 <%
-NtlmConfiguration ntlmConfiguration = ConfigurationProviderUtil.getConfiguration(NtlmConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), "ntlm--", new CompanyServiceSettingsLocator(company.getCompanyId(), NtlmConstants.SERVICE_NAME)));
+NtlmConfiguration ntlmConfiguration = ConfigurationProviderUtil.getConfiguration(NtlmConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), PortalSettingsNtlmConstants.PARAMETER_NAMESPACE, new CompanyServiceSettingsLocator(company.getCompanyId(), NtlmConstants.SERVICE_NAME)));
 
 boolean enabled = ntlmConfiguration.enabled();
 String domainController = ntlmConfiguration.domainController();
@@ -35,15 +35,15 @@ if (Validator.isNotNull(servicePassword)) {
 <aui:fieldset>
 	<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/portal_settings/ntlm" />
 
-	<aui:input label="enabled" name='<%= "ntlm--enabled" %>' type="checkbox" value="<%= enabled %>" />
+	<aui:input label="enabled" name='<%= PortalSettingsNtlmConstants.PARAMETER_NAMESPACE + "enabled" %>' type="checkbox" value="<%= enabled %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="domain-controller" name='<%= "ntlm--domainController" %>' type="text" value="<%= domainController %>" />
+	<aui:input cssClass="lfr-input-text-container" label="domain-controller" name='<%= PortalSettingsNtlmConstants.PARAMETER_NAMESPACE + "domainController" %>' type="text" value="<%= domainController %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="domain-controller-name-help" label="domain-controller-name" name='<%= "ntlm--domainControllerName" %>' type="text" value="<%= domainControllerName %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="domain-controller-name-help" label="domain-controller-name" name='<%= PortalSettingsNtlmConstants.PARAMETER_NAMESPACE + "domainControllerName" %>' type="text" value="<%= domainControllerName %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="domain" name='<%= "ntlm--domain" %>' type="text" value="<%= domain %>" />
+	<aui:input cssClass="lfr-input-text-container" label="domain" name='<%= PortalSettingsNtlmConstants.PARAMETER_NAMESPACE + "domain" %>' type="text" value="<%= domain %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="service-account" name='<%= "ntlm--serviceAccount" %>' type="text" value="<%= serviceAccount %>" />
+	<aui:input cssClass="lfr-input-text-container" label="service-account" name='<%= PortalSettingsNtlmConstants.PARAMETER_NAMESPACE + "serviceAccount" %>' type="text" value="<%= serviceAccount %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="service-password" name='<%= "ntlm--servicePassword" %>' type="password" value="<%= servicePassword %>" />
+	<aui:input cssClass="lfr-input-text-container" label="service-password" name='<%= PortalSettingsNtlmConstants.PARAMETER_NAMESPACE + "servicePassword" %>' type="password" value="<%= servicePassword %>" />
 </aui:fieldset>

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/java/com/liferay/portal/settings/authentication/openid/web/internal/portlet/action/PortalSettingsOpenIdFormMVCActionCommand.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/java/com/liferay/portal/settings/authentication/openid/web/internal/portlet/action/PortalSettingsOpenIdFormMVCActionCommand.java
@@ -16,6 +16,7 @@ package com.liferay.portal.settings.authentication.openid.web.internal.portlet.a
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.security.sso.openid.constants.OpenIdConstants;
+import com.liferay.portal.settings.authentication.openid.web.internal.portlet.constants.PortalSettingsOpenIdConstants;
 import com.liferay.portal.settings.portlet.action.BasePortalSettingsFormMVCActionCommand;
 import com.liferay.portal.settings.web.constants.PortalSettingsPortletKeys;
 
@@ -45,7 +46,7 @@ public class PortalSettingsOpenIdFormMVCActionCommand
 
 	@Override
 	protected String getParameterNamespace() {
-		return "openid--";
+		return PortalSettingsOpenIdConstants.PARAMETER_NAMESPACE;
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/java/com/liferay/portal/settings/authentication/openid/web/internal/portlet/constants/PortalSettingsOpenIdConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/java/com/liferay/portal/settings/authentication/openid/web/internal/portlet/constants/PortalSettingsOpenIdConstants.java
@@ -19,6 +19,6 @@ package com.liferay.portal.settings.authentication.openid.web.internal.portlet.c
  */
 public class PortalSettingsOpenIdConstants {
 
-	public static String PARAMETER_NAMESPACE = "openid_";
+	public static final String PARAMETER_NAMESPACE = "openid_";
 
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/java/com/liferay/portal/settings/authentication/openid/web/internal/portlet/constants/PortalSettingsOpenIdConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/java/com/liferay/portal/settings/authentication/openid/web/internal/portlet/constants/PortalSettingsOpenIdConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.settings.authentication.openid.web.internal.portlet.constants;
+
+/**
+ * @author Jose A. Jimenez
+ */
+public class PortalSettingsOpenIdConstants {
+
+	public static String PARAMETER_NAMESPACE = "openid_";
+
+}

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -24,7 +24,7 @@ page import="com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator" %
 page import="com.liferay.portal.kernel.settings.ParameterMapSettingsLocator" %><%@
 page import="com.liferay.portal.security.sso.openid.configuration.OpenIdConfiguration" %><%@
 page import="com.liferay.portal.security.sso.openid.constants.OpenIdConstants" %><%@
-page import="com.liferay.portal.settings.authentication.openid.web.internal.portlet.constants.PortalSettingsOpenIdConstants"%>
+page import="com.liferay.portal.settings.authentication.openid.web.internal.portlet.constants.PortalSettingsOpenIdConstants" %>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -23,7 +23,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 page import="com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator" %><%@
 page import="com.liferay.portal.kernel.settings.ParameterMapSettingsLocator" %><%@
 page import="com.liferay.portal.security.sso.openid.configuration.OpenIdConfiguration" %><%@
-page import="com.liferay.portal.security.sso.openid.constants.OpenIdConstants" %>
+page import="com.liferay.portal.security.sso.openid.constants.OpenIdConstants" %><%@
+page import="com.liferay.portal.settings.authentication.openid.web.internal.portlet.constants.PortalSettingsOpenIdConstants"%>
 
 <%@ page import="javax.portlet.ActionRequest" %>
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/openid.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-openid-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/openid.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/com.liferay.portal.settings.web/init.jsp" %>
 
 <%
-OpenIdConfiguration openIdConfiguration = ConfigurationProviderUtil.getConfiguration(OpenIdConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), "openid--", new CompanyServiceSettingsLocator(company.getCompanyId(), OpenIdConstants.SERVICE_NAME)));
+OpenIdConfiguration openIdConfiguration = ConfigurationProviderUtil.getConfiguration(OpenIdConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), PortalSettingsOpenIdConstants.PARAMETER_NAMESPACE, new CompanyServiceSettingsLocator(company.getCompanyId(), OpenIdConstants.SERVICE_NAME)));
 
 boolean enabled = openIdConfiguration.enabled();
 %>
@@ -25,5 +25,5 @@ boolean enabled = openIdConfiguration.enabled();
 <aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/portal_settings/openid" />
 
 <aui:fieldset>
-	<aui:input label="enabled" name="openid--enabled" type="checkbox" value="<%= enabled %>" />
+	<aui:input label="enabled" name='<%= PortalSettingsOpenIdConstants.PARAMETER_NAMESPACE + "enabled" %>' type="checkbox" value="<%= enabled %>" />
 </aui:fieldset>

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/action/PortalSettingsOpenSSOFormMVCActionCommand.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/action/PortalSettingsOpenSSOFormMVCActionCommand.java
@@ -16,6 +16,7 @@ package com.liferay.portal.settings.authentication.opensso.web.internal.portlet.
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants;
+import com.liferay.portal.settings.authentication.opensso.web.internal.portlet.constants.PortalSettingsOpenSSOConstants;
 import com.liferay.portal.settings.portlet.action.BasePortalSettingsFormMVCActionCommand;
 import com.liferay.portal.settings.web.constants.PortalSettingsPortletKeys;
 
@@ -45,7 +46,7 @@ public class PortalSettingsOpenSSOFormMVCActionCommand
 
 	@Override
 	protected String getParameterNamespace() {
-		return "opensso--";
+		return PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE;
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/constants/PortalSettingsOpenSSOConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/constants/PortalSettingsOpenSSOConstants.java
@@ -19,6 +19,6 @@ package com.liferay.portal.settings.authentication.opensso.web.internal.portlet.
  */
 public class PortalSettingsOpenSSOConstants {
 
-	public static String PARAMETER_NAMESPACE = "opensso_";
+	public static final String PARAMETER_NAMESPACE = "opensso_";
 
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/constants/PortalSettingsOpenSSOConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/constants/PortalSettingsOpenSSOConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.settings.authentication.opensso.web.internal.portlet.constants;
+
+/**
+ * @author Jose A. Jimenez
+ */
+public class PortalSettingsOpenSSOConstants {
+
+	public static String PARAMETER_NAMESPACE = "opensso--";
+
+}

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/constants/PortalSettingsOpenSSOConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/java/com/liferay/portal/settings/authentication/opensso/web/internal/portlet/constants/PortalSettingsOpenSSOConstants.java
@@ -19,6 +19,6 @@ package com.liferay.portal.settings.authentication.opensso.web.internal.portlet.
  */
 public class PortalSettingsOpenSSOConstants {
 
-	public static String PARAMETER_NAMESPACE = "opensso--";
+	public static String PARAMETER_NAMESPACE = "opensso_";
 
 }

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -31,7 +31,8 @@ page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.OpenSSOUtil" %><%@
 page import="com.liferay.portal.security.sso.opensso.configuration.OpenSSOConfiguration" %><%@
-page import="com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants" %>
+page import="com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants" %><%@
+page import="com.liferay.portal.settings.authentication.opensso.web.internal.portlet.constants.PortalSettingsOpenSSOConstants"%>
 
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.List" %>

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/init.jsp
@@ -32,7 +32,7 @@ page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.security.sso.OpenSSOUtil" %><%@
 page import="com.liferay.portal.security.sso.opensso.configuration.OpenSSOConfiguration" %><%@
 page import="com.liferay.portal.security.sso.opensso.constants.OpenSSOConstants" %><%@
-page import="com.liferay.portal.settings.authentication.opensso.web.internal.portlet.constants.PortalSettingsOpenSSOConstants"%>
+page import="com.liferay.portal.settings.authentication.opensso.web.internal.portlet.constants.PortalSettingsOpenSSOConstants" %>
 
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.List" %>

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/opensso.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/opensso.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/com.liferay.portal.settings.web/init.jsp" %>
 
 <%
-OpenSSOConfiguration openSSOConfiguration = ConfigurationProviderUtil.getConfiguration(OpenSSOConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), "opensso--", new CompanyServiceSettingsLocator(company.getCompanyId(), OpenSSOConstants.SERVICE_NAME)));
+OpenSSOConfiguration openSSOConfiguration = ConfigurationProviderUtil.getConfiguration(OpenSSOConfiguration.class, new ParameterMapSettingsLocator(request.getParameterMap(), PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE, new CompanyServiceSettingsLocator(company.getCompanyId(), OpenSSOConstants.SERVICE_NAME)));
 
 boolean enabled = openSSOConfiguration.enabled();
 boolean importFromLDAP = openSSOConfiguration.importFromLDAP();
@@ -33,19 +33,19 @@ String lastNameAttr = openSSOConfiguration.lastNameAttr();
 <aui:fieldset>
 	<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="/portal_settings/opensso" />
 
-	<aui:input label="enabled" name="opensso--enabled" type="checkbox" value="<%= enabled %>" />
+	<aui:input label="enabled" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "enabled" %>' type="checkbox" value="<%= enabled %>" />
 
-	<aui:input helpMessage="import-opensso-users-from-ldap-help" label="import-opensso-users-from-ldap" name="opensso--importFromLDAP" type="checkbox" value="<%= importFromLDAP %>" />
+	<aui:input helpMessage="import-opensso-users-from-ldap-help" label="import-opensso-users-from-ldap" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "importFromLDAP" %>' type="checkbox" value="<%= importFromLDAP %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="login-url-for-opensso-help" label="login-url" name="opensso--loginURL" type="text" value="<%= loginURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="login-url-for-opensso-help" label="login-url" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "loginURL" %>' type="text" value="<%= loginURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="logout-url-for-opensso-help" label="logout-url" name="opensso--logoutURL" type="text" value="<%= logoutURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="logout-url-for-opensso-help" label="logout-url" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "logoutURL" %>' type="text" value="<%= logoutURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="service-url-for-opensso-help" label="service-url" name="opensso--serviceURL" type="text" value="<%= serviceURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="service-url-for-opensso-help" label="service-url" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "serviceURL" %>'  type="text" value="<%= serviceURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="mappings-for-opensso-help" label="screen-name-attribute" name="opensso--screenNameAttr" type="text" value="<%= screenNameAttr %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="mappings-for-opensso-help" label="screen-name-attribute" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "screenNameAttr" %>' type="text" value="<%= screenNameAttr %>" />
 
-	<aui:input cssClass="lfr-input-text-container" label="email-address-attribute" name="opensso--emailAddressAttr" type="text" value="<%= emailAddressAttr %>" />
+	<aui:input cssClass="lfr-input-text-container" label="email-address-attribute" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "emailAddressAttr" %>' type="text" value="<%= emailAddressAttr %>" />
 
 	<%@ include file="/com.liferay.portal.settings.web/opensso_user_name.jspf" %>
 
@@ -63,13 +63,13 @@ String lastNameAttr = openSSOConfiguration.lastNameAttr();
 
 			var data = {};
 
-			data.<portlet:namespace />openSsoLoginURL = document.<portlet:namespace />fm['<portlet:namespace />opensso--loginURL'].value;
-			data.<portlet:namespace />openSsoLogoutURL = document.<portlet:namespace />fm['<portlet:namespace />opensso--logoutURL'].value;
-			data.<portlet:namespace />openSsoServiceURL = document.<portlet:namespace />fm['<portlet:namespace />opensso--serviceURL'].value;
-			data.<portlet:namespace />openSsoScreenNameAttr = document.<portlet:namespace />fm['<portlet:namespace />opensso--screenNameAttr'].value;
-			data.<portlet:namespace />openSsoEmailAddressAttr = document.<portlet:namespace />fm['<portlet:namespace />opensso--emailAddressAttr'].value;
-			data.<portlet:namespace />openSsoFirstNameAttr = document.<portlet:namespace />fm['<portlet:namespace />opensso--firstNameAttr'].value;
-			data.<portlet:namespace />openSsoLastNameAttr = document.<portlet:namespace />fm['<portlet:namespace />opensso--lastNameAttr'].value;
+			data.<portlet:namespace />openSsoLoginURL = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE %>loginURL'].value;
+			data.<portlet:namespace />openSsoLogoutURL = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE %>logoutURL'].value;
+			data.<portlet:namespace />openSsoServiceURL = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE %>serviceURL'].value;
+			data.<portlet:namespace />openSsoScreenNameAttr = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE %>screenNameAttr'].value;
+			data.<portlet:namespace />openSsoEmailAddressAttr = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE %>emailAddressAttr'].value;
+			data.<portlet:namespace />openSsoFirstNameAttr = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE %>firstNameAttr'].value;
+			data.<portlet:namespace />openSsoLastNameAttr = document.<portlet:namespace />fm['<portlet:namespace /><%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE %>lastNameAttr'].value;
 
 			var url = '<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_opensso" /></portlet:renderURL>';
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/opensso.jsp
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/opensso.jsp
@@ -41,7 +41,7 @@ String lastNameAttr = openSSOConfiguration.lastNameAttr();
 
 	<aui:input cssClass="lfr-input-text-container" helpMessage="logout-url-for-opensso-help" label="logout-url" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "logoutURL" %>' type="text" value="<%= logoutURL %>" />
 
-	<aui:input cssClass="lfr-input-text-container" helpMessage="service-url-for-opensso-help" label="service-url" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "serviceURL" %>'  type="text" value="<%= serviceURL %>" />
+	<aui:input cssClass="lfr-input-text-container" helpMessage="service-url-for-opensso-help" label="service-url" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "serviceURL" %>' type="text" value="<%= serviceURL %>" />
 
 	<aui:input cssClass="lfr-input-text-container" helpMessage="mappings-for-opensso-help" label="screen-name-attribute" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "screenNameAttr" %>' type="text" value="<%= screenNameAttr %>" />
 

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/opensso_user_name.jspf
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/opensso_user_name.jspf
@@ -14,6 +14,6 @@
  */
 --%>
 
-<aui:input cssClass="lfr-input-text-container" label="first-name-attribute" name="opensso--firstNameAttr" type="text" value="<%= firstNameAttr %>" />
+<aui:input cssClass="lfr-input-text-container" label="first-name-attribute" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "firstNameAttr" %>' type="text" value="<%= firstNameAttr %>" />
 
-<aui:input cssClass="lfr-input-text-container" label="last-name-attribute" name="opensso--lastNameAttr" type="text" value="<%= lastNameAttr %>" />
+<aui:input cssClass="lfr-input-text-container" label="last-name-attribute" name='<%= PortalSettingsOpenSSOConstants.PARAMETER_NAMESPACE + "lastNameAttr" %>' type="text" value="<%= lastNameAttr %>" />

--- a/util-taglib/src/META-INF/liferay-aui.tld
+++ b/util-taglib/src/META-INF/liferay-aui.tld
@@ -807,7 +807,7 @@
 			<type>boolean</type>
 		</attribute>
 		<attribute>
-			<description><![CDATA[A name for the component.]]></description>
+			<description><![CDATA[A name for the component. If the name contains -- the generated name will be an string from the first ocurrence of -- to the end of the name less 2 characters, assuming prefix--customName-- as a pattern for customName. The name will be used to create a normalized <code>id</code> if the <code>id</code> is not provided and the <code>type</code> is provided.]]></description>
 			<name>name</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>


### PR DESCRIPTION
@jcampoy wrote:
> After analyze this issue with Jorge and Chema, they let me know that they are planning to modify the taglibs so, we finally decided to change the parameter namespaces of some portal settings modules instead to modify the InputTag behaviour when names containing -- are present.
> 
> Note, ldap module has not been changed because is using the pattern settings--name-- in a right way.

cc/ @JorgeFerrer @jbalsas