### PR TITLE
LPS-70751 *ModelImpl never implement the interface

### DIFF
--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = a191c35b4c7697257fb40bc72fbfe9de14370da3
+	commit = 402ce767fa439f3deb7e15ed08643ac17b2a38a5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2f03d498ece75a4729e99d972029f06780245b31
+	parent = 0ff87603c365dc398ae20426e792e71d84b0dcc5
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e574714fc05221371a9cf554f3f15c1c1714fa0f
+	commit = 1bce5964dba9a0a925887d7a70a71f48aff2afcc
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4ffcb7eee0c3ff816153f59fa1f9765622371b74
+	parent = a7937426b573b36a02d94981e1c9c38c567a9bc1
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/portal-kernel/src/com/liferay/portal/kernel/jsonwebservice/JSONWebServiceNaming.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/jsonwebservice/JSONWebServiceNaming.java
@@ -58,8 +58,7 @@ public class JSONWebServiceNaming {
 
 		className = StringUtil.replace(className, ".kernel.", ".");
 		className =
-			StringUtil.replace(className, ".model.", ".model.impl.") +
-				"ModelImpl";
+			StringUtil.replace(className, ".model.", ".model.impl.") + "Impl";
 
 		return className;
 	}


### PR DESCRIPTION
this is a follow up of https://github.com/brianchandotcom/liferay-portal/pull/46997

/cc @topolik @stian-sigvartsen @igorspasic @nhpatt 

please guys have a look at this because it looks like this convention is not followed anymore. I was able to successfully invoke the method in UserService with this change. I have inspected some of the other classes and they all seem to follow this convention now, but I don't know if I am breaking anything else (I guess no). 

Also this block: https://github.com/csierra/liferay-portal-ee/blob/9160b7e56893d57835489533ba7c3bb037c6d228/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionImpl.java#L124-L138

looks like will fail consistently when the service lives in OSGi since the ClassLoader of the interface classes will typically be not the same as the implementation classes classloader. 

what do you guys think? 