### PR TITLE
LRQA-30653 Don't use default values when the real value is available.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -859,8 +859,7 @@ public class JenkinsResultsParserUtil {
 		throws IOException {
 
 		return toString(
-			url, checkCache, _MAX_RETRIES_DEFAULT, null, _RETRY_PERIOD_DEFAULT,
-			timeout);
+			url, checkCache, maxRetries, null, retryPeriod, timeout);
 	}
 
 	public static String toString(


### PR DESCRIPTION
Found a small bug in the recent changes to toString() methods.

Please publish com.liferay.jenkins.results.parser.jar after merging.