### PR TITLE
LRQA-29637 Create utility to make database requests

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 	compile group: "org.apache.ant", name: "ant", version: "1.9.4"
 	compile group: "org.eclipse.jgit", name: "org.eclipse.jgit", version: "4.6.0.201612231935-r"
 	compile group: "org.json", name: "json", version: "20140107"
+	compile group: "org.mariadb.jdbc", name: "mariadb-java-client", version: "1.5.4"
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
@@ -38,47 +38,33 @@ public class DBUtil {
 
 		List<Map<String, Object>> queryResult = new ArrayList<>();
 
-		Connection connection = null;
-		PreparedStatement ps = null;
+		Class.forName(dbType);
 
-		try {
-			Class.forName(dbType);
+		try (Connection connection =
+				DriverManager.getConnection(url, userName, password)) {
 
-			connection = DriverManager.getConnection(url, userName, password);
-
-			ps = connection.prepareStatement(query);
-
-			for (int i = 0; i < arguments.size(); i++) {
-				ps.setObject(i + 1, arguments.get(i));
-			}
-
-			ResultSet rs = ps.executeQuery();
-
-			ResultSetMetaData rsmd = rs.getMetaData();
-
-			while (rs.next()) {
-				Map<String, Object> row = new HashMap<>();
-
-				for (int i = 1; i <= rsmd.getColumnCount(); i++) {
-					row.put(rsmd.getColumnName(i), rs.getObject(i));
+			try (PreparedStatement ps = connection.prepareStatement(query)) {
+				for (int i = 0; i < arguments.size(); i++) {
+					ps.setObject(i + 1, arguments.get(i));
 				}
 
-				queryResult.add(row);
-			}
+				try (ResultSet rs = ps.executeQuery()) {
+					ResultSetMetaData rsmd = rs.getMetaData();
 
-			rs.close();
+					while (rs.next()) {
+						Map<String, Object> row = new HashMap<>();
+
+						for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+							row.put(rsmd.getColumnName(i), rs.getObject(i));
+						}
+
+						queryResult.add(row);
+					}
+				}
+			}
 		}
 		catch (SQLException sqle) {
 			sqle.printStackTrace();
-		}
-		finally {
-			if (ps != null) {
-				ps.close();
-			}
-
-			if (connection != null) {
-				connection.close();
-			}
 		}
 
 		return queryResult;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
@@ -32,33 +32,40 @@ import java.util.Map;
 public class DBUtil {
 
 	public static List<Map<String, Object>> executeQuery(
-			List<Object> arguments, String dbType, String url, String userName,
-			String password, String query)
+			List<Object> arguments, String dbDriverClassName, String url,
+			String userName, String password, String query)
 		throws ClassNotFoundException, SQLException {
 
-		List<Map<String, Object>> queryResult = new ArrayList<>();
+		List<Map<String, Object>> queryResultMap = new ArrayList<>();
 
-		Class.forName(dbType);
+		Class.forName(dbDriverClassName);
 
 		try (Connection connection =
 				DriverManager.getConnection(url, userName, password)) {
 
-			try (PreparedStatement ps = connection.prepareStatement(query)) {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(query)) {
+
 				for (int i = 0; i < arguments.size(); i++) {
-					ps.setObject(i + 1, arguments.get(i));
+					preparedStatement.setObject(i + 1, arguments.get(i));
 				}
 
-				try (ResultSet rs = ps.executeQuery()) {
-					ResultSetMetaData rsmd = rs.getMetaData();
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					ResultSetMetaData resultSetMetaData =
+						resultSet.getMetaData();
 
-					while (rs.next()) {
+					while (resultSet.next()) {
 						Map<String, Object> row = new HashMap<>();
 
-						for (int i = 1; i <= rsmd.getColumnCount(); i++) {
-							row.put(rsmd.getColumnName(i), rs.getObject(i));
+						for (int i = 1;
+							i <= resultSetMetaData.getColumnCount(); i++) {
+
+							row.put(
+								resultSetMetaData.getColumnName(i),
+								resultSet.getObject(i));
 						}
 
-						queryResult.add(row);
+						queryResultMap.add(row);
 					}
 				}
 			}
@@ -67,7 +74,7 @@ public class DBUtil {
 			sqle.printStackTrace();
 		}
 
-		return queryResult;
+		return queryResultMap;
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Leslie Wong
+ */
+public class DBUtil {
+
+	public static List<Map<String, Object>> executeQuery(
+			List<Object> arguments, String dbType, String url, String userName,
+			String password, String query)
+		throws ClassNotFoundException, SQLException {
+
+		List<Map<String, Object>> queryResult = new ArrayList<>();
+
+		Connection connection = null;
+		PreparedStatement ps = null;
+
+		try {
+			Class.forName(dbType);
+
+			connection = DriverManager.getConnection(url, userName, password);
+
+			ps = connection.prepareStatement(query);
+
+			for (int i = 0; i < arguments.size(); i++) {
+				ps.setObject(i + 1, arguments.get(i));
+			}
+
+			ResultSet rs = ps.executeQuery();
+
+			ResultSetMetaData rsmd = rs.getMetaData();
+
+			while (rs.next()) {
+				Map<String, Object> row = new HashMap<>();
+
+				for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+					row.put(rsmd.getColumnName(i), rs.getObject(i));
+				}
+
+				queryResult.add(row);
+			}
+
+			rs.close();
+		}
+		catch (SQLException sqle) {
+			sqle.printStackTrace();
+		}
+		finally {
+			if (ps != null) {
+				ps.close();
+			}
+
+			if (connection != null) {
+				connection.close();
+			}
+		}
+
+		return queryResult;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/DBUtil.java
@@ -72,6 +72,8 @@ public class DBUtil {
 		}
 		catch (SQLException sqle) {
 			sqle.printStackTrace();
+
+			throw sqle;
 		}
 
 		return queryResultMap;


### PR DESCRIPTION
http://issues.liferay.com/browse/LRQA-30526

@brianchandotcom We are accessing the DB directly because we need to access the upstream integration test results that are currently being pushed into a separate Testray instance. The purpose of this data is to allow us to use historical data to determine whether or not an integration test is flaky or not. This way, if an integration test fails in a pull request, we check to see how many times that particular test has failed in upstream in the past X number of days. If the number of failures exceeds a certain threshold, then we determine that the test is flaky and we do not auto-close based on that failure. If it is below the threshold, then the pull request will be automatically closed. The TestRay REST API is not able to support the kind of queries we will be making so we have been granted read-only access to the database.