### PR TITLE
LPS-70912 Optimize PageContextWrapper.findAttribute() to directly do …

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7603,6 +7603,22 @@
     #jsp.servlet.init.param.compilerTargetVM=
 
     #
+    # javax.servlet.jsp.PageContext.findAttribute(String) is mainly used by
+    # generated jsp servlet, which internally try page scope attributes first,
+    # then with many fallbacks. This is not necessary for liferay, as we always
+    # populate tag variables into page scope explicitly. The fallbacks won't be
+    # able to find anything, therefore wasting a lot of time.
+    #
+    # Set this property to true to force com.liferay.taglib.servlet.
+    # PageContextWrapper.findAttribute(String) directly doing getAttribute(
+    # String) to avoid the fallbacks overhead.
+    #
+    # In case a third party jsp code needs to rely on the fallbacks logic, this
+    # property needs to be set to false to restore the original logic.
+    #
+    jsp.pagecontext.force.get.attribute=true
+
+    #
     # Set the JspWriter buffer size. JspFactoryWrapper reads this value as the
     # buffer size when creating new JspWriters. This value should be kept at 0
     # for performance reasons.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1025,6 +1025,8 @@ public interface PropsKeys {
 
 	public static final String JSONWS_WEB_SERVICE_STRICT_HTTP_METHOD = "jsonws.web.service.strict.http.method";
 
+	public static final String JSP_PAGECONTEXT_FORCE_GET_ATTRIBUTE = "jsp.pagecontext.force.get.attribute";
+
 	public static final String JSP_WRITER_BUFFER_SIZE = "jsp.writer.buffer.size";
 
 	public static final String LAYOUT_AJAX_RENDER_ENABLE = "layout.ajax.render.enable";

--- a/util-taglib/src/com/liferay/taglib/servlet/PageContextWrapper.java
+++ b/util-taglib/src/com/liferay/taglib/servlet/PageContextWrapper.java
@@ -15,6 +15,9 @@
 package com.liferay.taglib.servlet;
 
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.taglib.BodyContentWrapper;
 
 import java.io.IOException;
@@ -48,6 +51,10 @@ public class PageContextWrapper extends PageContext {
 
 	@Override
 	public Object findAttribute(String name) {
+		if (_JSP_PAGECONTEXT_FORCE_GET_ATTRIBUTE) {
+			return _pageContext.getAttribute(name);
+		}
+
 		return _pageContext.findAttribute(name);
 	}
 
@@ -234,6 +241,10 @@ public class PageContextWrapper extends PageContext {
 	public void setAttribute(String name, Object value, int scope) {
 		_pageContext.setAttribute(name, value, scope);
 	}
+
+	private static final boolean _JSP_PAGECONTEXT_FORCE_GET_ATTRIBUTE =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.JSP_PAGECONTEXT_FORCE_GET_ATTRIBUTE));
 
 	private final PageContext _pageContext;
 


### PR DESCRIPTION
…PageContext.getAttribute() to avoid unncessary fallback, and provide a switch to turn this off, in case a third party code relies on PageContext.findAttribute() logic.