### PR TITLE
Lps 62777

### DIFF
--- a/modules/core/registry-impl/build.gradle
+++ b/modules/core/registry-impl/build.gradle
@@ -1,3 +1,6 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"

--- a/modules/core/registry-impl/src/main/java/com/liferay/registry/internal/ServiceTrackerMapFactoryImpl.java
+++ b/modules/core/registry-impl/src/main/java/com/liferay/registry/internal/ServiceTrackerMapFactoryImpl.java
@@ -21,11 +21,16 @@ import com.liferay.registry.collections.ServiceTrackerMap;
 import com.liferay.registry.collections.ServiceTrackerMapFactory;
 import com.liferay.registry.collections.ServiceTrackerMapListener;
 
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
 
@@ -39,18 +44,33 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 	}
 
 	public void clearServiceTrackerMaps() {
-		for (com.liferay.osgi.service.tracker.collections.map.
-				ServiceTrackerMap<?, ?> serviceTrackerMap :
-					_serviceTrackerMaps.keySet()) {
+		Iterator<Reference<com.liferay.osgi.service.tracker.collections.map.
+			ServiceTrackerMap<?, ?>>> iterator = _serviceTrackerMaps.iterator();
 
-			try {
-				serviceTrackerMap.close();
-			}
-			catch (Throwable t) {
+		while (iterator.hasNext()) {
+			Reference<com.liferay.osgi.service.tracker.collections.map.
+				ServiceTrackerMap<?, ?>>
+					serviceTrackerMapReference = iterator.next();
+
+			iterator.remove();
+
+			com.liferay.osgi.service.tracker.collections.map.
+				ServiceTrackerMap<?, ?> serviceTrackerMap =
+					serviceTrackerMapReference.get();
+
+			if (serviceTrackerMap != null) {
+				try {
+					serviceTrackerMap.close();
+				}
+				catch (Throwable t) {
+				}
 			}
 		}
 
-		_serviceTrackerMaps.clear();
+		// Drain the reference queue since there are no more service tracker
+		// references
+
+		while (_referenceQueue.poll() != null);
 	}
 
 	@Override
@@ -63,7 +83,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 					ServiceTrackerMapFactory.multiValueMap(
 						_bundleContext, clazz, propertyKey);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -83,7 +103,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						_bundleContext, clazz, filterString,
 						serviceReferenceMapperWrapper);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -107,7 +127,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						serviceReferenceMapperWrapper,
 						serviceReferenceComparatorAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -135,7 +155,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						serviceReferenceMapperWrapper,
 						serviceTrackerMapListenerWrapper);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -159,7 +179,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						serviceReferenceMapperWrapper,
 						serviceTrackerCustomizerAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -188,7 +208,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						serviceTrackerCustomizerAdapter,
 						serviceReferenceComparatorAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -208,7 +228,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						_bundleContext, clazz, propertyKey,
 						serviceTrackerCustomizerAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -223,7 +243,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 					ServiceTrackerMapFactory.singleValueMap(
 						_bundleContext, clazz, propertyKey);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -243,7 +263,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						_bundleContext, clazz, filterString,
 						serviceReferenceMapperWrapper);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -267,7 +287,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						serviceReferenceMapperWrapper,
 						serviceReferenceComparatorAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -291,7 +311,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						serviceReferenceMapperWrapper,
 						serviceTrackerCustomizerAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -321,7 +341,7 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						serviceTrackerCustomizerAdapter,
 						serviceReferenceComparatorAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
@@ -341,16 +361,38 @@ public class ServiceTrackerMapFactoryImpl implements ServiceTrackerMapFactory {
 						_bundleContext, clazz, propertyKey,
 						serviceTrackerCustomizerAdapter);
 
-		_serviceTrackerMaps.put(serviceTrackerMap, null);
+		addServiceTrackerMap(serviceTrackerMap);
 
 		return new ServiceTrackerMapWrapper<>(serviceTrackerMap);
 	}
 
+	protected void addServiceTrackerMap(
+		com.liferay.osgi.service.tracker.collections.map.
+			ServiceTrackerMap<?, ?> serviceTrackerMap) {
+
+		Reference<com.liferay.osgi.service.tracker.collections.map.
+			ServiceTrackerMap<?, ?>> reference = new WeakReference<>(
+				serviceTrackerMap, _referenceQueue);
+
+		_serviceTrackerMaps.add(reference);
+
+		while ((reference =
+					(Reference<com.liferay.osgi.service.tracker.collections.map.
+						ServiceTrackerMap<?, ?>>)
+							_referenceQueue.poll()) != null) {
+
+			_serviceTrackerMaps.remove(reference);
+		}
+	}
+
 	private final BundleContext _bundleContext;
-	private final Map
-		<com.liferay.osgi.service.tracker.collections.map.
-			ServiceTrackerMap<?, ?>, Void>
-				_serviceTrackerMaps = new WeakHashMap<>();
+	private final
+		ReferenceQueue<com.liferay.osgi.service.tracker.collections.map.
+			ServiceTrackerMap<?, ?>> _referenceQueue = new ReferenceQueue<>();
+	private final
+		Set<Reference<com.liferay.osgi.service.tracker.collections.map.
+			ServiceTrackerMap<?, ?>>> _serviceTrackerMaps =
+				Collections.newSetFromMap(new ConcurrentHashMap<>());
 
 	private static class EmitterWrapper<K>
 		implements ServiceReferenceMapper.Emitter<K> {


### PR DESCRIPTION
@brianchandotcom this is the fix to those recently started frequent hanging and aborted CI batches.

@csierra we dealt with the exact same problem for RegistryImpl about a year ago. See https://github.com/brianchandotcom/liferay-portal/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aclosed%20LPS-64246

Please remember WeakHashMap is HashMap which is not threadsafe, and it will cause infinite loops under concurrent accessing.

@hhuijser please be sure to SF out all usages to WeakHashMap in our codebase, that class should not be allowed to be used.

A sample hanging thread stack here for your reference:
```
"main" #1 prio=5 os_prio=0 tid=0xb630e400 nid=0x5d38 runnable [0xb66ed000]
   java.lang.Thread.State: RUNNABLE
	at java.util.WeakHashMap.put(WeakHashMap.java:453)
	at com.liferay.registry.internal.ServiceTrackerMapFactoryImpl.singleValueMap(ServiceTrackerMapFactoryImpl.java:246)
	at com.liferay.registry.collections.ServiceTrackerCollections.singleValueMap(ServiceTrackerCollections.java:527)
	at com.liferay.registry.collections.ServiceTrackerCollections.openSingleValueMap(ServiceTrackerCollections.java:449)
	at com.liferay.portal.kernel.portlet.bridges.mvc.MVCCommandCache.<init>(MVCCommandCache.java:69)
	at com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet.init(MVCPortlet.java:214)
	at javax.portlet.GenericPortlet.init(GenericPortlet.java:136)
	at com.liferay.portlet.InvokerPortletImpl.init(InvokerPortletImpl.java:296)
	at com.liferay.portal.monitoring.internal.portlet.MonitoringInvokerPortlet.init(MonitoringInvokerPortlet.java:141)
	at com.liferay.portlet.PortletInstanceFactoryImpl.init(PortletInstanceFactoryImpl.java:293)
	at com.liferay.portlet.PortletInstanceFactoryImpl.create(PortletInstanceFactoryImpl.java:193)
	at com.liferay.portal.kernel.portlet.PortletInstanceFactoryUtil.create(PortletInstanceFactoryUtil.java:49)
	at com.liferay.portlet.PortletBagFactory.create(PortletBagFactory.java:217)
	at com.liferay.portal.osgi.web.portlet.tracker.internal.PortletTracker.addingPortlet(PortletTracker.java:297)
	at com.liferay.portal.osgi.web.portlet.tracker.internal.PortletTracker.addingService(PortletTracker.java:157)
	at com.liferay.portal.osgi.web.portlet.tracker.internal.PortletTracker.addingService(PortletTracker.java:103)
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:941)
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:1)
	at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)
	at org.osgi.util.tracker.AbstractTracked.trackInitial(AbstractTracked.java:183)
	at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:318)
	at org.osgi.util.tracker.ServiceTracker.open(ServiceTracker.java:261)
	at com.liferay.osgi.util.ServiceTrackerFactory.open(ServiceTrackerFactory.java:93)
	at com.liferay.portal.osgi.web.portlet.tracker.internal.PortletTracker.activate(PortletTracker.java:232)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.felix.scr.impl.inject.BaseMethod.invokeMethod(BaseMethod.java:224)
	at org.apache.felix.scr.impl.inject.BaseMethod.access$500(BaseMethod.java:39)
	at org.apache.felix.scr.impl.inject.BaseMethod$Resolved.invoke(BaseMethod.java:617)
	at org.apache.felix.scr.impl.inject.BaseMethod.invoke(BaseMethod.java:501)
	at org.apache.felix.scr.impl.inject.ActivateMethod.invoke(ActivateMethod.java:302)
	at org.apache.felix.scr.impl.inject.ActivateMethod.invoke(ActivateMethod.java:294)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.createImplementationObject(SingleComponentManager.java:297)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.createComponent(SingleComponentManager.java:108)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:906)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getServiceInternal(SingleComponentManager.java:879)
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.activateInternal(AbstractComponentManager.java:748)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleStaticCustomizer.addedService(DependencyManager.java:1012)
	at org.apache.felix.scr.impl.manager.DependencyManager$SingleStaticCustomizer.addedService(DependencyManager.java:968)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerAdded(ServiceTracker.java:1215)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerAdded(ServiceTracker.java:1136)
	at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.trackAdding(ServiceTracker.java:945)
	at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.track(ServiceTracker.java:881)
	at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:1167)
	at org.apache.felix.scr.impl.BundleComponentActivator$ListenerInfo.serviceChanged(BundleComponentActivator.java:127)
	at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:109)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:917)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:862)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:801)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.register(ServiceRegistrationImpl.java:127)
	at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.registerService(ServiceRegistry.java:225)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:464)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:482)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:1001)
	at com.liferay.registry.internal.RegistryImpl.registerService(RegistryImpl.java:305)
	at com.liferay.portal.servlet.MainServlet.registerPortalInitialized(MainServlet.java:1317)
	at com.liferay.portal.servlet.MainServlet.init(MainServlet.java:420)
	at javax.servlet.GenericServlet.init(GenericServlet.java:244)
	at com.liferay.portal.test.rule.callback.MainServletTestCallback.beforeClass(MainServletTestCallback.java:96)
	at com.liferay.portal.test.rule.callback.MainServletTestCallback.beforeClass(MainServletTestCallback.java:42)
	at com.liferay.portal.kernel.test.rule.BaseTestRule$2.evaluate(BaseTestRule.java:78)
	at com.liferay.portal.kernel.test.rule.BaseTestRule$2.evaluate(BaseTestRule.java:81)
	at com.liferay.portal.kernel.test.rule.BaseTestRule$2.evaluate(BaseTestRule.java:81)
	at com.liferay.portal.kernel.test.rule.BaseTestRule$2.evaluate(BaseTestRule.java:81)
	at com.liferay.portal.test.rule.LiferayIntegrationTestRule$1$1.evaluate(LiferayIntegrationTestRule.java:146)
	at com.liferay.portal.kernel.test.rule.BaseTestRule$2.evaluate(BaseTestRule.java:81)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.run(JUnitTestRunner.java:532)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.launch(JUnitTestRunner.java:1179)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.main(JUnitTestRunner.java:1001)

   Locked ownable synchronizers:
	- <0x69d9ef80> (a java.util.concurrent.locks.ReentrantLock$FairSync)
```