### PR TITLE
LPS-70913 Bump up all CI elasticsearch timeouts to 30mins

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1567,13 +1567,13 @@ jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 			<echo file="${liferay.home}/osgi/portal/com.liferay.portal.search.elasticsearch.configuration.ElasticsearchConfiguration.cfg">
 				additionalConfigurations=\
 					cluster.routing.allocation.disk.threshold_enabled: false\n\
-					cluster.service.slow_task_logging_threshold: 600s\n\
+					cluster.service.slow_task_logging_threshold: 1800s\n\
 					httpEnabled: false\n\
-					index.indexing.slowlog.threshold.index.warn: 600s\n\
-					index.search.slowlog.threshold.fetch.warn: 600s\n\
-					index.search.slowlog.threshold.query.warn: 600s\n\
-					monitor.jvm.gc.old.warn: 600s\n\
-					monitor.jvm.gc.young.warn: 600s\n\
+					index.indexing.slowlog.threshold.index.warn: 1800s\n\
+					index.search.slowlog.threshold.fetch.warn: 1800s\n\
+					index.search.slowlog.threshold.query.warn: 1800s\n\
+					monitor.jvm.gc.old.warn: 1800s\n\
+					monitor.jvm.gc.young.warn: 1800s\n\
 					threadpool.bulk.size: 1\n\
 					threadpool.fetch_shard_started.size: 1\n\
 					threadpool.fetch_shard_store.size: 1\n\


### PR DESCRIPTION
@arboliveira not sure if this is something tunable, but see this pull https://github.com/brianchandotcom/liferay-portal/pull/47178#issuecomment-282476936 , it did not really fail for anything but an index took
```
took[11.7m], took_millis[703475], type[LiferayDocumentType], id[com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_PORTLET_com.liferay.portal.osgi.web.wab.extender.internal.configuration.WabExtenderConfiguration], routing[] , source[{"uid":"com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_PORTLET_com.liferay.portal.osgi.web.wab.extender.internal.configuration.WabExtenderConfiguration","companyId":"0","configurationModelId":"com.liferay.portal.osgi.web.wab.extender.internal.configuration.WabExtenderConfiguration","entryClassName":"com.liferay.configuration.admin.web.internal.model.ConfigurationModel","configurationModelFactoryPid":"com.liferay.portal.osgi.web.wab.extender.internal.configuration.WabExtenderConfiguration","title_zh_CN":"WAB?????????","title_es_ES":"Extensor WAB","title_ja_JP":"WAB Extender","title_iw_IL":"WAB Extender","title_nl_NL":"WAB-verlenger","title_fi_FI":"WAB Extender -laite","title_ca_ES":"Estensor WAB","title_hu_HU":"WAB b??v??t??","title_fr_FR":"Extendeur WAB","title":"WAB Extender","title_en_US":"WAB Extender","title_pt_BR":"Extensor WAB","title_de_DE":"WAB Extender","configurationModelAttributeName":"Stop timeout"}]
```

Passed the warning threshold, caused a warning failed the log scanner.

11.7mins is really slow... I am bumping it up to 30mins to avoid the false alarm failures, but I think we should take a closer look to see why it is taking so long for a simple indexing.