### PR TITLE
LPS-70914 NPE is thrown when deactivate user signing in

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java
@@ -456,7 +456,9 @@ public class AuthenticatedSessionManagerImpl
 			User user = (User)resultsMap.get("user");
 
 			if (authResult != Authenticator.SUCCESS) {
-				user = UserLocalServiceUtil.fetchUser(user.getUserId());
+				if (user != null) {
+					user = UserLocalServiceUtil.fetchUser(user.getUserId());
+				}
 
 				if (user != null) {
 					UserLocalServiceUtil.checkLockout(user);


### PR DESCRIPTION
This is an update for [LPS-70914](https://issues.liferay.com/browse/LPS-70914).<br><br>Hey Brian, this is a quick NPE check.  I believe this maintains the behavior introduced in https://issues.liferay.com/browse/LPS-70765.<br><br>/cc @shuyangzhou @pei-jung @sheltonz