### PR TITLE
LPS-70408 AggregateClassLoader must use the real parent setup for jnd…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/AggregateClassLoader.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/AggregateClassLoader.java
@@ -73,7 +73,7 @@ public class AggregateClassLoader extends ClassLoader {
 	}
 
 	public AggregateClassLoader(ClassLoader classLoader) {
-		_parentClassLoaderReference = new WeakReference<>(classLoader);
+		super(classLoader);
 	}
 
 	public void addClassLoader(ClassLoader classLoader) {
@@ -171,13 +171,7 @@ public class AggregateClassLoader extends ClassLoader {
 			}
 		}
 
-		ClassLoader parentClassLoader = _parentClassLoaderReference.get();
-
-		if (parentClassLoader == null) {
-			return null;
-		}
-
-		return parentClassLoader.getResource(name);
+		return super.getResource(name);
 	}
 
 	@Override
@@ -188,12 +182,7 @@ public class AggregateClassLoader extends ClassLoader {
 			urls.addAll(Collections.list(_getResources(classLoader, name)));
 		}
 
-		ClassLoader parentClassLoader = _parentClassLoaderReference.get();
-
-		if (parentClassLoader != null) {
-			urls.addAll(
-				Collections.list(_getResources(parentClassLoader, name)));
-		}
+		urls.addAll(Collections.list(_getResources(getParent(), name)));
 
 		return Collections.enumeration(urls);
 	}
@@ -238,14 +227,7 @@ public class AggregateClassLoader extends ClassLoader {
 		}
 
 		if (loadedClass == null) {
-			ClassLoader parentClassLoader = _parentClassLoaderReference.get();
-
-			if (parentClassLoader == null) {
-				throw new ClassNotFoundException(
-					"Parent class loader has been garbage collected");
-			}
-
-			loadedClass = _loadClass(parentClassLoader, name, resolve);
+			loadedClass = _loadClass(getParent(), name, resolve);
 		}
 		else if (resolve) {
 			resolveClass(loadedClass);
@@ -345,6 +327,5 @@ public class AggregateClassLoader extends ClassLoader {
 
 	private final List<EqualityWeakReference<ClassLoader>>
 		_classLoaderReferences = new ArrayList<>();
-	private final WeakReference<ClassLoader> _parentClassLoaderReference;
 
 }


### PR DESCRIPTION
…i lookup. Originally we weak referenced it for the purpose of allowing plugin classloader to be GCed, but I think we already referenced AggregateClassLoader itself in most of our classloader caching usages(if we have some missing spots, we can always fix them later), so it should be safe to allow AggregateClassLoader having a real parent now.

CC @holatuwol