### PR TITLE
Revert "LPS-71049 Close Tag earlier"

### DIFF
--- a/util-taglib/src/com/liferay/taglib/aui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/IconTag.java
@@ -177,7 +177,7 @@ public class IconTag extends BaseIconTag {
 			else {
 				jspWriter.write("<i class=\"icon-");
 				jspWriter.write(GetterUtil.getString(getImage()));
-				jspWriter.write("\" />");
+				jspWriter.write("\"></i>");
 			}
 
 			String label = getLabel();


### PR DESCRIPTION
This reverts commit 64afa64573e4c141b704f890c19435fabcae6a88.

For some reason closing <i> earlier cause front end failures, which I have no idea why, don't want to bother with it, just wastes 2 chars, no big deal.