### PR TITLE
LPS-70199

### DIFF
--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f959ce02c241152c99435ddc93268f72151b4330
+	commit = 1e321942312b0e90ee4452ab390e92fca6a0e49f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 391b0dcddd67d2b945aee9d279690cfa93b1388c
+	parent = a3ae0de7ff8995e598fb19b86d1763933a019492
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 3daf0d4d59108f22756eaac9900b3b5045c61643
+	commit = 47451512299b0204f77869db36214e4881d13c37
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 140d61b16896a9358fd671fc921e4541f9fe288e
+	parent = 4ef26d2c507e0ce979efab497bfc74eaa7e04d55
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0312fb4719e5bbcff77a17abdd6658e3d2bda838
+	commit = f2a0b34396e1b54a8f9fd6fc7329fdea80559a69
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3d7d4436c314d4a8e66dde9868698a4de750be08
+	parent = 057805df71b1f0f0ac9d6f6dc77a4ef91e40706b
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = cd31150fb642023eb1f5c3f462fd04c70287a924
+	commit = 571b9cb7f4b0c61e69bfb8c6ed899ee5519d37ed
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7dd254f5a68c3d070429443ebaa341e479dbbeae
+	parent = 8f230ca649420ff65f36212429a431a578720329
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/frontend-taglib/.gitrepo
+++ b/modules/apps/foundation/frontend-taglib/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 2c5b862ef7c67bc730f71c038dea013e02d235b0
+	commit = b2f16b890bea376eb8b0279983c13a9a4ccdb1d8
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e250c8f675cf6e76c141cbf5a75dad16ccf87e82
+	parent = d9e4f42248f6090228dd77046e6f9d50b7935b14
 	remote = git@github.com:liferay/com-liferay-frontend-taglib.git

--- a/modules/apps/foundation/frontend-theme/.gitrepo
+++ b/modules/apps/foundation/frontend-theme/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ce7c5bdb45430da518a5e8f9040c1988bfb10790
+	commit = 58e483013e60961b20a8a34ce81586f66b0ccd93
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b722de8b6074d85542dd60b66e6670e0d4ef8b51
+	parent = f33269924a385b61552325e36f12f0f75c6c40b9
 	remote = git@github.com:liferay/com-liferay-frontend-theme.git

--- a/modules/apps/foundation/hello-soy/.gitrepo
+++ b/modules/apps/foundation/hello-soy/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f36c92caf2f871e3a064743bcb92262747446d99
+	commit = bbfdae5edfcab56a6b1613606d0be93c7c6848ed
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5932facbdd0d968c7f0d2f9ca6f2381a6f8fceb2
+	parent = 8e01bc8e3049ff52966265947dfa4a6678cdabee
 	remote = git@github.com:liferay/com-liferay-hello-soy.git

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/CacheExportImportLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/CacheExportImportLifecycleListener.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.internal.lifecycle;
+
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lifecycle.EventAwareExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+import com.liferay.portal.servlet.filters.cache.CacheUtil;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Mate Thurzo
+ */
+@Component(immediate = true, service = ExportImportLifecycleListener.class)
+public class CacheExportImportLifecycleListener
+	implements EventAwareExportImportLifecycleListener {
+
+	@Override
+	public boolean isParallel() {
+		return false;
+	}
+
+	@Override
+	public void onLayoutExportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutExportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutExportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutImportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutImportProcessFinished(
+		PortletDataContext portletDataContext) {
+
+		clearCache();
+	}
+
+	@Override
+	public void onLayoutImportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutImportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutLocalPublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutLocalPublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutLocalPublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutRemotePublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutRemotePublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutRemotePublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletExportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletExportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletExportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletImportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletImportProcessFinished(
+		PortletDataContext portletDataContext) {
+
+		clearCache();
+	}
+
+	@Override
+	public void onPortletImportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletImportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletPublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletPublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletPublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelExportFailed(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelExportStarted(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelExportSucceeded(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelImportFailed(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			Throwable throwable)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelImportStarted(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	@Override
+	public void onStagedModelImportSucceeded(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+	}
+
+	protected void clearCache() {
+		CacheUtil.clearCache();
+		PermissionCacheUtil.clearCache();
+	}
+
+}

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/ExportImportProcessCallbackLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/ExportImportProcessCallbackLifecycleListener.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.internal.lifecycle;
+
+import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.ProcessAwareExportImportLifecycleListener;
+import com.liferay.exportimport.lar.ExportImportProcessCallbackUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Daniel Kocsis
+ */
+@Component(immediate = true, service = ExportImportLifecycleListener.class)
+public class ExportImportProcessCallbackLifecycleListener
+	implements ProcessAwareExportImportLifecycleListener {
+
+	@Override
+	public boolean isParallel() {
+		return false;
+	}
+
+	@Override
+	public void onProcessFailed(List<Serializable> attributes)
+		throws Exception {
+
+		ExportImportProcessCallbackUtil.popCallbackList();
+	}
+
+	@Override
+	public void onProcessStarted(List<Serializable> attributes)
+		throws Exception {
+
+		ExportImportProcessCallbackUtil.pushCallbackList();
+	}
+
+	@Override
+	public void onProcessSucceeded(List<Serializable> attributes)
+		throws Exception {
+
+		List<Callable<?>> callables =
+			ExportImportProcessCallbackUtil.popCallbackList();
+
+		for (Callable<?> callable : callables) {
+			try {
+				callable.call();
+			}
+			catch (Exception e) {
+				_log.error(
+					"Unable to execute export import process callback", e);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ExportImportProcessCallbackLifecycleListener.class);
+
+};

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/LoggerExportImportLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/LoggerExportImportLifecycleListener.java
@@ -1,0 +1,487 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.internal.lifecycle;
+
+import com.liferay.exportimport.kernel.lar.ExportImportClassedModelUtil;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lifecycle.EventAwareExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleEvent;
+import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.StagedGroupedModel;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Daniel Kocsis
+ */
+@Component(immediate = true, service = ExportImportLifecycleListener.class)
+public class LoggerExportImportLifecycleListener
+	implements EventAwareExportImportLifecycleListener {
+
+	public String getStagedModelLogFragment(StagedModel stagedModel) {
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(StringPool.OPEN_CURLY_BRACE);
+		sb.append("class: ");
+		sb.append(ExportImportClassedModelUtil.getClassName(stagedModel));
+
+		if (stagedModel instanceof StagedGroupedModel) {
+			StagedGroupedModel stagedGroupedModel =
+				(StagedGroupedModel)stagedModel;
+
+			sb.append(", groupId: ");
+			sb.append(stagedGroupedModel.getGroupId());
+		}
+
+		sb.append(", uuid: ");
+		sb.append(stagedModel.getUuid());
+		sb.append(StringPool.CLOSE_CURLY_BRACE);
+
+		return sb.toString();
+	}
+
+	@Override
+	public boolean isParallel() {
+		return false;
+	}
+
+	@Override
+	public void onExportImportLifecycleEvent(
+			ExportImportLifecycleEvent exportImportLifecycleEvent)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+	}
+
+	@Override
+	public void onLayoutExportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout export failed for group " + portletDataContext.getGroupId(),
+			throwable);
+	}
+
+	@Override
+	public void onLayoutExportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout export started for group " +
+				portletDataContext.getGroupId());
+	}
+
+	@Override
+	public void onLayoutExportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout export succeeded for group " +
+				portletDataContext.getGroupId());
+	}
+
+	@Override
+	public void onLayoutImportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout import failed for group " + portletDataContext.getGroupId(),
+			throwable);
+	}
+
+	@Override
+	public void onLayoutImportProcessFinished(
+			PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onLayoutImportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout import started for group " +
+				portletDataContext.getGroupId());
+	}
+
+	@Override
+	public void onLayoutImportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout import succeeded for group " +
+				portletDataContext.getGroupId());
+	}
+
+	@Override
+	public void onLayoutLocalPublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout publication failed for group " +
+				exportImportConfiguration.getGroupId(),
+			throwable);
+	}
+
+	@Override
+	public void onLayoutLocalPublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout publication started for group " +
+				exportImportConfiguration.getGroupId());
+	}
+
+	@Override
+	public void onLayoutLocalPublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout publication succeeded for group " +
+				exportImportConfiguration.getGroupId());
+	}
+
+	@Override
+	public void onLayoutRemotePublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout remote publication failed for group " +
+				exportImportConfiguration.getGroupId(),
+			throwable);
+	}
+
+	@Override
+	public void onLayoutRemotePublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout publication started for group " +
+				exportImportConfiguration.getGroupId());
+	}
+
+	@Override
+	public void onLayoutRemotePublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Layout remote publication succeeded for group " +
+				exportImportConfiguration.getGroupId());
+	}
+
+	@Override
+	public void onPortletExportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Portlet export failed for portlet " +
+				portletDataContext.getPortletId(),
+			throwable);
+	}
+
+	@Override
+	public void onPortletExportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Portlet export started for portlet " +
+				portletDataContext.getPortletId());
+	}
+
+	@Override
+	public void onPortletExportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Portlet export succeeded for portlet " +
+				portletDataContext.getPortletId());
+	}
+
+	@Override
+	public void onPortletImportFailed(
+			PortletDataContext portletDataContext, Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Portlet import failed for portlet " +
+				portletDataContext.getPortletId(),
+			throwable);
+	}
+
+	@Override
+	public void onPortletImportProcessFinished(
+			PortletDataContext portletDataContext)
+		throws Exception {
+	}
+
+	@Override
+	public void onPortletImportStarted(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Portlet import started for portlet " +
+				portletDataContext.getPortletId());
+	}
+
+	@Override
+	public void onPortletImportSucceeded(PortletDataContext portletDataContext)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Portlet import succeeded for portlet " +
+				portletDataContext.getPortletId());
+	}
+
+	@Override
+	public void onPortletPublicationFailed(
+			ExportImportConfiguration exportImportConfiguration,
+			Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		Map<String, Serializable> settingsMap =
+			exportImportConfiguration.getSettingsMap();
+
+		String portletId = MapUtil.getString(settingsMap, "portletId");
+
+		_log.debug(
+			"Portlet publication failed for portlet " + portletId, throwable);
+	}
+
+	@Override
+	public void onPortletPublicationStarted(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		Map<String, Serializable> settingsMap =
+			exportImportConfiguration.getSettingsMap();
+
+		String portletId = MapUtil.getString(settingsMap, "portletId");
+
+		_log.debug("Portlet publication started for portlet " + portletId);
+	}
+
+	@Override
+	public void onPortletPublicationSucceeded(
+			ExportImportConfiguration exportImportConfiguration)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		Map<String, Serializable> settingsMap =
+			exportImportConfiguration.getSettingsMap();
+
+		String portletId = MapUtil.getString(settingsMap, "portletId");
+
+		_log.debug("Portlet publication succeeded for portlet " + portletId);
+	}
+
+	@Override
+	public void onStagedModelExportFailed(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Staged model " + getStagedModelLogFragment(stagedModel) +
+				" export failed",
+			throwable);
+	}
+
+	@Override
+	public void onStagedModelExportStarted(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Staged model " + getStagedModelLogFragment(stagedModel) +
+				" export started");
+	}
+
+	@Override
+	public void onStagedModelExportSucceeded(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Staged model " + getStagedModelLogFragment(stagedModel) +
+				" export succeeded");
+	}
+
+	@Override
+	public void onStagedModelImportFailed(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			Throwable throwable)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Staged model " + getStagedModelLogFragment(stagedModel) +
+				" import failed",
+			throwable);
+	}
+
+	@Override
+	public void onStagedModelImportStarted(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Staged model " + getStagedModelLogFragment(stagedModel) +
+				" import started");
+	}
+
+	@Override
+	public void onStagedModelImportSucceeded(
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		_log.debug(
+			"Staged model " + getStagedModelLogFragment(stagedModel) +
+				" import succeeded");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LoggerExportImportLifecycleListener.class);
+
+}

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/NotificationExportImportLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lifecycle/NotificationExportImportLifecycleListener.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.internal.lifecycle;
+
+import com.liferay.exportimport.constants.ExportImportPortletKeys;
+import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.ProcessAwareExportImportLifecycleListener;
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
+import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Akos Thurzo
+ */
+@Component(immediate = true, service = {ExportImportLifecycleListener.class})
+public class NotificationExportImportLifecycleListener
+	implements ProcessAwareExportImportLifecycleListener {
+
+	@Override
+	public boolean isParallel() {
+		return false;
+	}
+
+	@Override
+	public void onProcessFailed(List<Serializable> attributes)
+		throws Exception {
+
+		sendNotification(BackgroundTaskConstants.STATUS_FAILED);
+	}
+
+	@Override
+	public void onProcessStarted(List<Serializable> attributes)
+		throws Exception {
+	}
+
+	@Override
+	public void onProcessSucceeded(List<Serializable> attributes)
+		throws Exception {
+
+		sendNotification(BackgroundTaskConstants.STATUS_SUCCESSFUL);
+	}
+
+	protected JSONObject getPayload(
+		long backgroundTaskId, long exportImportConfigurationId, int status) {
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+		jsonObject.put("backgroundTaskId", backgroundTaskId);
+		jsonObject.put(
+			"exportImportConfigurationId", exportImportConfigurationId);
+		jsonObject.put("status", status);
+
+		return jsonObject;
+	}
+
+	protected void sendNotification(int status) throws PortalException {
+		long backgroundTaskId = BackgroundTaskThreadLocal.getBackgroundTaskId();
+
+		BackgroundTask backgroundTask =
+			_backgroundTaskLocalService.getBackgroundTask(backgroundTaskId);
+
+		Map<String, Serializable> taskContextMap =
+			backgroundTask.getTaskContextMap();
+
+		long exportImportConfigurationId = GetterUtil.getLong(
+			taskContextMap.get("exportImportConfigurationId"));
+
+		_userNotificationEventLocalService.sendUserNotificationEvents(
+			backgroundTask.getUserId(), ExportImportPortletKeys.EXPORT_IMPORT,
+			UserNotificationDeliveryConstants.TYPE_WEBSITE,
+			getPayload(backgroundTaskId, exportImportConfigurationId, status));
+	}
+
+	@Reference
+	private BackgroundTaskLocalService _backgroundTaskLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private UserNotificationEventLocalService
+		_userNotificationEventLocalService;
+
+}

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/CacheExportImportLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/CacheExportImportLifecycleListener.java
@@ -17,204 +17,42 @@ package com.liferay.exportimport.lifecycle;
 import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
-import com.liferay.exportimport.kernel.lifecycle.EventAwareExportImportLifecycleListener;
-import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
-import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
-import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.exportimport.kernel.lifecycle.BaseExportImportLifecycleListener;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.servlet.filters.cache.CacheUtil;
 
-import org.osgi.service.component.annotations.Component;
-
 /**
  * @author Mate Thurzo
+ *
+ * @deprecated As of 4.0.0
  */
-@Component(immediate = true, service = ExportImportLifecycleListener.class)
+@Deprecated
 @ProviderType
 public class CacheExportImportLifecycleListener
-	implements EventAwareExportImportLifecycleListener {
+	extends BaseExportImportLifecycleListener {
 
 	@Override
 	public boolean isParallel() {
 		return false;
 	}
 
-	@Override
-	public void onLayoutExportFailed(
-			PortletDataContext portletDataContext, Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutExportStarted(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutExportSucceeded(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutImportFailed(
-			PortletDataContext portletDataContext, Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutImportProcessFinished(
-		PortletDataContext portletDataContext) {
-
-		clearCache();
-	}
-
-	@Override
-	public void onLayoutImportStarted(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutImportSucceeded(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutLocalPublicationFailed(
-			ExportImportConfiguration exportImportConfiguration,
-			Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutLocalPublicationStarted(
-			ExportImportConfiguration exportImportConfiguration)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutLocalPublicationSucceeded(
-			ExportImportConfiguration exportImportConfiguration)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutRemotePublicationFailed(
-			ExportImportConfiguration exportImportConfiguration,
-			Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutRemotePublicationStarted(
-			ExportImportConfiguration exportImportConfiguration)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutRemotePublicationSucceeded(
-			ExportImportConfiguration exportImportConfiguration)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletExportFailed(
-			PortletDataContext portletDataContext, Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletExportStarted(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletExportSucceeded(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletImportFailed(
-			PortletDataContext portletDataContext, Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletImportProcessFinished(
-		PortletDataContext portletDataContext) {
-
-		clearCache();
-	}
-
-	@Override
-	public void onPortletImportStarted(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletImportSucceeded(PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletPublicationFailed(
-			ExportImportConfiguration exportImportConfiguration,
-			Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletPublicationStarted(
-			ExportImportConfiguration exportImportConfiguration)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletPublicationSucceeded(
-			ExportImportConfiguration exportImportConfiguration)
-		throws Exception {
-	}
-
-	@Override
-	public void onStagedModelExportFailed(
-			PortletDataContext portletDataContext, StagedModel stagedModel,
-			Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onStagedModelExportStarted(
-			PortletDataContext portletDataContext, StagedModel stagedModel)
-		throws Exception {
-	}
-
-	@Override
-	public void onStagedModelExportSucceeded(
-			PortletDataContext portletDataContext, StagedModel stagedModel)
-		throws Exception {
-	}
-
-	@Override
-	public void onStagedModelImportFailed(
-			PortletDataContext portletDataContext, StagedModel stagedModel,
-			Throwable throwable)
-		throws Exception {
-	}
-
-	@Override
-	public void onStagedModelImportStarted(
-			PortletDataContext portletDataContext, StagedModel stagedModel)
-		throws Exception {
-	}
-
-	@Override
-	public void onStagedModelImportSucceeded(
-			PortletDataContext portletDataContext, StagedModel stagedModel)
-		throws Exception {
-	}
-
 	protected void clearCache() {
 		CacheUtil.clearCache();
 		PermissionCacheUtil.clearCache();
+	}
+
+	@Override
+	protected void onLayoutImportProcessFinished(
+		PortletDataContext portletDataContext) {
+
+		clearCache();
+	}
+
+	@Override
+	protected void onPortletImportProcessFinished(
+		PortletDataContext portletDataContext) {
+
+		clearCache();
 	}
 
 }

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/ExportImportProcessCallbackLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/ExportImportProcessCallbackLifecycleListener.java
@@ -16,8 +16,7 @@ package com.liferay.exportimport.lifecycle;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
-import com.liferay.exportimport.kernel.lifecycle.ProcessAwareExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.BaseProcessExportImportLifecycleListener;
 import com.liferay.exportimport.lar.ExportImportProcessCallbackUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -27,15 +26,15 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import org.osgi.service.component.annotations.Component;
-
 /**
  * @author Daniel Kocsis
+ *
+ * @deprecated As of 4.0.0
  */
-@Component(immediate = true, service = ExportImportLifecycleListener.class)
+@Deprecated
 @ProviderType
 public class ExportImportProcessCallbackLifecycleListener
-	implements ProcessAwareExportImportLifecycleListener {
+	extends BaseProcessExportImportLifecycleListener {
 
 	@Override
 	public boolean isParallel() {
@@ -43,21 +42,21 @@ public class ExportImportProcessCallbackLifecycleListener
 	}
 
 	@Override
-	public void onProcessFailed(List<Serializable> attributes)
+	protected void onProcessFailed(List<Serializable> attributes)
 		throws Exception {
 
 		ExportImportProcessCallbackUtil.popCallbackList();
 	}
 
 	@Override
-	public void onProcessStarted(List<Serializable> attributes)
+	protected void onProcessStarted(List<Serializable> attributes)
 		throws Exception {
 
 		ExportImportProcessCallbackUtil.pushCallbackList();
 	}
 
 	@Override
-	public void onProcessSucceeded(List<Serializable> attributes)
+	protected void onProcessSucceeded(List<Serializable> attributes)
 		throws Exception {
 
 		List<Callable<?>> callables =
@@ -77,4 +76,4 @@ public class ExportImportProcessCallbackLifecycleListener
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportImportProcessCallbackLifecycleListener.class);
 
-};
+}

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/LoggerExportImportLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/LoggerExportImportLifecycleListener.java
@@ -18,9 +18,8 @@ import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.exportimport.kernel.lar.ExportImportClassedModelUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
-import com.liferay.exportimport.kernel.lifecycle.EventAwareExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.BaseExportImportLifecycleListener;
 import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleEvent;
-import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
 import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -34,17 +33,34 @@ import java.io.Serializable;
 
 import java.util.Map;
 
-import org.osgi.service.component.annotations.Component;
-
 /**
  * @author Daniel Kocsis
+ *
+ * @deprecated As of 4.0.0
  */
-@Component(immediate = true, service = ExportImportLifecycleListener.class)
+@Deprecated
 @ProviderType
 public class LoggerExportImportLifecycleListener
-	implements EventAwareExportImportLifecycleListener {
+	extends BaseExportImportLifecycleListener {
 
-	public String getStagedModelLogFragment(StagedModel stagedModel) {
+	@Override
+	public boolean isParallel() {
+		return false;
+	}
+
+	@Override
+	public void onExportImportLifecycleEvent(
+			ExportImportLifecycleEvent exportImportLifecycleEvent)
+		throws Exception {
+
+		if (!_log.isDebugEnabled()) {
+			return;
+		}
+
+		super.onExportImportLifecycleEvent(exportImportLifecycleEvent);
+	}
+
+	protected String getStagedModelLogFragment(StagedModel stagedModel) {
 		StringBundler sb = new StringBundler(8);
 
 		sb.append(StringPool.OPEN_CURLY_BRACE);
@@ -67,22 +83,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public boolean isParallel() {
-		return false;
-	}
-
-	@Override
-	public void onExportImportLifecycleEvent(
-			ExportImportLifecycleEvent exportImportLifecycleEvent)
-		throws Exception {
-
-		if (!_log.isDebugEnabled()) {
-			return;
-		}
-	}
-
-	@Override
-	public void onLayoutExportFailed(
+	protected void onLayoutExportFailed(
 			PortletDataContext portletDataContext, Throwable throwable)
 		throws Exception {
 
@@ -96,7 +97,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutExportStarted(PortletDataContext portletDataContext)
+	protected void onLayoutExportStarted(PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -109,7 +110,8 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutExportSucceeded(PortletDataContext portletDataContext)
+	protected void onLayoutExportSucceeded(
+			PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -122,7 +124,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutImportFailed(
+	protected void onLayoutImportFailed(
 			PortletDataContext portletDataContext, Throwable throwable)
 		throws Exception {
 
@@ -136,13 +138,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutImportProcessFinished(
-			PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onLayoutImportStarted(PortletDataContext portletDataContext)
+	protected void onLayoutImportStarted(PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -155,7 +151,8 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutImportSucceeded(PortletDataContext portletDataContext)
+	protected void onLayoutImportSucceeded(
+			PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -168,7 +165,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutLocalPublicationFailed(
+	protected void onLayoutLocalPublicationFailed(
 			ExportImportConfiguration exportImportConfiguration,
 			Throwable throwable)
 		throws Exception {
@@ -184,7 +181,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutLocalPublicationStarted(
+	protected void onLayoutLocalPublicationStarted(
 			ExportImportConfiguration exportImportConfiguration)
 		throws Exception {
 
@@ -198,7 +195,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutLocalPublicationSucceeded(
+	protected void onLayoutLocalPublicationSucceeded(
 			ExportImportConfiguration exportImportConfiguration)
 		throws Exception {
 
@@ -212,7 +209,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutRemotePublicationFailed(
+	protected void onLayoutRemotePublicationFailed(
 			ExportImportConfiguration exportImportConfiguration,
 			Throwable throwable)
 		throws Exception {
@@ -228,7 +225,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutRemotePublicationStarted(
+	protected void onLayoutRemotePublicationStarted(
 			ExportImportConfiguration exportImportConfiguration)
 		throws Exception {
 
@@ -242,7 +239,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onLayoutRemotePublicationSucceeded(
+	protected void onLayoutRemotePublicationSucceeded(
 			ExportImportConfiguration exportImportConfiguration)
 		throws Exception {
 
@@ -256,7 +253,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletExportFailed(
+	protected void onPortletExportFailed(
 			PortletDataContext portletDataContext, Throwable throwable)
 		throws Exception {
 
@@ -271,7 +268,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletExportStarted(PortletDataContext portletDataContext)
+	protected void onPortletExportStarted(PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -284,7 +281,8 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletExportSucceeded(PortletDataContext portletDataContext)
+	protected void onPortletExportSucceeded(
+			PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -297,7 +295,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletImportFailed(
+	protected void onPortletImportFailed(
 			PortletDataContext portletDataContext, Throwable throwable)
 		throws Exception {
 
@@ -312,13 +310,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletImportProcessFinished(
-			PortletDataContext portletDataContext)
-		throws Exception {
-	}
-
-	@Override
-	public void onPortletImportStarted(PortletDataContext portletDataContext)
+	protected void onPortletImportStarted(PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -331,7 +323,8 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletImportSucceeded(PortletDataContext portletDataContext)
+	protected void onPortletImportSucceeded(
+			PortletDataContext portletDataContext)
 		throws Exception {
 
 		if (!_log.isDebugEnabled()) {
@@ -344,7 +337,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletPublicationFailed(
+	protected void onPortletPublicationFailed(
 			ExportImportConfiguration exportImportConfiguration,
 			Throwable throwable)
 		throws Exception {
@@ -363,7 +356,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletPublicationStarted(
+	protected void onPortletPublicationStarted(
 			ExportImportConfiguration exportImportConfiguration)
 		throws Exception {
 
@@ -380,7 +373,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onPortletPublicationSucceeded(
+	protected void onPortletPublicationSucceeded(
 			ExportImportConfiguration exportImportConfiguration)
 		throws Exception {
 
@@ -397,7 +390,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onStagedModelExportFailed(
+	protected void onStagedModelExportFailed(
 			PortletDataContext portletDataContext, StagedModel stagedModel,
 			Throwable throwable)
 		throws Exception {
@@ -413,7 +406,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onStagedModelExportStarted(
+	protected void onStagedModelExportStarted(
 			PortletDataContext portletDataContext, StagedModel stagedModel)
 		throws Exception {
 
@@ -427,7 +420,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onStagedModelExportSucceeded(
+	protected void onStagedModelExportSucceeded(
 			PortletDataContext portletDataContext, StagedModel stagedModel)
 		throws Exception {
 
@@ -441,7 +434,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onStagedModelImportFailed(
+	protected void onStagedModelImportFailed(
 			PortletDataContext portletDataContext, StagedModel stagedModel,
 			Throwable throwable)
 		throws Exception {
@@ -457,7 +450,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onStagedModelImportStarted(
+	protected void onStagedModelImportStarted(
 			PortletDataContext portletDataContext, StagedModel stagedModel)
 		throws Exception {
 
@@ -471,7 +464,7 @@ public class LoggerExportImportLifecycleListener
 	}
 
 	@Override
-	public void onStagedModelImportSucceeded(
+	protected void onStagedModelImportSucceeded(
 			PortletDataContext portletDataContext, StagedModel stagedModel)
 		throws Exception {
 

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/NotificationExportImportLifecycleListener.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/lifecycle/NotificationExportImportLifecycleListener.java
@@ -17,8 +17,7 @@ package com.liferay.exportimport.lifecycle;
 import aQute.bnd.annotation.ProviderType;
 
 import com.liferay.exportimport.constants.ExportImportPortletKeys;
-import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleListener;
-import com.liferay.exportimport.kernel.lifecycle.ProcessAwareExportImportLifecycleListener;
+import com.liferay.exportimport.kernel.lifecycle.BaseProcessExportImportLifecycleListener;
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
@@ -35,39 +34,21 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
-import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Akos Thurzo
+ *
+ * @deprecated As of 4.0.0
  */
-@Component(immediate = true, service = {ExportImportLifecycleListener.class})
+@Deprecated
 @ProviderType
 public class NotificationExportImportLifecycleListener
-	implements ProcessAwareExportImportLifecycleListener {
+	extends BaseProcessExportImportLifecycleListener {
 
 	@Override
 	public boolean isParallel() {
 		return false;
-	}
-
-	@Override
-	public void onProcessFailed(List<Serializable> attributes)
-		throws Exception {
-
-		sendNotification(BackgroundTaskConstants.STATUS_FAILED);
-	}
-
-	@Override
-	public void onProcessStarted(List<Serializable> attributes)
-		throws Exception {
-	}
-
-	@Override
-	public void onProcessSucceeded(List<Serializable> attributes)
-		throws Exception {
-
-		sendNotification(BackgroundTaskConstants.STATUS_SUCCESSFUL);
 	}
 
 	protected JSONObject getPayload(
@@ -81,6 +62,20 @@ public class NotificationExportImportLifecycleListener
 		jsonObject.put("status", status);
 
 		return jsonObject;
+	}
+
+	@Override
+	protected void onProcessFailed(List<Serializable> attributes)
+		throws Exception {
+
+		sendNotification(BackgroundTaskConstants.STATUS_FAILED);
+	}
+
+	@Override
+	protected void onProcessSucceeded(List<Serializable> attributes)
+		throws Exception {
+
+		sendNotification(BackgroundTaskConstants.STATUS_SUCCESSFUL);
 	}
 
 	protected void sendNotification(int status) throws PortalException {

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/resources/com/liferay/exportimport/lifecycle/packageinfo
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/resources/com/liferay/exportimport/lifecycle/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 1.1.0

--- a/modules/apps/web-experience/product-navigation/.gitrepo
+++ b/modules/apps/web-experience/product-navigation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 440444d21e1f6979d99e24157866465f5cf2c027
+	commit = 339e62785487cd9afd22c72179248789d1e47513
 	mergebuttonmergecommits = false
 	mode = push
-	parent = d73bd279fca0c6bc4526e661cb8e49637960a358
+	parent = fab52cadf4c41f543733019894042f7e4d59767b
 	remote = git@github.com:liferay/com-liferay-product-navigation.git


### PR DESCRIPTION
Hey Brian,

after discussing the breaking changes problem with @mhan810 we decided to make the implementation classes internal and deprecate the old versions without applying the new pattern. This way we can avoid breaking changes, and we are safe for the future.

thanks,
Daniel