### PR TITLE
LPS-70911 Add readme extension to removed jsp

### DIFF
--- a/portal-web/docroot/html/taglib/theme/layout_icon/page.jsp.readme
+++ b/portal-web/docroot/html/taglib/theme/layout_icon/page.jsp.readme
@@ -1,0 +1,3 @@
+The content of this JSP file was inlined to improve performance. To use your own
+content instead, remove the ".readme" extension and add your content to this
+file.


### PR DESCRIPTION
CC @shuyangzhou

Hi Brian, this adds back the inlined JSP file as a .readme file. The content of the readme file was done by @mwilliams2014, Thanks!