### PR TITLE
LPS-71116 JspBundleClassloader must have appserver's global classload…

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspBundleClassloader.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspBundleClassloader.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.osgi.web.servlet.jsp.compiler.internal;
 
+import com.liferay.portal.kernel.exception.PortalException;
+
 import java.io.IOException;
 
 import java.net.URL;
@@ -30,7 +32,7 @@ import org.osgi.framework.Bundle;
 public class JspBundleClassloader extends URLClassLoader {
 
 	public JspBundleClassloader(Bundle... bundles) {
-		super(new URL[0]);
+		super(new URL[0], PortalException.class.getClassLoader());
 
 		if (bundles.length == 0) {
 			throw new IllegalArgumentException(


### PR DESCRIPTION
…er as parent, otherwise NonSerializableObjectHandler won't be considered loaded by weblogic classloader, forcing weblogic to do a serialization copy for request attributes, then we will lose all non-serializable attributes, like ThemeDisplay.

@brianchandotcom backport please, @mhan810 needs this on ee-7.0.x
@mhan810 this is for the weblogic issue

CC @migue