### PR TITLE
LPS-71264

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /.bnd
 /.checkstyle
 /.idea
+/.m2
 /.sonar
 /.xmlcatalog
 /ActiveMQ

--- a/build-common.xml
+++ b/build-common.xml
@@ -1395,6 +1395,7 @@ rerun your task.
 				<entry key="jsp.precompile.from.source" value="${build.marketplace.apps.enabled}" />
 				<entry key="systemProp.build.bnd.print.enabled" value="${build.bnd.print.enabled}" />
 				<entry key="systemProp.build.performance.logger.enabled" value="${build.performance.logger.enabled}" />
+				<entry key="systemProp.maven.repo.local" value="${build.repository.local.dir}" />
 				<entry key="systemProp.repository.private.password" value="${build.repository.private.password}" />
 				<entry key="systemProp.repository.private.url" value="${build.repository.private.proxied.url}" />
 				<entry key="systemProp.repository.private.username" value="${build.repository.private.username}" />

--- a/build.properties
+++ b/build.properties
@@ -66,6 +66,7 @@
     build.bnd.print.enabled=false
     build.marketplace.apps.enabled=true
     build.performance.logger.enabled=false
+    build.repository.local.dir=
     build.repository.private.password=
     build.repository.private.url=
     build.repository.private.username=


### PR DESCRIPTION
Hi @brianchandotcom,

To put the `.m2` dir parallel to `.gradle`, please add this line to your `build.${user.home}.properties` and then run `ant setup-sdk`:

```properties
build.repository.local.dir=${project.dir}/.m2
```