### PR TITLE
LPS-71244 PackageInfo

### DIFF
--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 609494f61b0c4594e438a99e1c7393ce0fd9d73b
+	commit = d5d3faef5a6b0fc9256c7860e979ee196727a607
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f0ff2bec5672f44a69121f43413839bcec54d30f
+	parent = 424ea76ddd0be98e3b01d416e2f984f0d49da23a
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/user-groups-admin/.gitrepo
+++ b/modules/apps/foundation/user-groups-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 12e487791298dded48d07e2247310286b5435d82
+	commit = b8cb3f760ca76b903633955f447e218991ed7b7d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 760074827b183409aaedf0f434beeab54ae30f75
+	parent = 683612d6ecf5e2c798b4ba2d12e7ede229aed120
 	remote = git@github.com:liferay/com-liferay-user-groups-admin.git

--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 2254e5368632be88d36fc57a8d5f0811c7db5a63
+	commit = 0d014f71e1b03ac6f6c7797ded9f23cf9b82b5b8
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 36e9e16e431c9533626762cb2966ceb67b142d40
+	parent = 29b27798e83de5a85ef7e5b9f1c51a2816f6266e
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 32091731b9aec1aba41d2432618650515a3418e9
+	commit = 47f70d7145b9852591512bdf7a4dd47bc71afaed
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 6c825cc5e29791c841ea6acac4c55701da4d0acf
+	parent = e7d112a4b7c5d3ae5429b032beeed34890cb6dde
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0e42999a0cfc952e79c32a183880beb560567907
+	commit = 71f4c954603fc235b17fe242b3611802d2816733
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 27da76b302fa279439977456a248c0198ecb51de
+	parent = fab14a4a428ae92cadf179b77d531b3a848ddbb6
 	remote = git@github.com:liferay/com-liferay-staging.git

--- a/modules/apps/web-experience/trash/trash-service/bnd.bnd
+++ b/modules/apps/web-experience/trash/trash-service/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-Name: Liferay Trash Service
+Bundle-SymbolicName: com.liferay.trash.service
+Bundle-Version: 1.0.0
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title: Recycle Bin

--- a/modules/apps/web-experience/trash/trash-service/build.gradle
+++ b/modules/apps/web-experience/trash/trash-service/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.4.0"
+	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
+}

--- a/modules/apps/web-experience/trash/trash-service/build.gradle
+++ b/modules/apps/web-experience/trash/trash-service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.4.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 }

--- a/modules/apps/web-experience/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
+++ b/modules/apps/web-experience/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
@@ -28,7 +29,6 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.QueryFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -41,11 +41,13 @@ import java.util.Locale;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
+import org.osgi.service.component.annotations.Component;
+
 /**
  * @author Julio Camarero
  * @author Zsolt Berentey
  */
-@OSGiBeanProperties
+@Component(immediate = true, service = Indexer.class)
 public class TrashIndexer extends BaseIndexer<TrashEntry> {
 
 	public static final String CLASS_NAME = TrashEntry.class.getName();

--- a/modules/apps/web-experience/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
+++ b/modules/apps/web-experience/trash/trash-service/src/main/java/com/liferay/trash/internal/search/TrashIndexer.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.trash.internal.search;
+
+import com.liferay.portal.kernel.search.BaseIndexer;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.QueryFilter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
+import com.liferay.portal.kernel.trash.TrashHandler;
+import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.trash.kernel.model.TrashEntry;
+
+import java.util.List;
+import java.util.Locale;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+/**
+ * @author Julio Camarero
+ * @author Zsolt Berentey
+ */
+@OSGiBeanProperties
+public class TrashIndexer extends BaseIndexer<TrashEntry> {
+
+	public static final String CLASS_NAME = TrashEntry.class.getName();
+
+	public TrashIndexer() {
+		setDefaultSelectedFieldNames(
+			Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
+			Field.REMOVED_BY_USER_NAME, Field.REMOVED_DATE,
+			Field.ROOT_ENTRY_CLASS_NAME, Field.ROOT_ENTRY_CLASS_PK, Field.UID);
+		setFilterSearch(true);
+		setPermissionAware(true);
+	}
+
+	@Override
+	public String getClassName() {
+		return CLASS_NAME;
+	}
+
+	@Override
+	public BooleanQuery getFullQuery(SearchContext searchContext)
+		throws SearchException {
+
+		try {
+			BooleanFilter fullQueryBooleanFilter = new BooleanFilter();
+
+			fullQueryBooleanFilter.addRequiredTerm(
+				Field.COMPANY_ID, searchContext.getCompanyId());
+
+			List<TrashHandler> trashHandlers =
+				TrashHandlerRegistryUtil.getTrashHandlers();
+
+			for (TrashHandler trashHandler : trashHandlers) {
+				Filter filter = trashHandler.getExcludeFilter(searchContext);
+
+				if (filter != null) {
+					fullQueryBooleanFilter.add(
+						filter, BooleanClauseOccur.MUST_NOT);
+				}
+
+				processTrashHandlerExcludeQuery(
+					searchContext, fullQueryBooleanFilter, trashHandler);
+			}
+
+			long[] groupIds = searchContext.getGroupIds();
+
+			if (ArrayUtil.isNotEmpty(groupIds)) {
+				TermsFilter groupTermsFilter = new TermsFilter(Field.GROUP_ID);
+
+				groupTermsFilter.addValues(ArrayUtil.toStringArray(groupIds));
+
+				fullQueryBooleanFilter.add(
+					groupTermsFilter, BooleanClauseOccur.MUST);
+			}
+
+			fullQueryBooleanFilter.addRequiredTerm(
+				Field.STATUS, WorkflowConstants.STATUS_IN_TRASH);
+
+			BooleanQuery fullQuery = createFullQuery(
+				fullQueryBooleanFilter, searchContext);
+
+			return fullQuery;
+		}
+		catch (SearchException se) {
+			throw se;
+		}
+		catch (Exception e) {
+			throw new SearchException(e);
+		}
+	}
+
+	@Override
+	public boolean hasPermission(
+			PermissionChecker permissionChecker, String entryClassName,
+			long entryClassPK, String actionId)
+		throws Exception {
+
+		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
+			entryClassName);
+
+		return trashHandler.hasTrashPermission(
+			permissionChecker, 0, entryClassPK, actionId);
+	}
+
+	@Override
+	public void postProcessSearchQuery(
+			BooleanQuery searchQuery, BooleanFilter fullQueryBooleanFilter,
+			SearchContext searchContext)
+		throws Exception {
+
+		if (searchContext.getAttributes() == null) {
+			return;
+		}
+
+		addSearchTerm(searchQuery, searchContext, Field.CONTENT, true);
+		addSearchTerm(
+			searchQuery, searchContext, Field.REMOVED_BY_USER_NAME, true);
+		addSearchTerm(searchQuery, searchContext, Field.TITLE, true);
+		addSearchTerm(searchQuery, searchContext, Field.TYPE, false);
+		addSearchTerm(searchQuery, searchContext, Field.USER_NAME, true);
+	}
+
+	@Override
+	protected void doDelete(TrashEntry trashEntry) {
+	}
+
+	@Override
+	protected Document doGetDocument(TrashEntry trashEntry) {
+		return null;
+	}
+
+	@Override
+	protected String doGetSortField(String orderByCol) {
+		if (orderByCol.equals("removed-date")) {
+			return Field.REMOVED_DATE;
+		}
+		else if (orderByCol.equals("removed-by")) {
+			return Field.REMOVED_BY_USER_NAME;
+		}
+		else {
+			return orderByCol;
+		}
+	}
+
+	@Override
+	protected Summary doGetSummary(
+		Document document, Locale locale, String snippet,
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		return null;
+	}
+
+	@Override
+	protected void doReindex(String className, long classPK) {
+	}
+
+	@Override
+	protected void doReindex(String[] ids) {
+	}
+
+	@Override
+	protected void doReindex(TrashEntry trashEntry) {
+	}
+
+	/**
+	 * @deprecated As of 1.0.0, added strictly to support backwards
+	 *             compatibility of {@link
+	 *             TrashHandler#getExcludeQuery(SearchContext)}
+	 */
+	@Deprecated
+	protected void processTrashHandlerExcludeQuery(
+		SearchContext searchContext, BooleanFilter fullQueryBooleanFilter,
+		TrashHandler trashHandler) {
+
+		Query query = trashHandler.getExcludeQuery(searchContext);
+
+		if (query != null) {
+			fullQueryBooleanFilter.add(
+				new QueryFilter(query), BooleanClauseOccur.MUST_NOT);
+		}
+	}
+
+}

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -550,7 +550,6 @@
 	<bean class="com.liferay.portlet.asset.util.AssetEntryIndexer" id="com.liferay.portlet.asset.util.AssetEntryIndexer" />
 	<bean class="com.liferay.portlet.asset.util.AssetTagIndexer" id="com.liferay.portlet.asset.util.AssetTagIndexer" />
 	<bean class="com.liferay.portlet.asset.util.AssetVocabularyIndexer" id="com.liferay.portlet.asset.util.AssetVocabularyIndexer" />
-	<bean class="com.liferay.portlet.trash.util.TrashIndexer" id="com.liferay.portlet.trash.util.TrashIndexer" />
 	<bean class="com.liferay.portlet.usersadmin.util.ContactIndexer" id="com.liferay.portlet.usersadmin.util.ContactIndexer" />
 	<bean class="com.liferay.portlet.usersadmin.util.OrganizationIndexer" id="com.liferay.portlet.usersadmin.util.OrganizationIndexer" />
 	<bean class="com.liferay.portlet.rolesadmin.util.RolesAdminImpl" id="com.liferay.roles.admin.kernel.util.RolesAdmin" />

--- a/portal-impl/src/com/liferay/portlet/trash/util/TrashIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/trash/util/TrashIndexer.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.QueryFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -45,7 +44,6 @@ import javax.portlet.PortletResponse;
  * @author Julio Camarero
  * @author Zsolt Berentey
  */
-@OSGiBeanProperties
 public class TrashIndexer extends BaseIndexer<TrashEntry> {
 
 	public static final String CLASS_NAME = TrashEntry.class.getName();

--- a/portal-impl/src/com/liferay/portlet/trash/util/TrashIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/trash/util/TrashIndexer.java
@@ -43,7 +43,10 @@ import javax.portlet.PortletResponse;
 /**
  * @author Julio Camarero
  * @author Zsolt Berentey
+ * @deprecated As of 7.0.0, replaced by {@link
+ *             com.liferay.trash.internal.search.TrashIndexer}
  */
+@Deprecated
 public class TrashIndexer extends BaseIndexer<TrashEntry> {
 
 	public static final String CLASS_NAME = TrashEntry.class.getName();

--- a/portal-impl/src/com/liferay/portlet/trash/util/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/trash/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.0.3

--- a/portal-test-integration/src/com/liferay/portal/service/test/PortalRegisterTestUtil.java
+++ b/portal-test-integration/src/com/liferay/portal/service/test/PortalRegisterTestUtil.java
@@ -21,7 +21,6 @@ import com.liferay.portlet.asset.util.AssetEntryIndexer;
 import com.liferay.portlet.documentlibrary.util.DLFileEntryIndexer;
 import com.liferay.portlet.documentlibrary.util.DLFolderIndexer;
 import com.liferay.portlet.messageboards.util.MBMessageIndexer;
-import com.liferay.portlet.trash.util.TrashIndexer;
 import com.liferay.portlet.usersadmin.util.ContactIndexer;
 import com.liferay.portlet.usersadmin.util.OrganizationIndexer;
 
@@ -41,7 +40,6 @@ public class PortalRegisterTestUtil {
 		IndexerRegistryUtil.register(new DLFolderIndexer());
 		IndexerRegistryUtil.register(new MBMessageIndexer());
 		IndexerRegistryUtil.register(new OrganizationIndexer());
-		IndexerRegistryUtil.register(new TrashIndexer());
 
 		_indexersRegistered = true;
 	}


### PR DESCRIPTION
Hey @brianchandotcom,

The old class is in portla-impl, so, we cannot use:

`@Component(immediate = true, service = Indexer.class)`

Also, we cannot register the old class, because in this case we are going to have two classes registered as TrashIndexer.

Regards,
Eudaldo.
