### PR TITLE
LPS-71178 RoleLocalServiceUtil.getResourceRoles(long, String, int, String) always throws a NullPointerException due to missing SQL query

### DIFF
--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1324,6 +1324,26 @@
 				Role_.name ASC
 		]]>
 	</sql>
+	<sql id="com.liferay.portal.kernel.service.persistence.RoleFinder.findByC_N_S_P">
+		<![CDATA[
+			SELECT
+				Role_.name AS roleName, ResourceAction.actionId AS actionId
+			FROM
+				ResourcePermission
+			INNER JOIN
+				Role_ ON
+					(Role_.roleId = ResourcePermission.roleId)
+			INNER JOIN
+				ResourceAction ON
+					(ResourcePermission.name = ResourceAction.name) AND
+					(MOD(INTEGER_DIV(ResourcePermission.actionIds, ResourceAction.bitwiseValue), 2) = 1)
+			WHERE
+				(ResourcePermission.companyId = ?) AND
+				(ResourcePermission.name = ?) AND
+				(ResourcePermission.scope = ?) AND
+				(ResourcePermission.primKey = ?)
+		]]>
+	</sql>
 	<sql id="com.liferay.portal.kernel.service.persistence.RoleFinder.findByC_N_S_P_A">
 		<![CDATA[
 			SELECT

--- a/portal-impl/test/integration/com/liferay/portal/service/persistence/RoleFinderTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/persistence/RoleFinderTest.java
@@ -38,7 +38,9 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.TransactionalTestRule;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -94,6 +96,45 @@ public class RoleFinderTest {
 
 		ResourceBlockPermissionLocalServiceUtil.deleteResourceBlockPermission(
 			_resourceBlockPermission);
+	}
+
+	@Test
+	public void testFindByC_N_S_P() throws Exception {
+		long companyId = _resourcePermission.getCompanyId();
+		String name = _resourcePermission.getName();
+		int scope = _resourcePermission.getScope();
+		String primKey = _resourcePermission.getPrimKey();
+
+		Map<String, List<String>> expectedResourceRoles = new HashMap<>();
+
+		List<ResourcePermission> resourcePermissions =
+			ResourcePermissionLocalServiceUtil.getResourcePermissions(
+				companyId, name, scope, primKey);
+
+		List<ResourceAction> resourceActions =
+			ResourceActionLocalServiceUtil.getResourceActions(name);
+
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			long roleId = resourcePermission.getRoleId();
+
+			Role role = RoleLocalServiceUtil.getRole(roleId);
+
+			long actionIds = resourcePermission.getActionIds();
+
+			List<String> actionIdList = new ArrayList<>();
+
+			for (ResourceAction resourceAction : resourceActions) {
+				if ((resourceAction.getBitwiseValue() & actionIds) != 0) {
+					actionIdList.add(resourceAction.getActionId());
+				}
+			}
+
+			expectedResourceRoles.put(role.getName(), actionIdList);
+		}
+
+		Assert.assertEquals(
+			expectedResourceRoles,
+			RoleFinderUtil.findByC_N_S_P(companyId, name, scope, primKey));
 	}
 
 	@Test


### PR DESCRIPTION
This is an update for [LPS-71178](https://issues.liferay.com/browse/LPS-71178).<br><br>Hey Brian, this block of SQL has been gone for almost 5 years, so it's a little different from when it was first removed.  See 1afa11f8adc1.

I'm not sure if putting this SQL back violates the purpose of the older ticket (since it deals with permissions algorithms, which I'm completely unfamiliar with), but the query works fine, so I'll leave that call up to you.

/cc @pei-jung @mbowerman @rotty3000 @shuyangzhou