### PR TITLE
LRQA-31384 Get correct output snippet for gradle compile failures

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CompileFailureMessageGenerator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CompileFailureMessageGenerator.java
@@ -38,6 +38,10 @@ public class CompileFailureMessageGenerator
 		int end = consoleOutput.indexOf("Compile failed;");
 
 		if (end == -1) {
+			end = consoleOutput.indexOf("compileJava FAILED");
+		}
+
+		if (end == -1) {
 			return null;
 		}
 


### PR DESCRIPTION
We found another type of java compile failure message that the original compile failure message generator did not account for.

https://issues.liferay.com/browse/LRQA-31384

Kenji tested this locally against the original failure as well as the new one, and it generates the correct message. Here's a sample of the gradle compile failure Github message: https://gist.github.com/kenjiheigel/3875f883f53f14942b25cae30d2b8996