### PR TITLE
LPS-71184 Deprecate old classes

### DIFF
--- a/modules/apps/web-experience/rss/rss-web/src/main/java/com/liferay/rss/web/configuration/RSSWebConfigurationUtil.java
+++ b/modules/apps/web-experience/rss/rss-web/src/main/java/com/liferay/rss/web/configuration/RSSWebConfigurationUtil.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.rss.web.configuration;
+
+import com.liferay.portal.kernel.configuration.Configuration;
+import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
+
+/**
+ * @author Eudaldo Alonso
+ * @deprecated As of 2.2.0, with no direct replacement
+ */
+@Deprecated
+public class RSSWebConfigurationUtil {
+
+	public static String get(String key) {
+		return _configuration.get(key);
+	}
+
+	private static final Configuration _configuration =
+		ConfigurationFactoryUtil.getConfiguration(
+			RSSWebConfigurationUtil.class.getClassLoader(), "portlet");
+
+}

--- a/modules/apps/web-experience/rss/rss-web/src/main/java/com/liferay/rss/web/configuration/RSSWebConfigurationValues.java
+++ b/modules/apps/web-experience/rss/rss-web/src/main/java/com/liferay/rss/web/configuration/RSSWebConfigurationValues.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.rss.web.configuration;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+
+/**
+ * @author Eudaldo Alonso
+ * @deprecated As of 2.2.0, with no direct replacement
+ */
+@Deprecated
+public class RSSWebConfigurationValues {
+
+	public static final String DISPLAY_TEMPLATES_CONFIG = GetterUtil.getString(
+		RSSWebConfigurationUtil.get("display.templates.config"));
+
+}

--- a/modules/apps/web-experience/rss/rss-web/src/main/resources/META-INF/resources/feed.jspf
+++ b/modules/apps/web-experience/rss/rss-web/src/main/resources/META-INF/resources/feed.jspf
@@ -67,7 +67,7 @@
 						SyndEntry syndEntry = rssFeedEntry.getSyndEntry();
 					%>
 
-						<aui:fieldset collapsed="<%= (themeDisplay.isStateMaximized() || (j < rssPortletInstanceConfiguration.expandedEntriesPerFeed())) %>" collapsible="<%= true %>" cssClass="feed-entry" id='<%= "feed_" +i + "_panelId_" + j %>' label="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
+						<aui:fieldset collapsed="<%= (themeDisplay.isStateMaximized() || (j < rssPortletInstanceConfiguration.expandedEntriesPerFeed())) %>" collapsible="<%= true %>" cssClass="feed-entry" id='<%= "feed_" + i + "_panelId_" + j %>' label="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
 							<div class="feed-entry-content">
 								<c:if test="<%= rssPortletInstanceConfiguration.showFeedItemAuthor() && Validator.isNotNull(syndEntry.getAuthor()) %>">
 									<strong class="feed-entry-author small">

--- a/modules/apps/web-experience/rss/rss-web/src/main/resources/META-INF/resources/feed.jspf
+++ b/modules/apps/web-experience/rss/rss-web/src/main/resources/META-INF/resources/feed.jspf
@@ -67,7 +67,7 @@
 						SyndEntry syndEntry = rssFeedEntry.getSyndEntry();
 					%>
 
-						<aui:fieldset collapsed="<%= (themeDisplay.isStateMaximized() || (j < rssPortletInstanceConfiguration.expandedEntriesPerFeed())) %>" collapsible="<%= true %>" cssClass="feed-entry" id='<%= "panelId_" + j %>' label="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
+						<aui:fieldset collapsed="<%= (themeDisplay.isStateMaximized() || (j < rssPortletInstanceConfiguration.expandedEntriesPerFeed())) %>" collapsible="<%= true %>" cssClass="feed-entry" id='<%= "feed_" +i + "_panelId_" + j %>' label="<%= HtmlUtil.escape(syndEntry.getTitle()) %>">
 							<div class="feed-entry-content">
 								<c:if test="<%= rssPortletInstanceConfiguration.showFeedItemAuthor() && Validator.isNotNull(syndEntry.getAuthor()) %>">
 									<strong class="feed-entry-author small">


### PR DESCRIPTION
Hey @brianchandotcom,

Those classes were removed on 26f27d8, it was on August of the last year. I don't know why now (7 months later) we need to increment the semantic versioning of RSS Web module.

I've decided to re-add and deprecated the old classes, like in other pulls, instead of change the bundle version to 3.0.0, if you prefer to increment the bundle version, please let me know and I'll send you another pull.

Regards,
Eudaldo.