### PR TITLE
Lps 71384

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -1764,7 +1764,7 @@ this task.
 
 		<replace file="${app.server.tcserver.dir}/liferay/conf/catalina.properties">
 			<replacetoken><![CDATA[common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar]]></replacetoken>
-			<replacevalue><![CDATA[common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar,${catalina.home}/lib/ext,${catalina.home}/lib/ext/*.jar]]></replacevalue>
+			<replacevalue><![CDATA[common.loader=${catalina.base}/lib,${catalina.base}/lib/*.jar,${catalina.home}/lib,${catalina.home}/lib/*.jar,${catalina.home}/lib/ext/global,${catalina.home}/lib/ext/global/*.jar,${catalina.home}/lib/ext,${catalina.home}/lib/ext/*.jar]]></replacevalue>
 		</replace>
 
 		<replace file="${app.server.tcserver.dir}/liferay/conf/server.xml">
@@ -1851,7 +1851,7 @@ wrapper.java.additional.11="-Dfile.encoding=UTF-8"]]></replacevalue>
 
 		<replace file="${app.server.tomcat.dir}/conf/catalina.properties">
 			<replacetoken><![CDATA[common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"]]></replacetoken>
-			<replacevalue><![CDATA[common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar","${catalina.home}/lib/ext","${catalina.home}/lib/ext/*.jar"]]></replacevalue>
+			<replacevalue><![CDATA[common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar","${catalina.home}/lib/ext/global","${catalina.home}/lib/ext/global/*.jar","${catalina.home}/lib/ext","${catalina.home}/lib/ext/*.jar"]]></replacevalue>
 		</replace>
 
 		<replace file="${app.server.tomcat.dir}/conf/server.xml">

--- a/portal-impl/src/com/liferay/portal/deploy/hot/ExtHotDeployListener.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/ExtHotDeployListener.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.servlet.WebDirDetector;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
@@ -221,6 +222,16 @@ public class ExtHotDeployListener extends BaseHotDeployListener {
 		String portalWebDir = PortalUtil.getPortalWebDir();
 		String portalLibDir = PortalUtil.getPortalLibDir();
 		String pluginWebDir = WebDirDetector.getRootDir(portletClassLoader);
+
+		if (ServerDetector.isTomcat()) {
+			portalLibDir = globalLibDir.concat("/portal/");
+
+			FileUtil.mkdirs(portalLibDir);
+
+			globalLibDir = globalLibDir.concat("/global/");
+
+			FileUtil.mkdirs(globalLibDir);
+		}
 
 		copyJar(servletContext, globalLibDir, "ext-kernel");
 

--- a/support-tomcat/src/com/liferay/support/tomcat/webresources/ExtResourceSet.java
+++ b/support-tomcat/src/com/liferay/support/tomcat/webresources/ExtResourceSet.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.support.tomcat.webresources;
+
+import java.io.File;
+import java.io.InputStream;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.apache.catalina.WebResource;
+import org.apache.catalina.WebResourceRoot;
+import org.apache.catalina.util.ResourceSet;
+import org.apache.catalina.webresources.AbstractFileResourceSet;
+import org.apache.catalina.webresources.EmptyResource;
+import org.apache.catalina.webresources.FileResource;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class ExtResourceSet extends AbstractFileResourceSet {
+
+	public ExtResourceSet() {
+		super("/");
+	}
+
+	@Override
+	public WebResource getResource(String path) {
+		checkPath(path);
+
+		String webAppMount = getWebAppMount();
+
+		WebResourceRoot webResourceRoot = getRoot();
+
+		if (!path.startsWith(webAppMount)) {
+			return new EmptyResource(webResourceRoot, path);
+		}
+
+		File file = file(path.substring(webAppMount.length()), false);
+
+		if ((file == null) || !file.exists() || file.isDirectory()) {
+			return new EmptyResource(webResourceRoot, path);
+		}
+
+		return new FileResource(
+			webResourceRoot, path, file, true, getManifest());
+	}
+
+	@Override
+	public String[] list(String path) {
+		checkPath(path);
+
+		String webAppMount = getWebAppMount();
+
+		if (!path.equals(webAppMount)) {
+			return EMPTY_STRING_ARRAY;
+		}
+
+		File extBaseFile = getFileBase();
+
+		if (!extBaseFile.exists()) {
+			return EMPTY_STRING_ARRAY;
+		}
+
+		String[] extFiles = extBaseFile.list();
+
+		Arrays.sort(extFiles);
+
+		return extFiles;
+	}
+
+	@Override
+	public Set<String> listWebAppPaths(String path) {
+		checkPath(path);
+
+		String webAppMount = getWebAppMount();
+
+		ResourceSet<String> resourceSet = new ResourceSet<>();
+
+		if (path.startsWith(webAppMount)) {
+			File extBaseFile = getFileBase();
+
+			File[] files = extBaseFile.listFiles();
+
+			if (files != null) {
+				if (path.charAt(path.length() - 1) != '/') {
+					path = path.concat("/");
+				}
+
+				for (File file : files) {
+					if (file.isFile()) {
+						resourceSet.add(path.concat(file.getName()));
+					}
+				}
+			}
+		}
+
+		resourceSet.setLocked(true);
+
+		return resourceSet;
+	}
+
+	@Override
+	public boolean mkdir(String path) {
+		return false;
+	}
+
+	@Override
+	public boolean write(String path, InputStream is, boolean overwrite) {
+		return false;
+	}
+
+	@Override
+	protected void checkType(File file) {
+		if (file.exists() && !file.isDirectory()) {
+			throw new IllegalArgumentException(file + " is not a dirtectory");
+		}
+	}
+
+}

--- a/tools/servers/tomcat/conf/Catalina/localhost/ROOT.xml
+++ b/tools/servers/tomcat/conf/Catalina/localhost/ROOT.xml
@@ -21,4 +21,10 @@
 	-->
 
 	<!--<Manager className="com.liferay.support.tomcat.session.SessionLessManagerBase" />-->
+	<Resources>
+		<PreResources
+			className="com.liferay.support.tomcat.webresources.ExtResourceSet"
+			base="${catalina.base}/lib/ext/portal"
+			webAppMount="/WEB-INF/lib" />
+	</Resources>
 </Context>


### PR DESCRIPTION
@xbrianlee the sample-ext plugin should work after this pull. This is for Tomcat only. And since I modified the replacing logic of catalina.properties, you will need to rerun unzip-tomcat to get it updated.

@alee8888 please test it against tcserver, if it does not work, it must be caused by the missing ROOT.xml deployment. If that's the case, you need to fix the build script to deploy it in the same way as tomcat

CC @david-truong