### PR TITLE
LRQA-31410 Autoclose GitHub reports have invalid Test Report URLs

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TestResult.java
@@ -166,7 +166,7 @@ public class TestResult {
 		encodedTestName = encodedTestName.replace("]", "_");
 		encodedTestName = encodedTestName.replace("#", "_");
 
-		if (simpleClassName.equals("junit.framework")) {
+		if (packageName.equals("junit.framework")) {
 			encodedTestName = encodedTestName.replace(".", "_");
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-31410

Kenji tested this locally and generated this output: https://gist.github.com/kenjiheigel/14f58030bb214e2308e799a0733a1945. This should fix generated links for integration tests