### PR TITLE
LPS-71435 deprecate portal-dependency-jars prop

### DIFF
--- a/definitions/liferay-plugin-package_7_0_0.properties
+++ b/definitions/liferay-plugin-package_7_0_0.properties
@@ -99,6 +99,9 @@
     # folder to the deployed plugin's "lib" folder. The JAR files are also added
     # to the plugin's API class path container.
     #
+    # This property is deprecated as of 7.0 GA4 and only provided for backwards
+    # compatibility.
+    #
     #portal-dependency-jars=
     #portal-dependency-jars=\
     #    jstl-api.jar,\

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = fdfad3a79dbec5edd9e47591e1833a202d18cb1e
+	commit = c8f40dbfc6a43fb1d3a3694a41de7021090b39d4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 53d8f626d01baf7b0440464030fedc956b129206
+	parent = bbf27d073fd52d37dd7a2e14f0e05f7145248402
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = be8a88d05dcf2087661391ee7760a9c9a5773cda
+	commit = 9c2f85868ad827e06081935846992aa984f106c2
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c5a659b5a39c7f3ef2ec613a2f0b7072a0578a85
+	parent = 929bc560b3db3e62179c9533275cdaffd1cba10a
 	remote = git@github.com:liferay/com-liferay-frontend-js.git


### PR DESCRIPTION
This needs to be backported to 7.0.x.

Note, on liferay-portal-ee master, I'll send a different commit that mentions the DE specific version in which the deprecation is introduced.