### PR TITLE
LRQA-30908 Monitor fetch progress and overall performance.

### DIFF
--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c8d959cbacd4126a5f4db715cc17b7863d8a7e6b
+	commit = eba9d220555c63b6117beb0fb5864b9f17cbce8f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0fac22e47d2e1962af67e0090f494e3087425491
+	parent = a4c0545d3cd733ed48b4d9be4a36305446889c14
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -19,6 +19,8 @@ import com.jcraft.jsch.Session;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 
 import java.net.URISyntaxException;
 
@@ -51,6 +53,7 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryState;
 import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.lib.TextProgressMonitor;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
 import org.eclipse.jgit.transport.OpenSshConfig.Host;
@@ -361,10 +364,16 @@ public class GitWorkingDirectory {
 			fetchCommand.setRefSpecs(remoteConfig.getFetchRefSpecs());
 		}
 
+		Writer consoleWriter = new OutputStreamWriter(System.out);
+
+		fetchCommand.setProgressMonitor(new TextProgressMonitor(consoleWriter));
+
 		fetchCommand.setRemote(getRemoteURL(remoteConfig));
 		fetchCommand.setTimeout(360);
 
 		int retries = 0;
+
+		long start;
 
 		while (true) {
 			try {
@@ -379,6 +388,8 @@ public class GitWorkingDirectory {
 							"Fetching from  ", getRemoteURL(remoteConfig), " ",
 							refSpec.toString()));
 				}
+
+				start = System.currentTimeMillis();
 
 				fetchCommand.call();
 
@@ -400,6 +411,11 @@ public class GitWorkingDirectory {
 					throw te;
 				}
 			}
+
+			System.out.println(
+				"Fetch completed in " +
+					JenkinsResultsParserUtil.toDurationString(
+						System.currentTimeMillis() - start));
 		}
 	}
 


### PR DESCRIPTION
I can see better now why the single-threaded local-git sync service would fall behind. I have observed some fetches from users' forks that take close to 30 minutes. JGit has some features that can help us monitor the progress of the the fetch calls and I've also added a timer to print out how long each fetch takes. I don't know if this will provide any additional answers on why these fetches are so slow but at least we may be able to anticipate when the fetch will finish.