### PR TITLE
LPS-70824 Control Panel elements are not responsive to role permission definition toggles

### DIFF
--- a/modules/apps/web-experience/application-list/application-list-api/build.gradle
+++ b/modules/apps/web-experience/application-list/application-list-api/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.4.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"

--- a/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
+++ b/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
@@ -345,10 +345,6 @@ public class PanelAppRegistry {
 					userRole.getRoleId(), actionId);
 			}
 
-			portletLocalService.updatePortlet(
-				portlet.getCompanyId(), portlet.getPortletId(),
-				StringPool.BLANK, portlet.isActive());
-
 			portletPreferences.setValue(
 				"myAccountPermissionsInitialized", StringPool.TRUE);
 

--- a/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
+++ b/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
@@ -22,11 +22,14 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -35,14 +38,21 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortletCategoryKeys;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PredicateFilter;
+import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.StringPool;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import javax.portlet.PortletPreferences;
+import javax.portlet.ReadOnlyException;
+import javax.portlet.ValidatorException;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -196,6 +206,12 @@ public class PanelAppRegistry {
 	private static final Log _log = LogFactoryUtil.getLog(
 		PanelAppRegistry.class);
 
+	@Reference
+	private PortletPreferencesFactory _portletPreferencesFactory;
+
+	@Reference
+	private PrefsProps _prefsProps;
+
 	private ServiceTrackerMap<String, List<PanelApp>> _serviceTrackerMap;
 
 	private class PanelAppOrderComparator
@@ -267,8 +283,8 @@ public class PanelAppRegistry {
 				try {
 					initPersonalControlPanelPortletPermission(portlet);
 				}
-				catch (PortalException pe) {
-					_log.error(pe, pe);
+				catch (Exception e) {
+					_log.error(e, e);
 				}
 
 				panelApp.setPortlet(portlet);
@@ -287,7 +303,8 @@ public class PanelAppRegistry {
 
 		protected void initPersonalControlPanelPortletPermission(
 				Portlet portlet)
-			throws PortalException {
+			throws IOException, PortalException, ReadOnlyException,
+				ValidatorException {
 
 			String category = portlet.getControlPanelEntryCategory();
 
@@ -297,8 +314,23 @@ public class PanelAppRegistry {
 				return;
 			}
 
+			long companyId = portlet.getCompanyId();
+			String portletId = portlet.getPortletId();
+
+			PortletPreferences portletPreferences =
+				_portletPreferencesFactory.getLayoutPortletSetup(
+					companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+					LayoutConstants.DEFAULT_PLID, portletId,
+					PortletConstants.DEFAULT_PREFERENCES);
+
+			if (_prefsProps.getBoolean(
+					portletPreferences, "myAccountPermissionsInitialized")) {
+
+				return;
+			}
+
 			Role userRole = roleLocalService.getRole(
-				portlet.getCompanyId(), RoleConstants.USER);
+				companyId, RoleConstants.USER);
 
 			List<String> actionIds =
 				ResourceActionsUtil.getPortletResourceActions(
@@ -308,15 +340,19 @@ public class PanelAppRegistry {
 
 			if (actionIds.contains(actionId)) {
 				resourcePermissionLocalService.addResourcePermission(
-					portlet.getCompanyId(), portlet.getRootPortletId(),
-					ResourceConstants.SCOPE_COMPANY,
-					String.valueOf(portlet.getCompanyId()),
+					companyId, portlet.getRootPortletId(),
+					ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
 					userRole.getRoleId(), actionId);
 			}
 
 			portletLocalService.updatePortlet(
 				portlet.getCompanyId(), portlet.getPortletId(),
 				StringPool.BLANK, portlet.isActive());
+
+			portletPreferences.setValue(
+				"myAccountPermissionsInitialized", StringPool.TRUE);
+
+			portletPreferences.store();
 		}
 
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/BaseControlPanelEntry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/BaseControlPanelEntry.java
@@ -42,13 +42,7 @@ public abstract class BaseControlPanelEntry implements ControlPanelEntry {
 			return false;
 		}
 
-		if (hasAccessPermissionExplicitlyGranted(
-				permissionChecker, group, portlet)) {
-
-			return true;
-		}
-
-		return hasPermissionImplicitlyGranted(
+		return hasAccessPermissionExplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
 
@@ -174,17 +168,22 @@ public abstract class BaseControlPanelEntry implements ControlPanelEntry {
 		return false;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement.<p>This method was
+	 *             originally defined to always display user portlets in the
+	 *             Control Panel. In this version, this method should always
+	 *             return <code>false</code> and remains only to
+	 *             preserve binary compatibility. This method will be
+	 *             permanently removed in a future version.</p><p>In lieu of
+	 *             this method, the ACCESS_IN_CONTROL_PANEL permission is used
+	 *             to determine if a portlet should be displayed in the Control
+	 *             Panel and is included in the User role by default for the
+	 *             portlets listed under the My Account category.</p>
+	 */
+	@Deprecated
 	protected boolean hasPermissionImplicitlyGranted(
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
-
-		String category = portlet.getControlPanelEntryCategory();
-
-		if ((category != null) &&
-			category.equals(PortletCategoryKeys.USER_MY_ACCOUNT)) {
-
-			return true;
-		}
 
 		return false;
 	}


### PR DESCRIPTION
This is an update for [LPS-70824](https://issues.liferay.com/browse/LPS-70824).

This pull only does the work of wiring up the ACCESS_IN_CONTROL_PANEL permission to the User role.  It does not hide any of the other checkboxes.

/cc @jorgeferrer @pei-jung @ChrisKian