### PR TITLE
LPS-70824 Control Panel elements are not responsive to role permission definition toggles

### DIFF
--- a/modules/apps/web-experience/application-list/application-list-api/build.gradle
+++ b/modules/apps/web-experience/application-list/application-list-api/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.4.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"

--- a/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
+++ b/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
@@ -197,12 +197,6 @@ public class PanelAppRegistry {
 	protected GroupProvider groupProvider;
 	protected PortletLocalService portletLocalService;
 
-	@Reference
-	protected ResourcePermissionLocalService resourcePermissionLocalService;
-
-	@Reference
-	protected RoleLocalService roleLocalService;
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		PanelAppRegistry.class);
 
@@ -211,6 +205,12 @@ public class PanelAppRegistry {
 
 	@Reference
 	private PrefsProps _prefsProps;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	private ServiceTrackerMap<String, List<PanelApp>> _serviceTrackerMap;
 
@@ -330,7 +330,7 @@ public class PanelAppRegistry {
 				return;
 			}
 
-			Role userRole = roleLocalService.getRole(
+			Role userRole = _roleLocalService.getRole(
 				companyId, RoleConstants.USER);
 
 			List<String> actionIds =
@@ -340,7 +340,7 @@ public class PanelAppRegistry {
 			String actionId = ActionKeys.ACCESS_IN_CONTROL_PANEL;
 
 			if (actionIds.contains(actionId)) {
-				resourcePermissionLocalService.addResourcePermission(
+				_resourcePermissionLocalService.addResourcePermission(
 					companyId, portlet.getRootPortletId(),
 					ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
 					userRole.getRoleId(), actionId);

--- a/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
+++ b/modules/apps/web-experience/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelAppRegistry.java
@@ -346,10 +346,6 @@ public class PanelAppRegistry {
 					userRole.getRoleId(), actionId);
 			}
 
-			portletLocalService.updatePortlet(
-				portlet.getCompanyId(), portlet.getPortletId(),
-				StringPool.BLANK, portlet.isActive());
-
 			portletPreferences.setValue(
 				"myAccountAccessInControlPanelPermissionsInitialized",
 				StringPool.TRUE);

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/BaseControlPanelEntry.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/BaseControlPanelEntry.java
@@ -42,13 +42,7 @@ public abstract class BaseControlPanelEntry implements ControlPanelEntry {
 			return false;
 		}
 
-		if (hasAccessPermissionExplicitlyGranted(
-				permissionChecker, group, portlet)) {
-
-			return true;
-		}
-
-		return hasPermissionImplicitlyGranted(
+		return hasAccessPermissionExplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
 
@@ -174,17 +168,22 @@ public abstract class BaseControlPanelEntry implements ControlPanelEntry {
 		return false;
 	}
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement.<p>This method was
+	 *             originally defined to always display user portlets in the
+	 *             Control Panel. In this version, this method should always
+	 *             return <code>false</code> and remains only to
+	 *             preserve binary compatibility. This method will be
+	 *             permanently removed in a future version.</p><p>In lieu of
+	 *             this method, the ACCESS_IN_CONTROL_PANEL permission is used
+	 *             to determine if a portlet should be displayed in the Control
+	 *             Panel and is included in the User role by default for the
+	 *             portlets listed under the My Account category.</p>
+	 */
+	@Deprecated
 	protected boolean hasPermissionImplicitlyGranted(
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
-
-		String category = portlet.getControlPanelEntryCategory();
-
-		if ((category != null) &&
-			category.equals(PortletCategoryKeys.USER_MY_ACCOUNT)) {
-
-			return true;
-		}
 
 		return false;
 	}


### PR DESCRIPTION
This is an update for [LPS-70824](https://issues.liferay.com/browse/LPS-70824).<br><br>This pull only does the work of wiring up the ACCESS_IN_CONTROL_PANEL permission to the User role. It does not hide any of the other checkboxes.<br><br>/cc @jorgeferrer @pei-jung @ChrisKian