### PR TITLE
LRQA-30908 Bug fixes

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -660,15 +660,21 @@ public class LocalGitSyncUtil {
 
 				gitWorkingDirectory.fetch(null, upstreamRemoteConfig);
 
-				gitWorkingDirectory.checkoutBranch(
-					JenkinsResultsParserUtil.combine(
-						upstreamRemoteConfig.getName(), "/",
-						upstreamBranchName),
-					"-f");
+				String tempBranchName = "temp-" + start;
 
-				gitWorkingDirectory.deleteLocalBranch(upstreamBranchName);
+				try {
+					gitWorkingDirectory.createLocalBranch(tempBranchName);
 
-				gitWorkingDirectory.checkoutBranch(upstreamBranchName, "-b");
+					gitWorkingDirectory.checkoutBranch(tempBranchName);
+
+					gitWorkingDirectory.deleteLocalBranch(upstreamBranchName);
+
+					gitWorkingDirectory.checkoutBranch(
+						upstreamBranchName, "-b");
+				}
+				finally {
+					gitWorkingDirectory.deleteLocalBranch(tempBranchName);
+				}
 
 				gitWorkingDirectory.createLocalBranch(
 					cacheBranchName, true, null);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -681,7 +681,7 @@ public class LocalGitSyncUtil {
 
 				if (pullRequest) {
 					if (!gitWorkingDirectory.rebase(
-							true, cacheBranchName, upstreamBranchSha)) {
+							true, upstreamBranchSha, cacheBranchName)) {
 
 						throw new RuntimeException("Rebase failed.");
 					}


### PR DESCRIPTION
We discovered that the source-format failures are coming from a bug in jgit rebases. I've reworked the code to use regular git (via command-line) to perform rebases.

I've also fixed an intermittent bug that causes checkout failures.  This bug fixes a race condition that happens when a checkout command issued at exactly the same time that upstream is being updated. This prevents local-git sync logic from knowing when the checkout command is complete so it waits until it eventually times out.

Please publish a new com.liferay.jenkins.results.parser.jar after merging this pull request.