### PR TITLE
LRQA-30908 BUG - Local-git master branches are not being updated 

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -669,8 +669,10 @@ public class LocalGitSyncUtil {
 
 					gitWorkingDirectory.deleteLocalBranch(upstreamBranchName);
 
-					gitWorkingDirectory.checkoutBranch(
-						upstreamBranchName, "-b");
+					gitWorkingDirectory.createLocalBranch(
+						upstreamBranchName, true, upstreamBranchSha);
+
+					gitWorkingDirectory.checkoutBranch(upstreamBranchName);
 				}
 				finally {
 					gitWorkingDirectory.deleteLocalBranch(tempBranchName);


### PR DESCRIPTION
My previous change to remove the race condition has resulted in a problem where the local master branch is not updated so when it is pushed to the local-git master branch, it is always behind what is on local-git. This results in local-git master branches not being updated.

Please publish a new com.liferay.jenkins.results.parser.jar after merging.