### PR TITLE
Add portal-dependency-jars deprecatation comment in same file

### DIFF
--- a/definitions/liferay-plugin-package_7_0_0.properties
+++ b/definitions/liferay-plugin-package_7_0_0.properties
@@ -99,7 +99,8 @@
     # folder to the deployed plugin's "lib" folder. The JAR files are also added
     # to the plugin's API class path container.
     #
-    # This property is deprecated as of 7.0 GA4 and only provided for backwards
+    # This property is deprecated as of Liferay Digital Enterprise 7.0 Fix Pack
+    # 13 and Liferay CE Portal 7.0 GA4; its only provided for backwards
     # compatibility.
     #
     #portal-dependency-jars=


### PR DESCRIPTION
Hi Brian,

In the one file, I've mentioned the version of CE and DXP DE in which the deprecation was introduced. 