### PR TITLE
LRQA-30908 Compensate for missing primary branch

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -183,7 +183,9 @@ public class GitWorkingDirectory {
 
 		List<String> localBranchNames = getLocalBranchNames();
 
-		if (!localBranchNames.contains(branchName)) {
+		if (!branchName.contains("/") &&
+			!localBranchNames.contains(branchName)) {
+
 			throw new IllegalArgumentException(
 				JenkinsResultsParserUtil.combine(
 					"Unable to checkout ", branchName,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -663,14 +663,14 @@ public class LocalGitSyncUtil {
 					if (!localBranchNames.contains(upstreamBranchName)) {
 						updateLocalUpstreamBranch(
 							gitWorkingDirectory, upstreamBranchName,
-							upstreamBranchSha, upstreamRemoteConfig);
+							upstreamRemoteConfig);
 					}
 
 					return cacheBranchName;
 				}
 
 				updateLocalUpstreamBranch(
-					gitWorkingDirectory, upstreamBranchName, upstreamBranchSha,
+					gitWorkingDirectory, upstreamBranchName,
 					upstreamRemoteConfig);
 
 				gitWorkingDirectory.createLocalBranch(
@@ -861,8 +861,11 @@ public class LocalGitSyncUtil {
 
 	protected static void updateLocalUpstreamBranch(
 			GitWorkingDirectory gitWorkingDirectory, String upstreamBranchName,
-			String upstreamBranchSha, RemoteConfig upstreamRemoteConfig)
+			RemoteConfig upstreamRemoteConfig)
 		throws GitAPIException {
+
+		String upstreamBranchSha = gitWorkingDirectory.getRemoteBranchSha(
+			upstreamBranchName, upstreamRemoteConfig);
 
 		gitWorkingDirectory.rebaseAbort();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -606,12 +606,13 @@ public class LocalGitSyncUtil {
 
 		File repositoryDirectory = gitWorkingDirectory.getWorkingDirectory();
 
+		String originalBranchName = gitWorkingDirectory.getCurrentBranch();
+
 		System.out.println(
 			JenkinsResultsParserUtil.combine(
 				"Starting synchronization with local-git. Current repository ",
-				"directory is ", repositoryDirectory.getPath(), "."));
-
-		String originalBranchName = gitWorkingDirectory.getCurrentBranch();
+				"directory is ", repositoryDirectory.getPath(), ". Current",
+				"branch is ", originalBranchName));
 
 		RemoteConfig senderRemoteConfig = null;
 		RemoteConfig upstreamRemoteConfig = null;
@@ -670,9 +671,10 @@ public class LocalGitSyncUtil {
 				String tempBranchName = "temp-" + start;
 
 				try {
-					gitWorkingDirectory.createLocalBranch(tempBranchName);
+					gitWorkingDirectory.createLocalBranch(
+						tempBranchName, true, upstreamBranchSha);
 
-					gitWorkingDirectory.checkoutBranch(tempBranchName);
+					gitWorkingDirectory.checkoutBranch(tempBranchName, "-f");
 
 					gitWorkingDirectory.deleteLocalBranch(upstreamBranchName);
 


### PR DESCRIPTION
The debug statements that I added in my previous pull request helped me to discover that the HEAD ref not found error and the cannot checkout branch error are somewhat related. The HEAD ref not found error occurs when I try to create a new branch when the currently checked out branch doesn't exist.