### PR TITLE
LRQA-30908 Creating the branch before fetching can sometimes fail if the repository is in a headless state

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -851,9 +851,6 @@ public class LocalGitSyncUtil {
 					String currentBranch =
 						gitWorkingDirectory.getCurrentBranch();
 
-					gitWorkingDirectory.createLocalBranch(
-						newTimestampBranchName);
-
 					gitWorkingDirectory.fetch(
 						newTimestampBranchName, remoteCacheBranchName,
 						localGitRemoteConfig);


### PR DESCRIPTION
Please publish after merging.