### PR TITLE
LPS-67449 Spring beans are registered into OSGI through our bridge, t…

### DIFF
--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -363,9 +363,7 @@
 		</property>
 	</bean>
 	<bean class="com.liferay.portal.util.FriendlyURLNormalizerImpl" id="com.liferay.portal.kernel.util.FriendlyURLNormalizer" />
-	<bean class="com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil" id="com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil">
-		<property name="friendlyURLNormalizer" ref="com.liferay.portal.kernel.util.FriendlyURLNormalizer" />
-	</bean>
+	<bean class="com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil" id="com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil" />
 	<bean class="com.liferay.portal.kernel.util.HashCodeFactoryUtil" id="com.liferay.portal.kernel.util.HashCodeFactoryUtil">
 		<property name="hashCodeFactory">
 			<bean class="com.liferay.portal.util.HashCodeFactoryImpl" />

--- a/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.util;
 
 import com.liferay.portal.kernel.nio.charset.CharsetEncoderUtil;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
+import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.StringPool;
@@ -36,6 +37,7 @@ import java.util.regex.Pattern;
  * @author Shuyang Zhou
  */
 @DoPrivileged
+@OSGiBeanProperties(property = {"service.ranking:Integer=100"})
 public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLNormalizerUtil.java
@@ -14,10 +14,6 @@
 
 package com.liferay.portal.kernel.util;
 
-import com.liferay.registry.Registry;
-import com.liferay.registry.RegistryUtil;
-import com.liferay.registry.ServiceTracker;
-
 import java.util.regex.Pattern;
 
 /**
@@ -27,14 +23,7 @@ import java.util.regex.Pattern;
 public class FriendlyURLNormalizerUtil {
 
 	public static FriendlyURLNormalizer getFriendlyURLNormalizer() {
-		FriendlyURLNormalizer friendlyURLNormalizer =
-			_serviceTracker.getService();
-
-		if (friendlyURLNormalizer == null) {
-			return _friendlyURLNormalizer;
-		}
-
-		return friendlyURLNormalizer;
+		return _friendlyURLNormalizer;
 	}
 
 	public static String normalize(String friendlyURL) {
@@ -67,21 +56,11 @@ public class FriendlyURLNormalizerUtil {
 	@Deprecated
 	public void setFriendlyURLNormalizer(
 		FriendlyURLNormalizer friendlyURLNormalizer) {
-
-		_friendlyURLNormalizer = friendlyURLNormalizer;
 	}
 
-	private static FriendlyURLNormalizer _friendlyURLNormalizer;
-	private static final
-		ServiceTracker<FriendlyURLNormalizer, FriendlyURLNormalizer>
-			_serviceTracker;
-
-	static {
-		Registry registry = RegistryUtil.getRegistry();
-
-		_serviceTracker = registry.trackServices(FriendlyURLNormalizer.class);
-
-		_serviceTracker.open();
-	}
+	private static volatile FriendlyURLNormalizer _friendlyURLNormalizer =
+		ServiceProxyFactory.newServiceTrackedInstance(
+			FriendlyURLNormalizer.class, FriendlyURLNormalizerUtil.class,
+			"_friendlyURLNormalizer", true);
 
 }


### PR DESCRIPTION
…here's no need to set it. Set the service ranking to 100. Use ServiceProxyFactory in core, this provides better performance since this is a pushing type behavior instead of pulling (the field is updated when a new service with a higher ranking is deployed instead of asking for the service each time we use it).

CC @pavel-savinov @migue