### PR TITLE
LPS-71925 Also temporarily ignore modules-integration-oracle tests

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1050,7 +1050,7 @@
         modules-integration-db2105-jdk8,\
         modules-integration-hypersonic20-jdk8,\
         modules-integration-mysql56-jdk8,\
-        modules-integration-oracle121-jdk8,\
+        # modules-integration-oracle121-jdk8,\
         modules-integration-postgresql94-jdk8,\
         modules-integration-sybase160-jdk8,\
         modules-unit-jdk8,\


### PR DESCRIPTION
I should have included this one yesterday, also. Commerce team is still working through compile issues that are not locally reproducible, there is an issue with the sub-repo tester giving false positive results (leslie is working on this), and the PostgreSQL upgrades issue all preventing the Commerce fix from going in.