### PR TITLE
LRQA-28615 & LRQA-32057

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -523,6 +523,30 @@ public abstract class BaseBuild implements Build {
 	}
 
 	@Override
+	public Long getLatestStartTimestamp() {
+		Long latestStartTimestamp = getStartTimestamp();
+
+		if (latestStartTimestamp == null) {
+			return null;
+		}
+
+		for (Build downstreamBuild : getDownstreamBuilds(null)) {
+			Long downstreamBuildLatestStartTimestamp =
+				downstreamBuild.getLatestStartTimestamp();
+
+			if (downstreamBuildLatestStartTimestamp == null) {
+				return null;
+			}
+
+			latestStartTimestamp = Math.max(
+				latestStartTimestamp,
+				downstreamBuild.getLatestStartTimestamp());
+		}
+
+		return latestStartTimestamp;
+	}
+
+	@Override
 	public String getMaster() {
 		return master;
 	}
@@ -570,6 +594,23 @@ public abstract class BaseBuild implements Build {
 	@Override
 	public Map<String, String> getStartPropertiesTempMap() {
 		return getTempMap("start.properties");
+	}
+
+	@Override
+	public Long getStartTimestamp() {
+		JSONObject buildJSONObject = getBuildJSONObject("timestamp");
+
+		if (buildJSONObject == null) {
+			return null;
+		}
+
+		long timestamp = buildJSONObject.getLong("timestamp");
+
+		if (timestamp == 0) {
+			return null;
+		}
+
+		return timestamp;
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/Build.java
@@ -78,6 +78,8 @@ public interface Build {
 
 	public String getJobVariant();
 
+	public Long getLatestStartTimestamp();
+
 	public String getMaster();
 
 	public String getOperatingSystem();
@@ -91,6 +93,8 @@ public interface Build {
 	public String getResult();
 
 	public Map<String, String> getStartPropertiesTempMap();
+
+	public Long getStartTimestamp();
 
 	public String getStatus();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -802,6 +802,12 @@ public class GitWorkingDirectory {
 
 				throw new RuntimeException("Unable to rebase");
 			}
+
+			if (process != null) {
+				System.out.println(
+					JenkinsResultsParserUtil.readInputStream(
+						process.getInputStream()));
+			}
 		}
 		catch (Exception e) {
 			RepositoryState repositoryState = _repository.getRepositoryState();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -508,6 +508,43 @@ public class GitWorkingDirectory {
 		fetch(refSpec, remoteConfig);
 	}
 
+	public List<String> getBranchesContainingSHA(String sha) {
+		String command = "git branch --contains " + sha;
+
+		try {
+			Process process = JenkinsResultsParserUtil.executeBashCommands(
+				true, getWorkingDirectory(), command);
+
+			String output = JenkinsResultsParserUtil.readInputStream(
+				process.getInputStream());
+
+			if (output.contains("no such commit")) {
+				return Collections.emptyList();
+			}
+
+			System.out.println(output);
+
+			String[] outputLines = output.split("\n");
+
+			List<String> branchNamesList = new ArrayList<>(
+				outputLines.length - 1);
+
+			for (String outputLine : outputLines) {
+				if (branchNamesList.size() == outputLines.length -1) {
+					break;
+				}
+
+				branchNamesList.add(outputLine.trim());
+			}
+
+			return branchNamesList;
+		}
+		catch (IOException | InterruptedException e) {
+			throw new RuntimeException(
+				"Unable to find branches with SHA " + sha, e);
+		}
+	}
+
 	public List<Ref> getBranchRefs() throws GitAPIException {
 		ListBranchCommand listBranchCommand = _git.branchList();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -502,7 +502,8 @@ public class GitWorkingDirectory {
 
 		RefSpec refSpec = new RefSpec(
 			JenkinsResultsParserUtil.combine(
-				"refs/heads/", remoteBranchName, ":", localBranchName));
+				"refs/heads/", remoteBranchName, ":", "refs/heads/",
+				localBranchName));
 
 		fetch(refSpec, remoteConfig);
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -157,7 +157,7 @@ public class LocalGitSyncUtil {
 
 							if (upstreamUsername.equals("liferay")) {
 								gitWorkingDirectory.pushToRemote(
-									false, upstreamBranchName,
+									true, upstreamBranchName,
 									upstreamBranchName, localGitRemoteConfig);
 							}
 						}
@@ -731,6 +731,8 @@ public class LocalGitSyncUtil {
 					cacheBranchName, true, senderBranchSHA);
 
 				if (pullRequest) {
+					gitWorkingDirectory.checkoutBranch(cacheBranchName);
+
 					gitWorkingDirectory.rebase(
 						true, upstreamBranchSHA, cacheBranchName);
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -192,9 +192,15 @@ public class LocalGitSyncUtil {
 		String upstreamBranchName = gitWorkingDirectory.getUpstreamBranchName();
 
 		if (!gitWorkingDirectory.branchExists(upstreamBranchName, null)) {
+			RemoteConfig upstreamRemoteConfig =
+				gitWorkingDirectory.getRemoteConfig("upstream");
+
 			updateLocalUpstreamBranch(
 				gitWorkingDirectory, upstreamBranchName,
-				gitWorkingDirectory.getRemoteConfig("upstream"));
+				gitWorkingDirectory.getBranchSHA(
+					gitWorkingDirectory.getUpstreamBranchName(),
+					upstreamRemoteConfig),
+				upstreamRemoteConfig);
 		}
 
 		gitWorkingDirectory.checkoutBranch(upstreamBranchName);
@@ -710,7 +716,7 @@ public class LocalGitSyncUtil {
 
 						updateLocalUpstreamBranch(
 							gitWorkingDirectory, upstreamBranchName,
-							upstreamRemoteConfig);
+							upstreamBranchSHA, upstreamRemoteConfig);
 					}
 
 					updateCacheBranchTimestamp(
@@ -721,7 +727,7 @@ public class LocalGitSyncUtil {
 				}
 
 				updateLocalUpstreamBranch(
-					gitWorkingDirectory, upstreamBranchName,
+					gitWorkingDirectory, upstreamBranchName, upstreamBranchSHA,
 					upstreamRemoteConfig);
 
 				gitWorkingDirectory.fetch(
@@ -734,7 +740,7 @@ public class LocalGitSyncUtil {
 					gitWorkingDirectory.checkoutBranch(cacheBranchName);
 
 					gitWorkingDirectory.rebase(
-						true, upstreamBranchSHA, cacheBranchName);
+						true, upstreamBranchName, cacheBranchName);
 				}
 
 				cacheBranches(
@@ -860,7 +866,7 @@ public class LocalGitSyncUtil {
 
 					gitWorkingDirectory.createLocalBranch(
 						newTimestampBranchName, true,
-						gitWorkingDirectory.getRemoteBranchSHA(
+						gitWorkingDirectory.getBranchSHA(
 							remoteCacheBranchName, localGitRemoteConfig));
 
 					try {
@@ -901,11 +907,8 @@ public class LocalGitSyncUtil {
 
 	protected static void updateLocalUpstreamBranch(
 			GitWorkingDirectory gitWorkingDirectory, String upstreamBranchName,
-			RemoteConfig upstreamRemoteConfig)
+			String upstreamBranchSHA, RemoteConfig upstreamRemoteConfig)
 		throws GitAPIException {
-
-		String upstreamBranchSHA = gitWorkingDirectory.getRemoteBranchSHA(
-			upstreamBranchName, upstreamRemoteConfig);
 
 		gitWorkingDirectory.rebaseAbort();
 


### PR DESCRIPTION
[LRQA-28615](https://issues.liferay.com/browse/LRQA-28615) - Max wait time counting should not start until all batches are in running status.
[LRQA-32057](https://issues.liferay.com/browse/LRQA-32057) - Sometimes cache branches are not rebased.

Please publish com.liferay.jenkins.results.parser.jar after merging.