### PR TITLE
LRQA-32082 Prevent localization tests from running on release and EE upstream jobs

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationjahook.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationjahook.testcase
@@ -1,7 +1,8 @@
 <definition component-name="portal-plugins-osgi">
-	<property name="portal.release" value="true" />
+	<property name="portal.release" value="false" />
 	<property name="portal.upstream" value="true" />
 	<property name="plugins.deployment.type" value="osgi" />
+	<property name="test.run.environment" value="CE" />
 	<property name="testray.main.component.name" value="Localization Hooks" />
 
 	<set-up>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationzhhook.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/localizationhooks/OSGiLocalizationzhhook.testcase
@@ -1,7 +1,8 @@
 <definition component-name="portal-plugins-osgi">
-	<property name="portal.release" value="true" />
+	<property name="portal.release" value="false" />
 	<property name="portal.upstream" value="true" />
 	<property name="plugins.deployment.type" value="osgi" />
+	<property name="test.run.environment" value="CE" />
 	<property name="testray.main.component.name" value="Localization Hooks" />
 
 	<set-up>


### PR DESCRIPTION
These two custom language hooks were written for 6.2 and have not been updated to work on 7.0 per Sam Kong

cc/ @brianwulbern @JoyceWang08211 @ginsonren