### PR TITLE
LRQA-30908 BUG - Cache branch timestamp update failures should not break the pull request test.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -799,9 +799,9 @@ public class LocalGitSyncUtil {
 	}
 
 	protected static void updateCacheBranchTimestamp(
-			final String cacheBranchName,
-			final GitWorkingDirectory gitWorkingDirectory,
-			List<RemoteConfig> localGitRemoteConfigs) {
+		final String cacheBranchName,
+		final GitWorkingDirectory gitWorkingDirectory,
+		List<RemoteConfig> localGitRemoteConfigs) {
 
 		long start = System.currentTimeMillis();
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -332,11 +332,11 @@ public class LocalGitSyncUtil {
 				gitWorkingDirectory.getRemoteBranchNames(remoteConfig);
 		}
 		catch (GitAPIException gapie) {
-			gapie.printStackTrace();
-
 			System.out.println(
 				"Unable to get remote repository branch names from " +
 					GitWorkingDirectory.getRemoteURL(remoteConfig));
+
+			gapie.printStackTrace();
 
 			return;
 		}
@@ -628,6 +628,7 @@ public class LocalGitSyncUtil {
 									GitWorkingDirectory.getRemoteURL(
 										remoteConfig),
 									":", remoteBranchName));
+
 							gapie.printStackTrace();
 						}
 					}
@@ -757,10 +758,10 @@ public class LocalGitSyncUtil {
 				localGitRemoteConfigs = null;
 				senderRemoteConfig = null;
 
-				e.printStackTrace();
-
 				System.out.println(
 					"Synchronization with local-git failed. Retrying.");
+
+				e.printStackTrace();
 
 				gitWorkingDirectory.checkoutBranch(originalBranchName);
 
@@ -895,6 +896,11 @@ public class LocalGitSyncUtil {
 			}
 		}
 		catch (GitAPIException gapie) {
+			System.out.println(
+				JenkinsResultsParserUtil.combine(
+					"Unable to update cache branch timestamp on ", "branch ",
+					cacheBranchName));
+
 			gapie.printStackTrace();
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -801,8 +801,7 @@ public class LocalGitSyncUtil {
 	protected static void updateCacheBranchTimestamp(
 			final String cacheBranchName,
 			final GitWorkingDirectory gitWorkingDirectory,
-			List<RemoteConfig> localGitRemoteConfigs)
-		throws GitAPIException {
+			List<RemoteConfig> localGitRemoteConfigs) {
 
 		long start = System.currentTimeMillis();
 
@@ -896,7 +895,7 @@ public class LocalGitSyncUtil {
 			}
 		}
 		catch (GitAPIException gapie) {
-			throw new RuntimeException(gapie);
+			gapie.printStackTrace();
 		}
 
 		System.out.println(


### PR DESCRIPTION
Timestamp update failures should be expected because multiple threads may be updating the timestamp at the same time and only one can succeed.