### PR TITLE
LRQA-32095 Use the default 'timeout.explicit.wait used' set within 'test.properties'

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -7732,6 +7732,8 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 			</then>
 		</if>
 
+		<property name="default.timeout.explicit.wait" value="${timeout.explicit.wait}" />
+
 		<get-testcase-property property.name="timeout.explicit.wait" />
 
 		<if>
@@ -7741,6 +7743,11 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 					timeout.explicit.wait=${timeout.explicit.wait}
 				</echo>
 			</then>
+			<else>
+				<echo append="true" file="${test.ext.properties.file}">
+					timeout.explicit.wait=${default.timeout.explicit.wait}
+				</echo>
+			</else>
 		</if>
 	</target>
 

--- a/test.properties
+++ b/test.properties
@@ -1498,7 +1498,7 @@
     test.skip.tear.down=false
     #test.url=http://localhost:8080
     timeout.app.server.wait=1800
-    timeout.explicit.wait=120
+    timeout.explicit.wait=60
     #unzip.executable=
 
 ##


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32095