### PR TITLE
LRQA-32095 Restore setting for the explicit timeout in poshi tests to 120 | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1498,7 +1498,7 @@
     test.skip.tear.down=false
     #test.url=http://localhost:8080
     timeout.app.server.wait=1800
-    timeout.explicit.wait=60
+    timeout.explicit.wait=120
     #unzip.executable=
 
 ##


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32095