### PR TITLE
Lps 72085

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspReloader.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspReloader.java
@@ -38,35 +38,39 @@ public class JspReloader {
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleTracker = new BundleTracker<>(
-			bundleContext, Bundle.ACTIVE,
-			new BundleTrackerCustomizer<Void>() {
+			bundleContext, -1,
+			new BundleTrackerCustomizer<Bundle>() {
 
 				@Override
-				public Void addingBundle(
+				public Bundle addingBundle(
 					Bundle bundle, BundleEvent bundleEvent) {
 
-					File file = new File(
-						_WORK_DIR,
-						bundle.getSymbolicName() + StringPool.DASH +
-							bundle.getVersion());
-
-					if (file.exists() &&
-						(file.lastModified() < bundle.getLastModified())) {
-
-						FileUtil.deltree(file);
-					}
-
-					return null;
+					return bundle;
 				}
 
 				@Override
 				public void modifiedBundle(
-					Bundle bundle, BundleEvent bundleEvent, Void object) {
+					Bundle bundle, BundleEvent bundleEvent, Bundle oldBundle) {
+
+					int event = bundleEvent.getType();
+
+					if ((event == BundleEvent.UPDATED) ||
+						(event == BundleEvent.UNINSTALLED)) {
+
+						File file = new File(
+							_WORK_DIR,
+							bundle.getSymbolicName() + StringPool.DASH +
+								bundle.getVersion());
+
+						if (file.exists()) {
+							FileUtil.deltree(file);
+						}
+					}
 				}
 
 				@Override
 				public void removedBundle(
-					Bundle bundle, BundleEvent bundleEvent, Void object) {
+					Bundle bundle, BundleEvent bundleEvent, Bundle oldBundle) {
 				}
 
 			});
@@ -82,6 +86,6 @@ public class JspReloader {
 	private static final String _WORK_DIR =
 		PropsValues.LIFERAY_HOME + File.separator + "work" + File.separator;
 
-	private BundleTracker<Void> _bundleTracker;
+	private BundleTracker<Bundle> _bundleTracker;
 
 }


### PR DESCRIPTION
CC @jpince @alee8888

This fixes one issue we have on the CI jsp precompile. Basically, CI tomcat jvm is running on a different timezone setup comparing to host OS, which makes the precompiled results always out of date, forcing jasper to recompile them. Although this is technically a setup issue, we can still do better at the jspreloader level. the new logic is not time based, so that it won't suffer this no matter how the timezone is configured.

I am not sure whether this is the only reason for the slowness. @jpince please pay attention to timeout functional tests after this is merged and backported.

Thanks