### PR TITLE
LPS-71694

### DIFF
--- a/modules/apps/marketplace/marketplace-service/bnd.bnd
+++ b/modules/apps/marketplace/marketplace-service/bnd.bnd
@@ -7,5 +7,5 @@ Export-Package:\
 	com.liferay.marketplace.util.comparator
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title:
-Liferay-Require-SchemaVersion: 2.0.1
+Liferay-Require-SchemaVersion: 2.0.2
 Liferay-Service: true

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/upgrade/MarketplaceServiceUpgrade.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/upgrade/MarketplaceServiceUpgrade.java
@@ -56,6 +56,10 @@ public class MarketplaceServiceUpgrade implements UpgradeStepRegistrator {
 			"com.liferay.marketplace.service", "2.0.0", "2.0.1",
 			new com.liferay.marketplace.internal.upgrade.v2_0_1.
 				UpgradeCompanyId());
+
+		registry.register(
+			"com.liferay.marketplace.service", "2.0.1", "2.0.2",
+			new com.liferay.marketplace.internal.upgrade.v2_0_2.UpgradeApp());
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/upgrade/v2_0_2/UpgradeApp.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/upgrade/v2_0_2/UpgradeApp.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.marketplace.internal.upgrade.v2_0_2;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.io.IOException;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author Adam Brandizzi
+ */
+public class UpgradeApp extends UpgradeProcess {
+
+	protected void deleteApp(String contextName)
+		throws IOException, SQLException {
+
+		try (PreparedStatement ps = connection.prepareStatement(
+				"select appId from Marketplace_Module where contextName = ?")) {
+
+			ps.setString(1, contextName);
+
+			ResultSet rs = ps.executeQuery();
+
+			while (rs.next()) {
+				long appId = rs.getLong("appId");
+
+				runSQL("delete from Marketplace_Module where appId = " + appId);
+				runSQL("delete from Marketplace_App where appId = " + appId);
+			}
+		}
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		for (String contextName : _CONTEXT_NAMES) {
+			deleteApp(contextName);
+		}
+	}
+
+	private static final String[] _CONTEXT_NAMES = {
+		"jasperreports-web", "reports-portlet", "drools-web"
+	};
+
+}

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/upgrade/v2_0_2/UpgradeApp.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/upgrade/v2_0_2/UpgradeApp.java
@@ -24,37 +24,14 @@ import java.sql.SQLException;
 
 /**
  * @author Adam Brandizzi
+ * @author Ryan Park
  */
 public class UpgradeApp extends UpgradeProcess {
 
-	protected void deleteApp(String contextName)
-		throws IOException, SQLException {
-
-		try (PreparedStatement ps = connection.prepareStatement(
-				"select appId from Marketplace_Module where contextName = ?")) {
-
-			ps.setString(1, contextName);
-
-			ResultSet rs = ps.executeQuery();
-
-			while (rs.next()) {
-				long appId = rs.getLong("appId");
-
-				runSQL("delete from Marketplace_Module where appId = " + appId);
-				runSQL("delete from Marketplace_App where appId = " + appId);
-			}
-		}
-	}
-
 	@Override
 	protected void doUpgrade() throws Exception {
-		for (String contextName : _CONTEXT_NAMES) {
-			deleteApp(contextName);
-		}
+		runSQL("delete from Marketplace_App where appId is not null");
+		runSQL("delete from Marketplace_Module where moduleId is not null");
 	}
-
-	private static final String[] _CONTEXT_NAMES = {
-		"jasperreports-web", "reports-portlet", "drools-web"
-	};
 
 }


### PR DESCRIPTION
Hey Brian, SQL could be shortened to `delete from tableName` but I've added `where primaryKey is not null` because some DBs will have protections from the first statement.

Also, instead of finding all offending plugins it was easier to be super certain by simply removing all the entries from the table and having Marketplace reconstruct it.