### PR TITLE
LRQA-30908 Bug fixes

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -41,8 +41,7 @@ public class LocalGitSyncUtil {
 	public static void deleteCacheBranch(
 			GitWorkingDirectory gitWorkingDirectory, String receiverUsername,
 			String senderBranchName, String senderUsername,
-			String senderBranchSHA, String upstreamBranchName,
-			String upstreamBranchSHA)
+			String senderBranchSHA, String upstreamBranchSHA)
 		throws GitAPIException {
 
 		List<RemoteConfig> localGitRemoteConfigs = null;
@@ -104,14 +103,12 @@ public class LocalGitSyncUtil {
 	public static String synchronizeToLocalGit(
 			GitWorkingDirectory gitWorkingDirectory, String receiverUsername,
 			String senderBranchName, String senderUsername,
-			String senderBranchSHA, String upstreamBranchName,
-			String upstreamBranchSHA)
+			String senderBranchSHA, String upstreamBranchSHA)
 		throws GitAPIException, IOException {
 
 		return synchronizeToLocalGit(
 			gitWorkingDirectory, receiverUsername, 0, senderBranchName,
-			senderUsername, senderBranchSHA, upstreamBranchName,
-			upstreamBranchSHA);
+			senderUsername, senderBranchSHA, upstreamBranchSHA);
 	}
 
 	protected static void cacheBranch(
@@ -659,8 +656,7 @@ public class LocalGitSyncUtil {
 	protected static String synchronizeToLocalGit(
 			GitWorkingDirectory gitWorkingDirectory, String receiverUsername,
 			int retryCount, String senderBranchName, String senderUsername,
-			String senderBranchSHA, String upstreamBranchName,
-			String upstreamBranchSHA)
+			String senderBranchSHA, String upstreamBranchSHA)
 		throws GitAPIException, IOException {
 
 		long start = System.currentTimeMillis();
@@ -691,6 +687,9 @@ public class LocalGitSyncUtil {
 			String cacheBranchName = getCacheBranchName(
 				receiverUsername, senderUsername, senderBranchSHA,
 				upstreamBranchSHA);
+
+			String upstreamBranchName =
+				gitWorkingDirectory.getUpstreamBranchName();
 
 			if (!pullRequest) {
 				upstreamBranchSHA = gitWorkingDirectory.getBranchSHA(
@@ -773,7 +772,7 @@ public class LocalGitSyncUtil {
 				return synchronizeToLocalGit(
 					gitWorkingDirectory, receiverUsername, retryCount + 1,
 					senderBranchName, senderUsername, senderBranchSHA,
-					upstreamBranchName, upstreamBranchSHA);
+					upstreamBranchSHA);
 			}
 			finally {
 				if (localGitRemoteConfigs != null) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -692,6 +692,11 @@ public class LocalGitSyncUtil {
 				receiverUsername, senderUsername, senderBranchSHA,
 				upstreamBranchSHA);
 
+			if (!pullRequest) {
+				upstreamBranchSHA = gitWorkingDirectory.getBranchSHA(
+					upstreamBranchName, upstreamRemoteConfig);
+			}
+
 			List<RemoteConfig> localGitRemoteConfigs = null;
 
 			try {


### PR DESCRIPTION
Please publish after merging.

Synchronizing private subrepository pull requests with the master branch sometimes fails because the master branch in the private subrepo is not guaranteed to be up to date. This fix fetches branches that don't contain "-private" from the public repo.

@kenduenwald - Sometimes synchronization requests are made where the upstream SHA and the sender SHA are the same but the upstream SHA does not exist in upstream. In these cases, we should not attempt to fetch the upstream branch at the SHA that was passed in as the upstream SHA.