### PR TITLE
LPS-72116 portal-search-test-util: DocumentFixture must not truncate sortable fields at zero chars

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentFixture.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/DocumentFixture.java
@@ -53,6 +53,14 @@ public class DocumentFixture {
 		return document;
 	}
 
+	public void mockProperty(String property, String value) {
+		Mockito.when(
+			props.get(property)
+		).thenReturn(
+			value
+		);
+	}
+
 	public void setUp() {
 		setUpFastDateFormatFactoryUtil();
 		setUpPropsUtil();
@@ -61,14 +69,6 @@ public class DocumentFixture {
 	public void tearDown() {
 		tearDownFastDateFormatFactoryUtil();
 		tearDownPropsUtil();
-	}
-
-	protected void mockProperty(String property, String value) {
-		Mockito.when(
-			props.get(property)
-		).thenReturn(
-			value
-		);
 	}
 
 	protected void setUpFastDateFormatFactoryUtil() {
@@ -115,6 +115,8 @@ public class DocumentFixture {
 		mockProperty(
 			PropsKeys.INDEX_SEARCH_QUERY_SUGGESTION_SCORES_THRESHOLD, "0");
 		mockProperty(PropsKeys.INDEX_SEARCH_SCORING_ENABLED, "true");
+		mockProperty(
+			PropsKeys.INDEX_SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH, "255");
 
 		PropsUtil.setProps(props);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-72116