### PR TITLE
LPS-71275 Double "View in Context" link in Asset Publisher portlet when viewing the created thread

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/asset/full_content.jsp
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/asset/full_content.jsp
@@ -30,9 +30,3 @@ request.setAttribute("edit_message.jsp-thread", message.getThread());
 %>
 
 <liferay-util:include page="/message_boards/view_thread_message.jsp" servletContext="<%= application %>" />
-
-<c:if test="<%= assetRenderer != null %>">
-	<div class="asset-more">
-		<aui:a href="<%= assetRenderer.getURLViewInContext(liferayPortletRequest, liferayPortletResponse, null) %>"><liferay-ui:message key="view-in-context" /> &raquo;</aui:a>
-	</div>
-</c:if>


### PR DESCRIPTION
Issue fixed to show only one view in content link

Tested on:
Tomcat 8.x
MySql -5.x
Google Chrome, IE, Mozilla