### PR TITLE
LRQA-30908 Fix dual use of private repos for public and private branches

### DIFF
--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 67112dba876611cc2f7350ce7b184861ab5e9d7e
+	commit = 0748ff9fa3be460d5c2468ba6dcd46035cf6be5b
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 723ca2f378a65bbd32236f5e5927d9718dd11cc9
+	parent = ba6eb7e3b060277952157613e660e4dc2bab8bd8
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 357d7edb7a36beb8234e201ba40b8bac7fb55862
+	commit = d67cf28d436648f4e9ea0b99d9028d3671e183d4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7dde64bfce63cce2c4da3b3614b83a3b0533ed6b
+	parent = d8c5dd26d0161d04bbd34d4e686905a002d350fe
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d3d269aff4435d69daec04bfe094c8ce6e667f47
+	commit = b5b0a051386aa889ceaa0c26dd0e0f48d2fd0c9d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0bf8b989edd6e5d60eb8d4f111600014251f8ab4
+	parent = f4fff78480092d89076fec6612dee58b4e4929d1
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 837b2dbd55ab0f35806a98eb309bd3f830e8c3d3
+	commit = a96744209ff32b4646529d26012ddee3c36dd481
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b6456794ed7c9dd2e5338d73e9a8e413f281dbc3
+	parent = 27b0e19ad69a582714b6ee7d7a57835b7cda4183
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = da18a61423037ece2fc1f6b853b6c4402ed1bb18
+	commit = ce7b0d520bf2de5c297a5ee14b200421ba212edb
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7489d9f84f95c377fb6734574058a4686850a990
+	parent = ab0b5ed9b1faa915b4e9f81c8a13ef472be32453
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/apps/web-experience/trash/.gitrepo
+++ b/modules/apps/web-experience/trash/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0c72a3ee1947dacd8348d06b73763118a1a05d9f
+	commit = c5ff5c0d2c3699bf339eb3b06c7ed342b198566b
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 80f680c7f85070e189d899e51d7bce2910dae0dc
+	parent = 4ef8a128fbe5d89090d6d9cacb663605d06bf94f
 	remote = git@github.com:liferay/com-liferay-trash.git

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1180,31 +1180,15 @@ public class GitWorkingDirectory {
 	}
 
 	private RemoteConfig _getUpstreamRemoteConfig() throws GitAPIException {
-		if (!_repositoryName.contains("-private") &&
-			!_repositoryName.contains("-ee")) {
+		RemoteConfig upstreamRemoteConfig = _getRemoteConfig("upstream");
 
-			return _getRemoteConfig("upstream");
+		String upstreamRemoteURL = getRemoteURL(upstreamRemoteConfig);
+
+		if (upstreamRemoteURL.contains(_repositoryName + ".git")) {
+			return upstreamRemoteConfig;
 		}
 
-		if (_repositoryName.equals("liferay-jenkins-tools-private")) {
-			return _getRemoteConfig("upstream");
-		}
-
-		if ((_repositoryName.equals("liferay-plugins-ee") ||
-			 _repositoryName.equals("liferay-portal-ee")) &&
-			!_upstreamBranchName.contains("ee-") &&
-			!_upstreamBranchName.contains("-private")) {
-
-			return _getUpstreamPublicRemoteConfig();
-		}
-
-		if (_repositoryName.contains("-private") &&
-			!_upstreamBranchName.contains("-private")) {
-
-			return _getUpstreamPublicRemoteConfig();
-		}
-
-		return _getRemoteConfig("upstream");
+		return _getUpstreamPublicRemoteConfig();
 	}
 
 	private static final List<RepositoryState> _rebaseRepositoryStates =

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1067,7 +1067,27 @@ public class GitWorkingDirectory {
 		int x = remoteURL.lastIndexOf("/") + 1;
 		int y = remoteURL.indexOf(".git");
 
-		return remoteURL.substring(x, y);
+		String repositoryName = remoteURL.substring(x, y);
+
+		if (repositoryName.equals("liferay-jenkins-tools-private")) {
+			return repositoryName;
+		}
+
+		if ((repositoryName.equals("liferay-plugins-ee") ||
+			 repositoryName.equals("liferay-portal-ee")) &&
+			!_upstreamBranchName.contains("ee-") &&
+			!_upstreamBranchName.contains("-private")) {
+
+			repositoryName = repositoryName.replace("-ee", "");
+		}
+
+		if (repositoryName.contains("-private") &&
+			!_upstreamBranchName.contains("-private")) {
+
+			repositoryName = repositoryName.replace("-private", "");
+		}
+
+		return repositoryName;
 	}
 
 	protected String loadRepositoryUsername() throws GitAPIException {


### PR DESCRIPTION
Please publish after merging.

The changes that I made to loadRepositoryName() turned out to be incorrect. The GitWorkingDirectory instance needs to reinterpret private repository names as the public repository name in cases where the upstream branch is a branch from the public repository. The upstream remote will always point to the private repo so I added logic to create a remote that points to the public upstream repository when using a public upstream branch.