### PR TITLE
LRQA-32085 Cache the redact tokens.

### DIFF
--- a/modules/apps/foundation/frontend-editor/.gitrepo
+++ b/modules/apps/foundation/frontend-editor/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f22c9580634373152d02feecbd3b5caedde09e61
+	commit = 68f0076a43b4633304c1109ce5960f46e2bfcecb
 	mergebuttonmergecommits = false
 	mode = push
-	parent = fda3e796a2aea3366ac67e04a15e35f350ce1987
+	parent = 334c2babe05340ec40dac9f7b2d494ee5a2ebe73
 	remote = git@github.com:liferay/com-liferay-frontend-editor.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f4b9d8005dd095eb92b4f5c947658620f0f0a33c
+	commit = 590e3d556d929b72f943a0ecdfdb62a0e56d49f9
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 035ff24f49b12947dea4264d68e5f18e663bf45f
+	parent = 1af25d029c715fc264598bbd733f6057ce691906
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/frontend-taglib/.gitrepo
+++ b/modules/apps/foundation/frontend-taglib/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 589f23154957eab8bf798518f933982e06bf4d16
+	commit = 0a1d30f9948db4dbdf4ec6ea1f059f077b72bb8e
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 029cdc6ef8d713c5666be127a15a128719976761
+	parent = bf50dc804b043993826c99e26dc26e4810e1d774
 	remote = git@github.com:liferay/com-liferay-frontend-taglib.git

--- a/modules/apps/foundation/login/.gitrepo
+++ b/modules/apps/foundation/login/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 09ae7ecae698757adc88e8825f7a6b498e9f561c
+	commit = a429f4791982db44fee263ea843989ae21000c74
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3029a138b57beb28e5506cd5037bd699ab521cd9
+	parent = 4ca2ada8b41ed87c71decb5514818a151f3977ad
 	remote = git@github.com:liferay/com-liferay-login.git

--- a/modules/apps/foundation/mobile-device-rules/.gitrepo
+++ b/modules/apps/foundation/mobile-device-rules/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e53f3e32447dfa338be76fb3e3f855a96ad879b9
+	commit = 88eb935b95f9d99d1c54b55949f4e7d669c1d586
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 15af28c38a9d5a3c4161a62b7a16a0a17ebee535
+	parent = 2ab22b3800dbcaf0994c24670dd6f11a191de38e
 	remote = git@github.com:liferay/com-liferay-mobile-device-rules.git

--- a/modules/apps/foundation/password-policies-admin/.gitrepo
+++ b/modules/apps/foundation/password-policies-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e398679b4756efce0324f8a44290211242d37e98
+	commit = 9949865d0af43e9481da03d1fcdb7c581b94cd72
 	mergebuttonmergecommits = false
 	mode = push
-	parent = cb49bf1b052e6c36f88232415edf0f4ac9142333
+	parent = 42453b8548478e5009f7bf95d585625e61352a2d
 	remote = git@github.com:liferay/com-liferay-password-policies-admin.git

--- a/modules/apps/foundation/plugins-admin/.gitrepo
+++ b/modules/apps/foundation/plugins-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = da81b66f244abd94e40d1169152b36b9f0c0c804
+	commit = 0b1baf11dcb6f531d98df9d947ec9e810bb9db67
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 175c7d12095a24696e3c699ba559207cdc29b3a7
+	parent = 7b6335d844b540f8b0a1a0079a0665e5d3a45316
 	remote = git@github.com:liferay/com-liferay-plugins-admin.git

--- a/modules/apps/foundation/portal-scheduler/.gitrepo
+++ b/modules/apps/foundation/portal-scheduler/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 213d6427acc0e66f677f06ccc54eaa22fa55959b
+	commit = 07abbba4d14dda6f617ef254a80b51fbdce18570
 	mergebuttonmergecommits = false
 	mode = push
-	parent = fcae6bbe0c29906304c19e55acf3028d8a3ef1b0
+	parent = ceda35ec90516ef8b12da790666943e8454b6fdc
 	remote = git@github.com:liferay/com-liferay-portal-scheduler.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 24a11e6a2df5962421bc73a8d3be59d2b88b9e46
+	commit = 8d73501a49b95ddd48e7e2fa06dbd4722aa93b6a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7366a41a47e31e230392e4c199755d30db3cee33
+	parent = e8f2e74513e5a3dbdb5ba3f7cea9654f792cb3c4
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security-sso/.gitrepo
+++ b/modules/apps/foundation/portal-security-sso/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 7cc502d5dccc2a4c7d379a065e3683a4ba1dc821
+	commit = b9fb2d7dd9acdf67d6346a2c2376e898986c2d1a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4524c1df08c844b962bb133a05c069fa51896b5c
+	parent = 4b27a243385dd64519d3332d9d8c207fbe445c6b
 	remote = git@github.com:liferay/com-liferay-portal-security-sso.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 5227bb370d5f915e65afafec2cbd316223067ca4
+	commit = 26117a089ae0a967e8735e775ebf2b09870cff36
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 794eae8f9d52f84e0090eb6339cf87e7914019c1
+	parent = ab0ecda3cff3eb8a782ba5fc9774eb1cbd37827f
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal-settings/.gitrepo
+++ b/modules/apps/foundation/portal-settings/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4802b4f5719f8f716bb4afd81dcbe17341d75a54
+	commit = f794bdf80369a1cc96e7ab2f28d805d61557b64d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3acb72d492636fc4dead3d460527bf49fae1e3e1
+	parent = 00ada23cdf90bb9f422b54ca2f5e4d9b4473d04f
 	remote = git@github.com:liferay/com-liferay-portal-settings.git

--- a/modules/apps/foundation/portal-store/.gitrepo
+++ b/modules/apps/foundation/portal-store/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 9d31444fb670d0a5f006ac065eb6ca1e94aae0ab
+	commit = 26d2f54c769a4123ba0ad939fcac33f269717f30
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4caf118aa32fa885bc57b29483a5187241a54233
+	parent = 19c4b87cc0105f245afd78f80687f8df19275ecd
 	remote = git@github.com:liferay/com-liferay-portal-store.git

--- a/modules/apps/foundation/portal-template/.gitrepo
+++ b/modules/apps/foundation/portal-template/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 412714cba08e30f832ce5db89e6c5acfd8c887ec
+	commit = 50c580a1f9664e66f612f252fd5a1ffefd213312
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f19cb72dbf8ee987b1d8b288741da76fed2ae08d
+	parent = a8321a764ff60c475c12722e6fcc1f37d09820ab
 	remote = git@github.com:liferay/com-liferay-portal-template.git

--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f38012a36daa3f915383d9ae848e0d429adaf594
+	commit = 016ba3f2618064673c14a0922f7716277586f7fc
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a364373651cb68ad3d0d9f0f1d52d4a8b39ea4b2
+	parent = 4fd0cafa2ba6730c492ae510b9f962fa011826cd
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/foundation/roles/.gitrepo
+++ b/modules/apps/foundation/roles/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = fd7b5bb9b34eaa440ea06d927120e70acae1cc94
+	commit = 2d3fc977b5912019952322a16c6d263cb3daaac1
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 51532b98fd2f3dac4e568baa237fdbcfc6ed2089
+	parent = 456e03516dad5b6460729531a8d9b6455be03722
 	remote = git@github.com:liferay/com-liferay-roles.git

--- a/modules/apps/foundation/server/.gitrepo
+++ b/modules/apps/foundation/server/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0ec5ba06b7b7ab1364d1a7f3eb609469f92acf76
+	commit = 9391576a32f0958db396a56cf3aed82acd209e01
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2832566eb51c182f78f554559ca158ba81ee14ab
+	parent = 08a3a24fa32be4389d2dae06b9e6998791677f64
 	remote = git@github.com:liferay/com-liferay-server.git

--- a/modules/apps/foundation/user-groups-admin/.gitrepo
+++ b/modules/apps/foundation/user-groups-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b4d5b2be0b697d338db40ae981f31227f76ea13b
+	commit = 22a34eccf9f4217e26daa353d304ed060a62e80c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 64082aa3d4fae4cb2dfc9deb8f52017716450419
+	parent = 8171ada59418d15c183bf07c1946e9120d3f12e2
 	remote = git@github.com:liferay/com-liferay-user-groups-admin.git

--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d4eaab969ec9077fc04d601d515d5f83f58440cc
+	commit = 0450a573d7a486a4eabfda3d354a512e1043b083
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a728574befc6fcf71c953143036ad53ab940e0cb
+	parent = de872ee65632877a09b97ec8a6408042cad42d0e
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/ip-geocoder/.gitrepo
+++ b/modules/apps/ip-geocoder/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 05705cb28c79b30693e80e3a1dc870b87749d93a
+	commit = f1d90a4f10743a5695bc5a27a511cc175467f57e
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f1251959d7fa2de507dc0851289be16d08195c90
+	parent = ea34415d67749b72665871cd4490eb82a996da56
 	remote = git@github.com:liferay/com-liferay-ip-geocoder.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b0b261c5e07a3f816038c266f6f68387055e126d
+	commit = 250b1a60c3fd93558cebefa2f26dae7b41f70612
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e567dd03399c2c6c1b042345d122589367ea16c2
+	parent = fb39ba8f13af9134de0fd082d67f2807ee9b3866
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 65d1d65bea27b97ab81cbacabf1a270cc47d1ecf
+	commit = f63be74c5a1fc704f57aac22b209fad085fee9a2
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 02d8a4358f8c1c4ba28d59a41a646d6b4afa084c
+	parent = 7e531b4cd5230bbd9e6da6d5a8b59113691433f3
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 6217333bb9d8ffeefdfb5effdb4c69bc85fe99e9
+	commit = 9a97d040891b67b34fe5426e9c30e44ecf1d30f6
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0b3f4a57bc9be7acf0db9f8263c8c8567e3448a1
+	parent = 70f391b2edd93dfb7e5d4192216bb49688ee4926
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/apps/web-experience/application-list/.gitrepo
+++ b/modules/apps/web-experience/application-list/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f83147900d502d2dbd1c59adb82b17f3ae47e75a
+	commit = a925fa35deaa992bedfcd92ea4ff854f857e1dc2
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 116eeabcc234ae0e0de94257fbbe9a3085bdb636
+	parent = cbe7b7b44c4a5365b64b780f7671b85141bb5a6b
 	remote = git@github.com:liferay/com-liferay-application-list.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d110ea8ad6c9881bb40e7c6f3f8dd38a1f388724
+	commit = 3f09546801b037376b52376bdf877e53f7b8904c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 77e9b92ee47c9eedd1ab865bb59ab01387b7e00d
+	parent = 1cc6bf2ffd51429932b14cf2982c8a537ba767e7
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 8e239797e698df40b53db2f3a4450dc1deb29e4f
+	commit = 59ac43050a34b78d58b417f2c0881fb6b7c233a9
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7980323f0c8e7d0ce3aee3a95ee61dbb3d8a7059
+	parent = b517692d7e5d6b5beed76f4d403a7b0f6ce0b1f2
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = cd5229eed72a359c5e3d5ec30053bd68815e30ac
+	commit = 9effabca51eac404035b5ab6ba83d45c47da5f6b
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 57f6eea8d4f377d4fbb7e1f60aac734aef76422b
+	parent = ac4593ed2e3063f8c9d8122db68fed95fc2f6563
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/modules/apps/web-experience/nested-portlets/.gitrepo
+++ b/modules/apps/web-experience/nested-portlets/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4df223f3e70af227b514e69429a921dd30d890a4
+	commit = bfc27153335f0ca8e86d842a24a9a44437594463
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 31d318cbe2c26c489f2ce23b8a7cf10d7a6a1b25
+	parent = daee2a800183e5839a9a84098464d5d43822cc39
 	remote = git@github.com:liferay/com-liferay-nested-portlets.git

--- a/modules/apps/web-experience/portlet-configuration/.gitrepo
+++ b/modules/apps/web-experience/portlet-configuration/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 69eb7b995cadf3efac61a110c620a97266d6c1f2
+	commit = e9bc1cf18bf3f75a7a4969e62e96242aa4a4d90d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ed21210a658864b459b5a3f56f7780fec5107c6f
+	parent = 263cfde8c466d8fd6ae93cedafb2acb4bda222ff
 	remote = git@github.com:liferay/com-liferay-portlet-configuration.git

--- a/modules/apps/web-experience/portlet-display-template/.gitrepo
+++ b/modules/apps/web-experience/portlet-display-template/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ff41a0e3d4ba65a9e519e809bcb429ffad289dee
+	commit = eb349dcd39d55c295e3e6c3ad26b60ae16fdbcfa
 	mergebuttonmergecommits = false
 	mode = push
-	parent = cc5d18165c1954e75d376194a81a676e83c6393c
+	parent = 9478e7db1b10e09d379f2bc4121a535d4be1c42e
 	remote = git@github.com:liferay/com-liferay-portlet-display-template.git

--- a/modules/apps/web-experience/rss/.gitrepo
+++ b/modules/apps/web-experience/rss/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 914f5fba42b171274e8db493d3409c27294dcbe7
+	commit = ba494af69be7819b15b0963a27d20aba53c6018e
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 6e23f86ab79c0f3b07212e99780ceb3b4362d911
+	parent = 28858c3617c307057f6b09a2b43bf114ce50d2ef
 	remote = git@github.com:liferay/com-liferay-rss.git

--- a/modules/apps/web-experience/site-navigation/.gitrepo
+++ b/modules/apps/web-experience/site-navigation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 988b2437cffadbece05c2ca11334219f94d6b147
+	commit = b681efcd28c2085f5d5e17f40303d7fd0cf7393a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 38100d4d07722bd68920bfee10fe0effd6910774
+	parent = 88552571c63407131c4ad6446cbf5d4fc537af51
 	remote = git@github.com:liferay/com-liferay-site-navigation.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 88e0327e917d7ee8f7efe261579a06eba0e6b02b
+	commit = 7ab4ed36b7e4c857f7f713dbc06782d9dff7f319
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b3a7ee40eaf7a09ce3c07112d008019f46d3a151
+	parent = 415f3d36a7251e8b97dda2b8d35e21cb7b0f9c21
 	remote = git@github.com:liferay/com-liferay-site.git

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 6fae5ee3689e2d120a69a89200a948766dc0fefe
+	commit = 4b90acb33fec67ce46f691d26c3e7d4a798fa134
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 1d8be786596add8460ecc03d2fbc21ce0386cd39
+	parent = ac5286526afe07d089124cf1a524337de4bbc9f2
 	remote = git@github.com:liferay/com-liferay-staging.git

--- a/modules/apps/web-experience/trash/.gitrepo
+++ b/modules/apps/web-experience/trash/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c59583937a56deebc533edd8e714ebe3e2a611de
+	commit = a30a797257fd889d3adb7e9dd7de490b09c56c07
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 936f5dee2398a85b81dc3ca2d598b24eb8d022c7
+	parent = 2a4894134ef0dc13fcf4b5174fdbdf43b859649c
 	remote = git@github.com:liferay/com-liferay-trash.git


### PR DESCRIPTION
The redact tokens were being reloaded via http call to mirrors every time the SecurePrintStream flushed. These tokens should only be loaded once per jvm.

Please republish after merging.