### PR TITLE
LPS-71971 It is not safe to unconditionally get session after request…

### DIFF
--- a/modules/apps/foundation/portal-security-sso/portal-security-sso-openid-connect/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/service/preaction/OpenIdConnectSessionValidationFilter.java
+++ b/modules/apps/foundation/portal-security-sso/portal-security-sso-openid-connect/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/service/preaction/OpenIdConnectSessionValidationFilter.java
@@ -55,7 +55,11 @@ public class OpenIdConnectSessionValidationFilter
 
 		boolean endSession = false;
 
-		HttpSession httpSession = request.getSession();
+		HttpSession httpSession = request.getSession(false);
+
+		if (httpSession == null) {
+			return;
+		}
 
 		OpenIdConnectSession openIdConnectSession =
 			(OpenIdConnectSession)httpSession.getAttribute(


### PR DESCRIPTION
… serving. The response might have been committed already causing IllegalStateException.

CC @ehan we caught this from benchmark project auto reindexing. See the error stack below.
```
09:31:23,790 ERROR [http-apr-172.16.241.3-8080-exec-7][SecureFilter:61] java.lang.IllegalStateException: Cannot create a session after the response has been committed
java.lang.IllegalStateException: Cannot create a session after the response has been committed
        at org.apache.catalina.connector.Request.doGetSession(Request.java:2928)
        at org.apache.catalina.connector.Request.getSession(Request.java:2298)
        at org.apache.catalina.connector.RequestFacade.getSession(RequestFacade.java:895)
        at org.apache.catalina.connector.RequestFacade.getSession(RequestFacade.java:907)
        at javax.servlet.http.HttpServletRequestWrapper.getSession(HttpServletRequestWrapper.java:240)
        at com.liferay.portal.security.sso.openid.connect.internal.service.preaction.OpenIdConnectSessionValidationFilter.doFilterFinally(OpenIdConnectSessionValidationFilter.java:58)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.processDirectCallFilter(InvokerFilterChain.java:176)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.doFilter(InvokerFilterChain.java:96)
        at com.liferay.portal.kernel.servlet.BaseFilter.processFilter(BaseFilter.java:142)
        at com.liferay.portal.servlet.filters.secure.SecureFilter.processFilter(SecureFilter.java:337)
        at com.liferay.portal.kernel.servlet.BaseFilter.doFilter(BaseFilter.java:48)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.processDoFilter(InvokerFilterChain.java:207)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.doFilter(InvokerFilterChain.java:112)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.processDirectCallFilter(InvokerFilterChain.java:188)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.doFilter(InvokerFilterChain.java:96)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.processDirectCallFilter(InvokerFilterChain.java:168)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.doFilter(InvokerFilterChain.java:96)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.processDirectCallFilter(InvokerFilterChain.java:168)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain.doFilter(InvokerFilterChain.java:96)
        at com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilter.doFilter(InvokerFilter.java:99)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:240)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:207)
        at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:212)
        at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:106)
        at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:502)
        at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:141)
        at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:79)
        at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:88)
        at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:522)
        at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1095)
        at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:672)
        at org.apache.tomcat.util.net.AprEndpoint$SocketProcessor.doRun(AprEndpoint.java:2500)
        at org.apache.tomcat.util.net.AprEndpoint$SocketProcessor.run(AprEndpoint.java:2489)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.lang.Thread.run(Thread.java:745)

```

Since the goal of OpenIdConnectSessionValidationFilter is to invalidate the session, if there is no session at all, there will be no need to do anything, so that we don't need to try to create a new one.