### PR TITLE
LRQA-32262 BUG - Check for null  and account for UNSTABLE result.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -974,7 +974,7 @@ public abstract class BaseBuild implements Build {
 						return;
 					}
 
-					if (result.equals("ABORTED") || result.equals("FAILURE")) {
+					if ((result != null) && !result.equals("SUCCESS")) {
 						for (ReinvokeRule reinvokeRule : reinvokeRules) {
 							if (!badBuildNumbers.isEmpty()) {
 								break;


### PR DESCRIPTION
Please publish a new com.liferay.jenkins.results.parser.jar after merging.