### PR TITLE
Lps 72319

### DIFF
--- a/definitions/liferay-service-builder_7_0_0.dtd
+++ b/definitions/liferay-service-builder_7_0_0.dtd
@@ -484,6 +484,9 @@ delete*, set*, and update* require propagation of transactions. All other
 methods support transactions but are assumed to be read only. If you want
 additional methods to fall under transactions, add the method name to this
 element.
+
+The tx-required attribute is deprecated, please add a Transactional annotation
+to the service impl method instead and re-run the service builder.
 -->
 <!ELEMENT tx-required (#PCDATA)>
 

--- a/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
+++ b/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageLocalService.java
@@ -221,17 +221,22 @@ public interface WikiPageLocalService extends BaseLocalService,
 	public WikiPage getLatestPage(long resourcePrimKey, long nodeId,
 		int status, boolean preferApproved) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long nodeId, java.lang.String title)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long nodeId, java.lang.String title, double version)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long nodeId, java.lang.String title,
 		java.lang.Boolean head) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long resourcePrimKey) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long resourcePrimKey, java.lang.Boolean head)
 		throws PortalException;
 

--- a/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
+++ b/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
@@ -96,18 +96,23 @@ public interface WikiPageService extends BaseService {
 	public WikiPage getDraftPage(long nodeId, java.lang.String title)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long groupId, long nodeId, java.lang.String title)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long nodeId, java.lang.String title)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long nodeId, java.lang.String title, double version)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long nodeId, java.lang.String title,
 		java.lang.Boolean head) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long pageId) throws PortalException;
 
 	public WikiPage movePageToTrash(long nodeId, java.lang.String title)

--- a/modules/apps/collaboration/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
+++ b/modules/apps/collaboration/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.1.1

--- a/modules/apps/collaboration/wiki/wiki-service/service.xml
+++ b/modules/apps/collaboration/wiki/wiki-service/service.xml
@@ -293,10 +293,6 @@
 		<reference entity="TrashVersion" package-path="com.liferay.portlet.trash" />
 		<reference entity="WikiNode" package-path="com.liferay.wiki" />
 		<reference entity="WikiPageResource" package-path="com.liferay.wiki" />
-
-		<!-- Transactions -->
-
-		<tx-required>getPage</tx-required>
 	</entity>
 	<entity local-service="true" name="WikiPageResource" remote-service="false" uuid="true">
 

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 5f9e4ea88a25082ca16671ff8b7ffdcf96e4d7ca
+	commit = 6af629ad677b74cc31f05cd3661a0f596a51b13d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2ec52e80fdc2aa2de8efa16680a9863d6fc221f3
+	parent = 7e2d2edb28ed22982cec725107d3bc253a3b1d4d
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/sync/sync-service/service.xml
+++ b/modules/apps/sync/sync-service/service.xml
@@ -171,10 +171,6 @@
 		<reference entity="DLFolder" package-path="com.liferay.portlet.documentlibrary" />
 		<reference entity="DLSyncEvent" package-path="com.liferay.portlet.documentlibrary" />
 		<reference entity="DLTrash" package-path="com.liferay.portlet.documentlibrary" />
-
-		<!-- Transactions -->
-
-		<tx-required>getFileDeltaAsStream</tx-required>
 	</entity>
 	<exceptions>
 		<exception>SyncDeviceActive</exception>

--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -5484,10 +5484,17 @@ public class ServiceBuilder {
 		List<Element> txRequiredElements = entityElement.elements(
 			"tx-required");
 
-		for (Element txRequiredEl : txRequiredElements) {
-			String txRequired = txRequiredEl.getText();
+		if (!txRequiredElements.isEmpty()) {
+			System.err.println(
+				"The tx-required attribute is deprecated, please add a " +
+					"Transactional annotation to the service impl method " +
+						"instead and re-run the service builder.");
 
-			txRequiredList.add(txRequired);
+			for (Element txRequiredEl : txRequiredElements) {
+				String txRequired = txRequiredEl.getText();
+
+				txRequiredList.add(txRequired);
+			}
 		}
 
 		boolean resourceActionModel = _resourceActionModels.contains(

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service.xml
@@ -14,10 +14,6 @@
 		<reference entity="DLFileRank" package-path="com.liferay.portlet.documentlibrary" />
 		<reference entity="DLFolder" package-path="com.liferay.portlet.documentlibrary" />
 		<reference entity="TrashEntry" package-path="com.liferay.portlet.trash" />
-
-		<!-- Transactions -->
-
-		<tx-required>getFileAsStream</tx-required>
 	</entity>
 	<entity local-service="true" name="DLAppHelper" remote-service="false">
 
@@ -238,10 +234,6 @@
 		<reference entity="ExpandoTable" package-path="com.liferay.portlet.expando" />
 		<reference entity="RatingsStats" package-path="com.liferay.portlet.ratings" />
 		<reference entity="TrashEntry" package-path="com.liferay.portlet.trash" />
-
-		<!-- Transactions -->
-
-		<tx-required>getFileAsStream</tx-required>
 	</entity>
 	<entity human-name="document library file entry metadata" local-service="true" name="DLFileEntryMetadata" remote-service="false" uuid="true">
 

--- a/portal-impl/test/unit/com/liferay/portal/service/ServiceXMLTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/service/ServiceXMLTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service;
+
+import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Preston Crary
+ */
+public class ServiceXMLTest {
+
+	@Test
+	public void testTXRequired() throws Exception {
+		Path portalPath = Paths.get(System.getProperty("user.dir"));
+
+		Files.walkFileTree(
+			portalPath,
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult visitFile(
+						Path path, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path fileNamePath = path.getFileName();
+
+					String fileName = fileNamePath.toString();
+
+					if (fileName.equals("service.xml")) {
+						_assertNoTXRequiredElement(path.toFile());
+
+						return FileVisitResult.SKIP_SIBLINGS;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+	}
+
+	private void _assertNoTXRequiredElement(File file) throws IOException {
+		try (FileInputStream fileInputStream = new FileInputStream(file);
+			UnsyncBufferedReader unsyncBufferedReader =
+				new UnsyncBufferedReader(
+					new InputStreamReader(fileInputStream))) {
+
+			String line = null;
+
+			while ((line = unsyncBufferedReader.readLine()) != null) {
+				Assert.assertFalse(
+					"Remove deprecated tx-required element from " +
+						file.getPath(),
+					line.contains("<tx-required>"));
+			}
+		}
+	}
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/service/ServiceXMLTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/service/ServiceXMLTest.java
@@ -36,7 +36,16 @@ public class ServiceXMLTest {
 	public void testTXRequired() throws Exception {
 		Stream<Path> stream = Files.find(
 			Paths.get(System.getProperty("user.dir")), Integer.MAX_VALUE,
-			ServiceXMLTest::_isServiceXml, FileVisitOption.FOLLOW_LINKS);
+			(Path path, BasicFileAttributes basicFileAttributes) -> {
+				Path fileNamePath = path.getFileName();
+
+				if ("service.xml".equals(fileNamePath.toString())) {
+					return true;
+				}
+
+				return false;
+			},
+			FileVisitOption.FOLLOW_LINKS);
 
 		stream.forEach(ServiceXMLTest::_assertNoTXRequiredElement);
 	}
@@ -52,18 +61,6 @@ public class ServiceXMLTest {
 		catch (IOException ioe) {
 			throw new RuntimeException(ioe);
 		}
-	}
-
-	private static boolean _isServiceXml(
-		Path path, BasicFileAttributes basicFileAttributes) {
-
-		Path fileNamePath = path.getFileName();
-
-		if ("service.xml".equals(fileNamePath.toString())) {
-			return true;
-		}
-
-		return false;
 	}
 
 }

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryLocalService.java
@@ -400,13 +400,16 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 		java.lang.String version, boolean incrementCounter, int increment)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long fileEntryId,
 		java.lang.String version) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long fileEntryId,
 		java.lang.String version, boolean incrementCounter)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long fileEntryId,
 		java.lang.String version, boolean incrementCounter, int increment)
 		throws PortalException;
@@ -416,6 +419,7 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 	String)}
 	*/
 	@java.lang.Deprecated
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long userId, long fileEntryId,
 		java.lang.String version) throws PortalException;
 
@@ -424,6 +428,7 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 	String, boolean)}
 	*/
 	@java.lang.Deprecated
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long userId, long fileEntryId,
 		java.lang.String version, boolean incrementCounter)
 		throws PortalException;
@@ -433,6 +438,7 @@ public interface DLFileEntryLocalService extends BaseLocalService,
 	String, boolean, int)}
 	*/
 	@java.lang.Deprecated
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long userId, long fileEntryId,
 		java.lang.String version, boolean incrementCounter, int increment)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryService.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/service/DLFileEntryService.java
@@ -195,9 +195,11 @@ public interface DLFileEntryService extends BaseService {
 		long rootFolderId, java.lang.String[] mimeTypes, int status)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long fileEntryId,
 		java.lang.String version) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public InputStream getFileAsStream(long fileEntryId,
 		java.lang.String version, boolean incrementCounter)
 		throws PortalException;


### PR DESCRIPTION
@hhuijser please see https://github.com/shuyangzhou/liferay-portal/commit/99fa24edef22118e63466160022a1afba99abe9e , I am not sure whether there is a good solution for this. On one hand, we do want to avoid unused parameter for normal method. On the other hand for method reference method, we might not always use all the parameters that the functional interface asks for. So unless we have a way to tell the unused parameter belongs to a method that is being used via method reference, we don't have a solution.