### PR TITLE
LRQA-32503, LRQA-32505 

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -803,6 +803,18 @@ public abstract class BaseBuild implements Build {
 
 	@Override
 	public void reinvoke(ReinvokeRule reinvokeRule) {
+		String hostName = JenkinsResultsParserUtil.getHostName("");
+
+		Build parentBuild = getParentBuild();
+
+		String parentBuildStatus = parentBuild.getStatus();
+
+		if (!parentBuildStatus.equals("running") ||
+			!hostName.startsWith("cloud-10-0")) {
+
+			return;
+		}
+
 		if ((reinvokeRule != null) && !fromArchive) {
 			String message = JenkinsResultsParserUtil.combine(
 				reinvokeRule.getName(), " failure detected at ", getBuildURL(),
@@ -832,26 +844,6 @@ public abstract class BaseBuild implements Build {
 						"Unable to send reinvoke notification", e);
 				}
 			}
-		}
-
-		String hostName = JenkinsResultsParserUtil.getHostName("");
-
-		Build parentBuild = getParentBuild();
-
-		String parentBuildStatus = parentBuild.getStatus();
-
-		if (!parentBuildStatus.equals("running")) {
-			System.out.println(
-				"Parent build is no longer running. Reinvocation has been " +
-					"aborted.");
-
-			return;
-		}
-
-		if (!hostName.startsWith("cloud-10-0")) {
-			System.out.println("A build may not be reinvoked by " + hostName);
-
-			return;
 		}
 
 		String invocationURL = getInvocationURL();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1233,7 +1233,7 @@ public abstract class BaseBuild implements Build {
 				String url = downstreamBuildURLMatcher.group("url");
 
 				Pattern reinvocationPattern = Pattern.compile(
-					Pattern.quote(url) + " restarted at (?<url>[^\\n]*)\\.\\n");
+					Pattern.quote(url) + " restarted at (?<url>[^\\s]*)\\.");
 
 				Matcher reinvocationMatcher = reinvocationPattern.matcher(
 					consoleText);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -1342,7 +1342,7 @@ public abstract class BaseBuild implements Build {
 				}
 
 				sb.append(getBuildURL());
-				sb.append(".");
+				sb.append(".\n");
 
 				return sb.toString();
 			}


### PR DESCRIPTION
LRQA-32503 BUG - Prevent build object model failures when there are many reinvoked builds.
https://issues.liferay.com/browse/LRQA-32503

LRQA-32505 BUG - Reinvocation notifications should not be sent if the reinvocation is aborted
https://issues.liferay.com/browse/LRQA-32505

Please republish after merging.