### PR TITLE
LPS-72523 Knowledge-base Find Security Bugs whitelists

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/find-security-bugs-false-positives.txt
+++ b/modules/apps/knowledge-base/knowledge-base-service/find-security-bugs-false-positives.txt
@@ -1,0 +1,1 @@
+com/liferay/portal/kernel/theme/ThemeDisplay.getURLCurrent():SAFE@com/liferay/knowledge/base/internal/events/KBServicePreAction

--- a/modules/apps/knowledge-base/knowledge-base-service/fsb-exclude.xml
+++ b/modules/apps/knowledge-base/knowledge-base-service/fsb-exclude.xml
@@ -1,0 +1,20 @@
+<FindBugsFilter>
+	<Match>
+		<Class name="com.liferay.knowledge.base.service.persistence.impl.KBArticlePersistenceImpl" />
+		<Or>
+			<Method name="countByG_S_L" />
+			<Method name="countByG_S_M" />
+			<Method name="countByG_S_S" />
+			<Method name="filterCountByG_S_L" />
+			<Method name="filterCountByG_S_M" />
+			<Method name="filterCountByG_S_S" />
+			<Method name="filterFindByG_S_L" />
+			<Method name="filterFindByG_S_M" />
+			<Method name="filterFindByG_S_S" />
+			<Method name="findByG_S_L" />
+			<Method name="findByG_S_M" />
+			<Method name="findByG_S_S" />
+		</Or>
+		<Bug pattern="SQL_INJECTION_HIBERNATE" />
+	</Match>
+</FindBugsFilter>

--- a/modules/apps/knowledge-base/knowledge-base-web/find-security-bugs-false-positives.txt
+++ b/modules/apps/knowledge-base/knowledge-base-web/find-security-bugs-false-positives.txt
@@ -1,0 +1,10 @@
+com/liferay/document/library/display/context/DLMimeTypeDisplayContext.getCssClassFileMimeType(Ljava/lang/String;)Ljava/lang/String;:SAFE
+com/liferay/knowledge/base/model/KBArticleModel.getContent()Ljava/lang/String;:SAFE
+com/liferay/knowledge/base/model/KBTemplateModel.getContent()Ljava/lang/String;:SAFE
+com/liferay/portal/kernel/dao/search/SearchContainer.getEmptyResultsMessage():SAFE@org/apache/jsp/section/view_jsp
+com/liferay/portal/kernel/util/StringUtil.shorten(UNKNOWN,SAFE,""):SAFE@org/apache/jsp/admin/common/article_005fattachments_jsp
+com/liferay/portal/kernel/workflow/WorkflowConstants.getStatusLabel(I)Ljava/lang/String;:SAFE
+
+com/liferay/knowledge/base/web/internal/util/KBArticleAssetEntriesUtil.getURL(Ljavax/servlet/http/HttpServletRequest;Lcom/liferay/portal/kernel/theme/ThemeDisplay;Lcom/liferay/asset/kernel/model/AssetRendererFactory;Lcom/liferay/asset/kernel/model/AssetRenderer;)Ljava/lang/String;:SAFE
+
+org/apache/jsp/admin/common/edit_005farticle_jsp._getFriendlyURLPrefix(JJ)Ljava/lang/String;:SAFE

--- a/modules/apps/knowledge-base/knowledge-base-web/fsb-exclude.xml
+++ b/modules/apps/knowledge-base/knowledge-base-web/fsb-exclude.xml
@@ -1,0 +1,16 @@
+<FindBugsFilter>
+	<Match>
+		<Class name="org.apache.jsp.admin.common.error_jsp" />
+		<Bug pattern="SERVLET_HEADER_REFERER" />
+	</Match>
+	<Match>
+		<Or>
+			<Class name="org.apache.jsp.admin.configuration_jsp" />
+			<Class name="org.apache.jsp.article.configuration_jsp" />
+			<Class name="org.apache.jsp.display.configuration_jsp" />
+			<Class name="org.apache.jsp.search.configuration_jsp" />
+			<Class name="org.apache.jsp.section.configuration_jsp" />
+		</Or>
+		<Bug pattern="SERVLET_PARAMETER" />
+	</Match>
+</FindBugsFilter>


### PR DESCRIPTION
Hi Brian,

only knowledge-base changes. 

Based on [https://github.com/brianchandotcom/liferay-portal/pull/48900#issuecomment-300547641](https://github.com/brianchandotcom/liferay-portal/pull/48900#issuecomment-300547641):

> Can you add "@generated" to the patched files via your patch?
> 
> See the other patches, by doing that, you don't need the SF exclude.
> 
> Can you also send this as 2 pulls, one to modify findsecbugs, which I will backport right away, and the KB changes which I will need you to backport.
> 

I think we can backport the changes "as-is":
* ee-7.0.x code is the same as in master
* ee-6.2.x doesn't use find-security-bugs, we don't need those files there

But here they are :)

Thanks.

https://issues.liferay.com/browse/LPS-72456