### PR TITLE
LPS-72512 Comment out invalid Moderator message.boards.user.ranks pro…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -8977,17 +8977,17 @@
         Announcement|icon-comments|1.0
 
     message.boards.user.ranks=\
+        #Moderator=organization:Message Boards Administrator,\
+        #Moderator=organization-role:Message Boards Administrator,\
+        #Moderator=regular-role:Message Boards Administrator,\
+        #Moderator=site-role:Message Boards Administrator,\
+        #Moderator=user-group:Message Boards Administrator,\
         Youngling=0,\
         Padawan=25,\
         Jedi Knight=100,\
         Jedi Master=250,\
         Jedi Council Member=500,\
-        Yoda=1000,\
-        Moderator=organization:Message Boards Administrator,\
-        Moderator=organization-role:Message Boards Administrator,\
-        Moderator=regular-role:Message Boards Administrator,\
-        Moderator=site-role:Message Boards Administrator,\
-        Moderator=user-group:Message Boards Administrator
+        Yoda=1000
 
     #
     # Set this to true if message boards should be published to live by default.


### PR DESCRIPTION
…perties, these always cause and swallow exceptions which means we have a cache miss every time we try to look up the values in MBUtil._isEntityRank().