### PR TITLE
LPS-72098 Search query translators ignoring StringQuery (Lucene syntax) - fix

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.ibm.icu", name: "icu4j", version: "54.1.1"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.4.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "commons-cli", name: "commons-cli", version: "1.3.1"
 	provided group: "org.hdrhistogram", name: "HdrHistogram", version: "2.1.8"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/StringQueryTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/StringQueryTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.query;
+
+import com.liferay.portal.search.elasticsearch.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch.internal.connection.LiferayIndexCreator;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.query.BaseStringQueryTestCase;
+
+/**
+ * @author André de Oliveira
+ */
+public class StringQueryTest extends BaseStringQueryTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
+			StringQueryTest.class.getSimpleName());
+
+		return new ElasticsearchIndexingFixture(
+			elasticsearchFixture, BaseIndexingTestCase.COMPANY_ID,
+			new LiferayIndexCreator(elasticsearchFixture));
+	}
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test-util/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/build.gradle
@@ -3,7 +3,7 @@ targetCompatibility = "1.8"
 
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.11.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.test", version: "1.0.0"
 	provided group: "junit", name: "junit", version: "4.12"
 	provided group: "org.mockito", name: "mockito-core", version: "1.10.8"

--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/DocumentsAssert.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/DocumentsAssert.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util;
+
+import com.liferay.portal.kernel.search.Document;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+
+/**
+ * @author André de Oliveira
+ */
+public class DocumentsAssert {
+
+	public static void assertCount(
+		String message, Document[] documents, String field, int expectedCount) {
+
+		if (documents.length == expectedCount) {
+			return;
+		}
+
+		List<String> actualValues = _getValues(field, documents);
+
+		Assert.assertEquals(
+			message + "->" + actualValues, expectedCount, documents.length);
+	}
+
+	public static void assertValues(
+		String message, Document[] documents, String field,
+		List<String> expectedValues) {
+
+		List<String> actualValues = _getValues(field, documents);
+
+		Assert.assertEquals(
+			message + "->" + actualValues, expectedValues.toString(),
+			actualValues.toString());
+	}
+
+	private static List<String> _getValues(
+		String field, Document... documents) {
+
+		Stream<Document> documentsStream = Stream.of(documents);
+
+		Stream<String> valuesStream = documentsStream.map(
+			document -> document.get(field));
+
+		return valuesStream.collect(Collectors.toList());
+	}
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.search.test.util.indexing;
 
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
@@ -74,7 +73,6 @@ public abstract class BaseIndexingTestCase {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(COMPANY_ID);
-		searchContext.setEnd(QueryUtil.ALL_POS);
 		searchContext.setGroupIds(new long[] {GROUP_ID});
 
 		QueryConfig queryConfig = new QueryConfig();

--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseFieldQueryBuilderTestCase.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/mappings/BaseFieldQueryBuilderTestCase.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.search.analysis.FieldQueryBuilder;
+import com.liferay.portal.search.test.util.DocumentsAssert;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
@@ -127,28 +128,11 @@ public abstract class BaseFieldQueryBuilderTestCase
 		return null;
 	}
 
-	private static List<String> _getValues(String field, Document... docs) {
-		ArrayList<String> values = new ArrayList<>(docs.length);
-
-		for (Document document : docs) {
-			values.add(document.get(field));
-		}
-
-		return values;
-	}
-
 	private void _assertCount(String keywords, int count) throws Exception {
 		Hits hits = doSearch(keywords);
 
-		Document[] docs = hits.getDocs();
-
-		if (docs.length == 0) {
-			return;
-		}
-
-		List<String> values = _getValues(getField(), docs);
-
-		Assert.assertEquals(keywords + "->" + values, count, docs.length);
+		DocumentsAssert.assertCount(
+			keywords, hits.getDocs(), getField(), count);
 	}
 
 	private void _assertDocument(String... values) throws Exception {
@@ -158,9 +142,9 @@ public abstract class BaseFieldQueryBuilderTestCase
 
 		Document[] documents = hits.getDocs();
 
-		List<String> expectedValues = Arrays.asList(values);
-
 		String field = getField();
+
+		List<String> expectedValues = Arrays.asList(values);
 
 		List<String> actualValues = new ArrayList<>();
 
@@ -189,13 +173,8 @@ public abstract class BaseFieldQueryBuilderTestCase
 
 		Hits hits = doSearch(keywords);
 
-		Document[] documents = hits.getDocs();
-
-		List<String> actualValues = _getValues(getField(), documents);
-
-		Assert.assertEquals(
-			keywords + "->" + actualValues, expectedValues.toString(),
-			actualValues.toString());
+		DocumentsAssert.assertValues(
+			keywords, hits.getDocs(), getField(), expectedValues);
 	}
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseStringQueryTestCase.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/query/BaseStringQueryTestCase.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.query;
+
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.generic.StringQuery;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelpers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+/**
+ * @author Tibor Lipusz
+ * @author André de Oliveira
+ */
+public abstract class BaseStringQueryTestCase extends BaseIndexingTestCase {
+
+	@Test
+	public void testAnd() throws Exception {
+		addDocument("description", "java eclipse");
+		addDocument("description", "java liferay");
+		addDocument("description", "java liferay eclipse");
+
+		assertSearch(
+			"java AND eclipse", "description",
+			Arrays.asList("java eclipse", "java liferay eclipse"));
+
+		assertSearch(
+			"eclipse AND liferay", "description",
+			Arrays.asList("java liferay eclipse"));
+	}
+
+	@Test
+	public void testField() throws Exception {
+		addDocument("title", "java");
+		addDocument("title", "eclipse");
+		addDocument("title", "liferay");
+
+		assertSearch(
+			"title:(java OR eclipse)", "title",
+			Arrays.asList("java", "eclipse"));
+
+		assertSearch(
+			"description:(java OR eclipse)", "title", Collections.emptyList());
+	}
+
+	protected void addDocument(String fieldName, String... fieldValues)
+		throws Exception {
+
+		addDocument(DocumentCreationHelpers.singleText(fieldName, fieldValues));
+	}
+
+	protected void assertSearch(
+			String query, String fieldName, List<String> expectedValues)
+		throws Exception {
+
+		SearchContext searchContext = createSearchContext();
+
+		StringQuery stringQuery = _createStringQuery(query, searchContext);
+
+		IdempotentRetryAssert.retryAssert(
+			5, TimeUnit.SECONDS,
+			() -> {
+				Hits hits = search(searchContext, stringQuery);
+
+				DocumentsAssert.assertValues(
+					query, hits.getDocs(), fieldName, expectedValues);
+
+				return null;
+			});
+	}
+
+	private StringQuery _createStringQuery(
+		String query, SearchContext searchContext) {
+
+		StringQuery stringQuery = new StringQuery(query);
+
+		stringQuery.setQueryConfig(searchContext.getQueryConfig());
+
+		return stringQuery;
+	}
+
+}

--- a/modules/apps/portal-search-solr/portal-search-solr/build.gradle
+++ b/modules/apps/portal-search-solr/portal-search-solr/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.4.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "commons-lang", name: "commons-lang", version: "2.6"
 	provided group: "org.apache.lucene", name: "lucene-misc", version: "5.2.1"
 	provided group: "org.apache.lucene", name: "lucene-sandbox", version: "5.2.1"

--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/query/StringQueryTest.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/query/StringQueryTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr.internal.query;
+
+import com.liferay.portal.search.solr.internal.SolrIndexingFixture;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+import com.liferay.portal.search.test.util.query.BaseStringQueryTestCase;
+
+/**
+ * @author André de Oliveira
+ */
+public class StringQueryTest extends BaseStringQueryTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		return new SolrIndexingFixture();
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/generic/StringQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/generic/StringQuery.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.search.generic;
 
 import com.liferay.portal.kernel.search.BaseQueryImpl;
 import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.search.query.QueryVisitor;
 import com.liferay.portal.kernel.util.StringBundler;
 
 /**
@@ -25,6 +26,11 @@ public class StringQuery extends BaseQueryImpl implements Query {
 
 	public StringQuery(String query) {
 		_query = query;
+	}
+
+	@Override
+	public <T> T accept(QueryVisitor<T> queryVisitor) {
+		return queryVisitor.visitQuery(this);
 	}
 
 	public String getQuery() {


### PR DESCRIPTION
Author: @lipusz 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-72098

Thank you Tibor for the fix :+1: and *really* thank you for also contributing the test!