### PR TITLE
LPS-58771 A component should never hold another module's service via …

### DIFF
--- a/modules/apps/foundation/portal-template/portal-template-soy/src/main/java/com/liferay/portal/template/soy/internal/SoyManager.java
+++ b/modules/apps/foundation/portal-template/portal-template-soy/src/main/java/com/liferay/portal/template/soy/internal/SoyManager.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.template.soy.internal;
 
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.cache.SingleVMPool;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateManager;
@@ -22,6 +24,7 @@ import com.liferay.portal.template.BaseMultiTemplateManager;
 import com.liferay.portal.template.RestrictedTemplate;
 import com.liferay.portal.template.TemplateContextHelper;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -59,6 +62,13 @@ public class SoyManager extends BaseMultiTemplateManager {
 	public void init() {
 	}
 
+	@Reference(unbind = "-")
+	public void setSingleVMPool(SingleVMPool singleVMPool) {
+		_portalCache =
+			(PortalCache<HashSet<TemplateResource>, SoyTofuCacheBag>)
+				singleVMPool.getPortalCache(SoyTemplate.class.getName());
+	}
+
 	@Override
 	@Reference(service = SoyTemplateContextHelper.class, unbind = "-")
 	public void setTemplateContextHelper(
@@ -75,7 +85,8 @@ public class SoyManager extends BaseMultiTemplateManager {
 
 		Template template = new SoyTemplate(
 			templateResources, errorTemplateResource, helperUtilities,
-			(SoyTemplateContextHelper)templateContextHelper, privileged);
+			(SoyTemplateContextHelper)templateContextHelper, privileged,
+			_portalCache);
 
 		if (restricted) {
 			template = new RestrictedTemplate(
@@ -84,5 +95,8 @@ public class SoyManager extends BaseMultiTemplateManager {
 
 		return template;
 	}
+
+	private PortalCache<HashSet<TemplateResource>, SoyTofuCacheBag>
+		_portalCache;
 
 }

--- a/modules/apps/foundation/portal-template/portal-template-soy/src/main/java/com/liferay/portal/template/soy/internal/SoyTemplate.java
+++ b/modules/apps/foundation/portal-template/portal-template-soy/src/main/java/com/liferay/portal/template/soy/internal/SoyTemplate.java
@@ -26,7 +26,6 @@ import com.google.template.soy.tofu.SoyTofu.Renderer;
 import com.google.template.soy.tofu.SoyTofuOptions;
 
 import com.liferay.portal.kernel.cache.PortalCache;
-import com.liferay.portal.kernel.cache.SingleVMPoolUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -75,7 +74,8 @@ public class SoyTemplate extends AbstractMultiResourceTemplate {
 	public SoyTemplate(
 		List<TemplateResource> templateResources,
 		TemplateResource errorTemplateResource, Map<String, Object> context,
-		SoyTemplateContextHelper templateContextHelper, boolean privileged) {
+		SoyTemplateContextHelper templateContextHelper, boolean privileged,
+		PortalCache<HashSet<TemplateResource>, SoyTofuCacheBag> portalCache) {
 
 		super(
 			templateResources, errorTemplateResource, context,
@@ -85,7 +85,7 @@ public class SoyTemplate extends AbstractMultiResourceTemplate {
 		_privileged = privileged;
 
 		_soyMapData = new SoyMapData();
-		_soyTofuCacheHandler = new SoyTofuCacheHandler(_portalCache);
+		_soyTofuCacheHandler = new SoyTofuCacheHandler(portalCache);
 	}
 
 	@Override
@@ -356,9 +356,6 @@ public class SoyTemplate extends AbstractMultiResourceTemplate {
 
 	private static final Log _log = LogFactoryUtil.getLog(SoyTemplate.class);
 
-	private final PortalCache<HashSet<TemplateResource>, SoyTofuCacheBag>
-		_portalCache = SingleVMPoolUtil.getPortalCache(
-			SoyTemplate.class.getName());
 	private final boolean _privileged;
 	private final SoyMapData _soyMapData;
 	private final SoyTofuCacheHandler _soyTofuCacheHandler;


### PR DESCRIPTION
…portal util bridge, there is a great chance to run into an initializtion wiring deadlock. Caused by 53832d52eb52feecd49262d28875ec99b46e35f9

@brianchandotcom @jpince this should fix the startup hanging in lpkg-override

@tomwang2011 let's turn on the SF rule for SingleVMUtil and MultiVMPoolUtil in components, same thing as you did for HttpUtil/PortalUtil.

@mtambara you still need to rewrite the service tracker usage, and make sure we only get the PortalCache reference once, I am leaving that piece to you.