### PR TITLE
LPS-72652 Upgrade third-party to org.elasticsearch-2.4.0.LIFERAY-PATCHED.jar

### DIFF
--- a/modules/third-party/org-elasticsearch/bnd.bnd
+++ b/modules/third-party/org-elasticsearch/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-SymbolicName: org.elasticsearch
-Bundle-Version: 2.2.0.LIFERAY-PATCHED-2
+Bundle-Version: 2.4.0.LIFERAY-PATCHED
 Export-Package: org.elasticsearch.*

--- a/modules/third-party/org-elasticsearch/build.gradle
+++ b/modules/third-party/org-elasticsearch/build.gradle
@@ -5,7 +5,7 @@ apply plugin: "com.liferay.patcher"
 task patch(type: PatchTask)
 
 dependencies {
-	compile group: "org.elasticsearch", name: "elasticsearch", optional, transitive: false, version: "2.2.0"
+	compile group: "org.elasticsearch", name: "elasticsearch", optional, transitive: false, version: "2.4.0"
 }
 
 patch {


### PR DESCRIPTION
Author: @linolaoj 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-72652

cc/ @mhan810 Pull request upgrading `portal-search-elasticsearch` to 2.4 will follow as soon as `org.elasticsearch-2.4.0.LIFERAY-PATCHED.jar` becomes available.