### PR TITLE
LPS-72199 portal-search-test: move SearchPaginationTest from portal-impl/test/integration

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/pagination/test/SearchPaginationTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/pagination/test/SearchPaginationTest.java
@@ -12,8 +12,9 @@
  * details.
  */
 
-package com.liferay.portal.search;
+package com.liferay.portal.search.pagination.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
@@ -49,10 +50,12 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author Roberto Díaz
  */
+@RunWith(Arquillian.class)
 @Sync
 public class SearchPaginationTest {
 


### PR DESCRIPTION
Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/48936. `portal-search-test` is now a better home for this classic integration test.

https://issues.liferay.com/browse/LPS-72199