### PR TITLE
LRQA-32912 | master

### DIFF
--- a/build-test-elasticsearch.xml
+++ b/build-test-elasticsearch.xml
@@ -509,18 +509,18 @@ shield.transport.ssl: true</echo>
 			<if>
 				<os family="mac" />
 				<then>
-					<move file="${app.server.parent.dir}/kibana-${elastic.kibana.version}-darwin-x64" tofile="${elastic.kibana.dir}" />
+					<move file="${app.server.parent.dir}/kibana-${elastic.kibana.version}-darwin-x86_64" tofile="${elastic.kibana.dir}" />
 				</then>
 				<elseif>
 					<os family="unix" />
 					<then>
-						<move file="${app.server.parent.dir}/kibana-${elastic.kibana.version}-linux-x64" tofile="${elastic.kibana.dir}" />
+						<move file="${app.server.parent.dir}/kibana-${elastic.kibana.version}-linux-x86_64" tofile="${elastic.kibana.dir}" />
 					</then>
 				</elseif>
 				<elseif>
 					<os family="windows" />
 					<then>
-						<move file="${app.server.parent.dir}/kibana-${elastic.kibana.version}-windows" tofile="${elastic.kibana.dir}" />
+						<move file="${app.server.parent.dir}/kibana-${elastic.kibana.version}-windows-x86" tofile="${elastic.kibana.dir}" />
 					</then>
 				</elseif>
 			</if>

--- a/test.properties
+++ b/test.properties
@@ -514,25 +514,25 @@
 ## Elastic
 ##
 
-    elastic.kibana.version=4.4.2
+    elastic.kibana.version=4.6.1
     elastic.kibana.dir=${app.server.parent.dir}/kibana-${elastic.kibana.version}
-    elastic.kibana.tar.name.linux=kibana-${elastic.kibana.version}-linux-x64.tar.gz
-    elastic.kibana.tar.name.mac=kibana-${elastic.kibana.version}-darwin-x64.tar.gz
+    elastic.kibana.tar.name.linux=kibana-${elastic.kibana.version}-linux-x86_64.tar.gz
+    elastic.kibana.tar.name.mac=kibana-${elastic.kibana.version}-darwin-x86_64.tar.gz
     elastic.kibana.tar.url.linux=http://download.elastic.co/kibana/kibana/${elastic.kibana.tar.name.linux}
     elastic.kibana.tar.url.mac=http://download.elastic.co/kibana/kibana/${elastic.kibana.tar.name.mac}
-    elastic.kibana.zip.name.windows=kibana-${elastic.kibana.version}-windows.zip
+    elastic.kibana.zip.name.windows=kibana-${elastic.kibana.version}-windows-x86.zip
     elastic.kibana.zip.url.windows=http://download.elastic.co/kibana/kibana/${elastic.kibana.zip.name.windows}
 
-    elastic.marvel.version=2.2.1
+    elastic.marvel.version=2.4.1
     elastic.marvel.tar.name=marvel-${elastic.marvel.version}.tar.gz
     elastic.marvel.tar.url=http://download.elasticsearch.org/elasticsearch/marvel/${elastic.marvel.tar.name}
 
-    elastic.shield.version=2.2.1
+    elastic.shield.version=2.4.1
     elastic.shield.ca.dir=${elasticsearch.dir}/config/shield/ca
     elastic.shield.zip.name=shield-${elastic.shield.version}.zip
     elastic.shield.zip.url=http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/shield/${elastic.shield.version}/${elastic.shield.zip.name}
 
-    elasticsearch.version=2.2.1
+    elasticsearch.version=2.4.1
     elasticsearch.dir=${app.server.parent.dir}/elasticsearch-${elasticsearch.version}
     elasticsearch.analysis-icu.zip.name=analysis-icu-${elasticsearch.version}.zip
     elasticsearch.analysis-icu.zip.url=http://download.elastic.co/elasticsearch/release/org/elasticsearch/plugin/analysis-icu/${elasticsearch.version}/${elasticsearch.analysis-icu.zip.name}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32912

Note there is **no corresponding ee-7.0.x PR** since the Elasticsearch 2.4 jar hasn't been backported to ee-7.0.x.