### PR TITLE
LRQA-32965 Ignore basedirs that do not exist

### DIFF
--- a/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -414,6 +414,13 @@ public class PoshiRunnerContext {
 				continue;
 			}
 
+			if (!FileUtil.exists(basedir)) {
+				System.out.println(
+					"WARNING: basedir does not exist: " + basedir);
+
+				continue;
+			}
+
 			DirectoryScanner directoryScanner = new DirectoryScanner();
 
 			directoryScanner.setBasedir(basedir);


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32965

@stmerriss @jpince @brianchiu

Fix for this ticket:
https://issues.liferay.com/browse/LRQA-32926

These are updates to Poshi that will ignore the basedirs that do not exist.

@brianchandotcom 
If this looks okay, can we do a new Poshi Release?  Thanks!