### PR TITLE
Revert "LPS-70693 Ignore all adaptive-media tests until they are fixed"

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1291,8 +1291,7 @@
         */pacl/test/[\\w]+Test.class,\
         **/*ServiceHttpTest.java,\
         **/*ServiceJsonTest.java,\
-        **/*ServiceSoapTest.java,\
-        **/com/liferay/adaptive/media/**/*Test.java
+        **/*ServiceSoapTest.java
 
     test.class.names.includes=\
         **/src/test/**/*Test.java,\


### PR DESCRIPTION
Hey @brianchandotcom 

See commit https://github.com/liferay/com-liferay-adaptive-media/commit/bf4d4dfb9058991ff6519336e2aa403ce19bcaae in the Adaptive Media repo for the actual fix. The problem was a demo data creator module that had the .lfrbuild-portal file by mistake.

This reverts commit 9aafe42df62a5548862081a8e81a7f4d300bb53f.