### PR TITLE
LPS-59837 Dodge debris left behind by non-Search tests

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetTagNamesFacetedSearcherTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/AssetTagNamesFacetedSearcherTest.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
-import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
@@ -34,7 +33,6 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +41,6 @@ import org.junit.runner.RunWith;
  * @author Andrew Betts
  * @author André de Oliveira
  */
-@Ignore
 @RunWith(Arquillian.class)
 @Sync
 public class AssetTagNamesFacetedSearcherTest
@@ -69,11 +66,9 @@ public class AssetTagNamesFacetedSearcherTest
 
 	@Test
 	public void testSearchByFacet() throws Exception {
-		Group group = userSearchFixture.addGroup();
-
 		String tag = "enterprise. open-source for life";
 
-		userSearchFixture.addUser(group, tag);
+		addUser(tag);
 
 		SearchContext searchContext = getSearchContext(tag);
 
@@ -90,12 +85,9 @@ public class AssetTagNamesFacetedSearcherTest
 
 	@Test
 	public void testSearchQuoted() throws Exception {
-		Group group = userSearchFixture.addGroup();
+		String[] assetTagNames = {"Enterprise", "Open Source", "For   Life"};
 
-		String[] assetTagNames =
-			new String[] {"Enterprise", "Open Source", "For   Life"};
-
-		User user = userSearchFixture.addUser(group, assetTagNames);
+		User user = addUser(assetTagNames);
 
 		Map<String, String> expected = userSearchFixture.toMap(
 			user, assetTagNames);
@@ -107,6 +99,12 @@ public class AssetTagNamesFacetedSearcherTest
 		assertTags("\"For   Life\"", expected);
 	}
 
+	protected User addUser(String... assetTagNames) throws Exception {
+		Group group = userSearchFixture.addGroup();
+
+		return userSearchFixture.addUser(group, assetTagNames);
+	}
+
 	protected void assertTags(String keywords, Map<String, String> expected)
 		throws Exception {
 
@@ -115,14 +113,6 @@ public class AssetTagNamesFacetedSearcherTest
 		Hits hits = search(searchContext);
 
 		assertTags(keywords, hits, expected);
-	}
-
-	protected SearchContext getSearchContext(String keywords) throws Exception {
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext();
-
-		searchContext.setKeywords(keywords);
-
-		return searchContext;
 	}
 
 	private AssetTagNamesFacetFactory _assetTagNamesFacetFactory;

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/BaseFacetedSearcherTestCase.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/BaseFacetedSearcherTestCase.java
@@ -99,6 +99,10 @@ public abstract class BaseFacetedSearcherTestCase {
 		return _facetedSearcherManager.createFacetedSearcher();
 	}
 
+	protected SearchContext getSearchContext(String keywords) throws Exception {
+		return userSearchFixture.getSearchContext(keywords);
+	}
+
 	protected boolean isMissingScreenName(Document document) {
 		return Validator.isNull(document.get("screenName"));
 	}

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/FacetedSearcherTest.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.search.test.util.SearchMapUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -103,14 +102,6 @@ public class FacetedSearcherTest extends BaseFacetedSearcherTestCase {
 		group.setActive(false);
 
 		GroupLocalServiceUtil.updateGroup(group);
-	}
-
-	protected SearchContext getSearchContext(String keywords) throws Exception {
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext();
-
-		searchContext.setKeywords(keywords);
-
-		return searchContext;
 	}
 
 }

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ModifiedFacetedSearcherTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ModifiedFacetedSearcherTest.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.search.test.util.SearchMapUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
@@ -115,16 +114,6 @@ public class ModifiedFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 		dataJSONObject.put("ranges", jsonArray);
 
 		return dataJSONObject;
-	}
-
-	protected static SearchContext getSearchContext(String keywords)
-		throws Exception {
-
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext();
-
-		searchContext.setKeywords(keywords);
-
-		return searchContext;
 	}
 
 	protected static void setConfigurationRanges(Facet facet, String... ranges)

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/PermissionFilterFacetedSearcherTest.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -148,16 +147,6 @@ public class PermissionFilterFacetedSearcherTest
 			JournalArticle.class.getName(), 1);
 
 		assertFrequencies(facet.getFieldName(), searchContext, expected);
-	}
-
-	protected static SearchContext getSearchContext(String keywords)
-		throws Exception {
-
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext();
-
-		searchContext.setKeywords(keywords);
-
-		return searchContext;
 	}
 
 	protected void addArticle(

--- a/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ScopeFacetedSearcherTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/facet/faceted/searcher/test/ScopeFacetedSearcherTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.search.test.util.SearchMapUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
@@ -192,14 +191,6 @@ public class ScopeFacetedSearcherTest extends BaseFacetedSearcherTestCase {
 	protected static Map<String, Integer> toMap(Group group, Integer count) {
 		return Collections.singletonMap(
 			String.valueOf(group.getGroupId()), count);
-	}
-
-	protected SearchContext getSearchContext(String keywords) throws Exception {
-		SearchContext searchContext = SearchContextTestUtil.getSearchContext();
-
-		searchContext.setKeywords(keywords);
-
-		return searchContext;
 	}
 
 	private ScopeFacetFactory _scopeFacetFactory;


### PR DESCRIPTION
This fixes https://github.com/brianchandotcom/liferay-portal/pull/49274#issuecomment-305058549 and will likely prevent any flakiness of this kind in the future. Sorry about the disturbance but at least adding extra error information paid off. 😃  (https://github.com/brianchandotcom/liferay-portal/pull/49233#issue-231761708) Search tests will now filter only to groups created by themselves, ignoring leftover documents from tests elsewhere.

@Preston-Crary FYI. Apparently this may not be deleting the uploaded DLFileEntry objects post test:
https://github.com/liferay/liferay-portal/blob/9d29d91d159f6bc65ef15657d7d71560ca267ac7/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/webdav/test/WebDAVLitmusBasicTest.java#L175-L176