### PR TITLE
Revert "LPS-70904 Treat blank parameter as null"

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -495,7 +495,7 @@ public class PortletURLImpl
 			throw new IllegalArgumentException();
 		}
 
-		if ((value == null) || value.isEmpty()) {
+		if (value == null) {
 			removeParameter(name);
 
 			return;


### PR DESCRIPTION
This reverts commit 61c242879c393a70b536ebf3b92ecafc6c6a5e97.

@adolfopa I am reverting the change I did in LPS-70904, but for LPS-72571 the root problem is actually inside EditPageMVCActionCommand. When we are done with the action, we should clean up those prp values that are no longer true. prps are supposed to be used for inter portlet communication. But in this case, they are no difference from a standard session attributes, once attached no one is cleaning them up. Leaving them out of date and causing renderring problems. The reason that I am not fixing it for wiki, is because I don't know who else is using prp in this style. It is safer to restore the original behavior, then come back to do proper clean up case by case.