### PR TITLE
LRQA-32926 Add commerce to test.subrepo.dirs property

### DIFF
--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = cdaeda249ce36ac12ccc5ae770a450de3c972247
+	commit = 13fd7b380241866d7326800481ecf20d89eeef96
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 284e9418429ffd59ec33a8fb4fdb5e7de52ff207
+	parent = 922dd302c93298e901e83561f0ad6a2dc325967b
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/test.properties
+++ b/test.properties
@@ -1309,7 +1309,8 @@
 ##
 ## Test Subrepo Directories
 ##
-    test.subrepo.dirs=
+    test.subrepo.dirs=\
+        ${project.dir}/modules/private/apps/commerce/commerce-product-test/src/testFunctional
 
 ##
 ## Testray


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32926

We merged in updates into Poshi that will make the reference to commerce fail gracefully. ([LRQA-32399](https://issues.liferay.com/browse/LRQA-32399))