### PR TITLE
LPS-72874 Change source format property to point to correct directory

### DIFF
--- a/modules/test/source-formatter.properties
+++ b/modules/test/source-formatter.properties
@@ -6,4 +6,4 @@
 ##
 
     run.outside.portal.excludes=\
-        modules/test/poshi-runner/src/main/java/com/liferay/poshi/runner/util/GetterUtil.java
+        modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/GetterUtil.java


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-72874

@brianchandotcom This is for changing the value of _run.outside.portal.excludes_ in modules/test/source-formatter.properties to match the change from https://github.com/liferay/liferay-portal/commit/8087ef47f0e842c17566328c9b0b8be88269655b.