### PR TITLE
LPS-69102 Move the General file uploads settings UI from Server Administration to System Settings

### DIFF
--- a/modules/apps/foundation/portal/portal-upload/build.gradle
+++ b/modules/apps/foundation/portal/portal-upload/build.gradle
@@ -1,9 +1,12 @@
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.4.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	provided group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:static:portal-configuration:portal-configuration-persistence")
 }

--- a/modules/apps/foundation/portal/portal-upload/src/main/java/com/liferay/portal/upload/constants/LegacyUploadServletRequestPropsKeys.java
+++ b/modules/apps/foundation/portal/portal-upload/src/main/java/com/liferay/portal/upload/constants/LegacyUploadServletRequestPropsKeys.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upload.constants;
+
+/**
+ * @author Pei-Jung Lan
+ */
+public class LegacyUploadServletRequestPropsKeys {
+
+	public static final String[] KEYS = {
+		LegacyUploadServletRequestPropsKeys.
+			UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE,
+		LegacyUploadServletRequestPropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_TEMP_DIR
+	};
+
+	public static final String UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE =
+		"com.liferay.portal.upload.UploadServletRequestImpl.max.size";
+
+	public static final String UPLOAD_SERVLET_REQUEST_IMPL_TEMP_DIR =
+		"com.liferay.portal.upload.UploadServletRequestImpl.temp.dir";
+
+}

--- a/modules/apps/foundation/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/upgrade/UploadUpgrade.java
+++ b/modules/apps/foundation/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/upgrade/UploadUpgrade.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upload.internal.upgrade;
+
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
+import com.liferay.portal.kernel.util.PrefsProps;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upload.internal.upgrade.v1_0_0.UpgradeUploadServletRequestConfiguration;
+
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
+public class UploadUpgrade implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.register(
+			"com.liferay.portal.upload", "0.0.0", "0.0.1",
+			new DummyUpgradeStep());
+
+		registry.register(
+			"com.liferay.portal.upload", "0.0.1", "1.0.0",
+			new UpgradeUploadServletRequestConfiguration(
+				_configurationAdmin, _prefsProps));
+	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference
+	private PrefsProps _prefsProps;
+
+}

--- a/modules/apps/foundation/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/upgrade/v1_0_0/UpgradeUploadServletRequestConfiguration.java
+++ b/modules/apps/foundation/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/upgrade/v1_0_0/UpgradeUploadServletRequestConfiguration.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upload.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.PrefsProps;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.upload.configuration.UploadServletRequestConfiguration;
+import com.liferay.portal.upload.constants.LegacyUploadServletRequestPropsKeys;
+
+import java.util.Dictionary;
+
+import javax.portlet.PortletPreferences;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Pei-Jung Lan
+ */
+public class UpgradeUploadServletRequestConfiguration extends UpgradeProcess {
+
+	public UpgradeUploadServletRequestConfiguration(
+		ConfigurationAdmin configurationAdmin, PrefsProps prefsProps) {
+
+		_configurationAdmin = configurationAdmin;
+		_prefsProps = prefsProps;
+	}
+
+	protected void doUpgrade() throws Exception {
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			UploadServletRequestConfiguration.class.getName(),
+			StringPool.QUESTION);
+
+		Dictionary properties = configuration.getProperties();
+
+		if (properties == null) {
+			properties = new HashMapDictionary();
+		}
+
+		if (Validator.isNotNull(
+				_prefsProps.getString(
+					LegacyUploadServletRequestPropsKeys.
+						UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE))) {
+
+			properties.put(
+				"maxSize",
+				_prefsProps.getLong(
+					LegacyUploadServletRequestPropsKeys.
+						UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE));
+		}
+
+		if (Validator.isNotNull(
+				_prefsProps.getString(
+					LegacyUploadServletRequestPropsKeys.
+						UPLOAD_SERVLET_REQUEST_IMPL_TEMP_DIR))) {
+
+			properties.put(
+				"tempDir",
+				_prefsProps.getString(
+					LegacyUploadServletRequestPropsKeys.
+						UPLOAD_SERVLET_REQUEST_IMPL_TEMP_DIR));
+		}
+
+		configuration.update(properties);
+
+		PortletPreferences portletPreferences = _prefsProps.getPreferences();
+
+		for (String key : LegacyUploadServletRequestPropsKeys.KEYS) {
+			portletPreferences.reset(key);
+		}
+	}
+
+	private final ConfigurationAdmin _configurationAdmin;
+	private final PrefsProps _prefsProps;
+
+}

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1647,6 +1647,10 @@ public class PropsValues {
 
 	public static final boolean UPGRADE_DATABASE_TRANSACTIONS_DISABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.UPGRADE_DATABASE_TRANSACTIONS_DISABLED));
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public static final long UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE = GetterUtil.getLong(PropsUtil.get(PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE));
 
 	public static boolean USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE));

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProperties.java
@@ -1728,6 +1728,8 @@ public class VerifyProperties extends VerifyProcess {
 		"com.liferay.portal.servlet.filters.monitoring.MonitoringFilter",
 		"com.liferay.portal.servlet.filters.secure.SecureFilter",
 		"com.liferay.portal.servlet.filters.validhtml.ValidHtmlFilter",
+		"com.liferay.portal.upload.UploadServletRequestImpl.max.size",
+		"com.liferay.portal.upload.UploadServletRequestImpl.temp.dir",
 		"commons.pool.enabled", "company.settings.form.configuration",
 		"company.settings.form.identification",
 		"company.settings.form.miscellaneous", "company.settings.form.social",

--- a/portal-impl/src/portal-legacy-7.0.properties
+++ b/portal-impl/src/portal-legacy-7.0.properties
@@ -41,6 +41,9 @@ openoffice.server.host=127.0.0.1
 openoffice.server.port=8100
 openoffice.cache.enabled=true
 
+com.liferay.portal.upload.UploadServletRequestImpl.max.size=104857600
+#com.liferay.portal.upload.UploadServletRequestImpl.temp.dir=C:/Temp
+
 journal.image.small.max.size=51200
 
 journal.image.extensions=.gif,.jpeg,.jpg,.png

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7756,17 +7756,6 @@
 ##
 
     #
-    # Set the maximum upload servlet request content length. Default is 1024 *
-    # 1024 * 100.
-    #
-    com.liferay.portal.upload.UploadServletRequestImpl.max.size=104857600
-
-    #
-    # Set the temp directory for uploaded files.
-    #
-    #com.liferay.portal.upload.UploadServletRequestImpl.temp.dir=C:/Temp
-
-    #
     # Set the threshold size to prevent extraneous serialization of uploaded
     # data.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2352,8 +2352,16 @@ public interface PropsKeys {
 
 	public static final String UPGRADE_PROCESSES = "upgrade.processes";
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public static final String UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE = "com.liferay.portal.upload.UploadServletRequestImpl.max.size";
 
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public static final String UPLOAD_SERVLET_REQUEST_IMPL_TEMP_DIR = "com.liferay.portal.upload.UploadServletRequestImpl.temp.dir";
 
 	public static final String USER_GROUPS_COPY_LAYOUTS_TO_USER_PERSONAL_SITE = "user.groups.copy.layouts.to.user.personal.site";

--- a/readme/7.1/BREAKING_CHANGES.markdown
+++ b/readme/7.1/BREAKING_CHANGES.markdown
@@ -317,3 +317,37 @@ behavior is controlled by the *Buffered Increment* mechanism. You can find
 more information about this in the `portal.properties` file.
 
 ---------------------------------------
+### Moved Upload Servlet Request Portal Properties to OSGi Configuration
+- **Date:** 2017-May-30
+- **JIRA Ticket:** LPS-69102
+
+#### What changed?
+
+The Upload Servlet Request properties have been moved from `portal.properties`
+and Server Administration to an OSGi configuration named
+`UploadServletRequestConfiguration.java` in the `portal-upload` module.
+
+#### Who is affected?
+
+This affects anyone who is using the following portal properties:
+
+- `com.liferay.portal.upload.UploadServletRequestImpl.max.size`
+- `com.liferay.portal.upload.UploadServletRequestImpl.temp.dir`
+
+#### How should I update my code?
+
+Instead of overriding the `portal.properties` file, you can manage the
+properties from Portal's configuration administrator. This can be accessed by
+navigating to Liferay Portal's *Control Panel* &rarr; *Configuration* &rarr;
+*System Settings* &rarr; *Upload Servlet Request* and editing the settings there.
+
+If you would like to include the new configuration in your application, follow
+the instructions for
+[making your applications configurable in Liferay 7.0](https://dev.liferay.com/develop/tutorials/-/knowledge_base/7-0/making-your-applications-configurable).
+
+#### Why was this change made?
+
+This change was made as part of the modularization efforts to ease portal
+configuration changes.
+
+---------------------------------------


### PR DESCRIPTION
Hi Brian,

This is a resend of https://github.com/brianchandotcom/liferay-portal/pull/49270.

I didn't rename UploadUpgrade to Upgrade*.java because UploadUpgrade is an UpgradeStepRegistrator, and all UpgradeStepRegistrator have class names ending in *Upgrade.java. We use the Upgrade*.java naming pattern for UpgradeProcess.

/cc @jorgeferrer @drewbrokke