### PR TITLE
Revert "LPS-72855 Cache toolbarsJSONObject by languageId. ThemeDispla…

### DIFF
--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/build.gradle
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/build.gradle
@@ -1,9 +1,6 @@
 import com.liferay.gradle.util.FileUtil
 import com.liferay.gradle.util.copy.StripPathSegmentsAction
 
-sourceCompatibility = "1.8"
-targetCompatibility = "1.8"
-
 task buildAlloyEditor(type: Copy)
 
 File editorDestinationDir = file("tmp/META-INF/resources")

--- a/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
@@ -31,7 +31,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -68,14 +67,8 @@ public class AlloyEditorConfigContributor
 
 		jsonObject.put("extraPlugins", extraPlugins);
 
-		JSONObject toolbarsJSONObject =
-			_toolbarsJSONObjectCache.computeIfAbsent(
-				themeDisplay.getLanguageId(),
-				(key) -> {
-					return getToolbarsJSONObject(themeDisplay.getLocale());
-				});
-
-		jsonObject.put("toolbars", toolbarsJSONObject);
+		jsonObject.put(
+			"toolbars", getToolbarsJSONObject(themeDisplay.getLocale()));
 	}
 
 	protected JSONObject getStyleFormatJSONObject(
@@ -300,9 +293,6 @@ public class AlloyEditorConfigContributor
 	private static final int _CKEDITOR_STYLE_BLOCK = 1;
 
 	private static final int _CKEDITOR_STYLE_INLINE = 2;
-
-	private static final Map<String, JSONObject> _toolbarsJSONObjectCache =
-		new ConcurrentHashMap<>();
 
 	private volatile ResourceBundleLoader _resourceBundleLoader;
 


### PR DESCRIPTION
…y's languageId should always be the same as its locale, String.hashCode() is faster than Locale.hashCode() so using that as the key."

This reverts commit f2797181edbe810e1aa284d6fee484c17e7c0f56.