### PR TITLE
LPS-72754 Prefix and Suffix aren't stored nor displayed when guest creates account

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
@@ -285,20 +285,7 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		DynamicActionRequest dynamicActionRequest = new DynamicActionRequest(
-			actionRequest);
-
-		long prefixId = getListTypeId(
-			actionRequest, "prefixValue", ListTypeConstants.CONTACT_PREFIX);
-
-		dynamicActionRequest.setParameter("prefixId", String.valueOf(prefixId));
-
-		long suffixId = getListTypeId(
-			actionRequest, "suffixValue", ListTypeConstants.CONTACT_SUFFIX);
-
-		dynamicActionRequest.setParameter("suffixId", String.valueOf(suffixId));
-
-		actionRequest = dynamicActionRequest;
+		actionRequest = _wrapActionRequest(actionRequest);
 
 		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
 
@@ -827,6 +814,25 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 	protected Portal portal;
 
 	protected UserLocalService userLocalService;
+
+	private ActionRequest _wrapActionRequest(ActionRequest actionRequest)
+		throws Exception {
+
+		DynamicActionRequest dynamicActionRequest = new DynamicActionRequest(
+			actionRequest);
+
+		long prefixId = getListTypeId(
+			actionRequest, "prefixValue", ListTypeConstants.CONTACT_PREFIX);
+
+		dynamicActionRequest.setParameter("prefixId", String.valueOf(prefixId));
+
+		long suffixId = getListTypeId(
+			actionRequest, "suffixValue", ListTypeConstants.CONTACT_SUFFIX);
+
+		dynamicActionRequest.setParameter("suffixId", String.valueOf(suffixId));
+
+		return dynamicActionRequest;
+	}
 
 	private AnnouncementsDeliveryLocalService
 		_announcementsDeliveryLocalService;

--- a/modules/apps/foundation/vulcan/.gitrepo
+++ b/modules/apps/foundation/vulcan/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 99f65d45372be2bfe7ab98b76798a02970090f83
+	commit = c0db95c41e6e8d1fe73d26d393474dedcf276565
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 3feed57faa04736b0cf8096c0e725f2faeb018f9
+	parent = 2a13f635a76603f817081d2b3d3b803a271bde58
 	remote = git@github.com:liferay/com-liferay-vulcan.git

--- a/modules/apps/foundation/vulcan/gradle.properties
+++ b/modules/apps/foundation/vulcan/gradle.properties
@@ -1,2 +1,2 @@
-com.liferay.source.formatter.version=1.0.402
+com.liferay.source.formatter.version=1.0.403
 project.path.prefix=:apps:foundation:vulcan

--- a/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/PageMessageBodyWriter.java
+++ b/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/PageMessageBodyWriter.java
@@ -78,7 +78,7 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 		Class<?> type, Type genericType, Annotation[] annotations,
 		MediaType mediaType) {
 
-		Method resourceMethod = resourceInfo.getResourceMethod();
+		Method resourceMethod = _resourceInfo.getResourceMethod();
 
 		Class<?> returnType = resourceMethod.getReturnType();
 
@@ -117,7 +117,7 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 			OutputStream entityStream)
 		throws IOException, WebApplicationException {
 
-		Method resourceMethod = resourceInfo.getResourceMethod();
+		Method resourceMethod = _resourceInfo.getResourceMethod();
 
 		Type genericReturnType = resourceMethod.getGenericReturnType();
 
@@ -175,12 +175,6 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 		printWriter.close();
 	}
 
-	@Context
-	protected ResourceInfo resourceInfo;
-
-	@Context
-	protected UriInfo uriInfo;
-
 	private String _getCollectionURL(Class<T> modelClass) {
 		Optional<String> optional =
 			_uriResolver.getCollectionResourceURIOptional(modelClass);
@@ -188,7 +182,7 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 		String uri = optional.orElseThrow(
 			() -> new VulcanDeveloperError.UnresolvableURI(modelClass));
 
-		return _writerHelper.getAbsoluteURL(uriInfo, uri);
+		return _writerHelper.getAbsoluteURL(_uriInfo, uri);
 	}
 
 	private String _getPageURL(
@@ -216,7 +210,7 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 		FunctionalList<String> parentEmbeddedPathElements) {
 
 		_writerHelper.writeRelatedModel(
-			relatedModel, parentModel, parentEmbeddedPathElements, uriInfo,
+			relatedModel, parentModel, parentEmbeddedPathElements, _uriInfo,
 			(model, modelClass, url, embeddedPathElements) -> {
 				_writerHelper.writeFields(
 					model, modelClass, (fieldName, value) ->
@@ -291,7 +285,7 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 						jsonObjectBuilder, itemJSONObjectBuilder, types));
 
 				_writerHelper.writeSingleResourceURL(
-					item, modelClass, uriInfo, url ->
+					item, modelClass, _uriInfo, url ->
 						pageJSONMessageMapper.mapItemSelfURL(
 							jsonObjectBuilder, itemJSONObjectBuilder, url));
 
@@ -335,7 +329,7 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 		FunctionalList<String> parentEmbeddedPathElements) {
 
 		_writerHelper.writeRelatedModel(
-			relatedModel, parentModel, parentEmbeddedPathElements, uriInfo,
+			relatedModel, parentModel, parentEmbeddedPathElements, _uriInfo,
 			(model, modelClass, url, embeddedPathElements) ->
 				pageJSONMessageMapper.mapItemLinkedResourceURL(
 					pageJSONObjectBuilder, itemJSONObjectBuilder,
@@ -389,6 +383,12 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 
 	@Reference
 	private RepresentorManager _representorManager;
+
+	@Context
+	private ResourceInfo _resourceInfo;
+
+	@Context
+	private UriInfo _uriInfo;
 
 	@Reference
 	private URIResolver _uriResolver;

--- a/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/PageMessageBodyWriter.java
+++ b/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/PageMessageBodyWriter.java
@@ -17,6 +17,7 @@ package com.liferay.vulcan.jaxrs.writer.json.internal;
 import static org.osgi.service.component.annotations.ReferenceCardinality.AT_LEAST_ONE;
 import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
 
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.vulcan.error.VulcanDeveloperError;
 import com.liferay.vulcan.list.FunctionalList;
 import com.liferay.vulcan.message.RequestInfo;
@@ -33,6 +34,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
@@ -76,14 +78,15 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 		Class<?> type, Type genericType, Annotation[] annotations,
 		MediaType mediaType) {
 
-		Class<?> returnType = resourceInfo.getResourceMethod().getReturnType();
+		Method resourceMethod = resourceInfo.getResourceMethod();
+
+		Class<?> returnType = resourceMethod.getReturnType();
 
 		if (!returnType.isAssignableFrom(Page.class)) {
 			return false;
 		}
 
-		Type genericReturnType =
-			resourceInfo.getResourceMethod().getGenericReturnType();
+		Type genericReturnType = resourceMethod.getGenericReturnType();
 
 		Type[] actualTypeArguments =
 			((ParameterizedType)genericReturnType).getActualTypeArguments();
@@ -114,8 +117,9 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 			OutputStream entityStream)
 		throws IOException, WebApplicationException {
 
-		Type genericReturnType =
-			resourceInfo.getResourceMethod().getGenericReturnType();
+		Method resourceMethod = resourceInfo.getResourceMethod();
+
+		Type genericReturnType = resourceMethod.getGenericReturnType();
 
 		Type[] actualTypeArguments =
 			((ParameterizedType)genericReturnType).getActualTypeArguments();
@@ -135,7 +139,9 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 			bodyWriter ->
 				stringMediaType.equals(bodyWriter.getMediaType()) &&
 					bodyWriter.supports(page, modelClass, requestInfo)
-		).findFirst().orElseThrow(
+		).findFirst(
+
+		).orElseThrow(
 			() -> new VulcanDeveloperError.MustHaveMessageMapper(
 				stringMediaType, modelClass)
 		);
@@ -162,7 +168,9 @@ public class PageMessageBodyWriter<T> implements MessageBodyWriter<Page<T>> {
 
 		PrintWriter printWriter = new PrintWriter(entityStream, true);
 
-		printWriter.println(jsonObjectBuilder.build().toString());
+		JSONObject jsonObject = jsonObjectBuilder.build();
+
+		printWriter.println(jsonObject.toString());
 
 		printWriter.close();
 	}

--- a/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/SingleModelMessageBodyWriter.java
+++ b/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/SingleModelMessageBodyWriter.java
@@ -142,19 +142,13 @@ public class SingleModelMessageBodyWriter<T> implements MessageBodyWriter<T> {
 		printWriter.close();
 	}
 
-	@Context
-	protected HttpServletRequest httpServletRequest;
-
-	@Context
-	protected UriInfo uriInfo;
-
 	private <U, V> void _writeEmbeddedRelatedModel(
 		SingleModelJSONMessageMapper<?> singleModelJSONMessageMapper,
 		JSONObjectBuilder jsonObjectBuilder, RelatedModel<U, V> relatedModel,
 		U parentModel, FunctionalList<String> parentEmbeddedPathElements) {
 
 		_writerHelper.writeRelatedModel(
-			relatedModel, parentModel, parentEmbeddedPathElements, uriInfo,
+			relatedModel, parentModel, parentEmbeddedPathElements, _uriInfo,
 			(model, modelClass, url, embeddedPathElements) -> {
 				_writerHelper.writeFields(
 					model, modelClass, (fieldName, value) ->
@@ -199,7 +193,7 @@ public class SingleModelMessageBodyWriter<T> implements MessageBodyWriter<T> {
 		U parentModel, FunctionalList<String> parentEmbeddedPathElements) {
 
 		_writerHelper.writeRelatedModel(
-			relatedModel, parentModel, parentEmbeddedPathElements, uriInfo,
+			relatedModel, parentModel, parentEmbeddedPathElements, _uriInfo,
 			(model, modelClass, url, embeddedPathElements) ->
 				singleModelJSONMessageMapper.mapLinkedResourceURL(
 					jsonObjectBuilder, embeddedPathElements, url));
@@ -228,7 +222,7 @@ public class SingleModelMessageBodyWriter<T> implements MessageBodyWriter<T> {
 				jsonObjectBuilder, types));
 
 		_writerHelper.writeSingleResourceURL(
-			model, modelClass, uriInfo, url ->
+			model, modelClass, _uriInfo, url ->
 				singleModelJSONMessageMapper.mapSelfURL(
 					jsonObjectBuilder, url));
 
@@ -252,12 +246,18 @@ public class SingleModelMessageBodyWriter<T> implements MessageBodyWriter<T> {
 			jsonObjectBuilder, model, modelClass, requestInfo);
 	}
 
+	@Context
+	private HttpServletRequest _httpServletRequest;
+
 	@Reference
 	private RepresentorManager _representorManager;
 
 	@Reference(cardinality = AT_LEAST_ONE, policyOption = GREEDY)
 	private List<SingleModelJSONMessageMapper<T>>
 		_singleModelJSONMessageMappers;
+
+	@Context
+	private UriInfo _uriInfo;
 
 	@Reference
 	private URIResolver _uriResolver;

--- a/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/SingleModelMessageBodyWriter.java
+++ b/modules/apps/foundation/vulcan/vulcan-jaxrs-writer-json/src/main/java/com/liferay/vulcan/jaxrs/writer/json/internal/SingleModelMessageBodyWriter.java
@@ -17,6 +17,7 @@ package com.liferay.vulcan.jaxrs.writer.json.internal;
 import static org.osgi.service.component.annotations.ReferenceCardinality.AT_LEAST_ONE;
 import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
 
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.vulcan.error.VulcanDeveloperError;
 import com.liferay.vulcan.list.FunctionalList;
 import com.liferay.vulcan.message.RequestInfo;
@@ -121,7 +122,9 @@ public class SingleModelMessageBodyWriter<T> implements MessageBodyWriter<T> {
 				messageMapper ->
 					stringMediaType.equals(messageMapper.getMediaType()) &&
 						messageMapper.supports(model, modelClass, requestInfo)
-			).findFirst().orElseThrow(
+			).findFirst(
+
+			).orElseThrow(
 				() -> new VulcanDeveloperError.MustHaveMessageMapper(
 					stringMediaType, modelClass)
 			);
@@ -132,7 +135,9 @@ public class SingleModelMessageBodyWriter<T> implements MessageBodyWriter<T> {
 
 		PrintWriter printWriter = new PrintWriter(entityStream, true);
 
-		printWriter.println(jsonObjectBuilder.build().toString());
+		JSONObject jsonObject = jsonObjectBuilder.build();
+
+		printWriter.println(jsonObject.toString());
 
 		printWriter.close();
 	}

--- a/modules/apps/foundation/vulcan/vulcan-liferay-api/src/main/java/com/liferay/vulcan/liferay/internal/LiferayDispatcherResource.java
+++ b/modules/apps/foundation/vulcan/vulcan-liferay-api/src/main/java/com/liferay/vulcan/liferay/internal/LiferayDispatcherResource.java
@@ -49,7 +49,7 @@ public class LiferayDispatcherResource implements Resource {
 
 		Resource resource = _resources.get(path);
 
-		resourceContext.initResource(resource);
+		_resourceContext.initResource(resource);
 
 		if (resource instanceof GroupScoped) {
 			GroupScoped groupScoped = (GroupScoped)resource;
@@ -61,7 +61,7 @@ public class LiferayDispatcherResource implements Resource {
 	}
 
 	@Context
-	protected ResourceContext resourceContext;
+	private ResourceContext _resourceContext;
 
 	private final ResourceMapper _resourceMapper;
 	private final Map<String, Resource> _resources = new HashMap<>();

--- a/modules/apps/foundation/vulcan/vulcan-liferay-api/src/main/java/com/liferay/vulcan/liferay/internal/LiferayRootEndpoint.java
+++ b/modules/apps/foundation/vulcan/vulcan-liferay-api/src/main/java/com/liferay/vulcan/liferay/internal/LiferayRootEndpoint.java
@@ -87,7 +87,7 @@ public class LiferayRootEndpoint implements RootEndpoint {
 				groupScoped.setGroupId(GroupThreadLocal.getGroupId());
 			}
 
-			resourceContext.initResource(resource);
+			_resourceContext.initResource(resource);
 
 			return resource;
 		}
@@ -95,7 +95,7 @@ public class LiferayRootEndpoint implements RootEndpoint {
 			LiferayDispatcherResource liferayDispatcherResource =
 				new LiferayDispatcherResource((ResourceMapper)apiContributor);
 
-			resourceContext.initResource(liferayDispatcherResource);
+			_resourceContext.initResource(liferayDispatcherResource);
 
 			return liferayDispatcherResource;
 		}
@@ -104,7 +104,7 @@ public class LiferayRootEndpoint implements RootEndpoint {
 	}
 
 	@Context
-	protected ResourceContext resourceContext;
+	private ResourceContext _resourceContext;
 
 	private ServiceTrackerMap<String, APIContributor> _serviceTrackerMap;
 

--- a/modules/apps/foundation/vulcan/vulcan-sample-rest/src/main/java/com/liferay/vulcan/sample/rest/internal/vulcan/resource/PersonCollectionResource.java
+++ b/modules/apps/foundation/vulcan/vulcan-sample-rest/src/main/java/com/liferay/vulcan/sample/rest/internal/vulcan/resource/PersonCollectionResource.java
@@ -71,10 +71,10 @@ public class PersonCollectionResource
 	public Page<User> getPage(Pagination paginationParams) {
 		try {
 			List<User> users = _userService.getCompanyUsers(
-				company.getCompanyId(), paginationParams.getStartPosition(),
+				_company.getCompanyId(), paginationParams.getStartPosition(),
 				paginationParams.getEndPosition());
 			int count = _userService.getCompanyUsersCount(
-				company.getCompanyId());
+				_company.getCompanyId());
 
 			return paginationParams.createPage(users, count);
 		}
@@ -89,7 +89,7 @@ public class PersonCollectionResource
 	}
 
 	@Context
-	protected Company company;
+	private Company _company;
 
 	@Reference
 	private UserService _userService;


### PR DESCRIPTION
This is an update for [LPS-72754](https://issues.liferay.com/browse/LPS-72754).<br><br>Hey Brian, since we are abstracting the prefix/suffixId logic in 0ce7004, we should do the same in users-admin-web (this is where the logic was taken from in the first place).