### PR TITLE
LPS-72929 Fix leftover garbage output from LPS-34707 a94d4f1f876acea1…

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCActionCommand.java
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/action/ImportLayoutsMVCActionCommand.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.LayoutService;
-import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadException;
@@ -291,9 +290,6 @@ public class ImportLayoutsMVCActionCommand extends BaseMVCActionCommand {
 
 		JSONPortletResponseUtil.writeJSON(
 			actionRequest, actionResponse, jsonObject);
-
-		ServletResponseUtil.write(
-			response, String.valueOf(jsonObject.getInt("status")));
 	}
 
 	protected void importData(ActionRequest actionRequest, String folderName)


### PR DESCRIPTION
…ffa8f69a66cff046de24378e, in this commit, the repoonse content was changed to JSON to include both errorType and errorMessage, but forgot to remove the previous plain text errorType output.

@tomwang2011 please backport to ee-7.0.x and ee-6.2.x, another preparation for the same customer issue.