### PR TITLE
[TS] LPS-72517 FIX Bad facets, tokens crash Search Portlet

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexSearcher.java
@@ -505,14 +505,19 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 
 		searchRequestBuilder.setQuery(queryBuilder);
 
-		searchContext.setAttribute(
-			"queryString", searchRequestBuilder.toString());
+		String searchRequestBuilderString = searchRequestBuilder.toString();
+
+		searchContext.setAttribute("queryString", searchRequestBuilderString);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Search query " + searchRequestBuilderString);
+		}
 
 		SearchResponse searchResponse = searchRequestBuilder.get();
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
-				"The search engine processed " + queryBuilder.toString() +
+				"The search engine processed " + searchRequestBuilderString +
 					" in " + searchResponse.getTook());
 		}
 

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexSearcherHelperImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexSearcherHelperImpl.java
@@ -62,10 +62,6 @@ public class IndexSearcherHelperImpl implements IndexSearcherHelper {
 	public Hits search(SearchContext searchContext, Query query)
 		throws SearchException {
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("Search query " + getQueryString(searchContext, query));
-		}
-
 		SearchEngine searchEngine = _searchEngineHelper.getSearchEngine(
 			searchContext.getSearchEngineId());
 
@@ -77,10 +73,6 @@ public class IndexSearcherHelperImpl implements IndexSearcherHelper {
 	@Override
 	public long searchCount(SearchContext searchContext, Query query)
 		throws SearchException {
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Search query " + getQueryString(searchContext, query));
-		}
 
 		SearchEngine searchEngine = _searchEngineHelper.getSearchEngine(
 			searchContext.getSearchEngineId());

--- a/modules/apps/foundation/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/facet/tag/AssetTagNamesFacetTest.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/facet/tag/AssetTagNamesFacetTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.facet.tag;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author André de Oliveira
+ */
+public class AssetTagNamesFacetTest {
+
+	@Test
+	public void testFacetCollector() {
+		Facet assetTagNamesFacet = new AssetTagNamesFacet(null);
+
+		FacetCollector facetCollector = assetTagNamesFacet.getFacetCollector();
+
+		List<TermCollector> termCollectors = facetCollector.getTermCollectors();
+
+		Assert.assertTrue(termCollectors.isEmpty());
+	}
+
+}

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
@@ -448,8 +448,6 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 
 		solrQuery.setQuery(queryString);
 
-		searchContext.setAttribute("queryString", queryString);
-
 		List<String> filterQueries = new ArrayList<>();
 
 		if (query.getPreBooleanFilter() != null) {
@@ -471,11 +469,19 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 				filterQueries.toArray(new String[filterQueries.size()]));
 		}
 
+		String solrQueryString = solrQuery.toString();
+
+		searchContext.setAttribute("queryString", solrQueryString);
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Search query " + solrQueryString);
+		}
+
 		QueryResponse queryResponse = executeSearchRequest(solrQuery);
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
-				"The search engine processed " + solrQuery.getQuery() + " in " +
+				"The search engine processed " + solrQueryString + " in " +
 					queryResponse.getElapsedTime() + " ms");
 		}
 

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrQuerySuggester.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrQuerySuggester.java
@@ -140,11 +140,11 @@ public class SolrQuerySuggester extends BaseQuerySuggester {
 			return querySuggestions;
 		}
 		catch (Exception e) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to execute Solr query", e);
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to execute Solr query", e);
 			}
 
-			throw new SearchException(e.getMessage());
+			return new String[0];
 		}
 	}
 

--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/SolrQuerySuggesterTest.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/SolrQuerySuggesterTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr.internal;
+
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.solr.connection.SolrClientManager;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author André de Oliveira
+ */
+public class SolrQuerySuggesterTest {
+
+	@Test
+	public void testErrorReturnsEmptyResults() throws Exception {
+		SolrQuerySuggester solrQuerySuggester = createSolrQuerySuggester();
+
+		String[] querySuggestions = solrQuerySuggester.suggestKeywordQueries(
+			createSearchContext(), 0);
+
+		Assert.assertEquals(
+			Arrays.toString(querySuggestions), 0, querySuggestions.length);
+	}
+
+	protected SearchContext createSearchContext() {
+		return new SearchContext() {
+			{
+				setKeywords(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected SolrQuerySuggester createSolrQuerySuggester() {
+		return new SolrQuerySuggester() {
+			{
+				setSolrClientManager(Mockito.mock(SolrClientManager.class));
+			}
+		};
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/facet/BaseFacet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/facet/BaseFacet.java
@@ -18,12 +18,16 @@ import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
+import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.search.facet.util.BaseFacetValueValidator;
 import com.liferay.portal.kernel.search.facet.util.FacetValueValidator;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Raymond Augé
@@ -126,9 +130,28 @@ public abstract class BaseFacet implements Facet {
 
 	protected abstract BooleanClause<Filter> doGetFacetFilterBooleanClause();
 
-	private FacetCollector _facetCollector;
+	private FacetCollector _facetCollector = new NullFacetCollector();
 	private FacetConfiguration _facetConfiguration = new FacetConfiguration();
 	private FacetValueValidator _facetValueValidator;
 	private final SearchContext _searchContext;
+
+	private class NullFacetCollector implements FacetCollector {
+
+		@Override
+		public String getFieldName() {
+			return _facetConfiguration.getFieldName();
+		}
+
+		@Override
+		public TermCollector getTermCollector(String term) {
+			return null;
+		}
+
+		@Override
+		public List<TermCollector> getTermCollectors() {
+			return Collections.<TermCollector>emptyList();
+		}
+
+	}
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-72517

Thanks @daviddotzhang for the comprehensive analysis of all consumers of `Facet.getFacetCollectors`; made it clear this API wasn't invoker friendly enough. Now with an empty result by default (instead of a null) we can prevent `NullPointerException` "surprises" without a need to change all callers and add guard clauses.
