### PR TITLE
LPS-72687 Alphabetize parameters

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -90,8 +90,8 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	@Override

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderSearchTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFolderSearchTest.java
@@ -50,8 +50,8 @@ public class DLFolderSearchTest extends BaseSearchTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Ignore
 	@Override

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLCheckInCheckOutTest.java
@@ -78,8 +78,8 @@ public class DLCheckInCheckOutTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryLocalServiceTest.java
@@ -107,8 +107,8 @@ public class DLFileEntryLocalServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryServiceTest.java
@@ -64,8 +64,8 @@ public class DLFileEntryServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -81,8 +81,8 @@ public class DLFileEntryTypeServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionTest.java
@@ -83,8 +83,8 @@ public class DLFileVersionTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderLocalServiceTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFolderLocalServiceTest.java
@@ -57,8 +57,8 @@ public class DLFolderLocalServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/PDFProcessorTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/PDFProcessorTest.java
@@ -75,8 +75,8 @@ public class PDFProcessorTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
@@ -104,8 +104,8 @@ public class DLFileEntryTrashHandlerTest
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileShortcutTrashHandlerTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileShortcutTrashHandlerTest.java
@@ -76,8 +76,8 @@ public class DLFileShortcutTrashHandlerTest
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Override
 	public AssetEntry fetchAssetEntry(ClassedModel classedModel)

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFolderTrashHandlerTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFolderTrashHandlerTest.java
@@ -79,8 +79,8 @@ public class DLFolderTrashHandlerTest
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/verify/test/DLServiceVerifyProcessTest.java
@@ -98,8 +98,8 @@ public class DLServiceVerifyProcessTest extends BaseVerifyProcessTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/collaboration/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
+++ b/modules/apps/collaboration/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/search/test/MBMessageSearchTest.java
@@ -66,8 +66,8 @@ public class MBMessageSearchTest extends BaseSearchTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Ignore
 	@Override

--- a/modules/apps/collaboration/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageServiceTest.java
+++ b/modules/apps/collaboration/message-boards/message-boards-test/src/testIntegration/java/com/liferay/message/boards/service/test/MBMessageServiceTest.java
@@ -77,8 +77,8 @@ public class MBMessageServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/search/test/WikiPageTitleSearcherTest.java
+++ b/modules/apps/collaboration/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/search/test/WikiPageTitleSearcherTest.java
@@ -65,8 +65,8 @@ public class WikiPageTitleSearcherTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarBookingIndexerTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarBookingIndexerTest.java
@@ -70,8 +70,8 @@ public class CalendarBookingIndexerTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarSearcherTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/search/test/CalendarSearcherTest.java
@@ -66,8 +66,8 @@ public class CalendarSearcherTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -79,8 +79,8 @@ public class DDLRecordSearchTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetCategorySearchTest.java
+++ b/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetCategorySearchTest.java
@@ -54,8 +54,8 @@ public class AssetCategorySearchTest extends BaseSearchTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Ignore
 	@Override

--- a/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetTagsSearchTest.java
+++ b/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetTagsSearchTest.java
@@ -55,8 +55,8 @@ public class AssetTagsSearchTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetVocabularySearchTest.java
+++ b/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetVocabularySearchTest.java
@@ -49,8 +49,8 @@ public class AssetVocabularySearchTest extends BaseSearchTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Ignore
 	@Override

--- a/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetVocabularyServiceTest.java
@@ -67,8 +67,8 @@ public class AssetVocabularyServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			SynchronousDestinationTestRule.INSTANCE,
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {


### PR DESCRIPTION
Hi Brian, this fixes all the parameter orders from the pull I sent, if there are other occurrences they should be able to get picked up once Hugo adds the SF rule for this.

Hi @hhuijser, can you help add a SF rule for these cases, where if `new AggregateTestRule(...` is called we check if the parameters are alphabetized? The actual sorting logic to apply testrules is inside the constructor, thanks!