### PR TITLE
LPS-71578

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
-import com.liferay.portal.service.http.LayoutServiceHttp;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.exportimport.service.http.StagingServiceHttp;
 
@@ -262,7 +261,7 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 			Layout parentLayout = LayoutLocalServiceUtil.getLayout(
 				layout.getGroupId(), layout.isPrivateLayout(), parentLayoutId);
 
-			if (LayoutServiceHttp.hasLayout(
+			if (StagingServiceHttp.hasRemoteLayout(
 					httpPrincipal, parentLayout.getUuid(), remoteGroupId,
 					parentLayout.getPrivateLayout())) {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -974,6 +974,9 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 	public boolean hasLayout(String uuid, long groupId, boolean privateLayout)
 		throws PortalException {
 
+		GroupPermissionUtil.check(
+			getPermissionChecker(), groupId, ActionKeys.VIEW);
+
 		return layoutLocalService.hasLayout(uuid, groupId, privateLayout);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/http/StagingServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/http/StagingServiceHttp.java
@@ -116,6 +116,38 @@ public class StagingServiceHttp {
 		}
 	}
 
+	public static boolean hasRemoteLayout(HttpPrincipal httpPrincipal,
+		java.lang.String uuid, long groupId, boolean privateLayout)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(StagingServiceUtil.class,
+					"hasRemoteLayout", _hasRemoteLayoutParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, uuid,
+					groupId, privateLayout);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Boolean)returnObj).booleanValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static void propagateExportImportLifecycleEvent(
 		HttpPrincipal httpPrincipal, int code, int processFlag,
 		java.lang.String processId,
@@ -124,7 +156,7 @@ public class StagingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(StagingServiceUtil.class,
 					"propagateExportImportLifecycleEvent",
-					_propagateExportImportLifecycleEventParameterTypes2);
+					_propagateExportImportLifecycleEventParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, code,
 					processFlag, processId, arguments);
@@ -155,7 +187,7 @@ public class StagingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(StagingServiceUtil.class,
 					"publishStagingRequest",
-					_publishStagingRequestParameterTypes3);
+					_publishStagingRequestParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					stagingRequestId, privateLayout, parameterMap);
@@ -189,7 +221,7 @@ public class StagingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(StagingServiceUtil.class,
 					"publishStagingRequest",
-					_publishStagingRequestParameterTypes4);
+					_publishStagingRequestParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					stagingRequestId, exportImportConfiguration);
@@ -221,7 +253,7 @@ public class StagingServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(StagingServiceUtil.class,
-					"updateStagingRequest", _updateStagingRequestParameterTypes5);
+					"updateStagingRequest", _updateStagingRequestParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					stagingRequestId, fileName, bytes);
@@ -252,7 +284,7 @@ public class StagingServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(StagingServiceUtil.class,
 					"validateStagingRequest",
-					_validateStagingRequestParameterTypes6);
+					_validateStagingRequestParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					stagingRequestId, privateLayout, parameterMap);
@@ -286,21 +318,24 @@ public class StagingServiceHttp {
 	private static final Class<?>[] _createStagingRequestParameterTypes1 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _propagateExportImportLifecycleEventParameterTypes2 =
+	private static final Class<?>[] _hasRemoteLayoutParameterTypes2 = new Class[] {
+			java.lang.String.class, long.class, boolean.class
+		};
+	private static final Class<?>[] _propagateExportImportLifecycleEventParameterTypes3 =
 		new Class[] {
 			int.class, int.class, java.lang.String.class, java.util.List.class
 		};
-	private static final Class<?>[] _publishStagingRequestParameterTypes3 = new Class[] {
+	private static final Class<?>[] _publishStagingRequestParameterTypes4 = new Class[] {
 			long.class, boolean.class, java.util.Map.class
 		};
-	private static final Class<?>[] _publishStagingRequestParameterTypes4 = new Class[] {
+	private static final Class<?>[] _publishStagingRequestParameterTypes5 = new Class[] {
 			long.class,
 			com.liferay.exportimport.kernel.model.ExportImportConfiguration.class
 		};
-	private static final Class<?>[] _updateStagingRequestParameterTypes5 = new Class[] {
+	private static final Class<?>[] _updateStagingRequestParameterTypes6 = new Class[] {
 			long.class, java.lang.String.class, byte[].class
 		};
-	private static final Class<?>[] _validateStagingRequestParameterTypes6 = new Class[] {
+	private static final Class<?>[] _validateStagingRequestParameterTypes7 = new Class[] {
 			long.class, boolean.class, java.util.Map.class
 		};
 }

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/http/StagingServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/http/StagingServiceSoap.java
@@ -81,6 +81,21 @@ public class StagingServiceSoap {
 		}
 	}
 
+	public static boolean hasRemoteLayout(java.lang.String uuid, long groupId,
+		boolean privateLayout) throws RemoteException {
+		try {
+			boolean returnValue = StagingServiceUtil.hasRemoteLayout(uuid,
+					groupId, privateLayout);
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static void propagateExportImportLifecycleEvent(int code,
 		int processFlag, java.lang.String processId,
 		java.util.List<java.io.Serializable> arguments)

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/impl/StagingServiceImpl.java
@@ -58,6 +58,17 @@ public class StagingServiceImpl extends StagingServiceBaseImpl {
 	}
 
 	@Override
+	public boolean hasRemoteLayout(
+			String uuid, long groupId, boolean privateLayout)
+		throws PortalException {
+
+		GroupPermissionUtil.check(
+			getPermissionChecker(), groupId, ActionKeys.EXPORT_IMPORT_LAYOUTS);
+
+		return layoutLocalService.hasLayout(uuid, groupId, privateLayout);
+	}
+
+	@Override
 	public void propagateExportImportLifecycleEvent(
 			int code, int processFlag, String processId,
 			List<Serializable> arguments)

--- a/portal-kernel/src/com/liferay/exportimport/kernel/service/StagingService.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/service/StagingService.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.service.BaseService;
 import com.liferay.portal.kernel.transaction.Isolation;
+import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 
 import java.io.Serializable;
@@ -54,6 +55,9 @@ public interface StagingService extends BaseService {
 	 *
 	 * Never modify or reference this interface directly. Always use {@link StagingServiceUtil} to access the staging remote service. Add custom service methods to {@link com.liferay.portlet.exportimport.service.impl.StagingServiceImpl} and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasRemoteLayout(java.lang.String uuid, long groupId,
+		boolean privateLayout) throws PortalException;
 
 	/**
 	* @deprecated As of 7.0.0, with no direct replacement

--- a/portal-kernel/src/com/liferay/exportimport/kernel/service/StagingServiceUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/service/StagingServiceUtil.java
@@ -40,6 +40,11 @@ public class StagingServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to {@link com.liferay.portlet.exportimport.service.impl.StagingServiceImpl} and rerun ServiceBuilder to regenerate this class.
 	 */
+	public static boolean hasRemoteLayout(java.lang.String uuid, long groupId,
+		boolean privateLayout)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().hasRemoteLayout(uuid, groupId, privateLayout);
+	}
 
 	/**
 	* @deprecated As of 7.0.0, with no direct replacement

--- a/portal-kernel/src/com/liferay/exportimport/kernel/service/StagingServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/service/StagingServiceWrapper.java
@@ -32,6 +32,13 @@ public class StagingServiceWrapper implements StagingService,
 		_stagingService = stagingService;
 	}
 
+	@Override
+	public boolean hasRemoteLayout(java.lang.String uuid, long groupId,
+		boolean privateLayout)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _stagingService.hasRemoteLayout(uuid, groupId, privateLayout);
+	}
+
 	/**
 	* @deprecated As of 7.0.0, with no direct replacement
 	*/


### PR DESCRIPTION
@brianchandotcom this is a follow up pull for the same ticket.

- somehow the permission check was removed from the LayoutServiceImpl added it back
- @moltam89 suggested that the export import permission might not be suitable for layout service. we have agreed the best would be if the remote call in staging would control what permission would be needed to access this data and the layout can control differently. this way every area has control over their domain