### PR TITLE
LPS-73011 Default role's permission(Add to Page) definition are reset when restarting

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -1189,6 +1189,13 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		String[] roleNames = portlet.getRolesArray();
 
+		Portlet existingPortlet = portletPersistence.fetchByC_P(
+			portlet.getCompanyId(), portlet.getPortletId());
+
+		if (existingPortlet != null) {
+			roleNames = existingPortlet.getRolesArray();
+		}
+
 		if (roleNames.length == 0) {
 			return;
 		}


### PR DESCRIPTION
This is an update for [LPS-73011](https://issues.liferay.com/browse/LPS-73011).<br><br>/cc @hhuijser, @yuhai