### PR TITLE
Lps 69008

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/util/CacheFileNameContributor.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/util/CacheFileNameContributor.java
@@ -14,14 +14,15 @@
 
 package com.liferay.portal.servlet.filters.util;
 
-import com.liferay.portal.kernel.util.Function;
-import com.liferay.portal.kernel.util.KeyValuePair;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Carlos Sierra Andrés
  */
-public interface CacheFileNameContributor
-	extends Function<HttpServletRequest, KeyValuePair> {
+public interface CacheFileNameContributor {
+
+	public String getParameterName();
+
+	public String getParameterValue(HttpServletRequest request);
+
 }

--- a/portal-impl/src/com/liferay/portal/servlet/filters/util/CacheFileNameGenerator.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/util/CacheFileNameGenerator.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.Digester;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -52,16 +51,16 @@ public class CacheFileNameGenerator {
 		for (CacheFileNameContributor cacheFileNameContributor :
 				_cacheFileNameContributors) {
 
-			KeyValuePair keyValuePair = cacheFileNameContributor.apply(request);
+			String value = cacheFileNameContributor.getParameterValue(request);
 
-			if (keyValuePair == null) {
+			if (value == null) {
 				continue;
 			}
 
 			queryStringSB.append(StringPool.UNDERLINE);
-			queryStringSB.append(keyValuePair.getKey());
+			queryStringSB.append(cacheFileNameContributor.getParameterName());
 			queryStringSB.append(StringPool.UNDERLINE);
-			queryStringSB.append(keyValuePair.getValue());
+			queryStringSB.append(value);
 		}
 
 		cacheKeyGenerator.append(
@@ -85,10 +84,7 @@ public class CacheFileNameGenerator {
 	}
 
 	private static final List<CacheFileNameContributor>
-		_cacheFileNameContributors =
-			(List<CacheFileNameContributor>)(List<?>)
-				ServiceTrackerCollections.openList(
-					CacheFileNameContributor.class,
-					"(cache.file.name.contributor=true)");
+		_cacheFileNameContributors = ServiceTrackerCollections.openList(
+			CacheFileNameContributor.class);
 
 }

--- a/portal-impl/src/com/liferay/portal/servlet/filters/util/LanguageIdCacheFileNameContributor.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/util/LanguageIdCacheFileNameContributor.java
@@ -15,8 +15,6 @@
 package com.liferay.portal.servlet.filters.util;
 
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
-import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.util.Locale;
@@ -27,18 +25,22 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * @author Carlos Sierra Andrés
  */
-@OSGiBeanProperties(property = "cache.file.name.contributor=true")
 public class LanguageIdCacheFileNameContributor
 	implements CacheFileNameContributor {
 
 	@Override
-	public KeyValuePair apply(HttpServletRequest request) {
-		String languageId = request.getParameter("languageId");
+	public String getParameterName() {
+		return "languageId";
+	}
+
+	@Override
+	public String getParameterValue(HttpServletRequest request) {
+		String languageId = request.getParameter(getParameterName());
 
 		Set<Locale> availableLocales = LanguageUtil.getAvailableLocales();
 
 		if (availableLocales.contains(LocaleUtil.fromLanguageId(languageId))) {
-			return new KeyValuePair("languageId", languageId);
+			return languageId;
 		}
 
 		return null;

--- a/portal-impl/src/com/liferay/portal/servlet/filters/util/MinifierTypeCacheFileNameContributor.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/util/MinifierTypeCacheFileNameContributor.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.servlet.filters.util;
 
-import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
-import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.Validator;
 
 import javax.servlet.http.HttpServletRequest;
@@ -23,20 +21,24 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * @author Carlos Sierra Andrés
  */
-@OSGiBeanProperties(property = "cache.file.name.contributor=true")
 public class MinifierTypeCacheFileNameContributor
 	implements CacheFileNameContributor {
 
 	@Override
-	public KeyValuePair apply(HttpServletRequest request) {
-		String minifierType = request.getParameter("minifierType");
+	public String getParameterName() {
+		return "minifierType";
+	}
+
+	@Override
+	public String getParameterValue(HttpServletRequest request) {
+		String minifierType = request.getParameter(getParameterName());
 
 		if (Validator.isNull(minifierType)) {
 			return null;
 		}
 
 		if (minifierType.equals("css") || minifierType.equals("js")) {
-			return new KeyValuePair("minifierType", minifierType);
+			return minifierType;
 		}
 
 		return null;

--- a/portal-impl/src/com/liferay/portal/servlet/filters/util/ThemeIdCacheFileNameContributor.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/util/ThemeIdCacheFileNameContributor.java
@@ -16,8 +16,6 @@ package com.liferay.portal.servlet.filters.util;
 
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.service.ThemeLocalServiceUtil;
-import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
-import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import javax.servlet.http.HttpServletRequest;
@@ -25,22 +23,26 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * @author Carlos Sierra Andrés
  */
-@OSGiBeanProperties(property = "cache.file.name.contributor=true")
 public class ThemeIdCacheFileNameContributor
 	implements CacheFileNameContributor {
 
 	@Override
-	public KeyValuePair apply(HttpServletRequest request) {
-		long companyId = PortalUtil.getCompanyId(request);
-		String themeId = request.getParameter("themeId");
+	public String getParameterName() {
+		return "themeId";
+	}
 
-		Theme theme = ThemeLocalServiceUtil.fetchTheme(companyId, themeId);
+	@Override
+	public String getParameterValue(HttpServletRequest request) {
+		String themeId = request.getParameter(getParameterName());
 
-		if (theme != null) {
-			return new KeyValuePair("themeId", themeId);
+		Theme theme = ThemeLocalServiceUtil.fetchTheme(
+			PortalUtil.getCompanyId(request), themeId);
+
+		if (theme == null) {
+			return null;
 		}
 
-		return null;
+		return themeId;
 	}
 
 }


### PR DESCRIPTION
@brianchandotcom this fixes the type safe issue, in case you prefer to keep the standalone interface. If not, then this pull is not needed.

This does not fix the module contribution issues. If we want to allow modules provide their own contributors, CacheFileNameContributor must be moved to an exported package. And I don't think we want to export CacheFileNameGenerator. I am not really sure which package you would prefer.