### PR TITLE
LPS-73193 petra-json-ws-client - don't use emptyList type, objMapper would instantiate empty list. Pass class of an final List implementation

### DIFF
--- a/modules/apps/foundation/petra/petra-json-web-service-client/src/main/java/com/liferay/petra/json/web/service/client/BaseJSONWebServiceClientHandler.java
+++ b/modules/apps/foundation/petra/petra-json-web-service-client/src/main/java/com/liferay/petra/json/web/service/client/BaseJSONWebServiceClientHandler.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 
 import java.io.IOException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -103,7 +104,7 @@ public abstract class BaseJSONWebServiceClientHandler {
 		try {
 			TypeFactory typeFactory = objectMapper.getTypeFactory();
 
-			List<V> list = Collections.emptyList();
+			List<V> list = new ArrayList<>();
 
 			JavaType javaType = typeFactory.constructCollectionType(
 				list.getClass(), clazz);


### PR DESCRIPTION
Hi Brian please merge. Thank you! @ivicac