### PR TITLE
LPS-73304 Add liferay/adaptive_media_processor to the sync destinatio…

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/callback/SynchronousDestinationTestCallback.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/callback/SynchronousDestinationTestCallback.java
@@ -190,6 +190,8 @@ public class SynchronousDestinationTestCallback
 
 			ProxyModeThreadLocal.setForceSync(true);
 
+			replaceDestination("liferay/adaptive_media_processor");
+
 			replaceDestination(DestinationNames.ASYNC_SERVICE);
 			replaceDestination(DestinationNames.BACKGROUND_TASK);
 			replaceDestination(DestinationNames.BACKGROUND_TASK_STATUS);


### PR DESCRIPTION
…n list

@brianchandotcom in case there are more destinations from modules need this, I will refactor this to be typesafe way, rather than using string constant. But let's keep this simple for now, since this is the only case we have so far.

CC @adolfopa