### PR TITLE
LPS-73209 Add dummy socket proxy to stop accessing the internet durin…

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -729,6 +729,8 @@ information.
 				<jvmarg value="-Dosgi.state.dir=${liferay.home}/osgi/state" />
 				<jvmarg value="-Drelease.versions.test.other.dir=${release.versions.test.other.dir}" />
 				<jvmarg value="-Dsun.zip.disableMemoryMapping=true" />
+				<jvmarg value="-DsocksProxyHost=127.0.0.1" />
+				<jvmarg value="-DsocksProxyPort=8888" />
 				<misc />
 				<jvmarg value="-Duser.timezone=GMT" />
 				<classpath location="test-coverage" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -3051,6 +3051,39 @@ go</echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="setup-testable-tomcat-dummy-socket-proxy">
+		<sequential>
+			<local name="dummy.socket.proxy" />
+
+			<property name="dummy.socket.proxy" value="-DsocksProxyHost=127.0.0.1 -DsocksProxyPort=8888" />
+
+			<if>
+				<not>
+					<resourcecontains resource="${app.server.tomcat.dir}/bin/setenv.bat" substring="${dummy.socket.proxy}" />
+				</not>
+				<then>
+					<echo append="true" file="${app.server.tomcat.dir}/bin/setenv.bat">
+						<![CDATA[
+							set "CATALINA_OPTS=%CATALINA_OPTS% ${dummy.socket.proxy}"
+						]]>
+					</echo>
+				</then>
+			</if>
+			<if>
+				<not>
+					<resourcecontains resource="${app.server.tomcat.dir}/bin/setenv.sh" substring="${dummy.socket.proxy}" />
+				</not>
+				<then>
+					<echo append="true" file="${app.server.tomcat.dir}/bin/setenv.sh">
+						<![CDATA[
+							CATALINA_OPTS="${CATALINA_OPTS} ${dummy.socket.proxy}"
+						]]>
+					</echo>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="setup-testable-tomcat-gc">
 		<sequential>
 			<if>
@@ -3361,6 +3394,8 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 	<macrodef name="setup-testable-tomcat-setenv">
 		<sequential>
 			<setup-testable-tomcat-aspectj-agent />
+
+			<setup-testable-tomcat-dummy-socket-proxy />
 
 			<setup-testable-tomcat-gc />
 


### PR DESCRIPTION
…g tests

@brianchandotcom this is banning all network accesses in all tests (unit/integration/module integration), except for localhost accessing. We have ran into network caused test failure many times, and so far we cleared all of them, and we need this to prevent any future usages get added in.

@Ithildir do you think you can apply this to all ant/gradle jvms on CI? We have ran into many network caused build failures before. And we believe we are not downloading anything during build on CI, but we don't really know it or having a way to protect it. This can be used for that purpose too.