### PR TITLE
LPS-73026 Blog comment text is not translated

### DIFF
--- a/portal-impl/src/content/Language_zh_CN.properties
+++ b/portal-impl/src/content/Language_zh_CN.properties
@@ -5544,7 +5544,7 @@ x-cannot-be-unassociated-from-this-organization=<em>{0}</em>不能从这个组�
 x-cannot-be-unassociated-from-this-site=<em>{0}</em> 不能从这个站点中解除关联。
 x-changed-the-state-from-x-to-x={0}将状态从{1}改变为{2} 。
 x-child-sites={0}子网站
-x-comment={0} Comment (Automatic Copy)
+x-comment={0}评论
 x-comments=添加评论
 x-completed-the-task-x={0}完成了任务{1} 。
 x-convert-x-to-x=<span class="{0}">将{1}改变成</span>{2}


### PR DESCRIPTION
Fixed with due translations

tested on:
Tomcat : 8.x
MySql: 5.6
IE, Mozilla, Google Chrome