### PR TITLE
LPS-73466 Move upgrade processes implemented after the release of GA3…

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_4.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_4.java
@@ -16,33 +16,32 @@ package com.liferay.portal.upgrade;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ReleaseInfo;
-import com.liferay.portal.upgrade.v7_0_3.UpgradeGroup;
-import com.liferay.portal.upgrade.v7_0_3.UpgradeMessageBoards;
-import com.liferay.portal.upgrade.v7_0_3.UpgradeModules;
-import com.liferay.portal.upgrade.v7_0_3.UpgradeOracle;
-import com.liferay.portal.upgrade.v7_0_3.UpgradeOrganization;
-import com.liferay.portal.upgrade.v7_0_3.UpgradeSQLServer;
-import com.liferay.portal.upgrade.v7_0_3.UpgradeSybase;
+import com.liferay.portal.upgrade.v7_0_4.UpgradeContact;
+import com.liferay.portal.upgrade.v7_0_4.UpgradeEmailAddress;
+import com.liferay.portal.upgrade.v7_0_4.UpgradeExpando;
+import com.liferay.portal.upgrade.v7_0_4.UpgradeMBMailingList;
+import com.liferay.portal.upgrade.v7_0_4.UpgradeSchema;
+import com.liferay.portal.upgrade.v7_0_4.UpgradeUser;
 
 /**
- * @author Adolfo Pérez
+ * @author Samuel Ziemer
  */
-public class UpgradeProcess_7_0_3 extends UpgradeProcess {
+public class UpgradeProcess_7_0_4 extends UpgradeProcess {
 
 	@Override
 	public int getThreshold() {
-		return ReleaseInfo.RELEASE_7_0_3_BUILD_NUMBER;
+		return ReleaseInfo.RELEASE_7_0_4_BUILD_NUMBER;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		upgrade(UpgradeGroup.class);
-		upgrade(UpgradeMessageBoards.class);
-		upgrade(UpgradeModules.class);
-		upgrade(UpgradeOrganization.class);
-		upgrade(UpgradeOracle.class);
-		upgrade(UpgradeSQLServer.class);
-		upgrade(UpgradeSybase.class);
+		upgrade(UpgradeSchema.class);
+
+		upgrade(UpgradeContact.class);
+		upgrade(UpgradeEmailAddress.class);
+		upgrade(UpgradeExpando.class);
+		upgrade(UpgradeMBMailingList.class);
+		upgrade(UpgradeUser.class);
 
 		clearIndexesCache();
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeContact.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeContact.java
@@ -12,20 +12,20 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3;
+package com.liferay.portal.upgrade.v7_0_4;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.upgrade.v7_0_3.util.UserTable;
+import com.liferay.portal.upgrade.v7_0_4.util.ContactTable;
 
 /**
  * @author Ugurcan Cetin
  */
-public class UpgradeUser extends UpgradeProcess {
+public class UpgradeContact extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
 		alter(
-			UserTable.class,
+			ContactTable.class,
 			new AlterColumnType("emailAddress", "VARCHAR(254) null"));
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeEmailAddress.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeEmailAddress.java
@@ -12,22 +12,21 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3;
+package com.liferay.portal.upgrade.v7_0_4;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.upgrade.v7_0_3.util.MBMailingListTable;
+import com.liferay.portal.upgrade.v7_0_4.util.EmailAddressTable;
 
 /**
  * @author Ugurcan Cetin
  */
-public class UpgradeMBMailingList extends UpgradeProcess {
+public class UpgradeEmailAddress extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
 		alter(
-			MBMailingListTable.class,
-			new AlterColumnType("emailAddress", "VARCHAR(254) null"),
-			new AlterColumnType("outEmailAddress", "VARCHAR(254) null"));
+			EmailAddressTable.class,
+			new AlterColumnType("address", "VARCHAR(254) null"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeExpando.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeExpando.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3;
+package com.liferay.portal.upgrade.v7_0_4;
 
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeMBMailingList.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeMBMailingList.java
@@ -12,21 +12,22 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3;
+package com.liferay.portal.upgrade.v7_0_4;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.upgrade.v7_0_3.util.ContactTable;
+import com.liferay.portal.upgrade.v7_0_4.util.MBMailingListTable;
 
 /**
  * @author Ugurcan Cetin
  */
-public class UpgradeContact extends UpgradeProcess {
+public class UpgradeMBMailingList extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
 		alter(
-			ContactTable.class,
-			new AlterColumnType("emailAddress", "VARCHAR(254) null"));
+			MBMailingListTable.class,
+			new AlterColumnType("emailAddress", "VARCHAR(254) null"),
+			new AlterColumnType("outEmailAddress", "VARCHAR(254) null"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeSchema.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeSchema.java
@@ -12,21 +12,33 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3;
+package com.liferay.portal.upgrade.v7_0_4;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.upgrade.v7_0_3.util.EmailAddressTable;
+import com.liferay.portal.upgrade.v7_0_3.UpgradeMVCCVersion;
+import com.liferay.portal.upgrade.v7_0_4.util.ContactTable;
 
 /**
- * @author Ugurcan Cetin
+ * @author Adolfo Pérez
  */
-public class UpgradeEmailAddress extends UpgradeProcess {
+public class UpgradeSchema extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		alter(
-			EmailAddressTable.class,
-			new AlterColumnType("address", "VARCHAR(254) null"));
+		upgrade(UpgradeMVCCVersion.class);
 	}
 
+	/**
+	 * @author Ugurcan Cetin
+	 */
+	public static class UpgradeContact extends UpgradeProcess {
+
+		@Override
+		protected void doUpgrade() throws Exception {
+			alter(
+				ContactTable.class,
+				new AlterColumnType("emailAddress", "VARCHAR(254) null"));
+		}
+
+	}
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeUser.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/UpgradeUser.java
@@ -12,18 +12,21 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3;
+package com.liferay.portal.upgrade.v7_0_4;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.v7_0_4.util.UserTable;
 
 /**
- * @author Adolfo Pérez
+ * @author Ugurcan Cetin
  */
-public class UpgradeSchema extends UpgradeProcess {
+public class UpgradeUser extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		upgrade(UpgradeMVCCVersion.class);
+		alter(
+			UserTable.class,
+			new AlterColumnType("emailAddress", "VARCHAR(254) null"));
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/ContactTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/ContactTable.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3.util;
+package com.liferay.portal.upgrade.v7_0_4.util;
 
 import java.sql.Types;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/EmailAddressTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/EmailAddressTable.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3.util;
+package com.liferay.portal.upgrade.v7_0_4.util;
 
 import java.sql.Types;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/MBMailingListTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/MBMailingListTable.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3.util;
+package com.liferay.portal.upgrade.v7_0_4.util;
 
 import java.sql.Types;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/UserTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_4/util/UserTable.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.upgrade.v7_0_3.util;
+package com.liferay.portal.upgrade.v7_0_4.util;
 
 import java.sql.Types;
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -132,7 +132,8 @@
         com.liferay.portal.upgrade.UpgradeProcess_6_2_0\,\
         com.liferay.portal.upgrade.UpgradeProcess_7_0_0\,\
         com.liferay.portal.upgrade.UpgradeProcess_7_0_1\,\
-        com.liferay.portal.upgrade.UpgradeProcess_7_0_3
+        com.liferay.portal.upgrade.UpgradeProcess_7_0_3\,\
+        com.liferay.portal.upgrade.UpgradeProcess_7_0_4
 
     upgrade.processes.6012=${upgrade.processes.master}
     upgrade.processes.6100=${upgrade.processes.master}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ReleaseInfo.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ReleaseInfo.java
@@ -101,6 +101,8 @@ public class ReleaseInfo {
 
 	public static final int RELEASE_7_0_3_BUILD_NUMBER = 7003;
 
+	public static final int RELEASE_7_0_4_BUILD_NUMBER = 7004;
+
 	public static final int RELEASE_7_0_10_BUILD_NUMBER = 7010;
 
 	public static final Date getBuildDate() {


### PR DESCRIPTION
Hi Brian,

You requested TS look into moving upgrade processes implemented after the release of GA3 into a new upgrade version. There were 6 processes that needed to be moved from version 7_0_3 to 7_0_4. If you need anything else, let me know and I'll work on that as well.

Thanks,
Sam