### PR TITLE
LRQA-32801-1 Readable poshi translator: Add basic support for 'for' loops and conditionals

### DIFF
--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 1bdf9d82fbf7fd88680d97db27a00442f51a85ab
+	commit = 11f990a706defd9c8acb4d93385426a191c211ce
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f87a12251c765f5bf11fd11ff2e307ecebc7ed1a
+	parent = 4c99e4bb7efe158173151a37fff97450f53a83e4
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -76,59 +77,59 @@ public class UserIndexerTest {
 
 	@Test
 	public void testEmailAddress() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			StringUtil.toUpperCase(expectedEmail), expectedUser);
+			StringUtil.toUpperCase(expectedEmail), _expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressField() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			"emailAddress", expectedEmail, expectedUser);
+			"emailAddress", expectedEmail, _expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressPrefix() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
 			StringUtil.removeSubstring(expectedEmail, "@liferay.com"),
-			expectedUser);
+			_expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressSubstring() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
 			expectedEmail.substring(4, expectedEmail.length() - 7),
-			expectedUser);
+			_expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmptyQuery() throws Exception {
-		User user = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		assertSearch(StringPool.BLANK, user);
+		assertSearch(StringPool.BLANK, _expectedUser);
 	}
 
 	@Test
@@ -137,16 +138,16 @@ public class UserIndexerTest {
 		String middleName = "Watson";
 		String lastName = "Parker";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
-			"firstName", "\"Mary Jane\"", expectedUser);
+			"firstName", "\"Mary Jane\"", _expectedUser);
 
 		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
@@ -157,37 +158,37 @@ public class UserIndexerTest {
 		String middleName = "Joanne";
 		String lastName = "Parker";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
 		assertNoHits("firstName", "\"Mary Watson\"");
 		assertNoHits("firstName", "\"Mary Jane\" Missingword");
 
 		User actualUser = assertSearchOneUser(
-			"firstName", "Mary \"Jane Watson\"", expectedUser);
+			"firstName", "Mary \"Jane Watson\"", _expectedUser);
 
 		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
 
 	@Test
 	public void testLikeCharacter() throws Exception {
-		User user = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		assertSearch(StringPool.PERCENT, user);
+		assertSearch(StringPool.PERCENT, _expectedUser);
 
 		assertNoHits(StringPool.PERCENT + RandomTestUtil.randomString());
 	}
 
 	@Test
 	public void testLuceneQueryParserUnfriendlyCharacters() throws Exception {
-		User user = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		assertSearch(StringPool.AT, user);
+		assertSearch(StringPool.AT, _expectedUser);
 
 		assertNoHits(StringPool.AT + RandomTestUtil.randomString());
 		assertNoHits(StringPool.EXCLAMATION);
@@ -218,23 +219,23 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
-		User actualUser = assertSearchOneUser("Fir", expectedUser);
+		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
 		Assert.assertEquals("First", actualUser.getFirstName());
 
-		actualUser = assertSearchOneUser("LasT", expectedUser);
+		actualUser = assertSearchOneUser("LasT", _expectedUser);
 
 		Assert.assertEquals("Last", actualUser.getLastName());
 
-		actualUser = assertSearchOneUser("midd", expectedUser);
+		actualUser = assertSearchOneUser("midd", _expectedUser);
 
 		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
@@ -245,62 +246,62 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
-		User actualUser = assertSearchOneUser("Fir", expectedUser);
+		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
 		Assert.assertEquals("First", actualUser.getFirstName());
 
-		actualUser = assertSearchOneUser("asT", expectedUser);
+		actualUser = assertSearchOneUser("asT", _expectedUser);
 
 		Assert.assertEquals("Last", actualUser.getLastName());
 
-		actualUser = assertSearchOneUser("idd", expectedUser);
+		actualUser = assertSearchOneUser("idd", _expectedUser);
 
 		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
 
 	@Test
 	public void testScreenName() throws Exception {
-		User expectedUser = UserTestUtil.addUser(
+		_expectedUser = UserTestUtil.addUser(
 			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		User actualUser = assertSearchOneUser("Open4Life", expectedUser);
+		User actualUser = assertSearchOneUser("Open4Life", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameField() throws Exception {
-		User expectedUser = UserTestUtil.addUser(
+		_expectedUser = UserTestUtil.addUser(
 			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
 		User actualUser = assertSearchOneUser(
-			"screenName", "open4life", expectedUser);
+			"screenName", "open4life", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameSubstring() throws Exception {
-		User expectedUser = UserTestUtil.addUser(
+		_expectedUser = UserTestUtil.addUser(
 			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		User actualUser = assertSearchOneUser("open lite", expectedUser);
+		User actualUser = assertSearchOneUser("open lite", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		actualUser = assertSearchOneUser("OPE", expectedUser);
+		actualUser = assertSearchOneUser("OPE", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		actualUser = assertSearchOneUser("4lif", expectedUser);
+		actualUser = assertSearchOneUser("4lif", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
@@ -436,25 +437,25 @@ public class UserIndexerTest {
 			String firstName, String lastName, String middleName)
 		throws Exception {
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
-			"firstName", firstName, expectedUser);
+			"firstName", firstName, _expectedUser);
 
 		Assert.assertEquals(firstName, actualUser.getFirstName());
 
-		actualUser = assertSearchOneUser("lastName", lastName, expectedUser);
+		actualUser = assertSearchOneUser("lastName", lastName, _expectedUser);
 
 		Assert.assertEquals(lastName, actualUser.getLastName());
 
 		actualUser = assertSearchOneUser(
-			"middleName", middleName, expectedUser);
+			"middleName", middleName, _expectedUser);
 
 		Assert.assertEquals(middleName, actualUser.getMiddleName());
 	}
@@ -464,6 +465,9 @@ public class UserIndexerTest {
 
 		return strings.toString();
 	}
+
+	@DeleteAfterTestRun
+	private User _expectedUser;
 
 	private Indexer<User> _indexer;
 	private UserLocalService _userLocalService;

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -146,11 +146,18 @@ public class UserIndexerTest {
 		String middleName = "Watson";
 		String lastName = "Parker";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("firstName", "\"Mary Jane\"", user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals(firstName, user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
+
+		User actualUser = assertSearchOneUser(
+			"firstName", "\"Mary Jane\"", expectedUser);
+
+		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
 
 	@Test
@@ -159,14 +166,21 @@ public class UserIndexerTest {
 		String middleName = "Joanne";
 		String lastName = "Parker";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
+
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
+
+		_userLocalService.updateUser(expectedUser);
 
 		assertNoHits("firstName", "\"Mary Watson\"");
 		assertNoHits("firstName", "\"Mary Jane\" Missingword");
 
-		user = assertSearchOneUser("firstName", "Mary \"Jane Watson\"", user);
+		User actualUser = assertSearchOneUser(
+			"firstName", "Mary \"Jane Watson\"", expectedUser);
 
-		Assert.assertEquals(firstName, user.getFirstName());
+		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
 
 	@Test
@@ -213,19 +227,25 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("Fir", user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals("First", user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
 
-		user = assertSearchOneUser("LasT", user);
+		User actualUser = assertSearchOneUser("Fir", expectedUser);
 
-		Assert.assertEquals("Last", user.getLastName());
+		Assert.assertEquals("First", actualUser.getFirstName());
 
-		user = assertSearchOneUser("midd", user);
+		actualUser = assertSearchOneUser("LasT", expectedUser);
 
-		Assert.assertEquals("Middle", user.getMiddleName());
+		Assert.assertEquals("Last", actualUser.getLastName());
+
+		actualUser = assertSearchOneUser("midd", expectedUser);
+
+		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
 
 	@Test
@@ -234,19 +254,25 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("Fir", user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals("First", user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
 
-		user = assertSearchOneUser("asT", user);
+		User actualUser = assertSearchOneUser("Fir", expectedUser);
 
-		Assert.assertEquals("Last", user.getLastName());
+		Assert.assertEquals("First", actualUser.getFirstName());
 
-		user = assertSearchOneUser("idd", user);
+		actualUser = assertSearchOneUser("asT", expectedUser);
 
-		Assert.assertEquals("Middle", user.getMiddleName());
+		Assert.assertEquals("Last", actualUser.getLastName());
+
+		actualUser = assertSearchOneUser("idd", expectedUser);
+
+		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
 
 	@Test
@@ -324,17 +350,6 @@ public class UserIndexerTest {
 		_users.add(user);
 
 		return user;
-	}
-
-	protected User addUserNameFields(
-			String firstName, String lastName, String middleName)
-		throws Exception {
-
-		String screenName = testName.getMethodName();
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
 	}
 
 	protected User addUserScreenName(String screenName) throws Exception {
@@ -478,19 +493,27 @@ public class UserIndexerTest {
 			String firstName, String lastName, String middleName)
 		throws Exception {
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("firstName", firstName, user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals(firstName, user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
 
-		user = assertSearchOneUser("lastName", lastName, user);
+		User actualUser = assertSearchOneUser(
+			"firstName", firstName, expectedUser);
 
-		Assert.assertEquals(lastName, user.getLastName());
+		Assert.assertEquals(firstName, actualUser.getFirstName());
 
-		user = assertSearchOneUser("middleName", middleName, user);
+		actualUser = assertSearchOneUser("lastName", lastName, expectedUser);
 
-		Assert.assertEquals(middleName, user.getMiddleName());
+		Assert.assertEquals(lastName, actualUser.getLastName());
+
+		actualUser = assertSearchOneUser(
+			"middleName", middleName, expectedUser);
+
+		Assert.assertEquals(middleName, actualUser.getMiddleName());
 	}
 
 	protected String toString(List<String> strings) {

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -145,7 +145,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
 			"firstName", "\"Mary Jane\"", _expectedUser);
@@ -165,7 +165,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		assertNoHits("firstName", "\"Mary Watson\"");
 		assertNoHits("firstName", "\"Mary Jane\" Missingword");
@@ -226,7 +226,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
@@ -253,7 +253,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
@@ -444,7 +444,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
 			"firstName", firstName, _expectedUser);

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -79,50 +79,51 @@ public class UserIndexerTest {
 	public void testEmailAddress() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			StringUtil.toUpperCase(expectedEmail), _expectedUser);
+			StringUtil.toUpperCase(expectedEmailAddress), _expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressField() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			"emailAddress", expectedEmail, _expectedUser);
+			"emailAddress", expectedEmailAddress, _expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressPrefix() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			StringUtil.removeSubstring(expectedEmail, "@liferay.com"),
+			StringUtil.removeSubstring(expectedEmailAddress, "@liferay.com"),
 			_expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressSubstring() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			expectedEmail.substring(4, expectedEmail.length() - 7),
+			expectedEmailAddress.substring(
+				4, expectedEmailAddress.length() - 7),
 			_expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -84,38 +85,52 @@ public class UserIndexerTest {
 
 	@Test
 	public void testEmailAddress() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("Em.Ail@liferay.com", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			StringUtil.toUpperCase(expectedEmail), expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressField() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("emailAddress", "em.ail@liferay.com", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			"emailAddress", expectedEmail, expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressPrefix() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("EM.AIL", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			StringUtil.removeSubstring(expectedEmail, "@liferay.com"),
+			expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressSubstring() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("ail@life", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			expectedEmail.substring(4, expectedEmail.length() - 7),
+			expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
@@ -309,16 +324,6 @@ public class UserIndexerTest {
 		_users.add(user);
 
 		return user;
-	}
-
-	protected User addUserEmailAddress(String emailAddress) throws Exception {
-		String firstName = RandomTestUtil.randomString();
-		String lastName = RandomTestUtil.randomString();
-		String middleName = RandomTestUtil.randomString();
-		String screenName = testName.getMethodName();
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
 	}
 
 	protected User addUserNameFields(

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -277,37 +277,41 @@ public class UserIndexerTest {
 
 	@Test
 	public void testScreenName() throws Exception {
-		User user = addUserScreenName("Open4Life");
+		User expectedUser = UserTestUtil.addUser(
+			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		user = assertSearchOneUser("Open4Life", user);
+		User actualUser = assertSearchOneUser("Open4Life", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameField() throws Exception {
-		User user = addUserScreenName("Open4Life");
+		User expectedUser = UserTestUtil.addUser(
+			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		user = assertSearchOneUser("screenName", "open4life", user);
+		User actualUser = assertSearchOneUser(
+			"screenName", "open4life", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameSubstring() throws Exception {
-		User user = addUserScreenName("Open4Life");
+		User expectedUser = UserTestUtil.addUser(
+			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		user = assertSearchOneUser("open lite", user);
+		User actualUser = assertSearchOneUser("open lite", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		user = assertSearchOneUser("OPE", user);
+		actualUser = assertSearchOneUser("OPE", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		user = assertSearchOneUser("4lif", user);
+		actualUser = assertSearchOneUser("4lif", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Rule
@@ -350,16 +354,6 @@ public class UserIndexerTest {
 		_users.add(user);
 
 		return user;
-	}
-
-	protected User addUserScreenName(String screenName) throws Exception {
-		String firstName = RandomTestUtil.randomString();
-		String lastName = RandomTestUtil.randomString();
-		String middleName = RandomTestUtil.randomString();
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
 	}
 
 	protected void assertLength(Hits hits, int length) {

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -119,7 +120,7 @@ public class UserIndexerTest {
 
 	@Test
 	public void testEmptyQuery() throws Exception {
-		User user = addUser();
+		User user = UserTestUtil.addUser();
 
 		assertSearch(StringPool.BLANK, user);
 	}
@@ -155,7 +156,7 @@ public class UserIndexerTest {
 
 	@Test
 	public void testLikeCharacter() throws Exception {
-		User user = addUser();
+		User user = UserTestUtil.addUser();
 
 		assertSearch(StringPool.PERCENT, user);
 
@@ -164,7 +165,7 @@ public class UserIndexerTest {
 
 	@Test
 	public void testLuceneQueryParserUnfriendlyCharacters() throws Exception {
-		User user = addUser();
+		User user = UserTestUtil.addUser();
 
 		assertSearch(StringPool.AT, user);
 
@@ -270,17 +271,6 @@ public class UserIndexerTest {
 
 	@Rule
 	public TestName testName = new TestName();
-
-	protected User addUser() throws Exception {
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-		String firstName = RandomTestUtil.randomString();
-		String lastName = RandomTestUtil.randomString();
-		String middleName = RandomTestUtil.randomString();
-		String screenName = testName.getMethodName();
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
-	}
 
 	protected User addUser(
 			String firstName, String lastName, String middleName,

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,6 +53,7 @@ import org.junit.runner.RunWith;
 /**
  * @author André de Oliveira
  */
+@Ignore
 @RunWith(Arquillian.class)
 @Sync
 public class UserIndexerTest {

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -22,18 +22,14 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -42,17 +38,14 @@ import com.liferay.registry.RegistryUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 /**
@@ -79,8 +72,6 @@ public class UserIndexerTest {
 			IndexerRegistry.class);
 
 		_indexer = indexerRegistry.getIndexer(User.class);
-
-		_serviceContext = ServiceContextTestUtil.getServiceContext();
 	}
 
 	@Test
@@ -314,48 +305,6 @@ public class UserIndexerTest {
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
-	@Rule
-	public TestName testName = new TestName();
-
-	protected User addUser(
-			String firstName, String lastName, String middleName,
-			String screenName, String emailAddress)
-		throws Exception {
-
-		long creatorUserId = TestPropsValues.getUserId();
-		long companyId = TestPropsValues.getCompanyId();
-		boolean autoPassword = true;
-		String password1 = null;
-		String password2 = null;
-		boolean autoScreenName = false;
-		long facebookId = 0;
-		String openId = null;
-		Locale locale = LocaleUtil.getDefault();
-		long prefixId = 0;
-		long suffixId = 0;
-		boolean male = false;
-		int birthdayMonth = Calendar.JANUARY;
-		int birthdayDay = 1;
-		int birthdayYear = 1970;
-		String jobTitle = null;
-		long[] groupIds = new long[] {TestPropsValues.getGroupId()};
-		long[] organizationIds = null;
-		long[] roleIds = null;
-		long[] userGroupIds = null;
-		boolean sendMail = false;
-
-		User user = _userLocalService.addUser(
-			creatorUserId, companyId, autoPassword, password1, password2,
-			autoScreenName, screenName, emailAddress, facebookId, openId,
-			locale, firstName, middleName, lastName, prefixId, suffixId, male,
-			birthdayMonth, birthdayDay, birthdayYear, jobTitle, groupIds,
-			organizationIds, roleIds, userGroupIds, sendMail, _serviceContext);
-
-		_users.add(user);
-
-		return user;
-	}
-
 	protected void assertLength(Hits hits, int length) {
 		Assert.assertEquals(hits.toString(), length, hits.getLength());
 	}
@@ -517,10 +466,6 @@ public class UserIndexerTest {
 	}
 
 	private Indexer<User> _indexer;
-	private ServiceContext _serviceContext;
 	private UserLocalService _userLocalService;
-
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -132,14 +132,16 @@ public class CommandElement extends PoshiElement {
 				continue;
 			}
 
-			String readableBlock = sb.toString();
+			if (!line.startsWith("else {")) {
+				String readableBlock = sb.toString();
 
-			readableBlock = readableBlock.trim();
+				readableBlock = readableBlock.trim();
 
-			if (isValidReadableBlock(readableBlock)) {
-				readableBlocks.add(readableBlock);
+				if (isValidReadableBlock(readableBlock)) {
+					readableBlocks.add(readableBlock);
 
-				sb.setLength(0);
+					sb.setLength(0);
+				}
 			}
 
 			sb.append(line);

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -14,6 +14,9 @@
 
 package com.liferay.poshi.runner.elements;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dom4j.Element;
 
 /**
@@ -137,6 +140,43 @@ public class CommandElement extends PoshiElement {
 	@Override
 	protected String getBlockName() {
 		return getReadableCommandTitle();
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			line = line.trim();
+
+			if (line.startsWith("setUp") || line.startsWith("tearDown")) {
+				continue;
+			}
+
+			if ((line.endsWith(" {") && line.startsWith("test")) ||
+				line.startsWith("@")) {
+
+				readableBlocks.add(line);
+
+				continue;
+			}
+
+			sb.append(line);
+			sb.append("\n");
+
+			String readableBlock = sb.toString();
+
+			readableBlock = readableBlock.trim();
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+		}
+
+		return readableBlocks;
 	}
 
 	protected String getReadableCommandTitle() {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -143,4 +143,15 @@ public class CommandElement extends PoshiElement {
 		return "test" + attributeValue("name");
 	}
 
+	@Override
+	protected boolean isBalanceValidationRequired(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (readableSyntax.endsWith(";") || readableSyntax.endsWith("}")) {
+			return true;
+		}
+
+		return false;
+	}
+
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -153,15 +153,4 @@ public class CommandElement extends PoshiElement {
 		return "test" + attributeValue("name");
 	}
 
-	@Override
-	protected boolean isBalanceValidationRequired(String readableSyntax) {
-		readableSyntax = readableSyntax.trim();
-
-		if (readableSyntax.endsWith(";") || readableSyntax.endsWith("}")) {
-			return true;
-		}
-
-		return false;
-	}
-
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -81,6 +81,14 @@ public class CommandElement extends PoshiElement {
 				continue;
 			}
 
+			if (line.startsWith("@description")) {
+				PoshiElement poshiElement = new DescriptionElement(line);
+
+				add(poshiElement);
+
+				continue;
+			}
+
 			if (line.startsWith("@")) {
 				String name = getNameFromAssignment(line);
 				String value = getQuotedContent(line);
@@ -97,6 +105,14 @@ public class CommandElement extends PoshiElement {
 	@Override
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
+
+		for (PoshiElement poshiElement :
+				toPoshiElements(elements("description"))) {
+
+			sb.append("\n\t@description = \"");
+			sb.append(poshiElement.attributeValue("message"));
+			sb.append("\"");
+		}
 
 		for (PoshiElementAttribute poshiElementAttribute :
 				toPoshiElementAttributes(attributeList())) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -132,9 +132,6 @@ public class CommandElement extends PoshiElement {
 				continue;
 			}
 
-			sb.append(line);
-			sb.append("\n");
-
 			String readableBlock = sb.toString();
 
 			readableBlock = readableBlock.trim();
@@ -144,6 +141,9 @@ public class CommandElement extends PoshiElement {
 
 				sb.setLength(0);
 			}
+
+			sb.append(line);
+			sb.append("\n");
 		}
 
 		return readableBlocks;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -83,7 +83,7 @@ public class CommandElement extends PoshiElement {
 
 			if (line.startsWith("@")) {
 				String name = getNameFromAssignment(line);
-				String value = getValueFromAssignment(line);
+				String value = getQuotedContent(line);
 
 				addAttribute(name, value);
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandElement.java
@@ -14,6 +14,8 @@
 
 package com.liferay.poshi.runner.elements;
 
+import com.liferay.poshi.runner.util.RegexUtil;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,66 +44,34 @@ public class CommandElement extends PoshiElement {
 
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
-		StringBuilder sb = new StringBuilder();
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith("setUp")) {
+				System.out.println(readableBlock);
+			}
 
-		for (String line : readableSyntax.split("\n")) {
-			line = line.trim();
+			if (readableBlock.endsWith("}") || readableBlock.endsWith(";") ||
+				readableBlock.startsWith("@description")) {
 
-			String endKey = " {";
-
-			if (line.endsWith(endKey)) {
-				String startKey = "test";
-
-				if (line.startsWith(startKey)) {
-					int start = startKey.length();
-					int end = line.length() - endKey.length();
-
-					String name = line.substring(start, end);
-
-					addAttribute("name", name);
-				}
+				addElementFromReadableSyntax(readableBlock);
 
 				continue;
 			}
 
-			if (line.equals(");")) {
-				sb.append(line);
+			if (readableBlock.endsWith("{")) {
+				String name = RegexUtil.getGroup(
+					readableBlock, "test([\\w]*)", 1);
 
-				addElementFromReadableSyntax(sb.toString());
-
-				sb.setLength(0);
-
-				continue;
-			}
-
-			if (line.endsWith(";")) {
-				addElementFromReadableSyntax(line);
+				addAttribute("name", name);
 
 				continue;
 			}
 
-			if (line.equals("}")) {
-				continue;
-			}
-
-			if (line.startsWith("@description")) {
-				PoshiElement poshiElement = new DescriptionElement(line);
-
-				add(poshiElement);
-
-				continue;
-			}
-
-			if (line.startsWith("@")) {
-				String name = getNameFromAssignment(line);
-				String value = getQuotedContent(line);
+			if (readableBlock.startsWith("@")) {
+				String name = getNameFromAssignment(readableBlock);
+				String value = getQuotedContent(readableBlock);
 
 				addAttribute(name, value);
-
-				continue;
 			}
-
-			sb.append(line);
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionElement.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ConditionElement extends ExecuteElement {
+
+	public ConditionElement(Element element) {
+		super("condition", element);
+	}
+
+	public ConditionElement(String readableSyntax) {
+		super("condition", readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		return attributeValue("function");
+	}
+
+	@Override
+	protected String createReadableBlock(String content) {
+		String readableBlock = super.createReadableBlock(content);
+
+		readableBlock = readableBlock.trim();
+
+		if (readableBlock.endsWith(";")) {
+			readableBlock = readableBlock.substring(
+				0, readableBlock.length() - 1);
+		}
+
+		return readableBlock;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -14,6 +14,9 @@
 
 package com.liferay.poshi.runner.elements;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.dom4j.Element;
 
 /**
@@ -134,6 +137,47 @@ public class DefinitionElement extends PoshiElement {
 	@Override
 	protected String getPad() {
 		return "";
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			line = line.trim();
+
+			if (line.length() == 0) {
+				continue;
+			}
+
+			if (line.startsWith("@") && !line.startsWith("@description") &&
+				!line.startsWith("@priority")) {
+
+				readableBlocks.add(line);
+
+				continue;
+			}
+
+			if (line.startsWith("definition {")) {
+				continue;
+			}
+
+			sb.append(line);
+			sb.append("\n");
+
+			String readableBlock = sb.toString();
+
+			readableBlock = readableBlock.trim();
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+		}
+
+		return readableBlocks;
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -131,9 +131,6 @@ public class DefinitionElement extends PoshiElement {
 				continue;
 			}
 
-			sb.append(line);
-			sb.append("\n");
-
 			String readableBlock = sb.toString();
 
 			readableBlock = readableBlock.trim();
@@ -143,6 +140,9 @@ public class DefinitionElement extends PoshiElement {
 
 				sb.setLength(0);
 			}
+
+			sb.append(line);
+			sb.append("\n");
 		}
 
 		return readableBlocks;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -44,7 +44,7 @@ public class DefinitionElement extends PoshiElement {
 				!line.contains("@priority")) {
 
 				String name = getNameFromAssignment(line);
-				String value = getValueFromAssignment(line);
+				String value = getQuotedContent(line);
 
 				addAttribute(name, value);
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -34,52 +34,20 @@ public class DefinitionElement extends PoshiElement {
 
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
-		StringBuilder sb = new StringBuilder();
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith("@") &&
+				!readableBlock.startsWith("@description") &&
+				!readableBlock.startsWith("@priority")) {
 
-		for (String line : readableSyntax.split("\n")) {
-			line = line.trim();
-
-			if (line.length() == 0) {
-				continue;
-			}
-
-			if (line.startsWith("@") && !line.contains("@description") &&
-				!line.contains("@priority")) {
-
-				String name = getNameFromAssignment(line);
-				String value = getQuotedContent(line);
+				String name = getNameFromAssignment(readableBlock);
+				String value = getQuotedContent(readableBlock);
 
 				addAttribute(name, value);
 
 				continue;
 			}
 
-			if (line.startsWith("definition {")) {
-				continue;
-			}
-
-			if ((line.startsWith("property") || line.startsWith("var")) &&
-				(sb.length() == 0)) {
-
-				addElementFromReadableSyntax(line);
-
-				continue;
-			}
-
-			if (line.equals("}")) {
-				sb.append(line);
-
-				if (sb.length() > 1) {
-					addElementFromReadableSyntax(sb.toString());
-
-					sb.setLength(0);
-
-					continue;
-				}
-			}
-
-			sb.append(line);
-			sb.append("\n");
+			addElementFromReadableSyntax(readableBlock);
 		}
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DefinitionElement.java
@@ -136,4 +136,19 @@ public class DefinitionElement extends PoshiElement {
 		return "";
 	}
 
+	@Override
+	protected boolean isBalanceValidationRequired(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if ((readableSyntax.startsWith("@") && readableSyntax.contains("{")) ||
+			readableSyntax.startsWith("setUp") ||
+			readableSyntax.startsWith("tearDown") ||
+			readableSyntax.startsWith("test")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DescriptionElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/DescriptionElement.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class DescriptionElement extends PoshiElement {
+
+	public DescriptionElement(Element element) {
+		super("description", element);
+	}
+
+	public DescriptionElement(String readableSyntax) {
+		super("description", readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		return "description";
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		String message = getQuotedContent(readableSyntax);
+
+		addAttribute("message", message);
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseElement.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import java.util.List;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ElseElement extends ThenElement {
+
+	public ElseElement(Element element) {
+		super("else", element);
+	}
+
+	public ElseElement(String readableSyntax) {
+		super("else", readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		return "else";
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		String readableSyntax = super.toReadableSyntax();
+
+		return createReadableBlock(readableSyntax);
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		String content = getBracedContent(readableSyntax);
+
+		return super.getReadableBlocks(content);
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsElement.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class EqualsElement extends PoshiElement {
+
+	public EqualsElement(Element element) {
+		super("equals", element);
+	}
+
+	public EqualsElement(String readableSyntax) {
+		super("equals", readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		return "equals";
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		String[] equalsContentArray = readableSyntax.split("==");
+
+		String arg1 = equalsContentArray[0].trim();
+
+		arg1 = getQuotedContent(arg1);
+
+		addAttribute("arg1", arg1);
+
+		String arg2 = equalsContentArray[1].trim();
+
+		arg2 = getQuotedContent(arg2);
+
+		addAttribute("arg2", arg2);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\"");
+		sb.append(attributeValue("arg1"));
+		sb.append("\" == \"");
+		sb.append(attributeValue("arg2"));
+		sb.append("\"");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -71,7 +71,7 @@ public class ExecuteElement extends PoshiElement {
 			}
 
 			String name = getNameFromAssignment(assignment);
-			String value = getValueFromAssignment(assignment);
+			String value = getQuotedContent(assignment);
 
 			addAttribute(name, value);
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -57,6 +57,8 @@ public class ExecuteElement extends PoshiElement {
 		String[] assignments = content.split(",");
 
 		for (String assignment : assignments) {
+			assignment = assignment.trim();
+
 			if (executeType.equals("macro")) {
 				assignment = "var " + assignment;
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -14,6 +14,8 @@
 
 package com.liferay.poshi.runner.elements;
 
+import com.liferay.poshi.runner.util.RegexUtil;
+
 import org.dom4j.Element;
 
 /**
@@ -31,21 +33,9 @@ public class ExecuteElement extends PoshiElement {
 
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
-		int contentStart = readableSyntax.indexOf("(") + 1;
-
-		String classCommandName = readableSyntax.substring(0, contentStart - 1);
-
-		classCommandName = classCommandName.replace(".", "#");
-
-		int contentEnd = readableSyntax.lastIndexOf(")");
-
-		String content = "";
-
-		if (contentEnd > contentStart) {
-			content = readableSyntax.substring(contentStart, contentEnd);
-		}
-
 		String executeType = "macro";
+
+		String content = getParentheticalContent(readableSyntax);
 
 		if (content.contains("locator1") || content.contains("locator2") ||
 			content.contains("value1") || content.contains("value2")) {
@@ -53,7 +43,12 @@ public class ExecuteElement extends PoshiElement {
 			executeType = "function";
 		}
 
-		addAttribute(executeType, classCommandName);
+		String executeCommandName = RegexUtil.getGroup(
+			readableSyntax, "([^\\s]*)\\(", 1);
+
+		executeCommandName = executeCommandName.replace(".", "#");
+
+		addAttribute(executeType, executeCommandName);
 
 		if (content.length() == 0) {
 			return;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -16,6 +16,11 @@ package com.liferay.poshi.runner.elements;
 
 import com.liferay.poshi.runner.util.RegexUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.dom4j.Element;
 
 /**
@@ -62,7 +67,13 @@ public class ExecuteElement extends PoshiElement {
 			return;
 		}
 
-		String[] assignments = content.split(",");
+		List<String> assignments = new ArrayList<>();
+
+		Matcher matcher = _assignmentRegex.matcher(content);
+
+		while (matcher.find()) {
+			assignments.add(matcher.group());
+		}
 
 		for (String assignment : assignments) {
 			assignment = assignment.trim();
@@ -149,5 +160,8 @@ public class ExecuteElement extends PoshiElement {
 
 		return attributeValue("macro");
 	}
+
+	private static final Pattern _assignmentRegex = Pattern.compile(
+		"([^,]*? = \".*?\")");
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -31,6 +31,14 @@ public class ExecuteElement extends PoshiElement {
 		super("execute", readableSyntax);
 	}
 
+	public ExecuteElement(String name, Element element) {
+		super(name, element);
+	}
+
+	public ExecuteElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
+	}
+
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
 		String executeType = "macro";

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
@@ -112,14 +112,4 @@ public class ForElement extends PoshiElement {
 		return readableBlocks;
 	}
 
-	protected boolean isBalanceValidationRequired(String readableSyntax) {
-		readableSyntax = readableSyntax.trim();
-
-		if (readableSyntax.endsWith(";") || readableSyntax.endsWith("}")) {
-			return true;
-		}
-
-		return false;
-	}
-
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ForElement extends PoshiElement {
+
+	public ForElement(Element element) {
+		super("for", element);
+	}
+
+	public ForElement(String readableSyntax) {
+		super("for", readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(" (");
+
+		String param = attributeValue("param");
+
+		sb.append(param);
+
+		sb.append(" : \"");
+
+		String list = attributeValue("list");
+
+		sb.append(list);
+
+		sb.append("\")");
+
+		return "for" + sb.toString();
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith("for (")) {
+				String parentheticalContent = getParentheticalContent(
+					readableBlock);
+
+				String[] parentheticalContentArray =
+					parentheticalContent.split(":");
+
+				String param = parentheticalContentArray[0].trim();
+
+				addAttribute("param", param);
+
+				String list = getQuotedContent(
+					parentheticalContentArray[1].trim());
+
+				addAttribute("list", list);
+
+				continue;
+			}
+
+			addElementFromReadableSyntax(readableBlock);
+		}
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		String readableSyntax = super.toReadableSyntax();
+
+		return "\n" + createReadableBlock(readableSyntax);
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			if (line.startsWith("for (")) {
+				readableBlocks.add(line);
+
+				continue;
+			}
+
+			String readableBlock = sb.toString();
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+
+			sb.append(line);
+		}
+
+		return readableBlocks;
+	}
+
+	protected boolean isBalanceValidationRequired(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (readableSyntax.endsWith(";") || readableSyntax.endsWith("}")) {
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
@@ -14,10 +14,10 @@
 
 package com.liferay.poshi.runner.elements;
 
-import org.dom4j.Element;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.dom4j.Element;
 
 /**
  * @author Kenji Heigel
@@ -60,8 +60,8 @@ public class ForElement extends PoshiElement {
 				String parentheticalContent = getParentheticalContent(
 					readableBlock);
 
-				String[] parentheticalContentArray =
-					parentheticalContent.split(":");
+				String[] parentheticalContentArray = parentheticalContent.split(
+					":");
 
 				String param = parentheticalContentArray[0].trim();
 
@@ -99,6 +99,8 @@ public class ForElement extends PoshiElement {
 			}
 
 			String readableBlock = sb.toString();
+
+			readableBlock = readableBlock.trim();
 
 			if (isValidReadableBlock(readableBlock)) {
 				readableBlocks.add(readableBlock);

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ForElement.java
@@ -36,21 +36,14 @@ public class ForElement extends PoshiElement {
 	public String getBlockName() {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(" (");
-
-		String param = attributeValue("param");
-
-		sb.append(param);
-
+		sb.append("for ");
+		sb.append("(");
+		sb.append(attributeValue("param"));
 		sb.append(" : \"");
-
-		String list = attributeValue("list");
-
-		sb.append(list);
-
+		sb.append(attributeValue("list"));
 		sb.append("\")");
 
-		return "for" + sb.toString();
+		return sb.toString();
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfElement.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class IfElement extends PoshiElement {
+
+	public IfElement(Element element) {
+		super("if", element);
+	}
+
+	public IfElement(String readableSyntax) {
+		super("if", readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("if");
+
+		String[] conditionNames = {"condition", "equals", "isset"};
+
+		for (String conditionName : conditionNames) {
+			if (element(conditionName) != null) {
+				PoshiElement poshiElement = (PoshiElement)element(
+					conditionName);
+
+				sb.append(" (");
+				sb.append(poshiElement.toReadableSyntax());
+				sb.append(")");
+
+				break;
+			}
+		}
+
+		return sb.toString();
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith("if (")) {
+				String ifContent = getParentheticalContent(readableBlock);
+
+				addElementFromReadableSyntax(ifContent);
+
+				continue;
+			}
+
+			if (readableBlock.startsWith("else {")) {
+				addElementFromReadableSyntax(readableBlock);
+
+				continue;
+			}
+
+			PoshiElement thenElement = new ThenElement(readableBlock);
+
+			add(thenElement);
+		}
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n");
+
+		PoshiElement thenElement = (PoshiElement)element("then");
+
+		String thenReadableSyntax = thenElement.toReadableSyntax();
+
+		sb.append(createReadableBlock(thenReadableSyntax));
+
+		if (element("else") != null) {
+			PoshiElement elseElement = (PoshiElement)element("else");
+
+			sb.append(elseElement.toReadableSyntax());
+		}
+
+		return sb.toString();
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			if (line.startsWith("if (")) {
+				readableBlocks.add(line);
+
+				continue;
+			}
+
+			if (line.startsWith("else {")) {
+				sb.setLength(0);
+			}
+
+			sb.append(line);
+
+			String readableBlock = sb.toString();
+
+			readableBlock = readableBlock.trim();
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+
+			if (readableBlock.startsWith("else {")) {
+				sb.append("\n");
+			}
+		}
+
+		return readableBlocks;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfElement.java
@@ -38,9 +38,7 @@ public class IfElement extends PoshiElement {
 
 		sb.append("if");
 
-		String[] conditionNames = {"condition", "equals", "isset"};
-
-		for (String conditionName : conditionNames) {
+		for (String conditionName : _conditionNames) {
 			if (element(conditionName) != null) {
 				PoshiElement poshiElement = (PoshiElement)element(
 					conditionName);
@@ -135,5 +133,8 @@ public class IfElement extends PoshiElement {
 
 		return readableBlocks;
 	}
+
+	private static final String[] _conditionNames =
+		{"condition", "equals", "isset"};
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IssetElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IssetElement.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class IssetElement extends PoshiElement {
+
+	public IssetElement(Element element) {
+		super("isset", element);
+	}
+
+	public IssetElement(String readableSyntax) {
+		super("isset", readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		return "isset";
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		String issetContent = getParentheticalContent(readableSyntax);
+
+		addAttribute("var", issetContent);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		return "isset(" + attributeValue("var") + ")";
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -194,6 +194,12 @@ public abstract class PoshiElement extends DefaultElement {
 	}
 
 	protected boolean isBalanceValidationRequired(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (readableSyntax.endsWith(";") || readableSyntax.endsWith("}")) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -15,6 +15,7 @@
 package com.liferay.poshi.runner.elements;
 
 import com.liferay.poshi.runner.util.Dom4JUtil;
+import com.liferay.poshi.runner.util.RegexUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -91,12 +92,8 @@ public abstract class PoshiElement extends DefaultElement {
 		return name.replaceAll("var ", "");
 	}
 
-	protected static String getValueFromAssignment(String assignment) {
-		int start = assignment.indexOf("\"") + 1;
-
-		int end = assignment.indexOf("\"", start);
-
-		return assignment.substring(start, end);
+	protected static String getQuotedContent(String readableSyntax) {
+		return RegexUtil.getGroup(readableSyntax, ".*?\"(.*)\"", 1);
 	}
 
 	protected void addElementFromReadableSyntax(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -18,7 +18,9 @@ import com.liferay.poshi.runner.util.Dom4JUtil;
 import com.liferay.poshi.runner.util.RegexUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Stack;
 
 import org.dom4j.Attribute;
@@ -147,48 +149,28 @@ public abstract class PoshiElement extends DefaultElement {
 		Stack<Character> stack = new Stack<>();
 
 		for (char c : readableSyntax.toCharArray()) {
-			if (!stack.isEmpty() && (stack.peek() == '\"')) {
-				if (c == '\"') {
+			if (!stack.isEmpty()) {
+				Character topCodeBoundary = stack.peek();
+
+				if (c == _codeBoundariesMap.get(topCodeBoundary)) {
 					stack.pop();
+
+					continue;
 				}
+
+				if (topCodeBoundary == '\"') {
+					continue;
+				}
+			}
+
+			if (_codeBoundariesMap.containsKey(c)) {
+				stack.push(c);
 
 				continue;
 			}
 
-			if (c == '\"') {
-				stack.push('\"');
-			}
-
-			if (c == '{') {
-				stack.push('{');
-
-				continue;
-			}
-
-			if (c == '(') {
-				stack.push('(');
-
-				continue;
-			}
-
-			if (c == '}') {
-				if (stack.isEmpty()) {
-					return false;
-				}
-
-				if (stack.pop() != '{') {
-					return false;
-				}
-			}
-
-			if (c == ')') {
-				if (stack.isEmpty()) {
-					return false;
-				}
-
-				if (stack.pop() != '(') {
-					return false;
-				}
+			if (_codeBoundariesMap.containsValue(c)) {
+				return false;
 			}
 		}
 
@@ -270,6 +252,16 @@ public abstract class PoshiElement extends DefaultElement {
 
 			add(PoshiElementFactory.newPoshiElement(childElement));
 		}
+	}
+
+	private static final Map<Character, Character> _codeBoundariesMap =
+		new HashMap<>();
+
+	static {
+		_codeBoundariesMap.put('\"', '\"');
+		_codeBoundariesMap.put('(', ')');
+		_codeBoundariesMap.put('{', '}');
+		_codeBoundariesMap.put('[', ']');
 	}
 
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -83,6 +83,10 @@ public abstract class PoshiElement extends DefaultElement {
 		return sb.toString();
 	}
 
+	protected static String getBracedContent(String readableSyntax) {
+		return RegexUtil.getGroup(readableSyntax, ".*?\\{(.*)\\}", 1);
+	}
+
 	protected static String getNameFromAssignment(String assignment) {
 		String name = assignment.split("=")[0];
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -193,6 +193,30 @@ public abstract class PoshiElement extends DefaultElement {
 		return stack.isEmpty();
 	}
 
+	protected boolean isBalanceValidationRequired(String readableSyntax) {
+		return false;
+	}
+
+	protected boolean isValidReadableBlock(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (readableSyntax.startsWith("property") ||
+			readableSyntax.startsWith("var")) {
+
+			if (readableSyntax.endsWith(";")) {
+				return true;
+			}
+
+			return false;
+		}
+
+		if (isBalanceValidationRequired(readableSyntax)) {
+			return isBalancedReadableSyntax(readableSyntax);
+		}
+
+		return false;
+	}
+
 	protected List<PoshiElementAttribute> toPoshiElementAttributes(
 		List<?> list) {
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -146,9 +146,7 @@ public abstract class PoshiElement extends DefaultElement {
 	protected boolean isBalancedReadableSyntax(String readableSyntax) {
 		Stack<Character> stack = new Stack<>();
 
-		for (int i = 0; i < readableSyntax.length(); i++) {
-			char c = readableSyntax.charAt(i);
-
+		for (char c : readableSyntax.toCharArray()) {
 			if (!stack.isEmpty() && (stack.peek() == '\"')) {
 				if (c == '\"') {
 					stack.pop();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -19,6 +19,7 @@ import com.liferay.poshi.runner.util.RegexUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Stack;
 
 import org.dom4j.Attribute;
 import org.dom4j.Element;
@@ -136,6 +137,60 @@ public abstract class PoshiElement extends DefaultElement {
 
 	protected String getPad() {
 		return "\t";
+	}
+
+	protected boolean isBalancedReadableSyntax(String readableSyntax) {
+		Stack<Character> stack = new Stack<>();
+
+		for (int i = 0; i < readableSyntax.length(); i++) {
+			char c = readableSyntax.charAt(i);
+
+			if (!stack.isEmpty() && (stack.peek() == '\"')) {
+				if (c == '\"') {
+					stack.pop();
+				}
+
+				continue;
+			}
+
+			if (c == '\"') {
+				stack.push('\"');
+			}
+
+			if (c == '{') {
+				stack.push('{');
+
+				continue;
+			}
+
+			if (c == '(') {
+				stack.push('(');
+
+				continue;
+			}
+
+			if (c == '}') {
+				if (stack.isEmpty()) {
+					return false;
+				}
+
+				if (stack.pop() != '{') {
+					return false;
+				}
+			}
+
+			if (c == ')') {
+				if (stack.isEmpty()) {
+					return false;
+				}
+
+				if (stack.pop() != '(') {
+					return false;
+				}
+			}
+		}
+
+		return stack.isEmpty();
 	}
 
 	protected List<PoshiElementAttribute> toPoshiElementAttributes(

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElement.java
@@ -92,6 +92,10 @@ public abstract class PoshiElement extends DefaultElement {
 		return name.replaceAll("var ", "");
 	}
 
+	protected static String getParentheticalContent(String readableSyntax) {
+		return RegexUtil.getGroup(readableSyntax, ".*?\\((.*)\\)", 1);
+	}
+
 	protected static String getQuotedContent(String readableSyntax) {
 		return RegexUtil.getGroup(readableSyntax, ".*?\"(.*)\"", 1);
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -44,6 +44,10 @@ public class PoshiElementFactory {
 			return new ExecuteElement(element);
 		}
 
+		if (elementName.equals("for")) {
+			return new ForElement(element);
+		}
+
 		if (elementName.equals("property")) {
 			return new PropertyElement(element);
 		}
@@ -92,6 +96,10 @@ public class PoshiElementFactory {
 
 				if (line.startsWith("definition {")) {
 					return new DefinitionElement(readableSyntax);
+				}
+
+				if (line.startsWith("for (")) {
+					return new ForElement(readableSyntax);
 				}
 
 				if (line.startsWith("property ")) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -36,8 +36,20 @@ public class PoshiElementFactory {
 			return new CommandElement(element);
 		}
 
+		if (elementName.equals("condition")) {
+			return new ConditionElement(element);
+		}
+
 		if (elementName.equals("definition")) {
 			return new DefinitionElement(element);
+		}
+
+		if (elementName.equals("else")) {
+			return new ElseElement(element);
+		}
+
+		if (elementName.equals("equals")) {
+			return new EqualsElement(element);
 		}
 
 		if (elementName.equals("execute")) {
@@ -46,6 +58,14 @@ public class PoshiElementFactory {
 
 		if (elementName.equals("for")) {
 			return new ForElement(element);
+		}
+
+		if (elementName.equals("if")) {
+			return new IfElement(element);
+		}
+
+		if (elementName.equals("isset")) {
+			return new IssetElement(element);
 		}
 
 		if (elementName.equals("property")) {
@@ -58,6 +78,10 @@ public class PoshiElementFactory {
 
 		if (elementName.equals("tear-down")) {
 			return new TearDownElement(element);
+		}
+
+		if (elementName.equals("then")) {
+			return new ThenElement(element);
 		}
 
 		if (elementName.equals("var")) {
@@ -98,8 +122,28 @@ public class PoshiElementFactory {
 					return new DefinitionElement(readableSyntax);
 				}
 
+				if (line.startsWith("else {")) {
+					return new ElseElement(readableSyntax);
+				}
+
 				if (line.startsWith("for (")) {
 					return new ForElement(readableSyntax);
+				}
+
+				if (line.startsWith("if (")) {
+					return new IfElement(readableSyntax);
+				}
+
+				if (line.contains("==")) {
+					return new EqualsElement(readableSyntax);
+				}
+
+				if (line.startsWith("isset(")) {
+					return new IssetElement(readableSyntax);
+				}
+
+				if (line.endsWith(")")) {
+					return new ConditionElement(readableSyntax);
 				}
 
 				if (line.startsWith("property ")) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -80,6 +80,12 @@ public class PoshiElementFactory {
 					return new ExecuteElement(readableSyntax);
 				}
 
+				if (line.startsWith("@description") &&
+					!readableSyntax.endsWith("}")) {
+
+					return new DescriptionElement(readableSyntax);
+				}
+
 				if (line.startsWith("@")) {
 					continue;
 				}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -44,6 +44,10 @@ public class PoshiElementFactory {
 			return new DefinitionElement(element);
 		}
 
+		if (elementName.equals("description")) {
+			return new DescriptionElement(element);
+		}
+
 		if (elementName.equals("else")) {
 			return new ElseElement(element);
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ThenElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ThenElement.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ThenElement extends PoshiElement {
+
+	public ThenElement(Element element) {
+		super("then", element);
+	}
+
+	public ThenElement(String readableSyntax) {
+		super("then", readableSyntax);
+	}
+
+	public ThenElement(String name, Element element) {
+		super(name, element);
+	}
+
+	public ThenElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
+	}
+
+	@Override
+	public String getBlockName() {
+		return "then";
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			addElementFromReadableSyntax(readableBlock);
+		}
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			sb.append(line);
+
+			String readableBlock = sb.toString();
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+		}
+
+		return readableBlocks;
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/UnsupportedElement.java
@@ -34,6 +34,11 @@ public class UnsupportedElement extends PoshiElement {
 	}
 
 	@Override
+	public String toReadableSyntax() {
+		return "Unsupported element\n";
+	}
+
+	@Override
 	protected String getBlockName() {
 		return null;
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/VarElement.java
@@ -55,7 +55,7 @@ public class VarElement extends PoshiElement {
 
 		addAttribute("name", name);
 
-		String value = getValueFromAssignment(readableSyntax);
+		String value = getQuotedContent(readableSyntax);
 
 		if (value.contains("Util.")) {
 			value = value.replace("Util.", "Util#");

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/RegexUtil.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/util/RegexUtil.java
@@ -23,6 +23,18 @@ import java.util.regex.Pattern;
  */
 public class RegexUtil {
 
+	public static String getGroup(String content, String regex, int group) {
+		Pattern pattern = Pattern.compile(regex, Pattern.DOTALL);
+
+		Matcher matcher = pattern.matcher(content);
+
+		if (matcher.find()) {
+			return matcher.group(group);
+		}
+
+		return null;
+	}
+
 	public static String replace(String content, String regex, String group) {
 		Pattern pattern = Pattern.compile(regex);
 

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -33,7 +33,9 @@
         </execute>
     </command>
 
-    <command description="Ensure that the super admin can add pages, add portlets, navigate to the product menu, use the WYSIWYG editor, and view alert messages." name="Smoke" priority="5">
+    <command name="Smoke" priority="5">
+        <description message="Ensure that the super admin can add pages, add portlets, navigate to the product menu, use the WYSIWYG editor, and view alert messages." />
+
         <property name="portal.smoke" value="true" />
         <property name="test.assert.warning.exceptions" value="true" />
 

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -24,6 +24,14 @@
             <var name="portlet" value="Users and Organizations" />
         </execute>
 
+        <for list="${breadcrumbListVisible}" param="breadcrumbName">
+            <var name="key_breadcrumbName" value="${breadcrumbName}" />
+
+            <var method="StringUtil#upperCase('${breadcrumbName}')" name="breadcrumbNameUppercase" />
+
+            <execute function="AssertTextEquals" locator1="Breadcrumb#BREADCRUMB_ENTRY" value1="${breadcrumbNameUppercase}" />
+        </for>
+
         <execute macro="User#addCP">
             <var name="userEmailAddress" value="${userEmailAddress}" />
             <var name="userFirstName" value="${userFirstName}" />

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -47,6 +47,32 @@
         <property name="portal.smoke" value="true" />
         <property name="test.assert.warning.exceptions" value="true" />
 
+        <if>
+            <isset var="duplicate" />
+            <then>
+                <execute macro="Alert#viewErrorMessage">
+                    <var name="errorMessage" value="A configuration with this ID already exists. Please enter a unique ID." />
+                </execute>
+            </then>
+            <else>
+                <execute macro="Alert#viewSuccessMessage" />
+            </else>
+        </if>
+
+        <if>
+            <equals arg1="${check}" arg2="true" />
+            <then>
+                <execute macro="Alert#viewSuccessMessage" />
+            </then>
+        </if>
+
+        <if>
+            <condition function="IsElementPresent" locator1="Blogs#ADD_BLOGS_ENTRY" />
+            <then>
+                <execute macro="Alert#viewSuccessMessage" />
+            </then>
+        </if>
+
         <execute macro="Smoke#viewWelcomePage" />
 
         <execute macro="Smoke#runSmoke" />

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -26,6 +26,13 @@ definition {
 			portlet = "Users and Organizations"
 		);
 
+		for (breadcrumbName : "${breadcrumbListVisible}") {
+			var key_breadcrumbName = "${breadcrumbName}";
+			var breadcrumbNameUppercase = "StringUtil.upperCase('${breadcrumbName}')";
+
+			AssertTextEquals(locator1 = "Breadcrumb#BREADCRUMB_ENTRY", value1 = "${breadcrumbNameUppercase}");
+		}
+
 		User.addCP(
 			userEmailAddress = "${userEmailAddress}",
 			userFirstName = "${userFirstName}",

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -48,6 +48,23 @@ definition {
 		property portal.smoke = "true";
 		property test.assert.warning.exceptions = "true";
 
+		if (isset(duplicate)) {
+			Alert.viewErrorMessage(
+				errorMessage = "A configuration with this ID already exists. Please enter a unique ID."
+			);
+		}
+		else {
+			Alert.viewSuccessMessage();
+		}
+
+		if ("${check}" == "true") {
+			Alert.viewSuccessMessage();
+		}
+
+		if (IsElementPresent(locator1 = "Blogs#ADD_BLOGS_ENTRY")) {
+			Alert.viewSuccessMessage();
+		}
+
 		Smoke.viewWelcomePage();
 
 		Smoke.runSmoke();

--- a/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserServiceUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
+import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -120,7 +121,9 @@ public class UserTestUtil {
 	public static User addUser() throws Exception {
 		return addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			new long[] {TestPropsValues.getGroupId()},
@@ -183,7 +186,9 @@ public class UserTestUtil {
 	public static User addUser(Company company) throws Exception {
 		return addUser(
 			company.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			new long[] {TestPropsValues.getGroupId()},
@@ -193,7 +198,9 @@ public class UserTestUtil {
 	public static User addUser(long... groupIds) throws Exception {
 		return addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), groupIds,
 			ServiceContextTestUtil.getServiceContext());
@@ -202,7 +209,9 @@ public class UserTestUtil {
 	public static User addUser(long groupId, Locale locale) throws Exception {
 		return addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			locale, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new long[] {groupId},
 			ServiceContextTestUtil.getServiceContext());


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32801

#### Changes in this pull: 
* Trim strings where possible
* Uncouple logic - split the readable blocks into a list, then parse through that list instead of line by line.
* Add support for _for_ tags
* Add basic support (no nesting or logical operators) for _if, then, else, isset, equals, condition_ tags. 

#### Translation status
On master:
```
1163 / 2135 (54%) test commands were successfully translated
11 / 2135 test commands fail due to setup failures
1402 / 2135 test commands fail due to teardown failures
92 / 337 (27%) test files were successfully translated with 157 tests
Test commands that fail two way conversion: 428
```
With this pull: 
```
1414 / 2135 (66%) test commands were successfully translated
8 / 2135 test commands fail due to setup failures
108 / 2135 test commands fail due to teardown failures
182 / 337 (54%) test files were successfully translated with 520 tests
Test commands that fail two way conversion: 177
```

#### Preview Link
https://github.com/kenjiheigel/liferay-portal/commit/9e01be181b74cdbf2fd67ef96d7f44e825474285