### PR TITLE
Lps 73612

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
@@ -268,11 +268,10 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 				if (_log.isDebugEnabled()) {
 					_log.debug("No indexer exists for " + indexerClassName);
 				}
-
-				continue;
 			}
-
-			indexer.unregisterIndexerPostProcessor(indexerPostProcessor);
+			else {
+				indexer.unregisterIndexerPostProcessor(indexerPostProcessor);
+			}
 
 			synchronized (_queuedIndexerPostProcessors) {
 				_queuedIndexerPostProcessors.remove(indexerClassName);

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
@@ -177,16 +177,10 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 			else {
 				synchronized (_queuedIndexerPostProcessors) {
 					List<IndexerPostProcessor> indexerPostProcessors =
-						_queuedIndexerPostProcessors.get(indexerClassName);
-
-					if (indexerPostProcessors == null) {
-						indexerPostProcessors = new ArrayList<>();
-					}
+						_queuedIndexerPostProcessors.computeIfAbsent(
+							indexerClassName, (key) -> new ArrayList<>());
 
 					indexerPostProcessors.add(indexerPostProcessor);
-
-					_queuedIndexerPostProcessors.put(
-						indexerClassName, indexerPostProcessors);
 
 					if (_log.isDebugEnabled()) {
 						StringBundler sb = new StringBundler(5);

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
@@ -268,7 +268,16 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 			}
 
 			synchronized (_queuedIndexerPostProcessors) {
-				_queuedIndexerPostProcessors.remove(indexerClassName);
+				List<IndexerPostProcessor> indexerPostProcessors =
+					_queuedIndexerPostProcessors.get(indexerClassName);
+
+				if (indexerPostProcessors != null) {
+					indexerPostProcessors.remove(indexerPostProcessor);
+
+					if (indexerPostProcessors.isEmpty()) {
+						_queuedIndexerPostProcessors.remove(indexerClassName);
+					}
+				}
 			}
 		}
 	}

--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 1bdf9d82fbf7fd88680d97db27a00442f51a85ab
+	commit = 11f990a706defd9c8acb4d93385426a191c211ce
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f87a12251c765f5bf11fd11ff2e307ecebc7ed1a
+	parent = 4c99e4bb7efe158173151a37fff97450f53a83e4
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -76,59 +77,59 @@ public class UserIndexerTest {
 
 	@Test
 	public void testEmailAddress() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			StringUtil.toUpperCase(expectedEmail), expectedUser);
+			StringUtil.toUpperCase(expectedEmail), _expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressField() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			"emailAddress", expectedEmail, expectedUser);
+			"emailAddress", expectedEmail, _expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressPrefix() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
 			StringUtil.removeSubstring(expectedEmail, "@liferay.com"),
-			expectedUser);
+			_expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressSubstring() throws Exception {
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = expectedUser.getEmailAddress();
+		String expectedEmail = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
 			expectedEmail.substring(4, expectedEmail.length() - 7),
-			expectedUser);
+			_expectedUser);
 
 		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmptyQuery() throws Exception {
-		User user = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		assertSearch(StringPool.BLANK, user);
+		assertSearch(StringPool.BLANK, _expectedUser);
 	}
 
 	@Test
@@ -137,16 +138,16 @@ public class UserIndexerTest {
 		String middleName = "Watson";
 		String lastName = "Parker";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
-			"firstName", "\"Mary Jane\"", expectedUser);
+			"firstName", "\"Mary Jane\"", _expectedUser);
 
 		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
@@ -157,37 +158,37 @@ public class UserIndexerTest {
 		String middleName = "Joanne";
 		String lastName = "Parker";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
 		assertNoHits("firstName", "\"Mary Watson\"");
 		assertNoHits("firstName", "\"Mary Jane\" Missingword");
 
 		User actualUser = assertSearchOneUser(
-			"firstName", "Mary \"Jane Watson\"", expectedUser);
+			"firstName", "Mary \"Jane Watson\"", _expectedUser);
 
 		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
 
 	@Test
 	public void testLikeCharacter() throws Exception {
-		User user = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		assertSearch(StringPool.PERCENT, user);
+		assertSearch(StringPool.PERCENT, _expectedUser);
 
 		assertNoHits(StringPool.PERCENT + RandomTestUtil.randomString());
 	}
 
 	@Test
 	public void testLuceneQueryParserUnfriendlyCharacters() throws Exception {
-		User user = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		assertSearch(StringPool.AT, user);
+		assertSearch(StringPool.AT, _expectedUser);
 
 		assertNoHits(StringPool.AT + RandomTestUtil.randomString());
 		assertNoHits(StringPool.EXCLAMATION);
@@ -218,23 +219,23 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
-		User actualUser = assertSearchOneUser("Fir", expectedUser);
+		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
 		Assert.assertEquals("First", actualUser.getFirstName());
 
-		actualUser = assertSearchOneUser("LasT", expectedUser);
+		actualUser = assertSearchOneUser("LasT", _expectedUser);
 
 		Assert.assertEquals("Last", actualUser.getLastName());
 
-		actualUser = assertSearchOneUser("midd", expectedUser);
+		actualUser = assertSearchOneUser("midd", _expectedUser);
 
 		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
@@ -245,62 +246,62 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
-		User actualUser = assertSearchOneUser("Fir", expectedUser);
+		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
 		Assert.assertEquals("First", actualUser.getFirstName());
 
-		actualUser = assertSearchOneUser("asT", expectedUser);
+		actualUser = assertSearchOneUser("asT", _expectedUser);
 
 		Assert.assertEquals("Last", actualUser.getLastName());
 
-		actualUser = assertSearchOneUser("idd", expectedUser);
+		actualUser = assertSearchOneUser("idd", _expectedUser);
 
 		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
 
 	@Test
 	public void testScreenName() throws Exception {
-		User expectedUser = UserTestUtil.addUser(
+		_expectedUser = UserTestUtil.addUser(
 			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		User actualUser = assertSearchOneUser("Open4Life", expectedUser);
+		User actualUser = assertSearchOneUser("Open4Life", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameField() throws Exception {
-		User expectedUser = UserTestUtil.addUser(
+		_expectedUser = UserTestUtil.addUser(
 			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
 		User actualUser = assertSearchOneUser(
-			"screenName", "open4life", expectedUser);
+			"screenName", "open4life", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameSubstring() throws Exception {
-		User expectedUser = UserTestUtil.addUser(
+		_expectedUser = UserTestUtil.addUser(
 			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		User actualUser = assertSearchOneUser("open lite", expectedUser);
+		User actualUser = assertSearchOneUser("open lite", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		actualUser = assertSearchOneUser("OPE", expectedUser);
+		actualUser = assertSearchOneUser("OPE", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		actualUser = assertSearchOneUser("4lif", expectedUser);
+		actualUser = assertSearchOneUser("4lif", _expectedUser);
 
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
@@ -436,25 +437,25 @@ public class UserIndexerTest {
 			String firstName, String lastName, String middleName)
 		throws Exception {
 
-		User expectedUser = UserTestUtil.addUser();
+		_expectedUser = UserTestUtil.addUser();
 
-		expectedUser.setFirstName(firstName);
-		expectedUser.setMiddleName(middleName);
-		expectedUser.setLastName(lastName);
+		_expectedUser.setFirstName(firstName);
+		_expectedUser.setMiddleName(middleName);
+		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(expectedUser);
+		_userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
-			"firstName", firstName, expectedUser);
+			"firstName", firstName, _expectedUser);
 
 		Assert.assertEquals(firstName, actualUser.getFirstName());
 
-		actualUser = assertSearchOneUser("lastName", lastName, expectedUser);
+		actualUser = assertSearchOneUser("lastName", lastName, _expectedUser);
 
 		Assert.assertEquals(lastName, actualUser.getLastName());
 
 		actualUser = assertSearchOneUser(
-			"middleName", middleName, expectedUser);
+			"middleName", middleName, _expectedUser);
 
 		Assert.assertEquals(middleName, actualUser.getMiddleName());
 	}
@@ -464,6 +465,9 @@ public class UserIndexerTest {
 
 		return strings.toString();
 	}
+
+	@DeleteAfterTestRun
+	private User _expectedUser;
 
 	private Indexer<User> _indexer;
 	private UserLocalService _userLocalService;

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -146,11 +146,18 @@ public class UserIndexerTest {
 		String middleName = "Watson";
 		String lastName = "Parker";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("firstName", "\"Mary Jane\"", user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals(firstName, user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
+
+		User actualUser = assertSearchOneUser(
+			"firstName", "\"Mary Jane\"", expectedUser);
+
+		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
 
 	@Test
@@ -159,14 +166,21 @@ public class UserIndexerTest {
 		String middleName = "Joanne";
 		String lastName = "Parker";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
+
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
+
+		_userLocalService.updateUser(expectedUser);
 
 		assertNoHits("firstName", "\"Mary Watson\"");
 		assertNoHits("firstName", "\"Mary Jane\" Missingword");
 
-		user = assertSearchOneUser("firstName", "Mary \"Jane Watson\"", user);
+		User actualUser = assertSearchOneUser(
+			"firstName", "Mary \"Jane Watson\"", expectedUser);
 
-		Assert.assertEquals(firstName, user.getFirstName());
+		Assert.assertEquals(firstName, actualUser.getFirstName());
 	}
 
 	@Test
@@ -213,19 +227,25 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("Fir", user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals("First", user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
 
-		user = assertSearchOneUser("LasT", user);
+		User actualUser = assertSearchOneUser("Fir", expectedUser);
 
-		Assert.assertEquals("Last", user.getLastName());
+		Assert.assertEquals("First", actualUser.getFirstName());
 
-		user = assertSearchOneUser("midd", user);
+		actualUser = assertSearchOneUser("LasT", expectedUser);
 
-		Assert.assertEquals("Middle", user.getMiddleName());
+		Assert.assertEquals("Last", actualUser.getLastName());
+
+		actualUser = assertSearchOneUser("midd", expectedUser);
+
+		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
 
 	@Test
@@ -234,19 +254,25 @@ public class UserIndexerTest {
 		String lastName = "Last";
 		String middleName = "Middle";
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("Fir", user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals("First", user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
 
-		user = assertSearchOneUser("asT", user);
+		User actualUser = assertSearchOneUser("Fir", expectedUser);
 
-		Assert.assertEquals("Last", user.getLastName());
+		Assert.assertEquals("First", actualUser.getFirstName());
 
-		user = assertSearchOneUser("idd", user);
+		actualUser = assertSearchOneUser("asT", expectedUser);
 
-		Assert.assertEquals("Middle", user.getMiddleName());
+		Assert.assertEquals("Last", actualUser.getLastName());
+
+		actualUser = assertSearchOneUser("idd", expectedUser);
+
+		Assert.assertEquals("Middle", actualUser.getMiddleName());
 	}
 
 	@Test
@@ -324,17 +350,6 @@ public class UserIndexerTest {
 		_users.add(user);
 
 		return user;
-	}
-
-	protected User addUserNameFields(
-			String firstName, String lastName, String middleName)
-		throws Exception {
-
-		String screenName = testName.getMethodName();
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
 	}
 
 	protected User addUserScreenName(String screenName) throws Exception {
@@ -478,19 +493,27 @@ public class UserIndexerTest {
 			String firstName, String lastName, String middleName)
 		throws Exception {
 
-		User user = addUserNameFields(firstName, lastName, middleName);
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("firstName", firstName, user);
+		expectedUser.setFirstName(firstName);
+		expectedUser.setMiddleName(middleName);
+		expectedUser.setLastName(lastName);
 
-		Assert.assertEquals(firstName, user.getFirstName());
+		_userLocalService.updateUser(expectedUser);
 
-		user = assertSearchOneUser("lastName", lastName, user);
+		User actualUser = assertSearchOneUser(
+			"firstName", firstName, expectedUser);
 
-		Assert.assertEquals(lastName, user.getLastName());
+		Assert.assertEquals(firstName, actualUser.getFirstName());
 
-		user = assertSearchOneUser("middleName", middleName, user);
+		actualUser = assertSearchOneUser("lastName", lastName, expectedUser);
 
-		Assert.assertEquals(middleName, user.getMiddleName());
+		Assert.assertEquals(lastName, actualUser.getLastName());
+
+		actualUser = assertSearchOneUser(
+			"middleName", middleName, expectedUser);
+
+		Assert.assertEquals(middleName, actualUser.getMiddleName());
 	}
 
 	protected String toString(List<String> strings) {

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -145,7 +145,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
 			"firstName", "\"Mary Jane\"", _expectedUser);
@@ -165,7 +165,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		assertNoHits("firstName", "\"Mary Watson\"");
 		assertNoHits("firstName", "\"Mary Jane\" Missingword");
@@ -226,7 +226,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
@@ -253,7 +253,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser("Fir", _expectedUser);
 
@@ -444,7 +444,7 @@ public class UserIndexerTest {
 		_expectedUser.setMiddleName(middleName);
 		_expectedUser.setLastName(lastName);
 
-		_userLocalService.updateUser(_expectedUser);
+		_expectedUser = _userLocalService.updateUser(_expectedUser);
 
 		User actualUser = assertSearchOneUser(
 			"firstName", firstName, _expectedUser);

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -79,50 +79,51 @@ public class UserIndexerTest {
 	public void testEmailAddress() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			StringUtil.toUpperCase(expectedEmail), _expectedUser);
+			StringUtil.toUpperCase(expectedEmailAddress), _expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressField() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			"emailAddress", expectedEmail, _expectedUser);
+			"emailAddress", expectedEmailAddress, _expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressPrefix() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			StringUtil.removeSubstring(expectedEmail, "@liferay.com"),
+			StringUtil.removeSubstring(expectedEmailAddress, "@liferay.com"),
 			_expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressSubstring() throws Exception {
 		_expectedUser = UserTestUtil.addUser();
 
-		String expectedEmail = _expectedUser.getEmailAddress();
+		String expectedEmailAddress = _expectedUser.getEmailAddress();
 
 		User actualUser = assertSearchOneUser(
-			expectedEmail.substring(4, expectedEmail.length() - 7),
+			expectedEmailAddress.substring(
+				4, expectedEmailAddress.length() - 7),
 			_expectedUser);
 
-		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
+		Assert.assertEquals(expectedEmailAddress, actualUser.getEmailAddress());
 	}
 
 	@Test

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
@@ -84,38 +85,52 @@ public class UserIndexerTest {
 
 	@Test
 	public void testEmailAddress() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("Em.Ail@liferay.com", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			StringUtil.toUpperCase(expectedEmail), expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressField() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("emailAddress", "em.ail@liferay.com", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			"emailAddress", expectedEmail, expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressPrefix() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("EM.AIL", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			StringUtil.removeSubstring(expectedEmail, "@liferay.com"),
+			expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
 	public void testEmailAddressSubstring() throws Exception {
-		User user = addUserEmailAddress("Em.Ail@liferay.com");
+		User expectedUser = UserTestUtil.addUser();
 
-		user = assertSearchOneUser("ail@life", user);
+		String expectedEmail = expectedUser.getEmailAddress();
 
-		Assert.assertEquals("em.ail@liferay.com", user.getEmailAddress());
+		User actualUser = assertSearchOneUser(
+			expectedEmail.substring(4, expectedEmail.length() - 7),
+			expectedUser);
+
+		Assert.assertEquals(expectedEmail, actualUser.getEmailAddress());
 	}
 
 	@Test
@@ -309,16 +324,6 @@ public class UserIndexerTest {
 		_users.add(user);
 
 		return user;
-	}
-
-	protected User addUserEmailAddress(String emailAddress) throws Exception {
-		String firstName = RandomTestUtil.randomString();
-		String lastName = RandomTestUtil.randomString();
-		String middleName = RandomTestUtil.randomString();
-		String screenName = testName.getMethodName();
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
 	}
 
 	protected User addUserNameFields(

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -277,37 +277,41 @@ public class UserIndexerTest {
 
 	@Test
 	public void testScreenName() throws Exception {
-		User user = addUserScreenName("Open4Life");
+		User expectedUser = UserTestUtil.addUser(
+			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		user = assertSearchOneUser("Open4Life", user);
+		User actualUser = assertSearchOneUser("Open4Life", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameField() throws Exception {
-		User user = addUserScreenName("Open4Life");
+		User expectedUser = UserTestUtil.addUser(
+			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		user = assertSearchOneUser("screenName", "open4life", user);
+		User actualUser = assertSearchOneUser(
+			"screenName", "open4life", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Test
 	public void testScreenNameSubstring() throws Exception {
-		User user = addUserScreenName("Open4Life");
+		User expectedUser = UserTestUtil.addUser(
+			"Open4Life", new long[] {TestPropsValues.getGroupId()});
 
-		user = assertSearchOneUser("open lite", user);
+		User actualUser = assertSearchOneUser("open lite", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		user = assertSearchOneUser("OPE", user);
+		actualUser = assertSearchOneUser("OPE", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 
-		user = assertSearchOneUser("4lif", user);
+		actualUser = assertSearchOneUser("4lif", expectedUser);
 
-		Assert.assertEquals("open4life", user.getScreenName());
+		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
 	@Rule
@@ -350,16 +354,6 @@ public class UserIndexerTest {
 		_users.add(user);
 
 		return user;
-	}
-
-	protected User addUserScreenName(String screenName) throws Exception {
-		String firstName = RandomTestUtil.randomString();
-		String lastName = RandomTestUtil.randomString();
-		String middleName = RandomTestUtil.randomString();
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
 	}
 
 	protected void assertLength(Hits hits, int length) {

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -119,7 +120,7 @@ public class UserIndexerTest {
 
 	@Test
 	public void testEmptyQuery() throws Exception {
-		User user = addUser();
+		User user = UserTestUtil.addUser();
 
 		assertSearch(StringPool.BLANK, user);
 	}
@@ -155,7 +156,7 @@ public class UserIndexerTest {
 
 	@Test
 	public void testLikeCharacter() throws Exception {
-		User user = addUser();
+		User user = UserTestUtil.addUser();
 
 		assertSearch(StringPool.PERCENT, user);
 
@@ -164,7 +165,7 @@ public class UserIndexerTest {
 
 	@Test
 	public void testLuceneQueryParserUnfriendlyCharacters() throws Exception {
-		User user = addUser();
+		User user = UserTestUtil.addUser();
 
 		assertSearch(StringPool.AT, user);
 
@@ -270,17 +271,6 @@ public class UserIndexerTest {
 
 	@Rule
 	public TestName testName = new TestName();
-
-	protected User addUser() throws Exception {
-		String emailAddress = RandomTestUtil.randomString() + "@liferay.com";
-		String firstName = RandomTestUtil.randomString();
-		String lastName = RandomTestUtil.randomString();
-		String middleName = RandomTestUtil.randomString();
-		String screenName = testName.getMethodName();
-
-		return addUser(
-			firstName, lastName, middleName, screenName, emailAddress);
-	}
 
 	protected User addUser(
 			String firstName, String lastName, String middleName,

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,6 +53,7 @@ import org.junit.runner.RunWith;
 /**
  * @author André de Oliveira
  */
+@Ignore
 @RunWith(Arquillian.class)
 @Sync
 public class UserIndexerTest {

--- a/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
+++ b/modules/apps/foundation/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/indexer/test/UserIndexerTest.java
@@ -22,18 +22,14 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -42,17 +38,14 @@ import com.liferay.registry.RegistryUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 /**
@@ -79,8 +72,6 @@ public class UserIndexerTest {
 			IndexerRegistry.class);
 
 		_indexer = indexerRegistry.getIndexer(User.class);
-
-		_serviceContext = ServiceContextTestUtil.getServiceContext();
 	}
 
 	@Test
@@ -314,48 +305,6 @@ public class UserIndexerTest {
 		Assert.assertEquals("open4life", actualUser.getScreenName());
 	}
 
-	@Rule
-	public TestName testName = new TestName();
-
-	protected User addUser(
-			String firstName, String lastName, String middleName,
-			String screenName, String emailAddress)
-		throws Exception {
-
-		long creatorUserId = TestPropsValues.getUserId();
-		long companyId = TestPropsValues.getCompanyId();
-		boolean autoPassword = true;
-		String password1 = null;
-		String password2 = null;
-		boolean autoScreenName = false;
-		long facebookId = 0;
-		String openId = null;
-		Locale locale = LocaleUtil.getDefault();
-		long prefixId = 0;
-		long suffixId = 0;
-		boolean male = false;
-		int birthdayMonth = Calendar.JANUARY;
-		int birthdayDay = 1;
-		int birthdayYear = 1970;
-		String jobTitle = null;
-		long[] groupIds = new long[] {TestPropsValues.getGroupId()};
-		long[] organizationIds = null;
-		long[] roleIds = null;
-		long[] userGroupIds = null;
-		boolean sendMail = false;
-
-		User user = _userLocalService.addUser(
-			creatorUserId, companyId, autoPassword, password1, password2,
-			autoScreenName, screenName, emailAddress, facebookId, openId,
-			locale, firstName, middleName, lastName, prefixId, suffixId, male,
-			birthdayMonth, birthdayDay, birthdayYear, jobTitle, groupIds,
-			organizationIds, roleIds, userGroupIds, sendMail, _serviceContext);
-
-		_users.add(user);
-
-		return user;
-	}
-
 	protected void assertLength(Hits hits, int length) {
 		Assert.assertEquals(hits.toString(), length, hits.getLength());
 	}
@@ -517,10 +466,6 @@ public class UserIndexerTest {
 	}
 
 	private Indexer<User> _indexer;
-	private ServiceContext _serviceContext;
 	private UserLocalService _userLocalService;
-
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/configuration/easyconf/ClassLoaderComponentConfigurationTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/configuration/easyconf/ClassLoaderComponentConfigurationTest.java
@@ -76,21 +76,21 @@ public class ClassLoaderComponentConfigurationTest {
 
 			Assert.assertEquals(
 				"Unable to decode part \"xyz\" from \"" + s +
-					"\", preserve it literally.",
+					"\", preserve it literally",
 				logRecord.getMessage());
 
 			logRecord = logRecords.get(1);
 
 			Assert.assertEquals(
 				"Unable to decode part \"-1\" from \"" + s +
-					"\", preserve it literally.",
+					"\", preserve it literally",
 				logRecord.getMessage());
 
 			logRecord = logRecords.get(2);
 
 			Assert.assertEquals(
 				"Unable to decode part \"DEF\" from \"" + s +
-					"\", preserve it literally.",
+					"\", preserve it literally",
 				logRecord.getMessage());
 		}
 	}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/UserTestUtil.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserServiceUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
+import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -120,7 +121,9 @@ public class UserTestUtil {
 	public static User addUser() throws Exception {
 		return addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			new long[] {TestPropsValues.getGroupId()},
@@ -183,7 +186,9 @@ public class UserTestUtil {
 	public static User addUser(Company company) throws Exception {
 		return addUser(
 			company.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			new long[] {TestPropsValues.getGroupId()},
@@ -193,7 +198,9 @@ public class UserTestUtil {
 	public static User addUser(long... groupIds) throws Exception {
 		return addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), groupIds,
 			ServiceContextTestUtil.getServiceContext());
@@ -202,7 +209,9 @@ public class UserTestUtil {
 	public static User addUser(long groupId, Locale locale) throws Exception {
 		return addUser(
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
 			locale, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new long[] {groupId},
 			ServiceContextTestUtil.getServiceContext());


### PR DESCRIPTION
@brianchandotcom this is fixing the IndexerPostProcessorRegistryTest failures, which is caused by https://github.com/brianchandotcom/liferay-portal-ee/pull/17403 , you don't see the IndexerPostProcessorRegistryTest failures now in today's pulls, because test grouping changed again, the combination that exposed this issue is gone. Even after this fix, IndexerRegistryImpl is still not thread safe. We could end up having an Indexer holding an unregistered IndexerPostProcessor, in case there is a concurrent Indexer registering and IndexerPostProcessor unregistering. But this is a rare case, I am leaving the fix to @tomwang2011 as an exercise for solving complex race conditions. We will complete the race condition fix a bit later.

CC @peterpetrekanics @lipusz @CsabaTurcsan @mhan810
