### PR TITLE
LPS-73556 bad module name and missing configuration file in staging-processes-web for main.js

### DIFF
--- a/modules/apps/web-experience/staging/staging-processes-web/bnd.bnd
+++ b/modules/apps/web-experience/staging/staging-processes-web/bnd.bnd
@@ -1,6 +1,7 @@
 Bundle-Name: Liferay Staging Processes Web
 Bundle-SymbolicName: com.liferay.staging.processes.web
 Bundle-Version: 1.0.19
+Liferay-JS-Config: /META-INF/resources/js/config.js
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Data Management
 Web-ContextPath: /staging-processes-web

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/StagingProcessesPortlet.java
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/StagingProcessesPortlet.java
@@ -37,7 +37,6 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-staging-processes",
-		"com.liferay.portlet.footer-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/config.js
@@ -1,0 +1,32 @@
+;(function() {
+	AUI().applyConfig(
+		{
+			groups: {
+				stagingprocessesweb: {
+					base: MODULE_PATH + '/',
+					combine: Liferay.AUI.getCombine(),
+					modules: {
+						'liferay-staging-processes-export-import': {
+							path: 'js/main.js',
+							requires: [
+								'aui-datatype',
+								'aui-dialog-iframe-deprecated',
+								'aui-io-request',
+								'aui-modal',
+								'aui-parse-content',
+								'aui-toggler',
+								'aui-tree-view',
+								'liferay-notice',
+								'liferay-portlet-base',
+								'liferay-portlet-url',
+								'liferay-store',
+								'liferay-util-window'
+							]
+						},
+					},
+					root: MODULE_PATH + '/'
+				}
+			}
+		}
+	);
+})();

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -1,5 +1,5 @@
 AUI.add(
-	'liferay-export-import',
+	'liferay-staging-processes-export-import',
 	function(A) {
 		var $ = AUI.$;
 

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
@@ -82,7 +82,7 @@ PortletURL portletURL = renderResponse.createRenderURL();
 	</c:when>
 </c:choose>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-staging-processes-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="publishLayouts" var="publishProcessesURL">
 		<portlet:param name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_CUR_PARAM) %>" />
 		<portlet:param name="<%= SearchContainer.DEFAULT_DELTA_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_DELTA_PARAM) %>" />

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/new_publication/publish_layouts.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/new_publication/publish_layouts.jsp
@@ -341,7 +341,7 @@ renderResponse.setTitle(!configuredPublish ? LanguageUtil.get(request, "new-publ
 	Liferay.Util.toggleRadio('<portlet:namespace />rangeLast', '<portlet:namespace />rangeLastInputs', ['<portlet:namespace />startEndDate']);
 </aui:script>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-staging-processes-export-import">
 	var exportImport = new Liferay.ExportImport(
 		{
 			commentsNode: '#<%= PortletDataHandlerKeys.COMMENTS %>',

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/edit_template.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/edit_template.jsp
@@ -197,7 +197,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 	Liferay.Util.toggleRadio('<portlet:namespace />rangeLast', '<portlet:namespace />rangeLastInputs', ['<portlet:namespace />startEndDate']);
 </aui:script>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-staging-processes-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="publishLayouts" var="publishProcessesURL">
 		<portlet:param name="<%= Constants.CMD %>" value="<%= cmd %>" />
 		<portlet:param name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_CUR_PARAM) %>" />

--- a/tools/subrepo/push_to_subrepos.sh
+++ b/tools/subrepo/push_to_subrepos.sh
@@ -419,14 +419,14 @@ done
 
 info
 
-if [[ "${OPTION_VERIFY}" ]]; then
-	if ((TOTAL_FILES_COUNTER > 0)); then
+if ((TOTAL_FILES_COUNTER > 0)); then
+	if [[ "${OPTION_VERIFY}" ]]; then
 		info "${TOTAL_FILES_COUNTER} files require updating."
 	else
-		info "All files up to date."
+		info "${TOTAL_FILES_COUNTER} files were successfully updated."
 	fi
 else
-	info "${TOTAL_FILES_COUNTER} files were successfully updated."
+	info "All files up to date."
 fi
 
 REMAINING_RATE="$(get_remaining_rate)"


### PR DESCRIPTION
Hi Brian,

Originally Chema proposed these changes and he saw this pull request.
Bad module naming can cause name clashing issues and we used the same javascript module name 'liferay-export-import' both here and in export-import module in the portal.

I will send you similar modifications for export-import module also.

Thank you in advance
Péter Borkuti