### PR TITLE
LPS-73557 bad module name and missing configuration file in export-import-web for main.js

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-web/bnd.bnd
+++ b/modules/apps/web-experience/export-import/export-import-web/bnd.bnd
@@ -1,6 +1,7 @@
 Bundle-Name: Liferay Export Import Web
 Bundle-SymbolicName: com.liferay.exportimport.web
 Bundle-Version: 1.0.30
+Liferay-JS-Config: /META-INF/resources/js/config.js
 Export-Package:\
 	com.liferay.exportimport.web.constants,\
 	com.liferay.exportimport.web.trash

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportImportPortlet.java
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportImportPortlet.java
@@ -39,7 +39,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-export-import",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.footer-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/export_import.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportPortlet.java
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportPortlet.java
@@ -38,7 +38,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-export-import",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.footer-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/export_import.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ImportPortlet.java
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ImportPortlet.java
@@ -38,7 +38,6 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-export-import",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.footer-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/export_import.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_template.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/export_templates/edit_template.jsp
@@ -127,7 +127,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 	</aui:form>
 </div>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	var exportImport = new Liferay.ExportImport(
 		{
 			archivedSetupsNode: '#<%= PortletDataHandlerKeys.PORTLET_ARCHIVED_SETUPS_ALL %>',

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/new_export/export_layouts.jsp
@@ -156,7 +156,7 @@ renderResponse.setTitle(!configuredExport ? LanguageUtil.get(request, "new-custo
 	</aui:form>
 </div>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	var exportImport = new Liferay.ExportImport(
 		{
 			archivedSetupsNode: '#<%= PortletDataHandlerKeys.PORTLET_ARCHIVED_SETUPS_ALL %>',

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/view.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export/view.jsp
@@ -70,7 +70,7 @@ String searchContainerId = "exportLayoutProcesses";
 	</c:otherwise>
 </c:choose>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="exportLayouts" var="exportProcessesURL">
 		<portlet:param name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_CUR_PARAM) %>" />
 		<portlet:param name="<%= SearchContainer.DEFAULT_DELTA_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_DELTA_PARAM) %>" />

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/export_portlet.jsp
@@ -470,7 +470,7 @@ portletURL.setParameter("portletResource", portletResource);
 	</c:when>
 </c:choose>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="exportImport" var="exportProcessesURL">
 		<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.EXPORT %>" />
 		<portlet:param name="tabs2" value="export" />

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import/new_import/import_layouts_resources.jsp
@@ -393,7 +393,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(user
 	Liferay.Util.toggleSelectBox('<portlet:namespace /><%= PortletDataHandlerKeys.PORTLET_DATA_ALL %>', 'false', '<portlet:namespace />selectContents');
 </aui:script>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	new Liferay.ExportImport(
 		{
 			archivedSetupsNode: '#<%= PortletDataHandlerKeys.PORTLET_ARCHIVED_SETUPS_ALL %>',

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import/view.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import/view.jsp
@@ -71,7 +71,7 @@ GroupDisplayContextHelper groupDisplayContextHelper = new GroupDisplayContextHel
 	</c:otherwise>
 </c:choose>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="importLayouts" var="importProcessesURL">
 		<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.IMPORT %>" />
 		<portlet:param name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_CUR_PARAM) %>" />

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet.jsp
@@ -86,7 +86,7 @@ String[] tempFileNames = LayoutServiceUtil.getTempFileNames(scopeGroupId, Export
 	</c:when>
 </c:choose>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="exportImport" var="importProcessesURL">
 		<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.IMPORT %>" />
 		<portlet:param name="tabs2" value="import" />

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_resources.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/import_portlet_resources.jsp
@@ -320,7 +320,7 @@ ManifestSummary manifestSummary = ExportImportHelperUtil.getManifestSummary(them
 	</aui:button-row>
 </aui:form>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	new Liferay.ExportImport(
 		{
 			commentsNode: '#<%= PortletDataHandlerKeys.COMMENTS %>',

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/config.js
@@ -1,0 +1,32 @@
+;(function() {
+	AUI().applyConfig(
+		{
+			groups: {
+				exportimportweb: {
+					base: MODULE_PATH + '/',
+					combine: Liferay.AUI.getCombine(),
+					modules: {
+						'liferay-export-import-export-import': {
+							path: 'js/main.js',
+							requires: [
+								'aui-datatype',
+								'aui-dialog-iframe-deprecated',
+								'aui-io-request',
+								'aui-modal',
+								'aui-parse-content',
+								'aui-toggler',
+								'aui-tree-view',
+								'liferay-notice',
+								'liferay-portlet-base',
+								'liferay-portlet-url',
+								'liferay-store',
+								'liferay-util-window'
+							]
+						},
+					},
+					root: MODULE_PATH + '/'
+				}
+			}
+		}
+	);
+})();

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/js/main.js
@@ -1,5 +1,5 @@
 AUI.add(
-	'liferay-export-import',
+	'liferay-export-import-export-import',
 	function(A) {
 		var $ = AUI.$;
 

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
@@ -304,7 +304,7 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 	Liferay.Util.toggleRadio('<portlet:namespace />rangeLast', '<portlet:namespace />rangeLastInputs', ['<portlet:namespace />startEndDate']);
 </aui:script>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	var exportImport = new Liferay.ExportImport(
 		{
 			commentsNode: '#<%= PortletDataHandlerKeys.COMMENTS %>',

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish_portlet.jsp
@@ -499,7 +499,7 @@ portletURL.setParameter("tabs3", "current-and-previous");
 				</c:when>
 			</c:choose>
 
-			<aui:script use="liferay-export-import">
+			<aui:script use="liferay-export-import-export-import">
 				<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="publishPortlet" var="publishProcessesURL">
 					<portlet:param name="<%= Constants.CMD %>" value="<%= Constants.PUBLISH %>" />
 					<portlet:param name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_CUR_PARAM) %>" />

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/view_export_import.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/view_export_import.jsp
@@ -27,7 +27,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "process-details"));
 	<liferay-util:include page="/export_import_process.jsp" servletContext="<%= application %>" />
 </div>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-export-import-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="exportImport" var="exportImportProcessURL">
 		<portlet:param name="<%= Constants.CMD %>" value="export_import" />
 		<portlet:param name="backgroundTaskId" value="<%= String.valueOf(backgroundTaskId) %>" />

--- a/tools/subrepo/push_to_subrepos.sh
+++ b/tools/subrepo/push_to_subrepos.sh
@@ -419,14 +419,14 @@ done
 
 info
 
-if [[ "${OPTION_VERIFY}" ]]; then
-	if ((TOTAL_FILES_COUNTER > 0)); then
+if ((TOTAL_FILES_COUNTER > 0)); then
+	if [[ "${OPTION_VERIFY}" ]]; then
 		info "${TOTAL_FILES_COUNTER} files require updating."
 	else
-		info "All files up to date."
+		info "${TOTAL_FILES_COUNTER} files were successfully updated."
 	fi
 else
-	info "${TOTAL_FILES_COUNTER} files were successfully updated."
+	info "All files up to date."
 fi
 
 REMAINING_RATE="$(get_remaining_rate)"


### PR DESCRIPTION
Hi Brian,

The same issue as in LPS-73556, but it is in export-import module. Chema proposed this fixes to avoid name clashing in javascript modules.

Thank you in advance
Péter Borkuti