### PR TITLE
LRQA-32801 Add support for 'return' elements to the readable poshi converter

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecuteElement.java
@@ -46,6 +46,23 @@ public class ExecuteElement extends PoshiElement {
 
 	@Override
 	public void parseReadableSyntax(String readableSyntax) {
+		if (readableSyntax.contains("return(\n")) {
+			String returnFrom = RegexUtil.getGroup(
+				readableSyntax, ".*,(.*)\\)", 1);
+			String returnName = RegexUtil.getGroup(
+				readableSyntax, "var(.*?)=", 1);
+
+			ReturnElement returnElement = new ReturnElement(readableSyntax);
+
+			returnElement.addAttribute("from", returnFrom.trim());
+			returnElement.addAttribute("name", returnName.trim());
+
+			add(returnElement);
+
+			readableSyntax = RegexUtil.getGroup(
+				readableSyntax, "return\\((.*),", 1);
+		}
+
 		String executeType = "macro";
 
 		String content = getParentheticalContent(readableSyntax);
@@ -118,9 +135,27 @@ public class ExecuteElement extends PoshiElement {
 			return createReadableBlock(sb.toString());
 		}
 
-		String readableSyntax = super.toReadableSyntax();
+		StringBuilder sb = new StringBuilder();
 
-		return createReadableBlock(readableSyntax);
+		PoshiElement returnElement = null;
+
+		for (PoshiElement poshiElement : toPoshiElements(elements())) {
+			if (poshiElement instanceof ReturnElement) {
+				returnElement = poshiElement;
+
+				continue;
+			}
+
+			sb.append(poshiElement.toReadableSyntax());
+		}
+
+		String readableBlock = createReadableBlock(sb.toString());
+
+		if (returnElement == null) {
+			return readableBlock;
+		}
+
+		return returnElement.createReadableBlock(readableBlock);
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -76,6 +76,10 @@ public class PoshiElementFactory {
 			return new PropertyElement(element);
 		}
 
+		if (elementName.equals("return")) {
+			return new ReturnElement(element);
+		}
+
 		if (elementName.equals("set-up")) {
 			return new SetUpElement(element);
 		}
@@ -164,6 +168,10 @@ public class PoshiElementFactory {
 
 				if (line.startsWith("test") && line.endsWith(" {")) {
 					return new CommandElement(readableSyntax);
+				}
+
+				if (line.startsWith("var") && line.endsWith("return(")) {
+					return new ExecuteElement(readableSyntax);
 				}
 
 				if (line.startsWith("var ")) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ReturnElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ReturnElement.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import com.liferay.poshi.runner.util.RegexUtil;
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ReturnElement extends PoshiElement {
+
+	public ReturnElement(Element element) {
+		super("return", element);
+	}
+
+	public ReturnElement(String readableSyntax) {
+		super("return", readableSyntax);
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		return "";
+	}
+
+	@Override
+	protected String createReadableBlock(String content) {
+		StringBuilder sb = new StringBuilder();
+
+		String blockName = getBlockName();
+		String pad = getPad();
+
+		sb.append("\n\n");
+		sb.append(pad);
+		sb.append(blockName);
+		sb.append("(");
+
+		String trimmedContent = content.trim();
+
+		if (!trimmedContent.equals("")) {
+			if (content.contains("\n")) {
+				content = content.replace("\n\n", "\n");
+				content = content.replaceAll("\n", "\n" + pad);
+			}
+
+			if (trimmedContent.endsWith(";")) {
+				int index = content.lastIndexOf(";");
+
+				content = content.substring(0, index);
+			}
+
+			sb.append(content);
+			sb.append(",");
+
+			String contentPad = RegexUtil.getGroup(content, "([\\s]*).*", 1);
+
+			sb.append(contentPad);
+			sb.append(attributeValue("from"));
+			sb.append("\n");
+			sb.append(pad);
+		}
+
+		sb.append(");");
+
+		return sb.toString();
+	}
+
+	@Override
+	protected String getBlockName() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("var ");
+		sb.append(attributeValue("name"));
+		sb.append(" = return");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ReturnElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ReturnElement.java
@@ -15,6 +15,7 @@
 package com.liferay.poshi.runner.elements;
 
 import com.liferay.poshi.runner.util.RegexUtil;
+
 import org.dom4j.Element;
 
 /**
@@ -71,6 +72,7 @@ public class ReturnElement extends PoshiElement {
 			String contentPad = RegexUtil.getGroup(content, "([\\s]*).*", 1);
 
 			sb.append(contentPad);
+
 			sb.append(attributeValue("from"));
 			sb.append("\n");
 			sb.append(pad);

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -73,6 +73,11 @@
             </then>
         </if>
 
+        <execute macro="TestCase#getSiteName">
+            <return from="siteName" name="siteName" />
+            <var name="siteName" value="${siteName}" />
+        </execute>
+
         <execute macro="Smoke#viewWelcomePage" />
 
         <execute macro="Smoke#runSmoke" />

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -65,6 +65,13 @@ definition {
 			Alert.viewSuccessMessage();
 		}
 
+		var siteName = return(
+			TestCase.getSiteName(
+				siteName = "${siteName}"
+			),
+			siteName
+		);
+
 		Smoke.viewWelcomePage();
 
 		Smoke.runSmoke();


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-32801

#### Changes in this pull: 
* Add basic support for _return_ elements. 

#### Translation status
On master:
```
1414 / 2135 (66%) test commands were successfully translated
8 / 2135 test commands fail due to setup failures
108 / 2135 test commands fail due to teardown failures
182 / 337 (54%) test files were successfully translated with 520 tests
Test commands that fail two way conversion: 177
```

With this pull: 
```
1510 / 2150 (70%) test commands were successfully translated
5 / 2150 test commands fail due to setup failures
109 / 2150 test commands fail due to teardown failures
195 / 339 (57%) test files were successfully translated with 655 tests (30%)
Test commands that fail two way conversion: 84
```