### PR TITLE
LPS-72801 Title is not correct when creating Data Definitions

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/dynamic/data/mapping/util/DDLDDMDisplay.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/dynamic/data/mapping/util/DDLDDMDisplay.java
@@ -54,6 +54,13 @@ public class DDLDDMDisplay extends BaseDDMDisplay {
 
 		return LanguageUtil.get(resourceBundle, "data-definition");
 	}
+	
+	@Override
+	public String getTitle(Locale locale) {
+		ResourceBundle resourceBundle = getResourceBundle(locale);
+
+		return LanguageUtil.get(resourceBundle, "data-definitions");
+	}
 
 	@Override
 	public String getStructureType() {


### PR DESCRIPTION
Fixed the issue to display correct title while using Dynamic Data portlet for creating data definitions - 

Test Environment: 
Tomcat 7.x
Mysql: 5.6
Google Chrome, Mozilla and IE