### PR TITLE
[See description] LPS-73811 Delegate authorization to external repositories via repository capability

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/bnd.bnd
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/bnd.bnd
@@ -1,0 +1,8 @@
+Bundle-Name: Liferay Document Library Repository Authorization API
+Bundle-SymbolicName: com.liferay.document.library.repository.authorization.api
+Bundle-Version: 1.0.0
+Export-Package:\
+	com.liferay.document.library.repository.authorization.capability,\
+	com.liferay.document.library.repository.authorization.oauth2
+Liferay-Releng-Module-Group-Description:
+Liferay-Releng-Module-Group-Title: Document Library

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/build.gradle
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/build.gradle
@@ -2,12 +2,7 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
-	provided group: "com.liferay", name: "com.liferay.document.library.api", version: "3.2.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.13.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
-	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
-	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 }

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/build.gradle
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/build.gradle
@@ -1,0 +1,13 @@
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+dependencies {
+	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
+	provided group: "com.liferay", name: "com.liferay.document.library.api", version: "3.2.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.13.0"
+	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
+	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+}

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/capability/AuthorizationCapability.java
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/capability/AuthorizationCapability.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.repository.authorization.capability;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.repository.capabilities.Capability;
+
+import java.io.IOException;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface AuthorizationCapability extends Capability {
+
+	public boolean authorize(
+			HttpServletRequest request, HttpServletResponse response)
+		throws IOException, PortalException;
+
+	public boolean authorize(
+			PortletRequest portletRequest, PortletResponse portletResponse)
+		throws IOException, PortalException;
+
+}

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/capability/AuthorizationCapability.java
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/capability/AuthorizationCapability.java
@@ -30,11 +30,15 @@ import javax.servlet.http.HttpServletResponse;
  */
 public interface AuthorizationCapability extends Capability {
 
-	public boolean authorize(
+	public void authorize(
 			HttpServletRequest request, HttpServletResponse response)
 		throws IOException, PortalException;
 
-	public boolean authorize(
+	public void authorize(
+			PortletRequest portletRequest, PortletResponse portletResponse)
+		throws IOException, PortalException;
+
+	public boolean hasCustomRedirectFlow(
 			PortletRequest portletRequest, PortletResponse portletResponse)
 		throws IOException, PortalException;
 

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/capability/AuthorizationException.java
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/capability/AuthorizationException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.repository.authorization.capability;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class AuthorizationException extends PortalException {
+
+	protected AuthorizationException() {
+	}
+
+	protected AuthorizationException(String msg) {
+		super(msg);
+	}
+
+	protected AuthorizationException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+	protected AuthorizationException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/oauth2/OAuth2AuthorizationException.java
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/oauth2/OAuth2AuthorizationException.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.repository.authorization.oauth2;
+
+import com.liferay.document.library.repository.authorization.capability.AuthorizationException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class OAuth2AuthorizationException extends AuthorizationException {
+
+	public static final OAuth2AuthorizationException getErrorException(
+		String error, String description) {
+
+		Function<String, OAuth2AuthorizationException> function =
+			_exceptions.getOrDefault(error, OAuth2AuthorizationException::new);
+
+		return function.apply(description);
+	}
+
+	public static class AccessDenied extends OAuth2AuthorizationException {
+
+		public AccessDenied(String description) {
+			super(
+				String.format(
+					"The client is not authorized to request an " +
+						"authorization code using this method: %s",
+					description));
+		}
+
+	}
+
+	public static class InvalidRequest extends OAuth2AuthorizationException {
+
+		public InvalidRequest(String description) {
+			super(
+				String.format(
+					"The request is missing a required parameter, includes " +
+						"an invalid parameter value, includes a parameter " +
+							"more than once, or is otherwise malformed: %s",
+					description));
+		}
+
+	}
+
+	public static class InvalidScope extends OAuth2AuthorizationException {
+
+		public InvalidScope(String description) {
+			super(
+				String.format(
+					"The requested scope is invalid, unknown, or malformed: %s",
+					description));
+		}
+
+	}
+
+	public static class InvalidState extends OAuth2AuthorizationException {
+
+		public InvalidState(String state) {
+			super(
+				String.format(
+					"The resource owner returned an invalid state value: %s",
+					state));
+		}
+
+	}
+
+	public static class ServerError extends OAuth2AuthorizationException {
+
+		public ServerError(String description) {
+			super(
+				String.format(
+					"The authorization server encountered an unexpected " +
+						"condition that prevented it from fulfilling the " +
+							"request: %s",
+					description));
+		}
+
+	}
+
+	public static class TemporarilyUnavailable
+		extends OAuth2AuthorizationException {
+
+		public TemporarilyUnavailable(String description) {
+			super(
+				String.format(
+					"The authorization server is currently unable to handle " +
+						"the request due to a temporary overloading or " +
+							"maintenance of the server: %s",
+					description));
+		}
+
+	}
+
+	public static class UnauthorizedClient
+		extends OAuth2AuthorizationException {
+
+		public UnauthorizedClient(String description) {
+			super(
+				String.format(
+					"The resource owner or authorization server denied the " +
+						"request: %s",
+					description));
+		}
+
+	}
+
+	public static class UnsupportedResponseType
+		extends OAuth2AuthorizationException {
+
+		public UnsupportedResponseType(String description) {
+			super(
+				String.format(
+					"The authorization server does not support obtaining an" +
+						"authorization code using this method: %s",
+					description));
+		}
+
+	}
+
+	protected OAuth2AuthorizationException() {
+	}
+
+	protected OAuth2AuthorizationException(String msg) {
+		super(msg);
+	}
+
+	protected OAuth2AuthorizationException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+	protected OAuth2AuthorizationException(Throwable cause) {
+		super(cause);
+	}
+
+	private static final Map<
+		String, Function<String, OAuth2AuthorizationException>>
+			_exceptions = new HashMap<>(7);
+
+	static {
+		_exceptions.put(
+			"access_denied", OAuth2AuthorizationException.AccessDenied::new);
+		_exceptions.put(
+			"invalid_request",
+			OAuth2AuthorizationException.InvalidRequest::new);
+		_exceptions.put(
+			"invalid_scope", OAuth2AuthorizationException.InvalidScope::new);
+		_exceptions.put(
+			"server_error", OAuth2AuthorizationException.ServerError::new);
+		_exceptions.put(
+			"temporarily_unavailable",
+			OAuth2AuthorizationException.TemporarilyUnavailable::new);
+		_exceptions.put(
+			"unauthorized_client",
+			OAuth2AuthorizationException.UnauthorizedClient::new);
+		_exceptions.put(
+			"unsupported_response_type",
+			OAuth2AuthorizationException.UnsupportedResponseType::new);
+	}
+
+}

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/oauth2/Token.java
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/oauth2/Token.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.repository.authorization.oauth2;
+
+import java.util.Date;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface Token {
+
+	public String getAccessToken();
+
+	public Date getExpirationDate();
+
+	public String getRefreshToken();
+
+	public boolean isExpired();
+
+}

--- a/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/oauth2/TokenStore.java
+++ b/modules/apps/collaboration/document-library/document-library-repository-authorization-api/src/main/java/com/liferay/document/library/repository/authorization/oauth2/TokenStore.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.repository.authorization.oauth2;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Adolfo Pérez
+ */
+public interface TokenStore {
+
+	public void delete(String configurationId, long userId)
+		throws PortalException;
+
+	public Token get(String configurationId, long userId)
+		throws PortalException;
+
+	public Token getFresh(String configurationId, long userId)
+		throws PortalException;
+
+	public void save(String configurationId, long userId, Token token)
+		throws PortalException;
+
+}

--- a/modules/apps/collaboration/document-library/document-library-web/build.gradle
+++ b/modules/apps/collaboration/document-library/document-library-web/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:collaboration:document-library:document-library-repository-authorization-api")
 	provided project(":apps:collaboration:comment:comment-taglib")
 	provided project(":apps:collaboration:document-library:document-library-api")
 	provided project(":apps:collaboration:subscription:subscription-api")

--- a/modules/apps/collaboration/document-library/document-library-web/build.gradle
+++ b/modules/apps/collaboration/document-library/document-library-web/build.gradle
@@ -26,9 +26,9 @@ dependencies {
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
-	provided project(":apps:collaboration:document-library:document-library-repository-authorization-api")
 	provided project(":apps:collaboration:comment:comment-taglib")
 	provided project(":apps:collaboration:document-library:document-library-api")
+	provided project(":apps:collaboration:document-library:document-library-repository-authorization-api")
 	provided project(":apps:collaboration:subscription:subscription-api")
 	provided project(":apps:web-experience:asset:asset-taglib")
 	provided project(":apps:web-experience:trash:trash-api")

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLViewMVCRenderCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLViewMVCRenderCommand.java
@@ -18,11 +18,15 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
+import com.liferay.document.library.repository.authorization.capability.AuthorizationCapability;
 import com.liferay.document.library.web.constants.DLPortletKeys;
 import com.liferay.document.library.web.constants.DLWebKeys;
 import com.liferay.document.library.web.internal.portlet.toolbar.contributor.DLPortletToolbarContributor;
 import com.liferay.document.library.web.internal.util.DLTrashUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderConstants;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
 
@@ -57,7 +61,9 @@ public class DLViewMVCRenderCommand extends GetFolderMVCRenderCommand {
 			_dlPortletToolbarContributor);
 
 		try {
-			pingFolderRepository(renderRequest);
+			if (pingFolderRepository(renderRequest, renderResponse)) {
+				return MVCRenderConstants.MVC_PATH_VALUE_SKIP_DISPATCH;
+			}
 		}
 		catch (Exception e) {
 			SessionErrors.add(renderRequest, "repositoryPingFailed", e);
@@ -78,30 +84,45 @@ public class DLViewMVCRenderCommand extends GetFolderMVCRenderCommand {
 		return "/document_library/view.jsp";
 	}
 
-	protected void pingFolderRepository(RenderRequest renderRequest)
+	protected boolean pingFolderRepository(
+			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws Exception {
 
 		String mvcRenderCommandName = ParamUtil.getString(
 			renderRequest, "mvcRenderCommandName");
 
 		if (!mvcRenderCommandName.equals("/document_library/view_folder")) {
-			return;
+			return false;
 		}
 
 		long folderId = ParamUtil.getLong(renderRequest, "folderId");
 
 		if (folderId == DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			return;
+			return false;
 		}
 
 		DLFolder dlFolder = _dlFolderLocalService.fetchDLFolder(folderId);
 
 		if ((dlFolder == null) || !dlFolder.isMountPoint()) {
-			return;
+			return false;
 		}
 
-		_dlAppService.getFileEntriesCount(
-			dlFolder.getRepositoryId(), dlFolder.getFolderId());
+		Repository repository = RepositoryProviderUtil.getRepository(
+			dlFolder.getRepositoryId());
+
+		if (repository.isCapabilityProvided(AuthorizationCapability.class)) {
+			AuthorizationCapability authorizationCapability =
+				repository.getCapability(AuthorizationCapability.class);
+
+			return authorizationCapability.authorize(
+				renderRequest, renderResponse);
+		}
+		else {
+			_dlAppService.getFileEntriesCount(
+				dlFolder.getRepositoryId(), dlFolder.getFolderId());
+
+			return false;
+		}
 	}
 
 	@Reference

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLViewMVCRenderCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DLViewMVCRenderCommand.java
@@ -114,7 +114,9 @@ public class DLViewMVCRenderCommand extends GetFolderMVCRenderCommand {
 			AuthorizationCapability authorizationCapability =
 				repository.getCapability(AuthorizationCapability.class);
 
-			return authorizationCapability.authorize(
+			authorizationCapability.authorize(renderRequest, renderResponse);
+
+			return authorizationCapability.hasCustomRedirectFlow(
 				renderRequest, renderResponse);
 		}
 		else {

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ViewFileEntryMVCRenderCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ViewFileEntryMVCRenderCommand.java
@@ -69,10 +69,12 @@ public class ViewFileEntryMVCRenderCommand
 					fileEntryRepository.getCapability(
 						AuthorizationCapability.class);
 
-				boolean requestHandled = authorizationCapability.authorize(
+				authorizationCapability.authorize(
 					renderRequest, renderResponse);
 
-				if (requestHandled) {
+				if (authorizationCapability.hasCustomRedirectFlow(
+						renderRequest, renderResponse)) {
+
 					return MVCRenderConstants.MVC_PATH_VALUE_SKIP_DISPATCH;
 				}
 			}

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ViewFileEntryMVCRenderCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/ViewFileEntryMVCRenderCommand.java
@@ -14,8 +14,25 @@
 
 package com.liferay.document.library.web.internal.portlet.action;
 
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
+import com.liferay.document.library.kernel.exception.NoSuchFileVersionException;
+import com.liferay.document.library.repository.authorization.capability.AuthorizationCapability;
 import com.liferay.document.library.web.constants.DLPortletKeys;
+import com.liferay.portal.kernel.exception.NoSuchRepositoryEntryException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderConstants;
+import com.liferay.portal.kernel.repository.Repository;
+import com.liferay.portal.kernel.repository.RepositoryProviderUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import java.io.IOException;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -33,6 +50,46 @@ import org.osgi.service.component.annotations.Component;
 )
 public class ViewFileEntryMVCRenderCommand
 	extends GetFileEntryMVCRenderCommand {
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		try {
+			long fileEntryId = ParamUtil.getLong(renderRequest, "fileEntryId");
+
+			Repository fileEntryRepository =
+				RepositoryProviderUtil.getFileEntryRepository(fileEntryId);
+
+			if (fileEntryRepository.isCapabilityProvided(
+					AuthorizationCapability.class)) {
+
+				AuthorizationCapability authorizationCapability =
+					fileEntryRepository.getCapability(
+						AuthorizationCapability.class);
+
+				boolean requestHandled = authorizationCapability.authorize(
+					renderRequest, renderResponse);
+
+				if (requestHandled) {
+					return MVCRenderConstants.MVC_PATH_VALUE_SKIP_DISPATCH;
+				}
+			}
+		}
+		catch (NoSuchFileEntryException | NoSuchFileVersionException |
+			   NoSuchRepositoryEntryException | PrincipalException e) {
+
+			SessionErrors.add(renderRequest, e.getClass());
+
+			return "/document_library/error.jsp";
+		}
+		catch (IOException | PortalException e) {
+			throw new PortletException(e);
+		}
+
+		return super.render(renderRequest, renderResponse);
+	}
 
 	@Override
 	protected String getPath() {


### PR DESCRIPTION
Hey Brian,

This is the beginning of a story to support OAuth in Sharepoint Connector in Documents and Media.
This task simply allows Documents and Media to delegate the authorization to a Repository Capability that will be implemented in Sharepoint Connector module. 

Let me know if you have any question