### PR TITLE
[SEE DESCRIPTION] LPS-73691 Proper capitalization according to http://titlecapitalization.com/

### DIFF
--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -31,6 +31,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
+import java.io.IOException;
+
 import java.util.ResourceBundle;
 
 import javax.portlet.ActionRequest;
@@ -104,6 +106,8 @@ public class NotificationsPortlet extends MVCPortlet {
 			LanguageUtil.get(
 				resourceBundle,
 				"all-notifications-were-marked-as-read-successfully"));
+
+		_setRedirect(actionRequest, actionResponse);
 	}
 
 	public void markNotificationAsRead(
@@ -115,11 +119,7 @@ public class NotificationsPortlet extends MVCPortlet {
 
 		updateArchived(userNotificationEventId);
 
-		String redirect = ParamUtil.getString(actionRequest, "redirect");
-
-		if (Validator.isNotNull(redirect)) {
-			actionResponse.sendRedirect(redirect);
-		}
+		_setRedirect(actionRequest, actionResponse);
 	}
 
 	public void markNotificationsAsRead(
@@ -223,11 +223,7 @@ public class NotificationsPortlet extends MVCPortlet {
 			LanguageUtil.get(
 				resourceBundle, "your-configuration-was-saved-sucessfully"));
 
-		String redirect = ParamUtil.getString(actionRequest, "redirect");
-
-		if (Validator.isNotNull(redirect)) {
-			actionResponse.sendRedirect(redirect);
-		}
+		_setRedirect(actionRequest, actionResponse);
 	}
 
 	@Reference(
@@ -281,6 +277,17 @@ public class NotificationsPortlet extends MVCPortlet {
 
 		_userNotificationEventLocalService.updateUserNotificationEvent(
 			userNotificationEvent);
+	}
+
+	private void _setRedirect(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws IOException {
+
+		String redirect = ParamUtil.getString(actionRequest, "redirect");
+
+		if (Validator.isNotNull(redirect)) {
+			actionResponse.sendRedirect(redirect);
+		}
 	}
 
 	@Reference(

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -86,8 +86,8 @@ public class NotificationsPortlet extends MVCPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		final ThemeDisplay themeDisplay =
-			(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 
 		boolean actionRequired = ParamUtil.getBoolean(
 			actionRequest, "actionRequired");

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -108,11 +108,10 @@ public class NotificationsPortlet extends MVCPortlet {
 					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
 					false);
 
-		for (UserNotificationEvent notification : userNotificationEvents) {
-			notification.setArchived(true);
+		for (UserNotificationEvent userNotificationEvent :
+				userNotificationEvents) {
 
-			_userNotificationEventLocalService.updateUserNotificationEvent(
-				notification);
+			updateArchived(userNotificationEvent);
 		}
 
 		ResourceBundle resourceBundle =
@@ -277,6 +276,12 @@ public class NotificationsPortlet extends MVCPortlet {
 		if (userNotificationEvent == null) {
 			return;
 		}
+
+		updateArchived(userNotificationEvent);
+	}
+
+	protected void updateArchived(UserNotificationEvent userNotificationEvent)
+		throws Exception {
 
 		userNotificationEvent.setArchived(true);
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -16,7 +16,6 @@ package com.liferay.notifications.web.internal.portlet;
 
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.interval.IntervalActionProcessor;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
@@ -32,7 +31,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
-import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.portlet.ActionRequest;
@@ -91,45 +89,12 @@ public class NotificationsPortlet extends MVCPortlet {
 		final ThemeDisplay themeDisplay =
 			(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
-		int unreadNotificationEventsCount =
-			_userNotificationEventLocalService.
-				getArchivedUserNotificationEventsCount(
-					themeDisplay.getUserId(),
-					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
-					false);
+		boolean actionRequired = ParamUtil.getBoolean(
+			actionRequest, "actionRequired");
 
-		final IntervalActionProcessor<Void> intervalActionProcessor =
-			new IntervalActionProcessor<>(unreadNotificationEventsCount);
-
-		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
-
-				@Override
-				public Void performIntervalAction(int start, int end)
-					throws PortalException {
-
-					List<UserNotificationEvent> userNotificationEvents =
-						_userNotificationEventLocalService.
-							getArchivedUserNotificationEvents(
-								themeDisplay.getUserId(),
-								UserNotificationDeliveryConstants.TYPE_WEBSITE,
-								false, false, start, end);
-
-					for (UserNotificationEvent userNotificationEvent :
-							userNotificationEvents) {
-
-						updateArchived(userNotificationEvent);
-					}
-
-					intervalActionProcessor.incrementStart(
-						userNotificationEvents.size());
-
-					return null;
-				}
-
-			});
-
-		intervalActionProcessor.performIntervalActions();
+		_userNotificationEventLocalService.archiveUserNotificationEvents(
+			themeDisplay.getUserId(),
+			UserNotificationDeliveryConstants.TYPE_WEBSITE, actionRequired);
 
 		ResourceBundle resourceBundle =
 			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -17,6 +17,7 @@ package com.liferay.notifications.web.internal.portlet;
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.UserNotificationDeliveryLocalService;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
+import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.portlet.ActionRequest;
@@ -95,6 +97,23 @@ public class NotificationsPortlet extends MVCPortlet {
 	public void markAllNotificationsAsRead(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		List<UserNotificationEvent> userNotificationEvents =
+			_userNotificationEventLocalService.
+				getArchivedUserNotificationEvents(
+					themeDisplay.getUserId(),
+					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+					false);
+
+		for (UserNotificationEvent notification : userNotificationEvents) {
+			notification.setArchived(true);
+
+			_userNotificationEventLocalService.updateUserNotificationEvent(
+				notification);
+		}
 	}
 
 	public void markAsRead(

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -122,7 +122,7 @@ public class NotificationsPortlet extends MVCPortlet {
 			actionRequest, "requestProcessed",
 			LanguageUtil.get(
 				resourceBundle,
-				"all-notifications-were-marked-as-read-sucessfully"));
+				"all-notifications-were-marked-as-read-successfully"));
 	}
 
 	public void markAsRead(

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -92,6 +92,11 @@ public class NotificationsPortlet extends MVCPortlet {
 		}
 	}
 
+	public void markAllNotificationsAsRead(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+	}
+
 	public void markAsRead(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -15,6 +15,8 @@
 package com.liferay.notifications.web.internal.portlet;
 
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.interval.IntervalActionProcessor;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
@@ -86,21 +88,48 @@ public class NotificationsPortlet extends MVCPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
+		final ThemeDisplay themeDisplay =
+			(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
-		List<UserNotificationEvent> userNotificationEvents =
+		int unreadNotificationEventsCount =
 			_userNotificationEventLocalService.
-				getArchivedUserNotificationEvents(
+				getArchivedUserNotificationEventsCount(
 					themeDisplay.getUserId(),
 					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
 					false);
 
-		for (UserNotificationEvent userNotificationEvent :
-				userNotificationEvents) {
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(unreadNotificationEventsCount);
 
-			updateArchived(userNotificationEvent);
-		}
+		intervalActionProcessor.setPerformIntervalActionMethod(
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
+
+				@Override
+				public Void performIntervalAction(int start, int end)
+					throws PortalException {
+
+					List<UserNotificationEvent> userNotificationEvents =
+						_userNotificationEventLocalService.
+							getArchivedUserNotificationEvents(
+								themeDisplay.getUserId(),
+								UserNotificationDeliveryConstants.TYPE_WEBSITE,
+								false, false, start, end);
+
+					for (UserNotificationEvent userNotificationEvent :
+							userNotificationEvents) {
+
+						updateArchived(userNotificationEvent);
+					}
+
+					intervalActionProcessor.incrementStart(
+						userNotificationEvents.size());
+
+					return null;
+				}
+
+			});
+
+		intervalActionProcessor.performIntervalActions();
 
 		ResourceBundle resourceBundle =
 			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
@@ -281,7 +310,7 @@ public class NotificationsPortlet extends MVCPortlet {
 	}
 
 	protected void updateArchived(UserNotificationEvent userNotificationEvent)
-		throws Exception {
+		throws PortalException {
 
 		userNotificationEvent.setArchived(true);
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -107,7 +107,7 @@ public class NotificationsPortlet extends MVCPortlet {
 				resourceBundle,
 				"all-notifications-were-marked-as-read-successfully"));
 
-		_setRedirect(actionRequest, actionResponse);
+		_sendRedirect(actionRequest, actionResponse);
 	}
 
 	public void markNotificationAsRead(
@@ -119,7 +119,7 @@ public class NotificationsPortlet extends MVCPortlet {
 
 		updateArchived(userNotificationEventId);
 
-		_setRedirect(actionRequest, actionResponse);
+		_sendRedirect(actionRequest, actionResponse);
 	}
 
 	public void markNotificationsAsRead(
@@ -223,7 +223,7 @@ public class NotificationsPortlet extends MVCPortlet {
 			LanguageUtil.get(
 				resourceBundle, "your-configuration-was-saved-sucessfully"));
 
-		_setRedirect(actionRequest, actionResponse);
+		_sendRedirect(actionRequest, actionResponse);
 	}
 
 	@Reference(
@@ -279,7 +279,7 @@ public class NotificationsPortlet extends MVCPortlet {
 			userNotificationEvent);
 	}
 
-	private void _setRedirect(
+	private void _sendRedirect(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws IOException {
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -82,18 +82,6 @@ public class NotificationsPortlet extends MVCPortlet {
 		}
 	}
 
-	public void markAllAsRead(
-			ActionRequest actionRequest, ActionResponse actionResponse)
-		throws Exception {
-
-		long[] userNotificationEventIds = ParamUtil.getLongValues(
-			actionRequest, "rowIds");
-
-		for (long userNotificationEventId : userNotificationEventIds) {
-			updateArchived(userNotificationEventId);
-		}
-	}
-
 	public void markAllNotificationsAsRead(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
@@ -124,7 +112,7 @@ public class NotificationsPortlet extends MVCPortlet {
 				"all-notifications-were-marked-as-read-successfully"));
 	}
 
-	public void markAsRead(
+	public void markNotificationAsRead(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
@@ -137,6 +125,18 @@ public class NotificationsPortlet extends MVCPortlet {
 
 		if (Validator.isNotNull(redirect)) {
 			actionResponse.sendRedirect(redirect);
+		}
+	}
+
+	public void markNotificationsAsRead(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		long[] userNotificationEventIds = ParamUtil.getLongValues(
+			actionRequest, "rowIds");
+
+		for (long userNotificationEventId : userNotificationEventIds) {
+			updateArchived(userNotificationEventId);
 		}
 	}
 
@@ -159,11 +159,11 @@ public class NotificationsPortlet extends MVCPortlet {
 			if (actionName.equals("deleteUserNotificationEvent")) {
 				deleteUserNotificationEvent(actionRequest, actionResponse);
 			}
-			else if (actionName.equals("markAllAsRead")) {
-				markAllAsRead(actionRequest, actionResponse);
+			else if (actionName.equals("markNotificationsAsRead")) {
+				markNotificationsAsRead(actionRequest, actionResponse);
 			}
-			else if (actionName.equals("markAsRead")) {
-				markAsRead(actionRequest, actionResponse);
+			else if (actionName.equals("markNotificationAsRead")) {
+				markNotificationAsRead(actionRequest, actionResponse);
 			}
 			else if (actionName.equals("unsubscribe")) {
 				unsubscribe(actionRequest, actionResponse);

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -114,6 +114,15 @@ public class NotificationsPortlet extends MVCPortlet {
 			_userNotificationEventLocalService.updateUserNotificationEvent(
 				notification);
 		}
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
+
+		SessionMessages.add(
+			actionRequest, "requestProcessed",
+			LanguageUtil.get(
+				resourceBundle,
+				"all-notifications-were-marked-as-read-sucessfully"));
 	}
 
 	public void markAsRead(

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAllNotificationsAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAllNotificationsAsReadPortletConfigurationIcon.java
@@ -44,7 +44,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {"javax.portlet.name=" + NotificationsPortletKeys.NOTIFICATIONS},
 	service = PortletConfigurationIcon.class
 )
-public class MarkAsReadPortletConfigurationIcon
+public class MarkAllNotificationsAsReadPortletConfigurationIcon
 	extends BasePortletConfigurationIcon {
 
 	@Override

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.notifications.web.internal.portlet.configuration.icon;
+
+import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import org.osgi.service.component.annotations.Component;
+
+import java.util.ResourceBundle;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + NotificationsPortletKeys.NOTIFICATIONS},
+	service = PortletConfigurationIcon.class
+)
+public class MarkAsReadPortletConfigurationIcon
+	extends BasePortletConfigurationIcon {
+
+	@Override
+	public String getMessage(PortletRequest portletRequest) {
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", getLocale(portletRequest), getClass());
+
+		return LanguageUtil.get(
+			resourceBundle, "mark-all-notifications-as-read");
+	}
+
+	@Override
+	public String getURL(
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		return "http://localhost:8080";
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		return true;
+	}
+
+	@Override
+	public boolean isToolTip() {
+		return false;
+	}
+
+}

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -16,6 +16,7 @@ package com.liferay.notifications.web.internal.portlet.configuration.icon;
 
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -23,8 +24,10 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.ResourceBundle;
 
+import javax.portlet.ActionRequest;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -52,7 +55,14 @@ public class MarkAsReadPortletConfigurationIcon
 	public String getURL(
 		PortletRequest portletRequest, PortletResponse portletResponse) {
 
-		return "http://localhost:8080";
+		PortletURL portletURL = PortletURLFactoryUtil.create(
+			portletRequest, NotificationsPortletKeys.NOTIFICATIONS,
+			PortletRequest.ACTION_PHASE);
+
+		portletURL.setParameter(
+			ActionRequest.ACTION_NAME, "markAllNotificationsAsRead");
+
+		return portletURL.toString();
 	}
 
 	@Override

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -18,14 +18,15 @@ import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import org.osgi.service.component.annotations.Component;
-
-import java.util.ResourceBundle;
 
 /**
  * @author Alejandro Tardín
@@ -56,7 +57,7 @@ public class MarkAsReadPortletConfigurationIcon
 
 	@Override
 	public boolean isShow(PortletRequest portletRequest) {
-		return true;
+		return !ParamUtil.getBoolean(portletRequest, "actionRequired");
 	}
 
 	@Override

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -16,11 +16,15 @@ package com.liferay.notifications.web.internal.portlet.configuration.icon;
 
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
 
@@ -30,6 +34,7 @@ import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -67,12 +72,33 @@ public class MarkAsReadPortletConfigurationIcon
 
 	@Override
 	public boolean isShow(PortletRequest portletRequest) {
-		return !ParamUtil.getBoolean(portletRequest, "actionRequired");
+		if (!ParamUtil.getBoolean(portletRequest, "actionRequired")) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)portletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			int unreadNotificationEventsCount =
+				_userNotificationEventLocalService.
+					getArchivedUserNotificationEventsCount(
+						themeDisplay.getUserId(),
+						UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+						false);
+
+			if (unreadNotificationEventsCount > 0) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Override
 	public boolean isToolTip() {
 		return false;
 	}
+
+	@Reference
+	private UserNotificationEventLocalService
+		_userNotificationEventLocalService;
 
 }

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -67,6 +67,11 @@ public class MarkAsReadPortletConfigurationIcon
 		portletURL.setParameter(
 			ActionRequest.ACTION_NAME, "markAllNotificationsAsRead");
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		portletURL.setParameter("redirect", themeDisplay.getURLCurrent());
+
 		return portletURL.toString();
 	}
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/notification_action.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/notification_action.jsp
@@ -45,11 +45,11 @@ if (subscriptionId > 0) {
 		</c:when>
 		<c:otherwise>
 			<c:if test="<%= !userNotificationEvent.isArchived() %>">
-				<portlet:actionURL name="markNotificationAsRead" var="markAsReadURL">
+				<portlet:actionURL name="markNotificationAsRead" var="markNotificationAsReadURL">
 					<portlet:param name="userNotificationEventId" value="<%= String.valueOf(userNotificationEvent.getUserNotificationEventId()) %>" />
 				</portlet:actionURL>
 
-				<liferay-ui:icon message="mark-as-read" url="<%= markAsReadURL.toString() %>" />
+				<liferay-ui:icon message="mark-as-read" url="<%= markNotificationAsReadURL.toString() %>" />
 			</c:if>
 
 			<c:if test="<%= subscriptionId > 0 %>">

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/notification_action.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/notification_action.jsp
@@ -45,7 +45,7 @@ if (subscriptionId > 0) {
 		</c:when>
 		<c:otherwise>
 			<c:if test="<%= !userNotificationEvent.isArchived() %>">
-				<portlet:actionURL name="markAsRead" var="markAsReadURL">
+				<portlet:actionURL name="markNotificationAsRead" var="markAsReadURL">
 					<portlet:param name="userNotificationEventId" value="<%= String.valueOf(userNotificationEvent.getUserNotificationEventId()) %>" />
 				</portlet:actionURL>
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -51,7 +51,7 @@ if (unread) {
 		</liferay-ui:search-container-column-text>
 	</c:when>
 	<c:otherwise>
-		<portlet:actionURL name="markAsRead" var="markAsReadURL">
+		<portlet:actionURL name="markNotificationAsRead" var="markAsReadURL">
 			<portlet:param name="userNotificationEventId" value="<%= String.valueOf(userNotificationEvent.getUserNotificationEventId()) %>" />
 			<portlet:param name="redirect" value="<%= userNotificationFeedEntry.getLink() %>" />
 		</portlet:actionURL>

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -51,7 +51,7 @@ if (unread) {
 		</liferay-ui:search-container-column-text>
 	</c:when>
 	<c:otherwise>
-		<portlet:actionURL name="markNotificationAsRead" var="markAsReadURL">
+		<portlet:actionURL name="markNotificationAsRead" var="markNotificationAsReadURL">
 			<portlet:param name="userNotificationEventId" value="<%= String.valueOf(userNotificationEvent.getUserNotificationEventId()) %>" />
 			<portlet:param name="redirect" value="<%= userNotificationFeedEntry.getLink() %>" />
 		</portlet:actionURL>
@@ -60,7 +60,7 @@ if (unread) {
 			<c:if test="<%= unread %>">
 				<h4>
 			</c:if>
-				<a href="<%= markAsReadURL.toString() %>">
+				<a href="<%= markNotificationAsReadURL.toString() %>">
 					<%= userNotificationFeedEntry.getBody() %>
 				</a>
 			<c:if test="<%= unread %>">

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -100,7 +100,7 @@ int userNotificationEventsCount = UserNotificationEventLocalServiceUtil.getDeliv
 
 		form.attr('method', 'post');
 
-		submitForm(form, '<portlet:actionURL name="markAllAsRead" />');
+		submitForm(form, '<portlet:actionURL name="markNotificationsAsRead" />');
 	}
 </aui:script>
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/view.jsp
@@ -62,7 +62,7 @@ int userNotificationEventsCount = UserNotificationEventLocalServiceUtil.getDeliv
 	</liferay-frontend:management-bar-buttons>
 
 	<liferay-frontend:management-bar-action-buttons>
-		<liferay-frontend:management-bar-button href='<%= "javascript:" + renderResponse.getNamespace() + "markAsRead();" %>' icon="times" label="mark-as-read" />
+		<liferay-frontend:management-bar-button href='<%= "javascript:" + renderResponse.getNamespace() + "markNotificationsAsRead();" %>' icon="times" label="mark-as-read" />
 	</liferay-frontend:management-bar-action-buttons>
 </liferay-frontend:management-bar>
 
@@ -95,7 +95,7 @@ int userNotificationEventsCount = UserNotificationEventLocalServiceUtil.getDeliv
 </div>
 
 <aui:script>
-	function <portlet:namespace />markAsRead() {
+	function <portlet:namespace />markNotificationsAsRead() {
 		var form = AUI.$(document.<portlet:namespace />fm);
 
 		form.attr('method', 'post');

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+all-notifications-were-marked-as-read-sucessfully=All notifications were marked as read successfully
 javax.portlet.title.com_liferay_notifications_web_portlet_NotificationsPortlet=Notifications
 mark-all-notifications-as-read=Mark all notifications as read
 notifications-list=Notifications List

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
@@ -1,6 +1,6 @@
 all-notifications-were-marked-as-read-successfully=All notifications were marked as read successfully.
 javax.portlet.title.com_liferay_notifications_web_portlet_NotificationsPortlet=Notifications
-mark-all-notifications-as-read=Mark all notifications as read
+mark-all-notifications-as-read=Mark All Notifications as Read
 notifications-list=Notifications List
 receive-a-notification-when-someone=Receive a notification when someone:
 requests-list=Requests List

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
@@ -1,4 +1,4 @@
-all-notifications-were-marked-as-read-sucessfully=All notifications were marked as read successfully
+all-notifications-were-marked-as-read-successfully=All notifications were marked as read successfully.
 javax.portlet.title.com_liferay_notifications_web_portlet_NotificationsPortlet=Notifications
 mark-all-notifications-as-read=Mark all notifications as read
 notifications-list=Notifications List

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
@@ -1,4 +1,5 @@
 javax.portlet.title.com_liferay_notifications_web_portlet_NotificationsPortlet=Notifications
+mark-all-notifications-as-read=Mark all notifications as read
 notifications-list=Notifications List
 receive-a-notification-when-someone=Receive a notification when someone:
 requests-list=Requests List

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -174,9 +174,6 @@ public class UserNotificationEventLocalServiceImpl
 					updateUserNotificationEvent(userNotificationEvent);
 				}
 
-				intervalActionProcessor.incrementStart(
-					userNotificationEvents.size());
-
 				return null;
 			});
 

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -152,39 +152,32 @@ public class UserNotificationEventLocalServiceImpl
 			long userId, int deliveryType, boolean actionRequired)
 		throws PortalException {
 
-		int unreadNotificationEventsCount =
+		int userNotificationEventsCount =
 			getArchivedUserNotificationEventsCount(
 				userId, deliveryType, actionRequired, false);
 
 		final IntervalActionProcessor<Void> intervalActionProcessor =
-			new IntervalActionProcessor<>(unreadNotificationEventsCount);
+			new IntervalActionProcessor<>(userNotificationEventsCount);
 
 		intervalActionProcessor.setPerformIntervalActionMethod(
-			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
+			(start, end) -> {
+				List<UserNotificationEvent> userNotificationEvents =
+					getArchivedUserNotificationEvents(
+						userId, deliveryType, actionRequired, false, start,
+						end);
 
-				@Override
-				public Void performIntervalAction(int start, int end)
-					throws PortalException {
+				for (UserNotificationEvent userNotificationEvent :
+						userNotificationEvents) {
 
-					List<UserNotificationEvent> userNotificationEvents =
-						getArchivedUserNotificationEvents(
-							userId, deliveryType, actionRequired, false, start,
-							end);
+					userNotificationEvent.setArchived(true);
 
-					for (UserNotificationEvent userNotificationEvent :
-							userNotificationEvents) {
-
-						userNotificationEvent.setArchived(true);
-
-						updateUserNotificationEvent(userNotificationEvent);
-					}
-
-					intervalActionProcessor.incrementStart(
-						userNotificationEvents.size());
-
-					return null;
+					updateUserNotificationEvent(userNotificationEvent);
 				}
 
+				intervalActionProcessor.incrementStart(
+					userNotificationEvents.size());
+
+				return null;
 			});
 
 		intervalActionProcessor.performIntervalActions();

--- a/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserNotificationEventLocalServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.interval.IntervalActionProcessor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
@@ -144,6 +145,49 @@ public class UserNotificationEventLocalServiceImpl
 		}
 
 		return userNotificationEvents;
+	}
+
+	@Override
+	public void archiveUserNotificationEvents(
+			long userId, int deliveryType, boolean actionRequired)
+		throws PortalException {
+
+		int unreadNotificationEventsCount =
+			getArchivedUserNotificationEventsCount(
+				userId, deliveryType, actionRequired, false);
+
+		final IntervalActionProcessor<Void> intervalActionProcessor =
+			new IntervalActionProcessor<>(unreadNotificationEventsCount);
+
+		intervalActionProcessor.setPerformIntervalActionMethod(
+			new IntervalActionProcessor.PerformIntervalActionMethod<Void>() {
+
+				@Override
+				public Void performIntervalAction(int start, int end)
+					throws PortalException {
+
+					List<UserNotificationEvent> userNotificationEvents =
+						getArchivedUserNotificationEvents(
+							userId, deliveryType, actionRequired, false, start,
+							end);
+
+					for (UserNotificationEvent userNotificationEvent :
+							userNotificationEvents) {
+
+						userNotificationEvent.setArchived(true);
+
+						updateUserNotificationEvent(userNotificationEvent);
+					}
+
+					intervalActionProcessor.incrementStart(
+						userNotificationEvents.size());
+
+					return null;
+				}
+
+			});
+
+		intervalActionProcessor.performIntervalActions();
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalService.java
@@ -430,6 +430,9 @@ public interface UserNotificationEventLocalService extends BaseLocalService,
 	public long dynamicQueryCount(DynamicQuery dynamicQuery,
 		Projection projection);
 
+	public void archiveUserNotificationEvents(long userId, int deliveryType,
+		boolean actionRequired) throws PortalException;
+
 	public void deleteUserNotificationEvent(java.lang.String uuid,
 		long companyId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceUtil.java
@@ -576,6 +576,13 @@ public class UserNotificationEventLocalServiceUtil {
 		return getService().dynamicQueryCount(dynamicQuery, projection);
 	}
 
+	public static void archiveUserNotificationEvents(long userId,
+		int deliveryType, boolean actionRequired)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.archiveUserNotificationEvents(userId, deliveryType, actionRequired);
+	}
+
 	public static void deleteUserNotificationEvent(java.lang.String uuid,
 		long companyId) {
 		getService().deleteUserNotificationEvent(uuid, companyId);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserNotificationEventLocalServiceWrapper.java
@@ -617,6 +617,14 @@ public class UserNotificationEventLocalServiceWrapper
 	}
 
 	@Override
+	public void archiveUserNotificationEvents(long userId, int deliveryType,
+		boolean actionRequired)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_userNotificationEventLocalService.archiveUserNotificationEvents(userId,
+			deliveryType, actionRequired);
+	}
+
+	@Override
 	public void deleteUserNotificationEvent(java.lang.String uuid,
 		long companyId) {
 		_userNotificationEventLocalService.deleteUserNotificationEvent(uuid,


### PR DESCRIPTION
Hey Brian, in reply to: https://github.com/brianchandotcom/liferay-portal/pull/50489#issuecomment-317793281

I have updated the language key to be a title with the proper localization. See https://github.com/brianchandotcom/liferay-portal/pull/50546/commits/7b5a8d48e49f04380570bf9535f0699777b2ce7a

Regarding markAsRead and the renaming, we follow this approach:

**markNotificationAsRead** when only one notification is marked as read and we need the userNotificationEventId parameter. 
**markNotificationsAsRead** to mark more than one notification as read, usually passing rowIds parameter to specify which notifications. 
**markAllNotificationsAsRead** to mark all notifications as read (we don't need to provide the notifications that we want because it's all).

This change was necessary because otherwise with the new method in NotificationsPortlet we didn't know how to name the methods because we already had one method name markAllAsRead that was intended to mark only the selected notifications while markAsRead would only mark as read the notfiication that was passed.

Let me know if you need any other clarification. 

Thanks