### PR TITLE
LPS-73831 Equinox on purposely introduced this spec breaking switch i…

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6504,6 +6504,8 @@
         osgi.contract;osgi.contract=JavaServlet;version:Version=3;\
         uses:="javax.servlet,javax.servlet.http"
 
+    module.framework.properties.osgi.compatibility.eagerStart.LazyActivation=false
+
     module.framework.properties.osgi.console=localhost:11311
 
     module.framework.properties.osgi.context.bootdelegation=false


### PR DESCRIPTION
…n order to be backward compatible with pre-4.1 spec. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=177641 for details. Since Liferay started with OSGi 5 and now we are on 6, we never have to maintain such backward compatibility. We should by default to turn off the switch to stick with the current spec. With this switch turing on or absent, the observed broken behavior is, refreshing a INSTALLED bundle that has Bundle-ActivationPolicy set to lazy will cause it transitting to RESOLVED, STARTING and eventually ACTIVE state. While it supposes to stay at RESOLVED state according to OSGi 6 spec 10.4.8.5

CC @tinatian