### PR TITLE
LPS-73348 Individual role permissions on resourceBlock-managed resources are lost when a resource permission is set at the company level

### DIFF
--- a/modules/apps/foundation/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
@@ -29,7 +29,9 @@ import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocalCloseable;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourceTypePermission;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
@@ -38,9 +40,11 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.security.permission.comparator.ActionComparator;
 import com.liferay.portal.kernel.service.GroupService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceBlockLocalService;
 import com.liferay.portal.kernel.service.ResourceBlockService;
 import com.liferay.portal.kernel.service.ResourcePermissionService;
+import com.liferay.portal.kernel.service.ResourceTypePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -632,6 +636,20 @@ public class RolesAdminPortlet extends MVCPortlet {
 		long companyId = role.getCompanyId();
 		long roleId = role.getRoleId();
 
+		ResourceAction resourceAction =
+			_resourceActionLocalService.getResourceAction(
+				selResource, actionId);
+
+		ResourceTypePermission resourceTypePermission =
+			_resourceTypePermissionLocalService.fetchResourceTypePermission(
+				companyId, 0, selResource, roleId);
+
+		if (((resourceTypePermission != null) &&
+			 resourceTypePermission.hasAction(resourceAction)) == selected) {
+
+			return;
+		}
+
 		if (selected) {
 			if (scope == ResourceConstants.SCOPE_GROUP) {
 				_resourceBlockService.removeAllGroupScopePermissions(
@@ -723,9 +741,17 @@ public class RolesAdminPortlet extends MVCPortlet {
 	@Reference
 	private Portal _portal;
 
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
 	private ResourceBlockLocalService _resourceBlockLocalService;
 	private ResourceBlockService _resourceBlockService;
 	private ResourcePermissionService _resourcePermissionService;
+
+	@Reference
+	private ResourceTypePermissionLocalService
+		_resourceTypePermissionLocalService;
+
 	private RoleLocalService _roleLocalService;
 	private RoleService _roleService;
 	private UserService _userService;

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceTypePermissionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceTypePermissionLocalServiceImpl.java
@@ -38,6 +38,14 @@ public class ResourceTypePermissionLocalServiceImpl
 	extends ResourceTypePermissionLocalServiceBaseImpl {
 
 	@Override
+	public ResourceTypePermission fetchResourceTypePermission(
+		long companyId, long groupId, String name, long roleId) {
+
+		return resourceTypePermissionPersistence.fetchByC_G_N_R(
+			companyId, groupId, name, roleId);
+	}
+
+	@Override
 	public long getCompanyScopeActionIds(
 		long companyId, String name, long roleId) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourceTypePermissionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourceTypePermissionLocalService.java
@@ -138,6 +138,10 @@ public interface ResourceTypePermissionLocalService extends BaseLocalService,
 		long resourceTypePermissionId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public ResourceTypePermission fetchResourceTypePermission(long companyId,
+		long groupId, java.lang.String name, long roleId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ResourceTypePermission fetchResourceTypePermission(
 		long resourceTypePermissionId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourceTypePermissionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourceTypePermissionLocalServiceUtil.java
@@ -145,6 +145,12 @@ public class ResourceTypePermissionLocalServiceUtil {
 	}
 
 	public static com.liferay.portal.kernel.model.ResourceTypePermission fetchResourceTypePermission(
+		long companyId, long groupId, java.lang.String name, long roleId) {
+		return getService()
+				   .fetchResourceTypePermission(companyId, groupId, name, roleId);
+	}
+
+	public static com.liferay.portal.kernel.model.ResourceTypePermission fetchResourceTypePermission(
 		long resourceTypePermissionId) {
 		return getService().fetchResourceTypePermission(resourceTypePermissionId);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ResourceTypePermissionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ResourceTypePermissionLocalServiceWrapper.java
@@ -147,6 +147,13 @@ public class ResourceTypePermissionLocalServiceWrapper
 
 	@Override
 	public com.liferay.portal.kernel.model.ResourceTypePermission fetchResourceTypePermission(
+		long companyId, long groupId, java.lang.String name, long roleId) {
+		return _resourceTypePermissionLocalService.fetchResourceTypePermission(companyId,
+			groupId, name, roleId);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.model.ResourceTypePermission fetchResourceTypePermission(
 		long resourceTypePermissionId) {
 		return _resourceTypePermissionLocalService.fetchResourceTypePermission(resourceTypePermissionId);
 	}


### PR DESCRIPTION
This is an update for [LPS-73348](https://issues.liferay.com/browse/LPS-73348).

Hey @brianchandotcom, this is the backend part of a two-part fix for this ticket.  We can send the second part later under the same ticket, or if you'd prefer we can create a new ticket for the frontend changes.  Just let me know.

/cc @joshuacords, @pei-jung, @Preston-Crary