### PR TITLE
LPS-73668 Revert changes in LPS-73668

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-api/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-api/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/util/KnowledgeBaseUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/util/KnowledgeBaseUtil.java
@@ -51,10 +51,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * @author Brian Wing Shun Chan
  * @author Peter Shin
- * @author Jim Hinkey
- * @author David Zhang
+ * @author Brian Wing Shun Chan
  */
 public class KnowledgeBaseUtil {
 
@@ -149,7 +147,8 @@ public class KnowledgeBaseUtil {
 			title = String.valueOf(id);
 		}
 		else {
-			title = FriendlyURLNormalizerUtil.normalizeWithEncoding(title);
+			title = FriendlyURLNormalizerUtil.normalize(
+				title, _normalizationFriendlyUrlPattern);
 		}
 
 		return ModelHintsUtil.trimString(
@@ -250,6 +249,8 @@ public class KnowledgeBaseUtil {
 	private static final int _SQL_DATA_MAX_PARAMETERS = GetterUtil.getInteger(
 		PropsUtil.get(PropsKeys.SQL_DATA_MAX_PARAMETERS));
 
+	private static final Pattern _normalizationFriendlyUrlPattern =
+		Pattern.compile("[^a-z0-9_-]");
 	private static final Pattern _validFriendlyUrlPattern = Pattern.compile(
 		"/[a-z0-9_-]+");
 


### PR DESCRIPTION
Hey @daviddotzhang @petershin

I'm reverting the changes of LPS-73668 because they don't seem the right solution to me. This new change allows characters in the friendly url that weren't allowed before and that they are not allowed in the knowledge base article right now. 

If we add a knowledge base folder with the title (平仮名 the urlTitle field will contain the following value `-%E5%B9%B3%E4%BB%AE%E5%90%8D`which is not a friendly url. Before it would only have the `-` char.

Looking at the ticket description it seems that the issue is caused because we end up having 2 different folders with the exact same friendly url. This is the root issue and not the normalization or encoding of the friendly url. Actually, the exact same issue described in the ticket https://issues.liferay.com/browse/LPS-73668 can be reproduced with folders named "folder 1" and "folder-1" and it's actually failing with the current fix.

We have created 3 different LPS tickets with the issues that are causing the wrong behaviour described in https://issues.liferay.com/browse/LPS-73668 and we will fix them in the new LPSs.
Please see the following bugs:
https://issues.liferay.com/browse/LPS-73975
https://issues.liferay.com/browse/LPS-73971
https://issues.liferay.com/browse/LPS-73972

It seems that a BPR ticket was created and backported. We should rollback those changes in the ee branch as well. We should revert the BPR asap to avoid polluting the database with wrong data in urlTitle. 

@hhuijser and @petershin please send us the pulls related to knowledge base before sending them to Brian next time

Thanks guys.

cc/ @robertoDiaz