### PR TITLE
LRQA-34230 Display error thrown when plugin fails to compile | master

### DIFF
--- a/build-test-plugins.xml
+++ b/build-test-plugins.xml
@@ -397,13 +397,15 @@ plugins.includes=${test.plugin}</echo>
 
 		<for list="${test.plugins}" param="test.plugin">
 			<sequential>
-				<trycatch>
+				<trycatch property="test.plugin.failure">
 					<try>
 						<antcall target="test-plugin">
 							<param name="test.plugin" value="@{test.plugin}" />
 						</antcall>
 					</try>
 					<catch>
+						<echo>PLUGIN_FAILURE: ${test.plugin.failure}</echo>
+
 						<echo append="true" file="plugins-compile-failure">@{test.plugin},</echo>
 					</catch>
 				</trycatch>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-34230

@brianchandotcom - I want to display the errors that are being thrown within the random compilation errors being thrown, so we can get a better idea of why it's failing.

RE: https://github.com/brianchandotcom/liferay-plugins-ee/pull/22025