### PR TITLE
LPS-72347 Increase portal-kernel version

### DIFF
--- a/modules/apps/screens/screens-service/build.gradle
+++ b/modules/apps/screens/screens-service/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.screens.api", version: "3.3.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.14.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.40.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"


### PR DESCRIPTION
Hi @brianchandotcom, this change is necessary so that we can merge journal repo to portal. In portal there aren't any problems compiling screens as of now, but it will fail with the new changes from Journal. 

You can check the failing merge here: https://github.com/liferay/liferay-portal/pull/1778

Please let me know what you think. Thanks!

cc:// @nhpatt, @ealonso  