### PR TITLE
LPS-72589 Solr: introduce a catch-all field to use as default for Lucene syntax mode

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexSearcher.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/ElasticsearchIndexSearcher.java
@@ -280,7 +280,8 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 	}
 
 	protected void addHighlights(
-		SearchRequestBuilder searchRequestBuilder, QueryConfig queryConfig) {
+		SearchRequestBuilder searchRequestBuilder, SearchContext searchContext,
+		QueryConfig queryConfig) {
 
 		if (!queryConfig.isHighlightEnabled()) {
 			return;
@@ -295,8 +296,19 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 			HighlightUtil.HIGHLIGHT_TAG_CLOSE);
 		searchRequestBuilder.setHighlighterPreTags(
 			HighlightUtil.HIGHLIGHT_TAG_OPEN);
+
+		boolean highlighterRequireFieldMatch =
+			queryConfig.isHighlightRequireFieldMatch();
+
+		boolean luceneSyntax = GetterUtil.getBoolean(
+			searchContext.getAttribute("luceneSyntax"));
+
+		if (luceneSyntax) {
+			highlighterRequireFieldMatch = false;
+		}
+
 		searchRequestBuilder.setHighlighterRequireFieldMatch(
-			queryConfig.isHighlightRequireFieldMatch());
+			highlighterRequireFieldMatch);
 	}
 
 	protected void addPagination(
@@ -478,7 +490,7 @@ public class ElasticsearchIndexSearcher extends BaseIndexSearcher {
 		if (!count) {
 			addFacets(searchRequestBuilder, searchContext);
 			addGroupBy(searchRequestBuilder, searchContext, start, end);
-			addHighlights(searchRequestBuilder, queryConfig);
+			addHighlights(searchRequestBuilder, searchContext, queryConfig);
 			addPagination(searchRequestBuilder, start, end);
 			addSelectedFields(searchRequestBuilder, queryConfig);
 			addSort(searchRequestBuilder, searchContext.getSorts());

--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/StringQueryTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/query/StringQueryTest.java
@@ -21,10 +21,35 @@ import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.query.BaseStringQueryTestCase;
 
+import java.util.Arrays;
+
+import org.junit.Test;
+
 /**
  * @author André de Oliveira
  */
 public class StringQueryTest extends BaseStringQueryTestCase {
+
+	@Test
+	public void testBooleanOperatorNotDeepElasticsearch() throws Exception {
+		addDocuments("alpha bravo", "alpha charlie", "charlie delta");
+
+		assertSearch("+(NOT alpha) +charlie", Arrays.asList("charlie delta"));
+	}
+
+	@Test
+	public void testPrefixOperatorMustNotWithBooleanOperatorOrElasticsearch()
+		throws Exception {
+
+		addDocuments("alpha bravo", "alpha charlie", "charlie delta");
+
+		assertSearch(
+			"(-bravo) OR (alpha)",
+			Arrays.asList("alpha charlie", "charlie delta", "alpha bravo"));
+		assertSearch(
+			"(-bravo) OR alpha",
+			Arrays.asList("alpha charlie", "charlie delta", "alpha bravo"));
+	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() {

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrIndexSearcher.java
@@ -278,7 +278,10 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 		solrQuery.addHighlightField(localizedFieldName);
 	}
 
-	protected void addHighlights(SolrQuery solrQuery, QueryConfig queryConfig) {
+	protected void addHighlights(
+		SolrQuery solrQuery, SearchContext searchContext,
+		QueryConfig queryConfig) {
+
 		if (!queryConfig.isHighlightEnabled()) {
 			return;
 		}
@@ -293,8 +296,13 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 			addHighlightedField(solrQuery, queryConfig, highlightFieldName);
 		}
 
-		solrQuery.setHighlightRequireFieldMatch(
-			queryConfig.isHighlightRequireFieldMatch());
+		boolean luceneSyntax = GetterUtil.getBoolean(
+			searchContext.getAttribute("luceneSyntax"));
+
+		if (!luceneSyntax) {
+			solrQuery.setHighlightRequireFieldMatch(
+				queryConfig.isHighlightRequireFieldMatch());
+		}
 	}
 
 	protected void addPagination(
@@ -437,7 +445,7 @@ public class SolrIndexSearcher extends BaseIndexSearcher {
 		if (!count) {
 			addFacets(solrQuery, searchContext);
 			addGroupBy(solrQuery, searchContext, start, end);
-			addHighlights(solrQuery, queryConfig);
+			addHighlights(solrQuery, searchContext, queryConfig);
 			addPagination(solrQuery, searchContext, start, end);
 			addSelectedFields(solrQuery, queryConfig);
 			addSort(solrQuery, searchContext.getSorts());

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/query/StringQueryTranslatorImpl.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/query/StringQueryTranslatorImpl.java
@@ -17,10 +17,6 @@ package com.liferay.portal.search.solr.internal.query;
 import com.liferay.portal.kernel.search.generic.StringQuery;
 import com.liferay.portal.search.solr.query.StringQueryTranslator;
 
-import org.apache.lucene.analysis.core.KeywordAnalyzer;
-import org.apache.lucene.queryparser.classic.ParseException;
-import org.apache.lucene.queryparser.classic.QueryParser;
-
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -31,15 +27,14 @@ public class StringQueryTranslatorImpl implements StringQueryTranslator {
 
 	@Override
 	public org.apache.lucene.search.Query translate(StringQuery stringQuery) {
-		try {
-			QueryParser queryParser = new QueryParser(
-				"uuid", new KeywordAnalyzer());
+		return new org.apache.lucene.search.Query() {
 
-			return queryParser.parse(stringQuery.getQuery());
-		}
-		catch (ParseException pe) {
-			throw new IllegalArgumentException("Invalid query", pe);
-		}
+			@Override
+			public String toString(String field) {
+				return stringQuery.getQuery();
+			}
+
+		};
 	}
 
 }

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/schema.xml
@@ -465,8 +465,25 @@
 		<fieldType class="solr.PointType" dimension="2" name="point" subFieldSuffix="_d" />
 	</types>
 	<fields>
+		<copyField dest="all" source="assetTagNames" />
+		<copyField dest="all" source="assetCategoryTitle" />
+		<copyField dest="all" source="comments" />
+		<copyField dest="all" source="content*" />
+		<copyField dest="all" source="description*" />
+		<copyField dest="all" source="ddmContent" />
+		<copyField dest="all" source="firstName" />
+		<copyField dest="all" source="lastName" />
+		<copyField dest="all" source="middleName" />
+		<copyField dest="all" source="mimeType" />
+		<copyField dest="all" source="name" />
+		<copyField dest="all" source="screenName" />
+		<copyField dest="all" source="subtitle" />
+		<copyField dest="all" source="title*" />
+		<copyField dest="all" source="type" />
+		<copyField dest="all" source="userName" />
 		<copyField dest="assetTagNames.raw" source="assetTagNames" />
 		<field indexed="true" multiValued="false" name="_version_" stored="true" type="long" />
+		<field indexed="true" multiValued="true" name="all" stored="false" type="text" />
 		<field indexed="true" multiValued="true" name="ancestorOrganizationIds" stored="true" type="string" />
 		<field indexed="true" name="articleId" stored="true" type="string_keyword_lowercase" />
 		<field docValues="true" indexed="true" name="assetCategoryId" stored="true" type="string" />
@@ -662,6 +679,5 @@
 		<dynamicField docValues="true" indexed="true" multiValued="true" name="*" stored="true" type="string" />
 	</fields>
 	<uniqueKey>uid</uniqueKey>
-	<defaultSearchField>content</defaultSearchField>
 	<solrQueryParser defaultOperator="OR" />
 </schema>

--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/solrconfig.xml
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/resources/META-INF/resources/solrconfig.xml
@@ -44,7 +44,7 @@
 		<lst name="defaults">
 			<str name="echoParams">explicit</str>
 			<int name="rows">10</int>
-			<str name="df">text</str>
+			<str name="df">all</str>
 		</lst>
 	</requestHandler>
 	<requestHandler class="solr.SearchHandler" name="/query">
@@ -52,7 +52,7 @@
 			<str name="echoParams">explicit</str>
 			<str name="wt">json</str>
 			<str name="indent">true</str>
-			<str name="df">text</str>
+			<str name="df">all</str>
 		</lst>
 	</requestHandler>
 	<requestHandler class="solr.RealTimeGetHandler" name="/get">
@@ -68,13 +68,13 @@
 			<str name="v.layout">layout</str>
 			<str name="title">Solritas</str>
 			<str name="defType">edismax</str>
-			<str name="qf">text^0.5 content^1.0 title^1.0 features^1.0 name^1.0</str>
+			<str name="qf">all^0.5 content^1.0 title^1.0 features^1.0 name^1.0</str>
 			<str name="mm">100%</str>
 			<str name="q.alt">*:*</str>
 			<str name="rows">10</str>
 			<str name="fl">*,score</str>
-			<str name="mlt.qf">text^0.5 content^1.0 title^1.0 features^1.0 name^1.0</str>
-			<str name="mlt.fl">text,content,title,features,name</str>
+			<str name="mlt.qf">all^0.5 content^1.0 title^1.0 features^1.0 name^1.0</str>
+			<str name="mlt.fl">all,content,title,features,name</str>
 			<int name="mlt.count">3</int>
 			<str name="facet">on</str>
 			<str name="facet.field">cat</str>
@@ -99,7 +99,7 @@
 			<str name="f.manufacturedate_dt.facet.range.other">before</str>
 			<str name="f.manufacturedate_dt.facet.range.other">after</str>
 			<str name="hl">on</str>
-			<str name="hl.fl">text content title features name</str>
+			<str name="hl.fl">all content title features name</str>
 			<str name="f.name.hl.fragsize">0</str>
 			<str name="f.name.hl.alternateField">name</str>
 			<str name="spellcheck">on</str>
@@ -118,14 +118,14 @@
 	</requestHandler>
 	<requestHandler class="solr.UpdateRequestHandler" name="/update">
 		<lst name="defaults">
-			<str name="df">text</str>
+			<str name="df">all</str>
 			<str name="update.chain">replica</str>
 		</lst>
 	</requestHandler>
 	<requestHandler class="solr.extraction.ExtractingRequestHandler" name="/update/extract" startup="lazy">
 		<lst name="defaults">
-			<str name="df">text</str>
-			<str name="fmap.content">text</str>
+			<str name="df">all</str>
+			<str name="fmap.content">all</str>
 			<str name="lowernames">true</str>
 			<str name="uprefix">ignored_</str>
 			<str name="captureAttr">true</str>
@@ -180,7 +180,7 @@
 	</searchComponent>
 	<requestHandler class="solr.SearchHandler" name="/spell" startup="lazy">
 		<lst name="defaults">
-			<str name="df">text</str>
+			<str name="df">all</str>
 			<str name="spellcheck.dictionary">default</str>
 			<str name="spellcheck.dictionary">wordbreak</str>
 			<str name="spellcheck">on</str>
@@ -200,7 +200,7 @@
 	<searchComponent class="solr.TermVectorComponent" name="tvComponent" />
 	<requestHandler class="solr.SearchHandler" name="/tvrh" startup="lazy">
 		<lst name="defaults">
-			<str name="df">text</str>
+			<str name="df">all</str>
 			<bool name="tv">true</bool>
 		</lst>
 		<arr name="last-components">
@@ -231,7 +231,7 @@
 			<bool name="carrot.produceSummary">true</bool>
 			<bool name="carrot.outputSubClusters">false</bool>
 			<str name="defType">edismax</str>
-			<str name="qf">text^0.5 features^1.0 name^1.2 sku^1.5 id^10.0 manu^1.1 cat^1.4</str>
+			<str name="qf">all^0.5 features^1.0 name^1.2 sku^1.5 id^10.0 manu^1.1 cat^1.4</str>
 			<str name="q.alt">*:*</str>
 			<str name="rows">10</str>
 			<str name="fl">*,score</str>
@@ -257,7 +257,7 @@
 	<requestHandler class="solr.SearchHandler" name="/elevate" startup="lazy">
 		<lst name="defaults">
 			<str name="echoParams">explicit</str>
-			<str name="df">text</str>
+			<str name="df">all</str>
 		</lst>
 		<arr name="last-components">
 			<str>elevator</str>

--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/query/StringQueryTest.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/query/StringQueryTest.java
@@ -18,10 +18,35 @@ import com.liferay.portal.search.solr.internal.SolrIndexingFixture;
 import com.liferay.portal.search.test.util.indexing.IndexingFixture;
 import com.liferay.portal.search.test.util.query.BaseStringQueryTestCase;
 
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
 /**
  * @author André de Oliveira
  */
 public class StringQueryTest extends BaseStringQueryTestCase {
+
+	@Test
+	public void testBooleanOperatorNotDeepSolr() throws Exception {
+		addDocuments("alpha bravo", "alpha charlie", "charlie delta");
+
+		assertSearch("+(NOT alpha) +charlie", Collections.emptyList());
+	}
+
+	@Test
+	public void testPrefixOperatorMustNotWithBooleanOperatorOrSolr()
+		throws Exception {
+
+		addDocuments("alpha bravo", "alpha charlie", "charlie delta");
+
+		assertSearch(
+			"(-bravo) OR (alpha)",
+			Arrays.asList("alpha bravo", "alpha charlie"));
+		assertSearch(
+			"(-bravo) OR alpha", Arrays.asList("alpha bravo", "alpha charlie"));
+	}
 
 	@Override
 	protected IndexingFixture createIndexingFixture() throws Exception {


### PR DESCRIPTION
Author: @BryanEngler 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-72589