### PR TITLE
LPS-73788 Push the parent tx's ResourceBlockPermission clean up into …

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -55,7 +55,10 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.spring.aop.Skip;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CharPool;
@@ -84,6 +87,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 /**
  * Provides the local service for accessing, adding, checking, deleting, and
@@ -248,6 +252,18 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		userPersistence.addRoles(userId, roleIds);
 
 		reindex(userId);
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		super.afterPropertiesSet();
+
+		TransactionConfig.Builder builder = new TransactionConfig.Builder();
+
+		builder.setIsolation(Isolation.READ_COMMITTED);
+		builder.setPropagation(Propagation.REQUIRES_NEW);
+
+		_transactionConfig = builder.build();
 	}
 
 	/**
@@ -430,11 +446,28 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		List<ResourceBlockPermission> resourceBlockPermissions =
 			resourceBlockPermissionPersistence.findByRoleId(role.getRoleId());
 
-		for (ResourceBlockPermission resourceBlockPermission :
-				resourceBlockPermissions) {
+		try {
+			TransactionInvokerUtil.invoke(
+				_transactionConfig,
+				new Callable<Void>() {
 
-			resourceBlockPermissionLocalService.deleteResourceBlockPermission(
-				resourceBlockPermission);
+					@Override
+					public Void call() {
+						for (ResourceBlockPermission resourceBlockPermission :
+								resourceBlockPermissions) {
+
+							resourceBlockPermissionLocalService.
+								deleteResourceBlockPermission(
+									resourceBlockPermission);
+						}
+
+						return null;
+					}
+
+				});
+		}
+		catch (Throwable t) {
+			throw new PortalException(t);
 		}
 
 		List<ResourcePermission> resourcePermissions =
@@ -1729,5 +1762,6 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 		RoleLocalServiceImpl.class);
 
 	private final Map<String, Role> _systemRolesMap = new HashMap<>();
+	private TransactionConfig _transactionConfig;
 
 }


### PR DESCRIPTION
…a new tx, so that later when we do the real resource block clean up, we won't see the row lock from parent tx.

@inacionery This is our temp solution.

The ticket's problem should be fixed, and CI should also be ok. This can buy @preston-crary sometime to do the upgrade change.