### PR TITLE
LRQA-34199 Ignore SAMLBootstrap error

### DIFF
--- a/portal-web/test-ignorable-error-lines.xml
+++ b/portal-web/test-ignorable-error-lines.xml
@@ -200,6 +200,10 @@
 			<contains>Unable to add folder menu item</contains>
 			<matches></matches>
 		</ignore-error>
+		<ignore-error description="LRQA-34199, temporarily ignore SAMLBootstrap error">
+			<contains>The activate method has thrown an exception</contains>
+			<matches></matches>
+		</ignore-error>
 		<ignore-error description="WCM-202">
 			<contains>No score point assigners available</contains>
 			<matches></matches>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-34199

This pull is in preparation to switch to using master-private private modules instead of ee-7.0.x  private modules. The SAMLBootstrap error occurs on jboss and wildfly batch builds when using master-private private modules.

Please update master-private/git-commit-portal after merging this pull request so master-private pull request tester may also benefit from this change.

CC: @michaelhashimoto