### PR TITLE
LPS-74131 Undo the file builder change, this is needed because file b…

### DIFF
--- a/modules/apps/portal-mobile-device-detection-fiftyonedegrees/portal-mobile-device-detection-fiftyonedegrees/src/main/java/com/liferay/portal/mobile/device/detection/fiftyonedegrees/configuration/FiftyOneDegreesConfiguration.java
+++ b/modules/apps/portal-mobile-device-detection-fiftyonedegrees/portal-mobile-device-detection-fiftyonedegrees/src/main/java/com/liferay/portal/mobile/device/detection/fiftyonedegrees/configuration/FiftyOneDegreesConfiguration.java
@@ -30,9 +30,6 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface FiftyOneDegreesConfiguration {
 
-	@Meta.AD(deflt = "5000", required = false)
-	public int cacheSize();
-
 	@Meta.AD(deflt = "META-INF/51Degrees-LiteV3.2.dat", required = false)
 	public String fiftyOneDegreesDataFileName();
 


### PR DESCRIPTION
…uilder takes native memory, and currently on CI we just don't have enough memory to keep both heap and non-heap usages happy. By changing it back to heap memory usage, we can at least increase heap size (suffering hitting swap space) to prevent OOM.

@mhan810 I have to do this since ee-7.0.x is running out of native memory. @jeffreyyang update the data file here https://github.com/liferay/liferay-portal-ee/commit/4cb1f9e784900966c079a6e1643ecba6da9603e2 which is bigger than before. And all the lpkg tests can not run in test mode, so they are not loading the test data file but the real data file. The root problem is with 32bit process, we just don't have enough memory to keep both heap and non-heap usage happy. We must choose a side, and it can only be heap. But it also means we will hit swap space hard.

@brianchandotcom we are not far away from the point that, we have to switch back to 64 bit jvm, and the current CI hardware memory is just not going to be enough to support this.

@jpince this is for the lpkg batches OOM failures. The LPKG release batch is still going to fail due to a packaging script bug, @CAustin582 is working on that one.

EE side pull is at https://github.com/brianchandotcom/liferay-portal-ee/pull/18042
