### PR TITLE
LPS-74186 Make lpkg url portal profile awared

### DIFF
--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/WABWrapperUtil.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer/src/main/java/com/liferay/portal/lpkg/deployer/internal/WABWrapperUtil.java
@@ -60,6 +60,8 @@ public class WABWrapperUtil {
 		sb.append("&Web-ContextPath=/");
 		sb.append(contextName);
 		sb.append("&protocol=lpkg");
+		sb.append(StringPool.AMPERSAND);
+		sb.append(lpkgURL.getQuery());
 
 		return sb.toString();
 	}

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/connection/WabURLConnection.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/connection/WabURLConnection.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.osgi.web.wab.generator.WabGenerator;
 import com.liferay.portal.util.FastDateFormatFactoryImpl;
 import com.liferay.portal.util.FileImpl;
@@ -80,8 +81,18 @@ public class WabURLConnection extends URLConnection {
 					"protocol");
 		}
 
-		final File file = transferToTempFile(
-			new URL(protocols[0], null, url.getPath()));
+		String path = url.getPath();
+
+		String[] portalProfileNames = parameters.get(
+			"liferay-portal-profile-names");
+
+		if (ArrayUtil.isNotEmpty(portalProfileNames)) {
+			path = path.concat("?liferay-portal-profile-names=");
+
+			path = path.concat(StringUtil.merge(portalProfileNames));
+		}
+
+		final File file = transferToTempFile(new URL(protocols[0], null, path));
 
 		File processedFile = _wabGenerator.generate(
 			_classLoader, file, parameters);


### PR DESCRIPTION
@brianchandotcom @jpince this fixes the ee side lpkg build failures and the release night build issues.

The problem has always been there, but only started to be exposed by https://github.com/brianchandotcom/liferay-portal/pull/50900
Before that pull, ee only contained ee only themes. After that pull got cherrypicked to ee, ee started to contain both ce and ee themes, since they have the same symbolic name, they are conflicting with each other.

This fix is making the portal profile name part of the lpkg url query string, so that we can tell the difference between ce and ee themes.

But this does raise a question, do we really want ee release to contain ce only themes? What's the point?