### PR TITLE
Lps 74192

### DIFF
--- a/build-dist.xml
+++ b/build-dist.xml
@@ -1751,13 +1751,13 @@ this task.
 			<then>
 				<replace file="${app.server.tcserver.bin.dir}/setenv.bat">
 					<replacetoken><![CDATA[set JVM_OPTS=-Xmx512M -Xss256K]]></replacetoken>
-					<replacevalue><![CDATA[set JVM_OPTS=-Dfile.encoding=UTF-8 -Xmx1024M -Xss512K -XX:MaxMetaspaceSize=512m]]></replacevalue>
+					<replacevalue><![CDATA[set JVM_OPTS=-Dfile.encoding=UTF-8 -Xmx1024M -Xss512K -XX:MaxMetaspaceSize=512m -Duser.timezone=GMT]]></replacevalue>
 				</replace>
 			</then>
 			<else>
 				<replace file="${app.server.tcserver.bin.dir}/setenv.sh">
 					<replacetoken><![CDATA[JVM_OPTS="-Xmx512M -Xss256K"]]></replacetoken>
-					<replacevalue><![CDATA[JVM_OPTS="-Dfile.encoding=UTF-8 -Xmx1024M -Xss512K -XX:MaxPermSize=512m"]]></replacevalue>
+					<replacevalue><![CDATA[JVM_OPTS="-Dfile.encoding=UTF-8 -Xmx1024M -Xss512K -XX:MaxPermSize=512m -Duser.timezone=GMT"]]></replacevalue>
 				</replace>
 			</else>
 		</if>

--- a/portal-impl/src/system.properties
+++ b/portal-impl/src/system.properties
@@ -55,12 +55,6 @@
     user.country=US
     user.language=en
 
-    #
-    # Set the default time zone used by Liferay. This time zone is no longer set
-    # at the VM level. See LEP-2584.
-    #
-    user.timezone=UTC
-
 ##
 ## Java Advanced Imaging
 ##


### PR DESCRIPTION
@michaelhashimoto tcsever should really use the same logic as we setup setenv.sh for tomcat on CI. Please do some follow up refactor to merge them into a common logic for setenv.sh preparation, otherwise they can get out of sync in the long run.

@jhinkey not sure whether this is already documented or not. Basically all appservers need to set the user.timezone property at jvm level rather than portal level, as the appserver itself may also read this, it is too late to do this at portal level. If this has not been documented, we should do it.