### PR TITLE
LPS-74116 Modify method signature, add "throws"

### DIFF
--- a/portal-impl/src/com/liferay/portlet/ActionResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/ActionResponseImpl.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portlet;
 
+import java.io.IOException;
+
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletRequest;
 
@@ -29,7 +31,7 @@ public class ActionResponseImpl
 	}
 
 	@Override
-	public void sendRedirect(String location) {
+	public void sendRedirect(String location) throws IOException {
 		if ((location == null) ||
 			(!location.startsWith("/") && !location.contains("://") &&
 			 !location.startsWith("wsrp_rewrite?"))) {
@@ -54,7 +56,8 @@ public class ActionResponseImpl
 	}
 
 	@Override
-	public void sendRedirect(String location, String renderUrlParamName) {
+	public void sendRedirect(String location, String renderUrlParamName)
+		throws IOException {
 	}
 
 }

--- a/portal-impl/src/com/liferay/portlet/MimeResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/MimeResponseImpl.java
@@ -68,7 +68,9 @@ public abstract class MimeResponseImpl
 	}
 
 	@Override
-	public OutputStream getPortletOutputStream() throws IOException {
+	public OutputStream getPortletOutputStream()
+		throws IllegalStateException, IOException {
+
 		if (_calledGetWriter) {
 			throw new IllegalStateException(
 				"Unable to obtain OutputStream because Writer is already in " +
@@ -85,7 +87,7 @@ public abstract class MimeResponseImpl
 	}
 
 	@Override
-	public PrintWriter getWriter() throws IOException {
+	public PrintWriter getWriter() throws IllegalStateException, IOException {
 		if (_calledGetPortletOutputStream) {
 			throw new IllegalStateException(
 				"Cannot obtain Writer because OutputStream is already in use");

--- a/portal-impl/src/com/liferay/portlet/PortalPreferencesWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/PortalPreferencesWrapper.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.ReadOnlyException;
+import javax.portlet.ValidatorException;
 
 /**
  * @author Alexander Chow
@@ -102,7 +103,7 @@ public class PortalPreferencesWrapper
 	}
 
 	@Override
-	public void store() throws IOException {
+	public void store() throws IOException, ValidatorException {
 		_portalPreferencesImpl.store();
 	}
 

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesWrapper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 import java.util.Enumeration;
@@ -21,6 +22,7 @@ import java.util.Map;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.ReadOnlyException;
+import javax.portlet.ValidatorException;
 
 /**
  * @author Brian Wing Shun Chan
@@ -107,7 +109,7 @@ public class PortletPreferencesWrapper
 	}
 
 	@Override
-	public void store() {
+	public void store() throws IOException, ValidatorException {
 
 		// PLT.17.1, clv
 

--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -73,6 +73,7 @@ import java.util.function.BiConsumer;
 import javax.portlet.PortletMode;
 import javax.portlet.PortletModeException;
 import javax.portlet.PortletRequest;
+import javax.portlet.PortletSecurityException;
 import javax.portlet.PortletURL;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceURL;
@@ -645,7 +646,7 @@ public class PortletURLImpl
 	}
 
 	@Override
-	public void setSecure(boolean secure) {
+	public void setSecure(boolean secure) throws PortletSecurityException {
 		_secure = secure;
 
 		clearCache();


### PR DESCRIPTION
@brianchandotcom I know this looks a bit odd basing on our normal coding standard, but the new portlet tck tests are using reflection to assert those methods' signatures, we will have to give them that in order to pass it.