### PR TITLE
LPS-74267 Depend on latest kernel

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 2d0facabd73b7f1664e39c80e32260b6eca6de7d
+	commit = 46b509e3ea05ede22a7b686872447c6da55d9638
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2efe5ed7c1d8bc34700b52df3090b87966b79b0f
+	parent = 2632b531bccb330e09fd27ae85793b9719adf7f9
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c22380269c47d71ae9c9f7fa630823a369d004c8
+	commit = fef16bd104761c7c2b2d71c63484146a4cfc851a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b889c76d9284343e48fe00954240338379b071f1
+	parent = fe185740b7a004cd53c1555ba93a28a1180235b9
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/collaboration/document-library/document-library-repository-external/build.gradle
+++ b/modules/apps/collaboration/document-library/document-library-repository-external/build.gradle
@@ -2,6 +2,6 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.26.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.43.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 }

--- a/modules/apps/collaboration/invitation/.gitrepo
+++ b/modules/apps/collaboration/invitation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4e810b4b69529bdb2eee59f5fdc3dbbf74e40492
+	commit = f7409e938557ed8754043fd9cc5de34d7b313c95
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3374073312520100b962033af1a4ca769efbac8a
+	parent = 03c1e96e4e0368878c3748247123c6f0c9352f28
 	remote = git@github.com:liferay/com-liferay-invitation.git

--- a/modules/apps/collaboration/microblogs/.gitrepo
+++ b/modules/apps/collaboration/microblogs/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 26b71f6d87d1c7e5715d2df91add2444bff627fb
+	commit = b86697170cbc0bbb7ccc60da8beff0b4f1341d18
 	mergebuttonmergecommits = false
 	mode = push
-	parent = cc061dbe900d124ec02426a3d3b609d9154d95c3
+	parent = 3ee43d6934a040f88ae824a88652f2d0ab52b16a
 	remote = git@github.com:liferay/com-liferay-microblogs.git

--- a/modules/apps/collaboration/subscription/.gitrepo
+++ b/modules/apps/collaboration/subscription/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = bc1fefe202553cb0e13a26a59407cab83c37c30c
+	commit = 4639360622221972e12d90ceccdfa1daabf02b37
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f2bf24697c5d8f41d42d071882ea0708d1658d25
+	parent = 987e2b5a4ecce3397e4c6f19c914233ca77c36d6
 	remote = git@github.com:liferay/com-liferay-subscription.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = de1db2d20fb6c2a494079df38ab4cb9230168a3e
+	commit = ae0031a68104597edc6b9c467fbe6d8130c35da3
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 10351dc6e577434dcc749ba233feaf7970c898ac
+	parent = 3f41fd82d001ba62ecc91598fb0edcd6f8f91f5d
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d77b9e6abb5a0d62ba7d19219c2c67ed1d805c5c
+	commit = 85c5303a21b9e449bf4dde989a01fcbe70bdadf7
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e53fb836f4a97eaa756dfb12044d558b61cc2a03
+	parent = 77c9f2713931fb13f5cd71772e9435a0373a34a0
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 6e598b4702c236f837bc75098fe0a748dfffcc80
+	commit = f8aec58fee34eb9edc0614cf27c07e314bf84ffd
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 45d7855295d7251826a3ace832e45d902e4203ba
+	parent = 700a47bb8cd004d359a0b173ddc5343952cadbf7
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/forms-and-workflow/polls/.gitrepo
+++ b/modules/apps/forms-and-workflow/polls/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 82ac4c374900f3ea7f00fd0edd86043b3de376a2
+	commit = 9ad86efa9870de2eca4e243630ea870d6561f7b4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7e12c4afc358b7e16147bf5d91149723e2f7a221
+	parent = 6426df1c36c1931fa09a75b5c7d8e02e5cc950e6
 	remote = git@github.com:liferay/com-liferay-polls.git

--- a/modules/apps/foundation/contacts/.gitrepo
+++ b/modules/apps/foundation/contacts/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 8ece3217de1bf74a29c54f084eb950beb6562fb9
+	commit = b325f4b4e0c73191a8714b70753896917495adef
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 14ec0de4ddd35a8e085e47466dcaf7e09721d3d5
+	parent = eb747c137023b15ca39d3cd7776d41d26d428c24
 	remote = git@github.com:liferay/com-liferay-contacts.git

--- a/modules/apps/foundation/mobile-device-rules/.gitrepo
+++ b/modules/apps/foundation/mobile-device-rules/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 6834bbdae2eaf9a225b1d08edca0f7f91f4e9775
+	commit = 8673634a65b7af300a43bb311f242ca09afd6d4a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 54d440ad228fd2b4bac37765fc5ad3dafdd107d1
+	parent = 826b6f43aa504ba3e93075f5b343458603bbcadc
 	remote = git@github.com:liferay/com-liferay-mobile-device-rules.git

--- a/modules/apps/foundation/portal-background-task/.gitrepo
+++ b/modules/apps/foundation/portal-background-task/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 683700b974a81efdd71349c72bda5faa7bd2597b
+	commit = 1d7b2a7647edf15aff4e949d0555f42864e66b3b
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 86ebfee38604f3707ea5bb9398d114f2b5989830
+	parent = 104f2b454f95e6becaa7e5ee783a2acae2bed6e5
 	remote = git@github.com:liferay/com-liferay-portal-background-task.git

--- a/modules/apps/foundation/portal-configuration/.gitrepo
+++ b/modules/apps/foundation/portal-configuration/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 573e41d178af6c6f81d5985b2e35edf0972d0054
+	commit = cd96a670ebeb192288ea66f22e1374cda0d7c39d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 14a94bfcaecac25ba495edeaba61509e2a08bfa4
+	parent = eea0b3a5c647efffd47e122b626f8f6cbb32e0e2
 	remote = git@github.com:liferay/com-liferay-portal-configuration.git

--- a/modules/apps/foundation/portal-lock/.gitrepo
+++ b/modules/apps/foundation/portal-lock/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 67b2be15f48b8c1514f2b0d1b31d40f69b622823
+	commit = 2819bf0d78b134b01f08256dbe03d63dddf3ae66
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 62e31613e61d1000e736bf8ef0014c56a9326ee0
+	parent = 02dbc7f5bdbe6a837a3fe153ea93d8d0929e7d03
 	remote = git@github.com:liferay/com-liferay-portal-lock.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e700c21cb5d220843cfbbb8da402c56eedbe5aff
+	commit = ddd439796720155c1d2acb5f5efd70a963491932
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 18e767f6635e905572d2928d4dea2696f09130a8
+	parent = 23828e00d3bcc74c2c3aff39a9ee412ff6916ba7
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 3fb49322eb7b5e97aef9d8a37065a1d3da539050
+	commit = 5223db6e7fb619a61b58fe0c6063fef5a988d74c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = af7855a3ed4dd2af0e13be85b07a4057d8e0161c
+	parent = a668d79cc92819c738fa6099d65ba3ee0abe4cd8
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b280a115ade92789fb2a348cf02d404fa78d6277
+	commit = a321523658ccc61cee23667e8e8ab11c71fdaf18
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a4d8059694235bf36776f97823b8ed7f29f5260e
+	parent = 606d1e4f6f6ccc5dc2d6151787faa804c9f57a82
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/screens/.gitrepo
+++ b/modules/apps/screens/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ccfeebc233447f1acf049cbf120890350fed216f
+	commit = 935d89fd442fadaa484231ab2cb917154ecbe2e7
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9108da7dd3e2c20ebefe69f29d6199bded2b4bfb
+	parent = f2d8333957cd3543be5ddfd07ba0f62b0c5e0eda
 	remote = git@github.com:liferay/com-liferay-screens.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 377bfd451f3f57383d83b701945e682ea0154c4a
+	commit = bf1d8091ce9101011ffea097cda8d50df71ce5b0
 	mergebuttonmergecommits = false
 	mode = push
-	parent = bd6daf3feee83cb6dfb588b4be9741663fc1ae10
+	parent = b49ef13762bc21e27806a1a1fdd1634a77c4d7bf
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f8d910ea072eda6891a47427be19c18d9305b9d5
+	commit = a1e47d44f88ae54002b2fecdb69bf0267bc3634f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 50fa43aa48e0b1d0017ce7d9394882ff5d3eb727
+	parent = 07229599973001061d7340d97adf87ceef3927c8
 	remote = git@github.com:liferay/com-liferay-site.git

--- a/modules/apps/web-experience/trash/.gitrepo
+++ b/modules/apps/web-experience/trash/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 28fec30bfddeae0a1c1da7f3946f39629ea3d8b7
+	commit = 3b0c8ef6aa8428a2aa506fbac79e9d60157749f9
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 020b65b7403430e0eda6d52595564b529740a693
+	parent = 257bfd87df14a5de3f3c8ded90c41efdd3f48765
 	remote = git@github.com:liferay/com-liferay-trash.git


### PR DESCRIPTION
Hey @brianchandotcom,

We need this for the Sharepoint connector in EE (we're sending it here
first so that master and EE versions are consistent). The problem is
that BND is generating package version ranges that are unsatisfiable:
it requires [7.1.0,7.2.0), but 7.2.0 is deployed.

This error is not visible (yet) because this module is not deployed by
default (we'll add the .lfrbuild file is a separate ticket).

Thanks!

/cc @sergiogonzalez