### PR TITLE
LRQA-34441 Release Poshi 1.0.63 | master

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/testFunctional/test.properties
+++ b/modules/test/poshi-runner/poshi-runner/src/testFunctional/test.properties
@@ -12,6 +12,8 @@
 
     test.skip.tear.down=false
 
+    test.subrepo.dirs=
+
 ##
 ## Test Batch
 ##

--- a/portal-web/build-test.gradle
+++ b/portal-web/build-test.gradle
@@ -34,7 +34,7 @@ poshiRunner {
 	}
 
 	openCVVersion = "2.4.10-0.10"
-	version = "1.0.62"
+	version = "1.0.63"
 }
 
 task updateGradleCache


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-34441
https://issues.liferay.com/browse/LRQA-34353

New release of Poshi 1.0.63, these jars have already been cached in liferay-binaries-2017:
https://github.com/liferay/liferay-binaries-cache-2017/commit/1c6ebce6d6744467fc395cb15b4a0cdd9a49c163