### PR TITLE
Revert "portal-lpkg-deployer 2.0.20 apply"

### DIFF
--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/build.gradle
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/build.gradle
@@ -3,7 +3,7 @@ copyLibs {
 }
 
 dependencies {
-	provided group: "com.liferay", name: "com.liferay.portal.lpkg.deployer", version: "2.0.0"
+	provided project(":apps:static:portal-lpkg-deployer:portal-lpkg-deployer")
 
 	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.6.0"
 	testCompile project(":apps:static:portal-lpkg-deployer:portal-lpkg-deployer-test-util")


### PR DESCRIPTION
This reverts commit 5484d678e06f3820e8886006d753e7c5aea287bf.

The test needs to have a project dependency because it is bnd including an internal class from portal-lpkg-deployer. Without this the test will not be able to compile.

@shuyangzhou