### PR TITLE
LPS-74433 Set the thread to daemon, it makes no sense to let the prog…

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -229,6 +229,9 @@ public class SourceFormatter {
 
 		_printProgressStatusMessage("Initializing checks...");
 
+		_progressStatusThread.setDaemon(true);
+		_progressStatusThread.setName("SF Progress Status Thread");
+
 		_progressStatusThread.start();
 
 		_sourceProcessors.add(new BNDSourceProcessor());


### PR DESCRIPTION
…ress status thread blocking jvm from exiting. And give it a name, so that it is more debug friendly when reading thread dumps.

CC @hhuijser