### PR TITLE
Lps 74456

### DIFF
--- a/modules/apps/marketplace/marketplace-app-manager-web/build.gradle
+++ b/modules/apps/marketplace/marketplace-app-manager-web/build.gradle
@@ -12,4 +12,5 @@ dependencies {
 	provided group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:static:portal-bundle-blacklist:portal-bundle-blacklist")
 }

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerPortlet.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerPortlet.java
@@ -23,6 +23,7 @@ import com.liferay.marketplace.app.manager.web.internal.util.BundleUtil;
 import com.liferay.marketplace.bundle.BundleManagerUtil;
 import com.liferay.marketplace.exception.FileExtensionException;
 import com.liferay.marketplace.service.AppService;
+import com.liferay.portal.bundle.blacklist.BundleBlacklistManager;
 import com.liferay.portal.kernel.deploy.DeployManagerUtil;
 import com.liferay.portal.kernel.model.LayoutTemplate;
 import com.liferay.portal.kernel.model.Plugin;
@@ -62,6 +63,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -266,11 +268,16 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 
 		List<Bundle> bundles = BundleManagerUtil.getInstalledBundles();
 
+		List<String> symbolicNames = new ArrayList<>(bundleIds.length);
+
 		for (Bundle bundle : bundles) {
 			if (ArrayUtil.contains(bundleIds, bundle.getBundleId())) {
-				bundle.uninstall();
+				symbolicNames.add(bundle.getSymbolicName());
 			}
 		}
+
+		_bundleBlacklistManager.addToBlacklistAndUninstall(
+			symbolicNames.toArray(new String[symbolicNames.size()]));
 	}
 
 	public void updatePluginSetting(
@@ -531,6 +538,9 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 	private static final String _DEPLOY_TO_PREFIX = "DEPLOY_TO__";
 
 	private AppService _appService;
+
+	@Reference
+	private BundleBlacklistManager _bundleBlacklistManager;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/app_display_action.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/app_display_action.jsp
@@ -77,7 +77,7 @@ String bundleIds = _getBundleIds(appDisplay);
 			<portlet:param name="bundleIds" value="<%= bundleIds %>" />
 		</portlet:actionURL>
 
-		<liferay-ui:icon-delete url="<%= uninstallBundlesURL %>" />
+		<liferay-ui:icon-delete message="uninstall" url="<%= uninstallBundlesURL %>" />
 	</c:if>
 </liferay-ui:icon-menu>
 

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/bundle_action.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/bundle_action.jsp
@@ -61,5 +61,5 @@ Bundle bundle = (Bundle)row.getObject();
 		<portlet:param name="bundleIds" value="<%= String.valueOf(bundle.getBundleId()) %>" />
 	</portlet:actionURL>
 
-	<liferay-ui:icon-delete url="<%= uninstallBundlesURL %>" />
+	<liferay-ui:icon-delete message="uninstall" url="<%= uninstallBundlesURL %>" />
 </liferay-ui:icon-menu>

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/module_group_display_action.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/module_group_display_action.jsp
@@ -61,7 +61,7 @@ String bundleIds = _getBundleIds(moduleGroupDisplay);
 		<portlet:param name="bundleIds" value="<%= bundleIds %>" />
 	</portlet:actionURL>
 
-	<liferay-ui:icon-delete url="<%= uninstallBundlesURL %>" />
+	<liferay-ui:icon-delete message="uninstall" url="<%= uninstallBundlesURL %>" />
 </liferay-ui:icon-menu>
 
 <%!

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
@@ -383,7 +383,12 @@ public class BundleBlacklistTest {
 		_bundleContext.addServiceListener(serviceListener);
 
 		try {
-			_bundleBlacklistConfiguration.update(dictionary);
+			if (dictionary == null) {
+				_bundleBlacklistConfiguration.delete();
+			}
+			else {
+				_bundleBlacklistConfiguration.update(dictionary);
+			}
 
 			countDownLatch.await();
 		}

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
@@ -229,8 +229,7 @@ public class BundleBlacklistTest {
 
 		// Blacklist WAR wrapper
 
-		properties.put(
-			_PROP_KEY, new String[] {warWrapperBundle.getSymbolicName()});
+		properties.put(_PROP_KEY, warWrapperBundle.getSymbolicName());
 
 		_updateConfiguration(properties);
 
@@ -259,7 +258,7 @@ public class BundleBlacklistTest {
 
 		// Blacklist WAR
 
-		properties.put(_PROP_KEY, new String[] {warBundle.getSymbolicName()});
+		properties.put(_PROP_KEY, warBundle.getSymbolicName());
 
 		_updateConfiguration(properties);
 
@@ -278,7 +277,7 @@ public class BundleBlacklistTest {
 
 		// Blacklist JAR
 
-		properties.put(_PROP_KEY, new String[] {jarBundle.getSymbolicName()});
+		properties.put(_PROP_KEY, jarBundle.getSymbolicName());
 
 		_updateConfiguration(properties);
 
@@ -297,7 +296,7 @@ public class BundleBlacklistTest {
 
 		// Blacklist LPKG
 
-		properties.put(_PROP_KEY, new String[] {lpkgBundle.getSymbolicName()});
+		properties.put(_PROP_KEY, lpkgBundle.getSymbolicName());
 
 		_updateConfiguration(properties);
 

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/bnd.bnd
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Portal Bundle Blacklist
 Bundle-SymbolicName: com.liferay.portal.bundle.blacklist
 Bundle-Version: 1.0.0
+Export-Package: com.liferay.portal.bundle.blacklist

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/build.gradle
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	provided group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	provided group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:static:portal-lpkg-deployer:portal-lpkg-deployer")

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
@@ -141,54 +141,44 @@ public class BundleBlacklistManager {
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
-		ServiceReference<ConfigurationAdmin> serviceReference =
-			bundleContext.getServiceReference(ConfigurationAdmin.class);
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			BundleBlacklistConfiguration.class.getName(), StringPool.QUESTION);
 
-		try {
-			ConfigurationAdmin configurationAdmin = bundleContext.getService(
-				serviceReference);
+		Dictionary<String, Object> properties = configuration.getProperties();
 
-			Configuration configuration = configurationAdmin.getConfiguration(
-				BundleBlacklistConfiguration.class.getName(),
-				StringPool.QUESTION);
+		String[] blacklistBundleSymbolicNames = null;
 
-			Dictionary<String, Object> properties =
-				configuration.getProperties();
+		if (properties == null) {
+			properties = new HashMapDictionary<>();
+		}
+		else {
+			Object value = properties.get("blacklistBundleSymbolicNames");
 
-			String[] blacklistBundleSymbolicNames = null;
-
-			if (properties == null) {
-				properties = new HashMapDictionary<>();
+			if (value instanceof String) {
+				blacklistBundleSymbolicNames = new String[] {(String)value};
 			}
 			else {
-				Object value = properties.get("blacklistBundleSymbolicNames");
-
-				if (value instanceof String) {
-					blacklistBundleSymbolicNames = new String[] {(String)value};
-				}
-				else {
-					blacklistBundleSymbolicNames = (String[])value;
-				}
+				blacklistBundleSymbolicNames = (String[])value;
 			}
-
-			blacklistBundleSymbolicNames = updateFunction.apply(
-				blacklistBundleSymbolicNames);
-
-			if (blacklistBundleSymbolicNames == null) {
-				return;
-			}
-
-			properties.put(
-				"blacklistBundleSymbolicNames", blacklistBundleSymbolicNames);
-
-			_updateConfiguration(bundleContext, configuration, properties);
 		}
-		finally {
-			bundleContext.ungetService(serviceReference);
+
+		blacklistBundleSymbolicNames = updateFunction.apply(
+			blacklistBundleSymbolicNames);
+
+		if (blacklistBundleSymbolicNames == null) {
+			return;
 		}
+
+		properties.put(
+			"blacklistBundleSymbolicNames", blacklistBundleSymbolicNames);
+
+		_updateConfiguration(bundleContext, configuration, properties);
 	}
 
 	@Reference
 	private BundleBlacklist _bundleBlacklist;
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 
 }

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
@@ -19,6 +19,7 @@ import com.liferay.portal.bundle.blacklist.internal.BundleBlacklistConfiguration
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.IOException;
 
@@ -151,14 +152,10 @@ public class BundleBlacklistManager {
 			properties = new HashMapDictionary<>();
 		}
 		else {
-			Object value = properties.get("blacklistBundleSymbolicNames");
+			String value = (String)properties.get(
+				"blacklistBundleSymbolicNames");
 
-			if (value instanceof String) {
-				blacklistBundleSymbolicNames = new String[] {(String)value};
-			}
-			else {
-				blacklistBundleSymbolicNames = (String[])value;
-			}
+			blacklistBundleSymbolicNames = StringUtil.split(value);
 		}
 
 		blacklistBundleSymbolicNames = updateFunction.apply(
@@ -173,7 +170,8 @@ public class BundleBlacklistManager {
 		}
 		else {
 			properties.put(
-				"blacklistBundleSymbolicNames", blacklistBundleSymbolicNames);
+				"blacklistBundleSymbolicNames",
+				StringUtil.merge(blacklistBundleSymbolicNames));
 		}
 
 		_updateConfiguration(configuration, properties);

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
@@ -168,8 +168,13 @@ public class BundleBlacklistManager {
 			return;
 		}
 
-		properties.put(
-			"blacklistBundleSymbolicNames", blacklistBundleSymbolicNames);
+		if (blacklistBundleSymbolicNames.length == 0) {
+			properties.remove("blacklistBundleSymbolicNames");
+		}
+		else {
+			properties.put(
+				"blacklistBundleSymbolicNames", blacklistBundleSymbolicNames);
+		}
 
 		_updateConfiguration(configuration, properties);
 	}

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
@@ -92,9 +92,12 @@ public class BundleBlacklistManager {
 	}
 
 	private void _updateConfiguration(
-			BundleContext bundleContext, Configuration configuration,
-			Dictionary<String, Object> properties)
+			Configuration configuration, Dictionary<String, Object> properties)
 		throws IOException {
+
+		Bundle bundle = FrameworkUtil.getBundle(BundleBlacklistManager.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
 
 		CountDownLatch countDownLatch = new CountDownLatch(1);
 
@@ -137,10 +140,6 @@ public class BundleBlacklistManager {
 	private void _updateProperties(Function<String[], String[]> updateFunction)
 		throws IOException {
 
-		Bundle bundle = FrameworkUtil.getBundle(BundleBlacklistManager.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
 		Configuration configuration = _configurationAdmin.getConfiguration(
 			BundleBlacklistConfiguration.class.getName(), StringPool.QUESTION);
 
@@ -172,7 +171,7 @@ public class BundleBlacklistManager {
 		properties.put(
 			"blacklistBundleSymbolicNames", blacklistBundleSymbolicNames);
 
-		_updateConfiguration(bundleContext, configuration, properties);
+		_updateConfiguration(configuration, properties);
 	}
 
 	@Reference

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/BundleBlacklistManager.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.bundle.blacklist;
+
+import com.liferay.portal.bundle.blacklist.internal.BundleBlacklist;
+import com.liferay.portal.bundle.blacklist.internal.BundleBlacklistConfiguration;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringPool;
+
+import java.io.IOException;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceEvent;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Preston Crary
+ */
+@Component(immediate = true, service = BundleBlacklistManager.class)
+public class BundleBlacklistManager {
+
+	public void addToBlacklistAndUninstall(String... bundleSymbolicNames)
+		throws IOException {
+
+		_updateProperties(
+			blacklistBundleSymbolicNames -> {
+				if (blacklistBundleSymbolicNames == null) {
+					return bundleSymbolicNames;
+				}
+
+				Set<String> blacklistBundleSymbolicNamesSet = SetUtil.fromArray(
+					blacklistBundleSymbolicNames);
+
+				Collections.addAll(
+					blacklistBundleSymbolicNamesSet, bundleSymbolicNames);
+
+				return blacklistBundleSymbolicNamesSet.toArray(
+					new String[blacklistBundleSymbolicNamesSet.size()]);
+			});
+	}
+
+	public Collection<String> getBlacklistBundleSymbolicNames() {
+		return _bundleBlacklist.getBlacklistBundleSymbolicNames();
+	}
+
+	public void removeFromBlacklistAndInstall(String... bundleSymbolicNames)
+		throws IOException {
+
+		_updateProperties(
+			blacklistBundleSymbolicNames -> {
+				if (blacklistBundleSymbolicNames == null) {
+					return null;
+				}
+
+				Set<String> blacklistBundleSymbolicNamesSet = SetUtil.fromArray(
+					blacklistBundleSymbolicNames);
+
+				for (String bundleSymbolicName : bundleSymbolicNames) {
+					blacklistBundleSymbolicNamesSet.remove(bundleSymbolicName);
+				}
+
+				return blacklistBundleSymbolicNamesSet.toArray(
+					new String[blacklistBundleSymbolicNamesSet.size()]);
+			});
+	}
+
+	private void _updateConfiguration(
+			BundleContext bundleContext, Configuration configuration,
+			Dictionary<String, Object> properties)
+		throws IOException {
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		ServiceListener serviceListener = new ServiceListener() {
+
+			@Override
+			public void serviceChanged(ServiceEvent serviceEvent) {
+				if (serviceEvent.getType() != ServiceEvent.MODIFIED) {
+					return;
+				}
+
+				ServiceReference<?> serviceReference =
+					serviceEvent.getServiceReference();
+
+				Object service = bundleContext.getService(serviceReference);
+
+				if (_bundleBlacklist == service) {
+					countDownLatch.countDown();
+				}
+
+				bundleContext.ungetService(serviceReference);
+			}
+
+		};
+
+		bundleContext.addServiceListener(serviceListener);
+
+		try {
+			configuration.update(properties);
+
+			countDownLatch.await();
+		}
+		catch (InterruptedException ie) {
+		}
+		finally {
+			bundleContext.removeServiceListener(serviceListener);
+		}
+	}
+
+	private void _updateProperties(Function<String[], String[]> updateFunction)
+		throws IOException {
+
+		Bundle bundle = FrameworkUtil.getBundle(BundleBlacklistManager.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ServiceReference<ConfigurationAdmin> serviceReference =
+			bundleContext.getServiceReference(ConfigurationAdmin.class);
+
+		try {
+			ConfigurationAdmin configurationAdmin = bundleContext.getService(
+				serviceReference);
+
+			Configuration configuration = configurationAdmin.getConfiguration(
+				BundleBlacklistConfiguration.class.getName(),
+				StringPool.QUESTION);
+
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			String[] blacklistBundleSymbolicNames = null;
+
+			if (properties == null) {
+				properties = new HashMapDictionary<>();
+			}
+			else {
+				Object value = properties.get("blacklistBundleSymbolicNames");
+
+				if (value instanceof String) {
+					blacklistBundleSymbolicNames = new String[] {(String)value};
+				}
+				else {
+					blacklistBundleSymbolicNames = (String[])value;
+				}
+			}
+
+			blacklistBundleSymbolicNames = updateFunction.apply(
+				blacklistBundleSymbolicNames);
+
+			if (blacklistBundleSymbolicNames == null) {
+				return;
+			}
+
+			properties.put(
+				"blacklistBundleSymbolicNames", blacklistBundleSymbolicNames);
+
+			_updateConfiguration(bundleContext, configuration, properties);
+		}
+		finally {
+			bundleContext.ungetService(serviceReference);
+		}
+	}
+
+	@Reference
+	private BundleBlacklist _bundleBlacklist;
+
+}

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklist.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleBlacklist.java
@@ -64,6 +64,10 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class BundleBlacklist {
 
+	public List<String> getBlacklistBundleSymbolicNames() {
+		return new ArrayList<>(_uninstalledBundles.keySet());
+	}
+
 	@Activate
 	@Modified
 	protected void activate(


### PR DESCRIPTION
This is the integration between marketplace-app-manager-web and bundleblacklist.
It fixed the problem in https://issues.liferay.com/browse/LPS-74456, which is FileInstall install back the user uninstalled bundles over restart.
It also provides a way to reinstall back the uninstalled bundle through "Control Panel" -> "System Settings" -> "Bundle Blacklist" -> "Edit"
@mhan810 @david-truong I think we should have frontend team to create a dedicated UI for BundleBlacklist. This configuration editing works for now, but it is not easy to use, since user will have to manipulate symbolic names string, in case there are a lot of bundles got blacklisted, it can be a problem.

@jhinkey we may want to document this, feel free to ping @preston-crary if you have any questions.