### PR TITLE
LRQA-34833 Delete github/bundles in portal-license-jdk8 during test-tear-down

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2651,6 +2651,13 @@ ${output.content}</echo>
 						<delete file="${release.tool.dir}/git.diff" />
 					</then>
 				</if>
+
+				<if>
+					<available file="../bundles" type="dir" />
+					<then>
+						<delete dir="../bundles" />
+					</then>
+				</if>
 			</test-tear-down>
 		</run-batch-test>
 	</target>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-34833

resend of https://github.com/brianchandotcom/liferay-portal/pull/51431