### PR TITLE
LPS-74756 Deprecate StringUtil.randomize(String) as it only delegates…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil.java
@@ -2207,11 +2207,13 @@ public class StringUtil {
 	/**
 	 * Pseudorandomly permutes the characters of the string.
 	 *
+	 * @deprecated As of 7.0.0, replaced by {@link RandomUtil#shuffle(String)}
 	 * @param  s the string whose characters are to be randomized
 	 * @return a string of the same length as the string whose characters
 	 *         represent a pseudorandom permutation of the characters of the
 	 *         string
 	 */
+	@Deprecated
 	public static String randomize(String s) {
 		return RandomUtil.shuffle(s);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil_IW.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/StringUtil_IW.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.util;
 
+import com.liferay.portal.kernel.security.RandomUtil;
+
 /**
  * @author Brian Wing Shun Chan
  */
@@ -338,7 +340,7 @@ public class StringUtil_IW {
 	}
 
 	public java.lang.String randomize(java.lang.String s) {
-		return StringUtil.randomize(s);
+		return RandomUtil.shuffle(s);
 	}
 
 	public java.lang.String randomString() {


### PR DESCRIPTION
… to RandomUtil.shuffle(String).