### PR TITLE
LPS-67566

### DIFF
--- a/modules/apps/social-networking/social-networking-web/src/main/resources/META-INF/resources/members_activities/view_members_activities.jspf
+++ b/modules/apps/social-networking/social-networking-web/src/main/resources/META-INF/resources/members_activities/view_members_activities.jspf
@@ -38,5 +38,5 @@ String taglibFeedURLMessage = LanguageUtil.format(request, "subscribe-to-x's-act
 	feedTitle="<%= taglibFeedTitle %>"
 	feedType="<%= rssFeedType %>"
 	feedURL="<%= rssURL.toString() %>"
-	feedURLMessage="<%= taglibFeedURLMessage %>"
+	feedURLMessage="<%= HtmlUtil.escape(taglibFeedURLMessage) %>"
 />

--- a/modules/apps/social-networking/social-networking-web/src/main/resources/META-INF/resources/members_activities/view_members_activities.jspf
+++ b/modules/apps/social-networking/social-networking-web/src/main/resources/META-INF/resources/members_activities/view_members_activities.jspf
@@ -38,5 +38,5 @@ String taglibFeedURLMessage = LanguageUtil.format(request, "subscribe-to-x's-act
 	feedTitle="<%= taglibFeedTitle %>"
 	feedType="<%= rssFeedType %>"
 	feedURL="<%= rssURL.toString() %>"
-	feedURLMessage="<%= HtmlUtil.escape(taglibFeedURLMessage) %>"
+	feedURLMessage="<%= taglibFeedURLMessage %>"
 />

--- a/portal-web/docroot/html/taglib/ui/rss/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/rss/page.jsp
@@ -23,7 +23,7 @@ String url = (String)request.getAttribute("liferay-ui:rss:url");
 
 <liferay-ui:icon
 	label="<%= true %>"
-	message="<%= message %>"
+	message="<%= HtmlUtil.escape(message) %>"
 	method="get"
 	target="_blank"
 	url="<%= url %>"


### PR DESCRIPTION
Hi Brian,

We can't do the escape inside of `<liferay-ui:icon>` because some inputs to the `message` attribute contains HTML and some do not.  So we have to escape outside of `<liferay-ui:icon>`.

A better fix for this is to add a new `escape` attribute to `<liferay-ui:icon>` where we can toggle whether the message should be escaped or not. However, doing this will require a long manual review of all the existing use cases. In order to get the XSS patched up more quickly, we're going with the easier solution for now. I've created a ticket, [LPS-74799](https://issues.liferay.com/browse/LPS-74799), to track the more laborious/better solution.

cc @Richard678