### PR TITLE
LRQA-34625 Remove JGit API from JenkinsResultsParser.

### DIFF
--- a/modules/apps/foundation/configuration-admin/.gitrepo
+++ b/modules/apps/foundation/configuration-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 6db1959d8d2430fdcd67dd5e5251250a627f560c
+	commit = 5bec18c0e1d86fc243d80f1bf72d8d6206dd9b76
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7f04d62627b2e8f2a97b5d96e399f2ed5368adc3
+	parent = 7c6810a5a4bd4b61dde5bc7bb19163e2c8162360
 	remote = git@github.com:liferay/com-liferay-configuration-admin.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 52865b57eafd13d834f411a712aff2f0046bea56
+	commit = 9a84ca1b9169caff515114f9331c51250ff63356
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e7d22d3079eb8da88da2c52fd74629b3f0b4d8d9
+	parent = f4d28658e74ea991087a5ee4e61b57fb4154af03
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ef23a8eb685bf887538d87842813fbcb8a4b4bce
+	commit = 1d221d2b6a69418a986511672ba8444b5d258da7
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e4fc1927ff869ccaa8c77f8cade5511f2260ba10
+	parent = ac4bc3f10e3be0cf3121806270712db3aa92589e
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 05dae40c7175a9e390b69176fc457d4f17443d16
+	commit = f0b6560c0fcd385c9c87a30bade73a2282402a97
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 11ab9311ee5fb7516b4cc978d0a604e53dfd84e3
+	parent = 1baaa56d249adede74472f4bf95ce3f34b071e02
 	remote = git@github.com:liferay/com-liferay-site.git

--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -3,6 +3,5 @@ dependencies {
 	compile group: "commons-lang", name: "commons-lang", version: "2.6"
 	compile group: "dom4j", name: "dom4j", version: "1.6.1"
 	compile group: "org.apache.ant", name: "ant", version: "1.9.4"
-	compile group: "org.eclipse.jgit", name: "org.eclipse.jgit", version: "3.7.1.201504261725-r"
 	compile group: "org.json", name: "json", version: "20140107"
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -980,7 +980,7 @@ public abstract class BaseBuild implements Build {
 					message, "jenkins", "Slave Offline",
 					slaveOfflineRule.notificationList);
 			}
-			catch (InterruptedException | IOException e) {
+			catch (InterruptedException | IOException | TimeoutException e) {
 				throw new RuntimeException(
 					"Unable to send offline slave notification", e);
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -881,7 +882,9 @@ public abstract class BaseBuild implements Build {
 						message, "jenkins", "Build Reinvoked",
 						reinvokeRule.notificationList);
 				}
-				catch (InterruptedException | IOException e) {
+				catch (
+					InterruptedException | IOException | TimeoutException e) {
+
 					throw new RuntimeException(
 						"Unable to send reinvoke notification", e);
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * @author Peter Yoo
+ */
+public class BufferedProcess extends Process {
+
+	public BufferedProcess(int bufferSize, Process process) {
+		_bufferSize = bufferSize;
+		_process = process;
+
+		_errorStreamBuffer = new StreamBuffer(_process.getErrorStream());
+
+		_errorStream = new ByteArrayInputStream(_errorStreamBuffer._buffer);
+
+		_errorStreamBuffer.start();
+
+		_inputStreamBuffer = new StreamBuffer(_process.getInputStream());
+
+		_inputStream = new ByteArrayInputStream(_inputStreamBuffer._buffer);
+
+		_inputStreamBuffer.start();
+	}
+
+	@Override
+	public void destroy() {
+		_process.destroy();
+	}
+
+	@Override
+	public int exitValue() {
+		return _process.exitValue();
+	}
+
+	@Override
+	public InputStream getErrorStream() {
+		return _errorStream;
+	}
+
+	@Override
+	public InputStream getInputStream() {
+		return _inputStream;
+	}
+
+	@Override
+	public OutputStream getOutputStream() {
+		return _process.getOutputStream();
+	}
+
+	@Override
+	public int waitFor() throws InterruptedException {
+		return _process.waitFor();
+	}
+
+	private final int _bufferSize;
+	private final InputStream _errorStream;
+	private final StreamBuffer _errorStreamBuffer;
+	private final InputStream _inputStream;
+	private final StreamBuffer _inputStreamBuffer;
+	private final Process _process;
+
+	private class StreamBuffer extends Thread {
+
+		public StreamBuffer(InputStream inputStream) {
+			_inputStream = inputStream;
+			_buffer = new byte[_bufferSize];
+		}
+
+		public void run() {
+			try {
+				byte[] bytes = new byte[256];
+
+				int bytesRead = 0;
+
+				_index = 0;
+
+				while (bytesRead != -1) {
+					bytesRead = _inputStream.read(bytes);
+
+					if (bytesRead > 0) {
+						synchronized (_buffer) {
+							System.arraycopy(
+								bytes, 0, _buffer, _index, bytesRead);
+
+							_index += bytesRead;
+						}
+					}
+				}
+			}
+			catch (IOException ioe) {
+				throw new RuntimeException(ioe);
+			}
+		}
+
+		private final byte[] _buffer;
+		private int _index;
+		private final InputStream _inputStream;
+
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BufferedProcess.java
@@ -25,16 +25,17 @@ import java.io.OutputStream;
 public class BufferedProcess extends Process {
 
 	public BufferedProcess(int bufferSize, Process process) {
-		_bufferSize = bufferSize;
 		_process = process;
 
-		_errorStreamBuffer = new StreamBuffer(_process.getErrorStream());
+		_errorStreamBuffer = new StreamBuffer(
+			bufferSize, _process.getErrorStream());
 
 		_errorStream = new ByteArrayInputStream(_errorStreamBuffer._buffer);
 
 		_errorStreamBuffer.start();
 
-		_inputStreamBuffer = new StreamBuffer(_process.getInputStream());
+		_inputStreamBuffer = new StreamBuffer(
+			bufferSize, _process.getInputStream());
 
 		_inputStream = new ByteArrayInputStream(_inputStreamBuffer._buffer);
 
@@ -71,7 +72,6 @@ public class BufferedProcess extends Process {
 		return _process.waitFor();
 	}
 
-	private final int _bufferSize;
 	private final InputStream _errorStream;
 	private final StreamBuffer _errorStreamBuffer;
 	private final InputStream _inputStream;
@@ -80,9 +80,9 @@ public class BufferedProcess extends Process {
 
 	private class StreamBuffer extends Thread {
 
-		public StreamBuffer(InputStream inputStream) {
+		public StreamBuffer(int bufferSize, InputStream inputStream) {
 			_inputStream = inputStream;
-			_buffer = new byte[_bufferSize];
+			_buffer = new byte[bufferSize];
 		}
 
 		public void run() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author Peter Yoo
@@ -174,7 +175,7 @@ public class FilePropagator {
 	}
 
 	private int _executeBashCommands(List<String> commands, String targetSlave)
-		throws InterruptedException, IOException {
+		throws InterruptedException, IOException, TimeoutException {
 
 		StringBuffer sb = new StringBuffer("ssh -o NumberOfPasswordPrompts=0 ");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -678,30 +678,18 @@ public class GitWorkingDirectory {
 		String rebaseCommand = JenkinsResultsParserUtil.combine(
 			"git rebase ", sourceBranchName, " ", targetBranchName);
 
-		String sourceBranchSHA = getBranchSha(sourceBranchName);
+		BashCommandResult result = executeBashCommands(
+			1, 1000 * 60 * 10, rebaseCommand);
 
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Rebasing ", sourceBranchName, "(", sourceBranchSHA, ") to ",
-				targetBranchName));
+		if (result.getExitValue() != 0) {
+			if (abortOnFail) {
+				rebaseAbort();
+			}
 
-		try {
-			System.out.println(
-				executeBashCommands(1, 1000 * 60 * 10, rebaseCommand));
-		}
-		catch (RuntimeException re) {
-			try {
-				throw new RuntimeException(
-					JenkinsResultsParserUtil.combine(
-						"Unable to rebase ", targetBranchName, " to ",
-						sourceBranchName),
-					re);
-			}
-			finally {
-				if (abortOnFail) {
-					rebaseAbort();
-				}
-			}
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to rebase ", targetBranchName, " to ",
+					sourceBranchName));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -784,32 +784,12 @@ public class GitWorkingDirectory {
 			return _fetchRemoteURL.compareTo(otherGitRemote._fetchRemoteURL);
 		}
 
-		public String getFetchRefSpec() {
-			if (_fetchRefSpec == null) {
-				_fetchRefSpec = _gitWorkingDirectory.getGitConfigProperty(
-					JenkinsResultsParserUtil.combine(
-						"remote.", _name, ".fetch"));
-			}
-
-			return _fetchRefSpec;
+		public GitWorkingDirectory getGitWorkingDirectory() {
+			return _gitWorkingDirectory;
 		}
 
 		public String getName() {
 			return _name;
-		}
-
-		public String getPushRefSpec() {
-			if (_pushRefSpec == null) {
-				_pushRefSpec = _gitWorkingDirectory.getGitConfigProperty(
-					JenkinsResultsParserUtil.combine(
-						"remote.", _name, ".push"));
-			}
-
-			if (_pushRefSpec == null) {
-				return getFetchRefSpec();
-			}
-
-			return _fetchRefSpec;
 		}
 
 		public String getPushRemoteURL() {
@@ -879,11 +859,9 @@ public class GitWorkingDirectory {
 				"(?<name>[^\\s]+)[\\s]+(?<remoteURL>[^\\s]+)[\\s]+\\(",
 				"(?<type>[^\\s]+)\\)"));
 
-		private String _fetchRefSpec;
 		private final String _fetchRemoteURL;
 		private final GitWorkingDirectory _gitWorkingDirectory;
 		private final String _name;
-		private String _pushRefSpec;
 		private final String _pushRemoteURL;
 
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -411,12 +411,24 @@ public class GitWorkingDirectory {
 	public void deleteLocalBranch(String localBranchName) {
 		System.out.println("Deleting local branch " + localBranchName);
 
-		DeleteBranchCommand deleteBranchCommand = _git.branchDelete();
+		try {
+			Process process = JenkinsResultsParserUtil.executeBashCommands(
+				true, _workingDirectory, 1000 * 5,
+				"git branch -f -D" + localBranchName);
 
-		deleteBranchCommand.setBranchNames(localBranchName);
-		deleteBranchCommand.setForce(true);
+			if (process.exitValue() != 0) {
+				String errorMessage = JenkinsResultsParserUtil.combine(
+					"Unable to delete branch ", localBranchName, "\n",
+					JenkinsResultsParserUtil.readInputStream(
+						process.getErrorStream()));
 
-		deleteBranchCommand.call();
+				throw new RuntimeException(errorMessage);
+			}
+		}
+		catch (InterruptedException | IOException e) {
+			throw new RuntimeException(
+				"Unable to delete branch " + localBranchName);
+		}
 	}
 
 	public void deleteRemoteBranch(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -405,6 +405,8 @@ public class GitWorkingDirectory {
 				return null;
 			}
 
+			System.out.println(executionResult.getStandardOut());
+
 			if (branchName.equals("HEAD")) {
 				branchName = executionResult.getStandardOut();
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -672,7 +672,8 @@ public class GitWorkingDirectory {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
 					"Unable to rebase ", targetBranch.getName(), " to ",
-					sourceBranch.getName()));
+					sourceBranch.getName(), "\n",
+					executionResult.getStandardErr()));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -224,6 +224,10 @@ public class GitWorkingDirectory {
 		}
 	}
 
+	public void clean() {
+		clean(null);
+	}
+
 	public void clean(File workingDirectory) {
 		if (workingDirectory == null) {
 			workingDirectory = _workingDirectory;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -341,12 +341,16 @@ public class GitWorkingDirectory {
 
 		sb.append(remote.getName());
 
-		sb.append(" ");
-		sb.append(remoteBranch.getName());
+		String remoteBranchName = remoteBranch.getName();
 
-		if (localBranch != null) {
-			sb.append(":");
-			sb.append(localBranch.getName());
+		if ((remoteBranchName != null) && !remoteBranchName.isEmpty()) {
+			sb.append(" ");
+			sb.append(remoteBranch.getName());
+
+			if (localBranch != null) {
+				sb.append(":");
+				sb.append(localBranch.getName());
+			}
 		}
 
 		long start = System.currentTimeMillis();
@@ -365,6 +369,10 @@ public class GitWorkingDirectory {
 			"Fetch completed in " +
 				JenkinsResultsParserUtil.toDurationString(
 					System.currentTimeMillis() - start));
+	}
+
+	public void fetch(Remote remote) {
+		fetch(null, new Branch(null, remote, null));
 	}
 
 	public List<String> getBranchNamesContainingSha(String sha) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -729,7 +729,7 @@ public class GitWorkingDirectory {
 
 		BashCommandResult result = executeBashCommands(
 			"git remote rm " + gitRemote.getName());
-		
+
 		if (result.getExitValue() != 0) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
@@ -744,27 +744,16 @@ public class GitWorkingDirectory {
 		}
 	}
 
-	public void reset(String ref, ResetCommand.ResetType resetType) {
-		if ((ref != null) && (ref.equals("head") || ref.equals("HEAD"))) {
-			ref = null;
+	public void reset(String options) {
+		String command = "git reset " + options;
+
+		BashCommandResult result = executeBashCommands(command);
+
+		if (result.getExitValue() != 0) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to reset\n", result.getStandardErr()));
 		}
-
-		ResetCommand resetCommand = _git.reset();
-
-		resetCommand.setMode(resetType);
-
-		if (ref != null) {
-			resetCommand.setRef(ref);
-		}
-		else {
-			ref = Constants.HEAD;
-		}
-
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Resetting ", resetType.toString(), " to ", ref));
-
-		resetCommand.call();
 	}
 
 	public static class GitRemote implements Comparable<GitRemote> {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -673,10 +673,10 @@ public class GitWorkingDirectory {
 	}
 
 	public void rebase(
-		boolean abortOnFail, String sourceBranchName, String targetBranchName) {
+		boolean abortOnFail, Branch sourceBranch, Branch targetBranch) {
 
 		String rebaseCommand = JenkinsResultsParserUtil.combine(
-			"git rebase ", sourceBranchName, " ", targetBranchName);
+			"git rebase ", sourceBranch.getName(), " ", targetBranch.getName());
 
 		ExecutionResult executionResult = executeBashCommands(
 			1, 1000 * 60 * 10, rebaseCommand);
@@ -688,8 +688,8 @@ public class GitWorkingDirectory {
 
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to rebase ", targetBranchName, " to ",
-					sourceBranchName));
+					"Unable to rebase ", targetBranch.getName(), " to ",
+					sourceBranch.getName()));
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -262,7 +262,7 @@ public class GitWorkingDirectory {
 	}
 
 	public Branch createLocalBranch(
-		String localBranchName, boolean force, String startPoint) {
+		String branchName, boolean force, String startPoint) {
 
 		StringBuilder sb = new StringBuilder();
 
@@ -272,7 +272,7 @@ public class GitWorkingDirectory {
 			sb.append("-f ");
 		}
 
-		sb.append(localBranchName);
+		sb.append(branchName);
 
 		if (startPoint != null) {
 			sb.append(" ");
@@ -284,11 +284,11 @@ public class GitWorkingDirectory {
 		if (executionResult.getExitValue() != 0) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to create local branch ", localBranchName, " at ",
+					"Unable to create local branch ", branchName, " at ",
 					startPoint, "\n", executionResult.getStandardErr()));
 		}
 
-		return getLocalBranch(localBranchName);
+		return getLocalBranch(branchName);
 	}
 
 	public String createPullRequest(
@@ -318,14 +318,14 @@ public class GitWorkingDirectory {
 		return pullRequestURL;
 	}
 
-	public void deleteLocalBranch(String localBranchName) {
+	public void deleteLocalBranch(Branch branch) {
 		ExecutionResult executionResult = executeBashCommands(
-			"git branch -f -D " + localBranchName);
+			"git branch -f -D " + branch.getName());
 
 		if (executionResult.getExitValue() != 0) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to delete local branch ", localBranchName, "\n",
+					"Unable to delete local branch ", branch.getName(), "\n",
 					executionResult.getStandardErr()));
 		}
 	}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -911,6 +911,8 @@ public class GitWorkingDirectory {
 
 				process = JenkinsResultsParserUtil.executeBashCommands(
 					true, _workingDirectory, timeout, commands);
+
+				break;
 			}
 			catch (InterruptedException | IOException | TimeoutException e) {
 				if (retries == maxRetries) {
@@ -918,6 +920,10 @@ public class GitWorkingDirectory {
 						"Unable to execute bash commands: " +
 							Arrays.toString(commands),
 						e);
+				}
+				else {
+					System.out.println("Fetch attempt failed retrying... ");
+					e.printStackTrace();
 				}
 			}
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -221,7 +221,8 @@ public class GitWorkingDirectory {
 			workingDirectory = _workingDirectory;
 		}
 
-		ExecutionResult executionResult = executeBashCommands("git clean -dfx");
+		ExecutionResult executionResult = executeBashCommands(
+			1, 1000 * 60 * 10, "git clean -dfx");
 
 		if (executionResult.getExitValue() != 0) {
 			throw new RuntimeException(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -577,11 +577,42 @@ public class GitWorkingDirectory {
 
 		String[] lines = standardOut.split("\n");
 
-		for (int i = 0; i < lines.length; i = i + 2) {
-			Remote remote = new Remote(
-				this, Arrays.copyOfRange(lines, i, i + 2));
+		Arrays.sort(lines);
 
-			remotes.put(remote.getName(), remote);
+		int x = 0;
+
+		for (int i = 0; i < lines.length; i++) {
+			String line = lines[i];
+
+			if (line == null) {
+				continue;
+			}
+
+			line = line.trim();
+
+			if (line.isEmpty()) {
+				continue;
+			}
+
+			x = i;
+
+			break;
+		}
+
+		lines = Arrays.copyOfRange(lines, x, lines.length - 1);
+
+		try {
+			for (int i = 0; i < lines.length; i = i + 2) {
+				Remote remote = new Remote(
+					this, Arrays.copyOfRange(lines, i, i + 2));
+
+				remotes.put(remote.getName(), remote);
+			}
+		}
+		catch (Throwable t) {
+			System.out.println("Unable to parse remotes\n" + standardOut);
+
+			throw t;
 		}
 
 		return remotes;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -261,7 +261,7 @@ public class GitWorkingDirectory {
 		createLocalBranch(branchName, false, null);
 	}
 
-	public void createLocalBranch(
+	public Branch createLocalBranch(
 		String localBranchName, boolean force, String startPoint) {
 
 		StringBuilder sb = new StringBuilder();
@@ -287,6 +287,8 @@ public class GitWorkingDirectory {
 					"Unable to create local branch ", localBranchName, " at ",
 					startPoint, "\n", executionResult.getStandardErr()));
 		}
+
+		return getLocalBranch(localBranchName);
 	}
 
 	public String createPullRequest(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -247,6 +247,20 @@ public class GitWorkingDirectory {
 		}
 	}
 
+	public void commitStagedFilesToCurrentBranch(String message) {
+		String commitCommand = JenkinsResultsParserUtil.combine(
+			"git commit -m \'", message, "\' ");
+
+		ExecutionResult executionResult = executeBashCommands(commitCommand);
+
+		if (executionResult.getExitValue() != 0) {
+			throw new RuntimeException(
+				JenkinsResultsParserUtil.combine(
+					"Unable to commit staged files", "\n",
+					executionResult.getStandardErr()));
+		}
+	}
+
 	public Branch createLocalBranch(String branchName) {
 		return createLocalBranch(branchName, false, null);
 	}
@@ -744,6 +758,16 @@ public class GitWorkingDirectory {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
 					"Unable to reset\n", executionResult.getStandardErr()));
+		}
+	}
+
+	public void stageFileInCurrentBranch(String fileName) {
+		String command = "git stage " + fileName;
+
+		ExecutionResult result = executeBashCommands(command);
+
+		if (result.getExitValue() != 0) {
+			throw new RuntimeException("Unable to stage file " + fileName);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -247,8 +247,8 @@ public class GitWorkingDirectory {
 		}
 	}
 
-	public void createLocalBranch(String branchName) {
-		createLocalBranch(branchName, false, null);
+	public Branch createLocalBranch(String branchName) {
+		return createLocalBranch(branchName, false, null);
 	}
 
 	public Branch createLocalBranch(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -329,8 +329,6 @@ public class GitWorkingDirectory {
 	}
 
 	public void deleteRemoteBranch(Branch remoteBranch) {
-		Remote remote = remoteBranch._remote;
-
 		pushToRemote(true, null, remoteBranch);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -14,8 +14,6 @@
 
 package com.liferay.jenkins.results.parser;
 
-import com.jcraft.jsch.Session;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -29,35 +27,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.eclipse.jgit.api.AddCommand;
-import org.eclipse.jgit.api.CleanCommand;
-import org.eclipse.jgit.api.CommitCommand;
-import org.eclipse.jgit.api.CreateBranchCommand;
-import org.eclipse.jgit.api.DeleteBranchCommand;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.ListBranchCommand;
-import org.eclipse.jgit.api.ListBranchCommand.ListMode;
-import org.eclipse.jgit.api.LsRemoteCommand;
-import org.eclipse.jgit.api.PushCommand;
-import org.eclipse.jgit.api.RebaseCommand;
-import org.eclipse.jgit.api.ResetCommand;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.api.errors.JGitInternalException;
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.lib.RepositoryState;
-import org.eclipse.jgit.lib.StoredConfig;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig.Host;
-import org.eclipse.jgit.transport.PushResult;
-import org.eclipse.jgit.transport.RefSpec;
-import org.eclipse.jgit.transport.RemoteConfig;
-import org.eclipse.jgit.transport.RemoteRefUpdate;
-import org.eclipse.jgit.transport.SshSessionFactory;
-import org.eclipse.jgit.transport.URIish;
 
 import org.json.JSONObject;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -599,7 +599,7 @@ public class GitWorkingDirectory {
 			break;
 		}
 
-		lines = Arrays.copyOfRange(lines, x, lines.length - 1);
+		lines = Arrays.copyOfRange(lines, x, lines.length);
 
 		try {
 			for (int i = 0; i < lines.length; i = i + 2) {
@@ -851,6 +851,14 @@ public class GitWorkingDirectory {
 				throw new IllegalArgumentException(
 					"Duplicate remote input lines detected. " +
 						remoteInputLines[0]);
+			}
+
+			if ((remoteInputLines[0] == null) ||
+				(remoteInputLines[1] == null)) {
+
+				throw new IllegalArgumentException(
+					"Neither of the remoteInputLines may be NULL" +
+						Arrays.toString(remoteInputLines));
 			}
 
 			String name = null;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -91,7 +91,7 @@ public class GitWorkingDirectory {
 
 		if (remoteExists(remoteName)) {
 			if (force) {
-				removeGitRemote(getRemote(remoteName));
+				removeRemote(getRemote(remoteName));
 			}
 			else {
 				throw new IllegalArgumentException(
@@ -701,7 +701,7 @@ public class GitWorkingDirectory {
 		return false;
 	}
 
-	public void removeGitRemote(Remote remote) {
+	public void removeRemote(Remote remote) {
 		if (!remoteExists(remote.getName())) {
 			return;
 		}
@@ -717,9 +717,9 @@ public class GitWorkingDirectory {
 		}
 	}
 
-	public void removeGitRemotes(List<Remote> remotes) {
+	public void removeRemotes(List<Remote> remotes) {
 		for (Remote remote : remotes) {
-			removeGitRemote(remote);
+			removeRemote(remote);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -97,7 +97,7 @@ public class GitWorkingDirectory {
 
 		if (gitRemote != null) {
 			if (force) {
-				removeRemote(gitRemote);
+				removeGitRemote(gitRemote);
 			}
 			else {
 				throw new IllegalArgumentException(
@@ -720,44 +720,27 @@ public class GitWorkingDirectory {
 		return false;
 	}
 
-	public void removeRemote(GitRemote gitRemote) {
+	public void removeGitRemote(GitRemote gitRemote) {
 		if (!remoteExists(gitRemote.getName())) {
 			return;
 		}
 
 		System.out.println("Removing remote " + gitRemote.getName());
 
-		Process process = null;
-
-		try {
-			process = JenkinsResultsParserUtil.executeBashCommands(
-				true, _workingDirectory, 1000 * 60,
-				"git remote rm " + gitRemote.getName());
-		}
-		catch (InterruptedException | IOException e) {
-			throw new RuntimeException(
-				"Unable to remove remote " + gitRemote.getName(), e);
-		}
-
-		if ((process != null) && (process.exitValue() != 0)) {
-			try {
-				System.out.println(
-					JenkinsResultsParserUtil.readInputStream(
-						process.getErrorStream()));
-			}
-			catch (IOException ioe) {
-				ioe.printStackTrace();
-			}
-
+		BashCommandResult result = executeBashCommands(
+			"git remote rm " + gitRemote.getName());
+		
+		if (result.getExitValue() != 0) {
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(
-					"Unable to remove remote", gitRemote.getName()));
+					"Unable to remove remote ", gitRemote.getName(), "\n",
+					result.getStandardErr()));
 		}
 	}
 
-	public void removeRemotes(List<GitRemote> gitRemotes) {
+	public void removeGitRemotes(List<GitRemote> gitRemotes) {
 		for (GitRemote gitRemote : gitRemotes) {
-			removeRemote(gitRemote);
+			removeGitRemote(gitRemote);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1040,7 +1040,7 @@ public class GitWorkingDirectory {
 
 	protected List<Branch> getRemoteBranches(Remote remote) {
 		ExecutionResult executionResult = executeBashCommands(
-			1, 1000 * 5,
+			1, 1000 * 60,
 			JenkinsResultsParserUtil.combine(
 				"git ls-remote -h ", remote.getName()));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -89,10 +89,6 @@ public class GitWorkingDirectory {
 	public Remote addRemote(
 		boolean force, String remoteName, String remoteURL) {
 
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Adding remote ", remoteName, " with url: ", remoteURL));
-
 		Remote remote = getRemote(remoteName);
 
 		if (remote != null) {
@@ -155,16 +151,11 @@ public class GitWorkingDirectory {
 					" because it does not exist"));
 		}
 
-		if (branchName.equals(currentBranch._name)) {
+		if (branchName.equals(currentBranch.getName())) {
 			System.out.println(branchName + " is already checked out");
 
 			return;
 		}
-
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"The current branch is ", currentBranch._name,
-				". Checking out branch ", branchName, "."));
 
 		waitForIndexLock();
 
@@ -202,11 +193,11 @@ public class GitWorkingDirectory {
 		else {
 			int i = branchName.indexOf("/");
 
-			String remoteBranchName = branchName.substring(i + 1);
-
 			String remoteName = branchName.substring(0, i);
 
 			Remote remote = getRemote(remoteName);
+
+			String remoteBranchName = branchName.substring(i + 1);
 
 			Branch branch = getRemoteBranch(remoteBranchName, remote);
 
@@ -265,8 +256,6 @@ public class GitWorkingDirectory {
 	}
 
 	public void commitFileToCurrentBranch(String fileName, String message) {
-		System.out.println("Committing file to current branch " + fileName);
-
 		String commitCommand = JenkinsResultsParserUtil.combine(
 			"git commit -m \'", message, "\' ", fileName);
 
@@ -286,11 +275,6 @@ public class GitWorkingDirectory {
 
 	public void createLocalBranch(
 		String localBranchName, boolean force, String startPoint) {
-
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Creating branch ", localBranchName, " at starting point ",
-				startPoint));
 
 		StringBuilder sb = new StringBuilder();
 
@@ -345,8 +329,6 @@ public class GitWorkingDirectory {
 	}
 
 	public void deleteLocalBranch(String localBranchName) {
-		System.out.println("Deleting local branch " + localBranchName);
-
 		BashCommandResult result = executeBashCommands(
 			"git branch -f -D " + localBranchName);
 
@@ -361,11 +343,6 @@ public class GitWorkingDirectory {
 	public void deleteRemoteBranch(Branch remoteBranch) {
 		Remote remote = remoteBranch._remote;
 
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Deleting remote branch ", remoteBranch._name, " from ",
-				remote.getRemoteURL()));
-
 		pushToRemote(true, null, remoteBranch);
 	}
 
@@ -377,12 +354,6 @@ public class GitWorkingDirectory {
 		Remote remote = remoteBranch.getGitRemote();
 
 		sb.append(remote.getName());
-
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Fetching from ", remote.getName(), " ",
-				remoteBranch.getName()));
-
 		sb.append(" ");
 		sb.append(remoteBranch.getName());
 
@@ -418,8 +389,6 @@ public class GitWorkingDirectory {
 		if (standardOut.contains("no such commit")) {
 			return Collections.emptyList();
 		}
-
-		System.out.println(standardOut);
 
 		String[] lines = standardOut.split("\n");
 
@@ -671,11 +640,6 @@ public class GitWorkingDirectory {
 
 		Remote remote = remoteBranch._remote;
 
-		System.out.println(
-			JenkinsResultsParserUtil.combine(
-				"Pushing ", localBranchName, " to ", remote.getRemoteURL(), " ",
-				remoteBranch._name));
-
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("git push ");
@@ -767,8 +731,6 @@ public class GitWorkingDirectory {
 		if (!remoteExists(remote.getName())) {
 			return;
 		}
-
-		System.out.println("Removing remote " + remote.getName());
 
 		BashCommandResult result = executeBashCommands(
 			"git remote rm " + remote.getName());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -319,6 +319,10 @@ public class GitWorkingDirectory {
 	}
 
 	public void deleteLocalBranch(Branch branch) {
+		if (!branchExists(branch.getName(), null)) {
+			return;
+		}
+
 		ExecutionResult executionResult = executeBashCommands(
 			"git branch -f -D " + branch.getName());
 
@@ -327,6 +331,14 @@ public class GitWorkingDirectory {
 				JenkinsResultsParserUtil.combine(
 					"Unable to delete local branch ", branch.getName(), "\n",
 					executionResult.getStandardErr()));
+		}
+	}
+
+	public void deleteLocalBranch(String branchName) {
+		Branch branch = getLocalBranch(branchName);
+
+		if (branch != null) {
+			deleteLocalBranch(branch);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -255,7 +255,7 @@ public class JenkinsResultsParserUtil {
 
 		processBuilder.directory(basedir.getAbsoluteFile());
 
-		Process process = processBuilder.start();
+		Process process = new BufferedProcess(1000000, processBuilder.start());
 
 		long duration = 0;
 		long start = System.currentTimeMillis();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -285,7 +285,7 @@ public class JenkinsResultsParserUtil {
 		if (debug) {
 			InputStream inputStream = process.getInputStream();
 
-			inputStream.mark(inputStream.available());
+			inputStream.mark(Integer.MAX_VALUE);
 
 			System.out.println(
 				"Output stream: " + readInputStream(inputStream));
@@ -296,7 +296,7 @@ public class JenkinsResultsParserUtil {
 		if (debug && (returnCode != 0)) {
 			InputStream inputStream = process.getErrorStream();
 
-			inputStream.mark(inputStream.available());
+			inputStream.mark(Integer.MAX_VALUE);
 
 			System.out.println("Error stream: " + readInputStream(inputStream));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -59,7 +59,7 @@ public class LocalGitSyncUtil {
 		finally {
 			if (localGitRemoteConfigs != null) {
 				try {
-					gitWorkingDirectory.removeRemotes(localGitRemoteConfigs);
+					gitWorkingDirectory.removeGitRemotes(localGitRemoteConfigs);
 				}
 				catch (Exception e) {
 					e.printStackTrace();
@@ -782,7 +782,7 @@ public class LocalGitSyncUtil {
 			finally {
 				if (localGitRemoteConfigs != null) {
 					try {
-						gitWorkingDirectory.removeRemotes(
+						gitWorkingDirectory.removeGitRemotes(
 							localGitRemoteConfigs);
 					}
 					catch (Exception e) {
@@ -805,7 +805,7 @@ public class LocalGitSyncUtil {
 		finally {
 			if (senderRemoteConfig != null) {
 				try {
-					gitWorkingDirectory.removeRemote(senderRemoteConfig);
+					gitWorkingDirectory.removeGitRemote(senderRemoteConfig);
 				}
 				catch (Exception e) {
 					e.printStackTrace();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -39,21 +39,21 @@ public class LocalGitSyncUtil {
 		String senderBranchName, String senderUsername, String senderBranchSHA,
 		String upstreamBranchSHA) {
 
-		List<GitWorkingDirectory.Remote> localGitRemoteConfigs = null;
+		List<GitWorkingDirectory.Remote> localGitRemotes = null;
 
 		try {
-			localGitRemoteConfigs = getLocalGitRemotes(gitWorkingDirectory);
+			localGitRemotes = getLocalGitRemotes(gitWorkingDirectory);
 
 			deleteCacheBranch(
 				getCacheBranchName(
 					receiverUsername, senderUsername, senderBranchSHA,
 					upstreamBranchSHA),
-				gitWorkingDirectory, localGitRemoteConfigs);
+				gitWorkingDirectory, localGitRemotes);
 		}
 		finally {
-			if (localGitRemoteConfigs != null) {
+			if (localGitRemotes != null) {
 				try {
-					gitWorkingDirectory.removeGitRemotes(localGitRemoteConfigs);
+					gitWorkingDirectory.removeRemotes(localGitRemotes);
 				}
 				catch (Exception e) {
 					e.printStackTrace();
@@ -738,7 +738,7 @@ public class LocalGitSyncUtil {
 			finally {
 				if (localGitRemotes != null) {
 					try {
-						gitWorkingDirectory.removeGitRemotes(localGitRemotes);
+						gitWorkingDirectory.removeRemotes(localGitRemotes);
 					}
 					catch (Exception e) {
 						e.printStackTrace();
@@ -760,7 +760,7 @@ public class LocalGitSyncUtil {
 		finally {
 			if (senderRemote != null) {
 				try {
-					gitWorkingDirectory.removeGitRemote(senderRemote);
+					gitWorkingDirectory.removeRemote(senderRemote);
 				}
 				catch (Exception e) {
 					e.printStackTrace();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitSyncUtil.java
@@ -614,6 +614,15 @@ public class LocalGitSyncUtil {
 		GitWorkingDirectory.Branch originalBranch =
 			gitWorkingDirectory.getCurrentBranch();
 
+		if (originalBranch == null) {
+			gitWorkingDirectory.reset("--hard");
+
+			originalBranch = gitWorkingDirectory.getBranch(
+				gitWorkingDirectory.getUpstreamBranchName(), null);
+
+			gitWorkingDirectory.checkoutBranch(originalBranch);
+		}
+
 		System.out.println(
 			JenkinsResultsParserUtil.combine(
 				"Starting synchronization with local-git. Current repository ",

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
@@ -131,7 +131,7 @@ public class MergeCentralSubrepositoryUtil {
 
 		centralGitWorkingDirectory.checkoutBranch(topLevelBranchName);
 
-		centralGitWorkingDirectory.deleteLocalBranch(mergeBranchName);
+		centralGitWorkingDirectory.deleteBranch(mergeBranchName);
 
 		centralGitWorkingDirectory.createLocalBranch(mergeBranchName);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralSubrepositoryUtil.java
@@ -340,7 +340,7 @@ public class MergeCentralSubrepositoryUtil {
 				false, mergeBranch, mergeBranch.getName(), originRemote);
 		}
 		finally {
-			centralGitWorkingDirectory.removeGitRemote(originRemote);
+			centralGitWorkingDirectory.removeRemote(originRemote);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteExecutor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RemoteExecutor.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author Peter Yoo
@@ -169,7 +170,7 @@ public class RemoteExecutor {
 		}
 
 		private int _executeBashCommands()
-			throws InterruptedException, IOException {
+			throws InterruptedException, IOException, TimeoutException {
 
 			StringBuffer sb = new StringBuffer(
 				"ssh -o NumberOfPasswordPrompts=0 ");


### PR DESCRIPTION
The JGit API is starting to cause OutOfMemory exceptions due to the size of the liferay-portal-ee repository. We've decided to remove it and rely exclusively on command line git command execution instead.

https://issues.liferay.com/browse/LRQA-34625