### PR TITLE
LPS-66460 Allow for numeric user screen names without any limitations

### DIFF
--- a/modules/apps/foundation/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/servlet/FriendlyURLServlet.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/servlet/FriendlyURLServlet.java
@@ -102,41 +102,25 @@ public class FriendlyURLServlet extends HttpServlet {
 		if (group == null) {
 			String screenName = friendlyURL.substring(1);
 
-			if (_user || !Validator.isNumber(screenName)) {
-				User user = userLocalService.fetchUserByScreenName(
-					companyId, screenName);
+			User user = userLocalService.fetchUserByScreenName(
+				companyId, screenName);
 
-				if (user != null) {
-					group = user.getGroup();
-				}
-				else if (_log.isWarnEnabled()) {
-					_log.warn("No user exists with friendly URL " + screenName);
-				}
+			if (user != null) {
+				group = user.getGroup();
 			}
-			else {
-				long groupId = GetterUtil.getLong(screenName);
+			else if (_log.isWarnEnabled()) {
+				_log.warn("No user exists with friendly URL " + screenName);
+			}
+		}
 
-				group = groupLocalService.fetchGroup(groupId);
+		if (group == null) {
+			long groupId = GetterUtil.getLong(friendlyURL.substring(1));
 
-				if (group == null) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(
-							"No group exists with friendly URL " + groupId +
-								". Try fetching by screen name instead.");
-					}
+			group = groupLocalService.fetchGroup(groupId);
 
-					User user = userLocalService.fetchUserByScreenName(
-						companyId, screenName);
-
-					if (user != null) {
-						group = user.getGroup();
-					}
-					else if (_log.isWarnEnabled()) {
-						_log.warn(
-							"No user or group exists with friendly URL " +
-								groupId);
-					}
-				}
+			if ((group == null) && _log.isDebugEnabled()) {
+				_log.debug(
+					"No group exists with friendly URL " + groupId + ".");
 			}
 		}
 

--- a/modules/apps/foundation/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/servlet/FriendlyURLServlet.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/servlet/FriendlyURLServlet.java
@@ -114,17 +114,6 @@ public class FriendlyURLServlet extends HttpServlet {
 		}
 
 		if (group == null) {
-			long groupId = GetterUtil.getLong(friendlyURL.substring(1));
-
-			group = groupLocalService.fetchGroup(groupId);
-
-			if ((group == null) && _log.isDebugEnabled()) {
-				_log.debug(
-					"No group exists with friendly URL " + groupId + ".");
-			}
-		}
-
-		if (group == null) {
 			StringBundler sb = new StringBundler(5);
 
 			sb.append("{companyId=");

--- a/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.CharPool;
@@ -181,9 +182,9 @@ public class FriendlyURLServletTest {
 
 		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
 
-		String numericScreenName = "12345";
+		long numericScreenName = RandomTestUtil.nextLong();
 
-		_user = UserTestUtil.addUser(numericScreenName);
+		_user = UserTestUtil.addUser(String.valueOf(numericScreenName));
 
 		Group userGroup = _user.getGroup();
 

--- a/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -80,7 +80,6 @@ public class FriendlyURLServletTest {
 	public void setUp() throws Exception {
 		PropsValues.LOCALES_ENABLED = new String[] {"en_US", "hu_HU", "de_DE"};
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = true;
-		PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = true;
 
 		LanguageUtil.init();
 
@@ -120,8 +119,6 @@ public class FriendlyURLServletTest {
 			PropsKeys.LOCALES_ENABLED);
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE));
-		PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = GetterUtil.getBoolean(
-			PropsUtil.get(PropsKeys.USERS_SCREEN_NAME_ALLOW_NUMERIC));
 
 		LanguageUtil.init();
 

--- a/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -20,12 +20,14 @@ import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -155,6 +157,26 @@ public class FriendlyURLServletTest {
 			null);
 	}
 
+	@Test
+	public void testGetRedirectWithNumericUserScreenName() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
+
+		String numericScreenName = "12345";
+
+		_user = UserTestUtil.addUser(numericScreenName);
+
+		Group userGroup = _user.getGroup();
+
+		_layout = LayoutTestUtil.addLayout(userGroup);
+
+		testGetRedirect(
+			mockHttpServletRequest, getPath(userGroup, _layout),
+			Portal.PATH_MAIN, new FriendlyURLServlet.Redirect(getURL(_layout)));
+	}
+
 	protected String getI18nLanguageId(HttpServletRequest request) {
 		String path = GetterUtil.getString(request.getPathInfo());
 
@@ -260,5 +282,8 @@ public class FriendlyURLServletTest {
 	private final I18nServlet _i18nServlet = new I18nServlet();
 	private Layout _layout;
 	private ServiceTracker<Servlet, Servlet> _serviceTracker;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 }

--- a/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -136,6 +136,20 @@ public class FriendlyURLServletTest {
 			new FriendlyURLServlet.Redirect(getURL(_layout)));
 	}
 
+	@Test(expected = NoSuchGroupException.class)
+	public void testGetRedirectWithGroupId() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
+
+		String path = "/" + _group.getGroupId() + _layout.getFriendlyURL();
+
+		testGetRedirect(
+			mockHttpServletRequest, path, Portal.PATH_MAIN,
+			new FriendlyURLServlet.Redirect(getURL(_layout)));
+	}
+
 	@Test
 	public void testGetRedirectWithI18nPath() throws Exception {
 		testGetI18nRedirect("/fr", "/en");

--- a/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
+++ b/modules/apps/foundation/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/servlet/test/FriendlyURLServletTest.java
@@ -79,6 +79,7 @@ public class FriendlyURLServletTest {
 	public void setUp() throws Exception {
 		PropsValues.LOCALES_ENABLED = new String[] {"en_US", "hu_HU", "de_DE"};
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = true;
+		PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = true;
 
 		LanguageUtil.init();
 
@@ -118,6 +119,8 @@ public class FriendlyURLServletTest {
 			PropsKeys.LOCALES_ENABLED);
 		PropsValues.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE = GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.LOCALE_USE_DEFAULT_IF_NOT_AVAILABLE));
+		PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.USERS_SCREEN_NAME_ALLOW_NUMERIC));
 
 		LanguageUtil.init();
 

--- a/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
+++ b/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.site.service.persistence.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
 import com.liferay.portal.kernel.exception.GroupParentException;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.NoSuchResourcePermissionException;
@@ -945,6 +946,14 @@ public class GroupServiceTest {
 		Assert.assertEquals(
 			LocaleUtil.SPAIN,
 			PortalUtil.getSiteDefaultLocale(group.getGroupId()));
+	}
+
+	@Test(expected = GroupFriendlyURLException.class)
+	public void testUpdateFriendlyURLToGroupId() throws Exception {
+		String friendlyURL = "/" + _group.getGroupId();
+
+		GroupLocalServiceUtil.updateFriendlyURL(
+			_group.getGroupId(), friendlyURL);
 	}
 
 	@Test

--- a/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
+++ b/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
@@ -905,8 +905,16 @@ public class GroupServiceTest {
 	}
 
 	@Test(expected = GroupFriendlyURLException.class)
-	public void testSetNumericFriendlyURL() throws Exception {
+	public void testSetNumericFriendlyURLToGroupId() throws Exception {
 		String friendlyURL = "/" + _group.getGroupId();
+
+		GroupLocalServiceUtil.updateFriendlyURL(
+			_group.getGroupId(), friendlyURL);
+	}
+
+	@Test(expected = GroupFriendlyURLException.class)
+	public void testSetNumericFriendlyURLToRandomLong() throws Exception {
+		String friendlyURL = "/" + RandomTestUtil.nextLong();
 
 		GroupLocalServiceUtil.updateFriendlyURL(
 			_group.getGroupId(), friendlyURL);

--- a/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
+++ b/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
@@ -121,10 +121,16 @@ public class GroupServiceTest {
 			companyGroup.getFriendlyURL(), false, companyGroup.isActive(),
 			serviceContext);
 
-		Assert.assertTrue(companyStagingGroup.isCompanyStagingGroup());
+		try {
+			Assert.assertTrue(companyStagingGroup.isCompanyStagingGroup());
 
-		Assert.assertEquals(
-			companyGroup.getGroupId(), companyStagingGroup.getLiveGroupId());
+			Assert.assertEquals(
+				companyGroup.getGroupId(),
+				companyStagingGroup.getLiveGroupId());
+		}
+		finally {
+			GroupLocalServiceUtil.deleteGroup(companyStagingGroup);
+		}
 	}
 
 	@Test
@@ -931,29 +937,37 @@ public class GroupServiceTest {
 	public void testUpdateAvailableLocales() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 
-		List<Locale> availableLocales = Arrays.asList(
-			LocaleUtil.GERMANY, LocaleUtil.SPAIN, LocaleUtil.US);
+		try {
+			List<Locale> availableLocales = Arrays.asList(
+				LocaleUtil.GERMANY, LocaleUtil.SPAIN, LocaleUtil.US);
 
-		group = GroupTestUtil.updateDisplaySettings(
-			group.getGroupId(), availableLocales, null);
+			group = GroupTestUtil.updateDisplaySettings(
+				group.getGroupId(), availableLocales, null);
 
-		Assert.assertEquals(
-			new HashSet<>(availableLocales),
-			LanguageUtil.getAvailableLocales(group.getGroupId()));
-
-		GroupLocalServiceUtil.deleteGroup(group);
+			Assert.assertEquals(
+				new HashSet<>(availableLocales),
+				LanguageUtil.getAvailableLocales(group.getGroupId()));
+		}
+		finally {
+			GroupLocalServiceUtil.deleteGroup(group);
+		}
 	}
 
 	@Test
 	public void testUpdateDefaultLocale() throws Exception {
 		Group group = GroupTestUtil.addGroup();
 
-		group = GroupTestUtil.updateDisplaySettings(
-			group.getGroupId(), null, LocaleUtil.SPAIN);
+		try {
+			group = GroupTestUtil.updateDisplaySettings(
+				group.getGroupId(), null, LocaleUtil.SPAIN);
 
-		Assert.assertEquals(
-			LocaleUtil.SPAIN,
-			PortalUtil.getSiteDefaultLocale(group.getGroupId()));
+			Assert.assertEquals(
+				LocaleUtil.SPAIN,
+				PortalUtil.getSiteDefaultLocale(group.getGroupId()));
+		}
+		finally {
+			GroupLocalServiceUtil.deleteGroup(group);
+		}
 	}
 
 	@Test

--- a/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
+++ b/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -473,6 +474,69 @@ public class GroupServiceTest {
 			0,
 			GroupLocalServiceUtil.searchCount(
 				TestPropsValues.getCompanyId(), null, "cabina14", groupParams));
+	}
+
+	@Test
+	public void testFriendlyURLDefaults() throws Exception {
+		long companyId = _group.getCompanyId();
+
+		String defaultNewGroupFriendlyURL =
+			StringPool.SLASH +
+				FriendlyURLNormalizerUtil.normalize(
+					_group.getName(LocaleUtil.getDefault()));
+
+		Assert.assertNotNull(
+			GroupLocalServiceUtil.fetchFriendlyURLGroup(
+				companyId, defaultNewGroupFriendlyURL));
+
+		long groupId = _group.getGroupId();
+
+		GroupLocalServiceUtil.updateFriendlyURL(groupId, null);
+
+		Assert.assertNull(
+			GroupLocalServiceUtil.fetchFriendlyURLGroup(
+				companyId, defaultNewGroupFriendlyURL));
+
+		String defaultFriendlyURL = "/group-" + groupId;
+
+		Assert.assertNotNull(
+			GroupLocalServiceUtil.fetchFriendlyURLGroup(
+				companyId, defaultFriendlyURL));
+
+		GroupLocalServiceUtil.updateFriendlyURL(
+			groupId, StringPool.SLASH + RandomTestUtil.randomString());
+
+		Group group = GroupTestUtil.addGroup();
+
+		try {
+			GroupLocalServiceUtil.updateFriendlyURL(
+				group.getGroupId(), defaultFriendlyURL);
+
+			GroupLocalServiceUtil.updateFriendlyURL(groupId, null);
+
+			Assert.assertNotNull(
+				GroupLocalServiceUtil.fetchFriendlyURLGroup(
+					companyId, defaultFriendlyURL + "-1"));
+		}
+		finally {
+			GroupLocalServiceUtil.deleteGroup(group);
+		}
+	}
+
+	@Test(expected = GroupFriendlyURLException.class)
+	public void testFriendlyURLSetToGroupId() throws Exception {
+		String friendlyURL = "/" + _group.getGroupId();
+
+		GroupLocalServiceUtil.updateFriendlyURL(
+			_group.getGroupId(), friendlyURL);
+	}
+
+	@Test(expected = GroupFriendlyURLException.class)
+	public void testFriendlyURLSetToRandomLong() throws Exception {
+		String friendlyURL = "/" + RandomTestUtil.nextLong();
+
+		GroupLocalServiceUtil.updateFriendlyURL(
+			_group.getGroupId(), friendlyURL);
 	}
 
 	@Test
@@ -902,22 +966,6 @@ public class GroupServiceTest {
 		finally {
 			GroupLocalServiceUtil.deleteGroup(group);
 		}
-	}
-
-	@Test(expected = GroupFriendlyURLException.class)
-	public void testSetNumericFriendlyURLToGroupId() throws Exception {
-		String friendlyURL = "/" + _group.getGroupId();
-
-		GroupLocalServiceUtil.updateFriendlyURL(
-			_group.getGroupId(), friendlyURL);
-	}
-
-	@Test(expected = GroupFriendlyURLException.class)
-	public void testSetNumericFriendlyURLToRandomLong() throws Exception {
-		String friendlyURL = "/" + RandomTestUtil.nextLong();
-
-		GroupLocalServiceUtil.updateFriendlyURL(
-			_group.getGroupId(), friendlyURL);
 	}
 
 	@Test

--- a/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
+++ b/modules/apps/web-experience/site/site-test/src/testIntegration/java/com/liferay/site/service/persistence/test/GroupServiceTest.java
@@ -898,6 +898,14 @@ public class GroupServiceTest {
 		}
 	}
 
+	@Test(expected = GroupFriendlyURLException.class)
+	public void testSetNumericFriendlyURL() throws Exception {
+		String friendlyURL = "/" + _group.getGroupId();
+
+		GroupLocalServiceUtil.updateFriendlyURL(
+			_group.getGroupId(), friendlyURL);
+	}
+
 	@Test
 	public void testSubsites() throws Exception {
 		Group group1 = GroupTestUtil.addGroup();
@@ -946,14 +954,6 @@ public class GroupServiceTest {
 		Assert.assertEquals(
 			LocaleUtil.SPAIN,
 			PortalUtil.getSiteDefaultLocale(group.getGroupId()));
-	}
-
-	@Test(expected = GroupFriendlyURLException.class)
-	public void testUpdateFriendlyURLToGroupId() throws Exception {
-		String friendlyURL = "/" + _group.getGroupId();
-
-		GroupLocalServiceUtil.updateFriendlyURL(
-			_group.getGroupId(), friendlyURL);
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -3901,9 +3901,9 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		friendlyURL = StringPool.SLASH + getFriendlyURL(friendlyName);
 
-		String originalFriendlyURL = friendlyURL;
+		long i = 0;
 
-		for (int i = 1;; i++) {
+		while (true) {
 			try {
 				validateFriendlyURL(
 					companyId, groupId, classNameId, classPK, friendlyURL);
@@ -3914,12 +3914,10 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				int type = gfurle.getType();
 
 				if (type == GroupFriendlyURLException.DUPLICATE) {
-					friendlyURL = originalFriendlyURL + i;
+					friendlyURL = friendlyURL + "-" + ++i;
 				}
 				else {
-					friendlyURL = StringPool.SLASH + classPK;
-
-					break;
+					friendlyURL = StringPool.SLASH + "group-" + classPK;
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -4283,8 +4283,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			if (((classNameId != groupClassNameId) &&
 				 !groupIdFriendlyURL.equals(String.valueOf(classPK)) &&
 				 !PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC) ||
-				((classNameId == groupClassNameId) &&
-				 !groupIdFriendlyURL.equals(String.valueOf(groupId)))) {
+				(classNameId == groupClassNameId)) {
 
 				GroupFriendlyURLException gfurle =
 					new GroupFriendlyURLException(

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6905,21 +6905,11 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				userId, screenName, screenNameValidator);
 		}
 
-		if (Validator.isNumber(screenName)) {
-			if (!PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC) {
-				throw new UserScreenNameException.MustNotBeNumeric(
-					userId, screenName);
-			}
+		if (Validator.isNumber(screenName) &&
+			!PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC) {
 
-			if (!screenName.equals(String.valueOf(userId))) {
-				Group group = groupPersistence.fetchByPrimaryKey(
-					GetterUtil.getLong(screenName));
-
-				if (group != null) {
-					throw new UserScreenNameException.MustNotBeUsedByGroup(
-						userId, screenName, group);
-				}
-			}
+			throw new UserScreenNameException.MustNotBeNumeric(
+				userId, screenName);
 		}
 
 		String[] anonymousNames = BaseServiceImpl.ANONYMOUS_NAMES;

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1749,11 +1749,7 @@
     # Set this to true when you want the validation to allow for creation of
     # numeric screen names.
     #
-    # If this property is set to true, not all numeric values are allowed. The
-    # friendly URL for a user is its screen name. The friendly URL for a group
-    # is its group ID. The two are not allowed to be the same.
-    #
-    users.screen.name.allow.numeric=false
+    users.screen.name.allow.numeric=true
 
     #
     # Set this to true to always autogenerate user screen names even if the user

--- a/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
@@ -45,6 +45,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -53,6 +54,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -60,6 +62,7 @@ import java.util.List;
 
 import javax.portlet.PortletPreferences;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -169,6 +172,11 @@ public class UserServiceTest {
 		public static final AggregateTestRule aggregateTestRule =
 			new LiferayIntegrationTestRule();
 
+		@Before
+		public void setup() throws Exception {
+			PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = true;
+		}
+
 		@Test
 		public void shouldAddUser() throws Exception {
 			String numericScreenName = "12345";
@@ -189,6 +197,12 @@ public class UserServiceTest {
 			_user = UserTestUtil.addUser(String.valueOf(groupId));
 
 			Assert.assertEquals(String.valueOf(groupId), _user.getScreenName());
+		}
+
+		@After
+		public void tearDown() throws Exception {
+			PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = GetterUtil.getBoolean(
+				PropsUtil.get(PropsKeys.USERS_SCREEN_NAME_ALLOW_NUMERIC));
 		}
 
 		@DeleteAfterTestRun

--- a/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.service;
 
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
+import com.liferay.portal.kernel.exception.UserScreenNameException;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -198,6 +199,13 @@ public class UserServiceTest {
 			_user = UserTestUtil.addUser(String.valueOf(groupId));
 
 			Assert.assertEquals(String.valueOf(groupId), _user.getScreenName());
+		}
+
+		@Test(expected = UserScreenNameException.MustNotBeNumeric.class)
+		public void shouldThrowException() throws Exception {
+			PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = false;
+
+			UserTestUtil.addUser(String.valueOf(RandomTestUtil.nextLong()));
 		}
 
 		@After

--- a/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
@@ -173,11 +173,6 @@ public class UserServiceTest {
 		public static final AggregateTestRule aggregateTestRule =
 			new LiferayIntegrationTestRule();
 
-		@Before
-		public void setup() throws Exception {
-			PropsValues.USERS_SCREEN_NAME_ALLOW_NUMERIC = true;
-		}
-
 		@Test
 		public void shouldAddUser() throws Exception {
 			long numericScreenName = RandomTestUtil.nextLong();

--- a/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
@@ -179,11 +179,12 @@ public class UserServiceTest {
 
 		@Test
 		public void shouldAddUser() throws Exception {
-			String numericScreenName = "12345";
+			long numericScreenName = RandomTestUtil.nextLong();
 
-			_user = UserTestUtil.addUser(numericScreenName);
+			_user = UserTestUtil.addUser(String.valueOf(numericScreenName));
 
-			Assert.assertEquals(numericScreenName, _user.getScreenName());
+			Assert.assertEquals(
+				String.valueOf(numericScreenName), _user.getScreenName());
 		}
 
 		@Test

--- a/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/service/UserServiceTest.java
@@ -162,6 +162,43 @@ public class UserServiceTest {
 
 	}
 
+	public static class WhenAddingUserWithNumericScreenName {
+
+		@ClassRule
+		@Rule
+		public static final AggregateTestRule aggregateTestRule =
+			new LiferayIntegrationTestRule();
+
+		@Test
+		public void shouldAddUser() throws Exception {
+			String numericScreenName = "12345";
+
+			_user = UserTestUtil.addUser(numericScreenName);
+
+			Assert.assertEquals(numericScreenName, _user.getScreenName());
+		}
+
+		@Test
+		public void shouldAddUserWhenScreenNameMatchesExistingGroupId()
+			throws Exception {
+
+			_group = GroupTestUtil.addGroup();
+
+			long groupId = _group.getGroupId();
+
+			_user = UserTestUtil.addUser(String.valueOf(groupId));
+
+			Assert.assertEquals(String.valueOf(groupId), _user.getScreenName());
+		}
+
+		@DeleteAfterTestRun
+		private Group _group;
+
+		@DeleteAfterTestRun
+		private User _user;
+
+	}
+
 	public static class WhenCompanySecurityStrangersWithMXDisabled {
 
 		@ClassRule


### PR DESCRIPTION
This is an update for [LPS-66460](https://issues.liferay.com/browse/LPS-66460).<br><br>Hey Brian, this is our proposed implementation.  It does not yet include the update to the "breaking changes" document or an Upgrade process since we would like to make sure we have the right solution first. 

Key points:

1. This pull does not add an extra portal property
2. The default friendlyURL for a group being updated with a blank friendlyURL field is now "group-{groupId}", e.g. group-12345
3. The `users.screen.name.allow.numeric` now defaults to true
4. A group will no longer be accessible by using its groupId as the friendlyURL in any case (since we are removing this "feature" _completely_)

Please let us know what you think. Thanks!

/cc @pei-jung, @jorgeferrer