### PR TITLE
LPS-74652 Do delete rather than unschedule. The difference between de…

### DIFF
--- a/modules/apps/foundation/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/foundation/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -1092,7 +1092,7 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 			SchedulerClusterInvokingThreadLocal.setEnabled(false);
 
 			try {
-				unschedule(schedulerEntry, storageType);
+				delete(schedulerEntry, storageType);
 			}
 			catch (SchedulerException se) {
 				_log.error(se, se);


### PR DESCRIPTION
…lete and unschedule is if we are going to keep job details in storage, the stored job details can be scheduled with a trigger later. But here, we are not going to reuse job detail, so we should do delete rather than unschedule.