### PR TITLE
LPS-74843 FIX: With an Asset Publisher and the guest user, AssetSearcher logs ERROR NoSuchResourceActionException

### DIFF
--- a/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetSearcherTest.java
+++ b/modules/apps/web-experience/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetSearcherTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.service.test.ServiceTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.asset.util.AssetSearcher;
+
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author André de Oliveira
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class AssetSearcherTest {
+
+	@ClassRule
+	@Rule
+	public static final TestRule testRule = new AggregateTestRule(
+		new LiferayIntegrationTestRule(),
+		SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGuestUser() throws Exception {
+		setGuestUser();
+
+		AssetEntryQuery assetEntryQuery = getAssetEntryQuery();
+
+		assetEntryQuery.setClassNameIds(
+			getClassNameIds("com.liferay.blogs.kernel.model.BlogsEntry"));
+
+		search(assetEntryQuery, getSearchContext());
+	}
+
+	@Test
+	public void testGuestUserBorrowedPermissions() throws Exception {
+		setGuestUser();
+
+		AssetEntryQuery assetEntryQuery = getAssetEntryQuery();
+
+		assetEntryQuery.setClassNameIds(
+			getClassNameIds(
+				"com.liferay.calendar.model.CalendarBooking",
+				"com.liferay.dynamic.data.lists.model.DDLRecord"));
+
+		search(assetEntryQuery, getSearchContext());
+	}
+
+	protected AssetEntryQuery getAssetEntryQuery() {
+		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
+
+		assetEntryQuery.setGroupIds(new long[] {_group.getGroupId()});
+
+		return assetEntryQuery;
+	}
+
+	protected long[] getClassNameIds(String... classNames) {
+		Stream<String> stream = Stream.of(classNames);
+
+		return stream.mapToLong(
+			PortalUtil::getClassNameId
+		).toArray();
+	}
+
+	protected SearchContext getSearchContext() {
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(_group.getCompanyId());
+		searchContext.setGroupIds(new long[] {_group.getGroupId()});
+
+		return searchContext;
+	}
+
+	protected void search(
+			AssetEntryQuery assetEntryQuery, SearchContext searchContext)
+		throws Exception {
+
+		AssetSearcher assetSearcher = new AssetSearcher();
+
+		assetSearcher.setAssetEntryQuery(assetEntryQuery);
+
+		assetSearcher.search(searchContext);
+	}
+
+	protected void setGuestUser() throws Exception {
+		ServiceTestUtil.setUser(
+			_userLocalService.getDefaultUser(_group.getCompanyId()));
+	}
+
+	@Inject
+	private static UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -1841,10 +1841,11 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 
 	private void _addPermissionFilter(
 			BooleanFilter booleanFilter, String entryClassName,
-			SearchContext searchContext)
+			Indexer<?> indexer, SearchContext searchContext)
 		throws Exception {
 
-		Filter filter = getFacetBooleanFilter(entryClassName, searchContext);
+		Filter filter = indexer.getFacetBooleanFilter(
+			entryClassName, searchContext);
 
 		if (filter != null) {
 			booleanFilter.add(filter, BooleanClauseOccur.MUST);
@@ -1932,7 +1933,8 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 
 		_addStagingFilter(booleanFilter, indexer, searchContext);
 
-		_addPermissionFilter(booleanFilter, entryClassName, searchContext);
+		_addPermissionFilter(
+			booleanFilter, entryClassName, indexer, searchContext);
 
 		_addIndexerProvidedPreFilters(booleanFilter, indexer, searchContext);
 


### PR DESCRIPTION
Caused by LPS-72998. This is blocking the daily performance monitor test for Asset Publisher. (Apologies @tinatian @shuyangzhou)

https://issues.liferay.com/browse/LPS-74843
https://issues.liferay.com/browse/LPS-72998