### PR TITLE
LPS-75012 Refine spring extender debug output formatting

### DIFF
--- a/modules/apps/foundation/portal-osgi-debug/portal-osgi-debug-spring-extender/src/main/java/com/liferay/portal/osgi/debug/spring/extender/internal/UnavailableComponentScanner.java
+++ b/modules/apps/foundation/portal-osgi-debug/portal-osgi-debug-spring-extender/src/main/java/com/liferay/portal/osgi/debug/spring/extender/internal/UnavailableComponentScanner.java
@@ -20,6 +20,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.osgi.debug.spring.extender.internal.configuration.UnavailableComponentScannerConfiguration;
 
@@ -126,7 +127,13 @@ public class UnavailableComponentScanner {
 
 			if (!unavailableComponentDeclarations.isEmpty()) {
 				sb.append("Found unavailable component in bundle ");
-				sb.append(bundle);
+				sb.append("{id: ");
+				sb.append(bundle.getBundleId());
+				sb.append(", name: ");
+				sb.append(bundle.getSymbolicName());
+				sb.append(", version: ");
+				sb.append(bundle.getVersion());
+				sb.append("}");
 				sb.append(".\n");
 
 				for (Map.Entry<
@@ -134,29 +141,24 @@ public class UnavailableComponentScanner {
 						List<ComponentDependencyDeclaration>> entry :
 							unavailableComponentDeclarations.entrySet()) {
 
-					sb.append("\tComponent ");
-					sb.append(entry.getKey());
+					sb.append("\tComponent with id ");
+
+					ComponentDeclaration componentDeclaration = entry.getKey();
+
+					sb.append(componentDeclaration.getId());
+
 					sb.append(" is unavailable due to missing required ");
-					sb.append("dependencies: ");
+					sb.append("dependencies:\n\t\t");
 
-					List<ComponentDependencyDeclaration>
-						componentDependencyDeclarations = entry.getValue();
-
-					for (int i = 0; i < componentDependencyDeclarations.size();
-						i++) {
-
-						if (i != 0) {
-							sb.append(", ");
-						}
-
-						ComponentDependencyDeclaration
-							componentDependencyDeclaration =
-								componentDependencyDeclarations.get(i);
+					for (ComponentDependencyDeclaration
+							componentDependencyDeclaration :
+								entry.getValue()) {
 
 						sb.append(componentDependencyDeclaration);
+						sb.append("\n\t\t");
 					}
 
-					sb.append(".");
+					sb.setStringAt(StringPool.NEW_LINE, sb.index() - 1);
 				}
 			}
 		}


### PR DESCRIPTION
@mhan810 @david-truong @jhinkey the output is like this now:
```
14:15:43,937 WARN  [Spring Extender Unavailable Component Scanner][UnavailableComponentScanner:174] Found unavailable component in bundle {id: 542, name: com.liferay.screens.service, version: 1.0.28}.
	Component with id 28 is unavailable due to missing required dependencies:
		ServiceDependency[interface com.liferay.blogs.service.BlogsEntryService null]
```

The component id can be further used in gogo:
```
g! dm ci 28
[542] com.liferay.screens.service
 [28] com.liferay.portal.spring.extender.internal.context.ModuleApplicationContextRegistrator unregistered
    com.liferay.asset.kernel.service.AssetEntryLocalService service required available
    com.liferay.asset.kernel.service.AssetEntryService service required available
    com.liferay.asset.kernel.service.persistence.AssetEntryPersistence service required available
    com.liferay.asset.publisher.web.util.AssetPublisherUtil service required available
    com.liferay.blogs.service.BlogsEntryService service required unavailable
    com.liferay.counter.kernel.service.CounterLocalService service required available
    com.liferay.document.library.kernel.service.DLAppLocalService service required available
........
```