### PR TITLE
Lps 75014

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6460,6 +6460,19 @@ osb.lcs.portlet.oauth.consumer.secret=${osb.lcs.portlet.oauth.consumer.secret}</
 	</root>
 </log4j:configuration>]]></echo>
 
+		<echo file="${liferay.home}/osgi/log4j/com.liferay.portal.osgi.web.wab.generator-log4j-ext.xml"><![CDATA[<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.portal.osgi.web.wab.generator.internal.WabGenerator">
+		<priority value="ERROR" />
+	</category>
+
+	<category name="com.liferay.portal.osgi.web.wab.generator.internal.processor.WabProcessor">
+		<priority value="WARN" />
+	</category>
+</log4j:configuration>]]></echo>
+
 		<echo file="${liferay.home}/osgi/log4j/com.liferay.portal.search.elasticsearch-log4j-ext.xml"><![CDATA[<?xml version="1.0"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/WabGenerator.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/WabGenerator.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -136,9 +137,23 @@ public class WabGenerator
 
 		bundleTracker.open();
 
-		countDownLatch.await();
+		while (true) {
+			if (countDownLatch.await(1, TimeUnit.MINUTES)) {
+				break;
+			}
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Waiting on startup required bundles to become active : " +
+						requiredForStartupLocations);
+			}
+		}
 
 		bundleTracker.close();
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("All startup required bundles are active now.");
+		}
 	}
 
 	@Deactivate

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator/src/main/resources/META-INF/module-log4j.xml
@@ -2,6 +2,10 @@
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.portal.osgi.web.wab.generator.internal.WabGenerator">
+		<priority value="WARN" />
+	</category>
+
 	<category name="com.liferay.portal.osgi.web.wab.generator.internal.processor.WabProcessor">
 		<priority value="WARN" />
 	</category>


### PR DESCRIPTION
@mhan810 @david-truong @jhinkey this is the logging for waiting on startup required bundles.
The log will look like this:
```
15:04:30,477 WARN  [localhost-startStop-1][WabGenerator:146] Waiting on startup required bundles to become active : [webbundle:/opt/liferay-portal-trunk/osgi/war/classic-theme.war?bundle-symbolicname=classic-theme&web-contextpath=/classic-theme&protocol=file]
```
The value inside "[]" is a comma separated list of bundle locations. We can only print location, as this info is collected before bundle installation, we don't have any other info about the bundle yet.