### PR TITLE
LPS-74927 Clean up unused dynamic imports, since we have ClassloaderT…

### DIFF
--- a/modules/apps/foundation/portal-cache/portal-cache/bnd.bnd
+++ b/modules/apps/foundation/portal-cache/portal-cache/bnd.bnd
@@ -1,7 +1,6 @@
 Bundle-Name: Liferay Portal Cache
 Bundle-SymbolicName: com.liferay.portal.cache
 Bundle-Version: 2.4.2
-DynamicImport-Package: *
 Export-Package:\
 	com.liferay.portal.cache,\
 	com.liferay.portal.cache.configuration,\

--- a/modules/apps/foundation/portal/portal-cluster-multiple/bnd.bnd
+++ b/modules/apps/foundation/portal/portal-cluster-multiple/bnd.bnd
@@ -1,7 +1,6 @@
 Bundle-Name: Liferay Portal Cluster Multiple
 Bundle-SymbolicName: com.liferay.portal.cluster.multiple
 Bundle-Version: 1.0.18
-DynamicImport-Package: *
 Import-Package:\
 	!COM.ibm.netrexx.*,\
 	\


### PR DESCRIPTION
…racker support added by LPS-72911, do not need dynamic imports to find classes while serializing/deserializing.