### PR TITLE
LPS-74871 Allow user to select their language in the beginning of the user setup process

### DIFF
--- a/modules/apps/analytics/.gitrepo
+++ b/modules/apps/analytics/.gitrepo
@@ -6,6 +6,6 @@
 	cmdver = liferay
 	commit = 0000000000000000000000000000000000000000
 	mergebuttonmergecommits = false
-	mode = push
+	mode = pull
 	parent = 0000000000000000000000000000000000000000
 	remote = git@github.com:liferay/com-liferay-analytics.git

--- a/modules/apps/foundation/users-admin/users-admin-impl/build.gradle
+++ b/modules/apps/foundation/users-admin/users-admin-impl/build.gradle
@@ -2,7 +2,9 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
+	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay", name: "com.liferay.exportimport.api", version: "2.0.0"
+	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.users.admin.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.xstream.configurator.api", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"

--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/configuration/UserSetupConfiguration.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/configuration/UserSetupConfiguration.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.users.admin.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Drew Brokke
+ */
+@ExtendedObjectClassDefinition(category = "foundation")
+@Meta.OCD(
+	id = "com.liferay.users.admin.internal.configuration.UserSetupConfiguration",
+	localization = "content/Language", name = "user-setup-configuration-name"
+)
+public interface UserSetupConfiguration {
+
+	@Meta.AD(
+		deflt = "true", description = "language-selection-required-help",
+		required = false
+	)
+	public boolean languageSelectionRequired();
+
+}

--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/configuration/definition/UserSetupConfigurationBeanDeclaration.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/configuration/definition/UserSetupConfigurationBeanDeclaration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.users.admin.internal.configuration.definition;
+
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+import com.liferay.users.admin.internal.configuration.UserSetupConfiguration;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class UserSetupConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return UserSetupConfiguration.class;
+	}
+
+}

--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/events/LoginPostAction.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/events/LoginPostAction.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.users.admin.internal.events;
+
+import com.liferay.portal.kernel.events.Action;
+import com.liferay.portal.kernel.events.ActionException;
+import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsKeys;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pei-Jung Lan
+ */
+@Component(
+	immediate = true, property = {"key=" + PropsKeys.LOGIN_EVENTS_POST},
+	service = LifecycleAction.class
+)
+public class LoginPostAction extends Action {
+
+	@Override
+	public void run(HttpServletRequest request, HttpServletResponse response)
+		throws ActionException {
+
+		try {
+			User user = _portal.getUser(request);
+
+			if (!user.isSetupComplete()) {
+				String redirect =
+					_portal.getPathMain() + _PATH_PORTAL_SELECT_LANGUAGE;
+
+				response.sendRedirect(redirect);
+			}
+		}
+		catch (Exception e) {
+			throw new ActionException(e);
+		}
+	}
+
+	private static final String _PATH_PORTAL_SELECT_LANGUAGE =
+		"/portal/select_language";
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/events/LoginPostAction.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/events/LoginPostAction.java
@@ -70,10 +70,8 @@ public class LoginPostAction extends Action {
 				return;
 			}
 
-			String redirect =
-				_portal.getPathMain() + _PATH_PORTAL_SELECT_LANGUAGE;
-
-			response.sendRedirect(redirect);
+			response.sendRedirect(
+				_portal.getPathMain() + _PATH_PORTAL_SELECT_LANGUAGE);
 		}
 		catch (Exception e) {
 			throw new ActionException(e);

--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/events/LoginPostAction.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/events/LoginPostAction.java
@@ -14,6 +14,7 @@
 
 package com.liferay.users.admin.internal.events;
 
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.events.Action;
 import com.liferay.portal.kernel.events.ActionException;
 import com.liferay.portal.kernel.events.LifecycleAction;
@@ -23,17 +24,23 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.users.admin.internal.configuration.UserSetupConfiguration;
+
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
  */
 @Component(
+	configurationPid = "com.liferay.users.admin.internal.configuration.UserSetupConfiguration",
 	immediate = true, property = {"key=" + PropsKeys.LOGIN_EVENTS_POST},
 	service = LifecycleAction.class
 )
@@ -46,7 +53,9 @@ public class LoginPostAction extends Action {
 		try {
 			User user = _portal.getUser(request);
 
-			if ((user == null) || user.isSetupComplete()) {
+			if ((user == null) || user.isSetupComplete() ||
+				!_userSetupConfiguration.languageSelectionRequired()) {
+
 				return;
 			}
 
@@ -78,10 +87,19 @@ public class LoginPostAction extends Action {
 		}
 	}
 
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_userSetupConfiguration = ConfigurableUtil.createConfigurable(
+			UserSetupConfiguration.class, properties);
+	}
+
 	private static final String _PATH_PORTAL_SELECT_LANGUAGE =
 		"/portal/select_language";
 
 	@Reference
 	private Portal _portal;
+
+	private UserSetupConfiguration _userSetupConfiguration;
 
 }

--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/exportimport/data/handler/OrganizationStagedModelDataHandler.java
@@ -490,7 +490,7 @@ public class OrganizationStagedModelDataHandler
 
 			StagedModelDataHandlerUtil.importReferenceStagedModel(
 				portletDataContext, organization, Organization.class,
-				organization.getParentOrganizationId());
+				Long.valueOf(organization.getParentOrganizationId()));
 		}
 	}
 

--- a/modules/apps/foundation/users-admin/users-admin-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/foundation/users-admin/users-admin-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,2 @@
+language-selection-required-help=If true, new users will be required to select a language as the first step to complete their set up. The default value is true.
+user-setup-configuration-name=User Setup

--- a/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
@@ -691,6 +691,14 @@ public class PortalRequestProcessor extends TilesRequestProcessor {
 				return path;
 			}
 
+			// Authenticated users can always select or update their language
+
+			if (path.equals(_PATH_PORTAL_SELECT_LANGUAGE) ||
+				path.equals(_PATH_PORTAL_UPDATE_LANGUAGE)) {
+
+				return path;
+			}
+
 			// Authenticated users can always agree to terms of use
 
 			if (path.equals(_PATH_PORTAL_UPDATE_TERMS_OF_USE)) {
@@ -1022,6 +1030,9 @@ public class PortalRequestProcessor extends TilesRequestProcessor {
 		"/portal/render_portlet";
 
 	private static final String _PATH_PORTAL_RESILIENCY = "/portal/resiliency";
+
+	private static final String _PATH_PORTAL_SELECT_LANGUAGE =
+		"/portal/select_language";
 
 	private static final String _PATH_PORTAL_SETUP_WIZARD =
 		"/portal/setup_wizard";

--- a/portal-web/docroot/WEB-INF/struts-config.xml
+++ b/portal-web/docroot/WEB-INF/struts-config.xml
@@ -77,6 +77,8 @@
 
 		<action path="/portal/robots" type="com.liferay.portal.action.RobotsAction" />
 
+		<action forward="portal.select_language" path="/portal/select_language" />
+
 		<action path="/portal/session_click" type="com.liferay.portal.action.SessionClickAction" />
 
 		<action path="/portal/session_tree_js_click" type="com.liferay.portal.action.SessionTreeJSClickAction" />

--- a/portal-web/docroot/WEB-INF/tiles-defs.xml
+++ b/portal-web/docroot/WEB-INF/tiles-defs.xml
@@ -63,6 +63,11 @@
 
 	<definition name="portal.progress_poller" path="/portal/progress_poller.jsp" />
 
+	<definition extends="portal" name="portal.select_language">
+		<put name="title" value="choose-a-language" />
+		<put name="content" value="/portal/select_language.jsp" />
+	</definition>
+
 	<definition extends="portal" name="portal.setup_wizard">
 		<put name="pop_up" value="true" />
 		<put name="title" value="basic-configuration" />

--- a/portal-web/docroot/html/portal/select_language.jsp
+++ b/portal-web/docroot/html/portal/select_language.jsp
@@ -1,0 +1,48 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/html/portal/init.jsp" %>
+
+<%
+String currentURL = PortalUtil.getCurrentURL(request);
+%>
+
+<aui:form action='<%= themeDisplay.getPathMain() + "/portal/update_language" %>' method="post" name="fm">
+	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+
+	<aui:select label="" name="languageId">
+
+		<%
+		for (Locale curLocale : LanguageUtil.getAvailableLocales()) {
+		%>
+
+			<aui:option
+				label="<%= curLocale.getDisplayName(curLocale) %>"
+				lang="<%= LocaleUtil.toW3cLanguageId(curLocale) %>"
+				selected="<%= (locale.getLanguage().equals(curLocale.getLanguage()) && locale.getCountry().equals(curLocale.getCountry())) %>"
+				value="<%= LocaleUtil.toLanguageId(curLocale) %>"
+			/>
+
+		<%
+		}
+		%>
+
+	</aui:select>
+
+	<aui:button-row>
+		<aui:button cssClass="btn-lg" type="submit" value="save" />
+	</aui:button-row>
+</aui:form>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/User.macro
@@ -1057,6 +1057,20 @@
 		</if>
 	</command>
 
+	<command name="chooseLanguage">
+		<if>
+			<isset var="language" />
+			<then>
+				<execute function="Select" locator1="Select#CHOOSE_A_LANGUAGE" value1="${language}" />
+			</then>
+			<else>
+				<execute function="AssertSelectedLabel" locator1="Select#CHOOSE_A_LANGUAGE" value1="English (United States)" />
+			</else>
+		</if>
+
+		<execute macro="Button#clickSave" />
+	</command>
+
 	<command name="createAccount">
 		<execute macro="SignInNavigator#gotoCreateAccount" />
 
@@ -1710,6 +1724,15 @@
 		<execute function="Click" locator1="Button#SIGN_IN" value1="Sign In" />
 
 		<execute function="AssertElementNotPresent" locator1="Button#SIGN_IN" value1="Sign In" />
+
+		<if>
+			<condition function="IsElementPresent" locator1="//h2[.='Choose a Language']" />
+			<then>
+				<execute macro="User#chooseLanguage">
+					<var name="language" value="${language}" />
+				</execute>
+			</then>
+		</if>
 
 		<execute macro="User#acceptEndUserLicenseAgreement" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Select.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Select.path
@@ -34,6 +34,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CHOOSE_A_LANGUAGE</td>
+	<td>//select[contains(@name,'languageId')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>CONTENT_ALL_CONTENT</td>
 	<td>//option[contains(@id,'allContent')]</td>
 	<td></td>


### PR DESCRIPTION
This is an update for [LPS-74871](https://issues.liferay.com/browse/LPS-74871).

From the description in the Jira ticket:

---

**The propsed changes:**

- There is a new Configuration called "User Setup" that contains an option called "languageSelectionRequired". It defaults to true.
- If true, a new user will be required to select a language immediately after they log in as the first step to complete their setup (before agreeing to the TOC, etc).
- We use a LoginPostAction to check if the user's setup is complete, if the configuration does not require it, or if any other setup steps have completed. If any of these things are true, the language selection screen will not be shown.
- We add the language selection page in portal-web and update the struts config and tiles defs to point to it, since all the other setup steps are also accessed through this method.

**Looking forward:**

- In the future, we may want to extract all the setup steps into their own module, that way they are all grouped logically. Similarly, we would extract all the relevant portal properties and put them in the new UserSetupConfiguration interface.

This pull does **not** make any changes related to Time Zones. Those changes will be in another ticket if they are necessary.

---

/cc @pei-jung, @jorgeferrer, @alee8888, @xbrianlee