### PR TITLE
LRQA-35329 Don't translate the echo readable syntax to an execute element

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -231,7 +231,9 @@ public class ExecutePoshiElement extends BasePoshiElement {
 			return false;
 		}
 
-		if (readableSyntax.startsWith("property ")) {
+		if (readableSyntax.startsWith("echo(") ||
+			readableSyntax.startsWith("property ")) {
+
 			return false;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-35329

This is the bug fix for the inconsistent Poshi unit test failures in upstream.