### PR TITLE
Lps 75087

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/convert/test/DocumentLibraryConvertProcessTest.java
@@ -43,6 +43,8 @@ import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -82,6 +84,7 @@ import org.junit.runner.RunWith;
  * @author Manuel de la Peña
  */
 @RunWith(Arquillian.class)
+@Sync
 public class DocumentLibraryConvertProcessTest {
 
 	@ClassRule
@@ -89,7 +92,8 @@ public class DocumentLibraryConvertProcessTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			PermissionCheckerTestRule.INSTANCE);
+			PermissionCheckerTestRule.INSTANCE,
+			SynchronousDestinationTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {

--- a/modules/apps/collaboration/notifications/.gitrepo
+++ b/modules/apps/collaboration/notifications/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 92745e8bab0f4c62c99430827edac9ff7adad408
+	commit = bdd0f0260f9aff21782db5d8a92830c53ca74c98
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 54f7948de77b635ce1fdb3fbddee57041dffe616
+	parent = 83763917f9eeaee842b4e9e61a773aedd3a5ad34
 	remote = git@github.com:liferay/com-liferay-notifications.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = da85e5163dc3b032c16fd9c90ce2e0096d5fd0f4
+	commit = 5899c2ed8d33198a0ca79c530cbfd08a9926be02
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 8e5b6349c3869b275b8e79ce5b68f8757ae675ce
+	parent = 4f1fa4d2882fdece2a88009adba86e9bbd9f7b0b
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/organization/test/OrganizationMembershipPolicyRolesTest.java
+++ b/modules/apps/foundation/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/organization/test/OrganizationMembershipPolicyRolesTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +51,7 @@ import org.junit.runner.RunWith;
 /**
  * @author Roberto Díaz
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class OrganizationMembershipPolicyRolesTest
 	extends BaseOrganizationMembershipPolicyTestCase {

--- a/modules/apps/foundation/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/test/util/MembershipPolicyTestUtil.java
+++ b/modules/apps/foundation/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/test/util/MembershipPolicyTestUtil.java
@@ -196,7 +196,7 @@ public class MembershipPolicyTestUtil {
 		String facebookSn = RandomTestUtil.randomString();
 		String jabberSn = RandomTestUtil.randomString();
 		String skypeSn = RandomTestUtil.randomString();
-		String twitterSn = RandomTestUtil.randomString();
+		String twitterSn = StringPool.BLANK;
 
 		List<Address> addresses = new ArrayList<>();
 		List<EmailAddress> emailAddresses = new ArrayList<>();

--- a/test.properties
+++ b/test.properties
@@ -1332,6 +1332,7 @@
     test.class.names.excludes=\
         modules/apps/adaptive-media/**,\
         modules/apps/chat/**,\
+        modules/apps/foundation/portal-security/portal-security-membership-policy-test/**,\
         modules/apps/mail-reader/**,\
         modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/test/java/com/liferay/portal/bundle/blacklist/BundleBlacklistSetUpBatchTest.java,\
         modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistVerifyReinstalledTest.java,\


### PR DESCRIPTION
…istener would see users with twitter accounts, and trying to connect to twitter which is against the no network access rule in test. This was not a problem before, because scheduler is disabled in portal-impl integration tests, but enabled in modules integration tests. This is caused by 2dcb43a8603ba73f558c848bb429fa64906d47f8

@ealonso this commit https://github.com/shuyangzhou/liferay-portal/commit/d1ca836fe547de69b2caff652cf6405cf81a7aca fixes the SOCKS proxy issue caused by https://github.com/brianchandotcom/liferay-portal/pull/52038

And your test moving change somehow broke this https://github.com/shuyangzhou/liferay-portal/commit/53633ef51906c50e2ad3a3ea834a9e715a893f7a . I am just disabling this test, please fix it yourself and re-enable it.

@michaelhashimoto there could be other stable failures caused by the test moving, if so please disable the tests and let @ealonso know. I am out of office on Oct 10. If you need anything go asking @mtambara