### PR TITLE
LRQA-34625 Implement support for public-only remotes

### DIFF
--- a/modules/apps/collaboration/notifications/.gitrepo
+++ b/modules/apps/collaboration/notifications/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 92745e8bab0f4c62c99430827edac9ff7adad408
+	commit = bdd0f0260f9aff21782db5d8a92830c53ca74c98
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 54f7948de77b635ce1fdb3fbddee57041dffe616
+	parent = 83763917f9eeaee842b4e9e61a773aedd3a5ad34
 	remote = git@github.com:liferay/com-liferay-notifications.git

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -83,12 +83,20 @@ public class GitWorkingDirectory {
 
 		_repositoryName = repositoryName;
 
-		if (!_privateOnlyRepositories.contains(_repositoryName)) {
-			if (upstreamBranchName.equals("master")) {
-				setUpstreamRemoteToPublicRepository();
+		if (_publicOnlyRepositories.contains(_repositoryName)) {
+			setUpstreamRemoteToPublicRepository();
+		}
+		else {
+			if (_privateOnlyRepositories.contains(_repositoryName)) {
+				setUpstreamRemoteToPrivateRepository();
 			}
 			else {
-				setUpstreamRemoteToPrivateRepository();
+				if (upstreamBranchName.equals("master")) {
+					setUpstreamRemoteToPublicRepository();
+				}
+				else {
+					setUpstreamRemoteToPrivateRepository();
+				}
 			}
 		}
 
@@ -1295,6 +1303,10 @@ public class GitWorkingDirectory {
 			"liferay-jenkins-ee", "liferay-jenkins-tools-private",
 			"liferay-plugins-ee", "liferay-portal-ee",
 			"liferay-qa-portal-legacy-ee", "liferay-release-tool-ee"
+		});
+	private static final List<String> _publicOnlyRepositories = Arrays.asList(
+		new String[] {
+			"liferay-blade-samples", "liferay-plugins", "liferay-portal"
 		});
 
 	private File _gitDirectory;


### PR DESCRIPTION
I discovered a case where we have a repository that is public only and has upstream branches that are used in CI that is not named master.

Please publish after merging