### PR TITLE
LRQA-34625 Don't validate the branch before attempting to checkout

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -144,25 +144,6 @@ public class GitWorkingDirectory {
 	}
 
 	public void checkoutBranch(Branch branch, String options) {
-		if (!branchExists(branch.getName(), null)) {
-			throw new IllegalArgumentException(
-				JenkinsResultsParserUtil.combine(
-					"The branch ", branch.getName(), " could not be found"));
-		}
-
-		Branch currentBranch = getCurrentBranch();
-
-		if (currentBranch != null) {
-			String currentBranchName = currentBranch.getName();
-
-			if (currentBranchName.equals(branch.getName())) {
-				System.out.println(
-					currentBranchName + " is already checked out");
-
-				return;
-			}
-		}
-
 		waitForIndexLock();
 
 		StringBuilder sb = new StringBuilder();
@@ -222,7 +203,7 @@ public class GitWorkingDirectory {
 			timeout++;
 
 			if (timeout >= 59) {
-				currentBranch = getCurrentBranch();
+				Branch currentBranch = getCurrentBranch();
 
 				if ((currentBranch != null) &&
 					branchName.equals(currentBranch.getName())) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1289,7 +1289,8 @@ public class GitWorkingDirectory {
 	private static final List<String> _publicOnlyRepositoryNames =
 		Arrays.asList(
 			new String[] {
-				"liferay-blade-samples", "liferay-plugins", "liferay-portal"
+				"liferay-binaries-cache-2017", "liferay-blade-samples",
+				"liferay-plugins", "liferay-portal", "portals-pluto"
 			});
 
 	private File _gitDirectory;


### PR DESCRIPTION
My recent fix to the git cache branch cleanup logic has revealed that checking the existence of a branch too soon after performing the same check sometimes results in a successful return code but no results. I've decided to remove the logic that validates the branch to be checked out before actually attempting to check it out.

Please publish after merging.