### PR TITLE
LPS-75102 Any user can add a user through the UserService (whether through the UI or the JSONWS)

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 283c0b848b33e935953250a1942e6544d6fd11a8
+	commit = 9945f1d101e365333af90cc278743599df5541cd
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ebc3e83a20df0263fbbe278fcb915b6d63188e08
+	parent = 7ee01da52a9fedb51e93117d8d3be5d0c016a0e4
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e98c24b342cbba8a9437183641b43f8318cebf38
+	commit = dcf9d51e2f3bba6d8e625360772cb33551173a6c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 321be3ce00d1bd45e1ec4e9896de7d1378974b53
+	parent = 8385785267f1ab07468fcc77c4bf7ea1ed58f100
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/image-uploader/.gitrepo
+++ b/modules/apps/collaboration/image-uploader/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 836010109cd2af7b12b5a50607a624eb481938ef
+	commit = ae00010989b8d1856c7104130d25736aac12a83d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ce84414b357e1377699144c8f6728746cafc1c4a
+	parent = 4f0a33572386570a37cf66e16fbade11f412ddbd
 	remote = git@github.com:liferay/com-liferay-image-uploader.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c343f14efef09a8ba1370ae543bc7ddafa2ca272
+	commit = 675f1a4b829a9a218e7d2e1f4d9abbb3d9813ea7
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 311e254a62acef9550facb8c0ab4ff34079f495e
+	parent = 608a724c32b6013b8bb62341e10a9f4f7947a455
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = fd5c6df189363a762d48df072b382a7f495bec35
+	commit = 3a6e7da2513b5d988e709ef72101bf7622778943
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 10087aefb454b551a6cadc5a48445483985a018a
+	parent = d78b29f114f222ea8f1f1cb049bb2bea6b5cbe46
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/foundation/frontend-css/.gitrepo
+++ b/modules/apps/foundation/frontend-css/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0decaab414277e48fc4e3dddf2a43e20da20a5b0
+	commit = 23bb5d523c780ce230f50df8ab472a5d546dcd39
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9543313174b2c00ffaf010cd6cac68ae4bc536c9
+	parent = 60c0ee86cc31f091ece0b567088b7de83b402406
 	remote = git@github.com:liferay/com-liferay-frontend-css.git

--- a/modules/apps/foundation/petra/.gitrepo
+++ b/modules/apps/foundation/petra/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = aac7c7acb31f06cabce15b04b338e36cacf92722
+	commit = 8d9225b5b1c3588bc8546dc4fa751c9f4d2b6b8f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e6c44c93fc36179168c274afcc8f8d8884789dc4
+	parent = f3df326379962f37972b53319b6f9c52016f1419
 	remote = git@github.com:liferay/com-liferay-petra.git

--- a/modules/apps/foundation/portal-configuration/.gitrepo
+++ b/modules/apps/foundation/portal-configuration/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 32d16eafb9d9c3a2afec36c2614d8624ddb85819
+	commit = 5634bc7530d4725412f0ed0676117a022b67c1c7
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ace62302db52ef4b9e913b5f92578ec546d85896
+	parent = 801cf1a6f4a0661715ff1f462b25826326619053
 	remote = git@github.com:liferay/com-liferay-portal-configuration.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 555adc605c7d61106c59fb4d1e531e5b9488b6cc
+	commit = 37d129de1380cf549a754fe50f21f6da60d065dd
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3f8d9b2ad3faecc2b837ce43d2d8cd761af6d0a1
+	parent = 0c7a7f73d101d0b4f3b4527dcb08dfbbb219e86a
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-store/.gitrepo
+++ b/modules/apps/foundation/portal-store/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 7f40f27d456546b3af161e5bb68ae25e6303eff2
+	commit = 89cbac75d2b407cf9d80062a04f168f97492a4d4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9d4334c041e9ce38b2d8c891194b262d9d180406
+	parent = c56d7670d8f9681eacabe13f6820bdbcc15d919f
 	remote = git@github.com:liferay/com-liferay-portal-store.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b377d4501e5c9b98769a0e1a8aed95782927c259
+	commit = 2c4d56f7327e28de69e9030f6f183ac14d88c700
 	mergebuttonmergecommits = false
 	mode = push
-	parent = d82416fe95056b67007a04bd03353887d478c6de
+	parent = 98593a787fd405d4bf267d00a26acb6b9e017b05
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/screens/.gitrepo
+++ b/modules/apps/screens/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 7551357b25b268a7f546ddda8dbf99b77d2ddfec
+	commit = f76e70e38de1fa10e566a4586b5c2c94fafa4bce
 	mergebuttonmergecommits = false
 	mode = push
-	parent = dd02913cab571cb9af748478950969ca6d6cb8a5
+	parent = 9f19d97ac77dd15b0fa8e553d593a3e9b8320e5d
 	remote = git@github.com:liferay/com-liferay-screens.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = fbf3fdf995ed53df94604f12ab9f157167671690
+	commit = 506c5d784f3f929b12777c3cd4b1e110f0897885
 	mergebuttonmergecommits = false
 	mode = push
-	parent = eb868031b4c3746732b2cf3b5658cc2c315e57ab
+	parent = 05284fa98a9240776afc6a388955558b2c386ae8
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c4122d01dcef3b4f6df0128f2dcd8a41323895eb
+	commit = e7129f18980bc44982b02ce5e7d512d58db16ce4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a8ba7069d373dd87b619c6f3aec335be4d7b62c1
+	parent = 64b9cd29b22aaa03b012dc1cf949e9466bbe5684
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c68143299b79b507808eaf360456d86ef1603652
+	commit = 6fa6b09cfc32b138e752705b4b131175dc24e612
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b669882ac8f5fca39b905dd32b1080470a3278b5
+	parent = 736cecdbc44ba2c7d2f270683e463a053356d308
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/portal-impl/src/com/liferay/portal/service/permission/OrganizationPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/OrganizationPermissionImpl.java
@@ -82,7 +82,7 @@ public class OrganizationPermissionImpl implements OrganizationPermission {
 		throws PortalException {
 
 		if (ArrayUtil.isEmpty(organizationIds)) {
-			return true;
+			return false;
 		}
 
 		for (long organizationId : organizationIds) {


### PR DESCRIPTION
This is an update for [LPS-75102](https://issues.liferay.com/browse/LPS-75102).

Hey Brian, this particular method in `OrganizationPermissionImpl` is used exclusively in `UserServiceImpl` in the `checkAddUserPermission` method.  The it looks like that block was originally designed to simply be a null check but the result is we effectively give "ADD_USER" permission to _any_ user that is not a member of an organization. Let me know if you have any questions about this change.

/cc @pei-jung, @jorgeferrer