### PR TITLE
LRQA-33663 Add custom script junit test class in jenkins results parser jar

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2502,6 +2502,31 @@ ${output.content}</echo>
 		</exec>
 	</target>
 
+	<target name="patching-tool-custom-scripts-jdk8">
+		<fail message="Please set the property liferay.jenkins.dir" >
+			<condition>
+				<not>
+					<isset property="liferay.jenkins.dir" />
+				</not>
+			</condition>
+		</fail>
+
+		<run-batch-test>
+			<test-action>
+				<sequential>
+					<trycatch property="failure.message">
+						<try>
+							<ant antfile="${liferay.jenkins.dir}/commands/custom-scripts/build-test.xml" inheritAll="false" target="run-patching-tool-custom-scripts" />
+						</try>
+						<catch>
+							<fail message="${failure.message}" />
+						</catch>
+					</trycatch>
+				</sequential>
+			</test-action>
+		</run-batch-test>
+	</target>
+
 	<target name="plugins-compile-jdk8">
 		<run-batch-test>
 			<test-action>

--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compile group: "commons-codec", name: "commons-codec", version: "1.9"
 	compile group: "commons-lang", name: "commons-lang", version: "2.6"
 	compile group: "dom4j", name: "dom4j", version: "1.6.1"
+	compile group: "junit", name: "junit", version: "4.12"
 	compile group: "org.apache.ant", name: "ant", version: "1.9.4"
 	compile group: "org.json", name: "json", version: "20140107"
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CustomScriptTest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CustomScriptTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ *	@author Yi-Chen Tsai
+ */
+
+@RunWith(Parameterized.class)
+public class CustomScriptTest {
+
+	@Parameters(name = "{0}")
+	public static Collection<Object[]> getList() throws Exception {
+		Collection<Object[]> testNameList = new ArrayList<>();
+
+		testNameList.add(new String[] {System.getProperty("testName")});
+
+		return testNameList;
+	}
+
+	public CustomScriptTest(String testName) throws Exception {
+	}
+
+	@Test
+	public void test() throws Exception {
+		String testResult = System.getProperty("actual");
+
+		String expectedResult = System.getProperty("expected");
+
+		Assert.assertEquals(expectedResult, testResult);
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CustomScriptTest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CustomScriptTest.java
@@ -14,7 +14,7 @@
 
 package com.liferay.jenkins.results.parser;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Assert;
@@ -31,12 +31,10 @@ import org.junit.runners.Parameterized.Parameters;
 public class CustomScriptTest {
 
 	@Parameters(name = "{0}")
-	public static Collection<Object[]> getList() throws Exception {
-		Collection<Object[]> testNameList = new ArrayList<>();
-
-		testNameList.add(new String[] {System.getProperty("testName")});
-
-		return testNameList;
+	public static Collection<Object[]> getTestNames() throws Exception {
+		return Arrays.asList(new Object[][] {
+			new Object[] {System.getProperty("testName")}
+		});
 	}
 
 	public CustomScriptTest(String testName) throws Exception {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-33663

The patcher team has asked that we create a test that verifies whether or not any errors are thrown when a patch is applied to a portal bundle. To support this kind of test, we are implementing a framework that allows users to write a custom ant script that will be run as a test. This pull request contains a junit test class that will be used to generate the junit xml results for these tests.

