### PR TITLE
LPS-75361 Fix MVCActionCommandTest initialization race condition, usi…

### DIFF
--- a/portal-impl/test/integration/com/liferay/portal/kernel/portlet/bridges/mvc/MVCActionCommandTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/portlet/bridges/mvc/MVCActionCommandTest.java
@@ -23,25 +23,19 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.bundle.mvcactioncommand.Tes
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SyntheticBundleRule;
-import com.liferay.registry.Filter;
-import com.liferay.registry.Registry;
-import com.liferay.registry.RegistryUtil;
-import com.liferay.registry.ServiceTracker;
 
 import java.util.Map;
 
 import javax.portlet.ActionRequest;
-import javax.portlet.GenericPortlet;
 import javax.portlet.PortletConfig;
 import javax.portlet.PortletResponse;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,26 +57,6 @@ public class MVCActionCommandTest {
 			new LiferayIntegrationTestRule(),
 			new SyntheticBundleRule("bundle.mvcactioncommand"));
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		Registry registry = RegistryUtil.getRegistry();
-
-		Filter filter = registry.getFilter(
-			"(&(javax.portlet.name=" + TestPortlet.PORTLET_NAME +
-				")(objectClass=javax.portlet.Portlet))");
-
-		_genericPortletServiceTracker = registry.trackServices(filter);
-
-		_genericPortletServiceTracker.open();
-
-		_genericPortlet = _genericPortletServiceTracker.getService();
-	}
-
-	@AfterClass
-	public static void tearDownClass() {
-		_genericPortletServiceTracker.close();
-	}
-
 	@Test
 	public void testMultipleMVCActionCommandsWithMultipleParameters()
 		throws Exception {
@@ -96,8 +70,7 @@ public class MVCActionCommandTest {
 			ActionRequest.ACTION_NAME,
 			TestMVCActionCommand2.TEST_MVC_ACTION_COMMAND_NAME);
 
-		_genericPortlet.processAction(
-			mockActionRequest, new MockActionResponse());
+		_portlet.processAction(mockActionRequest, new MockActionResponse());
 
 		Assert.assertNotNull(
 			mockActionRequest.getAttribute(
@@ -127,8 +100,7 @@ public class MVCActionCommandTest {
 				StringPool.COMMA +
 					TestMVCActionCommand2.TEST_MVC_ACTION_COMMAND_NAME);
 
-		_genericPortlet.processAction(
-			mockActionRequest, new MockActionResponse());
+		_portlet.processAction(mockActionRequest, new MockActionResponse());
 
 		Assert.assertNotNull(
 			mockActionRequest.getAttribute(
@@ -154,8 +126,7 @@ public class MVCActionCommandTest {
 			ActionRequest.ACTION_NAME,
 			TestMVCActionCommand1.TEST_MVC_ACTION_COMMAND_NAME);
 
-		_genericPortlet.processAction(
-			mockActionRequest, new MockActionResponse());
+		_portlet.processAction(mockActionRequest, new MockActionResponse());
 
 		Assert.assertNotNull(
 			mockActionRequest.getAttribute(
@@ -166,9 +137,8 @@ public class MVCActionCommandTest {
 				TestMVCActionCommand1.TEST_MVC_ACTION_COMMAND_ATTRIBUTE));
 	}
 
-	private static GenericPortlet _genericPortlet;
-	private static ServiceTracker<GenericPortlet, GenericPortlet>
-		_genericPortletServiceTracker;
+	@Inject(filter = "javax.portlet.name=" + TestPortlet.PORTLET_NAME)
+	private final javax.portlet.Portlet _portlet = null;
 
 	private static class MockLiferayPortletConfig
 		extends MockPortletConfig implements LiferayPortletConfig {


### PR DESCRIPTION
…ng ServiceTracker.getService() is a very bad practise. You don't know whether you will get the service or when it will be available, leaving the test a chance to see NPE.