### PR TITLE
LPS-75072 Unlock time shouldn't be shown when the user's account mus be unlocked manually

### DIFF
--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
@@ -51,9 +51,17 @@ if (reminderAttempts == null) {
 
 		<%
 		UserLockoutException.PasswordPolicyLockout ule = (UserLockoutException.PasswordPolicyLockout)errorException;
+		boolean isRequireUnlock = ule.passwordPolicy.isRequireUnlock();
 		%>
 
-		<liferay-ui:message arguments="<%= ule.user.getUnlockDate() %>" key="this-account-is-locked-until-x" translateArguments="<%= false %>" />
+		<c:choose>
+			<c:when test="<%= isRequireUnlock %>">
+				<liferay-ui:message key="this-account-is-locked" />
+			</c:when>
+			<c:otherwise>
+				<liferay-ui:message arguments="<%= ule.user.getUnlockDate() %>" key="this-account-is-locked-until-x" translateArguments="<%= false %>" />
+			</c:otherwise>
+		</c:choose>
 	</liferay-ui:error>
 
 	<liferay-ui:error exception="<%= UserReminderQueryException.class %>" message="your-answer-does-not-match-what-is-in-our-database" />

--- a/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/foundation/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -126,9 +126,17 @@
 
 					<%
 					UserLockoutException.PasswordPolicyLockout ule = (UserLockoutException.PasswordPolicyLockout)errorException;
+					boolean isRequireUnlock = ule.passwordPolicy.isRequireUnlock();
 					%>
 
-					<liferay-ui:message arguments="<%= ule.user.getUnlockDate() %>" key="this-account-is-locked-until-x" translateArguments="<%= false %>" />
+					<c:choose>
+						<c:when test="<%= isRequireUnlock %>">
+							<liferay-ui:message key="this-account-is-locked" />
+						</c:when>
+						<c:otherwise>
+							<liferay-ui:message arguments="<%= ule.user.getUnlockDate() %>" key="this-account-is-locked-until-x" translateArguments="<%= false %>" />
+						</c:otherwise>
+					</c:choose>
 				</liferay-ui:error>
 
 				<liferay-ui:error exception="<%= UserPasswordException.class %>" message="authentication-failed" />


### PR DESCRIPTION
Hi Brian,

https://issues.liferay.com/browse/LPS-75072

Thanks.

/cc @hudakl @csierra