### PR TITLE
LRQA-35480 Readable poshi translation: Add support for take-screenshot, fail, task, toggle, on, off, elseif elements

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/AndPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/AndPoshiElement.java
@@ -101,7 +101,9 @@ public class AndPoshiElement extends BasePoshiElement {
 			return false;
 		}
 
-		if (readableSyntax.contains(" || ")) {
+		if (readableSyntax.contains(" || ") ||
+			readableSyntax.startsWith("else if (")) {
+
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/AndPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/AndPoshiElement.java
@@ -97,11 +97,7 @@ public class AndPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof AndPoshiElement ||
-			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement ||
-			parentPoshiElement instanceof OrPoshiElement)) {
-
+		if (!isConditionValidInParent(parentPoshiElement)) {
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
@@ -139,6 +139,7 @@ public abstract class BasePoshiElement
 		return "\t";
 	}
 
+
 	protected String getParentheticalContent(String readableSyntax) {
 		return RegexUtil.getGroup(readableSyntax, ".*?\\((.*)\\)", 1);
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
@@ -197,6 +197,21 @@ public abstract class BasePoshiElement
 		return false;
 	}
 
+	protected boolean isConditionValidInParent(
+		PoshiElement parentPoshiElement) {
+
+		if (parentPoshiElement instanceof AndPoshiElement ||
+			parentPoshiElement instanceof ElseIfPoshiElement ||
+			parentPoshiElement instanceof IfPoshiElement ||
+			parentPoshiElement instanceof NotPoshiElement ||
+			parentPoshiElement instanceof OrPoshiElement) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	protected boolean isValidReadableBlock(String readableSyntax) {
 		readableSyntax = readableSyntax.trim();
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
@@ -189,14 +189,6 @@ public abstract class BasePoshiElement
 		return false;
 	}
 
-	protected boolean isElementType(String name, Element element) {
-		if (name.equals(element.getName())) {
-			return true;
-		}
-
-		return false;
-	}
-
 	protected boolean isConditionValidInParent(
 		PoshiElement parentPoshiElement) {
 
@@ -206,6 +198,14 @@ public abstract class BasePoshiElement
 			parentPoshiElement instanceof NotPoshiElement ||
 			parentPoshiElement instanceof OrPoshiElement) {
 
+			return true;
+		}
+
+		return false;
+	}
+
+	protected boolean isElementType(String name, Element element) {
+		if (name.equals(element.getName())) {
 			return true;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/BasePoshiElement.java
@@ -139,7 +139,6 @@ public abstract class BasePoshiElement
 		return "\t";
 	}
 
-
 	protected String getParentheticalContent(String readableSyntax) {
 		return RegexUtil.getGroup(readableSyntax, ".*?\\((.*)\\)", 1);
 	}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/CommandPoshiElement.java
@@ -203,7 +203,7 @@ public class CommandPoshiElement extends BasePoshiElement {
 				continue;
 			}
 
-			if (!line.startsWith("else {")) {
+			if (!line.startsWith("else {") && !line.startsWith("else if")) {
 				String readableBlock = sb.toString();
 
 				readableBlock = readableBlock.trim();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
@@ -79,7 +79,8 @@ public class ConditionPoshiElement extends ExecutePoshiElement {
 		}
 
 		if (readableSyntax.contains(" && ") ||
-			readableSyntax.contains(" || ") || readableSyntax.startsWith("!")) {
+			readableSyntax.contains(" || ") || readableSyntax.startsWith("!") ||
+			readableSyntax.startsWith("else if (")) {
 
 			return false;
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ConditionPoshiElement.java
@@ -74,11 +74,7 @@ public class ConditionPoshiElement extends ExecutePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof AndPoshiElement ||
-			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement ||
-			parentPoshiElement instanceof OrPoshiElement)) {
-
+		if (!isConditionValidInParent(parentPoshiElement)) {
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EchoPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EchoPoshiElement.java
@@ -66,6 +66,15 @@ public class EchoPoshiElement extends BasePoshiElement {
 		super(_ELEMENT_NAME, readableSyntax);
 	}
 
+	protected EchoPoshiElement(String name, Element element) {
+		super(name, element);
+	}
+
+	protected EchoPoshiElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
+	}
+
+
 	@Override
 	protected String createReadableBlock(String content) {
 		StringBuilder sb = new StringBuilder();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EchoPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EchoPoshiElement.java
@@ -74,7 +74,6 @@ public class EchoPoshiElement extends BasePoshiElement {
 		super(name, readableSyntax);
 	}
 
-
 	@Override
 	protected String createReadableBlock(String content) {
 		StringBuilder sb = new StringBuilder();

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseIfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseIfPoshiElement.java
@@ -73,19 +73,11 @@ public class ElseIfPoshiElement extends IfPoshiElement {
 	}
 
 	protected ElseIfPoshiElement(Element element) {
-		super("elseif", element);
+		super(_ELEMENT_NAME, element);
 	}
 
 	protected ElseIfPoshiElement(String readableSyntax) {
-		super("elseif", readableSyntax);
-	}
-
-	protected ElseIfPoshiElement(String name, Element element) {
-		super(name, element);
-	}
-
-	protected ElseIfPoshiElement(String name, String readableSyntax) {
-		super(name, readableSyntax);
+		super(_ELEMENT_NAME, readableSyntax);
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseIfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseIfPoshiElement.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class ElseIfPoshiElement extends IfPoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new ElseIfPoshiElement(element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (_isElementType(readableSyntax)) {
+			return new ElseIfPoshiElement(readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith("else if (")) {
+				add(
+					PoshiElementFactory.newPoshiElement(
+						this, getParentheticalContent(readableBlock)));
+
+				continue;
+			}
+
+			add(PoshiElementFactory.newPoshiElement(this, readableBlock));
+		}
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		PoshiElement thenElement = (PoshiElement)element("then");
+
+		String thenReadableSyntax = thenElement.toReadableSyntax();
+
+		sb.append(createReadableBlock(thenReadableSyntax));
+
+		return sb.toString();
+	}
+
+	protected ElseIfPoshiElement() {
+	}
+
+	protected ElseIfPoshiElement(Element element) {
+		super("elseif", element);
+	}
+
+	protected ElseIfPoshiElement(String readableSyntax) {
+		super("elseif", readableSyntax);
+	}
+
+	protected ElseIfPoshiElement(String name, Element element) {
+		super(name, element);
+	}
+
+	protected ElseIfPoshiElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
+	}
+
+	@Override
+	protected String getReadableName() {
+		return "else if";
+	}
+
+	private boolean _isElementType(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (!isBalancedReadableSyntax(readableSyntax)) {
+			return false;
+		}
+
+		if (!readableSyntax.startsWith("else if (")) {
+			return false;
+		}
+
+		if (!readableSyntax.endsWith("}")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final String _ELEMENT_NAME = "elseif";
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseIfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ElseIfPoshiElement.java
@@ -112,4 +112,5 @@ public class ElseIfPoshiElement extends IfPoshiElement {
 	}
 
 	private static final String _ELEMENT_NAME = "elseif";
+
 }

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
@@ -90,11 +90,7 @@ public class EqualsPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof AndPoshiElement ||
-			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement ||
-			parentPoshiElement instanceof OrPoshiElement)) {
-
+		if (!isConditionValidInParent(parentPoshiElement)) {
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/EqualsPoshiElement.java
@@ -96,7 +96,8 @@ public class EqualsPoshiElement extends BasePoshiElement {
 
 		if (readableSyntax.contains(" && ") ||
 			readableSyntax.contains(" || ") ||
-			readableSyntax.startsWith("!(")) {
+			readableSyntax.startsWith("!(") ||
+			readableSyntax.startsWith("else if (")) {
 
 			return false;
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -258,6 +258,7 @@ public class ExecutePoshiElement extends BasePoshiElement {
 		}
 
 		if (readableSyntax.startsWith("echo(") ||
+			readableSyntax.startsWith("fail(") ||
 			readableSyntax.startsWith("property ")) {
 
 			return false;

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/ExecutePoshiElement.java
@@ -259,7 +259,8 @@ public class ExecutePoshiElement extends BasePoshiElement {
 
 		if (readableSyntax.startsWith("echo(") ||
 			readableSyntax.startsWith("fail(") ||
-			readableSyntax.startsWith("property ")) {
+			readableSyntax.startsWith("property ") ||
+			readableSyntax.startsWith("takeScreenshot")) {
 
 			return false;
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/FailPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/FailPoshiElement.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class FailPoshiElement extends BasePoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new FailPoshiElement(element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (_isElementType(readableSyntax)) {
+			return new FailPoshiElement(readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		String content = getQuotedContent(readableSyntax);
+
+		addAttribute("message", content);
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		String message = attributeValue("message");
+
+		return createReadableBlock(message);
+	}
+
+	protected FailPoshiElement() {
+	}
+
+	protected FailPoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected FailPoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	@Override
+	protected String createReadableBlock(String content) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n\n");
+		sb.append(getPad());
+		sb.append(getBlockName());
+		sb.append("(\"");
+		sb.append(content.trim());
+		sb.append("\");");
+
+		return sb.toString();
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "fail";
+	}
+
+	private boolean _isElementType(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (!isBalancedReadableSyntax(readableSyntax)) {
+			return false;
+		}
+
+		if (!readableSyntax.endsWith(");")) {
+			return false;
+		}
+
+		if (!readableSyntax.startsWith("fail(")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final String _ELEMENT_NAME = "fail";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/FailPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/FailPoshiElement.java
@@ -19,7 +19,7 @@ import org.dom4j.Element;
 /**
  * @author Kenji Heigel
  */
-public class FailPoshiElement extends BasePoshiElement {
+public class FailPoshiElement extends EchoPoshiElement {
 
 	@Override
 	public PoshiElement clone(Element element) {
@@ -41,20 +41,6 @@ public class FailPoshiElement extends BasePoshiElement {
 		return null;
 	}
 
-	@Override
-	public void parseReadableSyntax(String readableSyntax) {
-		String content = getQuotedContent(readableSyntax);
-
-		addAttribute("message", content);
-	}
-
-	@Override
-	public String toReadableSyntax() {
-		String message = attributeValue("message");
-
-		return createReadableBlock(message);
-	}
-
 	protected FailPoshiElement() {
 	}
 
@@ -64,20 +50,6 @@ public class FailPoshiElement extends BasePoshiElement {
 
 	protected FailPoshiElement(String readableSyntax) {
 		super(_ELEMENT_NAME, readableSyntax);
-	}
-
-	@Override
-	protected String createReadableBlock(String content) {
-		StringBuilder sb = new StringBuilder();
-
-		sb.append("\n\n");
-		sb.append(getPad());
-		sb.append(getBlockName());
-		sb.append("(\"");
-		sb.append(content.trim());
-		sb.append("\");");
-
-		return sb.toString();
 	}
 
 	@Override

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -71,7 +71,9 @@ public class IfPoshiElement extends BasePoshiElement {
 
 		sb.append(createReadableBlock(thenReadableSyntax));
 
-		for (PoshiElement elseifElement : (List<PoshiElement>) elements("elseif")) {
+		for (PoshiElement elseifElement :
+				(List<PoshiElement>)elements("elseif")) {
+
 			sb.append(elseifElement.toReadableSyntax());
 		}
 
@@ -125,10 +127,6 @@ public class IfPoshiElement extends BasePoshiElement {
 		return sb.toString();
 	}
 
-	protected String getReadableName() {
-		return getName();
-	}
-
 	protected List<String> getReadableBlocks(String readableSyntax) {
 		StringBuilder sb = new StringBuilder();
 
@@ -139,8 +137,8 @@ public class IfPoshiElement extends BasePoshiElement {
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
-				(readableBlock.length() == 0)) {
+			if (line.startsWith(getReadableName() + " (") &&
+				line.endsWith("{") && (readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);
 
@@ -164,6 +162,10 @@ public class IfPoshiElement extends BasePoshiElement {
 		}
 
 		return readableBlocks;
+	}
+
+	protected String getReadableName() {
+		return getName();
 	}
 
 	private boolean _isElementType(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -71,6 +71,10 @@ public class IfPoshiElement extends BasePoshiElement {
 
 		sb.append(createReadableBlock(thenReadableSyntax));
 
+		for (PoshiElement elseifElement : (List<PoshiElement>) elements("elseif")) {
+			sb.append(elseifElement.toReadableSyntax());
+		}
+
 		if (element("else") != null) {
 			PoshiElement elseElement = (PoshiElement)element("else");
 
@@ -103,7 +107,7 @@ public class IfPoshiElement extends BasePoshiElement {
 	protected String getBlockName() {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(getName());
+		sb.append(getReadableName());
 
 		for (String conditionName : _conditionNames) {
 			if (element(conditionName) != null) {
@@ -121,6 +125,10 @@ public class IfPoshiElement extends BasePoshiElement {
 		return sb.toString();
 	}
 
+	protected String getReadableName() {
+		return getName();
+	}
+
 	protected List<String> getReadableBlocks(String readableSyntax) {
 		StringBuilder sb = new StringBuilder();
 
@@ -131,7 +139,7 @@ public class IfPoshiElement extends BasePoshiElement {
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getName() + " (") && line.endsWith("{") &&
+			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
 				(readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IfPoshiElement.java
@@ -71,10 +71,8 @@ public class IfPoshiElement extends BasePoshiElement {
 
 		sb.append(createReadableBlock(thenReadableSyntax));
 
-		for (PoshiElement elseifElement :
-				(List<PoshiElement>)elements("elseif")) {
-
-			sb.append(elseifElement.toReadableSyntax());
+		for (PoshiElement elseIfElement : toPoshiElements(elements("elseif"))) {
+			sb.append(elseIfElement.toReadableSyntax());
 		}
 
 		if (element("else") != null) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IsSetPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IsSetPoshiElement.java
@@ -76,7 +76,9 @@ public class IsSetPoshiElement extends BasePoshiElement {
 			return false;
 		}
 
-		if (readableSyntax.startsWith("!")) {
+		if (readableSyntax.startsWith("!") ||
+			readableSyntax.startsWith("else if (")) {
+
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IsSetPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/IsSetPoshiElement.java
@@ -72,11 +72,7 @@ public class IsSetPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof AndPoshiElement ||
-			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement ||
-			parentPoshiElement instanceof OrPoshiElement)) {
-
+		if (!isConditionValidInParent(parentPoshiElement)) {
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
@@ -88,6 +88,10 @@ public class NotPoshiElement extends BasePoshiElement {
 
 		readableSyntax = readableSyntax.trim();
 
+		if (readableSyntax.startsWith("else if (")) {
+			return false;
+		}
+
 		if (readableSyntax.startsWith("!")) {
 			return true;
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/NotPoshiElement.java
@@ -82,10 +82,7 @@ public class NotPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof AndPoshiElement ||
-			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof OrPoshiElement)) {
-
+		if (!isConditionValidInParent(parentPoshiElement)) {
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OffPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OffPoshiElement.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kenji Heigel
+ */
+public class OffPoshiElement extends OnPoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new OffPoshiElement(element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (isElementType(readableSyntax)) {
+			return new OffPoshiElement(readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "off";
+	}
+
+	protected OffPoshiElement() {
+	}
+
+	protected OffPoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected OffPoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	private static final String _ELEMENT_NAME = "off";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OffPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OffPoshiElement.java
@@ -16,9 +16,6 @@ package com.liferay.poshi.runner.elements;
 
 import org.dom4j.Element;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * @author Kenji Heigel
  */
@@ -44,11 +41,6 @@ public class OffPoshiElement extends OnPoshiElement {
 		return null;
 	}
 
-	@Override
-	protected String getBlockName() {
-		return "off";
-	}
-
 	protected OffPoshiElement() {
 	}
 
@@ -58,6 +50,11 @@ public class OffPoshiElement extends OnPoshiElement {
 
 	protected OffPoshiElement(String readableSyntax) {
 		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "off";
 	}
 
 	private static final String _ELEMENT_NAME = "off";

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
@@ -59,36 +59,11 @@ public class OnPoshiElement extends BasePoshiElement {
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("\n");
-
-		sb.append(getPad());
-		sb.append(getBlockName());
-
-		sb.append(" {");
-
-		List<PoshiElement> poshiElements = toPoshiElements(elements());
-
-		for (int i = 0; i < poshiElements.size(); i++) {
-			PoshiElement poshiElement = poshiElements.get(i);
-
-			String readableSyntax = poshiElement.toReadableSyntax();
-
-			if (i == 0) {
-				if (readableSyntax.startsWith("\n\n")) {
-					readableSyntax = readableSyntax.replaceFirst("\n\n", "\n");
-				}
-			}
-
-			readableSyntax = readableSyntax.replaceAll("\n", "\n" + getPad());
-
-			sb.append(readableSyntax.replaceAll("\n\t\n", "\n\n"));
+		for (PoshiElement poshiElement : toPoshiElements(elements())) {
+			sb.append(poshiElement.toReadableSyntax());
 		}
 
-		sb.append("\n");
-		sb.append(getPad());
-		sb.append("}");
-
-		return sb.toString();
+		return createReadableBlock(sb.toString());
 	}
 
 	protected OnPoshiElement() {
@@ -105,11 +80,6 @@ public class OnPoshiElement extends BasePoshiElement {
 	@Override
 	protected String getBlockName() {
 		return "on";
-	}
-
-	@Override
-	protected String getPad() {
-		return super.getPad() + "\t";
 	}
 
 	protected List<String> getReadableBlocks(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kenji Heigel
+ */
+public class OnPoshiElement extends BasePoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new OnPoshiElement(_ELEMENT_NAME, element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (isElementType(readableSyntax)) {
+			return new OnPoshiElement(_ELEMENT_NAME, readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith(getBlockName() + " {")) {
+				continue;
+			}
+
+			add(PoshiElementFactory.newPoshiElement(this, readableBlock));
+		}
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n");
+
+		sb.append(getPad());
+		sb.append(getBlockName());
+
+		sb.append(" {");
+
+		List<PoshiElement> poshiElements = toPoshiElements(elements());
+
+		for (int i = 0; i < poshiElements.size(); i++) {
+			PoshiElement poshiElement = poshiElements.get(i);
+
+			String readableSyntax = poshiElement.toReadableSyntax();
+
+			if (i == 0) {
+				if (readableSyntax.startsWith("\n\n")) {
+					readableSyntax = readableSyntax.replaceFirst("\n\n", "\n");
+				}
+			}
+
+			readableSyntax = readableSyntax.replaceAll("\n", "\n" + getPad());
+
+			sb.append(readableSyntax.replaceAll("\n\t\n", "\n\n"));
+		}
+
+		sb.append("\n");
+		sb.append(getPad());
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected String getReadableName() {
+		return getName();
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			String readableBlock = sb.toString();
+
+			readableBlock = readableBlock.trim();
+
+			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
+					(readableBlock.length() == 0)) {
+
+				readableBlocks.add(line);
+
+				continue;
+			}
+
+			if (line.endsWith("{") && readableBlocks.isEmpty()) {
+				continue;
+			}
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+
+			sb.append(line);
+			sb.append("\n");
+		}
+
+		return readableBlocks;
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "on";
+	}
+
+	@Override
+	protected String getPad() {
+		return super.getPad() + "\t";
+	}
+
+	protected OnPoshiElement() {
+	}
+
+	protected OnPoshiElement(String name, Element element) {
+		super(name, element);
+	}
+
+	protected OnPoshiElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
+	}
+
+	protected boolean isElementType(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (!isBalancedReadableSyntax(readableSyntax)) {
+			return false;
+		}
+
+		if (!readableSyntax.startsWith(getBlockName() + " {")) {
+			return false;
+		}
+
+		if (!readableSyntax.endsWith("}")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final String _ELEMENT_NAME = "on";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OnPoshiElement.java
@@ -14,10 +14,10 @@
 
 package com.liferay.poshi.runner.elements;
 
-import org.dom4j.Element;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.dom4j.Element;
 
 /**
  * @author Kenji Heigel
@@ -91,8 +91,25 @@ public class OnPoshiElement extends BasePoshiElement {
 		return sb.toString();
 	}
 
-	protected String getReadableName() {
-		return getName();
+	protected OnPoshiElement() {
+	}
+
+	protected OnPoshiElement(String name, Element element) {
+		super(name, element);
+	}
+
+	protected OnPoshiElement(String name, String readableSyntax) {
+		super(name, readableSyntax);
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "on";
+	}
+
+	@Override
+	protected String getPad() {
+		return super.getPad() + "\t";
 	}
 
 	protected List<String> getReadableBlocks(String readableSyntax) {
@@ -105,8 +122,8 @@ public class OnPoshiElement extends BasePoshiElement {
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
-					(readableBlock.length() == 0)) {
+			if (line.startsWith(getReadableName() + " (") &&
+				line.endsWith("{") && (readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);
 
@@ -130,25 +147,8 @@ public class OnPoshiElement extends BasePoshiElement {
 		return readableBlocks;
 	}
 
-	@Override
-	protected String getBlockName() {
-		return "on";
-	}
-
-	@Override
-	protected String getPad() {
-		return super.getPad() + "\t";
-	}
-
-	protected OnPoshiElement() {
-	}
-
-	protected OnPoshiElement(String name, Element element) {
-		super(name, element);
-	}
-
-	protected OnPoshiElement(String name, String readableSyntax) {
-		super(name, readableSyntax);
+	protected String getReadableName() {
+		return getName();
 	}
 
 	protected boolean isElementType(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OrPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OrPoshiElement.java
@@ -97,11 +97,7 @@ public class OrPoshiElement extends BasePoshiElement {
 	private boolean _isElementType(
 		PoshiElement parentPoshiElement, String readableSyntax) {
 
-		if (!(parentPoshiElement instanceof AndPoshiElement ||
-			parentPoshiElement instanceof IfPoshiElement ||
-			parentPoshiElement instanceof NotPoshiElement ||
-			parentPoshiElement instanceof OrPoshiElement)) {
-
+		if (!isConditionValidInParent(parentPoshiElement)) {
 			return false;
 		}
 

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OrPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/OrPoshiElement.java
@@ -101,6 +101,12 @@ public class OrPoshiElement extends BasePoshiElement {
 			return false;
 		}
 
+		if (readableSyntax.contains(" && ") ||
+			readableSyntax.startsWith("else if (")) {
+
+			return false;
+		}
+
 		if (readableSyntax.contains(" || ")) {
 			return true;
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/PoshiElementFactory.java
@@ -24,6 +24,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.dom4j.Document;
@@ -107,7 +109,11 @@ public class PoshiElementFactory {
 
 			File dir = basePoshiElementClassFile.getParentFile();
 
-			for (File file : dir.listFiles()) {
+			List<File> dirFiles = Arrays.asList(dir.listFiles());
+
+			Collections.sort(dirFiles);
+
+			for (File file : dirFiles) {
 				String fileName = file.getName();
 
 				if (fileName.endsWith(

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TakeScreenshotPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TakeScreenshotPoshiElement.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+/**
+ * @author Kenji Heigel
+ */
+public class TakeScreenshotPoshiElement extends BasePoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new TakeScreenshotPoshiElement(element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (_isElementType(readableSyntax)) {
+			return new TakeScreenshotPoshiElement(readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		String readableSyntax = super.toReadableSyntax();
+
+		return createReadableBlock(readableSyntax);
+	}
+
+	protected TakeScreenshotPoshiElement() {
+	}
+
+	protected TakeScreenshotPoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected TakeScreenshotPoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	@Override
+	protected String createReadableBlock(String content) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n\n");
+		sb.append(getPad());
+		sb.append(getBlockName());
+		sb.append("();");
+
+		return sb.toString();
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "takeScreenshot";
+	}
+
+	private boolean _isElementType(String readableSyntax) {
+		if (readableSyntax.startsWith(getBlockName())) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String _ELEMENT_NAME = "take-screenshot";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
@@ -14,10 +14,10 @@
 
 package com.liferay.poshi.runner.elements;
 
-import org.dom4j.Element;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.dom4j.Element;
 
 /**
  * @author Kenji Heigel
@@ -49,7 +49,7 @@ public class TaskPoshiElement extends BasePoshiElement {
 		for (String readableBlock : getReadableBlocks(readableSyntax)) {
 			if (readableBlock.startsWith("task (")) {
 				String parentheticalContent = getParentheticalContent(
-						readableBlock);
+					readableBlock);
 
 				String summary = getQuotedContent(parentheticalContent);
 
@@ -100,8 +100,20 @@ public class TaskPoshiElement extends BasePoshiElement {
 		return sb.toString();
 	}
 
-	protected String getReadableName() {
-		return getName();
+	protected TaskPoshiElement() {
+	}
+
+	protected TaskPoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected TaskPoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "task";
 	}
 
 	protected List<String> getReadableBlocks(String readableSyntax) {
@@ -114,8 +126,8 @@ public class TaskPoshiElement extends BasePoshiElement {
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
-					(readableBlock.length() == 0)) {
+			if (line.startsWith(getReadableName() + " (") &&
+				line.endsWith("{") && (readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);
 
@@ -139,20 +151,8 @@ public class TaskPoshiElement extends BasePoshiElement {
 		return readableBlocks;
 	}
 
-	@Override
-	protected String getBlockName() {
-		return "task";
-	}
-
-	protected TaskPoshiElement() {
-	}
-
-	protected TaskPoshiElement(Element element) {
-		super(_ELEMENT_NAME, element);
-	}
-
-	protected TaskPoshiElement(String readableSyntax) {
-		super(_ELEMENT_NAME, readableSyntax);
+	protected String getReadableName() {
+		return getName();
 	}
 
 	private boolean _isElementType(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
@@ -66,36 +66,17 @@ public class TaskPoshiElement extends BasePoshiElement {
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("\n\n");
+		sb.append("\n");
 
-		sb.append(getPad());
-		sb.append(getBlockName());
+		StringBuilder content = new StringBuilder();
 
-		sb.append(" (\"");
-		sb.append(attributeValue("summary"));
-		sb.append("\") {");
-
-		List<PoshiElement> poshiElements = toPoshiElements(elements());
-
-		for (int i = 0; i < poshiElements.size(); i++) {
-			PoshiElement poshiElement = poshiElements.get(i);
-
-			String readableSyntax = poshiElement.toReadableSyntax();
-
-			if (i == 0) {
-				if (readableSyntax.startsWith("\n\n")) {
-					readableSyntax = readableSyntax.replaceFirst("\n\n", "\n");
-				}
-			}
-
-			readableSyntax = readableSyntax.replaceAll("\n", "\n" + getPad());
-
-			sb.append(readableSyntax.replaceAll("\n\t\n", "\n\n"));
+		for (PoshiElement poshiElement : toPoshiElements(elements())) {
+			content.append(poshiElement.toReadableSyntax());
 		}
 
-		sb.append("\n");
-		sb.append(getPad());
-		sb.append("}");
+		String readableBlock = createReadableBlock(content.toString());
+
+		sb.append(readableBlock);
 
 		return sb.toString();
 	}
@@ -113,7 +94,13 @@ public class TaskPoshiElement extends BasePoshiElement {
 
 	@Override
 	protected String getBlockName() {
-		return "task";
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("task (\"");
+		sb.append(attributeValue("summary"));
+		sb.append("\")");
+
+		return sb.toString();
 	}
 
 	protected List<String> getReadableBlocks(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TaskPoshiElement.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kenji Heigel
+ */
+public class TaskPoshiElement extends BasePoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new TaskPoshiElement(element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (_isElementType(readableSyntax)) {
+			return new TaskPoshiElement(readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith("task (")) {
+				String parentheticalContent = getParentheticalContent(
+						readableBlock);
+
+				String summary = getQuotedContent(parentheticalContent);
+
+				addAttribute("summary", summary);
+
+				continue;
+			}
+
+			add(PoshiElementFactory.newPoshiElement(this, readableBlock));
+		}
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n\n");
+
+		sb.append(getPad());
+		sb.append(getBlockName());
+
+		sb.append(" (\"");
+		sb.append(attributeValue("summary"));
+		sb.append("\") {");
+
+		List<PoshiElement> poshiElements = toPoshiElements(elements());
+
+		for (int i = 0; i < poshiElements.size(); i++) {
+			PoshiElement poshiElement = poshiElements.get(i);
+
+			String readableSyntax = poshiElement.toReadableSyntax();
+
+			if (i == 0) {
+				if (readableSyntax.startsWith("\n\n")) {
+					readableSyntax = readableSyntax.replaceFirst("\n\n", "\n");
+				}
+			}
+
+			readableSyntax = readableSyntax.replaceAll("\n", "\n" + getPad());
+
+			sb.append(readableSyntax.replaceAll("\n\t\n", "\n\n"));
+		}
+
+		sb.append("\n");
+		sb.append(getPad());
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected String getReadableName() {
+		return getName();
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			String readableBlock = sb.toString();
+
+			readableBlock = readableBlock.trim();
+
+			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
+					(readableBlock.length() == 0)) {
+
+				readableBlocks.add(line);
+
+				continue;
+			}
+
+			if (line.endsWith("{") && readableBlocks.isEmpty()) {
+				continue;
+			}
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+
+			sb.append(line);
+			sb.append("\n");
+		}
+
+		return readableBlocks;
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "task";
+	}
+
+	protected TaskPoshiElement() {
+	}
+
+	protected TaskPoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected TaskPoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	private boolean _isElementType(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (!isBalancedReadableSyntax(readableSyntax)) {
+			return false;
+		}
+
+		if (!readableSyntax.startsWith("task (")) {
+			return false;
+		}
+
+		if (!readableSyntax.endsWith("}")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final String _ELEMENT_NAME = "task";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
@@ -14,10 +14,10 @@
 
 package com.liferay.poshi.runner.elements;
 
-import org.dom4j.Element;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.dom4j.Element;
 
 /**
  * @author Kenji Heigel
@@ -49,7 +49,7 @@ public class TogglePoshiElement extends BasePoshiElement {
 		for (String readableBlock : getReadableBlocks(readableSyntax)) {
 			if (readableBlock.startsWith("toggle (")) {
 				String parentheticalContent = getParentheticalContent(
-						readableBlock);
+					readableBlock);
 
 				String summary = getQuotedContent(parentheticalContent);
 
@@ -90,8 +90,20 @@ public class TogglePoshiElement extends BasePoshiElement {
 		return sb.toString();
 	}
 
-	protected String getReadableName() {
-		return getName();
+	protected TogglePoshiElement() {
+	}
+
+	protected TogglePoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected TogglePoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "toggle";
 	}
 
 	protected List<String> getReadableBlocks(String readableSyntax) {
@@ -104,8 +116,8 @@ public class TogglePoshiElement extends BasePoshiElement {
 
 			readableBlock = readableBlock.trim();
 
-			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
-					(readableBlock.length() == 0)) {
+			if (line.startsWith(getReadableName() + " (") &&
+				line.endsWith("{") && (readableBlock.length() == 0)) {
 
 				readableBlocks.add(line);
 
@@ -129,20 +141,8 @@ public class TogglePoshiElement extends BasePoshiElement {
 		return readableBlocks;
 	}
 
-	@Override
-	protected String getBlockName() {
-		return "toggle";
-	}
-
-	protected TogglePoshiElement() {
-	}
-
-	protected TogglePoshiElement(Element element) {
-		super(_ELEMENT_NAME, element);
-	}
-
-	protected TogglePoshiElement(String readableSyntax) {
-		super(_ELEMENT_NAME, readableSyntax);
+	protected String getReadableName() {
+		return getName();
 	}
 
 	private boolean _isElementType(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
@@ -17,6 +17,7 @@ package com.liferay.poshi.runner.elements;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.liferay.poshi.runner.util.Dom4JUtil;
 import org.dom4j.Element;
 
 /**
@@ -66,26 +67,17 @@ public class TogglePoshiElement extends BasePoshiElement {
 	public String toReadableSyntax() {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("\n\n");
-
-		sb.append(getPad());
-		sb.append(getBlockName());
-
-		sb.append(" (\"");
-		sb.append(attributeValue("name"));
-		sb.append("\") {");
-
-		PoshiElement onPoshiElement = (PoshiElement)element("on");
-
-		sb.append(onPoshiElement.toReadableSyntax());
-
-		PoshiElement offPoshiElement = (PoshiElement)element("off");
-
-		sb.append(offPoshiElement.toReadableSyntax());
-
 		sb.append("\n");
-		sb.append(getPad());
-		sb.append("}");
+
+		StringBuilder content = new StringBuilder();
+
+		for (PoshiElement poshiElement : toPoshiElements(elements())) {
+			content.append(poshiElement.toReadableSyntax());
+		}
+
+		String readableBlock = createReadableBlock(content.toString());
+
+		sb.append(readableBlock);
 
 		return sb.toString();
 	}
@@ -103,7 +95,13 @@ public class TogglePoshiElement extends BasePoshiElement {
 
 	@Override
 	protected String getBlockName() {
-		return "toggle";
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("toggle (\"");
+		sb.append(attributeValue("name"));
+		sb.append("\")");
+
+		return sb.toString();
 	}
 
 	protected List<String> getReadableBlocks(String readableSyntax) {

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
@@ -17,7 +17,6 @@ package com.liferay.poshi.runner.elements;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.liferay.poshi.runner.util.Dom4JUtil;
 import org.dom4j.Element;
 
 /**

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/elements/TogglePoshiElement.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.poshi.runner.elements;
+
+import org.dom4j.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kenji Heigel
+ */
+public class TogglePoshiElement extends BasePoshiElement {
+
+	@Override
+	public PoshiElement clone(Element element) {
+		if (isElementType(_ELEMENT_NAME, element)) {
+			return new TogglePoshiElement(element);
+		}
+
+		return null;
+	}
+
+	@Override
+	public PoshiElement clone(
+		PoshiElement parentPoshiElement, String readableSyntax) {
+
+		if (_isElementType(readableSyntax)) {
+			return new TogglePoshiElement(readableSyntax);
+		}
+
+		return null;
+	}
+
+	@Override
+	public void parseReadableSyntax(String readableSyntax) {
+		for (String readableBlock : getReadableBlocks(readableSyntax)) {
+			if (readableBlock.startsWith("toggle (")) {
+				String parentheticalContent = getParentheticalContent(
+						readableBlock);
+
+				String summary = getQuotedContent(parentheticalContent);
+
+				addAttribute("name", summary);
+
+				continue;
+			}
+
+			add(PoshiElementFactory.newPoshiElement(this, readableBlock));
+		}
+	}
+
+	@Override
+	public String toReadableSyntax() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n\n");
+
+		sb.append(getPad());
+		sb.append(getBlockName());
+
+		sb.append(" (\"");
+		sb.append(attributeValue("name"));
+		sb.append("\") {");
+
+		PoshiElement onPoshiElement = (PoshiElement)element("on");
+
+		sb.append(onPoshiElement.toReadableSyntax());
+
+		PoshiElement offPoshiElement = (PoshiElement)element("off");
+
+		sb.append(offPoshiElement.toReadableSyntax());
+
+		sb.append("\n");
+		sb.append(getPad());
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected String getReadableName() {
+		return getName();
+	}
+
+	protected List<String> getReadableBlocks(String readableSyntax) {
+		StringBuilder sb = new StringBuilder();
+
+		List<String> readableBlocks = new ArrayList<>();
+
+		for (String line : readableSyntax.split("\n")) {
+			String readableBlock = sb.toString();
+
+			readableBlock = readableBlock.trim();
+
+			if (line.startsWith(getReadableName() + " (") && line.endsWith("{") &&
+					(readableBlock.length() == 0)) {
+
+				readableBlocks.add(line);
+
+				continue;
+			}
+
+			if (line.endsWith("{") && readableBlocks.isEmpty()) {
+				continue;
+			}
+
+			if (isValidReadableBlock(readableBlock)) {
+				readableBlocks.add(readableBlock);
+
+				sb.setLength(0);
+			}
+
+			sb.append(line);
+			sb.append("\n");
+		}
+
+		return readableBlocks;
+	}
+
+	@Override
+	protected String getBlockName() {
+		return "toggle";
+	}
+
+	protected TogglePoshiElement() {
+	}
+
+	protected TogglePoshiElement(Element element) {
+		super(_ELEMENT_NAME, element);
+	}
+
+	protected TogglePoshiElement(String readableSyntax) {
+		super(_ELEMENT_NAME, readableSyntax);
+	}
+
+	private boolean _isElementType(String readableSyntax) {
+		readableSyntax = readableSyntax.trim();
+
+		if (!isBalancedReadableSyntax(readableSyntax)) {
+			return false;
+		}
+
+		if (!readableSyntax.startsWith("toggle (")) {
+			return false;
+		}
+
+		if (!readableSyntax.endsWith("}")) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private static final String _ELEMENT_NAME = "toggle";
+
+}

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -43,6 +43,8 @@
 					<execute macro="Alert#viewErrorMessage">
 						<var name="errorMessage" value="A configuration with this ID already exists. Please enter a unique ID." />
 					</execute>
+
+					<echo message="Please enter a unique ID." />
 				</then>
 				<else>
 					<execute macro="Alert#viewSuccessMessage" />
@@ -199,5 +201,42 @@ document.getElementById('demo').innerHTML = 'FAIL';
 		<execute function="Type" value1="Welcome" />
 
 		<execute function="AssertElementPresent#assertElementPresent" locator1="Home#PAGE" value1="Welcome" />
+	</command>
+
+	<command name="AddBlogsEntries" priority="4">
+		<description message="Ensure that a user can add multiple Blogs Entries." />
+
+		<property name="testray.component.names" value="Blogs" />
+		<property name="testray.main.component.name" value="Blogs" />
+
+		<task summary="Add a blogs entry called 'Blogs Entry1 Title' with content 'Blogs Entry1 Content'">
+			<execute macro="Navigator#openURL" />
+
+			<execute macro="ProductMenu#gotoPortlet">
+				<var name="category" value="Content" />
+				<var name="panel" value="Site Administration" />
+				<var name="portlet" value="Blogs" />
+			</execute>
+
+			<execute macro="Blogs#addEntry">
+				<var name="entryContent" value="Blogs Entry1 Content" />
+				<var name="entryTitle" value="Blogs Entry1 Title" />
+			</execute>
+		</task>
+
+		<task summary="Add a blogs entry called 'Blogs Entry2 Title' with content 'Blogs Entry2 Content'">
+			<execute macro="Navigator#openURL" />
+
+			<execute macro="ProductMenu#gotoPortlet">
+				<var name="category" value="Content" />
+				<var name="panel" value="Site Administration" />
+				<var name="portlet" value="Blogs" />
+			</execute>
+
+			<execute macro="Blogs#addEntry">
+				<var name="entryContent" value="Blogs Entry2 Content" />
+				<var name="entryTitle" value="Blogs Entry2 Title" />
+			</execute>
+		</task>
 	</command>
 </definition>

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -149,6 +149,19 @@
 			</then>
 		</if>
 
+		<if>
+			<condition function="IsElementPresent" locator1="Blogs#ADD_BLOGS_ENTRY" />
+			<then>
+				<execute macro="Alert#viewSuccessMessage" />
+			</then>
+			<elseif>
+				<equals arg1="${check}" arg2="true" />
+				<then>
+					<execute macro="Alert#viewErrorMessage" />
+				</then>
+			</elseif>
+		</if>
+
 		<execute macro="TestCase#getSiteName">
 			<return from="siteName" name="siteName" />
 			<var name="siteName" value="${siteName}" />

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -239,4 +239,18 @@ document.getElementById('demo').innerHTML = 'FAIL';
 			</execute>
 		</task>
 	</command>
+
+	<command name="GotoLinkToPageChildPages">
+		<var name="key_pageName" value="${parentPage}" />
+
+		<toggle name="LPS-68869">
+			<on>
+				<execute function="Click" locator1="DDLEditRecord#LINK_TO_PAGE_PAGE_TOGGLER" />
+			</on>
+
+			<off>
+				<execute function="Click" locator1="DDLEditRecord#LINK_TO_PAGE_PAGE_CARET" />
+			</off>
+		</toggle>
+	</command>
 </definition>

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -162,6 +162,8 @@ document.getElementById('demo').innerHTML = 'FAIL';
 
 		<execute macro="Smoke#viewWelcomePage" />
 
+		<take-screenshot />
+
 		<while>
 			<condition function="IsElementPresent" locator1="AssetCategorization#TAGS_REMOVE_ICON_GENERIC" />
 			<then>

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/PoshiSyntax.testcase
@@ -118,6 +118,16 @@
 		</if>
 
 		<if>
+			<condition function="IsElementPresent" locator1="Blogs#ADD_BLOGS_ENTRY" />
+			<then>
+				<execute macro="Alert#viewSuccessMessage" />
+			</then>
+			<else>
+				<fail message="Element not present" />
+            </else>
+		</if>
+
+		<if>
 			<and>
 				<condition function="IsElementPresent" locator1="Blogs#ADD_BLOGS_ENTRY" />
 				<equals arg1="${check}" arg2="true" />

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -126,6 +126,8 @@ document.getElementById('demo').innerHTML = 'FAIL';
 
 		Smoke.viewWelcomePage();
 
+		takeScreenshot();
+
 		while (IsElementPresent(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC")) {
 			Click(locator1 = "AssetCategorization#TAGS_REMOVE_ICON_GENERIC");
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -41,6 +41,8 @@ definition {
 				Alert.viewErrorMessage(
 					errorMessage = "A configuration with this ID already exists. Please enter a unique ID."
 				);
+
+				echo("Please enter a unique ID.");
 			}
 			else {
 				Alert.viewSuccessMessage();
@@ -152,5 +154,42 @@ document.getElementById('demo').innerHTML = 'FAIL';
 		Type(value1 = "Welcome");
 
 		AssertElementPresent.assertElementPresent(locator1 = "Home#PAGE", value1 = "Welcome");
+	}
+
+	@description = "Ensure that a user can add multiple Blogs Entries."
+	@priority = "4"
+	testAddBlogsEntries {
+		property testray.component.names = "Blogs";
+		property testray.main.component.name = "Blogs";
+
+		task ("Add a blogs entry called 'Blogs Entry1 Title' with content 'Blogs Entry1 Content'") {
+			Navigator.openURL();
+
+			ProductMenu.gotoPortlet(
+				category = "Content",
+				panel = "Site Administration",
+				portlet = "Blogs"
+			);
+
+			Blogs.addEntry(
+				entryContent = "Blogs Entry1 Content",
+				entryTitle = "Blogs Entry1 Title"
+			);
+		}
+
+		task ("Add a blogs entry called 'Blogs Entry2 Title' with content 'Blogs Entry2 Content'") {
+			Navigator.openURL();
+
+			ProductMenu.gotoPortlet(
+				category = "Content",
+				panel = "Site Administration",
+				portlet = "Blogs"
+			);
+
+			Blogs.addEntry(
+				entryContent = "Blogs Entry2 Content",
+				entryTitle = "Blogs Entry2 Title"
+			);
+		}
 	}
 }

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -112,6 +112,13 @@ definition {
 			Alert.viewSuccessMessage();
 		}
 
+		if (IsElementPresent(locator1 = "Blogs#ADD_BLOGS_ENTRY")) {
+			Alert.viewSuccessMessage();
+		}
+		else if ("${check}" == "true") {
+			Alert.viewErrorMessage();
+		}
+
 		var siteName = return(
 			TestCase.getSiteName(
 				siteName = "${siteName}"

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -97,6 +97,13 @@ definition {
 			Alert.viewSuccessMessage();
 		}
 
+		if (IsElementPresent(locator1 = "Blogs#ADD_BLOGS_ENTRY")) {
+			Alert.viewSuccessMessage();
+		}
+		else {
+			fail("Element not present");
+		}
+
 		if ((IsElementPresent(locator1 = "Blogs#ADD_BLOGS_ENTRY")) && ("${check}" == "true") && (isSet(duplicate))) {
 			Alert.viewSuccessMessage();
 		}

--- a/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
+++ b/modules/test/poshi-runner/poshi-runner/src/test/resources/com/liferay/poshi/runner/dependencies/ReadableSyntax.testcase
@@ -192,4 +192,17 @@ document.getElementById('demo').innerHTML = 'FAIL';
 			);
 		}
 	}
+
+	testGotoLinkToPageChildPages {
+		var key_pageName = "${parentPage}";
+
+		toggle ("LPS-68869") {
+			on {
+				Click(locator1 = "DDLEditRecord#LINK_TO_PAGE_PAGE_TOGGLER");
+			}
+			off {
+				Click(locator1 = "DDLEditRecord#LINK_TO_PAGE_PAGE_CARET");
+			}
+		}
+	}
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-35480

Resend of https://github.com/brianchandotcom/liferay-portal/pull/52481. @kevin-yen, @pyoo47

#### Key changes
* Added support for `take-screenshot`, `fail`, `task`, `toggle`, `on`, `off`, `elseif` elements
* Stabilized unit tests

#### Translation status
##### At head:
1885 / 2145 \(87%\) test commands were successfully translated
264 / 326 \(80%\) test files were successfully translated accounting for 1213 / 2145 \(56%\) test commands
##### With this pull:
2034 / 2145 \(94%\) test commands were successfully translated
267 / 326 \(81%\) test files were successfully translated accounting for 1274 / 2145 \(59%\) test commands