### PR TITLE
LPS-75201 ConfigurationTemporarySwapper causes intermittent CI integration test failures

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLAppServiceTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLAppServiceTest.java
@@ -334,6 +334,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 			},
 			level = "ERROR", loggerClass = JDBCExceptionReporter.class
 		)
+		@Ignore
 		@Test
 		public void shouldSucceedWithConcurrentAccess() throws Exception {
 			_users = new User[ServiceTestUtil.THREAD_COUNT];
@@ -377,6 +378,7 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 				_users.length, successCount);
 		}
 
+		@Ignore
 		@Test
 		public void shouldSucceedWithNullBytes() throws Exception {
 			String fileName = RandomTestUtil.randomString();


### PR DESCRIPTION
This is an update for [LPS-75201](https://issues.liferay.com/browse/LPS-75201).<br><br>Hey @sergiogonzalez, I was asked by @jpince to ignore these tests as well, though I didn't end up making any changes to these test in my other work.  We're still trying to find the root cause of these intermittent failures.  Let me know if you have anny questions.  Thanks!<br><br>/cc @jpince, @pei-jung