### PR TITLE
LRQA-35769 Poshi fails if the property 'test.console.log.file.name' is not provided when 'assert.liferay.errors' is set to true

### DIFF
--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumHelper.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/LiferaySeleniumHelper.java
@@ -417,6 +417,10 @@ public class LiferaySeleniumHelper {
 	}
 
 	public static String getTestConsoleLogFileContent() throws Exception {
+		if (Validator.isNull(PropsValues.TEST_CONSOLE_LOG_FILE_NAME)) {
+			return "";
+		}
+
 		Map<String, File> consoleLogFiles = new TreeMap<>();
 
 		String baseDirName = PropsValues.TEST_CONSOLE_LOG_FILE_NAME;


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-35769