### PR TITLE
LPS-75601 Avoid displaying extra comma when author is null

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_folder_descriptive.jsp
@@ -35,7 +35,14 @@ rowURL.setParameter("folderId", String.valueOf(folder.getFolderId()));
 %>
 
 <h5 class="text-default">
-	<liferay-ui:message arguments="<%= new String[] {folder.getUserName(), modifiedDateDescription} %>" key="x-modified-x-ago" />
+	<c:choose>
+		<c:when test="<%= Validator.isNull(folder.getUserName()) %>">
+			<liferay-ui:message arguments="<%= new String[] {modifiedDateDescription} %>" key="modified-x-ago" />
+		</c:when>
+		<c:otherwise>
+			<liferay-ui:message arguments="<%= new String[] {folder.getUserName(), modifiedDateDescription} %>" key="x-modified-x-ago" />
+		</c:otherwise>
+	</c:choose>
 </h5>
 
 <h4>


### PR DESCRIPTION
Sharepoint folders do not have the concept of "author", so we have
nothing to display. In this case, use an alternative literal so that
we don't display an extra comma.