### PR TITLE
Revert LPS-75780 | master

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ddf5e7c342218a93cd2a6c0ddfb70a97d048dcad
+	commit = b5835f04428f0f22ac285810ccbbe52059533d8a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c34e88eb425777e257ae3c64136a45d324772a61
+	parent = 320788e654e6a4a57cf4d05fe65d2fa6272d6cad
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e6e98389a4d8c2c366d5c7530fe6a149c4bbb3c8
+	commit = 32d9020af7ab81604023d45d401c5761698576bd
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 709821892f9d2fb50a18ab86da2eb7f04a53d272
+	parent = abe26704efabae678b4e304be033a1d673f28594
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/collaboration/comment/.gitrepo
+++ b/modules/apps/collaboration/comment/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 3db3251c23fbc4ff872cbdd70c55d8eaa7dccc70
+	commit = 960dbc17f7e78b9eb02369a4defbe200ffb7421f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 1dfacfaa871f4dfa7a98bf2518ff6acfce59bd73
+	parent = 32fe7ca4c1bb8103b8c018f149338e8282ef737b
 	remote = git@github.com:liferay/com-liferay-comment.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 049d027d00bb9c37a91e3285e3a5a7f25535fd82
+	commit = bbb5609b215838cbfdfec2bd20eb9621487b568f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0afb15424a6fccdce2d5b91b02805c70ba9c2f0e
+	parent = cbe0aa50f5bf44cb8dc8542166de90b39f1d94c9
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/flags/.gitrepo
+++ b/modules/apps/collaboration/flags/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 60423945fc350ae1a4920cd94bd964df281e22c6
+	commit = 03bde50c7d10fa7ed57ebce6f0cef950b52c478e
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 56c5c7c161bbf3a3bd315921d1e6ae600a4d6a86
+	parent = 86f8991fe6186c610476fc922770f2ade61a1847
 	remote = git@github.com:liferay/com-liferay-flags.git

--- a/modules/apps/collaboration/item-selector/.gitrepo
+++ b/modules/apps/collaboration/item-selector/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b8c80b0a64a54f68272b9f8ecb85868016628590
+	commit = 8c60857b14b508d9acc2f4e09b0ac5c71bc7e983
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f85c9c1b8e35b15f0f8884b1d1df371726ab1041
+	parent = 47b8a7078c3e3e0bc1b07bd497b0305d8d4c614b
 	remote = git@github.com:liferay/com-liferay-item-selector.git

--- a/modules/apps/collaboration/mentions/.gitrepo
+++ b/modules/apps/collaboration/mentions/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 77900e9a778e4fe1baead1155636a21607ed18f7
+	commit = de6d6c1fd2e69d2e6a17fe5b3d7837f47070f339
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 41788abefbfa11afbc6fe4926b806abe1dc804b6
+	parent = cb14eb0cb46fdccb3f3f721013dfddf650929eee
 	remote = git@github.com:liferay/com-liferay-mentions.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 09585a97ef968591edcc12ccc610182dff4eb2d5
+	commit = 8454f4af52e382529b91accb5adaa2be7dc4344a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = aa0d33f59d7033f300e9636f96543dcec6776ce4
+	parent = f39d0a86fc3ffc90f67f229ba6ac4bbd59e357cf
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/recent-documents/.gitrepo
+++ b/modules/apps/collaboration/recent-documents/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 953fe96949c009e5a5fcb0fbbe8e9dba41f1ec82
+	commit = d41cdf86650e660255f0b34e00ea891c0ea46054
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0368fcf914fdd4e76cbce4f49e11fec8fe7edb11
+	parent = d0d4b7d1435dad1a9c97e94a4138cb9eaf87b0a5
 	remote = git@github.com:liferay/com-liferay-recent-documents.git

--- a/modules/apps/collaboration/social/.gitrepo
+++ b/modules/apps/collaboration/social/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 78d8d212c1e71cb1d036889cb3cdb55b4b180c50
+	commit = 1bc81a192bf8f698f0c613bc5eff628878b8fac5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = cc1f2867333ec20cbacd97b2dc56a936c2eef244
+	parent = 8e01b8b0296d18cb7a1be9244f1d55806c59e218
 	remote = git@github.com:liferay/com-liferay-social.git

--- a/modules/apps/collaboration/subscription/.gitrepo
+++ b/modules/apps/collaboration/subscription/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 95f4c8be884ec07c567f670a7817b8e357511dad
+	commit = 23aaafe85420d89799fd69aa7bb89ca1a37aa7cb
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0e10512380773ffdbcc3152e8ae077db9a0563ad
+	parent = baf32b9dc6ba35bb0bb8111ff43d2cf02e7da9b3
 	remote = git@github.com:liferay/com-liferay-subscription.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 3052a454c9dcf99674eefe146e8d05997010c25c
+	commit = 98a26fe2811066fdc0879b6e4e0649e276adfd82
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 350f265abb67cfe0263f92a7a7a1283e9ac3114d
+	parent = 8043335b1706c384f3315b59521c6fbb8d3d9ccc
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = afa19e5973d2676ee78f5312cdf751488dee891a
+	commit = e852a1ed2117a31a2d271070df7b8ac22f57a82f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 61e68c0f62d023906613cf31e0bfd18b01203f81
+	parent = fc2c85d7d654c8098ed5a8000442b9a6e300d0ec
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4fb1e74f9e0286b92c0071e3246f77c5ab65cfe4
+	commit = 77f128a4511730d0a28bfc9e8b3812b94322eade
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b31e3d3bbe6e4db679f7dddb22b36679044291f2
+	parent = ae88d1a8010c2c0dc73c1b12640514d041ad6092
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/forms-and-workflow/polls/.gitrepo
+++ b/modules/apps/forms-and-workflow/polls/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c21db2630bed1558ded3845dbac34de5464011e9
+	commit = 6563b53a1cedacdbcf83257cbb7455b69699528e
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 53c466b06ed353202267dc09f713bf7652c8456a
+	parent = 4ad77c043431801066101029c1f750f788cf8a86
 	remote = git@github.com:liferay/com-liferay-polls.git

--- a/modules/apps/foundation/configuration-admin/.gitrepo
+++ b/modules/apps/foundation/configuration-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4ef6299e82525c4839cc23ffe3a6467f0d0f6f3e
+	commit = fc5034dd3b5202a4104d7173baeb9a96fe5decd6
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e6298d2f45ac892d5fe6621f557c335de379ff3e
+	parent = 4e5e18fc60976f5928295b643d76c85c7ec56f13
 	remote = git@github.com:liferay/com-liferay-configuration-admin.git

--- a/modules/apps/foundation/contacts/.gitrepo
+++ b/modules/apps/foundation/contacts/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = fa3974152afd68982b6904c9a935073e8d665c01
+	commit = 678b56d08b0abe01f39c33004963d4f33f4fa0a6
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9d0989f4f4960e8d562eab1b23501030cd0265e5
+	parent = e77a7dfd76da93c0976995937e480a9111df2432
 	remote = git@github.com:liferay/com-liferay-contacts.git

--- a/modules/apps/foundation/expando/.gitrepo
+++ b/modules/apps/foundation/expando/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 54deeb7afde0a86c2bf1ce2d24a9a2d1594240ce
+	commit = 6f05e3877847a50daafc038c9b63efd5d06d7e9a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 58e7b494e294a7d80b7fa5c0a65b49500561558a
+	parent = 0f03702392355d91c2578dcfd5d1151bc05313c1
 	remote = git@github.com:liferay/com-liferay-expando.git

--- a/modules/apps/foundation/frontend-css/.gitrepo
+++ b/modules/apps/foundation/frontend-css/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ac7292c96671dff13e4a943acb25a2763f80892f
+	commit = baf4b6aaf8cf9a22552112080f3119ef9ea5c658
 	mergebuttonmergecommits = false
 	mode = push
-	parent = fd709391dde3e2eb95745bf64e4d9133e76cd0f8
+	parent = dca45c1e76c1c79f49ef1f4d48c514db6af7b86c
 	remote = git@github.com:liferay/com-liferay-frontend-css.git

--- a/modules/apps/foundation/frontend-editor/.gitrepo
+++ b/modules/apps/foundation/frontend-editor/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 233197e950f1540f58ae680f6eccbf69bea84737
+	commit = 18840c0933eb87c6d5d3651255da25eb1b5d1362
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 93b257c85fe2059667cf616eb57d9b6115bcfbe6
+	parent = 9e56c511a1d0accc8883dd494fbf8e3f5490914d
 	remote = git@github.com:liferay/com-liferay-frontend-editor.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d07d5275bcfd885e330dabbea20519a5438ca99b
+	commit = fc8978bbbd664a0f4bd5dd29b4412b962235d592
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 58f0b83007ccae4f492f3e701b6117a80b967f8f
+	parent = 45a650f10c9e0050f61777b3c2ee92d238857517
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.30"
+String alloyUIVersion = "3.1.0-deprecated.29"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/foundation/frontend-theme/.gitrepo
+++ b/modules/apps/foundation/frontend-theme/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 96263404825c46911f15836ff33f9bb2b3e70128
+	commit = fbabd035c962b167164d4fa7dc6f5691de8f2499
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 78ad5876b08c113f5a8a10166b7bcbe87ec73265
+	parent = 54b4fc0c6ccddd00a6266cc0fbc2de9840c9d00b
 	remote = git@github.com:liferay/com-liferay-frontend-theme.git

--- a/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.30"
+String alloyUIVersion = "3.1.0-deprecated.29"
 String fontAwesomeVersion = "3.2.1"
 
 File themeDestinationDir = file("src/main/resources/META-INF/resources/_unstyled");

--- a/modules/apps/foundation/login/.gitrepo
+++ b/modules/apps/foundation/login/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d973880236f3a14eb287e623e6070088190173ff
+	commit = 8ad460486a5b7f59689d2cc94ffd675557297bdf
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c648362f9f615b62c40eab8a7ae0a34a5348acb4
+	parent = 6701c7eb4b10324b6b85dccc04f1b8a6506d572b
 	remote = git@github.com:liferay/com-liferay-login.git

--- a/modules/apps/foundation/mobile-device-rules/.gitrepo
+++ b/modules/apps/foundation/mobile-device-rules/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c0a7ac480b0c472e87daa4fe2f3851611b239f44
+	commit = 858250174a3e118d68813e927bffd281c0dc8b1f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5d19a0137a32334206bd882f98fc6b66820e2d3a
+	parent = 477c8f806bd4520f17909a86fa8cdb6599e7fbab
 	remote = git@github.com:liferay/com-liferay-mobile-device-rules.git

--- a/modules/apps/foundation/petra/.gitrepo
+++ b/modules/apps/foundation/petra/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 073d0ba7d05bb4107491b84bb143073de80204b6
+	commit = 338695594c9cb32bf6540708f8a00be74cb581f6
 	mergebuttonmergecommits = false
 	mode = push
-	parent = e587e186589140511fd5a36a6d68178384218f1b
+	parent = 84851cca56c61c83c46abbbd3fd2ae2f86a3f157
 	remote = git@github.com:liferay/com-liferay-petra.git

--- a/modules/apps/foundation/portal-background-task/.gitrepo
+++ b/modules/apps/foundation/portal-background-task/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 36c4c6c380fba20a4c916df2f3457db05c2b05aa
+	commit = 3fda79f9d4e876ec39b45bacaeb88a71536b0ff4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c835eb4a1c9219cfba9546a7a485bd680da5dbc3
+	parent = d7c5ffc2c05ee04f3f24ebb2f689d6c069a57f5c
 	remote = git@github.com:liferay/com-liferay-portal-background-task.git

--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 772709697671cdf18304e346eafee253454b472a
+	commit = 3c774ee50ce444ffb4ddf31aa4392f76641e52a9
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c718f729ac928af907aaa5a382b83d7938aecddc
+	parent = 9477881a211f313adf06c5ef7b2d5a61795b2880
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/foundation/portal-configuration/.gitrepo
+++ b/modules/apps/foundation/portal-configuration/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 3e3eed30d57679547df0c4538610b54bb298e111
+	commit = 4ac09dc8da1a3eb55bbeab36abe7070b42d4836d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 24771e96f5a48966928f0136caff87f56cafe67d
+	parent = 44d19fa5ade3ea121f000ee02e110f06ebb1c038
 	remote = git@github.com:liferay/com-liferay-portal-configuration.git

--- a/modules/apps/foundation/portal-language/.gitrepo
+++ b/modules/apps/foundation/portal-language/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b72417a685d8233ee1bff7aa4e117cf84db1ffe3
+	commit = 874e66ed671dbb8ae7f2e4879998b8acda079634
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3fe102514b17aac160c09d41f3e5a9cffd404c2d
+	parent = 04700fca4cc28e9d49c00fce6d1669f11d3d6130
 	remote = git@github.com:liferay/com-liferay-portal-language.git

--- a/modules/apps/foundation/portal-remote/.gitrepo
+++ b/modules/apps/foundation/portal-remote/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b6ddfbaa553acf5d571762360d69b730e8d76f9f
+	commit = dcf17750457eaea57bb31b84a77a715b952c95ee
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0c7a701c7b3420ca6dd964f80e46a8e5ed88ef0f
+	parent = 1b45ee6c1c9ed3548aff44ec6e78184ff5b9c9a4
 	remote = git@github.com:liferay/com-liferay-portal-remote.git

--- a/modules/apps/foundation/portal-scheduler/.gitrepo
+++ b/modules/apps/foundation/portal-scheduler/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 02225597c65ea5ce44f3fd4114b46ba7be0d9473
+	commit = 1796ffa98e2407cc6597baf70caaa64c6b353dfc
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4b98b8cc89014cf2a709e9d64debea68a4dc1d69
+	parent = 8dd66f8c8c258c7ae73712a8702aabf9baf21617
 	remote = git@github.com:liferay/com-liferay-portal-scheduler.git

--- a/modules/apps/foundation/portal-scripting/.gitrepo
+++ b/modules/apps/foundation/portal-scripting/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 5de2afc96451c3cd868d82f9da33cca25307f61f
+	commit = 982c4c98bd567991b10700b5cf96ec2d14165916
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 3fae76e244286b6a71366f9d6540e27abf89a8bd
+	parent = 6d265fbe867f22d1c1e617808be3ed40abf047da
 	remote = git@github.com:liferay/com-liferay-portal-scripting.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 63cd27d712f3ca69337233bd63ac384580a19ca9
+	commit = 7ee778a95fbb5b62c9763cbe3041b79ccd6d8ef5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = fd05b724f02b71e6e8976b2f4d7a9f9a6ff3d38a
+	parent = b913409012f2b3c0b8a263f027b5c745066856d5
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-security-audit/.gitrepo
+++ b/modules/apps/foundation/portal-security-audit/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 382bf90c3eac231cc2a133fbe94ac10e61d68647
+	commit = 1d389b40e0de4f2f7b7a83075a95060471856e85
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a18b14a9a81de6bd4a00de66896aeba5641fd787
+	parent = b3d5e53a6f1aacff3376a6cd7237af3c708505c9
 	remote = git@github.com:liferay/com-liferay-portal-security-audit.git

--- a/modules/apps/foundation/portal-security-sso/.gitrepo
+++ b/modules/apps/foundation/portal-security-sso/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 7835a5386802b35fb87030408c69e992d07fb862
+	commit = 1400f8ef7f0cca798e8b58dc3f25a6437f1bb388
 	mergebuttonmergecommits = false
 	mode = push
-	parent = aa2df3c32acc82b470e0b75801dc5a2a8ae56efc
+	parent = ea4af084d2775cdca7e8ce8b79770adf1bd96b53
 	remote = git@github.com:liferay/com-liferay-portal-security-sso.git

--- a/modules/apps/foundation/portal-security/.gitrepo
+++ b/modules/apps/foundation/portal-security/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0f99374c2a64ecc5a15e22bf0e4b958c20eef7a4
+	commit = 0e5ba73f650ea207c28e559b67de4f0cc8ec9a53
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 7b0155f95b3fc61fdef5cb99c8c177fcfcf960d4
+	parent = beadb250cb1cdf0ce10e2a345f5e4e068777219e
 	remote = git@github.com:liferay/com-liferay-portal-security.git

--- a/modules/apps/foundation/portal-settings/.gitrepo
+++ b/modules/apps/foundation/portal-settings/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 63a1083251c4e177b19514090216195b3bb48c1f
+	commit = 548782096e2d82661b61d64af1e84166cc3ff5fe
 	mergebuttonmergecommits = false
 	mode = push
-	parent = be353d042b0ad370a4821ea1f4efda3ed23becb0
+	parent = d632bd146490a11d0a567e04ae119b39dd83b92a
 	remote = git@github.com:liferay/com-liferay-portal-settings.git

--- a/modules/apps/foundation/portal-store/.gitrepo
+++ b/modules/apps/foundation/portal-store/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 9ac26e177d738956b45036240e2a5a067fd9de05
+	commit = 089980941faed274ab869f959c775f1be7a12260
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c5ab7fe9fce8f72fc1316f656518900cf69a7315
+	parent = 5fc8c7c1ea5c2a37b404933080d2d160f5f422ea
 	remote = git@github.com:liferay/com-liferay-portal-store.git

--- a/modules/apps/foundation/portal-template/.gitrepo
+++ b/modules/apps/foundation/portal-template/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 334426750337a99fc8dc614e51794dfc60fdb5b3
+	commit = ff98eb4da0773f90e374dae3925cc323230717e1
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4af71fad9693ae97e4d73d206129cd41b7617d44
+	parent = 0e64430aaa04835befce85e8059c23355ba7b62c
 	remote = git@github.com:liferay/com-liferay-portal-template.git

--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4bfb1390abd9cc23744519fcc53b1aab6a46ba89
+	commit = 94255629b485ef51ad3b6bea9727ce1f7a69da73
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2299a15e5ecb7da6d76fdad30009fbc1044a1230
+	parent = 890df958d6c8668250324c547765c321e258af55
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/foundation/server/.gitrepo
+++ b/modules/apps/foundation/server/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = db3582027a18d31b709b68b29f110f5bfdc40d83
+	commit = 5e92b58d16c6c4d7443cb2a154cce0b6a95d1738
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 0feef777b275ed0852107c5be0421e75f986d9bb
+	parent = 82652eec1a91ece1c94d6b138373224b87b9fa87
 	remote = git@github.com:liferay/com-liferay-server.git

--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 9fc98023a683b3b3a1870b41fedaf9c4ba06c348
+	commit = 2fa573b72fd1372cbd7e975f300438601eb9ad3a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c87daae0beb53b8f6258380c186970d9bbda53bd
+	parent = 3255b7b0c9f539108c686f88b88164f17da2fc33
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/ip-geocoder/.gitrepo
+++ b/modules/apps/ip-geocoder/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 38972d2f88119d247e6613c0e4701e3d5a3bd1b4
+	commit = ba4b9df4b31ddebb1261b4664f93226fb70c6971
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 13fb8d80b79df73e6821facc7f020aa42b6b210d
+	parent = a657ec619c8c3cff420660eaec3f4c72a66741aa
 	remote = git@github.com:liferay/com-liferay-ip-geocoder.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 35bc6eb4a1f862b95431efd5da4be1a985f9aed1
+	commit = 96b30762df00d6e8d4b3a42a8e1299f413f60e08
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c3749d283ec0b4ec660b435995c2617637726b54
+	parent = a431031b98dd216de238b0739a39c5aa95ecdc07
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 312039409c15cb7b1e07b30e57d8789ca3f9eb79
+	commit = eb27d38505946d3af3f1e21d1edc2b2705929607
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 90147a595e9650b6506cb861c580f3bca5e6fa89
+	parent = 6e92428d5b450225bcb18a01729f8530dabc42c4
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/sync/.gitrepo
+++ b/modules/apps/sync/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 099e44d473a829d45028bf026d8d494007583ae8
+	commit = 1d3a04e63539b271a06307a1c199f509539726e9
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 728a8f4dcca70339ae73cce3493c674b88f652bb
+	parent = fd796bfc569b8429bdece623da2f4fc1becb58ac
 	remote = git@github.com:liferay/com-liferay-sync.git

--- a/modules/apps/web-experience/application-list/.gitrepo
+++ b/modules/apps/web-experience/application-list/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 298eecf693b974b36c82a74e8f558e2e01ddc203
+	commit = 21ed99d29378aa548b0678314f56b0203596895d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2ae755948c33a729415fcb86fae775ebe6714970
+	parent = 63292b7e2c6b83e563f572652794b776dfc27c63
 	remote = git@github.com:liferay/com-liferay-application-list.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 3f0ab7715d6d31c3a4018e449d35328265373388
+	commit = b6deaad4df0e09007505fcfa9384df8772169fca
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 445e03d165e347e518adb19da6adb0c58d7de921
+	parent = 7ca2c1c457695af8e80fd6a1559c464dbc394820
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 46ce7e5f75fae460577981d5eb5b782986417fc5
+	commit = bd3a6904904613aaa1324b1ea8d2fcd5f63c90b5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 61ddb7e175f0ff39de2b640d0722391d447ab899
+	parent = c4cde7c0a2929628da8125f13ef61c242343b6d8
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/iframe/.gitrepo
+++ b/modules/apps/web-experience/iframe/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 5a5fadd08487f3dd932cedc855c40ad19aa01ca5
+	commit = cea1fcc1b44e98a0f75a3a3d152216953965a869
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 48fd1a1f0bd1ae1fc27d782e3d34aa50f5798a33
+	parent = 17e71a06c0179cd5854dcb0e1aaa8e7ab72fe3ae
 	remote = git@github.com:liferay/com-liferay-iframe.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ddb4d7907337a9b92786c3d0df1e062213919bf9
+	commit = bded7dfaa70b9d8541758f2288bbd81868a130d1
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f1b9d959df66280bb475baad23ea88eb5a2f9d05
+	parent = 7e37feeaba73da227d926d0ed44ad9de61e1f0d8
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/modules/apps/web-experience/nested-portlets/.gitrepo
+++ b/modules/apps/web-experience/nested-portlets/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d5fa7a8f89e0601b470556b77095178788675c46
+	commit = 7623ba925991efc40ad781cc1f1d8bc89b99e14c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2e0d2092a9e2d8777db894a12fdacf798c184f20
+	parent = f5952800e21bd448ff9fb50f4108a0b40aa9b757
 	remote = git@github.com:liferay/com-liferay-nested-portlets.git

--- a/modules/apps/web-experience/product-navigation/.gitrepo
+++ b/modules/apps/web-experience/product-navigation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4546eb3140fdd3c291c553fdf2ba3e4c4b7d9614
+	commit = a8cb08946709190b6336c44631eac4fc284c90be
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b9a4996dfe0583d83af519a12f3f348d32134d11
+	parent = 832d666b2a6336f5a9c3200a0d95e210faec30bc
 	remote = git@github.com:liferay/com-liferay-product-navigation.git

--- a/modules/apps/web-experience/rss/.gitrepo
+++ b/modules/apps/web-experience/rss/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = b306ad9700404a180c45883f0d8b2b9f54271ff6
+	commit = 159ce7798c5a233d390f9d73c1827d5bf9ae4500
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 913445da65a638d5b94b87f19f9b88edf98f0d10
+	parent = 55e07f215a7f0a82bbc5e32d0da4ed06bba4bc32
 	remote = git@github.com:liferay/com-liferay-rss.git

--- a/modules/apps/web-experience/site-navigation/.gitrepo
+++ b/modules/apps/web-experience/site-navigation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d30129017aa235efcdc9d70aad7f077a6c1169a5
+	commit = ad1c29374363f5de02354ff086a68e41ab17a2e1
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5f2448caf57b5e76d488c7758284472694f6f7b3
+	parent = 2f754c03e22da82745dc4d29e94856639afe5870
 	remote = git@github.com:liferay/com-liferay-site-navigation.git

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 8bd58533ecfc51533a0b2a3909e75bbd9b479156
+	commit = 58d7d3ed9042c2fc91e838d341a6574f8f3b7795
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9068a9f99bf6c8df95979c450ba1ef98efbe6750
+	parent = 98b9c127ca34a8ceb8fcae9ecec9b7fd91abf4ef
 	remote = git@github.com:liferay/com-liferay-staging.git

--- a/modules/apps/web-experience/trash/.gitrepo
+++ b/modules/apps/web-experience/trash/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 337f543ee836625d408eee2570f8f2b41fc39271
+	commit = 742316b44015df1121414227cdd7163c14599cdf
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5773edcdee27e6b6eb2c687aa146ed1de651e2a1
+	parent = f540af14a4ac314bf2b9d4a8897091fa96b9e9cd
 	remote = git@github.com:liferay/com-liferay-trash.git


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-75780

@brianchandotcom 
Most recent pulls are starting to have all functional tests fail (and all pulls will auto-close), and I'm fairly certain it was caused by this pull:
https://github.com/brianchandotcom/liferay-portal/pull/52860

I've sent a revert here to confirm, but I won't be around to check to see if it really worked.
@brianwulbern Can you keep an eye on this pull too? You can ci close it if it doesn't solve anything.

The issue is that the sign in portlet is greyed out, so none of the tests are actually able to sign in.

![before4](https://user-images.githubusercontent.com/871745/32584168-eac7059e-c4ab-11e7-9c3f-9c39dc8cd5a7.jpg)

cc @jonmak08