### PR TITLE
LPS-75739 Remove trademark symbol

### DIFF
--- a/modules/apps/document-library-google-docs/app.bnd
+++ b/modules/apps/document-library-google-docs/app.bnd
@@ -1,5 +1,5 @@
 Liferay-Releng-App-Description: The Liferay Plugin for Google Drive&trade; lets users create shortcuts to Google Drive&trade; files in their Documents and Media repositories. These documents can be viewed and managed from Documents and Media. Once deployed, you can configure this app from the Control Panel.
-Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Plugin for Google Drive&trade;
+Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Plugin for Google Drive
 Liferay-Releng-Bundle: false
 Liferay-Releng-Category: Productivity
 Liferay-Releng-Demo-Url:


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-35371

Package names must consist of only letters and digits. The addition of the trademark symbol is causing lpkg errors.

/cc @patriciajeanperez @jeffreyyang @stmerriss @nicolelau