### PR TITLE
Lps 75010

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-content-service/src/main/java/com/liferay/document/library/content/service/persistence/impl/DLContentPersistenceImpl.java
+++ b/modules/apps/collaboration/document-library/document-library-content-service/src/main/java/com/liferay/document/library/content/service/persistence/impl/DLContentPersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.document.library.content.model.impl.DLContentImpl;
 import com.liferay.document.library.content.model.impl.DLContentModelImpl;
 import com.liferay.document.library.content.service.persistence.DLContentPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -1383,8 +1381,7 @@ public class DLContentPersistenceImpl extends BasePersistenceImpl<DLContent>
 					if ((companyId != dlContent.getCompanyId()) ||
 							(repositoryId != dlContent.getRepositoryId()) ||
 							!StringUtil.wildcardMatches(dlContent.getPath(),
-								path, CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								path, '_', '%', '\\', true)) {
 						list = null;
 
 						break;

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarResourcePersistenceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/persistence/impl/CalendarResourcePersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.calendar.model.impl.CalendarResourceImpl;
 import com.liferay.calendar.model.impl.CalendarResourceModelImpl;
 import com.liferay.calendar.service.persistence.CalendarResourcePersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -5715,9 +5713,8 @@ public class CalendarResourcePersistenceImpl extends BasePersistenceImpl<Calenda
 				for (CalendarResource calendarResource : list) {
 					if ((companyId != calendarResource.getCompanyId()) ||
 							!StringUtil.wildcardMatches(
-								calendarResource.getCode(), code,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true) ||
+								calendarResource.getCode(), code, '_', '%',
+								'\\', true) ||
 							(active != calendarResource.getActive())) {
 						list = null;
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.knowledge.base.model.impl.KBArticleImpl;
 import com.liferay.knowledge.base.model.impl.KBArticleModelImpl;
 import com.liferay.knowledge.base.service.persistence.KBArticlePersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -25159,9 +25157,8 @@ public class KBArticlePersistenceImpl extends BasePersistenceImpl<KBArticle>
 				for (KBArticle kbArticle : list) {
 					if ((groupId != kbArticle.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								kbArticle.getSections(), sections,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true) ||
+								kbArticle.getSections(), sections, '_', '%',
+								'\\', true) ||
 							(latest != kbArticle.getLatest())) {
 						list = null;
 
@@ -26831,10 +26828,8 @@ public class KBArticlePersistenceImpl extends BasePersistenceImpl<KBArticle>
 				for (KBArticle kbArticle : list) {
 					if ((groupId != kbArticle.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								kbArticle.getSections(), sections,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true) ||
-							(main != kbArticle.getMain())) {
+								kbArticle.getSections(), sections, '_', '%',
+								'\\', true) || (main != kbArticle.getMain())) {
 						list = null;
 
 						break;
@@ -28502,9 +28497,8 @@ public class KBArticlePersistenceImpl extends BasePersistenceImpl<KBArticle>
 				for (KBArticle kbArticle : list) {
 					if ((groupId != kbArticle.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								kbArticle.getSections(), sections,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true) ||
+								kbArticle.getSections(), sections, '_', '%',
+								'\\', true) ||
 							(status != kbArticle.getStatus())) {
 						list = null;
 

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/service/persistence/impl/SyncDLObjectPersistenceImpl.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/service/persistence/impl/SyncDLObjectPersistenceImpl.java
@@ -16,8 +16,6 @@ package com.liferay.sync.service.persistence.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -190,9 +188,8 @@ public class SyncDLObjectPersistenceImpl extends BasePersistenceImpl<SyncDLObjec
 			if ((list != null) && !list.isEmpty()) {
 				for (SyncDLObject syncDLObject : list) {
 					if (!StringUtil.wildcardMatches(
-								syncDLObject.getTreePath(), treePath,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								syncDLObject.getTreePath(), treePath, '_', '%',
+								'\\', true)) {
 						list = null;
 
 						break;
@@ -2961,9 +2958,8 @@ public class SyncDLObjectPersistenceImpl extends BasePersistenceImpl<SyncDLObjec
 			if ((list != null) && !list.isEmpty()) {
 				for (SyncDLObject syncDLObject : list) {
 					if (!StringUtil.wildcardMatches(
-								syncDLObject.getTreePath(), treePath,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true) ||
+								syncDLObject.getTreePath(), treePath, '_', '%',
+								'\\', true) ||
 							Objects.equals(event, syncDLObject.getEvent())) {
 						list = null;
 

--- a/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/service/persistence/impl/SyncDevicePersistenceImpl.java
+++ b/modules/apps/sync/sync-service/src/main/java/com/liferay/sync/service/persistence/impl/SyncDevicePersistenceImpl.java
@@ -16,8 +16,6 @@ package com.liferay.sync.service.persistence.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -1832,9 +1830,8 @@ public class SyncDevicePersistenceImpl extends BasePersistenceImpl<SyncDevice>
 				for (SyncDevice syncDevice : list) {
 					if ((companyId != syncDevice.getCompanyId()) ||
 							!StringUtil.wildcardMatches(
-								syncDevice.getUserName(), userName,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false)) {
+								syncDevice.getUserName(), userName, '_', '%',
+								'\\', false)) {
 						list = null;
 
 						break;

--- a/modules/apps/web-experience/asset/asset-display-template-service/src/main/java/com/liferay/asset/display/template/service/persistence/impl/AssetDisplayTemplatePersistenceImpl.java
+++ b/modules/apps/web-experience/asset/asset-display-template-service/src/main/java/com/liferay/asset/display/template/service/persistence/impl/AssetDisplayTemplatePersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.asset.display.template.model.impl.AssetDisplayTemplateImpl;
 import com.liferay.asset.display.template.model.impl.AssetDisplayTemplateModelImpl;
 import com.liferay.asset.display.template.service.persistence.AssetDisplayTemplatePersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -1070,9 +1068,8 @@ public class AssetDisplayTemplatePersistenceImpl extends BasePersistenceImpl<Ass
 				for (AssetDisplayTemplate assetDisplayTemplate : list) {
 					if ((groupId != assetDisplayTemplate.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								assetDisplayTemplate.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false)) {
+								assetDisplayTemplate.getName(), name, '_', '%',
+								'\\', false)) {
 						list = null;
 
 						break;

--- a/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentCollectionPersistenceImpl.java
+++ b/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentCollectionPersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.fragment.model.impl.FragmentCollectionImpl;
 import com.liferay.fragment.model.impl.FragmentCollectionModelImpl;
 import com.liferay.fragment.service.persistence.FragmentCollectionPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -1325,9 +1323,8 @@ public class FragmentCollectionPersistenceImpl extends BasePersistenceImpl<Fragm
 				for (FragmentCollection fragmentCollection : list) {
 					if ((groupId != fragmentCollection.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								fragmentCollection.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false)) {
+								fragmentCollection.getName(), name, '_', '%',
+								'\\', false)) {
 						list = null;
 
 						break;

--- a/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentEntryPersistenceImpl.java
+++ b/modules/apps/web-experience/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentEntryPersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.fragment.model.impl.FragmentEntryImpl;
 import com.liferay.fragment.model.impl.FragmentEntryModelImpl;
 import com.liferay.fragment.service.persistence.FragmentEntryPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -2793,9 +2791,8 @@ public class FragmentEntryPersistenceImpl extends BasePersistenceImpl<FragmentEn
 					if ((groupId != fragmentEntry.getGroupId()) ||
 							(fragmentCollectionId != fragmentEntry.getFragmentCollectionId()) ||
 							!StringUtil.wildcardMatches(
-								fragmentEntry.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false)) {
+								fragmentEntry.getName(), name, '_', '%', '\\',
+								false)) {
 						list = null;
 
 						break;

--- a/modules/apps/web-experience/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateCollectionPersistenceImpl.java
+++ b/modules/apps/web-experience/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateCollectionPersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.layout.page.template.model.impl.LayoutPageTemplateCollectionI
 import com.liferay.layout.page.template.model.impl.LayoutPageTemplateCollectionModelImpl;
 import com.liferay.layout.page.template.service.persistence.LayoutPageTemplateCollectionPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -1347,8 +1345,7 @@ public class LayoutPageTemplateCollectionPersistenceImpl
 					if ((groupId != layoutPageTemplateCollection.getGroupId()) ||
 							!StringUtil.wildcardMatches(
 								layoutPageTemplateCollection.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false)) {
+								'_', '%', '\\', false)) {
 						list = null;
 
 						break;

--- a/modules/apps/web-experience/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateEntryPersistenceImpl.java
+++ b/modules/apps/web-experience/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateEntryPersistenceImpl.java
@@ -22,8 +22,6 @@ import com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryImpl;
 import com.liferay.layout.page.template.model.impl.LayoutPageTemplateEntryModelImpl;
 import com.liferay.layout.page.template.service.persistence.LayoutPageTemplateEntryPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -2301,9 +2299,8 @@ public class LayoutPageTemplateEntryPersistenceImpl extends BasePersistenceImpl<
 					if ((groupId != layoutPageTemplateEntry.getGroupId()) ||
 							(layoutPageTemplateCollectionId != layoutPageTemplateEntry.getLayoutPageTemplateCollectionId()) ||
 							!StringUtil.wildcardMatches(
-								layoutPageTemplateEntry.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false)) {
+								layoutPageTemplateEntry.getName(), name, '_',
+								'%', '\\', false)) {
 						list = null;
 
 						break;

--- a/modules/apps/web-experience/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/service/persistence/impl/SiteNavigationMenuPersistenceImpl.java
+++ b/modules/apps/web-experience/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/service/persistence/impl/SiteNavigationMenuPersistenceImpl.java
@@ -16,8 +16,6 @@ package com.liferay.site.navigation.service.persistence.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -1068,9 +1066,8 @@ public class SiteNavigationMenuPersistenceImpl extends BasePersistenceImpl<SiteN
 				for (SiteNavigationMenu siteNavigationMenu : list) {
 					if ((groupId != siteNavigationMenu.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								siteNavigationMenu.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								siteNavigationMenu.getName(), name, '_', '%',
+								'\\', true)) {
 						list = null;
 
 						break;

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -26,7 +26,6 @@ import ${apiPackagePath}.service.persistence.${entity.name}Persistence;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_field_comparator.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl_finder_field_comparator.ftl
@@ -35,7 +35,7 @@
 		(${finderCol.name} < ${entity.varName}.get${finderCol.methodName}())
 	</#if>
 <#elseif stringUtil.equals(finderCol.comparator, "LIKE")>
-	!StringUtil.wildcardMatches(${entity.varName}.get${finderCol.methodName}(), ${finderCol.name}, CharPool.UNDERLINE, CharPool.PERCENT, CharPool.BACK_SLASH,
+	!StringUtil.wildcardMatches(${entity.varName}.get${finderCol.methodName}(), ${finderCol.name}, '_', '%', '\\',
 	<#if finderCol.isCaseSensitive()>
 		true
 	<#else>

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupPersistenceImpl.java
@@ -16,8 +16,6 @@ package com.liferay.portal.service.persistence.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -8133,8 +8131,7 @@ public class GroupPersistenceImpl extends BasePersistenceImpl<Group>
 				for (Group group : list) {
 					if ((companyId != group.getCompanyId()) ||
 							!StringUtil.wildcardMatches(group.getTreePath(),
-								treePath, CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true) ||
+								treePath, '_', '%', '\\', true) ||
 							(site != group.getSite())) {
 						list = null;
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/OrganizationPersistenceImpl.java
@@ -16,8 +16,6 @@ package com.liferay.portal.service.persistence.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -4829,9 +4827,8 @@ public class OrganizationPersistenceImpl extends BasePersistenceImpl<Organizatio
 				for (Organization organization : list) {
 					if ((companyId != organization.getCompanyId()) ||
 							!StringUtil.wildcardMatches(
-								organization.getTreePath(), treePath,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								organization.getTreePath(), treePath, '_', '%',
+								'\\', true)) {
 						list = null;
 
 						break;

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPreferencesPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PortletPreferencesPersistenceImpl.java
@@ -16,8 +16,6 @@ package com.liferay.portal.service.persistence.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -4327,8 +4325,7 @@ public class PortletPreferencesPersistenceImpl extends BasePersistenceImpl<Portl
 							(ownerType != portletPreferences.getOwnerType()) ||
 							!StringUtil.wildcardMatches(
 								portletPreferences.getPortletId(), portletId,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								'_', '%', '\\', true)) {
 						list = null;
 
 						break;

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/ResourcePermissionPersistenceImpl.java
@@ -16,8 +16,6 @@ package com.liferay.portal.service.persistence.impl;
 
 import aQute.bnd.annotation.ProviderType;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -2026,9 +2024,8 @@ public class ResourcePermissionPersistenceImpl extends BasePersistenceImpl<Resou
 				for (ResourcePermission resourcePermission : list) {
 					if ((companyId != resourcePermission.getCompanyId()) ||
 							!StringUtil.wildcardMatches(
-								resourcePermission.getPrimKey(), primKey,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								resourcePermission.getPrimKey(), primKey, '_',
+								'%', '\\', true)) {
 						list = null;
 
 						break;

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetCategoryPersistenceImpl.java
@@ -21,8 +21,6 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.service.persistence.AssetCategoryPersistence;
 import com.liferay.asset.kernel.service.persistence.AssetEntryPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -7683,9 +7681,8 @@ public class AssetCategoryPersistenceImpl extends BasePersistenceImpl<AssetCateg
 				for (AssetCategory assetCategory : list) {
 					if ((groupId != assetCategory.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								assetCategory.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false) ||
+								assetCategory.getName(), name, '_', '%', '\\',
+								false) ||
 							(vocabularyId != assetCategory.getVocabularyId())) {
 						list = null;
 
@@ -8747,9 +8744,8 @@ public class AssetCategoryPersistenceImpl extends BasePersistenceImpl<AssetCateg
 				for (AssetCategory assetCategory : list) {
 					if ((groupId != assetCategory.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								assetCategory.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false) ||
+								assetCategory.getName(), name, '_', '%', '\\',
+								false) ||
 							!ArrayUtil.contains(vocabularyIds,
 								assetCategory.getVocabularyId())) {
 						list = null;

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagPersistenceImpl.java
@@ -21,8 +21,6 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.service.persistence.AssetEntryPersistence;
 import com.liferay.asset.kernel.service.persistence.AssetTagPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -4002,8 +4000,7 @@ public class AssetTagPersistenceImpl extends BasePersistenceImpl<AssetTag>
 				for (AssetTag assetTag : list) {
 					if ((groupId != assetTag.getGroupId()) ||
 							!StringUtil.wildcardMatches(assetTag.getName(),
-								name, CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								name, '_', '%', '\\', true)) {
 						list = null;
 
 						break;
@@ -5003,8 +5000,7 @@ public class AssetTagPersistenceImpl extends BasePersistenceImpl<AssetTag>
 				for (AssetTag assetTag : list) {
 					if (!ArrayUtil.contains(groupIds, assetTag.getGroupId()) ||
 							!StringUtil.wildcardMatches(assetTag.getName(),
-								name, CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true)) {
+								name, '_', '%', '\\', true)) {
 						list = null;
 
 						break;

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetVocabularyPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetVocabularyPersistenceImpl.java
@@ -20,8 +20,6 @@ import com.liferay.asset.kernel.exception.NoSuchVocabularyException;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.persistence.AssetVocabularyPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -3695,9 +3693,8 @@ public class AssetVocabularyPersistenceImpl extends BasePersistenceImpl<AssetVoc
 				for (AssetVocabulary assetVocabulary : list) {
 					if ((groupId != assetVocabulary.getGroupId()) ||
 							!StringUtil.wildcardMatches(
-								assetVocabulary.getName(), name,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, false)) {
+								assetVocabulary.getName(), name, '_', '%',
+								'\\', false)) {
 						list = null;
 
 						break;

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFolderPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFolderPersistenceImpl.java
@@ -21,8 +21,6 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.persistence.DLFileEntryTypePersistence;
 import com.liferay.document.library.kernel.service.persistence.DLFolderPersistence;
 
-import com.liferay.petra.string.CharPool;
-
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -9056,9 +9054,8 @@ public class DLFolderPersistenceImpl extends BasePersistenceImpl<DLFolder>
 					if ((groupId != dlFolder.getGroupId()) ||
 							(mountPoint != dlFolder.getMountPoint()) ||
 							!StringUtil.wildcardMatches(
-								dlFolder.getTreePath(), treePath,
-								CharPool.UNDERLINE, CharPool.PERCENT,
-								CharPool.BACK_SLASH, true) ||
+								dlFolder.getTreePath(), treePath, '_', '%',
+								'\\', true) ||
 							(hidden != dlFolder.getHidden())) {
 						list = null;
 


### PR DESCRIPTION
@brianchandotcom we need to talk about the SB release process tomorrow.
Right now all changes to SB are backported, since we need to release from ee. But changes like these petra ones can not be backported. Customer may use new SB release from an old portal, which means we will generate code with petra usage, while portal does not really have them. Their code will break on compile.

For now, we are just using char literal values in SB, this way customers will not see the issue and we can still continue to portal compat kernel CharPool. This can be used in the next petra StringPool apply too. But not other applys, like StringBundler, and many others.

We will have to fix the release process for SB on master, in order to continue the rest of the petra apply.

CC @mhan810