### PR TITLE
[TS] LPS-74388

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/RemoteElasticsearchConnection.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/RemoteElasticsearchConnection.java
@@ -185,6 +185,9 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 			"path.logs", props.get(PropsKeys.LIFERAY_HOME) + "/logs");
 		settingsBuilder.put(
 			"path.work", SystemProperties.get(SystemProperties.TMP_DIR));
+		settingsBuilder.put(
+			"request.headers.X-Found-Cluster",
+			elasticsearchConfiguration.clusterName());
 	}
 
 	@Modified


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-74388

Add missing "request.headers.X-Found-Cluster" parameter that it is neccesary for Elastic cloud (see: https://www.elastic.co/guide/en/cloud/current/security.html#security-transport )