### PR TITLE
LPS-75807 Public Render Parameters submitted in a ResourceRequest via…

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -897,7 +897,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		}
 
 		_mergePublicRenderParameters(
-			dynamicRequest, publicRenderParametersMap, preferences);
+			dynamicRequest, publicRenderParametersMap, preferences,
+			getLifecycle());
 
 		_processCheckbox(dynamicRequest);
 
@@ -954,7 +955,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             #_mergePublicRenderParameters(DynamicServletRequest, Map,
-	 *             PortletPreferences)}
+	 *             PortletPreferences, String)}
 	 */
 	@Deprecated
 	protected void mergePublicRenderParameters(
@@ -962,7 +963,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		long plid) {
 
 		_mergePublicRenderParameters(
-			dynamicRequest, Collections.emptyMap(), preferences);
+			dynamicRequest, Collections.emptyMap(), preferences,
+			getLifecycle());
 	}
 
 	protected String removePortletNamespace(
@@ -978,7 +980,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 	private void _mergePublicRenderParameters(
 		DynamicServletRequest dynamicRequest,
 		Map<String, String[]> publicRenderParametersMap,
-		PortletPreferences preferences) {
+		PortletPreferences preferences, String lifecycle) {
 
 		Set<PublicRenderParameter> publicRenderParameters =
 			_portlet.getPublicRenderParameters();
@@ -986,6 +988,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		if (publicRenderParameters.isEmpty()) {
 			return;
 		}
+
+		boolean resourcePhase = lifecycle.equals(PortletRequest.RESOURCE_PHASE);
 
 		Enumeration<String> enumeration = preferences.getNames();
 
@@ -1007,7 +1011,14 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 				String name = publicRenderParameter.getIdentifier();
 
-				if (dynamicRequest.getParameter(name) == null) {
+				String[] requestValues = dynamicRequest.getParameterValues(
+					name);
+
+				if ((requestValues != null) && resourcePhase) {
+					dynamicRequest.setParameterValues(
+						name, ArrayUtil.append(requestValues, values));
+				}
+				else {
 					dynamicRequest.setParameterValues(name, values);
 				}
 			}

--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -952,6 +952,9 @@ public class PortletURLImpl
 			renderParams = _mergeWithRenderParameters(renderParams);
 		}
 
+		boolean resourcePhase = _lifecycle.equals(
+			PortletRequest.RESOURCE_PHASE);
+
 		for (Map.Entry<String, String[]> entry : renderParams.entrySet()) {
 			String name = entry.getKey();
 			String[] values = entry.getValue();
@@ -960,11 +963,13 @@ public class PortletURLImpl
 				continue;
 			}
 
-			String publicRenderParameterName = getPublicRenderParameterName(
-				name);
+			if (!resourcePhase) {
+				String publicRenderParameterName = getPublicRenderParameterName(
+					name);
 
-			if (Validator.isNotNull(publicRenderParameterName)) {
-				name = publicRenderParameterName;
+				if (Validator.isNotNull(publicRenderParameterName)) {
+					name = publicRenderParameterName;
+				}
 			}
 
 			for (String value : values) {
@@ -1088,6 +1093,9 @@ public class PortletURLImpl
 
 		int previousSbIndex = sb.index();
 
+		boolean resourcePhase = _lifecycle.equals(
+			PortletRequest.RESOURCE_PHASE);
+
 		for (Map.Entry<String, String[]> entry : renderParams.entrySet()) {
 			String name = entry.getKey();
 			String[] values = entry.getValue();
@@ -1096,11 +1104,13 @@ public class PortletURLImpl
 				continue;
 			}
 
-			String publicRenderParameterName = getPublicRenderParameterName(
-				name);
+			if (resourcePhase) {
+				String publicRenderParameterName = getPublicRenderParameterName(
+					name);
 
-			if (Validator.isNotNull(publicRenderParameterName)) {
-				name = publicRenderParameterName;
+				if (Validator.isNotNull(publicRenderParameterName)) {
+					name = publicRenderParameterName;
+				}
 			}
 
 			for (String value : values) {


### PR DESCRIPTION
… ResourceURL do not contain prepended parameter values and incorrectly cause value changes to be propagated to other portlets on the same portal page