### PR TITLE
LPS-76035 Remove messaging/portal resiliency integration. Will readd …

### DIFF
--- a/modules/apps/foundation/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
+++ b/modules/apps/foundation/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/DefaultMessageBus.java
@@ -25,8 +25,6 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.messaging.MessageBusEventListener;
 import com.liferay.portal.kernel.messaging.MessageListener;
-import com.liferay.portal.kernel.nio.intraband.messaging.IntrabandBridgeDestination;
-import com.liferay.portal.kernel.resiliency.spi.SPIUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -300,14 +298,6 @@ public class DefaultMessageBus implements ManagedServiceFactory, MessageBus {
 	}
 
 	protected void doAddDestination(Destination destination) {
-		Class<?> clazz = destination.getClass();
-
-		if (SPIUtil.isSPI() &&
-			!clazz.equals(IntrabandBridgeDestination.class)) {
-
-			destination = new IntrabandBridgeDestination(destination);
-		}
-
 		_destinations.put(destination.getName(), destination);
 
 		for (MessageBusEventListener messageBusEventListener :


### PR DESCRIPTION
…when we have time to fix portal resiliency in the future.

@jrao wait until this pull and https://github.com/brianchandotcom/liferay-portal/pull/53034 are merged, then you are good to continue petra-messaging extraction. And please make sure to keep it under modules/apps/foundation/petra, rather than modules/core/petra. Modules in modules/core/petra are only allowed to have jdk and other core/petra dependencies.

And we will continue on the finished core/petra modules' usage apply, you don't need to worry about those.

CC @rotty3000 @mhan810