### PR TITLE
LPS-76274 Category properties do not display after being saved

### DIFF
--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = dc4fd2b9ce72767749d4893afedb885e807dcff3
+	commit = ff55c92bd186a59d60585cc7c437471a25901c03
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9e6a63bcd72232f5b3688673a180e95544b324b8
+	parent = 8d0a38e88ae33ddbafab751f4f59349eac635afa
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/foundation/users-admin/.gitrepo
+++ b/modules/apps/foundation/users-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = dbc8d7bb14c77c272b885e3ddffd8de17075fce6
+	commit = 051743e64f64588d13de187a3eb818c392712c31
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a271fadb08ee911fe1e49004878b27b666a923c7
+	parent = f864b8df3b5a714d56178ad0ed61baa97f41d2d6
 	remote = git@github.com:liferay/com-liferay-users-admin.git

--- a/modules/apps/web-experience/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetCategoryPropertyAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/web-experience/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetCategoryPropertyAssetCategoryLocalServiceWrapper.java
@@ -23,6 +23,7 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalServiceWrapper;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -34,11 +35,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
  */
+@Component(immediate = true, service = ServiceWrapper.class)
 public class AssetCategoryPropertyAssetCategoryLocalServiceWrapper
 	extends AssetCategoryLocalServiceWrapper {
 

--- a/modules/apps/web-experience/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/service/AssetTagStatsAssetTagLocalServiceWrapper.java
+++ b/modules/apps/web-experience/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/service/AssetTagStatsAssetTagLocalServiceWrapper.java
@@ -19,12 +19,15 @@ import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalServiceWrapper;
 import com.liferay.asset.tag.stats.service.AssetTagStatsLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceWrapper;
 
+import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
  */
+@Component(immediate = true, service = ServiceWrapper.class)
 public class AssetTagStatsAssetTagLocalServiceWrapper
 	extends AssetTagLocalServiceWrapper {
 

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = a83861adde36f05106d8b900001fded3b21f5db0
+	commit = e4546af90158e734c0bd214c8ac98eec287785e3
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b05e59d0b29daf7b1c96b707e23f140b5167bc43
+	parent = d2702bf3ebc38e308d4b35a99964e5dafb497a05
 	remote = git@github.com:liferay/com-liferay-staging.git

--- a/portal-impl/src/content/Language_lt.properties
+++ b/portal-impl/src/content/Language_lt.properties
@@ -441,7 +441,6 @@ country.zimbabwe=Zimbabvė
 ## Currency
 ##
 
-
 ##
 ## Language
 ##

--- a/portal-impl/src/content/Language_ro.properties
+++ b/portal-impl/src/content/Language_ro.properties
@@ -4535,7 +4535,6 @@ country.zimbabwe=Zimbabwe
 ## Currency
 ##
 
-
 ##
 ## Language
 ##

--- a/portal-impl/src/content/Language_sl.properties
+++ b/portal-impl/src/content/Language_sl.properties
@@ -4145,7 +4145,6 @@ country.zimbabwe=Zimbabve
 ## Currency
 ##
 
-
 ##
 ## Language
 ##

--- a/portal-impl/src/content/Language_th.properties
+++ b/portal-impl/src/content/Language_th.properties
@@ -10,26 +10,21 @@ lang.line.end=right
 ## Portlet descriptions and titles
 ##
 
-
 ##
 ## Category titles
 ##
-
 
 ##
 ## Model resources
 ##
 
-
 ##
 ## Action names
 ##
 
-
 ##
 ## Messages
 ##
-
 
 ##
 ## Country
@@ -288,7 +283,6 @@ country.zimbabwe=ซิมบาบเว
 ##
 ## Currency
 ##
-
 
 ##
 ## Language

--- a/portal-impl/src/content/Language_uk.properties
+++ b/portal-impl/src/content/Language_uk.properties
@@ -4141,7 +4141,6 @@ country.zimbabwe=Зімбабве
 ## Currency
 ##
 
-
 ##
 ## Language
 ##


### PR DESCRIPTION
Hi Brian, the commits with different LPS are intentional. It's so that they can be related to the stories that were sent before. Thanks.

cc:// @ealonso