### PR TITLE
Revert "LPS-76237 Using the right blogs model class name"

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/content/processor/BlogsEntryExportImportContentProcessor.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/content/processor/BlogsEntryExportImportContentProcessor.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Daniel Kocsis
  */
 @Component(
-	property = {"model.class.name=com.liferay.blogs.model.BlogsEntry"},
+	property = {"model.class.name=com.liferay.blogs.kernel.model.BlogsEntry"},
 	service = {
 		BlogsEntryExportImportContentProcessor.class,
 		ExportImportContentProcessor.class

--- a/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/data/handler/BlogsEntryStagedModelDataHandler.java
+++ b/modules/apps/collaboration/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/exportimport/data/handler/BlogsEntryStagedModelDataHandler.java
@@ -498,7 +498,7 @@ public class BlogsEntryStagedModelDataHandler
 
 	@Reference(
 		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(model.class.name=com.liferay.blogs.model.BlogsEntry)",
+		target = "(model.class.name=com.liferay.blogs.kernel.model.BlogsEntry)",
 		unbind = "-"
 	)
 	protected void setExportImportContentProcessor(


### PR DESCRIPTION
This reverts commit 41cdc363e6f867899e63cd91400344a20dbbaeed.

@brianchandotcom this is fixing another CI failure. It got merged in by https://github.com/brianchandotcom/liferay-portal/pull/53431

The subrepo change https://github.com/liferay/com-liferay-adaptive-media/commit/143085c8d49ebc46784094d208a694496bc405e5#diff-2240d7120a23a5437d9e8f230c01ebeb is not in, but the portal one got merged. That's why this is failing.

At this phase considering CI is in really bad shape. We should not force merge subrepo, as it might add other issues.

QA must provide a way to synchronously change matching parts from portal and subrepos, otherwise we can never safely merge this kind of changes.