### PR TITLE
Revert "LPS-76173 Mark class as component"

### DIFF
--- a/modules/apps/web-experience/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetCategoryPropertyAssetCategoryLocalServiceWrapper.java
+++ b/modules/apps/web-experience/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/service/AssetCategoryPropertyAssetCategoryLocalServiceWrapper.java
@@ -23,7 +23,6 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalServiceWrapper;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringPool;
@@ -35,13 +34,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
  */
-@Component(immediate = true, service = ServiceWrapper.class)
 public class AssetCategoryPropertyAssetCategoryLocalServiceWrapper
 	extends AssetCategoryLocalServiceWrapper {
 


### PR DESCRIPTION
This reverts commit c9307a3257ab7b8604f210bb5dff72cd7ca28d8b.

CC @shuyangzhou @jkappler

This causes a NPE at many tests such as:
```
     [exec] com.liferay.portal.security.membership.policy.organization.test.OrganizationMembershipPolicyMembershipsTest > testVerifyWhenAddingOrganization FAILED
     [exec]     java.lang.NullPointerException
     [exec]         at com.liferay.asset.categories.internal.service.AssetCategoryPropertyAssetCategoryLocalServiceWrapper.addCategory(AssetCategoryPropertyAssetCategoryLocalServiceWrapper.java:72)
     [exec]         at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [exec]         at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
     [exec]         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
...
     [exec]         at com.sun.proxy.$Proxy95.addCategory(Unknown Source)
     [exec]         at com.liferay.portlet.asset.service.impl.AssetCategoryLocalServiceImpl.addCategory(AssetCategoryLocalServiceImpl.java:157)
```