### PR TITLE
Revert LPS-76298

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletIdCodec.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletIdCodec.java
@@ -30,8 +30,9 @@ import java.security.InvalidParameterException;
 public class PortletIdCodec {
 
 	public static final int PORTLET_INSTANCE_KEY_MAX_LENGTH =
-		255 - PortletIdCodec._INSTANCE_SEPARATOR.length() +
-			PortletIdCodec._USER_SEPARATOR.length() + 31;
+		255 - (
+			PortletIdCodec._INSTANCE_SEPARATOR.length() +
+				PortletIdCodec._USER_SEPARATOR.length() + 31);
 
 	public static String decodeInstanceId(String portletId) {
 		int index = portletId.indexOf(_INSTANCE_SEPARATOR);


### PR DESCRIPTION
@brianchandotcom Please see https://ideone.com/j6rDQb; the parentheses affects the order of operations unless if Ideone is using a different version of Java than Liferay uses.

Also, if it is true that the parentheses aren't doing anything, then we should change all the +'s to -'s, rather than simply removing the parentheses. According to https://introcs.cs.princeton.edu/java/11precedence/, + and - have the same level of precedence, and have left-to-right associativity. Meaning that if the parentheses are gone or if the parentheses are not actually doing anything, the expression will be evaluated mathematically as `(((255 - PortletIdCodec._INSTANCE_SEPARATOR.length()) + PortletIdCodec._USER_SEPARATOR.length()) + 31)`, as opposed to `(255 - ((PortletIdCodec._INSTANCE_SEPARATOR.length()) + PortletIdCodec._USER_SEPARATOR.length()) + 31))`