### PR TITLE
LRQA-36041 Revert sort

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -764,9 +764,10 @@ public class JenkinsResultsParserUtil {
 			(ThreadPoolExecutor)Executors.newFixedThreadPool(maximumPoolSize);
 
 		if (autoShutDown) {
+			threadPoolExecutor.setKeepAliveTime(5, TimeUnit.SECONDS);
+
 			threadPoolExecutor.allowCoreThreadTimeOut(true);
 			threadPoolExecutor.setCorePoolSize(maximumPoolSize);
-			threadPoolExecutor.setKeepAliveTime(5, TimeUnit.SECONDS);
 			threadPoolExecutor.setMaximumPoolSize(maximumPoolSize);
 		}
 


### PR DESCRIPTION
The original sequence of these lines was important because you have to set a keep alive time above zero before you set allowCoreThreadTimeout to true. If you don't, the following exception is thrown.

```
Caused by: java.lang.IllegalArgumentException: Core threads must have nonzero keep alive times
```

This reverts commit 9595c2a2d4cd4b2e34309ded1567ffa01b8bbfd5.