### PR TITLE
LPS-76354

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/portlet/action/EditUserMVCActionCommand.java
@@ -484,8 +484,6 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 				actionRequest, "announcementsType" + type + "Email");
 			boolean sms = ParamUtil.getBoolean(
 				actionRequest, "announcementsType" + type + "Sms");
-			boolean website = ParamUtil.getBoolean(
-				actionRequest, "announcementsType" + type + "Website");
 
 			AnnouncementsDelivery announcementsDelivery =
 				new AnnouncementsDeliveryImpl();
@@ -493,7 +491,6 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 			announcementsDelivery.setType(type);
 			announcementsDelivery.setEmail(email);
 			announcementsDelivery.setSms(sms);
-			announcementsDelivery.setWebsite(website);
 
 			announcementsDeliveries.add(announcementsDelivery);
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java
@@ -2556,8 +2556,7 @@ public class UserServiceImpl extends UserServiceBaseImpl {
 			announcementsDeliveryService.updateDelivery(
 				userId, announcementsDelivery.getType(),
 				announcementsDelivery.getEmail(),
-				announcementsDelivery.getSms(),
-				announcementsDelivery.getWebsite());
+				announcementsDelivery.getSms());
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/announcements/service/http/AnnouncementsDeliveryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/http/AnnouncementsDeliveryServiceHttp.java
@@ -57,11 +57,44 @@ import com.liferay.portal.kernel.util.MethodKey;
 public class AnnouncementsDeliveryServiceHttp {
 	public static com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
 		HttpPrincipal httpPrincipal, long userId, java.lang.String type,
-		boolean email, boolean sms, boolean website)
+		boolean email, boolean sms)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(AnnouncementsDeliveryServiceUtil.class,
 					"updateDelivery", _updateDeliveryParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
+					type, email, sms);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.announcements.kernel.model.AnnouncementsDelivery)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
+		HttpPrincipal httpPrincipal, long userId, java.lang.String type,
+		boolean email, boolean sms, boolean website)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(AnnouncementsDeliveryServiceUtil.class,
+					"updateDelivery", _updateDeliveryParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
 					type, email, sms, website);
@@ -90,6 +123,9 @@ public class AnnouncementsDeliveryServiceHttp {
 
 	private static Log _log = LogFactoryUtil.getLog(AnnouncementsDeliveryServiceHttp.class);
 	private static final Class<?>[] _updateDeliveryParameterTypes0 = new Class[] {
+			long.class, java.lang.String.class, boolean.class, boolean.class
+		};
+	private static final Class<?>[] _updateDeliveryParameterTypes1 = new Class[] {
 			long.class, java.lang.String.class, boolean.class, boolean.class,
 			boolean.class
 		};

--- a/portal-impl/src/com/liferay/portlet/announcements/service/http/AnnouncementsDeliveryServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/http/AnnouncementsDeliveryServiceSoap.java
@@ -66,6 +66,28 @@ import java.rmi.RemoteException;
 @ProviderType
 public class AnnouncementsDeliveryServiceSoap {
 	public static com.liferay.announcements.kernel.model.AnnouncementsDeliverySoap updateDelivery(
+		long userId, java.lang.String type, boolean email, boolean sms)
+		throws RemoteException {
+		try {
+			com.liferay.announcements.kernel.model.AnnouncementsDelivery returnValue =
+				AnnouncementsDeliveryServiceUtil.updateDelivery(userId, type,
+					email, sms);
+
+			return com.liferay.announcements.kernel.model.AnnouncementsDeliverySoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#updateDelivery(long, String, boolean, boolean)}
+	*/
+	@Deprecated
+	public static com.liferay.announcements.kernel.model.AnnouncementsDeliverySoap updateDelivery(
 		long userId, java.lang.String type, boolean email, boolean sms,
 		boolean website) throws RemoteException {
 		try {

--- a/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsDeliveryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsDeliveryLocalServiceImpl.java
@@ -144,19 +144,32 @@ public class AnnouncementsDeliveryLocalServiceImpl
 
 	@Override
 	public AnnouncementsDelivery updateDelivery(
-			long userId, String type, boolean email, boolean sms,
-			boolean website)
+			long userId, String type, boolean email, boolean sms)
 		throws PortalException {
 
 		AnnouncementsDelivery delivery = getUserDelivery(userId, type);
 
 		delivery.setEmail(email);
 		delivery.setSms(sms);
-		delivery.setWebsite(website);
+		delivery.setWebsite(true);
 
 		announcementsDeliveryPersistence.update(delivery);
 
 		return delivery;
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #updateDelivery(long, String, boolean, boolean)}
+	 */
+	@Deprecated
+	@Override
+	public AnnouncementsDelivery updateDelivery(
+			long userId, String type, boolean email, boolean sms,
+			boolean website)
+		throws PortalException {
+
+		return updateDelivery(userId, type, email, sms);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsDeliveryServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsDeliveryServiceImpl.java
@@ -31,6 +31,31 @@ public class AnnouncementsDeliveryServiceImpl
 
 	@Override
 	public AnnouncementsDelivery updateDelivery(
+			long userId, String type, boolean email, boolean sms)
+		throws PortalException {
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (!PortalPermissionUtil.contains(
+				permissionChecker, ActionKeys.ADD_USER) &&
+			!UserPermissionUtil.contains(
+				permissionChecker, userId, ActionKeys.UPDATE)) {
+
+			throw new PrincipalException.MustHavePermission(
+				permissionChecker, ActionKeys.ADD_USER, ActionKeys.UPDATE);
+		}
+
+		return announcementsDeliveryLocalService.updateDelivery(
+			userId, type, email, sms);
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link
+	 *             #updateDelivery(long, String, boolean, boolean)}
+	 */
+	@Deprecated
+	@Override
+	public AnnouncementsDelivery updateDelivery(
 			long userId, String type, boolean email, boolean sms,
 			boolean website)
 		throws PortalException {

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryLocalService.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryLocalService.java
@@ -255,6 +255,15 @@ public interface AnnouncementsDeliveryLocalService extends BaseLocalService,
 		AnnouncementsDelivery announcementsDelivery);
 
 	public AnnouncementsDelivery updateDelivery(long userId,
+		java.lang.String type, boolean email, boolean sms)
+		throws PortalException;
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#updateDelivery(long, String, boolean, boolean)}
+	*/
+	@java.lang.Deprecated
+	public AnnouncementsDelivery updateDelivery(long userId,
 		java.lang.String type, boolean email, boolean sms, boolean website)
 		throws PortalException;
 }

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryLocalServiceUtil.java
@@ -293,6 +293,17 @@ public class AnnouncementsDeliveryLocalServiceUtil {
 	}
 
 	public static com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
+		long userId, java.lang.String type, boolean email, boolean sms)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().updateDelivery(userId, type, email, sms);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#updateDelivery(long, String, boolean, boolean)}
+	*/
+	@Deprecated
+	public static com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
 		long userId, java.lang.String type, boolean email, boolean sms,
 		boolean website)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryLocalServiceWrapper.java
@@ -318,6 +318,19 @@ public class AnnouncementsDeliveryLocalServiceWrapper
 
 	@Override
 	public com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
+		long userId, java.lang.String type, boolean email, boolean sms)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _announcementsDeliveryLocalService.updateDelivery(userId, type,
+			email, sms);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#updateDelivery(long, String, boolean, boolean)}
+	*/
+	@Deprecated
+	@Override
+	public com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
 		long userId, java.lang.String type, boolean email, boolean sms,
 		boolean website)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryService.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryService.java
@@ -57,6 +57,15 @@ public interface AnnouncementsDeliveryService extends BaseService {
 	public java.lang.String getOSGiServiceIdentifier();
 
 	public AnnouncementsDelivery updateDelivery(long userId,
+		java.lang.String type, boolean email, boolean sms)
+		throws PortalException;
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#updateDelivery(long, String, boolean, boolean)}
+	*/
+	@java.lang.Deprecated
+	public AnnouncementsDelivery updateDelivery(long userId,
 		java.lang.String type, boolean email, boolean sms, boolean website)
 		throws PortalException;
 }

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryServiceUtil.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryServiceUtil.java
@@ -51,6 +51,17 @@ public class AnnouncementsDeliveryServiceUtil {
 	}
 
 	public static com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
+		long userId, java.lang.String type, boolean email, boolean sms)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().updateDelivery(userId, type, email, sms);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#updateDelivery(long, String, boolean, boolean)}
+	*/
+	@Deprecated
+	public static com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
 		long userId, java.lang.String type, boolean email, boolean sms,
 		boolean website)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsDeliveryServiceWrapper.java
@@ -46,6 +46,19 @@ public class AnnouncementsDeliveryServiceWrapper
 
 	@Override
 	public com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
+		long userId, java.lang.String type, boolean email, boolean sms)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _announcementsDeliveryService.updateDelivery(userId, type,
+			email, sms);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, replaced by {@link
+	#updateDelivery(long, String, boolean, boolean)}
+	*/
+	@Deprecated
+	@Override
+	public com.liferay.announcements.kernel.model.AnnouncementsDelivery updateDelivery(
 		long userId, java.lang.String type, boolean email, boolean sms,
 		boolean website)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0


### PR DESCRIPTION
@drewbrokke Sending this through you since it seems more related to Users than Announcements, but let me know if you'd like to have this go elsewhere.

Based off of LPS-216, it seems the Website option should always be checked, however, we're depending on disabled checkboxes to achieve that. Instead, we should enforce this rule in the backend so that it never changes.

I would have liked to remove the entire Website option since I don't see the use for it but that requires a major version increase to portal-kernel which I'd like to avoid.

Let me know if you have any questions.