### PR TITLE
LPS-76337 Assimilate portal-search-facet module into portal-search

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search/build.gradle
@@ -16,11 +16,11 @@ dependencies {
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "commons-lang", name: "commons-lang", version: "2.6"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
+	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	provided group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:foundation:portal-search:portal-search-api")
 
 	testCompile group: "com.liferay", name: "com.liferay.petra.memory", version: "1.0.0"
 	testCompile group: "com.liferay", name: "com.liferay.registry.api", version: "1.1.0"
-	testCompile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 }

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.search.facet.internal.faceted.searcher;
+package com.liferay.portal.search.internal.searcher;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherManagerImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherManagerImpl.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.search.facet.internal.faceted.searcher;
+package com.liferay.portal.search.internal.searcher;
 
 import com.liferay.expando.kernel.util.ExpandoBridgeFactory;
 import com.liferay.portal.kernel.search.IndexSearcherHelper;

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
@@ -110,7 +110,7 @@
 	</command>
 
 	<command name="AddFormTemplate" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="Navigator#openURL" />
 
@@ -2846,7 +2846,7 @@
 	</command>
 
 	<command name="DeleteList" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="Navigator#openURL" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/cpdynamicdatalists/CPDynamicdatalists.testcase
@@ -1493,7 +1493,7 @@
 
 	<command name="AddListRecordWithLinkToPageField" priority="5">
 		<description message="This is a use case for LPS-65726" />
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="ProductMenu#gotoPortlet">
 			<var name="category" value="Navigation" />
@@ -3372,7 +3372,7 @@
 	</command>
 
 	<command name="EditDataDefinition" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="Navigator#openURL" />
 
@@ -3752,7 +3752,7 @@
 	</command>
 
 	<command name="EditListRecord" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="Navigator#openURL" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/pgdynamicdatalists/PGDynamicdatalists.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/pgdynamicdatalists/PGDynamicdatalists.testcase
@@ -551,7 +551,7 @@
 	</command>
 
 	<command name="ConfigureSpreadsheetListPG" priority="5">
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="Navigator#openURL" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/pgdynamicdatalists/PGDynamicdatalists.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/pgdynamicdatalists/PGDynamicdatalists.testcase
@@ -1894,7 +1894,7 @@
 
 	<command name="ViewListRecordWithUploadedFreeMarkerDisplayTemplate" priority="5">
 		<property name="custom.properties" value="freemarker.engine.restricted.variables=${line.separator}restricted.variables=" />
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 		<property name="testray.component.names" value="Training" />
 
 		<execute macro="Navigator#openURL" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/dynamicdatalists/usecase/DynamicdatalistsUsecase.testcase
@@ -629,7 +629,7 @@
 
 	<command name="AddRecordWithRepeatableTextField" priority="5">
 		<description message="This is a use case for LPS-65069." />
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 
 		<execute macro="Navigator#openURL" />
 
@@ -3874,7 +3874,7 @@
 	<command name="ViewRequiredNestedDocumentsAndMediaField" priority="5">
 		<description message="This is a use case for LPS-60155." />
 
-		<property name="portal.acceptance" value="true" />
+		<property name="portal.acceptance" value="quarantine" />
 		<property name="testray.component.names" value="Training" />
 
 		<execute macro="Navigator#openURL" />


### PR DESCRIPTION
All classes in `portal-search-facet` are internal implementation; transferring to `portal-search`. The `portal-search-facet` module itself will be removed by LPS-76382 and won't be part of any 7.1 LPKG. (cc/ @shuyangzhou)

I named the package as plain `com.liferay.portal.search.internal.searcher` because`FacetedSearcherImpl` itself will soon be refactored into smaller classes (following the new indexer architecture from https://issues.liferay.com/browse/LPS-73604) and focus will be on its "searcher" aspect - every Searcher is already "faceted" by nature.

https://issues.liferay.com/browse/LPS-76337
https://issues.liferay.com/browse/LPS-76382