### PR TITLE
LPS-76472 Disable JVM monitor when testing on the CI to avoid GC warn…

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/main/java/com/liferay/portal/search/elasticsearch/internal/connection/EmbeddedElasticsearchConnection.java
@@ -466,6 +466,8 @@ public class EmbeddedElasticsearchConnection
 				"index.search.slowlog.threshold.query.warn", "-1");
 			settingsBuilder.put("index.translog.flush_threshold_ops", "1");
 			settingsBuilder.put("index.translog.interval", "1ms");
+			settingsBuilder.put(
+				"monitor.jvm.enabled", Boolean.FALSE.toString());
 		}
 	}
 


### PR DESCRIPTION
…ings causing test failures. See org.elasticsearch.monitor.jvm.JvmMonitorService.