### PR TITLE
LPS-76518 Fix very weak assertion, searching a large string containin…

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -375,9 +375,10 @@ public class DefaultExportImportContentProcessorTest {
 			content.contains(
 				"@data_handler_group_friendly_url@@" +
 					_stagingGroup.getFriendlyURL() + "@"));
+		Assert.assertTrue(
+			content, content.contains("@data_handler_path_context@/en@"));
 		Assert.assertFalse(
-			content, content.contains(PortalUtil.getPathContext()));
-		Assert.assertFalse(content, content.contains("/en/en"));
+			content, content.contains("@data_handler_path_context@/de@"));
 
 		setFinalStaticField(
 			PropsValues.class.getDeclaredField(


### PR DESCRIPTION
…g random strings for '/de' can fail. This only improves the worst case, there are other cases in this test that can still randomly fail from all the contains checking but this is the most frequent failing assertion.