### PR TITLE
LPS-76465 SolrQuerySuggester error on startup: Field must be declared volatile

### DIFF
--- a/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrQuerySuggester.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/main/java/com/liferay/portal/search/solr/internal/SolrQuerySuggester.java
@@ -380,7 +380,7 @@ public class SolrQuerySuggester extends BaseQuerySuggester {
 		policy = ReferencePolicy.DYNAMIC,
 		policyOption = ReferencePolicyOption.GREEDY
 	)
-	protected Tokenizer tokenizer;
+	protected volatile Tokenizer tokenizer;
 
 	private static final long _GLOBAL_GROUP_ID = 0;
 


### PR DESCRIPTION
CI doesn't test Solr, so there shouldn't be a need to run the PR tester on this pull. Local tests with Solr passed.

Author: @wcao20170619 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-76465