### PR TITLE
LPS-74152 As a developer I would like to support scoped configuration without needing to declare a metatype as a factory

### DIFF
--- a/modules/apps/collaboration/bookmarks/.gitrepo
+++ b/modules/apps/collaboration/bookmarks/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = bd77de98f0f3bf9428d1ea9bec4d943c3d4dcc71
+	commit = 74a8c954f9e46cc05c25dd8cbe1fe53b64fe456b
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 328fc0099083eb1eef50cb561c4af6d105d426a4
+	parent = e15130fae1cb3c0a920fd7c1e8e70793f813498e
 	remote = git@github.com:liferay/com-liferay-bookmarks.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 86a3ebf493c8af270296f06e60771fb6495e5fb1
+	commit = b56dc7721b10b478f98528bfc7f11a9d1f57be2d
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a1f0664e5f175398ff16536f8130d25f096c4a1e
+	parent = b6c2fade355bb63a79e8e5f82fe4166880127fc1
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/item-selector/.gitrepo
+++ b/modules/apps/collaboration/item-selector/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 952fc556c801ac8f5ee444dc72b4f642c57fc830
+	commit = 001a207d3e2498e28fe1c73afbc98b7829520de4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 2df114a0c16871b08f3d55c32bbfb863554b0758
+	parent = fbe4fa5f717e133dc7ff42cf6b95b41447bf6e1f
 	remote = git@github.com:liferay/com-liferay-item-selector.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = a2244f959fd9bffdf5ca7c96b861ce4f3c43efc4
+	commit = faeacc916c56f27d9223c5b6aab0bd5341c4a103
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 9b5eec04d27e2ea864eae0dcd6e1311c72187847
+	parent = 077014d21f548b22945ad0c718c7ffec35066115
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/social/.gitrepo
+++ b/modules/apps/collaboration/social/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 41cab38b3dd6a7d6b478b9ad620d6f34eb25764f
+	commit = f80c04871b1d81e558d5ce94416bb72058579eac
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 198f741b70bd7ad362b0a5ab3e8083337993c611
+	parent = 8651c366b0ed84f7c557aaf009469d6e797e7021
 	remote = git@github.com:liferay/com-liferay-social.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = cf05e2c96af9158d09d9ed9f9a84d34e8a979bc9
+	commit = 6d91d80aafdfd00e15c575b7a7abde364c7ee6d0
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ae56c18392e336eaabd0e856b0c4da23a7f49b07
+	parent = d6d8fd8a216125a8a7f55d246be15d63eb578e7d
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = d8041730faa3e08795b33e46d1556dc501570626
+	commit = 5679980bb6f842098f857af23e612640c0b3511a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = cec74844d043b42668e7e9f238b84d25030d464b
+	parent = 9d4073087cbe7a3bcc83798d80ae4bc135751d20
 	remote = git@github.com:liferay/com-liferay-dynamic-data-lists.git

--- a/modules/apps/foundation/configuration-admin/.gitrepo
+++ b/modules/apps/foundation/configuration-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 75159346e19dd8cc6954667d71436374e4b3f48c
+	commit = a10c8594776fcd07b92027690700066edf766a3a
 	mergebuttonmergecommits = false
 	mode = push
-	parent = a6b3e9d7dfe7ba2c90511dd8a584878a4093e09e
+	parent = d314c9883a6561927faec82cb21e9d0f706c970f
 	remote = git@github.com:liferay/com-liferay-configuration-admin.git

--- a/modules/apps/foundation/frontend-css/.gitrepo
+++ b/modules/apps/foundation/frontend-css/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = baf4b6aaf8cf9a22552112080f3119ef9ea5c658
+	commit = 95981740cbe4a4adeb89ae154f3e45fd12c80041
 	mergebuttonmergecommits = false
 	mode = push
-	parent = dca45c1e76c1c79f49ef1f4d48c514db6af7b86c
+	parent = 3294dafda56d79553233d96bbbc9ab356916d273
 	remote = git@github.com:liferay/com-liferay-frontend-css.git

--- a/modules/apps/foundation/frontend-taglib/.gitrepo
+++ b/modules/apps/foundation/frontend-taglib/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 7b7b8ce8c488cc91efa92e2a2db8791f1f841768
+	commit = c8f9251f6e4a7e4fe19bcb3d7e669ee581fcdde2
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 1c278b6f240b05c144950aaac9bbea70f5525442
+	parent = fe4d04662f8ef8a52614ece5ceebd29634acd334
 	remote = git@github.com:liferay/com-liferay-frontend-taglib.git

--- a/modules/apps/foundation/frontend-theme/.gitrepo
+++ b/modules/apps/foundation/frontend-theme/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = a28f973459889acbbbf60e9a019868987359d1aa
+	commit = b7997bec86331b2ddb90cea8601cf7f804d9bed9
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 89ca11f181d5d3025fbbe1a13e20f34930eca598
+	parent = e7f9fbb607752a09d5da4b5fa4f003cf33a813e8
 	remote = git@github.com:liferay/com-liferay-frontend-theme.git

--- a/modules/apps/foundation/mobile-device-rules/.gitrepo
+++ b/modules/apps/foundation/mobile-device-rules/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = fe3f195d3aaf4a1429c08580bb811b1406959cec
+	commit = 3b167699da3217c4116c094160fb69438a9edfb6
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f6893626b728a7bb830ea3056f18d4d9f4a65327
+	parent = e35c0f276bb44aa735675beba0c1fac316fe8f5e
 	remote = git@github.com:liferay/com-liferay-mobile-device-rules.git

--- a/modules/apps/foundation/portal-cache/.gitrepo
+++ b/modules/apps/foundation/portal-cache/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 6371c6b670137046bdda2c0dea5bd0bb1a73d964
+	commit = efc6ff96d35560d67055d5ac955625d8c9efca67
 	mergebuttonmergecommits = false
 	mode = push
-	parent = c44bf5513d00b94ae2d6788ebfd5b856e317ff7e
+	parent = fb9e15cd9cdb906dfaed14de6743daeb8f2a2964
 	remote = git@github.com:liferay/com-liferay-portal-cache.git

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
@@ -3,11 +3,11 @@ targetCompatibility = "1.8"
 
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
-	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.35.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:static:portal-configuration:portal-configuration-metatype")
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
@@ -4,7 +4,7 @@ targetCompatibility = "1.8"
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.35.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopeKey.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopeKey.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+/**
+ * @author Drew Brokke
+ */
+public class ScopeKey {
+
+	public ScopeKey(
+		Class<?> objectClass, ExtendedObjectClassDefinition.Scope scope,
+		String scopePrimKey) {
+
+		Objects.requireNonNull(
+			objectClass,
+			"The objectClass parameter must not be null. A ScopeKey must " +
+				"correspond to an existing configuration bean class.");
+
+		Objects.requireNonNull(
+			scope,
+			"The scope parameter must not be null. A ScopeKey must " +
+				"correspond to an existing scope from " +
+					"ExtendedObjectClassDefinition.Scope.");
+
+		if (scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM)) {
+			throw new IllegalArgumentException(
+				"A ScopeKey can only be used for the following scopes from " +
+					"ExtendedObjectClassDefinition.Scope: COMPANY, GROUP, " +
+						"PORTLET_INSTANCE.");
+		}
+
+		if (Validator.isNull(scopePrimKey)) {
+			throw new IllegalArgumentException(
+				"The scopePrimKey parameter must not be null. A ScopeKey " +
+					"must correspond to a primary key for the given scope.");
+		}
+
+		_objectClass = objectClass;
+		_scope = scope;
+		_scopePrimKey = scopePrimKey;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		ScopeKey otherScopeKey = (ScopeKey)obj;
+
+		if (_objectClass.equals(otherScopeKey.getObjectClass()) &&
+			_scope.equals(otherScopeKey.getScope()) &&
+			_scopePrimKey.equals(otherScopeKey.getScopePrimKey())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public Class<?> getObjectClass() {
+		return _objectClass;
+	}
+
+	public ExtendedObjectClassDefinition.Scope getScope() {
+		return _scope;
+	}
+
+	public String getScopePrimKey() {
+		return _scopePrimKey;
+	}
+
+	@Override
+	public int hashCode() {
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_objectClass.getName());
+		sb.append(_scope.getValue());
+		sb.append(_scopePrimKey);
+
+		String s = sb.toString();
+
+		return s.hashCode();
+	}
+
+	private final Class<?> _objectClass;
+	private final ExtendedObjectClassDefinition.Scope _scope;
+	private final String _scopePrimKey;
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanManagedService.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanManagedService.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal;
+
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
+import com.liferay.portal.configuration.settings.internal.util.ConfigurationPidUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import java.util.Dictionary;
+import java.util.function.Consumer;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ManagedService;
+
+/**
+ * @author Drew Brokke
+ */
+public class ScopedConfigurationBeanManagedService implements ManagedService {
+
+	public ScopedConfigurationBeanManagedService(
+		BundleContext bundleContext, Class<?> configurationBeanClass,
+		Consumer<Object> configurationBeanConsumer, ScopeKey scopeKey) {
+
+		_bundleContext = bundleContext;
+		_configurationBeanClass = configurationBeanClass;
+		_configurationBeanConsumer = configurationBeanConsumer;
+		_scopeKey = scopeKey;
+	}
+
+	public void register() {
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		properties.put(
+			Constants.SERVICE_PID,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				ConfigurationPidUtil.getConfigurationPid(
+					_configurationBeanClass),
+				_scopeKey.getScope(), _scopeKey.getScopePrimKey()));
+
+		_managedServiceServiceRegistration = _bundleContext.registerService(
+			ManagedService.class, this, properties);
+	}
+
+	public void unregister() {
+		_managedServiceServiceRegistration.unregister();
+	}
+
+	@Override
+	public void updated(final Dictionary<String, ?> properties) {
+		if (System.getSecurityManager() != null) {
+			AccessController.doPrivileged(
+				new ScopedConfigurationBeanManagedService.
+					UpdatePrivilegedAction(properties));
+		}
+		else {
+			doUpdated(properties);
+		}
+	}
+
+	protected void doUpdated(Dictionary<String, ?> properties) {
+		if (properties == null) {
+			_configurationBeanConsumer.accept(null);
+		}
+		else {
+			_configurationBeanConsumer.accept(
+				ConfigurableUtil.createConfigurable(
+					_configurationBeanClass, properties));
+		}
+	}
+
+	protected class UpdatePrivilegedAction implements PrivilegedAction<Void> {
+
+		@Override
+		public Void run() {
+			doUpdated(_properties);
+
+			return null;
+		}
+
+		private UpdatePrivilegedAction(Dictionary<String, ?> properties) {
+			_properties = properties;
+		}
+
+		private final Dictionary<String, ?> _properties;
+
+	}
+
+	private final BundleContext _bundleContext;
+	private final Class<?> _configurationBeanClass;
+	private final Consumer<Object> _configurationBeanConsumer;
+	private ServiceRegistration<ManagedService>
+		_managedServiceServiceRegistration;
+	private final ScopeKey _scopeKey;
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanProvider.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanProvider.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
+import com.liferay.portal.configuration.settings.internal.util.ConfigurationPidUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.ConfigurationListener;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	immediate = true,
+	service =
+		{ConfigurationListener.class, ScopedConfigurationBeanProvider.class}
+)
+public class ScopedConfigurationBeanProvider implements ConfigurationListener {
+
+	@Override
+	public void configurationEvent(ConfigurationEvent event) {
+		if (event.getType() != ConfigurationEvent.CM_UPDATED) {
+			return;
+		}
+
+		String pid = event.getFactoryPid();
+
+		if (pid == null) {
+			pid = event.getPid();
+		}
+
+		ExtendedObjectClassDefinition.Scope scope =
+			ConfigurationScopedPidUtil.getScope(pid);
+
+		if (scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM)) {
+			return;
+		}
+
+		try {
+			ScopeKey scopeKey = new ScopeKey(
+				_configurationBeanClasses.get(
+					ConfigurationScopedPidUtil.getBasePid(pid)),
+				scope, ConfigurationScopedPidUtil.getScopePrimKey(pid));
+
+			if (_scopedConfigurationBeans.containsKey(scopeKey)) {
+				return;
+			}
+
+			AtomicReference<ScopedConfigurationBeanManagedService>
+				managedServiceAtomicReference = new AtomicReference<>();
+
+			ScopedConfigurationBeanManagedService
+				configurationBeanManagedService =
+					new ScopedConfigurationBeanManagedService(
+						_bundleContext, scopeKey.getObjectClass(),
+						configurationBean -> {
+							if ((configurationBean == null) &&
+								_scopedConfigurationBeans.containsKey(
+									scopeKey)) {
+
+								_scopedConfigurationBeans.remove(scopeKey);
+
+								ScopedConfigurationBeanManagedService
+									managedService =
+										managedServiceAtomicReference.get();
+
+								managedService.unregister();
+
+								return;
+							}
+
+							_scopedConfigurationBeans.put(
+								scopeKey, configurationBean);
+						},
+						scopeKey);
+
+			managedServiceAtomicReference.set(configurationBeanManagedService);
+
+			configurationBeanManagedService.register();
+		}
+		catch (IllegalArgumentException | NullPointerException e) {
+			if (_log.isInfoEnabled()) {
+				_log.info(e);
+			}
+		}
+	}
+
+	public Object get(ScopeKey scopeKey) {
+		return _scopedConfigurationBeans.get(scopeKey);
+	}
+
+	public boolean has(ScopeKey scopeKey) {
+		return _scopedConfigurationBeans.containsKey(scopeKey);
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		unbind = "removeConfigurationBeanDeclaration"
+	)
+	protected void addConfigurationBeanDeclaration(
+		ConfigurationBeanDeclaration configurationBeanDeclaration) {
+
+		Class<?> configurationBeanClass =
+			configurationBeanDeclaration.getConfigurationBeanClass();
+
+		String configurationPid = ConfigurationPidUtil.getConfigurationPid(
+			configurationBeanClass);
+
+		_configurationBeanClasses.put(configurationPid, configurationBeanClass);
+	}
+
+	protected void removeConfigurationBeanDeclaration(
+		ConfigurationBeanDeclaration configurationBeanDeclaration) {
+
+		String configurationPid = ConfigurationPidUtil.getConfigurationPid(
+			configurationBeanDeclaration.getConfigurationBeanClass());
+
+		if (_configurationBeanClasses.containsKey(configurationPid)) {
+			_configurationBeanClasses.remove(configurationPid);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ScopedConfigurationBeanProvider.class);
+
+	private BundleContext _bundleContext;
+	private final Map<String, Class<?>> _configurationBeanClasses =
+		new ConcurrentHashMap<>();
+	private final Map<ScopeKey, Object> _scopedConfigurationBeans =
+		new ConcurrentHashMap<>();
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.configuration.settings.internal;
 
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -67,6 +68,29 @@ import org.osgi.util.tracker.ServiceTracker;
 @Component(immediate = true, service = SettingsLocatorHelper.class)
 @DoPrivileged
 public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
+
+	@Override
+	public Settings getCompanyConfigurationBeanSettings(
+		long companyId, String configurationPid, Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid),
+			ExtendedObjectClassDefinition.Scope.COMPANY,
+			String.valueOf(companyId));
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+	}
 
 	public PortletPreferences getCompanyPortletPreferences(
 		long companyId, String settingsId) {

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -296,6 +296,8 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	private ServiceTracker
 		<ConfigurationBeanDeclaration, ConfigurationBeanManagedService>
 			_configurationBeanDeclarationServiceTracker;
+	private final Map<Class<?>, LocationVariableResolver>
+		_configurationBeanLocationVariableResolvers = new ConcurrentHashMap<>();
 	private final Map<Class<?>, Settings> _configurationBeanSettings =
 		new ConcurrentHashMap<>();
 	private GroupLocalService _groupLocalService;
@@ -330,6 +332,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 								new ClassLoaderResourceManager(classLoader),
 								SettingsLocatorHelperImpl.this);
 
+						_configurationBeanLocationVariableResolvers.put(
+							configurationBeanClass, locationVariableResolver);
+
 						_configurationBeanSettings.put(
 							configurationBeanClass,
 							new ConfigurationBeanSettings(
@@ -355,8 +360,11 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 
 			configurationBeanManagedService.unregister();
 
-			_configurationBeanClasses.remove(
+			Class<?> configurationBeanClass = _configurationBeanClasses.remove(
 				configurationBeanManagedService.getConfigurationPid());
+
+			_configurationBeanLocationVariableResolvers.remove(
+				configurationBeanClass);
 
 			_configurationBeanSettings.remove(
 				configurationBeanManagedService.getConfigurationPid());

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -140,6 +140,28 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 		return getConfigurationBeanSettings(configurationPid);
 	}
 
+	@Override
+	public Settings getGroupConfigurationBeanSettings(
+		long groupId, String configurationPid, Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid),
+			ExtendedObjectClassDefinition.Scope.GROUP, String.valueOf(groupId));
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+	}
+
 	public PortletPreferences getGroupPortletPreferences(
 		long groupId, String settingsId) {
 

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -202,6 +202,28 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 		return _portalPropertiesSettings;
 	}
 
+	@Override
+	public Settings getPortletInstanceConfigurationBeanSettings(
+		String portletId, String configurationPid, Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid),
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE, portletId);
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+	}
+
 	public PortletPreferences getPortletInstancePortletPreferences(
 		long companyId, long ownerId, int ownerType, long plid,
 		String portletId) {

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -306,6 +306,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	private PortletPreferencesFactory _portletPreferencesFactory;
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
+	@Reference
+	private ScopedConfigurationBeanProvider _scopedConfigurationBeanProvider;
+
 	private class ConfigurationBeanDeclarationServiceTracker
 		extends ServiceTracker
 			<ConfigurationBeanDeclaration, ConfigurationBeanManagedService> {

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -73,23 +73,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	public Settings getCompanyConfigurationBeanSettings(
 		long companyId, String configurationPid, Settings parentSettings) {
 
-		if (!_configurationBeanClasses.containsKey(configurationPid)) {
-			return parentSettings;
-		}
-
-		ScopeKey scopeKey = new ScopeKey(
-			_configurationBeanClasses.get(configurationPid),
+		return _getScopedConfigurationBeanSettings(
 			ExtendedObjectClassDefinition.Scope.COMPANY,
-			String.valueOf(companyId));
-
-		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
-			return parentSettings;
-		}
-
-		return new ConfigurationBeanSettings(
-			_configurationBeanLocationVariableResolvers.get(
-				scopeKey.getObjectClass()),
-			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+			String.valueOf(companyId), configurationPid, parentSettings);
 	}
 
 	public PortletPreferences getCompanyPortletPreferences(
@@ -144,22 +130,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	public Settings getGroupConfigurationBeanSettings(
 		long groupId, String configurationPid, Settings parentSettings) {
 
-		if (!_configurationBeanClasses.containsKey(configurationPid)) {
-			return parentSettings;
-		}
-
-		ScopeKey scopeKey = new ScopeKey(
-			_configurationBeanClasses.get(configurationPid),
-			ExtendedObjectClassDefinition.Scope.GROUP, String.valueOf(groupId));
-
-		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
-			return parentSettings;
-		}
-
-		return new ConfigurationBeanSettings(
-			_configurationBeanLocationVariableResolvers.get(
-				scopeKey.getObjectClass()),
-			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+		return _getScopedConfigurationBeanSettings(
+			ExtendedObjectClassDefinition.Scope.GROUP, String.valueOf(groupId),
+			configurationPid, parentSettings);
 	}
 
 	public PortletPreferences getGroupPortletPreferences(
@@ -206,22 +179,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	public Settings getPortletInstanceConfigurationBeanSettings(
 		String portletId, String configurationPid, Settings parentSettings) {
 
-		if (!_configurationBeanClasses.containsKey(configurationPid)) {
-			return parentSettings;
-		}
-
-		ScopeKey scopeKey = new ScopeKey(
-			_configurationBeanClasses.get(configurationPid),
-			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE, portletId);
-
-		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
-			return parentSettings;
-		}
-
-		return new ConfigurationBeanSettings(
-			_configurationBeanLocationVariableResolvers.get(
-				scopeKey.getObjectClass()),
-			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+		return _getScopedConfigurationBeanSettings(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE, portletId,
+			configurationPid, parentSettings);
 	}
 
 	public PortletPreferences getPortletInstancePortletPreferences(
@@ -354,6 +314,28 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 
 		_configurationBeanClasses.remove(
 			configurationPidMapping.getConfigurationPid());
+	}
+
+	private Settings _getScopedConfigurationBeanSettings(
+		ExtendedObjectClassDefinition.Scope scope, String scopePrimKey,
+		String configurationPid, Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid), scope,
+			scopePrimKey);
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/foundation/portal-remote/.gitrepo
+++ b/modules/apps/foundation/portal-remote/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 157b17854a77507e16aa209f32ea09d9d788eecf
+	commit = cc48419104f58e297fe3419084464976075a834b
 	mergebuttonmergecommits = false
 	mode = push
-	parent = f3a26398f497f94236e83817a0825c2ffe194862
+	parent = 8035a3f49945acab794a96a750623f7926b8d56f
 	remote = git@github.com:liferay/com-liferay-portal-remote.git

--- a/modules/apps/foundation/portal-scheduler/.gitrepo
+++ b/modules/apps/foundation/portal-scheduler/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = f9e4d526a277f4b45712a9ffa0fdaf98a8d13815
+	commit = 7d9a193acf6cd2a2966b2bae5843c3a17556b246
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5bbe6a2ee48b774bfb2737bfcf2b1bcc9cdf0947
+	parent = a197a9ebc1ece0be6645b0774c3d2e1cd14eb2fc
 	remote = git@github.com:liferay/com-liferay-portal-scheduler.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = cd9b8f7921a003e4bd2be58f1a7aa224a976eb16
+	commit = 71d2a35afc0ee587ffd904be28557d5490f511df
 	mergebuttonmergecommits = false
 	mode = push
-	parent = b906f710ce5a96a12ec94bc7ae830fbc18be4bc2
+	parent = 73fe2edc8aa5fdb6c2f89a4838c05ef703cfa8f7
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/foundation/portal-template/.gitrepo
+++ b/modules/apps/foundation/portal-template/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = cc715eb7423417393184ade1a4e5b7f4939c4e45
+	commit = 6f240c68b741cad0bcdc905300c635a665a14403
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4e22b402b839961de8b75d592422291a1698b43f
+	parent = ad7d55e89dd547be1cc2cb677b6f320dd073df5f
 	remote = git@github.com:liferay/com-liferay-portal-template.git

--- a/modules/apps/foundation/portal/.gitrepo
+++ b/modules/apps/foundation/portal/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 85fb102434512a467bd6878c57e38995ab44f526
+	commit = 18e6029f759db095e1f96c05792bef8ef853364c
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 286a2a9b81b9cd695c46156e97603b21d39b503a
+	parent = 6367242bb3eaea17dac8a060aa1acbcb3967ef8a
 	remote = git@github.com:liferay/com-liferay-portal.git

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/bnd.bnd
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Configuration Metatype
 Bundle-SymbolicName: com.liferay.portal.configuration.metatype
-Bundle-Version: 2.0.12
+Bundle-Version: 2.1.0
 Export-Package:\
 	com.liferay.portal.configuration.metatype.annotations,\
 	com.liferay.portal.configuration.metatype.bnd.util,\

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtil.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtil.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.metatype.util;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Drew Brokke
+ */
+public class ConfigurationScopedPidUtil {
+
+	public static final String PID_SCOPE_SEPARATOR_COMPANY = "__COMPANY__";
+
+	public static final String PID_SCOPE_SEPARATOR_GROUP = "__GROUP__";
+
+	public static final String PID_SCOPE_SEPARATOR_PORTLET_INSTANCE =
+		"__PORTLET_INSTANCE__";
+
+	public static String buildConfigurationScopedPid(
+		String basePid, ExtendedObjectClassDefinition.Scope scope,
+		String scopePrimKey) {
+
+		Objects.requireNonNull(
+			basePid,
+			"The basePid must not be null. A scoped PID must correspond to a " +
+				"configuration PID");
+
+		if ((scope == null) ||
+			scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM)) {
+
+			return basePid;
+		}
+
+		Objects.requireNonNull(
+			scopePrimKey,
+			"The scopePrimKey must not be null. A scoped PID must correspond " +
+				"to a primary key for its scope.");
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(basePid);
+		sb.append(getScopeSeparatorString(scope));
+		sb.append(scopePrimKey);
+
+		return sb.toString();
+	}
+
+	public static String getBasePid(String scopedPid) {
+		if (Validator.isNull(scopedPid)) {
+			return null;
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_COMPANY)) {
+			return StringUtil.split(scopedPid, PID_SCOPE_SEPARATOR_COMPANY)[0];
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_GROUP)) {
+			return StringUtil.split(scopedPid, PID_SCOPE_SEPARATOR_GROUP)[0];
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_PORTLET_INSTANCE)) {
+			return StringUtil.split(
+				scopedPid, PID_SCOPE_SEPARATOR_PORTLET_INSTANCE)[0];
+		}
+
+		return scopedPid;
+	}
+
+	public static ExtendedObjectClassDefinition.Scope getScope(
+		String scopedPid) {
+
+		if (Validator.isNull(scopedPid)) {
+			return null;
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_COMPANY)) {
+			return ExtendedObjectClassDefinition.Scope.COMPANY;
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_GROUP)) {
+			return ExtendedObjectClassDefinition.Scope.GROUP;
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_PORTLET_INSTANCE)) {
+			return ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE;
+		}
+
+		return ExtendedObjectClassDefinition.Scope.SYSTEM;
+	}
+
+	public static String getScopePrimKey(String scopedPid) {
+		if (Validator.isNull(scopedPid)) {
+			return null;
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_COMPANY)) {
+			return StringUtil.split(scopedPid, PID_SCOPE_SEPARATOR_COMPANY)[1];
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_GROUP)) {
+			return StringUtil.split(scopedPid, PID_SCOPE_SEPARATOR_GROUP)[1];
+		}
+
+		if (scopedPid.contains(PID_SCOPE_SEPARATOR_PORTLET_INSTANCE)) {
+			return StringUtil.split(
+				scopedPid, PID_SCOPE_SEPARATOR_PORTLET_INSTANCE)[1];
+		}
+
+		return null;
+	}
+
+	public static String getScopeSeparatorString(
+		ExtendedObjectClassDefinition.Scope scope) {
+
+		return _scopeSeparatorMap.get(scope);
+	}
+
+	private static final Map<ExtendedObjectClassDefinition.Scope, String>
+		_scopeSeparatorMap = new HashMap<>();
+
+	static {
+		_scopeSeparatorMap.put(
+			ExtendedObjectClassDefinition.Scope.COMPANY,
+			PID_SCOPE_SEPARATOR_COMPANY);
+		_scopeSeparatorMap.put(
+			ExtendedObjectClassDefinition.Scope.GROUP,
+			PID_SCOPE_SEPARATOR_GROUP);
+		_scopeSeparatorMap.put(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+			PID_SCOPE_SEPARATOR_PORTLET_INSTANCE);
+	}
+
+}

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/resources/com/liferay/portal/configuration/metatype/util/packageinfo
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/resources/com/liferay/portal/configuration/metatype/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.1.0

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/src/test/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtilTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/src/test/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtilTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.metatype.util;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class ConfigurationScopedPidUtilTest {
+
+	@Before
+	public void setUp() {
+		_basePid = RandomTestUtil.randomString();
+		_scopePrimKey = String.valueOf(RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testBuildScopedPid() {
+		ExtendedObjectClassDefinition.Scope scope =
+			ExtendedObjectClassDefinition.Scope.COMPANY;
+
+		Assert.assertEquals(
+			_basePid,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.SYSTEM,
+				_scopePrimKey));
+
+		Assert.assertEquals(
+			_basePid,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, null, _scopePrimKey));
+
+		Assert.assertEquals(
+			_basePid + ConfigurationScopedPidUtil.PID_SCOPE_SEPARATOR_COMPANY +
+				_scopePrimKey,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.COMPANY,
+				_scopePrimKey));
+
+		Assert.assertEquals(
+			_basePid + ConfigurationScopedPidUtil.PID_SCOPE_SEPARATOR_GROUP +
+				_scopePrimKey,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.GROUP,
+				_scopePrimKey));
+
+		Assert.assertEquals(
+			_basePid +
+				ConfigurationScopedPidUtil.
+					PID_SCOPE_SEPARATOR_PORTLET_INSTANCE + _scopePrimKey,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+				_scopePrimKey));
+
+		try {
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				null, ExtendedObjectClassDefinition.Scope.COMPANY,
+				_scopePrimKey);
+
+			Assert.fail(
+				"buildConfigurationScopedPid must not allow a null base PID");
+		}
+		catch (NullPointerException npe) {
+		}
+
+		try {
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.COMPANY, null);
+
+			Assert.fail(
+				"buildConfigurationScopedPid must not allow a null " +
+					"scopePrimKey");
+		}
+		catch (NullPointerException npe) {
+		}
+	}
+
+	@Test
+	public void testGetBasePid() {
+		Assert.assertEquals(null, ConfigurationScopedPidUtil.getBasePid(null));
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(_basePid));
+
+		String encodedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.COMPANY,
+				_scopePrimKey);
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, ExtendedObjectClassDefinition.Scope.GROUP, _scopePrimKey);
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+			_scopePrimKey);
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(encodedPid));
+	}
+
+	@Test
+	public void testGetScope() {
+		Assert.assertEquals(null, ConfigurationScopedPidUtil.getScope(null));
+
+		Assert.assertEquals(
+			ExtendedObjectClassDefinition.Scope.SYSTEM,
+			ConfigurationScopedPidUtil.getScope(_basePid));
+
+		String encodedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.COMPANY,
+				_scopePrimKey);
+
+		Assert.assertEquals(
+			ExtendedObjectClassDefinition.Scope.COMPANY,
+			ConfigurationScopedPidUtil.getScope(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, ExtendedObjectClassDefinition.Scope.GROUP, _scopePrimKey);
+
+		Assert.assertEquals(
+			ExtendedObjectClassDefinition.Scope.GROUP,
+			ConfigurationScopedPidUtil.getScope(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+			_scopePrimKey);
+
+		Assert.assertEquals(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+			ConfigurationScopedPidUtil.getScope(encodedPid));
+	}
+
+	@Test
+	public void testGetScopePK() {
+		Assert.assertEquals(
+			null, ConfigurationScopedPidUtil.getScopePrimKey(null));
+
+		Assert.assertEquals(
+			null, ConfigurationScopedPidUtil.getScopePrimKey(_basePid));
+
+		String encodedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, ExtendedObjectClassDefinition.Scope.COMPANY,
+				_scopePrimKey);
+
+		Assert.assertEquals(
+			_scopePrimKey,
+			ConfigurationScopedPidUtil.getScopePrimKey(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, ExtendedObjectClassDefinition.Scope.GROUP, _scopePrimKey);
+
+		Assert.assertEquals(
+			_scopePrimKey,
+			ConfigurationScopedPidUtil.getScopePrimKey(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+			_scopePrimKey);
+
+		Assert.assertEquals(
+			_scopePrimKey,
+			ConfigurationScopedPidUtil.getScopePrimKey(encodedPid));
+	}
+
+	@Test
+	public void testGetScopeSeparatorString() {
+		Assert.assertEquals(
+			null,
+			ConfigurationScopedPidUtil.getScopeSeparatorString(
+				ExtendedObjectClassDefinition.Scope.SYSTEM));
+
+		Assert.assertEquals(
+			ConfigurationScopedPidUtil.PID_SCOPE_SEPARATOR_COMPANY,
+			ConfigurationScopedPidUtil.getScopeSeparatorString(
+				ExtendedObjectClassDefinition.Scope.COMPANY));
+
+		Assert.assertEquals(
+			ConfigurationScopedPidUtil.PID_SCOPE_SEPARATOR_GROUP,
+			ConfigurationScopedPidUtil.getScopeSeparatorString(
+				ExtendedObjectClassDefinition.Scope.GROUP));
+
+		Assert.assertEquals(
+			ConfigurationScopedPidUtil.PID_SCOPE_SEPARATOR_PORTLET_INSTANCE,
+			ConfigurationScopedPidUtil.getScopeSeparatorString(
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE));
+	}
+
+	private String _basePid;
+	private String _scopePrimKey;
+
+}

--- a/modules/apps/static/portal-osgi-web/.gitrepo
+++ b/modules/apps/static/portal-osgi-web/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 1902acd5b1c768f66674aa9c42b0209e3132e822
+	commit = 5f5c6f80b2870a29f69d0ed4d1ef80a42bd8579f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 26163e3160e69742a19f966b040d78ff0ce247c0
+	parent = 2a5725f7e421cec49ef8a38bc562802a9ad9f3e9
 	remote = git@github.com:liferay/com-liferay-portal-osgi-web.git

--- a/modules/apps/web-experience/asset/.gitrepo
+++ b/modules/apps/web-experience/asset/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 6a7b43ba82940520f3337c10dec1c5668758a48d
+	commit = 74198be9f0d67ad34f7e6e30afbf14c2ce4bdcd5
 	mergebuttonmergecommits = false
 	mode = push
-	parent = d69f50bd8d85919945336e8611c9e54806f383a0
+	parent = 90e43cf7cf8ee77f99b0ba2071b50c2ba00a5ed3
 	remote = git@github.com:liferay/com-liferay-asset.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 928e30bbb09159b30e33b0714eba1ae8c6514080
+	commit = 367ab706f69c2c98e8b19e676b5e8952bdb57992
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 4c09e48b50861880836ef82dd9fb4fd40b8c01e1
+	parent = 065a126d040c991cff7215aa7d2438a8f3cd8a05
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/product-navigation/.gitrepo
+++ b/modules/apps/web-experience/product-navigation/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = e9ed77489ce712a8d771a6564f02f36695c076e9
+	commit = 9ad3b17eae0302d24d750fef38ac30dd19afb320
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 12f18e7745cd35adc0686eb4e989acec992db89a
+	parent = 9fba5563142093b30f064d8ee54ffe7594fe8aaf
 	remote = git@github.com:liferay/com-liferay-product-navigation.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = c9e05f59181d89aba0133a191ec3fbab3ab20e05
+	commit = c286a595b5303e5735ef29674aa94fc259a38c2e
 	mergebuttonmergecommits = false
 	mode = push
-	parent = ca87f1a2bdd84aa5489c832d78c42ed68b458714
+	parent = ab7537047ef864b6f6f70170dc1941967cbac502
 	remote = git@github.com:liferay/com-liferay-site.git

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = ea507677e83bfc2bdd35290573e1af79b76be58b
+	commit = 233cb16a0c136044002359868b8be455565ce1ad
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 6a99d54422e19067c5fb3049904ec3b925289a82
+	parent = 89253868228b6995d06761481139efb7617aec13
 	remote = git@github.com:liferay/com-liferay-staging.git

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -225,8 +225,10 @@ public class PortletPreferencesLocalServiceImpl
 
 		String defaultPreferences = PortletConstants.DEFAULT_PREFERENCES;
 
+		String portletName = PortletIdCodec.decodePortletName(portletId);
+
 		Portlet portlet = portletLocalService.fetchPortletById(
-			companyId, PortletIdCodec.decodePortletName(portletId));
+			companyId, portletName);
 
 		if (portlet != null) {
 			defaultPreferences = portlet.getDefaultPreferences();
@@ -243,7 +245,7 @@ public class PortletPreferencesLocalServiceImpl
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-					PortletKeys.PREFS_PLID_SHARED, portletId,
+					PortletKeys.PREFS_PLID_SHARED, portletName,
 					defaultPreferences),
 				companyConfigurationBeanSettings);
 
@@ -255,7 +257,7 @@ public class PortletPreferencesLocalServiceImpl
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP,
-					PortletKeys.PREFS_PLID_SHARED, portletId,
+					PortletKeys.PREFS_PLID_SHARED, portletName,
 					defaultPreferences),
 				groupConfigurationBeanSettings);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.settings.PortletInstanceSettingsLocator;
 import com.liferay.portal.kernel.settings.PortletPreferencesSettings;
 import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsLocatorHelperUtil;
 import com.liferay.portal.kernel.spring.aop.Property;
 import com.liferay.portal.kernel.spring.aop.Retry;
 import com.liferay.portal.kernel.spring.aop.Skip;
@@ -231,13 +232,24 @@ public class PortletPreferencesLocalServiceImpl
 			defaultPreferences = portlet.getDefaultPreferences();
 		}
 
+		String configurationPid =
+			portletInstanceSettingsLocator.getConfigurationPid();
+
+		Settings companyConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.getCompanyConfigurationBeanSettings(
+				companyId, configurationPid, portalPreferencesSettings);
+
 		Settings companyPortletPreferencesSettings =
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
 					PortletKeys.PREFS_PLID_SHARED, portletId,
 					defaultPreferences),
-				portalPreferencesSettings);
+				companyConfigurationBeanSettings);
+
+		Settings groupConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.getGroupConfigurationBeanSettings(
+				groupId, configurationPid, companyPortletPreferencesSettings);
 
 		Settings groupPortletPreferencesSettings =
 			new PortletPreferencesSettings(
@@ -245,7 +257,13 @@ public class PortletPreferencesLocalServiceImpl
 					companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP,
 					PortletKeys.PREFS_PLID_SHARED, portletId,
 					defaultPreferences),
-				companyPortletPreferencesSettings);
+				groupConfigurationBeanSettings);
+
+		Settings portletInstanceConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.
+				getPortletInstanceConfigurationBeanSettings(
+					portletId, configurationPid,
+					groupPortletPreferencesSettings);
 
 		long ownerId = portletInstanceSettingsLocator.getOwnerId();
 		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
@@ -264,7 +282,7 @@ public class PortletPreferencesLocalServiceImpl
 			_getStrictPreferences(
 				companyId, ownerId, ownerType, plid, portletId,
 				defaultPreferences),
-			groupPortletPreferencesSettings);
+			portletInstanceConfigurationBeanSettings);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
@@ -36,17 +36,20 @@ public class CompanyServiceSettingsLocator implements SettingsLocator {
 	}
 
 	@Override
-	public Settings getSettings() {
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
+	public Settings getSettings() throws SettingsException {
+		SystemSettingsLocator systemSettingsLocator = new SystemSettingsLocator(
+			_configurationPid);
 
 		Settings portalPreferencesSettings =
 			_settingsLocatorHelper.getPortalPreferencesSettings(
-				_companyId, configurationBeanSettings);
+				_companyId, systemSettingsLocator.getSettings());
+
+		Settings companyConfigurationBeanSettings =
+			_settingsLocatorHelper.getCompanyConfigurationBeanSettings(
+				_companyId, _configurationPid, portalPreferencesSettings);
 
 		return _settingsLocatorHelper.getCompanyPortletPreferencesSettings(
-			_companyId, _settingsId, portalPreferencesSettings);
+			_companyId, _settingsId, companyConfigurationBeanSettings);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
@@ -21,10 +21,7 @@ package com.liferay.portal.kernel.settings;
 public class CompanyServiceSettingsLocator implements SettingsLocator {
 
 	public CompanyServiceSettingsLocator(long companyId, String settingsId) {
-		_companyId = companyId;
-		_settingsId = settingsId;
-
-		_configurationPid = settingsId;
+		this(companyId, settingsId, settingsId);
 	}
 
 	public CompanyServiceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
@@ -41,22 +41,17 @@ public class GroupServiceSettingsLocator implements SettingsLocator {
 
 	@Override
 	public Settings getSettings() throws SettingsException {
-		long companyId = getCompanyId(_groupId);
+		CompanyServiceSettingsLocator companyServiceSettingsLocator =
+			new CompanyServiceSettingsLocator(
+				getCompanyId(_groupId), _settingsId, _configurationPid);
 
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
-
-		Settings portalPreferencesSettings =
-			_settingsLocatorHelper.getPortalPreferencesSettings(
-				companyId, configurationBeanSettings);
-
-		Settings companyPortletPreferencesSettings =
-			_settingsLocatorHelper.getCompanyPortletPreferencesSettings(
-				companyId, _settingsId, portalPreferencesSettings);
+		Settings groupConfigurationBeanSettings =
+			_settingsLocatorHelper.getGroupConfigurationBeanSettings(
+				_groupId, _configurationPid,
+				companyServiceSettingsLocator.getSettings());
 
 		return _settingsLocatorHelper.getGroupPortletPreferencesSettings(
-			_groupId, _settingsId, companyPortletPreferencesSettings);
+			_groupId, _settingsId, groupConfigurationBeanSettings);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
@@ -25,10 +25,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 public class GroupServiceSettingsLocator implements SettingsLocator {
 
 	public GroupServiceSettingsLocator(long groupId, String settingsId) {
-		_groupId = groupId;
-		_settingsId = settingsId;
-
-		_configurationPid = settingsId;
+		this(groupId, settingsId, settingsId);
 	}
 
 	public GroupServiceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -66,13 +66,12 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 
 	@Override
 	public Settings getSettings() throws SettingsException {
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
+		SystemSettingsLocator systemSettingsLocator = new SystemSettingsLocator(
+			_configurationPid);
 
 		Settings portalPreferencesSettings = new PortletPreferencesSettings(
 			PrefsPropsUtil.getPreferences(_layout.getCompanyId()),
-			configurationBeanSettings);
+			systemSettingsLocator.getSettings());
 
 		return PortletPreferencesLocalServiceUtil.getPortletInstanceSettings(
 			_layout.getCompanyId(), _layout.getGroupId(), _portletInstanceKey,

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -29,11 +29,9 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 	public PortletInstanceSettingsLocator(
 		Layout layout, String portletInstanceKey) {
 
-		_layout = layout;
-		_portletInstanceKey = portletInstanceKey;
-
-		_configurationPid = PortletIdCodec.decodePortletName(
-			portletInstanceKey);
+		this(
+			layout, portletInstanceKey,
+			PortletIdCodec.decodePortletName(portletInstanceKey));
 	}
 
 	public PortletInstanceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -44,6 +44,10 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 		_configurationPid = configurationPid;
 	}
 
+	public String getConfigurationPid() {
+		return _configurationPid;
+	}
+
 	public long getOwnerId() {
 		if (isEmbeddedPortlet()) {
 			return _layout.getGroupId();

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
@@ -22,6 +22,9 @@ import aQute.bnd.annotation.ProviderType;
 @ProviderType
 public interface SettingsLocatorHelper {
 
+	public Settings getCompanyConfigurationBeanSettings(
+		long companyId, String configurationPid, Settings parentSettings);
+
 	public Settings getCompanyPortletPreferencesSettings(
 		long companyId, String settingsId, Settings parentSettings);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
@@ -53,6 +53,9 @@ public interface SettingsLocatorHelper {
 	@Deprecated
 	public Settings getPortalPropertiesSettings();
 
+	public Settings getPortletInstanceConfigurationBeanSettings(
+		String portletId, String configurationPid, Settings parentSettings);
+
 	public Settings getPortletInstancePortletPreferencesSettings(
 		long companyId, long ownerId, int ownerType, long plid,
 		String portletId, Settings parentSettings);

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
@@ -38,6 +38,9 @@ public interface SettingsLocatorHelper {
 	public Settings getConfigurationBeanSettings(
 		String configurationPid, Settings parentSettings);
 
+	public Settings getGroupConfigurationBeanSettings(
+		long groupId, String configurationPid, Settings parentSettings);
+
 	public Settings getGroupPortletPreferencesSettings(
 		long groupId, String settingsId, Settings parentSettings);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelperUtil.java
@@ -22,11 +22,33 @@ import com.liferay.registry.collections.ServiceTrackerList;
  */
 public class SettingsLocatorHelperUtil {
 
+	public static Settings getCompanyConfigurationBeanSettings(
+		long companyId, String configurationPid, Settings parentSettings) {
+
+		return getSettingsLocatorHelper().getCompanyConfigurationBeanSettings(
+			companyId, configurationPid, parentSettings);
+	}
+
 	public static Settings getCompanyPortletPreferencesSettings(
 		long companyId, String settingsId, Settings parentSettings) {
 
 		return getSettingsLocatorHelper().getCompanyPortletPreferencesSettings(
 			companyId, settingsId, parentSettings);
+	}
+
+	public static Settings getGroupConfigurationBeanSettings(
+		long groupId, String configurationPid, Settings parentSettings) {
+
+		return getSettingsLocatorHelper().getGroupConfigurationBeanSettings(
+			groupId, configurationPid, parentSettings);
+	}
+
+	public static Settings getPortletInstanceConfigurationBeanSettings(
+		String portletId, String configurationPid, Settings parentSettings) {
+
+		return getSettingsLocatorHelper().
+			getPortletInstanceConfigurationBeanSettings(
+				portletId, configurationPid, parentSettings);
 	}
 
 	public static SettingsLocatorHelper getSettingsLocatorHelper() {


### PR DESCRIPTION
This is an update for [LPS-74152](https://issues.liferay.com/browse/LPS-74152).<br><br>Hey Brian, this pull allows reading configurations that are scoped at different levels per this proposal: https://github.com/drewbrokke/liferay-portal/pull/319.  There will be additional changes that facilitate saving configurations at different scopes, and also a database upgrade for the Configuration table to represent scoping data.  The idea is to support scoping any configuration without requiring that it is declared as a factory metatype.  Please let me know if you have any questions.<br><br>/cc @pei-jung, @jorgeferrer, @stian-sigvartsen