### PR TITLE
LRQA-36681 Extend timeout for get location in DXP tests | master

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6997,6 +6997,8 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 	<target name="prepare-poshi-runner-properties">
 		<echo append="true" file="${test.ext.properties.file}">
 			component.names=${component.names}
+			get.location.max.retries=${test.get.location.max.retries}
+			get.location.timeout=${test.get.location.timeout}
 			ignore.errors.file.name=${project.dir}/portal-web/test-ignorable-error-lines.xml
 			output.dir.name=${selenium.output.dir.name}
 			product.names=${product.names}

--- a/test.properties
+++ b/test.properties
@@ -1644,6 +1644,8 @@
     test.evaluate.logs=true
     test.ext.properties.file=portal-web/test/test-portal-web-ext.properties
     #test.fix.pack.base.url=
+    test.get.location.max.retries=3
+    test.get.location.timeout=15
     #test.include.dir.names=
     #test.jdbc.drivers.url=
     #test.latest.marketplace.apps=


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-36681

Increase the get location timeout to 15 seconds instead of 5 seconds.  (Before a recent change to Poshi Runner the default was 60 seconds)

@brianwulbern