### PR TITLE
LPS-74152 As a developer I would like to support scoped configuration without needing to declare a metatype as a factory

### DIFF
--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
@@ -3,11 +3,11 @@ targetCompatibility = "1.8"
 
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
-	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.35.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	provided project(":apps:static:portal-configuration:portal-configuration-metatype")
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/build.gradle
@@ -4,7 +4,7 @@ targetCompatibility = "1.8"
 dependencies {
 	provided group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.35.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopeKey.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopeKey.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+/**
+ * @author Drew Brokke
+ */
+public class ScopeKey {
+
+	public ScopeKey(Class<?> objectClass, Scope scope, String scopePrimKey) {
+		Objects.requireNonNull(
+			objectClass,
+			"The objectClass parameter must not be null. A ScopeKey must " +
+				"correspond to an existing configuration bean class.");
+
+		Objects.requireNonNull(
+			scope,
+			"The scope parameter must not be null. A ScopeKey must " +
+				"correspond to an existing scope from " +
+					"ExtendedObjectClassDefinition.Scope.");
+
+		if (scope.equals(Scope.SYSTEM)) {
+			throw new IllegalArgumentException(
+				"A ScopeKey can only be used for the following scopes from " +
+					"ExtendedObjectClassDefinition.Scope: COMPANY, GROUP, " +
+						"PORTLET_INSTANCE.");
+		}
+
+		if (Validator.isNull(scopePrimKey)) {
+			throw new IllegalArgumentException(
+				"The scopePrimKey parameter must not be null. A ScopeKey " +
+					"must correspond to a primary key for the given scope.");
+		}
+
+		_objectClass = objectClass;
+		_scope = scope;
+		_scopePrimKey = scopePrimKey;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		ScopeKey otherScopeKey = (ScopeKey)obj;
+
+		if (_objectClass.equals(otherScopeKey.getObjectClass()) &&
+			_scope.equals(otherScopeKey.getScope()) &&
+			_scopePrimKey.equals(otherScopeKey.getScopePrimKey())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public Class<?> getObjectClass() {
+		return _objectClass;
+	}
+
+	public Scope getScope() {
+		return _scope;
+	}
+
+	public String getScopePrimKey() {
+		return _scopePrimKey;
+	}
+
+	@Override
+	public int hashCode() {
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_objectClass.getName());
+		sb.append(_scope.getValue());
+		sb.append(_scopePrimKey);
+
+		String s = sb.toString();
+
+		return s.hashCode();
+	}
+
+	private final Class<?> _objectClass;
+	private final Scope _scope;
+	private final String _scopePrimKey;
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanManagedService.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanManagedService.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal;
+
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
+import com.liferay.portal.configuration.settings.internal.util.ConfigurationPidUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import java.util.Dictionary;
+import java.util.function.Consumer;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ManagedService;
+
+/**
+ * @author Drew Brokke
+ */
+public class ScopedConfigurationBeanManagedService implements ManagedService {
+
+	public ScopedConfigurationBeanManagedService(
+		BundleContext bundleContext, Class<?> configurationBeanClass,
+		Consumer<Object> configurationBeanConsumer, ScopeKey scopeKey) {
+
+		_bundleContext = bundleContext;
+		_configurationBeanClass = configurationBeanClass;
+		_configurationBeanConsumer = configurationBeanConsumer;
+		_scopeKey = scopeKey;
+	}
+
+	public void register() {
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		properties.put(
+			Constants.SERVICE_PID,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				ConfigurationPidUtil.getConfigurationPid(
+					_configurationBeanClass),
+				_scopeKey.getScope(), _scopeKey.getScopePrimKey()));
+
+		_managedServiceServiceRegistration = _bundleContext.registerService(
+			ManagedService.class, this, properties);
+	}
+
+	public void unregister() {
+		_managedServiceServiceRegistration.unregister();
+	}
+
+	@Override
+	public void updated(final Dictionary<String, ?> properties) {
+		if (System.getSecurityManager() != null) {
+			AccessController.doPrivileged(
+				new ScopedConfigurationBeanManagedService.
+					UpdatePrivilegedAction(properties));
+		}
+		else {
+			doUpdated(properties);
+		}
+	}
+
+	protected void doUpdated(Dictionary<String, ?> properties) {
+		if (properties == null) {
+			_configurationBeanConsumer.accept(null);
+		}
+		else {
+			_configurationBeanConsumer.accept(
+				ConfigurableUtil.createConfigurable(
+					_configurationBeanClass, properties));
+		}
+	}
+
+	protected class UpdatePrivilegedAction implements PrivilegedAction<Void> {
+
+		@Override
+		public Void run() {
+			doUpdated(_properties);
+
+			return null;
+		}
+
+		private UpdatePrivilegedAction(Dictionary<String, ?> properties) {
+			_properties = properties;
+		}
+
+		private final Dictionary<String, ?> _properties;
+
+	}
+
+	private final BundleContext _bundleContext;
+	private final Class<?> _configurationBeanClass;
+	private final Consumer<Object> _configurationBeanConsumer;
+	private ServiceRegistration<ManagedService>
+		_managedServiceServiceRegistration;
+	private final ScopeKey _scopeKey;
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanProvider.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/ScopedConfigurationBeanProvider.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
+import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
+import com.liferay.portal.configuration.settings.internal.util.ConfigurationPidUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.ConfigurationEvent;
+import org.osgi.service.cm.ConfigurationListener;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+/**
+ * @author Drew Brokke
+ */
+@Component(
+	immediate = true,
+	service =
+		{ConfigurationListener.class, ScopedConfigurationBeanProvider.class}
+)
+public class ScopedConfigurationBeanProvider implements ConfigurationListener {
+
+	@Override
+	public void configurationEvent(ConfigurationEvent event) {
+		if (event.getType() != ConfigurationEvent.CM_UPDATED) {
+			return;
+		}
+
+		String pid = event.getFactoryPid();
+
+		if (pid == null) {
+			pid = event.getPid();
+		}
+
+		Scope scope = ConfigurationScopedPidUtil.getScope(pid);
+
+		if (scope.equals(Scope.SYSTEM)) {
+			return;
+		}
+
+		try {
+			ScopeKey scopeKey = new ScopeKey(
+				_configurationBeanClasses.get(
+					ConfigurationScopedPidUtil.getBasePid(pid)),
+				scope, ConfigurationScopedPidUtil.getScopePrimKey(pid));
+
+			if (_scopedConfigurationBeans.containsKey(scopeKey)) {
+				return;
+			}
+
+			AtomicReference<ScopedConfigurationBeanManagedService>
+				managedServiceAtomicReference = new AtomicReference<>();
+
+			ScopedConfigurationBeanManagedService
+				configurationBeanManagedService =
+					new ScopedConfigurationBeanManagedService(
+						_bundleContext, scopeKey.getObjectClass(),
+						configurationBean -> {
+							if ((configurationBean == null) &&
+								_scopedConfigurationBeans.containsKey(
+									scopeKey)) {
+
+								_scopedConfigurationBeans.remove(scopeKey);
+
+								ScopedConfigurationBeanManagedService
+									managedService =
+										managedServiceAtomicReference.get();
+
+								managedService.unregister();
+
+								return;
+							}
+
+							_scopedConfigurationBeans.put(
+								scopeKey, configurationBean);
+						},
+						scopeKey);
+
+			managedServiceAtomicReference.set(configurationBeanManagedService);
+
+			configurationBeanManagedService.register();
+		}
+		catch (IllegalArgumentException | NullPointerException e) {
+			if (_log.isInfoEnabled()) {
+				_log.info(e);
+			}
+		}
+	}
+
+	public Object get(ScopeKey scopeKey) {
+		return _scopedConfigurationBeans.get(scopeKey);
+	}
+
+	public boolean has(ScopeKey scopeKey) {
+		return _scopedConfigurationBeans.containsKey(scopeKey);
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	@Reference(
+		cardinality = ReferenceCardinality.MULTIPLE,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		unbind = "removeConfigurationBeanDeclaration"
+	)
+	protected void addConfigurationBeanDeclaration(
+		ConfigurationBeanDeclaration configurationBeanDeclaration) {
+
+		Class<?> configurationBeanClass =
+			configurationBeanDeclaration.getConfigurationBeanClass();
+
+		String configurationPid = ConfigurationPidUtil.getConfigurationPid(
+			configurationBeanClass);
+
+		_configurationBeanClasses.put(configurationPid, configurationBeanClass);
+	}
+
+	protected void removeConfigurationBeanDeclaration(
+		ConfigurationBeanDeclaration configurationBeanDeclaration) {
+
+		String configurationPid = ConfigurationPidUtil.getConfigurationPid(
+			configurationBeanDeclaration.getConfigurationBeanClass());
+
+		if (_configurationBeanClasses.containsKey(configurationPid)) {
+			_configurationBeanClasses.remove(configurationPid);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ScopedConfigurationBeanProvider.class);
+
+	private BundleContext _bundleContext;
+	private final Map<String, Class<?>> _configurationBeanClasses =
+		new ConcurrentHashMap<>();
+	private final Map<ScopeKey, Object> _scopedConfigurationBeans =
+		new ConcurrentHashMap<>();
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.configuration.settings.internal;
 
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -67,6 +68,29 @@ import org.osgi.util.tracker.ServiceTracker;
 @Component(immediate = true, service = SettingsLocatorHelper.class)
 @DoPrivileged
 public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
+
+	@Override
+	public Settings getCompanyConfigurationBeanSettings(
+		long companyId, String configurationPid, Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid),
+			ExtendedObjectClassDefinition.Scope.COMPANY,
+			String.valueOf(companyId));
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+	}
 
 	public PortletPreferences getCompanyPortletPreferences(
 		long companyId, String settingsId) {

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -296,6 +296,8 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	private ServiceTracker
 		<ConfigurationBeanDeclaration, ConfigurationBeanManagedService>
 			_configurationBeanDeclarationServiceTracker;
+	private final Map<Class<?>, LocationVariableResolver>
+		_configurationBeanLocationVariableResolvers = new ConcurrentHashMap<>();
 	private final Map<Class<?>, Settings> _configurationBeanSettings =
 		new ConcurrentHashMap<>();
 	private GroupLocalService _groupLocalService;
@@ -330,6 +332,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 								new ClassLoaderResourceManager(classLoader),
 								SettingsLocatorHelperImpl.this);
 
+						_configurationBeanLocationVariableResolvers.put(
+							configurationBeanClass, locationVariableResolver);
+
 						_configurationBeanSettings.put(
 							configurationBeanClass,
 							new ConfigurationBeanSettings(
@@ -355,8 +360,11 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 
 			configurationBeanManagedService.unregister();
 
-			_configurationBeanClasses.remove(
+			Class<?> configurationBeanClass = _configurationBeanClasses.remove(
 				configurationBeanManagedService.getConfigurationPid());
+
+			_configurationBeanLocationVariableResolvers.remove(
+				configurationBeanClass);
 
 			_configurationBeanSettings.remove(
 				configurationBeanManagedService.getConfigurationPid());

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.configuration.settings.internal;
 
-import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -73,23 +73,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	public Settings getCompanyConfigurationBeanSettings(
 		long companyId, String configurationPid, Settings parentSettings) {
 
-		if (!_configurationBeanClasses.containsKey(configurationPid)) {
-			return parentSettings;
-		}
-
-		ScopeKey scopeKey = new ScopeKey(
-			_configurationBeanClasses.get(configurationPid),
-			ExtendedObjectClassDefinition.Scope.COMPANY,
-			String.valueOf(companyId));
-
-		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
-			return parentSettings;
-		}
-
-		return new ConfigurationBeanSettings(
-			_configurationBeanLocationVariableResolvers.get(
-				scopeKey.getObjectClass()),
-			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+		return _getScopedConfigurationBeanSettings(
+			Scope.COMPANY, String.valueOf(companyId), configurationPid,
+			parentSettings);
 	}
 
 	public PortletPreferences getCompanyPortletPreferences(
@@ -144,22 +130,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	public Settings getGroupConfigurationBeanSettings(
 		long groupId, String configurationPid, Settings parentSettings) {
 
-		if (!_configurationBeanClasses.containsKey(configurationPid)) {
-			return parentSettings;
-		}
-
-		ScopeKey scopeKey = new ScopeKey(
-			_configurationBeanClasses.get(configurationPid),
-			ExtendedObjectClassDefinition.Scope.GROUP, String.valueOf(groupId));
-
-		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
-			return parentSettings;
-		}
-
-		return new ConfigurationBeanSettings(
-			_configurationBeanLocationVariableResolvers.get(
-				scopeKey.getObjectClass()),
-			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+		return _getScopedConfigurationBeanSettings(
+			Scope.GROUP, String.valueOf(groupId), configurationPid,
+			parentSettings);
 	}
 
 	public PortletPreferences getGroupPortletPreferences(
@@ -206,22 +179,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	public Settings getPortletInstanceConfigurationBeanSettings(
 		String portletId, String configurationPid, Settings parentSettings) {
 
-		if (!_configurationBeanClasses.containsKey(configurationPid)) {
-			return parentSettings;
-		}
-
-		ScopeKey scopeKey = new ScopeKey(
-			_configurationBeanClasses.get(configurationPid),
-			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE, portletId);
-
-		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
-			return parentSettings;
-		}
-
-		return new ConfigurationBeanSettings(
-			_configurationBeanLocationVariableResolvers.get(
-				scopeKey.getObjectClass()),
-			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+		return _getScopedConfigurationBeanSettings(
+			Scope.PORTLET_INSTANCE, portletId, configurationPid,
+			parentSettings);
 	}
 
 	public PortletPreferences getPortletInstancePortletPreferences(
@@ -354,6 +314,28 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 
 		_configurationBeanClasses.remove(
 			configurationPidMapping.getConfigurationPid());
+	}
+
+	private Settings _getScopedConfigurationBeanSettings(
+		Scope scope, String scopePrimKey, String configurationPid,
+		Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid), scope,
+			scopePrimKey);
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -140,6 +140,28 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 		return getConfigurationBeanSettings(configurationPid);
 	}
 
+	@Override
+	public Settings getGroupConfigurationBeanSettings(
+		long groupId, String configurationPid, Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid),
+			ExtendedObjectClassDefinition.Scope.GROUP, String.valueOf(groupId));
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+	}
+
 	public PortletPreferences getGroupPortletPreferences(
 		long groupId, String settingsId) {
 

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -202,6 +202,28 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 		return _portalPropertiesSettings;
 	}
 
+	@Override
+	public Settings getPortletInstanceConfigurationBeanSettings(
+		String portletId, String configurationPid, Settings parentSettings) {
+
+		if (!_configurationBeanClasses.containsKey(configurationPid)) {
+			return parentSettings;
+		}
+
+		ScopeKey scopeKey = new ScopeKey(
+			_configurationBeanClasses.get(configurationPid),
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE, portletId);
+
+		if (!_scopedConfigurationBeanProvider.has(scopeKey)) {
+			return parentSettings;
+		}
+
+		return new ConfigurationBeanSettings(
+			_configurationBeanLocationVariableResolvers.get(
+				scopeKey.getObjectClass()),
+			_scopedConfigurationBeanProvider.get(scopeKey), parentSettings);
+	}
+
 	public PortletPreferences getPortletInstancePortletPreferences(
 		long companyId, long ownerId, int ownerType, long plid,
 		String portletId) {

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings/src/main/java/com/liferay/portal/configuration/settings/internal/SettingsLocatorHelperImpl.java
@@ -306,6 +306,9 @@ public class SettingsLocatorHelperImpl implements SettingsLocatorHelper {
 	private PortletPreferencesFactory _portletPreferencesFactory;
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
+	@Reference
+	private ScopedConfigurationBeanProvider _scopedConfigurationBeanProvider;
+
 	private class ConfigurationBeanDeclarationServiceTracker
 		extends ServiceTracker
 			<ConfigurationBeanDeclaration, ConfigurationBeanManagedService> {

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/bnd.bnd
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Configuration Metatype
 Bundle-SymbolicName: com.liferay.portal.configuration.metatype
-Bundle-Version: 2.0.12
+Bundle-Version: 2.1.0
 Export-Package:\
 	com.liferay.portal.configuration.metatype.annotations,\
 	com.liferay.portal.configuration.metatype.bnd.util,\

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedObjectClassDefinition.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/java/com/liferay/portal/configuration/metatype/annotations/ExtendedObjectClassDefinition.java
@@ -16,6 +16,9 @@ package com.liferay.portal.configuration.metatype.annotations;
 
 import aQute.bnd.annotation.xml.XMLAttribute;
 
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -54,6 +57,10 @@ public @interface ExtendedObjectClassDefinition {
 			return _value.equals(value);
 		}
 
+		public String getDelimiterString() {
+			return StringBundler.concat(_separator, name(), _separator);
+		}
+
 		public String getValue() {
 			return _value;
 		}
@@ -66,6 +73,8 @@ public @interface ExtendedObjectClassDefinition {
 		private Scope(String value) {
 			_value = value;
 		}
+
+		private static final String _separator = StringPool.DOUBLE_UNDERLINE;
 
 		private final String _value;
 

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtil.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtil.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.metatype.util;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+/**
+ * @author Drew Brokke
+ */
+public class ConfigurationScopedPidUtil {
+
+	public static String buildConfigurationScopedPid(
+		String basePid, Scope scope, String scopePrimKey) {
+
+		Objects.requireNonNull(
+			basePid,
+			"The basePid must not be null. A scoped PID must correspond to a " +
+				"configuration PID");
+
+		if ((scope == null) || scope.equals(Scope.SYSTEM)) {
+			return basePid;
+		}
+
+		Objects.requireNonNull(
+			scopePrimKey,
+			"The scopePrimKey must not be null. A scoped PID must correspond " +
+				"to a primary key for its scope.");
+
+		return StringBundler.concat(
+			basePid, scope.getDelimiterString(), scopePrimKey);
+	}
+
+	public static String getBasePid(String scopedPid) {
+		if (Validator.isNull(scopedPid)) {
+			return null;
+		}
+
+		for (Scope scope : Scope.values()) {
+			String separator = scope.getDelimiterString();
+
+			if (scopedPid.contains(separator)) {
+				return StringUtil.split(scopedPid, separator)[0];
+			}
+		}
+
+		return scopedPid;
+	}
+
+	public static Scope getScope(String scopedPid) {
+		if (Validator.isNull(scopedPid)) {
+			return null;
+		}
+
+		for (Scope scope : Scope.values()) {
+			String separator = scope.getDelimiterString();
+
+			if (scopedPid.contains(scope.getDelimiterString())) {
+				return scope;
+			}
+		}
+
+		return Scope.SYSTEM;
+	}
+
+	public static String getScopePrimKey(String scopedPid) {
+		if (Validator.isNull(scopedPid)) {
+			return null;
+		}
+
+		for (Scope scope : Scope.values()) {
+			String separator = scope.getDelimiterString();
+
+			if (scopedPid.contains(separator)) {
+				return StringUtil.split(scopedPid, separator)[1];
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/resources/com/liferay/portal/configuration/metatype/util/packageinfo
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/src/main/resources/com/liferay/portal/configuration/metatype/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.1.0

--- a/modules/apps/static/portal-configuration/portal-configuration-metatype/src/test/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtilTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-metatype/src/test/java/com/liferay/portal/configuration/metatype/util/ConfigurationScopedPidUtilTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.metatype.util;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class ConfigurationScopedPidUtilTest {
+
+	@Before
+	public void setUp() {
+		_basePid = RandomTestUtil.randomString();
+		_scopePrimKey = String.valueOf(RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testBuildScopedPid() {
+		Assert.assertEquals(
+			_basePid,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.SYSTEM, _scopePrimKey));
+
+		Assert.assertEquals(
+			_basePid,
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, null, _scopePrimKey));
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				_basePid, Scope.COMPANY.getDelimiterString(), _scopePrimKey),
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.COMPANY, _scopePrimKey));
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				_basePid, Scope.GROUP.getDelimiterString(), _scopePrimKey),
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.GROUP, _scopePrimKey));
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				_basePid, Scope.PORTLET_INSTANCE.getDelimiterString(),
+				_scopePrimKey),
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.PORTLET_INSTANCE, _scopePrimKey));
+
+		try {
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				null, Scope.COMPANY, _scopePrimKey);
+
+			Assert.fail(
+				"buildConfigurationScopedPid must not allow a null base PID");
+		}
+		catch (NullPointerException npe) {
+		}
+
+		try {
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.COMPANY, null);
+
+			Assert.fail(
+				"buildConfigurationScopedPid must not allow a null " +
+					"scopePrimKey");
+		}
+		catch (NullPointerException npe) {
+		}
+	}
+
+	@Test
+	public void testGetBasePid() {
+		Assert.assertEquals(null, ConfigurationScopedPidUtil.getBasePid(null));
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(_basePid));
+
+		String encodedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.COMPANY, _scopePrimKey);
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, Scope.GROUP, _scopePrimKey);
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, Scope.PORTLET_INSTANCE, _scopePrimKey);
+
+		Assert.assertEquals(
+			_basePid, ConfigurationScopedPidUtil.getBasePid(encodedPid));
+	}
+
+	@Test
+	public void testGetScope() {
+		Assert.assertEquals(null, ConfigurationScopedPidUtil.getScope(null));
+
+		Assert.assertEquals(
+			Scope.SYSTEM, ConfigurationScopedPidUtil.getScope(_basePid));
+
+		String encodedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.COMPANY, _scopePrimKey);
+
+		Assert.assertEquals(
+			Scope.COMPANY, ConfigurationScopedPidUtil.getScope(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, Scope.GROUP, _scopePrimKey);
+
+		Assert.assertEquals(
+			Scope.GROUP, ConfigurationScopedPidUtil.getScope(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, Scope.PORTLET_INSTANCE, _scopePrimKey);
+
+		Assert.assertEquals(
+			Scope.PORTLET_INSTANCE,
+			ConfigurationScopedPidUtil.getScope(encodedPid));
+	}
+
+	@Test
+	public void testGetScopePK() {
+		Assert.assertEquals(
+			null, ConfigurationScopedPidUtil.getScopePrimKey(null));
+
+		Assert.assertEquals(
+			null, ConfigurationScopedPidUtil.getScopePrimKey(_basePid));
+
+		String encodedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				_basePid, Scope.COMPANY, _scopePrimKey);
+
+		Assert.assertEquals(
+			_scopePrimKey,
+			ConfigurationScopedPidUtil.getScopePrimKey(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, Scope.GROUP, _scopePrimKey);
+
+		Assert.assertEquals(
+			_scopePrimKey,
+			ConfigurationScopedPidUtil.getScopePrimKey(encodedPid));
+
+		encodedPid = ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+			_basePid, Scope.PORTLET_INSTANCE, _scopePrimKey);
+
+		Assert.assertEquals(
+			_scopePrimKey,
+			ConfigurationScopedPidUtil.getScopePrimKey(encodedPid));
+	}
+
+	@Test
+	public void testGetScopeSeparatorString() {
+		Assert.assertEquals("__SYSTEM__", Scope.SYSTEM.getDelimiterString());
+
+		Assert.assertEquals("__COMPANY__", Scope.COMPANY.getDelimiterString());
+
+		Assert.assertEquals("__GROUP__", Scope.GROUP.getDelimiterString());
+
+		Assert.assertEquals(
+			"__PORTLET_INSTANCE__", Scope.PORTLET_INSTANCE.getDelimiterString());
+	}
+
+	private String _basePid;
+	private String _scopePrimKey;
+
+}

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -225,8 +225,10 @@ public class PortletPreferencesLocalServiceImpl
 
 		String defaultPreferences = PortletConstants.DEFAULT_PREFERENCES;
 
+		String portletName = PortletIdCodec.decodePortletName(portletId);
+
 		Portlet portlet = portletLocalService.fetchPortletById(
-			companyId, PortletIdCodec.decodePortletName(portletId));
+			companyId, portletName);
 
 		if (portlet != null) {
 			defaultPreferences = portlet.getDefaultPreferences();
@@ -243,7 +245,7 @@ public class PortletPreferencesLocalServiceImpl
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-					PortletKeys.PREFS_PLID_SHARED, portletId,
+					PortletKeys.PREFS_PLID_SHARED, portletName,
 					defaultPreferences),
 				companyConfigurationBeanSettings);
 
@@ -255,7 +257,7 @@ public class PortletPreferencesLocalServiceImpl
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP,
-					PortletKeys.PREFS_PLID_SHARED, portletId,
+					PortletKeys.PREFS_PLID_SHARED, portletName,
 					defaultPreferences),
 				groupConfigurationBeanSettings);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.settings.PortletInstanceSettingsLocator;
 import com.liferay.portal.kernel.settings.PortletPreferencesSettings;
 import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsLocatorHelperUtil;
 import com.liferay.portal.kernel.spring.aop.Property;
 import com.liferay.portal.kernel.spring.aop.Retry;
 import com.liferay.portal.kernel.spring.aop.Skip;
@@ -231,13 +232,24 @@ public class PortletPreferencesLocalServiceImpl
 			defaultPreferences = portlet.getDefaultPreferences();
 		}
 
+		String configurationPid =
+			portletInstanceSettingsLocator.getConfigurationPid();
+
+		Settings companyConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.getCompanyConfigurationBeanSettings(
+				companyId, configurationPid, portalPreferencesSettings);
+
 		Settings companyPortletPreferencesSettings =
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
 					PortletKeys.PREFS_PLID_SHARED, portletId,
 					defaultPreferences),
-				portalPreferencesSettings);
+				companyConfigurationBeanSettings);
+
+		Settings groupConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.getGroupConfigurationBeanSettings(
+				groupId, configurationPid, companyPortletPreferencesSettings);
 
 		Settings groupPortletPreferencesSettings =
 			new PortletPreferencesSettings(
@@ -245,7 +257,13 @@ public class PortletPreferencesLocalServiceImpl
 					companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP,
 					PortletKeys.PREFS_PLID_SHARED, portletId,
 					defaultPreferences),
-				companyPortletPreferencesSettings);
+				groupConfigurationBeanSettings);
+
+		Settings portletInstanceConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.
+				getPortletInstanceConfigurationBeanSettings(
+					portletId, configurationPid,
+					groupPortletPreferencesSettings);
 
 		long ownerId = portletInstanceSettingsLocator.getOwnerId();
 		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
@@ -264,7 +282,7 @@ public class PortletPreferencesLocalServiceImpl
 			_getStrictPreferences(
 				companyId, ownerId, ownerType, plid, portletId,
 				defaultPreferences),
-			groupPortletPreferencesSettings);
+			portletInstanceConfigurationBeanSettings);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
@@ -36,17 +36,20 @@ public class CompanyServiceSettingsLocator implements SettingsLocator {
 	}
 
 	@Override
-	public Settings getSettings() {
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
+	public Settings getSettings() throws SettingsException {
+		SystemSettingsLocator systemSettingsLocator = new SystemSettingsLocator(
+			_configurationPid);
 
 		Settings portalPreferencesSettings =
 			_settingsLocatorHelper.getPortalPreferencesSettings(
-				_companyId, configurationBeanSettings);
+				_companyId, systemSettingsLocator.getSettings());
+
+		Settings companyConfigurationBeanSettings =
+			_settingsLocatorHelper.getCompanyConfigurationBeanSettings(
+				_companyId, _configurationPid, portalPreferencesSettings);
 
 		return _settingsLocatorHelper.getCompanyPortletPreferencesSettings(
-			_companyId, _settingsId, portalPreferencesSettings);
+			_companyId, _settingsId, companyConfigurationBeanSettings);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/CompanyServiceSettingsLocator.java
@@ -21,10 +21,7 @@ package com.liferay.portal.kernel.settings;
 public class CompanyServiceSettingsLocator implements SettingsLocator {
 
 	public CompanyServiceSettingsLocator(long companyId, String settingsId) {
-		_companyId = companyId;
-		_settingsId = settingsId;
-
-		_configurationPid = settingsId;
+		this(companyId, settingsId, settingsId);
 	}
 
 	public CompanyServiceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
@@ -41,22 +41,17 @@ public class GroupServiceSettingsLocator implements SettingsLocator {
 
 	@Override
 	public Settings getSettings() throws SettingsException {
-		long companyId = getCompanyId(_groupId);
+		CompanyServiceSettingsLocator companyServiceSettingsLocator =
+			new CompanyServiceSettingsLocator(
+				getCompanyId(_groupId), _settingsId, _configurationPid);
 
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
-
-		Settings portalPreferencesSettings =
-			_settingsLocatorHelper.getPortalPreferencesSettings(
-				companyId, configurationBeanSettings);
-
-		Settings companyPortletPreferencesSettings =
-			_settingsLocatorHelper.getCompanyPortletPreferencesSettings(
-				companyId, _settingsId, portalPreferencesSettings);
+		Settings groupConfigurationBeanSettings =
+			_settingsLocatorHelper.getGroupConfigurationBeanSettings(
+				_groupId, _configurationPid,
+				companyServiceSettingsLocator.getSettings());
 
 		return _settingsLocatorHelper.getGroupPortletPreferencesSettings(
-			_groupId, _settingsId, companyPortletPreferencesSettings);
+			_groupId, _settingsId, groupConfigurationBeanSettings);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
@@ -25,10 +25,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 public class GroupServiceSettingsLocator implements SettingsLocator {
 
 	public GroupServiceSettingsLocator(long groupId, String settingsId) {
-		_groupId = groupId;
-		_settingsId = settingsId;
-
-		_configurationPid = settingsId;
+		this(groupId, settingsId, settingsId);
 	}
 
 	public GroupServiceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -66,13 +66,12 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 
 	@Override
 	public Settings getSettings() throws SettingsException {
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
+		SystemSettingsLocator systemSettingsLocator = new SystemSettingsLocator(
+			_configurationPid);
 
 		Settings portalPreferencesSettings = new PortletPreferencesSettings(
 			PrefsPropsUtil.getPreferences(_layout.getCompanyId()),
-			configurationBeanSettings);
+			systemSettingsLocator.getSettings());
 
 		return PortletPreferencesLocalServiceUtil.getPortletInstanceSettings(
 			_layout.getCompanyId(), _layout.getGroupId(), _portletInstanceKey,

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -29,11 +29,9 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 	public PortletInstanceSettingsLocator(
 		Layout layout, String portletInstanceKey) {
 
-		_layout = layout;
-		_portletInstanceKey = portletInstanceKey;
-
-		_configurationPid = PortletIdCodec.decodePortletName(
-			portletInstanceKey);
+		this(
+			layout, portletInstanceKey,
+			PortletIdCodec.decodePortletName(portletInstanceKey));
 	}
 
 	public PortletInstanceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -44,6 +44,10 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 		_configurationPid = configurationPid;
 	}
 
+	public String getConfigurationPid() {
+		return _configurationPid;
+	}
+
 	public long getOwnerId() {
 		if (isEmbeddedPortlet()) {
 			return _layout.getGroupId();

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
@@ -22,6 +22,9 @@ import aQute.bnd.annotation.ProviderType;
 @ProviderType
 public interface SettingsLocatorHelper {
 
+	public Settings getCompanyConfigurationBeanSettings(
+		long companyId, String configurationPid, Settings parentSettings);
+
 	public Settings getCompanyPortletPreferencesSettings(
 		long companyId, String settingsId, Settings parentSettings);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
@@ -53,6 +53,9 @@ public interface SettingsLocatorHelper {
 	@Deprecated
 	public Settings getPortalPropertiesSettings();
 
+	public Settings getPortletInstanceConfigurationBeanSettings(
+		String portletId, String configurationPid, Settings parentSettings);
+
 	public Settings getPortletInstancePortletPreferencesSettings(
 		long companyId, long ownerId, int ownerType, long plid,
 		String portletId, Settings parentSettings);

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelper.java
@@ -38,6 +38,9 @@ public interface SettingsLocatorHelper {
 	public Settings getConfigurationBeanSettings(
 		String configurationPid, Settings parentSettings);
 
+	public Settings getGroupConfigurationBeanSettings(
+		long groupId, String configurationPid, Settings parentSettings);
+
 	public Settings getGroupPortletPreferencesSettings(
 		long groupId, String settingsId, Settings parentSettings);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/SettingsLocatorHelperUtil.java
@@ -22,11 +22,33 @@ import com.liferay.registry.collections.ServiceTrackerList;
  */
 public class SettingsLocatorHelperUtil {
 
+	public static Settings getCompanyConfigurationBeanSettings(
+		long companyId, String configurationPid, Settings parentSettings) {
+
+		return getSettingsLocatorHelper().getCompanyConfigurationBeanSettings(
+			companyId, configurationPid, parentSettings);
+	}
+
 	public static Settings getCompanyPortletPreferencesSettings(
 		long companyId, String settingsId, Settings parentSettings) {
 
 		return getSettingsLocatorHelper().getCompanyPortletPreferencesSettings(
 			companyId, settingsId, parentSettings);
+	}
+
+	public static Settings getGroupConfigurationBeanSettings(
+		long groupId, String configurationPid, Settings parentSettings) {
+
+		return getSettingsLocatorHelper().getGroupConfigurationBeanSettings(
+			groupId, configurationPid, parentSettings);
+	}
+
+	public static Settings getPortletInstanceConfigurationBeanSettings(
+		String portletId, String configurationPid, Settings parentSettings) {
+
+		return getSettingsLocatorHelper().
+			getPortletInstanceConfigurationBeanSettings(
+				portletId, configurationPid, parentSettings);
 	}
 
 	public static SettingsLocatorHelper getSettingsLocatorHelper() {


### PR DESCRIPTION
Resent from https://github.com/brianchandotcom/liferay-portal/pull/53817

This is an update for [LPS-74152](https://issues.liferay.com/browse/LPS-74152).<br><br>Hey Brian, this pull allows reading configurations that are scoped at different levels per this proposal: https://github.com/drewbrokke/liferay-portal/pull/319.  There will be additional changes that facilitate saving configurations at different scopes, and also a database upgrade for the Configuration table to represent scoping data.  The idea is to support scoping any configuration without requiring that it is declared as a factory metatype.  Please let me know if you have any questions.<br><br>/cc @pei-jung, @jorgeferrer, @stian-sigvartsen