### PR TITLE
LPS-75201 ConfigurationTemporarySwapper causes intermittent CI integration test failures

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLAppServiceTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLAppServiceTest.java
@@ -190,7 +190,6 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 			addFileEntry(group.getGroupId(), parentFolder.getFolderId());
 		}
 
-		@Ignore
 		@Test(expected = FileSizeException.class)
 		public void shouldFailIfSizeLimitExceeded() throws Exception {
 			try (ConfigurationTemporarySwapper configurationTemporarySwapper =
@@ -238,7 +237,6 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 				group.getGroupId(), parentFolder.getFolderId(), sourceFileName);
 		}
 
-		@Ignore
 		@Test(expected = FileExtensionException.class)
 		public void shouldFailIfSourceFileNameExtensionNotSupported()
 			throws Exception {
@@ -1359,7 +1357,6 @@ public class DLAppServiceTest extends BaseDLAppTestCase {
 			}
 		}
 
-		@Ignore
 		@Test(expected = FileSizeException.class)
 		public void shouldFailIfSizeLimitExceeded() throws Exception {
 			String fileName = RandomTestUtil.randomString();


### PR DESCRIPTION
This is an update for [LPS-75201](https://issues.liferay.com/browse/LPS-75201).<br><br>Hey Brian, this reverts the ignores for the tests that use the ConfigurationTemporarySwapper.  The other two tests I ignored (`shouldSucceedWithConcurrentAccess` and `shouldSucceedWithNullBytes`) still fail, but they do not use the swapper.  I ignored them per request from @jpince here: https://github.com/brianchandotcom/liferay-portal/pull/52563#issue-269651815, so I am not turning them back on with this pull.<br><br>/cc @pei-jung, @sergiogonzalez, @jpince