### PR TITLE
LPS-77132 Create a Util to facilitate saving and deleting ConfigAdmin configurations during tests

### DIFF
--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util-test/src/testIntegration/java/com/liferay/portal/configuration/test/util/test/ConfigurationTemporarySwapperTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util-test/src/testIntegration/java/com/liferay/portal/configuration/test/util/test/ConfigurationTemporarySwapperTest.java
@@ -19,11 +19,7 @@ import com.liferay.osgi.util.service.OSGiServiceUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
-import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapperException;
-import com.liferay.portal.kernel.search.SearchPermissionChecker;
 import com.liferay.portal.kernel.util.HashMapDictionary;
-import com.liferay.portal.kernel.util.PrefsProps;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.IOException;
 
@@ -72,8 +68,7 @@ public class ConfigurationTemporarySwapperTest {
 				try (ConfigurationTemporarySwapper
 						configurationTemporarySwapper =
 							new ConfigurationTemporarySwapper(
-								SearchPermissionChecker.class, _pid,
-								new HashMapDictionary<>())) {
+								_pid, new HashMapDictionary<>())) {
 
 					Assert.assertTrue(persistenceManager.exists(_pid));
 				}
@@ -82,55 +77,6 @@ public class ConfigurationTemporarySwapperTest {
 					String.valueOf(persistenceManager.load(_pid)),
 					persistenceManager.exists(_pid));
 			});
-	}
-
-	@Test(
-		expected = ConfigurationTemporarySwapperException.MustFindService.class
-	)
-	public void testWillFailIfNoServiceFound() throws Exception {
-		_pid = StringUtil.randomString(20);
-
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					HasNoImplementation.class, _pid,
-					new HashMapDictionary<>())) {
-
-			Assert.fail();
-		}
-	}
-
-	@Test(
-		expected =
-			ConfigurationTemporarySwapperException.
-				ServiceMustConsumeConfiguration.class
-	)
-	public void testWillFailIfServiceDoesNotConsumeConfiguration()
-		throws Exception {
-
-		_pid = StringUtil.randomString(20);
-
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					SearchPermissionChecker.class, _pid,
-					new HashMapDictionary<>())) {
-
-			Assert.fail();
-		}
-	}
-
-	@Test(
-		expected =
-			ConfigurationTemporarySwapperException.ServiceMustHaveBundle.class
-	)
-	public void testWillFailIfServiceDoesNotHaveABundle() throws Exception {
-		_pid = StringUtil.randomString(20);
-
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					PrefsProps.class, _pid, new HashMapDictionary<>())) {
-
-			Assert.fail();
-		}
 	}
 
 	@Test
@@ -157,8 +103,7 @@ public class ConfigurationTemporarySwapperTest {
 				try (ConfigurationTemporarySwapper
 						configurationTemporarySwapper =
 							new ConfigurationTemporarySwapper(
-								SearchPermissionChecker.class, _pid,
-								temporaryValues)) {
+								_pid, temporaryValues)) {
 				}
 
 				Assert.assertTrue(persistenceManager.exists(_pid));
@@ -187,8 +132,7 @@ public class ConfigurationTemporarySwapperTest {
 		temporaryValues.put(testKey, testValue);
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					SearchPermissionChecker.class, _pid, temporaryValues)) {
+				new ConfigurationTemporarySwapper(_pid, temporaryValues)) {
 
 			Configuration testConfiguration = _getConfiguration(
 				_pid, StringPool.QUESTION);
@@ -263,8 +207,5 @@ public class ConfigurationTemporarySwapperTest {
 	}
 
 	private String _pid;
-
-	private interface HasNoImplementation {
-	}
 
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util-test/src/testIntegration/java/com/liferay/portal/configuration/test/util/test/ConfigurationTestUtilTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util-test/src/testIntegration/java/com/liferay/portal/configuration/test/util/test/ConfigurationTestUtilTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.test.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.osgi.util.service.OSGiServiceUtil;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.StringPool;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.List;
+
+import org.apache.felix.cm.PersistenceManager;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Drew Brokke
+ */
+@RunWith(Arquillian.class)
+public class ConfigurationTestUtilTest {
+
+	@After
+	public void tearDown() throws Exception {
+		if (_testConfigurationExists()) {
+			Configuration configuration = _getConfiguration();
+
+			configuration.delete();
+		}
+	}
+
+	@Test
+	public void testDeleteConfiguration() throws Exception {
+		_getConfiguration();
+
+		Assert.assertTrue(_testConfigurationExists());
+
+		ConfigurationTestUtil.deleteConfiguration(_pid);
+
+		Assert.assertFalse(_testConfigurationExists());
+
+		Configuration configuration = _getConfiguration();
+
+		Assert.assertTrue(_testConfigurationExists());
+
+		ConfigurationTestUtil.deleteConfiguration(configuration);
+
+		Assert.assertFalse(_testConfigurationExists());
+	}
+
+	@Test
+	public void testSaveConfiguration() throws Exception {
+		Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+		String value1 = RandomTestUtil.randomString();
+
+		properties.put(_TEST_KEY, value1);
+
+		ConfigurationTestUtil.saveConfiguration(_pid, properties);
+
+		Configuration configuration = _assertConfigurationValue(value1);
+
+		String value2 = RandomTestUtil.randomString();
+
+		properties.put(_TEST_KEY, value2);
+
+		ConfigurationTestUtil.saveConfiguration(configuration, properties);
+
+		_assertConfigurationValue(value2);
+	}
+
+	private Configuration _assertConfigurationValue(String value)
+		throws Exception {
+
+		Assert.assertTrue(_testConfigurationExists());
+
+		Configuration configuration = _getConfiguration();
+
+		Dictionary<String, Object> properties = configuration.getProperties();
+
+		Assert.assertEquals(value, properties.get(_TEST_KEY));
+
+		return configuration;
+	}
+
+	private Configuration _getConfiguration() throws Exception {
+		return OSGiServiceUtil.callService(
+			_bundleContext, ConfigurationAdmin.class,
+			configurationAdmin -> configurationAdmin.getConfiguration(
+				_pid, StringPool.QUESTION));
+	}
+
+	private boolean _testConfigurationExists() {
+		return OSGiServiceUtil.callService(
+			_bundleContext, PersistenceManager.class,
+			persistenceManager -> persistenceManager.exists(_pid));
+	}
+
+	private static final String _TEST_KEY =
+		"ConfigurationTestUtilTest_TEST_KEY";
+
+	private static final BundleContext _bundleContext;
+	private static final String _pid =
+		"TestPID_" + RandomTestUtil.randomString();
+
+	static {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ConfigurationTemporarySwapperTest.class);
+
+		if (bundle == null) {
+			_bundleContext = null;
+		}
+		else {
+			_bundleContext = bundle.getBundleContext();
+		}
+	}
+
+	private final List<Configuration> _configurations = new ArrayList<>();
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util/bnd.bnd
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Configuration Test Utilities
 Bundle-SymbolicName: com.liferay.portal.configuration.test.util
-Bundle-Version: 1.0.4
+Bundle-Version: 1.1.0
 Export-Package: com.liferay.portal.configuration.test.util
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Configuration Framework

--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTemporarySwapper.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTemporarySwapper.java
@@ -30,6 +30,12 @@ import org.osgi.service.cm.ConfigurationAdmin;
  */
 public class ConfigurationTemporarySwapper implements AutoCloseable {
 
+	/**
+	 * @deprecated As of 1.1.0, replaced by {@link
+	 *             #ConfigurationTemporarySwapper(String,
+	 *             Dictionary<String, Object>)}
+	 */
+	@Deprecated
 	public ConfigurationTemporarySwapper(
 			Class<?> serviceClass, String pid,
 			Dictionary<String, Object> properties)

--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTemporarySwapperException.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTemporarySwapperException.java
@@ -18,7 +18,9 @@ import com.liferay.portal.kernel.exception.PortalException;
 
 /**
  * @author Drew Brokke
+ * @deprecated As of 1.1.0, with no direct replacement
  */
+@Deprecated
 public class ConfigurationTemporarySwapperException extends PortalException {
 
 	public ConfigurationTemporarySwapperException(String msg) {

--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTestUtil.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTestUtil.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.test.util;
+
+import com.liferay.osgi.util.service.OSGiServiceUtil;
+import com.liferay.petra.string.StringPool;
+
+import java.util.Dictionary;
+import java.util.concurrent.CountDownLatch;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.cm.ConfigurationListener;
+
+/**
+ * @author Drew Brokke
+ */
+public class ConfigurationTestUtil {
+
+	public static void deleteConfiguration(Configuration configuration)
+		throws Exception {
+
+		_updateProperties(configuration, null);
+	}
+
+	public static void deleteConfiguration(String pid) throws Exception {
+		_updateProperties(_getConfiguration(pid), null);
+	}
+
+	public static void saveConfiguration(
+			Configuration configuration, Dictionary<String, Object> properties)
+		throws Exception {
+
+		_updateProperties(configuration, properties);
+	}
+
+	public static void saveConfiguration(
+			String pid, Dictionary<String, Object> properties)
+		throws Exception {
+
+		_updateProperties(_getConfiguration(pid), properties);
+	}
+
+	private static Configuration _getConfiguration(String pid)
+		throws Exception {
+
+		return OSGiServiceUtil.callService(
+			_bundleContext, ConfigurationAdmin.class,
+			configurationAdmin -> configurationAdmin.getConfiguration(
+				pid, StringPool.QUESTION));
+	}
+
+	private static void _updateProperties(
+			Configuration configuration, Dictionary<String, Object> dictionary)
+		throws Exception {
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		String markerPID = ConfigurationTestUtil.class.getName();
+
+		ConfigurationListener configurationListener = configurationEvent -> {
+			if (markerPID.equals(configurationEvent.getPid())) {
+				countDownLatch.countDown();
+			}
+		};
+
+		ServiceRegistration<ConfigurationListener> serviceRegistration =
+			_bundleContext.registerService(
+				ConfigurationListener.class, configurationListener, null);
+
+		try {
+			if (dictionary == null) {
+				configuration.delete();
+			}
+			else {
+				configuration.update(dictionary);
+			}
+
+			Configuration markerConfiguration = OSGiServiceUtil.callService(
+				_bundleContext, ConfigurationAdmin.class,
+				configurationAdmin -> configurationAdmin.getConfiguration(
+					markerPID, StringPool.QUESTION));
+
+			markerConfiguration.delete();
+
+			countDownLatch.await();
+		}
+		finally {
+			serviceRegistration.unregister();
+		}
+	}
+
+	private static final BundleContext _bundleContext;
+
+	static {
+		Bundle bundle = FrameworkUtil.getBundle(
+			ConfigurationTemporarySwapper.class);
+
+		_bundleContext = bundle.getBundleContext();
+	}
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/resources/com/liferay/portal/configuration/test/util/packageinfo
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util/src/main/resources/com/liferay/portal/configuration/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
This is an update for [LPS-77132](https://issues.liferay.com/browse/LPS-77132).<br><br>Hey Brian, most of the tests passed here: https://github.com/drewbrokke/liferay-portal/pull/412#issuecomment-357806741.  Almost all of the failures were from `com.liferay.fragment.entry.processor.editable.test.FragmentEntryProcessorEditableTest.testFragmentEntryProcessorEditable`, which looks to be a common failure right now.  This is a resend of https://github.com/brianchandotcom/liferay-portal/pull/54389#issue-288700489, but I have added tests in this pull.<br><br>/cc @pei-jung, @Preston-Crary, @shuyangzhou