### PR TITLE
LPS-77312 Replace Object with BaseModel in BaseUADEntity*TestCase

### DIFF
--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsEntryUADEntityAggregatorTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsEntryUADEntityAggregatorTest.java
@@ -18,6 +18,7 @@ import com.liferay.announcements.kernel.model.AnnouncementsEntry;
 import com.liferay.announcements.uad.constants.AnnouncementsUADConstants;
 import com.liferay.announcements.uad.test.AnnouncementsEntryUADEntityTestHelper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.test.rule.Inject;
@@ -44,7 +45,7 @@ public class AnnouncementsEntryUADEntityAggregatorTest
 		new LiferayIntegrationTestRule();
 
 	@Override
-	protected Object addDataObject(long userId) throws Exception {
+	protected BaseModel<?> addBaseModel(long userId) throws Exception {
 		AnnouncementsEntry announcementsEntry =
 			_announcementsEntryUADEntityTestHelper.addAnnouncementsEntry(
 				userId);

--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsFlagUADEntityAggregatorTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/aggregator/test/AnnouncementsFlagUADEntityAggregatorTest.java
@@ -18,6 +18,7 @@ import com.liferay.announcements.kernel.model.AnnouncementsFlag;
 import com.liferay.announcements.uad.constants.AnnouncementsUADConstants;
 import com.liferay.announcements.uad.test.AnnouncementsFlagUADEntityTestHelper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.test.rule.Inject;
@@ -44,7 +45,7 @@ public class AnnouncementsFlagUADEntityAggregatorTest
 		new LiferayIntegrationTestRule();
 
 	@Override
-	protected Object addDataObject(long userId) throws Exception {
+	protected BaseModel<?> addBaseModel(long userId) throws Exception {
 		AnnouncementsFlag announcementsFlag =
 			_announcementsFlagUADEntityTestHelper.addAnnouncementsFlag(userId);
 

--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsEntryUADEntityAnonymizerTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsEntryUADEntityAnonymizerTest.java
@@ -59,11 +59,6 @@ public class AnnouncementsEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected long getBaseModelPrimaryKey(BaseModel baseModel) {
-		return (long)baseModel.getPrimaryKeyObj();
-	}
-
-	@Override
 	protected String getUADRegistryKey() {
 		return AnnouncementsUADConstants.ANNOUNCEMENTS_ENTRY;
 	}

--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsEntryUADEntityAnonymizerTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsEntryUADEntityAnonymizerTest.java
@@ -19,6 +19,7 @@ import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalService;
 import com.liferay.announcements.uad.constants.AnnouncementsUADConstants;
 import com.liferay.announcements.uad.test.AnnouncementsEntryUADEntityTestHelper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -47,7 +48,7 @@ public class AnnouncementsEntryUADEntityAnonymizerTest
 		new LiferayIntegrationTestRule();
 
 	@Override
-	protected Object addDataObject(long userId) throws Exception {
+	protected BaseModel<?> addBaseModel(long userId) throws Exception {
 		AnnouncementsEntry announcementsEntry =
 			_announcementsEntryUADEntityTestHelper.addAnnouncementsEntry(
 				userId);
@@ -58,10 +59,8 @@ public class AnnouncementsEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected long getDataObjectId(Object dataObject) {
-		AnnouncementsEntry announcementsEntry = (AnnouncementsEntry)dataObject;
-
-		return announcementsEntry.getEntryId();
+	protected long getBaseModelPrimaryKey(BaseModel baseModel) {
+		return (long)baseModel.getPrimaryKeyObj();
 	}
 
 	@Override
@@ -70,11 +69,11 @@ public class AnnouncementsEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected boolean isDataObjectAutoAnonymized(long dataObjectId, User user)
+	protected boolean isBaseModelAutoAnonymized(long baseModelPK, User user)
 		throws Exception {
 
 		AnnouncementsEntry announcementsEntry =
-			_announcementsEntryLocalService.getEntry(dataObjectId);
+			_announcementsEntryLocalService.getEntry(baseModelPK);
 
 		if ((user.getUserId() != announcementsEntry.getUserId()) &&
 			!StringUtil.equals(
@@ -87,7 +86,7 @@ public class AnnouncementsEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected boolean isDataObjectDeleted(long dataObjectId) {
+	protected boolean isBaseModelDeleted(long dataObjectId) {
 		if (_announcementsEntryLocalService.fetchAnnouncementsEntry(
 				dataObjectId) == null) {
 

--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsFlagUADEntityAnonymizerTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsFlagUADEntityAnonymizerTest.java
@@ -57,11 +57,6 @@ public class AnnouncementsFlagUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected long getBaseModelPrimaryKey(BaseModel baseModel) {
-		return (long)baseModel.getPrimaryKeyObj();
-	}
-
-	@Override
 	protected String getUADRegistryKey() {
 		return AnnouncementsUADConstants.ANNOUNCEMENTS_FLAG;
 	}

--- a/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsFlagUADEntityAnonymizerTest.java
+++ b/modules/apps/collaboration/announcements/announcements-uad-test/src/testIntegration/java/com/liferay/announcements/uad/anonymizer/test/AnnouncementsFlagUADEntityAnonymizerTest.java
@@ -19,6 +19,7 @@ import com.liferay.announcements.kernel.service.AnnouncementsFlagLocalService;
 import com.liferay.announcements.uad.constants.AnnouncementsUADConstants;
 import com.liferay.announcements.uad.test.AnnouncementsFlagUADEntityTestHelper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -46,7 +47,7 @@ public class AnnouncementsFlagUADEntityAnonymizerTest
 		new LiferayIntegrationTestRule();
 
 	@Override
-	protected Object addDataObject(long userId) throws Exception {
+	protected BaseModel<?> addBaseModel(long userId) throws Exception {
 		AnnouncementsFlag announcementsFlag =
 			_announcementsFlagUADEntityTestHelper.addAnnouncementsFlag(userId);
 
@@ -56,10 +57,8 @@ public class AnnouncementsFlagUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected long getDataObjectId(Object dataObject) {
-		AnnouncementsFlag announcementsFlag = (AnnouncementsFlag)dataObject;
-
-		return announcementsFlag.getFlagId();
+	protected long getBaseModelPrimaryKey(BaseModel baseModel) {
+		return (long)baseModel.getPrimaryKeyObj();
 	}
 
 	@Override
@@ -68,11 +67,11 @@ public class AnnouncementsFlagUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected boolean isDataObjectAutoAnonymized(long dataObjectId, User user)
+	protected boolean isBaseModelAutoAnonymized(long baseModelPK, User user)
 		throws Exception {
 
 		AnnouncementsFlag announcementsFlag =
-			_announcementsFlagLocalService.getAnnouncementsFlag(dataObjectId);
+			_announcementsFlagLocalService.getAnnouncementsFlag(baseModelPK);
 
 		if (user.getUserId() != announcementsFlag.getUserId()) {
 			return true;
@@ -82,9 +81,9 @@ public class AnnouncementsFlagUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected boolean isDataObjectDeleted(long dataObjectId) {
+	protected boolean isBaseModelDeleted(long baseModelPK) {
 		if (_announcementsFlagLocalService.fetchAnnouncementsFlag(
-				dataObjectId) == null) {
+				baseModelPK) == null) {
 
 			return true;
 		}

--- a/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/aggregator/test/BookmarksEntryUADEntityAggregatorTest.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/aggregator/test/BookmarksEntryUADEntityAggregatorTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.bookmarks.model.BookmarksEntry;
 import com.liferay.bookmarks.uad.constants.BookmarksUADConstants;
 import com.liferay.bookmarks.uad.test.BookmarksEntryUADEntityTestHelper;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.test.rule.Inject;
@@ -46,7 +47,7 @@ public class BookmarksEntryUADEntityAggregatorTest
 		new LiferayIntegrationTestRule();
 
 	@Override
-	public Object addDataObjectWithStatusByUserId(
+	public BaseModel<?> addBaseModelWithStatusByUserId(
 			long userId, long statusByUserId)
 		throws Exception {
 
@@ -60,7 +61,7 @@ public class BookmarksEntryUADEntityAggregatorTest
 	}
 
 	@Override
-	protected Object addDataObject(long userId) throws Exception {
+	protected BaseModel<?> addBaseModel(long userId) throws Exception {
 		BookmarksEntry bookmarksEntry =
 			_bookmarksEntryUADEntityTestHelper.addBookmarksEntry(userId);
 

--- a/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/anonymizer/test/BookmarksEntryUADEntityAnonymizerTest.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/anonymizer/test/BookmarksEntryUADEntityAnonymizerTest.java
@@ -19,6 +19,7 @@ import com.liferay.bookmarks.model.BookmarksEntry;
 import com.liferay.bookmarks.service.BookmarksEntryLocalService;
 import com.liferay.bookmarks.uad.constants.BookmarksUADConstants;
 import com.liferay.bookmarks.uad.test.BookmarksEntryUADEntityTestHelper;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -49,7 +50,7 @@ public class BookmarksEntryUADEntityAnonymizerTest
 		new LiferayIntegrationTestRule();
 
 	@Override
-	public Object addDataObjectWithStatusByUserId(
+	public BaseModel<?> addBaseModelWithStatusByUserId(
 			long userId, long statusByUserId)
 		throws Exception {
 
@@ -63,7 +64,7 @@ public class BookmarksEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected Object addDataObject(long userId) throws Exception {
+	protected BaseModel<?> addBaseModel(long userId) throws Exception {
 		BookmarksEntry bookmarksEntry =
 			_bookmarksEntryUADEntityTestHelper.addBookmarksEntry(userId);
 
@@ -73,10 +74,8 @@ public class BookmarksEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected long getDataObjectId(Object dataObject) {
-		BookmarksEntry bookmarksEntry = (BookmarksEntry)dataObject;
-
-		return bookmarksEntry.getEntryId();
+	protected long getBaseModelPrimaryKey(BaseModel baseModel) {
+		return (long)baseModel.getPrimaryKeyObj();
 	}
 
 	@Override
@@ -85,11 +84,11 @@ public class BookmarksEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected boolean isDataObjectAutoAnonymized(long dataObjectId, User user)
+	protected boolean isBaseModelAutoAnonymized(long baseModelPK, User user)
 		throws Exception {
 
 		BookmarksEntry bookmarksEntry = _bookmarksEntryLocalService.getEntry(
-			dataObjectId);
+			baseModelPK);
 
 		if ((user.getUserId() != bookmarksEntry.getStatusByUserId()) &&
 			!StringUtil.equals(
@@ -105,8 +104,8 @@ public class BookmarksEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected boolean isDataObjectDeleted(long dataObjectId) {
-		if (_bookmarksEntryLocalService.fetchBookmarksEntry(dataObjectId) ==
+	protected boolean isBaseModelDeleted(long baseModelPK) {
+		if (_bookmarksEntryLocalService.fetchBookmarksEntry(baseModelPK) ==
 				null) {
 
 			return true;

--- a/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/anonymizer/test/BookmarksEntryUADEntityAnonymizerTest.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-uad-test/src/testIntegration/java/com/liferay/bookmarks/uad/anonymizer/test/BookmarksEntryUADEntityAnonymizerTest.java
@@ -74,11 +74,6 @@ public class BookmarksEntryUADEntityAnonymizerTest
 	}
 
 	@Override
-	protected long getBaseModelPrimaryKey(BaseModel baseModel) {
-		return (long)baseModel.getPrimaryKeyObj();
-	}
-
-	@Override
 	protected String getUADRegistryKey() {
 		return BookmarksUADConstants.BOOKMARKS_ENTRY;
 	}

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAggregatorTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAggregatorTestCase.java
@@ -15,6 +15,7 @@
 package com.liferay.user.associated.data.test.util;
 
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -62,15 +63,15 @@ public abstract class BaseUADEntityAggregatorTestCase {
 
 	@Test
 	public void testCount() throws Exception {
-		addDataObject(_user.getUserId());
+		addBaseModel(_user.getUserId());
 
 		Assert.assertEquals(1, _uadEntityAggregator.count(_user.getUserId()));
 	}
 
 	@Test
 	public void testGetUADEntities() throws Exception {
-		addDataObject(TestPropsValues.getUserId());
-		addDataObject(_user.getUserId());
+		addBaseModel(TestPropsValues.getUserId());
+		addBaseModel(_user.getUserId());
 
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
 			_user.getUserId());
@@ -89,7 +90,7 @@ public abstract class BaseUADEntityAggregatorTestCase {
 		WhenHasStatusByUserIdField whenHasStatusByUserIdField =
 			(WhenHasStatusByUserIdField)this;
 
-		whenHasStatusByUserIdField.addDataObjectWithStatusByUserId(
+		whenHasStatusByUserIdField.addBaseModelWithStatusByUserId(
 			TestPropsValues.getUserId(), _user.getUserId());
 
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
@@ -103,7 +104,7 @@ public abstract class BaseUADEntityAggregatorTestCase {
 	}
 
 	@Test
-	public void testGetUADEntitiesWithNoDataObject() throws Exception {
+	public void testGetUADEntitiesWithNoBaseModel() throws Exception {
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
 			_user.getUserId());
 
@@ -112,7 +113,7 @@ public abstract class BaseUADEntityAggregatorTestCase {
 
 	@Test
 	public void testGetUADEntity() throws Exception {
-		addDataObject(_user.getUserId());
+		addBaseModel(_user.getUserId());
 
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
 			_user.getUserId());
@@ -127,7 +128,7 @@ public abstract class BaseUADEntityAggregatorTestCase {
 		Assert.assertEquals(uadEntityId, uadEntity.getUADEntityId());
 	}
 
-	protected abstract Object addDataObject(long userId) throws Exception;
+	protected abstract BaseModel<?> addBaseModel(long userId) throws Exception;
 
 	protected abstract String getUADRegistryKey();
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
@@ -167,7 +167,9 @@ public abstract class BaseUADEntityAnonymizerTestCase {
 
 	protected abstract BaseModel<?> addBaseModel(long userId) throws Exception;
 
-	protected abstract long getBaseModelPrimaryKey(BaseModel baseModel);
+	protected long getBaseModelPrimaryKey(BaseModel baseModel) {
+		return (long)baseModel.getPrimaryKeyObj();
+	}
 
 	protected abstract String getUADRegistryKey();
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
@@ -15,6 +15,7 @@
 package com.liferay.user.associated.data.test.util;
 
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -72,40 +73,39 @@ public abstract class BaseUADEntityAnonymizerTestCase {
 
 	@Test
 	public void testAutoAnonymize() throws Exception {
-		Object dataObject = addDataObject(_user.getUserId());
+		BaseModel baseModel = addBaseModel(_user.getUserId());
 
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
 			_user.getUserId());
 
 		_uadEntityAnonymizer.autoAnonymize(uadEntities.get(0));
 
-		long dataObjectId = getDataObjectId(dataObject);
+		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
-		Assert.assertTrue(isDataObjectAutoAnonymized(dataObjectId, _user));
+		Assert.assertTrue(isBaseModelAutoAnonymized(baseModelPK, _user));
 	}
 
 	@Test
 	public void testAutoAnonymizeAll() throws Exception {
-		Object dataObject = addDataObject(TestPropsValues.getUserId());
-		Object dataObjectAutoAnonymize = addDataObject(_user.getUserId());
+		BaseModel baseModel = addBaseModel(TestPropsValues.getUserId());
+		BaseModel autoAnonymizedBaseModel = addBaseModel(_user.getUserId());
 
 		_uadEntityAnonymizer.autoAnonymizeAll(_user.getUserId());
 
-		long dataObjectId = getDataObjectId(dataObject);
+		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
 		Assert.assertFalse(
-			isDataObjectAutoAnonymized(
-				dataObjectId, TestPropsValues.getUser()));
+			isBaseModelAutoAnonymized(baseModelPK, TestPropsValues.getUser()));
 
-		long dataObjectAutoAnoymizeId = getDataObjectId(
-			dataObjectAutoAnonymize);
+		long autoAnonymizedBaseModelPK = getBaseModelPrimaryKey(
+			autoAnonymizedBaseModel);
 
 		Assert.assertTrue(
-			isDataObjectAutoAnonymized(dataObjectAutoAnoymizeId, _user));
+			isBaseModelAutoAnonymized(autoAnonymizedBaseModelPK, _user));
 	}
 
 	@Test
-	public void testAutoAnonymizeAllWithNoDataObject() throws Exception {
+	public void testAutoAnonymizeAllWithNoBaseModel() throws Exception {
 		_uadEntityAnonymizer.autoAnonymizeAll(_user.getUserId());
 	}
 
@@ -116,8 +116,8 @@ public abstract class BaseUADEntityAnonymizerTestCase {
 		WhenHasStatusByUserIdField whenHasStatusByUserIdField =
 			(WhenHasStatusByUserIdField)this;
 
-		Object dataObject =
-			whenHasStatusByUserIdField.addDataObjectWithStatusByUserId(
+		BaseModel baseModel =
+			whenHasStatusByUserIdField.addBaseModelWithStatusByUserId(
 				TestPropsValues.getUserId(), _user.getUserId());
 
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
@@ -125,9 +125,9 @@ public abstract class BaseUADEntityAnonymizerTestCase {
 
 		_uadEntityAnonymizer.autoAnonymize(uadEntities.get(0));
 
-		long dataObjectId = getDataObjectId(dataObject);
+		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
-		Assert.assertTrue(isDataObjectAutoAnonymized(dataObjectId, _user));
+		Assert.assertTrue(isBaseModelAutoAnonymized(baseModelPK, _user));
 	}
 
 	@Test
@@ -137,8 +137,8 @@ public abstract class BaseUADEntityAnonymizerTestCase {
 		WhenHasStatusByUserIdField whenHasStatusByUserIdField =
 			(WhenHasStatusByUserIdField)this;
 
-		Object dataObject =
-			whenHasStatusByUserIdField.addDataObjectWithStatusByUserId(
+		BaseModel baseModel =
+			whenHasStatusByUserIdField.addBaseModelWithStatusByUserId(
 				TestPropsValues.getUserId(), _user.getUserId());
 
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
@@ -146,57 +146,57 @@ public abstract class BaseUADEntityAnonymizerTestCase {
 
 		_uadEntityAnonymizer.autoAnonymize(uadEntities.get(0));
 
-		long dataObjectId = getDataObjectId(dataObject);
+		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
-		Assert.assertTrue(isDataObjectAutoAnonymized(dataObjectId, _user));
+		Assert.assertTrue(isBaseModelAutoAnonymized(baseModelPK, _user));
 	}
 
 	@Test
 	public void testDelete() throws Exception {
-		Object dataObject = addDataObject(_user.getUserId());
+		BaseModel baseModel = addBaseModel(_user.getUserId());
 
 		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
 			_user.getUserId());
 
 		_uadEntityAnonymizer.delete(uadEntities.get(0));
 
-		long dataObjectId = getDataObjectId(dataObject);
+		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
-		Assert.assertTrue(isDataObjectDeleted(dataObjectId));
+		Assert.assertTrue(isBaseModelDeleted(baseModelPK));
 	}
 
 	@Test
 	public void testDeleteAll() throws Exception {
-		Object dataObject = addDataObject(TestPropsValues.getUserId());
-		Object dataObjectDelete = addDataObject(_user.getUserId());
+		BaseModel baseModel = addBaseModel(TestPropsValues.getUserId());
+		BaseModel deletedBaseModel = addBaseModel(_user.getUserId());
 
 		_uadEntityAnonymizer.deleteAll(_user.getUserId());
 
-		long dataObjectId = getDataObjectId(dataObject);
+		long baseModelPK = getBaseModelPrimaryKey(baseModel);
 
-		Assert.assertFalse(isDataObjectDeleted(dataObjectId));
+		Assert.assertFalse(isBaseModelDeleted(baseModelPK));
 
-		long dataObjectDeleteId = getDataObjectId(dataObjectDelete);
+		long deletedBaseModelPK = getBaseModelPrimaryKey(deletedBaseModel);
 
-		Assert.assertTrue(isDataObjectDeleted(dataObjectDeleteId));
+		Assert.assertTrue(isBaseModelDeleted(deletedBaseModelPK));
 	}
 
 	@Test
-	public void testDeleteAllWithNoDataObject() throws Exception {
+	public void testDeleteAllWithNoBaseModel() throws Exception {
 		_uadEntityAnonymizer.deleteAll(_user.getUserId());
 	}
 
-	protected abstract Object addDataObject(long userId) throws Exception;
+	protected abstract BaseModel<?> addBaseModel(long userId) throws Exception;
 
-	protected abstract long getDataObjectId(Object dataObject);
+	protected abstract long getBaseModelPrimaryKey(BaseModel baseModel);
 
 	protected abstract String getUADRegistryKey();
 
-	protected abstract boolean isDataObjectAutoAnonymized(
-			long dataObjectId, User user)
+	protected abstract boolean isBaseModelAutoAnonymized(
+			long baseModelPK, User user)
 		throws Exception;
 
-	protected abstract boolean isDataObjectDeleted(long dataObjectId);
+	protected abstract boolean isBaseModelDeleted(long baseModelPK);
 
 	private UADEntityAggregator _uadEntityAggregator;
 	private ServiceTracker<UADEntityAggregator, UADEntityAggregator>

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADEntityAnonymizerTestCase.java
@@ -131,27 +131,6 @@ public abstract class BaseUADEntityAnonymizerTestCase {
 	}
 
 	@Test
-	public void testAutoAnonymizeUserOnly() throws Exception {
-		Assume.assumeTrue(this instanceof WhenHasStatusByUserIdField);
-
-		WhenHasStatusByUserIdField whenHasStatusByUserIdField =
-			(WhenHasStatusByUserIdField)this;
-
-		BaseModel baseModel =
-			whenHasStatusByUserIdField.addBaseModelWithStatusByUserId(
-				TestPropsValues.getUserId(), _user.getUserId());
-
-		List<UADEntity> uadEntities = _uadEntityAggregator.getUADEntities(
-			_user.getUserId());
-
-		_uadEntityAnonymizer.autoAnonymize(uadEntities.get(0));
-
-		long baseModelPK = getBaseModelPrimaryKey(baseModel);
-
-		Assert.assertTrue(isBaseModelAutoAnonymized(baseModelPK, _user));
-	}
-
-	@Test
 	public void testDelete() throws Exception {
 		BaseModel baseModel = addBaseModel(_user.getUserId());
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/WhenHasStatusByUserIdField.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/WhenHasStatusByUserIdField.java
@@ -14,12 +14,14 @@
 
 package com.liferay.user.associated.data.test.util;
 
+import com.liferay.portal.kernel.model.BaseModel;
+
 /**
  * @author Noah Sherrill
  */
 public interface WhenHasStatusByUserIdField {
 
-	public Object addDataObjectWithStatusByUserId(
+	public BaseModel<?> addBaseModelWithStatusByUserId(
 			long userId, long statusByUserId)
 		throws Exception;
 


### PR DESCRIPTION
Hi Brian,

This is the follow-up of https://github.com/brianchandotcom/liferay-portal/pull/54608 to return BaseModel instead of Object in the BaseUADEntity*TestCase.

/cc @noahsherrillwork, @drewbrokke, @willnewbury, @JorgeFerrer