### PR TITLE
LPS-76948 GroupServiceSettingsLocator will also get scoped configurations

### DIFF
--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/constants/SettingsLocatorTestConstants.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/constants/SettingsLocatorTestConstants.java
@@ -19,6 +19,10 @@ package com.liferay.portal.configuration.settings.internal.constants;
  */
 public class SettingsLocatorTestConstants {
 
+	public static final String PORTLET_PREFERENCES_FORMAT =
+		"<portlet-preferences><preference><name>%s</name><value>%s</value>" +
+			"</preference></portlet-preferences>";
+
 	public static final String TEST_CONFIGURATION_PID =
 		"com.liferay.portal.configuration.settings.internal.samples." +
 			"TestConfiguration";

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
@@ -41,7 +41,7 @@ public abstract class BaseSettingsLocatorTestCase {
 		_configurationPids.clear();
 	}
 
-	protected String getValueFromSettings() throws Exception {
+	protected String getSettingsValue() throws Exception {
 		if (settingsLocator == null) {
 			return null;
 		}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
@@ -14,23 +14,43 @@
 
 package com.liferay.portal.configuration.settings.internal.test;
 
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsLocator;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Dictionary;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
 
 /**
  * @author Drew Brokke
  */
+@RunWith(Arquillian.class)
 public abstract class BaseSettingsLocatorTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		companyId = TestPropsValues.getCompanyId();
+		groupId = TestPropsValues.getGroupId();
+	}
 
 	@After
 	public void tearDown() throws Exception {
@@ -67,6 +87,10 @@ public abstract class BaseSettingsLocatorTestCase {
 		return value;
 	}
 
+	protected static long companyId;
+	protected static long groupId;
+
+	protected final String portletId = RandomTestUtil.randomString();
 	protected SettingsLocator settingsLocator;
 
 	private final Set<String> _configurationPids = new HashSet<>();

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
@@ -93,6 +93,6 @@ public abstract class BaseSettingsLocatorTestCase {
 	protected final String portletId = RandomTestUtil.randomString();
 	protected SettingsLocator settingsLocator;
 
-	private final Set<String> _configurationPids = new HashSet<>();
+	private static final Set<String> _configurationPids = new HashSet<>();
 
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
@@ -16,6 +16,8 @@ package com.liferay.portal.configuration.settings.internal.test;
 
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsLocator;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 
@@ -39,6 +41,16 @@ public abstract class BaseSettingsLocatorTestCase {
 		_configurationPids.clear();
 	}
 
+	protected String getValueFromSettings() throws Exception {
+		if (settingsLocator == null) {
+			return null;
+		}
+
+		Settings settings = settingsLocator.getSettings();
+
+		return settings.getValue(SettingsLocatorTestConstants.TEST_KEY, null);
+	}
+
 	protected String saveConfiguration(String configurationPid)
 		throws Exception {
 
@@ -54,6 +66,8 @@ public abstract class BaseSettingsLocatorTestCase {
 
 		return value;
 	}
+
+	protected SettingsLocator settingsLocator;
 
 	private final Set<String> _configurationPids = new HashSet<>();
 

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
@@ -14,49 +14,33 @@
 
 package com.liferay.portal.configuration.settings.internal.test;
 
-import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
 import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * @author Drew Brokke
  */
-@RunWith(Arquillian.class)
 public class CompanyServiceSettingsLocatorTest
 	extends BaseSettingsLocatorTestCase {
 
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
-
 	@Before
 	public void setUp() throws Exception {
-		_companyId = TestPropsValues.getCompanyId();
-		_portletId = RandomTestUtil.randomString();
-
 		settingsLocator = new CompanyServiceSettingsLocator(
-			_companyId, _portletId,
+			companyId, portletId,
 			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
 	}
 
@@ -69,7 +53,7 @@ public class CompanyServiceSettingsLocatorTest
 		String scopedPid =
 			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
 				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
-				Scope.COMPANY, String.valueOf(_companyId));
+				Scope.COMPANY, String.valueOf(companyId));
 
 		String companyConfigurationValue = saveConfiguration(scopedPid);
 
@@ -79,8 +63,8 @@ public class CompanyServiceSettingsLocatorTest
 
 		_portletPreferencesList.add(
 			PortletPreferencesLocalServiceUtil.addPortletPreferences(
-				_companyId, _companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
-				_portletId, null,
+				companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
+				portletId, null,
 				String.format(
 					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
 					SettingsLocatorTestConstants.TEST_KEY,
@@ -88,9 +72,6 @@ public class CompanyServiceSettingsLocatorTest
 
 		Assert.assertEquals(companyPortletPreferencesValue, getSettingsValue());
 	}
-
-	private long _companyId;
-	private String _portletId;
 
 	@DeleteAfterTestRun
 	private final List<PortletPreferences> _portletPreferencesList =

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
@@ -64,7 +64,7 @@ public class CompanyServiceSettingsLocatorTest
 	public void testReturnsCompanyScopedValues() throws Exception {
 		Assert.assertEquals(
 			SettingsLocatorTestConstants.TEST_DEFAULT_VALUE,
-			getValueFromSettings());
+			getSettingsValue());
 
 		String scopedPid =
 			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
@@ -73,7 +73,7 @@ public class CompanyServiceSettingsLocatorTest
 
 		String companyConfigurationValue = saveConfiguration(scopedPid);
 
-		Assert.assertEquals(companyConfigurationValue, getValueFromSettings());
+		Assert.assertEquals(companyConfigurationValue, getSettingsValue());
 
 		String companyPortletPreferencesValue = RandomTestUtil.randomString();
 
@@ -86,8 +86,7 @@ public class CompanyServiceSettingsLocatorTest
 					SettingsLocatorTestConstants.TEST_KEY,
 					companyPortletPreferencesValue)));
 
-		Assert.assertEquals(
-			companyPortletPreferencesValue, getValueFromSettings());
+		Assert.assertEquals(companyPortletPreferencesValue, getSettingsValue());
 	}
 
 	private long _companyId;

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
@@ -21,8 +21,6 @@ import com.liferay.portal.configuration.settings.internal.constants.SettingsLoca
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
-import com.liferay.portal.kernel.settings.Settings;
-import com.liferay.portal.kernel.settings.SettingsLocator;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -48,7 +46,7 @@ public class CompanyServiceSettingsLocatorTest
 		_companyId = TestPropsValues.getCompanyId();
 		_portletId = RandomTestUtil.randomString();
 
-		_settingsLocator = new CompanyServiceSettingsLocator(
+		settingsLocator = new CompanyServiceSettingsLocator(
 			_companyId, _portletId,
 			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
 	}
@@ -83,23 +81,11 @@ public class CompanyServiceSettingsLocatorTest
 			companyPortletPreferencesValue, getValueFromSettings());
 	}
 
-	protected String getValueFromSettings() throws Exception {
-		if (_settingsLocator == null) {
-			return null;
-		}
-
-		Settings settings = _settingsLocator.getSettings();
-
-		return settings.getValue(SettingsLocatorTestConstants.TEST_KEY, null);
-	}
-
 	private long _companyId;
 	private String _portletId;
 
 	@DeleteAfterTestRun
 	private final List<PortletPreferences> _portletPreferencesList =
 		new ArrayList<>();
-
-	private SettingsLocator _settingsLocator;
 
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
@@ -75,7 +75,7 @@ public class CompanyServiceSettingsLocatorTest
 				_companyId, _companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
 				_portletId, null,
 				String.format(
-					_PORTLET_PREFERENCE_FORMAT,
+					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
 					SettingsLocatorTestConstants.TEST_KEY,
 					companyPortletPreferencesValue)));
 
@@ -92,10 +92,6 @@ public class CompanyServiceSettingsLocatorTest
 
 		return settings.getValue(SettingsLocatorTestConstants.TEST_KEY, null);
 	}
-
-	private static final String _PORTLET_PREFERENCE_FORMAT =
-		"<portlet-preferences><preference><name>%s</name><value>%s</value>" +
-			"</preference></portlet-preferences>";
 
 	private long _companyId;
 	private String _portletId;

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
@@ -21,16 +21,20 @@ import com.liferay.portal.configuration.settings.internal.constants.SettingsLoca
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +44,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class CompanyServiceSettingsLocatorTest
 	extends BaseSettingsLocatorTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
 
 	@Before
 	public void setUp() throws Exception {

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
@@ -14,50 +14,33 @@
 
 package com.liferay.portal.configuration.settings.internal.test;
 
-import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
 import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * @author Drew Brokke
  */
-@RunWith(Arquillian.class)
 public class GroupServiceSettingsLocatorTest
 	extends BaseSettingsLocatorTestCase {
 
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
-
 	@Before
 	public void setUp() throws Exception {
-		_companyId = TestPropsValues.getCompanyId();
-		_portletId = RandomTestUtil.randomString();
-		_groupId = TestPropsValues.getGroupId();
-
 		settingsLocator = new GroupServiceSettingsLocator(
-			_groupId, _portletId,
+			groupId, portletId,
 			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
 	}
 
@@ -70,7 +53,7 @@ public class GroupServiceSettingsLocatorTest
 		String companyScopedPid =
 			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
 				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
-				Scope.COMPANY, String.valueOf(_companyId));
+				Scope.COMPANY, String.valueOf(companyId));
 
 		String companyConfigurationValue = saveConfiguration(companyScopedPid);
 
@@ -80,8 +63,8 @@ public class GroupServiceSettingsLocatorTest
 
 		_portletPreferencesList.add(
 			PortletPreferencesLocalServiceUtil.addPortletPreferences(
-				_companyId, _companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
-				_portletId, null,
+				companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
+				portletId, null,
 				String.format(
 					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
 					SettingsLocatorTestConstants.TEST_KEY,
@@ -92,7 +75,7 @@ public class GroupServiceSettingsLocatorTest
 		String groupScopedPid =
 			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
 				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
-				Scope.GROUP, String.valueOf(_groupId));
+				Scope.GROUP, String.valueOf(groupId));
 
 		String groupConfigurationValue = saveConfiguration(groupScopedPid);
 
@@ -102,8 +85,8 @@ public class GroupServiceSettingsLocatorTest
 
 		_portletPreferencesList.add(
 			PortletPreferencesLocalServiceUtil.addPortletPreferences(
-				_companyId, _groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP, 0,
-				_portletId, null,
+				companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP, 0,
+				portletId, null,
 				String.format(
 					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
 					SettingsLocatorTestConstants.TEST_KEY,
@@ -111,10 +94,6 @@ public class GroupServiceSettingsLocatorTest
 
 		Assert.assertEquals(groupPortletPreferencesValue, getSettingsValue());
 	}
-
-	private long _companyId;
-	private long _groupId;
-	private String _portletId;
 
 	@DeleteAfterTestRun
 	private final List<PortletPreferences> _portletPreferencesList =

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
@@ -65,7 +65,7 @@ public class GroupServiceSettingsLocatorTest
 	public void testReturnsGroupScopedValues() throws Exception {
 		Assert.assertEquals(
 			SettingsLocatorTestConstants.TEST_DEFAULT_VALUE,
-			getValueFromSettings());
+			getSettingsValue());
 
 		String companyScopedPid =
 			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
@@ -74,7 +74,7 @@ public class GroupServiceSettingsLocatorTest
 
 		String companyConfigurationValue = saveConfiguration(companyScopedPid);
 
-		Assert.assertEquals(companyConfigurationValue, getValueFromSettings());
+		Assert.assertEquals(companyConfigurationValue, getSettingsValue());
 
 		String companyPortletPreferencesValue = RandomTestUtil.randomString();
 
@@ -87,8 +87,7 @@ public class GroupServiceSettingsLocatorTest
 					SettingsLocatorTestConstants.TEST_KEY,
 					companyPortletPreferencesValue)));
 
-		Assert.assertEquals(
-			companyPortletPreferencesValue, getValueFromSettings());
+		Assert.assertEquals(companyPortletPreferencesValue, getSettingsValue());
 
 		String groupScopedPid =
 			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
@@ -97,7 +96,7 @@ public class GroupServiceSettingsLocatorTest
 
 		String groupConfigurationValue = saveConfiguration(groupScopedPid);
 
-		Assert.assertEquals(groupConfigurationValue, getValueFromSettings());
+		Assert.assertEquals(groupConfigurationValue, getSettingsValue());
 
 		String groupPortletPreferencesValue = RandomTestUtil.randomString();
 
@@ -110,8 +109,7 @@ public class GroupServiceSettingsLocatorTest
 					SettingsLocatorTestConstants.TEST_KEY,
 					groupPortletPreferencesValue)));
 
-		Assert.assertEquals(
-			groupPortletPreferencesValue, getValueFromSettings());
+		Assert.assertEquals(groupPortletPreferencesValue, getSettingsValue());
 	}
 
 	private long _companyId;

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
@@ -21,8 +21,6 @@ import com.liferay.portal.configuration.settings.internal.constants.SettingsLoca
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
-import com.liferay.portal.kernel.settings.Settings;
-import com.liferay.portal.kernel.settings.SettingsLocator;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -58,7 +56,7 @@ public class GroupServiceSettingsLocatorTest
 		_portletId = RandomTestUtil.randomString();
 		_groupId = TestPropsValues.getGroupId();
 
-		_settingsLocator = new GroupServiceSettingsLocator(
+		settingsLocator = new GroupServiceSettingsLocator(
 			_groupId, _portletId,
 			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
 	}
@@ -116,16 +114,6 @@ public class GroupServiceSettingsLocatorTest
 			groupPortletPreferencesValue, getValueFromSettings());
 	}
 
-	protected String getValueFromSettings() throws Exception {
-		if (_settingsLocator == null) {
-			return null;
-		}
-
-		Settings settings = _settingsLocator.getSettings();
-
-		return settings.getValue(SettingsLocatorTestConstants.TEST_KEY, null);
-	}
-
 	private long _companyId;
 	private long _groupId;
 	private String _portletId;
@@ -133,7 +121,5 @@ public class GroupServiceSettingsLocatorTest
 	@DeleteAfterTestRun
 	private final List<PortletPreferences> _portletPreferencesList =
 		new ArrayList<>();
-
-	private SettingsLocator _settingsLocator;
 
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
+import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
+import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
+import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
+import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
+import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsLocator;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Drew Brokke
+ */
+@RunWith(Arquillian.class)
+public class GroupServiceSettingsLocatorTest
+	extends BaseSettingsLocatorTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_companyId = TestPropsValues.getCompanyId();
+		_portletId = RandomTestUtil.randomString();
+		_groupId = TestPropsValues.getGroupId();
+
+		_settingsLocator = new GroupServiceSettingsLocator(
+			_groupId, _portletId,
+			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
+	}
+
+	@Test
+	public void testReturnsGroupScopedValues() throws Exception {
+		Assert.assertEquals(
+			SettingsLocatorTestConstants.TEST_DEFAULT_VALUE,
+			getValueFromSettings());
+
+		String companyScopedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
+				Scope.COMPANY, String.valueOf(_companyId));
+
+		String companyConfigurationValue = saveConfiguration(companyScopedPid);
+
+		Assert.assertEquals(companyConfigurationValue, getValueFromSettings());
+
+		String companyPortletPreferencesValue = RandomTestUtil.randomString();
+
+		_portletPreferencesList.add(
+			PortletPreferencesLocalServiceUtil.addPortletPreferences(
+				_companyId, _companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
+				_portletId, null,
+				String.format(
+					_portletPreferenceFormat,
+					SettingsLocatorTestConstants.TEST_KEY,
+					companyPortletPreferencesValue)));
+
+		Assert.assertEquals(
+			companyPortletPreferencesValue, getValueFromSettings());
+
+		String groupScopedPid =
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
+				Scope.GROUP, String.valueOf(_groupId));
+
+		String groupConfigurationValue = saveConfiguration(groupScopedPid);
+
+		Assert.assertEquals(groupConfigurationValue, getValueFromSettings());
+
+		String groupPortletPreferencesValue = RandomTestUtil.randomString();
+
+		_portletPreferencesList.add(
+			PortletPreferencesLocalServiceUtil.addPortletPreferences(
+				_companyId, _groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP, 0,
+				_portletId, null,
+				String.format(
+					_portletPreferenceFormat,
+					SettingsLocatorTestConstants.TEST_KEY,
+					groupPortletPreferencesValue)));
+
+		Assert.assertEquals(
+			groupPortletPreferencesValue, getValueFromSettings());
+	}
+
+	protected String getValueFromSettings() throws Exception {
+		if (_settingsLocator == null) {
+			return null;
+		}
+
+		Settings settings = _settingsLocator.getSettings();
+
+		return settings.getValue(SettingsLocatorTestConstants.TEST_KEY, null);
+	}
+
+	private static final String _portletPreferenceFormat =
+		"<portlet-preferences><preference><name>%s</name><value>%s</value>" +
+			"</preference></portlet-preferences>";
+
+	private long _companyId;
+	private long _groupId;
+	private String _portletId;
+
+	@DeleteAfterTestRun
+	private final List<PortletPreferences> _portletPreferencesList =
+		new ArrayList<>();
+
+	private SettingsLocator _settingsLocator;
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
@@ -85,7 +85,7 @@ public class GroupServiceSettingsLocatorTest
 				_companyId, _companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
 				_portletId, null,
 				String.format(
-					_portletPreferenceFormat,
+					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
 					SettingsLocatorTestConstants.TEST_KEY,
 					companyPortletPreferencesValue)));
 
@@ -108,7 +108,7 @@ public class GroupServiceSettingsLocatorTest
 				_companyId, _groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP, 0,
 				_portletId, null,
 				String.format(
-					_portletPreferenceFormat,
+					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
 					SettingsLocatorTestConstants.TEST_KEY,
 					groupPortletPreferencesValue)));
 
@@ -125,10 +125,6 @@ public class GroupServiceSettingsLocatorTest
 
 		return settings.getValue(SettingsLocatorTestConstants.TEST_KEY, null);
 	}
-
-	private static final String _portletPreferenceFormat =
-		"<portlet-preferences><preference><name>%s</name><value>%s</value>" +
-			"</preference></portlet-preferences>";
 
 	private long _companyId;
 	private long _groupId;

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
@@ -32,8 +32,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.osgi.service.cm.ConfigurationAdmin;
-
 /**
  * @author Drew Brokke
  */
@@ -226,9 +224,6 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID, scope,
 				scopePrimKey));
 	}
-
-	@Inject
-	private ConfigurationAdmin _configurationAdmin;
 
 	@Inject
 	private SettingsLocatorHelper _settingsLocatorHelper;

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
@@ -14,39 +14,24 @@
 
 package com.liferay.portal.configuration.settings.internal.test;
 
-import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
  * @author Drew Brokke
  */
-@RunWith(Arquillian.class)
 public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
 
 	@Test
 	public void testGetCompanyScopedConfigurationSettings() throws Exception {
-		long companyId = TestPropsValues.getCompanyId();
-
 		Settings companySettings =
 			_settingsLocatorHelper.getCompanyConfigurationBeanSettings(
 				companyId, SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
@@ -91,8 +76,6 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 
 	@Test
 	public void testGetGroupScopedConfigurationSettings() throws Exception {
-		long groupId = TestPropsValues.getGroupId();
-
 		Settings groupSettings =
 			_settingsLocatorHelper.getGroupConfigurationBeanSettings(
 				groupId, SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
@@ -137,8 +120,6 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 	@Test
 	public void testGetPortletInstanceScopedConfigurationSettings()
 		throws Exception {
-
-		String portletId = RandomTestUtil.randomString();
 
 		String portletInstanceKey =
 			portletId + "_INSTANCE_" + RandomTestUtil.randomString();
@@ -226,6 +207,6 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 	}
 
 	@Inject
-	private SettingsLocatorHelper _settingsLocatorHelper;
+	private static SettingsLocatorHelper _settingsLocatorHelper;
 
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
@@ -168,7 +168,7 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_KEY,
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));
 
-		String companyValue = saveScopedConfiguration(
+		String portletInstanceValue = saveScopedConfiguration(
 			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
 			portletInstanceKey);
 
@@ -181,7 +181,7 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 		Assert.assertNotSame(systemSettings, portletInstanceSettings);
 
 		Assert.assertEquals(
-			companyValue,
+			portletInstanceValue,
 			portletInstanceSettings.getValue(
 				SettingsLocatorTestConstants.TEST_KEY,
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
@@ -41,22 +41,17 @@ public class GroupServiceSettingsLocator implements SettingsLocator {
 
 	@Override
 	public Settings getSettings() throws SettingsException {
-		long companyId = getCompanyId(_groupId);
+		CompanyServiceSettingsLocator companyServiceSettingsLocator =
+			new CompanyServiceSettingsLocator(
+				getCompanyId(_groupId), _settingsId, _configurationPid);
 
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
-
-		Settings portalPreferencesSettings =
-			_settingsLocatorHelper.getPortalPreferencesSettings(
-				companyId, configurationBeanSettings);
-
-		Settings companyPortletPreferencesSettings =
-			_settingsLocatorHelper.getCompanyPortletPreferencesSettings(
-				companyId, _settingsId, portalPreferencesSettings);
+		Settings groupConfigurationBeanSettings =
+			_settingsLocatorHelper.getGroupConfigurationBeanSettings(
+				_groupId, _configurationPid,
+				companyServiceSettingsLocator.getSettings());
 
 		return _settingsLocatorHelper.getGroupPortletPreferencesSettings(
-			_groupId, _settingsId, companyPortletPreferencesSettings);
+			_groupId, _settingsId, groupConfigurationBeanSettings);
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [LPS-76948](https://issues.liferay.com/browse/LPS-76948).<br><br>Hey Brian, this is a resend per your request here: https://github.com/brianchandotcom/liferay-portal/pull/54660#issuecomment-359998862.  I renamed the method to reflect the return value, and also moved a few variables to the base case, making them static where I could.  Let me know if you have any questions.<br><br>/cc @pei-jung, @JorgeFerrer, @stian-sigvartsen