### PR TITLE
LPS-76949 PortletInstanceSettingsLocator will also get scoped configurations

### DIFF
--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
@@ -15,18 +15,26 @@
 package com.liferay.portal.configuration.settings.internal.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
+import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsLocator;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.After;
@@ -71,6 +79,11 @@ public abstract class BaseSettingsLocatorTestCase {
 		return settings.getValue(SettingsLocatorTestConstants.TEST_KEY, null);
 	}
 
+	protected String saveConfiguration() throws Exception {
+		return saveConfiguration(
+			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
+	}
+
 	protected String saveConfiguration(String configurationPid)
 		throws Exception {
 
@@ -87,6 +100,36 @@ public abstract class BaseSettingsLocatorTestCase {
 		return value;
 	}
 
+	protected String savePortletPreferences(long ownerId, int ownerType)
+		throws Exception {
+
+		String value = RandomTestUtil.randomString();
+
+		_portletPreferencesList.add(
+			_portletPreferencesLocalService.addPortletPreferences(
+				companyId, ownerId, ownerType, 0, portletId, null,
+				String.format(
+					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
+					SettingsLocatorTestConstants.TEST_KEY, value)));
+
+		return value;
+	}
+
+	protected String saveScopedConfiguration(Scope scope, long scopePrimKey)
+		throws Exception {
+
+		return saveScopedConfiguration(scope, String.valueOf(scopePrimKey));
+	}
+
+	protected String saveScopedConfiguration(Scope scope, String scopePrimKey)
+		throws Exception {
+
+		return saveConfiguration(
+			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
+				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID, scope,
+				scopePrimKey));
+	}
+
 	protected static long companyId;
 	protected static long groupId;
 
@@ -94,5 +137,13 @@ public abstract class BaseSettingsLocatorTestCase {
 	protected SettingsLocator settingsLocator;
 
 	private static final Set<String> _configurationPids = new HashSet<>();
+
+	@Inject
+	private static PortletPreferencesLocalService
+		_portletPreferencesLocalService;
+
+	@DeleteAfterTestRun
+	private final List<PortletPreferences> _portletPreferencesList =
+		new ArrayList<>();
 
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/BaseSettingsLocatorTestCase.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -103,11 +104,19 @@ public abstract class BaseSettingsLocatorTestCase {
 	protected String savePortletPreferences(long ownerId, int ownerType)
 		throws Exception {
 
+		return savePortletPreferences(
+			ownerId, ownerType, portletId, PortletKeys.PREFS_PLID_SHARED);
+	}
+
+	protected String savePortletPreferences(
+			long ownerId, int ownerType, String portletId, long plid)
+		throws Exception {
+
 		String value = RandomTestUtil.randomString();
 
 		_portletPreferencesList.add(
 			_portletPreferencesLocalService.addPortletPreferences(
-				companyId, ownerId, ownerType, 0, portletId, null,
+				companyId, ownerId, ownerType, plid, portletId, null,
 				String.format(
 					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
 					SettingsLocatorTestConstants.TEST_KEY, value)));

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/CompanyServiceSettingsLocatorTest.java
@@ -15,17 +15,9 @@
 package com.liferay.portal.configuration.settings.internal.test;
 
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
-import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
-import com.liferay.portal.kernel.model.PortletPreferences;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,31 +42,15 @@ public class CompanyServiceSettingsLocatorTest
 			SettingsLocatorTestConstants.TEST_DEFAULT_VALUE,
 			getSettingsValue());
 
-		String scopedPid =
-			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
-				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
-				Scope.COMPANY, String.valueOf(companyId));
-
-		String companyConfigurationValue = saveConfiguration(scopedPid);
+		String companyConfigurationValue = saveScopedConfiguration(
+			Scope.COMPANY, companyId);
 
 		Assert.assertEquals(companyConfigurationValue, getSettingsValue());
 
-		String companyPortletPreferencesValue = RandomTestUtil.randomString();
-
-		_portletPreferencesList.add(
-			PortletPreferencesLocalServiceUtil.addPortletPreferences(
-				companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
-				portletId, null,
-				String.format(
-					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
-					SettingsLocatorTestConstants.TEST_KEY,
-					companyPortletPreferencesValue)));
+		String companyPortletPreferencesValue = savePortletPreferences(
+			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
 		Assert.assertEquals(companyPortletPreferencesValue, getSettingsValue());
 	}
-
-	@DeleteAfterTestRun
-	private final List<PortletPreferences> _portletPreferencesList =
-		new ArrayList<>();
 
 }

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/GroupServiceSettingsLocatorTest.java
@@ -15,13 +15,10 @@
 package com.liferay.portal.configuration.settings.internal.test;
 
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
-import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.kernel.model.PortletPreferences;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 
 import java.util.ArrayList;
@@ -50,47 +47,23 @@ public class GroupServiceSettingsLocatorTest
 			SettingsLocatorTestConstants.TEST_DEFAULT_VALUE,
 			getSettingsValue());
 
-		String companyScopedPid =
-			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
-				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
-				Scope.COMPANY, String.valueOf(companyId));
-
-		String companyConfigurationValue = saveConfiguration(companyScopedPid);
+		String companyConfigurationValue = saveScopedConfiguration(
+			Scope.COMPANY, companyId);
 
 		Assert.assertEquals(companyConfigurationValue, getSettingsValue());
 
-		String companyPortletPreferencesValue = RandomTestUtil.randomString();
-
-		_portletPreferencesList.add(
-			PortletPreferencesLocalServiceUtil.addPortletPreferences(
-				companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, 0,
-				portletId, null,
-				String.format(
-					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
-					SettingsLocatorTestConstants.TEST_KEY,
-					companyPortletPreferencesValue)));
+		String companyPortletPreferencesValue = savePortletPreferences(
+			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
 		Assert.assertEquals(companyPortletPreferencesValue, getSettingsValue());
 
-		String groupScopedPid =
-			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
-				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID,
-				Scope.GROUP, String.valueOf(groupId));
-
-		String groupConfigurationValue = saveConfiguration(groupScopedPid);
+		String groupConfigurationValue = saveScopedConfiguration(
+			Scope.GROUP, groupId);
 
 		Assert.assertEquals(groupConfigurationValue, getSettingsValue());
 
-		String groupPortletPreferencesValue = RandomTestUtil.randomString();
-
-		_portletPreferencesList.add(
-			PortletPreferencesLocalServiceUtil.addPortletPreferences(
-				companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP, 0,
-				portletId, null,
-				String.format(
-					SettingsLocatorTestConstants.PORTLET_PREFERENCES_FORMAT,
-					SettingsLocatorTestConstants.TEST_KEY,
-					groupPortletPreferencesValue)));
+		String groupPortletPreferencesValue = savePortletPreferences(
+			groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP);
 
 		Assert.assertEquals(groupPortletPreferencesValue, getSettingsValue());
 	}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/PortletInstanceSettingsLocatorTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/PortletInstanceSettingsLocatorTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.settings.internal.test;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
+import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.settings.PortletInstanceSettingsLocator;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.util.test.LayoutTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class PortletInstanceSettingsLocatorTest
+	extends BaseSettingsLocatorTestCase {
+
+	@Before
+	public void setUp() throws Exception {
+		_layout = LayoutTestUtil.addLayout(groupId);
+
+		_portletInstanceKey =
+			portletId + "_INSTANCE_" + RandomTestUtil.randomString();
+
+		settingsLocator = new PortletInstanceSettingsLocator(
+			_layout, _portletInstanceKey,
+			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
+	}
+
+	@Test
+	public void testReturnsPortletInstanceScopedValues() throws Exception {
+		Assert.assertEquals(
+			SettingsLocatorTestConstants.TEST_DEFAULT_VALUE,
+			getSettingsValue());
+
+		Assert.assertEquals(
+			saveScopedConfiguration(Scope.COMPANY, companyId),
+			getSettingsValue());
+
+		Assert.assertEquals(
+			savePortletPreferences(
+				companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY),
+			getSettingsValue());
+
+		Assert.assertEquals(
+			saveScopedConfiguration(Scope.GROUP, groupId), getSettingsValue());
+
+		Assert.assertEquals(
+			savePortletPreferences(groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP),
+			getSettingsValue());
+
+		Assert.assertEquals(
+			saveScopedConfiguration(
+				Scope.PORTLET_INSTANCE, _portletInstanceKey),
+			getSettingsValue());
+
+		Assert.assertEquals(
+			savePortletPreferences(
+				PortletKeys.PREFS_PLID_SHARED,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, _portletInstanceKey,
+				_layout.getPlid()),
+			getSettingsValue());
+	}
+
+	@DeleteAfterTestRun
+	private Layout _layout;
+
+	private String _portletInstanceKey;
+
+}

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
@@ -14,8 +14,7 @@
 
 package com.liferay.portal.configuration.settings.internal.test;
 
-import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
-import com.liferay.portal.configuration.metatype.util.ConfigurationScopedPidUtil;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition.Scope;
 import com.liferay.portal.configuration.settings.internal.constants.SettingsLocatorTestConstants;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
@@ -57,8 +56,7 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));
 
 		String companyValue = saveScopedConfiguration(
-			ExtendedObjectClassDefinition.Scope.COMPANY,
-			String.valueOf(companyId));
+			Scope.COMPANY, String.valueOf(companyId));
 
 		companySettings =
 			_settingsLocatorHelper.getCompanyConfigurationBeanSettings(
@@ -101,7 +99,7 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));
 
 		String groupValue = saveScopedConfiguration(
-			ExtendedObjectClassDefinition.Scope.GROUP, String.valueOf(groupId));
+			Scope.GROUP, String.valueOf(groupId));
 
 		groupSettings =
 			_settingsLocatorHelper.getGroupConfigurationBeanSettings(
@@ -150,8 +148,7 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));
 
 		String portletInstanceValue = saveScopedConfiguration(
-			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
-			portletInstanceKey);
+			Scope.PORTLET_INSTANCE, portletInstanceKey);
 
 		portletInstanceSettings =
 			_settingsLocatorHelper.getPortletInstanceConfigurationBeanSettings(

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
@@ -191,21 +191,6 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));
 	}
 
-	protected String saveConfiguration() throws Exception {
-		return saveConfiguration(
-			SettingsLocatorTestConstants.TEST_CONFIGURATION_PID);
-	}
-
-	protected String saveScopedConfiguration(
-			ExtendedObjectClassDefinition.Scope scope, String scopePrimKey)
-		throws Exception {
-
-		return saveConfiguration(
-			ConfigurationScopedPidUtil.buildConfigurationScopedPid(
-				SettingsLocatorTestConstants.TEST_CONFIGURATION_PID, scope,
-				scopePrimKey));
-	}
-
 	@Inject
 	private static SettingsLocatorHelper _settingsLocatorHelper;
 

--- a/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-settings-test/src/testIntegration/java/com/liferay/portal/configuration/settings/internal/test/SettingsLocatorHelperTest.java
@@ -55,8 +55,7 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_KEY,
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));
 
-		String companyValue = saveScopedConfiguration(
-			Scope.COMPANY, String.valueOf(companyId));
+		String companyValue = saveScopedConfiguration(Scope.COMPANY, companyId);
 
 		companySettings =
 			_settingsLocatorHelper.getCompanyConfigurationBeanSettings(
@@ -98,8 +97,7 @@ public class SettingsLocatorHelperTest extends BaseSettingsLocatorTestCase {
 				SettingsLocatorTestConstants.TEST_KEY,
 				SettingsLocatorTestConstants.TEST_DEFAULT_VALUE));
 
-		String groupValue = saveScopedConfiguration(
-			Scope.GROUP, String.valueOf(groupId));
+		String groupValue = saveScopedConfiguration(Scope.GROUP, groupId);
 
 		groupSettings =
 			_settingsLocatorHelper.getGroupConfigurationBeanSettings(

--- a/modules/apps/foundation/portal-configuration/portal-configuration-test-util/build.gradle
+++ b/modules/apps/foundation/portal-configuration/portal-configuration-test-util/build.gradle
@@ -4,6 +4,7 @@ targetCompatibility = "1.8"
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.osgi.util", version: "3.2.0"
 	provided group: "com.liferay", name: "com.liferay.petra.function", version: "1.0.0"
+	provided group: "com.liferay", name: "com.liferay.petra.reflect", version: "1.1.0"
 	provided group: "com.liferay", name: "com.liferay.petra.string", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.38.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.test", version: "1.0.0"

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.settings.PortletInstanceSettingsLocator;
 import com.liferay.portal.kernel.settings.PortletPreferencesSettings;
 import com.liferay.portal.kernel.settings.Settings;
+import com.liferay.portal.kernel.settings.SettingsLocatorHelperUtil;
 import com.liferay.portal.kernel.spring.aop.Property;
 import com.liferay.portal.kernel.spring.aop.Retry;
 import com.liferay.portal.kernel.spring.aop.Skip;
@@ -231,13 +232,24 @@ public class PortletPreferencesLocalServiceImpl
 			defaultPreferences = portlet.getDefaultPreferences();
 		}
 
+		String configurationPid =
+			portletInstanceSettingsLocator.getConfigurationPid();
+
+		Settings companyConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.getCompanyConfigurationBeanSettings(
+				companyId, configurationPid, portalPreferencesSettings);
+
 		Settings companyPortletPreferencesSettings =
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
 					PortletKeys.PREFS_PLID_SHARED, portletId,
 					defaultPreferences),
-				portalPreferencesSettings);
+				companyConfigurationBeanSettings);
+
+		Settings groupConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.getGroupConfigurationBeanSettings(
+				groupId, configurationPid, companyPortletPreferencesSettings);
 
 		Settings groupPortletPreferencesSettings =
 			new PortletPreferencesSettings(
@@ -245,7 +257,13 @@ public class PortletPreferencesLocalServiceImpl
 					companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP,
 					PortletKeys.PREFS_PLID_SHARED, portletId,
 					defaultPreferences),
-				companyPortletPreferencesSettings);
+				groupConfigurationBeanSettings);
+
+		Settings portletInstanceConfigurationBeanSettings =
+			SettingsLocatorHelperUtil.
+				getPortletInstanceConfigurationBeanSettings(
+					portletId, configurationPid,
+					groupPortletPreferencesSettings);
 
 		long ownerId = portletInstanceSettingsLocator.getOwnerId();
 		int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
@@ -264,7 +282,7 @@ public class PortletPreferencesLocalServiceImpl
 			_getStrictPreferences(
 				companyId, ownerId, ownerType, plid, portletId,
 				defaultPreferences),
-			groupPortletPreferencesSettings);
+			portletInstanceConfigurationBeanSettings);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -225,8 +225,10 @@ public class PortletPreferencesLocalServiceImpl
 
 		String defaultPreferences = PortletConstants.DEFAULT_PREFERENCES;
 
+		String portletName = PortletIdCodec.decodePortletName(portletId);
+
 		Portlet portlet = portletLocalService.fetchPortletById(
-			companyId, PortletIdCodec.decodePortletName(portletId));
+			companyId, portletName);
 
 		if (portlet != null) {
 			defaultPreferences = portlet.getDefaultPreferences();
@@ -243,7 +245,7 @@ public class PortletPreferencesLocalServiceImpl
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-					PortletKeys.PREFS_PLID_SHARED, portletId,
+					PortletKeys.PREFS_PLID_SHARED, portletName,
 					defaultPreferences),
 				companyConfigurationBeanSettings);
 
@@ -255,7 +257,7 @@ public class PortletPreferencesLocalServiceImpl
 			new PortletPreferencesSettings(
 				_getStrictPreferences(
 					companyId, groupId, PortletKeys.PREFS_OWNER_TYPE_GROUP,
-					PortletKeys.PREFS_PLID_SHARED, portletId,
+					PortletKeys.PREFS_PLID_SHARED, portletName,
 					defaultPreferences),
 				groupConfigurationBeanSettings);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/GroupServiceSettingsLocator.java
@@ -25,10 +25,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 public class GroupServiceSettingsLocator implements SettingsLocator {
 
 	public GroupServiceSettingsLocator(long groupId, String settingsId) {
-		_groupId = groupId;
-		_settingsId = settingsId;
-
-		_configurationPid = settingsId;
+		this(groupId, settingsId, settingsId);
 	}
 
 	public GroupServiceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -66,13 +66,12 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 
 	@Override
 	public Settings getSettings() throws SettingsException {
-		Settings configurationBeanSettings =
-			_settingsLocatorHelper.getConfigurationBeanSettings(
-				_configurationPid);
+		SystemSettingsLocator systemSettingsLocator = new SystemSettingsLocator(
+			_configurationPid);
 
 		Settings portalPreferencesSettings = new PortletPreferencesSettings(
 			PrefsPropsUtil.getPreferences(_layout.getCompanyId()),
-			configurationBeanSettings);
+			systemSettingsLocator.getSettings());
 
 		return PortletPreferencesLocalServiceUtil.getPortletInstanceSettings(
 			_layout.getCompanyId(), _layout.getGroupId(), _portletInstanceKey,

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -29,11 +29,9 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 	public PortletInstanceSettingsLocator(
 		Layout layout, String portletInstanceKey) {
 
-		_layout = layout;
-		_portletInstanceKey = portletInstanceKey;
-
-		_configurationPid = PortletIdCodec.decodePortletName(
-			portletInstanceKey);
+		this(
+			layout, portletInstanceKey,
+			PortletIdCodec.decodePortletName(portletInstanceKey));
 	}
 
 	public PortletInstanceSettingsLocator(

--- a/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java
@@ -44,6 +44,10 @@ public class PortletInstanceSettingsLocator implements SettingsLocator {
 		_configurationPid = configurationPid;
 	}
 
+	public String getConfigurationPid() {
+		return _configurationPid;
+	}
+
 	public long getOwnerId() {
 		if (isEmbeddedPortlet()) {
 			return _layout.getGroupId();


### PR DESCRIPTION
This is an update for [LPS-76949](https://issues.liferay.com/browse/LPS-76949).<br><br>Hey Brian, this is the last step in the story for reading scoped configurations.  Tests passed here: https://github.com/drewbrokke/liferay-portal/pull/439#issuecomment-360680992.<br><br>/cc @pei-jung, @JorgeFerrer, @stian-sigvartsen