### PR TITLE
LPS-77404 use 6.1 type name for 6.1 definiton

### DIFF
--- a/definitions/liferay-workflow-definition_6_1_0.xsd
+++ b/definitions/liferay-workflow-definition_6_1_0.xsd
@@ -330,28 +330,8 @@
 	</xs:group>
 	<xs:group name="task-timer-actions-group">
 		<xs:choice>
-			<xs:element name="timer-action">
-				<xs:complexType>
-					<xs:complexContent>
-						<xs:extension base="action-complex-type">
-							<xs:sequence>
-								<xs:element name="execution-type" type="task-execution-type" />
-							</xs:sequence>
-						</xs:extension>
-					</xs:complexContent>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="timer-notification">
-				<xs:complexType>
-					<xs:complexContent>
-						<xs:extension base="task-notification-complex-type">
-							<xs:sequence>
-								<xs:element name="execution-type" type="task-execution-type" />
-							</xs:sequence>
-						</xs:extension>
-					</xs:complexContent>
-				</xs:complexType>
-			</xs:element>
+			<xs:element name="timer-action" type="action-complex-type" />
+			<xs:element name="timer-notification" type="notification-complex-type" />
 			<xs:element minOccurs="0" name="reassignments">
 				<xs:complexType>
 					<xs:choice>


### PR DESCRIPTION
From https://github.com/brianchandotcom/liferay-portal/pull/54935

Brian,
I just realize 61 type name is different from the others, this is an addition commit to correct.
Sorry for the trouble.