### PR TITLE
LPS-77404 use 6.1 type name for 6.1 definition

### DIFF
--- a/definitions/liferay-workflow-definition_6_1_0.xsd
+++ b/definitions/liferay-workflow-definition_6_1_0.xsd
@@ -344,7 +344,7 @@
 			<xs:element name="timer-notification">
 				<xs:complexType>
 					<xs:complexContent>
-						<xs:extension base="task-notification-complex-type">
+						<xs:extension base="notification-complex-type">
 							<xs:sequence>
 								<xs:element name="execution-type" type="task-execution-type" />
 							</xs:sequence>


### PR DESCRIPTION
From #54935

Brian,
I realize 61 type name is different from the others, this is an additional commit to correct.
Sorry for the trouble.