### PR TITLE
LPS-77542 Hide operands if there is a field or constant, avoiding issue with "belongs to" rule

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder_render_rule_condition.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder_render_rule_condition.js
@@ -806,7 +806,6 @@ AUI.add(
 							}
 						];
 					}
-					secondOperandType.cleanSelect();
 					secondOperandType.set('options', options);
 				}
 			},

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder_render_rule_condition.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/form_builder_render_rule_condition.js
@@ -746,8 +746,6 @@ AUI.add(
 			_updateSecondOperandFieldVisibility: function(index) {
 				var instance = this;
 
-				instance._hideSecondOperandField(index);
-
 				var secondOperandType = instance._getSecondOperandType(index);
 
 				if (secondOperandType.get('visible')) {
@@ -758,10 +756,12 @@ AUI.add(
 					var secondOperandOptions = instance._getSecondOperand(index, 'options');
 
 					if (secondOperandTypeValue === 'field') {
+						instance._hideSecondOperandField(index);
 						secondOperandFields.set('visible', true);
 						secondOperandOptions.cleanSelect();
 					}
 					else if (instance._isConstant(secondOperandTypeValue)) {
+						instance._hideSecondOperandField(index);
 						var options = instance._getFieldOptions(instance._getFirstOperandValue(index));
 
 						if (options.length > 0 && instance._getFieldType(instance._getFirstOperandValue(index)) !== 'text') {


### PR DESCRIPTION
Tests ran on https://github.com/rafaprax/liferay-portal/pull/280.

Tests failures are unrelated.

Thx

\\cc @pedroqueiroz94 