### PR TITLE
LPS-76781 Resolve method must be captured because, according to the spec, the promise executor is called right inside the Promise constructor, so the assignment has not taken place yet.

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
@@ -271,11 +271,23 @@ Liferay = window.Liferay || {};
 	var componentsFn = {};
 	var componentPromiseWrappers = {};
 
-	var _createPromiseWrapper = function(promise, resolve) {
-		return {
-			promise: promise,
-			resolve: resolve || function() {}
-		};
+	var _createPromiseWrapper = function(value) {
+		if(value) {
+			return {
+				promise: Promise.resolve(value),
+				resolve: function() {}
+			}
+		} else {
+			var promiseResolve;
+			var promise = new Promise(function (resolve) {
+				promiseResolve = resolve;
+			});
+
+			return {
+				promise: promise,
+				resolve: promiseResolve
+			}
+		}
 	};
 
 	Liferay.component = function(id, value) {
@@ -312,9 +324,7 @@ Liferay = window.Liferay || {};
 					componentPromiseWrapper.resolve(value);
 				}
 				else {
-					componentPromiseWrappers[id] = _createPromiseWrapper(
-						Promise.resolve(value)
-					);
+					componentPromiseWrappers[id] = _createPromiseWrapper(value);
 				}
 			}
 		}
@@ -345,20 +355,14 @@ Liferay = window.Liferay || {};
 			);
 		}
 		else {
-			var componentPromise = componentPromiseWrappers[component];
+			var componentPromiseWrapper = componentPromiseWrappers[component];
 
-			if (!componentPromise) {
-				componentPromise = new Promise(
-					function (resolve) {
-						componentPromiseWrappers[component] = _createPromiseWrapper(componentPromise, resolve);
-					}
-				);
-			}
-			else {
-				componentPromise = componentPromise.promise;
+			if (!componentPromiseWrapper) {
+				componentPromiseWrappers[component] =
+					componentPromiseWrapper = _createPromiseWrapper();
 			}
 
-			return componentPromise;
+			return componentPromiseWrapper.promise;
 		}
 	};
 

--- a/modules/apps/foundation/frontend-js/frontend-js-web/test/liferay/LiferayComponent.es.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/test/liferay/LiferayComponent.es.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// import PortletBase from '../../src/main/resources/META-INF/resources/liferay/liferay.js';
-
 import fs from 'fs';
 
 describe('LiferayComponent', () => {
@@ -13,16 +11,21 @@ describe('LiferayComponent', () => {
 					fire: () => 0,
 				},
 			};
+
 			const AUI = Object.assign(
-				() => ({
-					namespace: () => 0,
-					mix: () => 0,
-				}),
+				() => (
+					{
+						namespace: () => 0,
+						mix: () => 0,
+					}
+				),
 				{
 					$: Object.assign(
-						() => ({
-							on: () => 0,
-						}),
+						() => (
+							{
+								on: () => 0,
+							}
+						),
 						{
 							ajaxSetup: () => 0,
 							ajaxPrefilter: () => 0,
@@ -34,6 +37,7 @@ describe('LiferayComponent', () => {
 					},
 				}
 			);
+
 			const themeDisplay = {
 				getPathContext: () => 0,
 			};
@@ -64,22 +68,23 @@ describe('LiferayComponent', () => {
 
 			Liferay.component('myButton', myButton);
 
-			return Liferay.componentReady('myButton').then(component => {
-				expect(component).toBe(myButton);
-			});
+			return Liferay.componentReady('myButton').then(
+				component => {
+					expect(component).toBe(myButton);
+				}
+			);
 		});
 
 		it('should return an array of components if called before they are registered', () => {
 			const myButton1 = {myButton1: 'myButton1'};
 			const myButton2 = {myButton2: 'myButton2'};
 
-			const promise = Liferay.componentReady(
-				'myButton1',
-				'myButton2'
-			).then(components => {
-				expect(components[0]).toBe(myButton1);
-				expect(components[1]).toBe(myButton2);
-			});
+			const promise = Liferay.componentReady('myButton1','myButton2').then(
+				([component1, component2]) => {
+					expect(component1).toBe(myButton1);
+					expect(component2).toBe(myButton2);
+				}
+			);
 
 			Liferay.component('myButton1', myButton1);
 			Liferay.component('myButton2', myButton2);
@@ -95,9 +100,9 @@ describe('LiferayComponent', () => {
 			Liferay.component('myButton2', myButton2);
 
 			return Liferay.componentReady('myButton1', 'myButton2').then(
-				components => {
-					expect(components[0]).toBe(myButton1);
-					expect(components[1]).toBe(myButton2);
+				([component1, component2]) => {
+					expect(component1).toBe(myButton1);
+					expect(component2).toBe(myButton2);
 				}
 			);
 		});
@@ -115,12 +120,7 @@ describe('LiferayComponent', () => {
 			Liferay.component('myButton', 1);
 			Liferay.component('myButton', 2);
 
-			expect(msg).toEqual(
-				'Component with id \'myButton\' is being registered twice. ' +
-					'This can lead to unexpected behaviour in the ' +
-					'\'Liferay.component\' and \'Liferay.componentReady\' APIs, ' +
-					'as well as the \'*:registered\' events. '
-			);
+			expect(msg).toEqual('Component with id "myButton" is being registered twice. This can lead to unexpected behaviour in the "Liferay.component" and "Liferay.componentReady" APIs, as well as in the "*:registered" events. ');
 		});
 	});
 });

--- a/modules/apps/foundation/frontend-js/frontend-js-web/test/liferay/LiferayComponent.es.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/test/liferay/LiferayComponent.es.js
@@ -1,0 +1,126 @@
+'use strict';
+
+// import PortletBase from '../../src/main/resources/META-INF/resources/liferay/liferay.js';
+
+import fs from 'fs';
+
+describe('LiferayComponent', () => {
+	describe('Liferay.componentReady', () => {
+		beforeEach(() => {
+			const window = {
+				Liferay: {
+					namespace: 0,
+					fire: () => 0,
+				},
+			};
+			const AUI = Object.assign(
+				() => ({
+					namespace: () => 0,
+					mix: () => 0,
+				}),
+				{
+					$: Object.assign(
+						() => ({
+							on: () => 0,
+						}),
+						{
+							ajaxSetup: () => 0,
+							ajaxPrefilter: () => 0,
+						}
+					),
+					_: {
+						assign: () => 0,
+						forEach: () => 0,
+					},
+				}
+			);
+			const themeDisplay = {
+				getPathContext: () => 0,
+			};
+
+			const script = fs.readFileSync(
+				'./src/main/resources/META-INF/resources/liferay/liferay.js'
+			);
+
+			eval(script.toString());
+		});
+
+		it('should return a single component if called before it is registered', () => {
+			const myButton = {myButton: 'myButton'};
+
+			const promise = Liferay.componentReady('myButton').then(
+				component => {
+					expect(component).toBe(myButton);
+				}
+			);
+
+			Liferay.component('myButton', myButton);
+
+			return promise;
+		});
+
+		it('should return a single component if called after it is registered', () => {
+			const myButton = {myButton: 'myButton'};
+
+			Liferay.component('myButton', myButton);
+
+			return Liferay.componentReady('myButton').then(component => {
+				expect(component).toBe(myButton);
+			});
+		});
+
+		it('should return an array of components if called before they are registered', () => {
+			const myButton1 = {myButton1: 'myButton1'};
+			const myButton2 = {myButton2: 'myButton2'};
+
+			const promise = Liferay.componentReady(
+				'myButton1',
+				'myButton2'
+			).then(components => {
+				expect(components[0]).toBe(myButton1);
+				expect(components[1]).toBe(myButton2);
+			});
+
+			Liferay.component('myButton1', myButton1);
+			Liferay.component('myButton2', myButton2);
+
+			return promise;
+		});
+
+		it('should return an array of components if called after they are registered', () => {
+			const myButton1 = {myButton1: 'myButton1'};
+			const myButton2 = {myButton2: 'myButton2'};
+
+			Liferay.component('myButton1', myButton1);
+			Liferay.component('myButton2', myButton2);
+
+			return Liferay.componentReady('myButton1', 'myButton2').then(
+				components => {
+					expect(components[0]).toBe(myButton1);
+					expect(components[1]).toBe(myButton2);
+				}
+			);
+		});
+
+		it('should warn through console when a component is registered twice', () => {
+			let msg = '';
+
+			console.warn = function() {
+				for (let i = 0; i < arguments.length; i++) {
+					msg += arguments[i].toString();
+					msg += ' ';
+				}
+			};
+
+			Liferay.component('myButton', 1);
+			Liferay.component('myButton', 2);
+
+			expect(msg).toEqual(
+				'Component with id \'myButton\' is being registered twice. ' +
+					'This can lead to unexpected behaviour in the ' +
+					'\'Liferay.component\' and \'Liferay.componentReady\' APIs, ' +
+					'as well as the \'*:registered\' events. '
+			);
+		});
+	});
+});

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/base/BaseClayTag.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/base/BaseClayTag.java
@@ -55,7 +55,8 @@ public abstract class BaseClayTag extends TemplateRendererTag {
 				themeDisplay.getPathThemeImages().concat("/clay/icons.svg"));
 		}
 
-		setHydrate(_hydrate);
+		super.setComponentId(_componentId);
+		setHydrate(_hydrate || Validator.isNotNull(_componentId));
 		setTemplateNamespace(_componentBaseName + ".render");
 
 		return super.doStartTag();
@@ -74,6 +75,11 @@ public abstract class BaseClayTag extends TemplateRendererTag {
 				"clay-", _moduleBaseName, "/lib/", _componentBaseName));
 	}
 
+	@Override
+	public void setComponentId(String componentId) {
+		_componentId = componentId;
+	}
+
 	public void setElementClasses(String elementClasses) {
 		putValue("elementClasses", elementClasses);
 	}
@@ -87,6 +93,7 @@ public abstract class BaseClayTag extends TemplateRendererTag {
 	}
 
 	private final String _componentBaseName;
+	private String _componentId;
 	private final boolean _hydrate;
 	private final String _moduleBaseName;
 

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -28,6 +28,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>destroyOnHide</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -82,6 +88,12 @@
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -119,6 +131,12 @@
 		<attribute>
 			<description></description>
 			<name>block</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -214,6 +232,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -298,6 +322,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -353,6 +383,12 @@
 		<attribute>
 			<description></description>
 			<name>buttonType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -425,6 +461,12 @@
 		<attribute>
 			<description></description>
 			<name>actionItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -544,6 +586,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -622,6 +670,12 @@
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -659,6 +713,12 @@
 		<attribute>
 			<description></description>
 			<name>actionItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -790,6 +850,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -851,6 +917,12 @@
 		<attribute>
 			<description></description>
 			<name>buttonStyle</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -922,6 +994,12 @@
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>elementClasses</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -956,6 +1034,12 @@
 		<name>progressbar</name>
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.ProgressBarTag</tag-class>
 		<body-content>empty</body-content>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 		<attribute>
 			<description></description>
 			<name>elementClasses</name>
@@ -1007,6 +1091,12 @@
 		<attribute>
 			<description></description>
 			<name>checked</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1066,6 +1156,12 @@
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1118,6 +1214,12 @@
 		<name>sticker</name>
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.soy.StickerTag</tag-class>
 		<body-content>empty</body-content>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 		<attribute>
 			<description></description>
 			<name>elementClasses</name>
@@ -1192,6 +1294,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>componentId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>destroyOnHide</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1241,6 +1349,12 @@
 		<attribute>
 			<description></description>
 			<name>actionItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>componentId</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>


### PR DESCRIPTION
/CC @jbalsas 
