### PR TITLE
LPS-77940 configuration-admin-api is exporting the wrong package path

### DIFF
--- a/modules/apps/foundation/configuration-admin/configuration-admin-api/bnd.bnd
+++ b/modules/apps/foundation/configuration-admin/configuration-admin-api/bnd.bnd
@@ -2,7 +2,7 @@ Bundle-Name: Liferay Configuration Admin API
 Bundle-SymbolicName: com.liferay.configuration.admin.api
 Bundle-Version: 1.0.0
 Export-Package:\
-	com.liferay.configuration.admin.categories,\
+	com.liferay.configuration.admin.category,\
 	com.liferay.configuration.admin.constants,\
 	com.liferay.configuration.admin.definition
 Liferay-Releng-Module-Group-Description:


### PR DESCRIPTION
This is an update for [LPS-77940](https://issues.liferay.com/browse/LPS-77940).<br><br>Hey Brian, this fixes a deploy-time error with configuration-admin-web.  It's causing the smoke tests to fail.<br><br>/cc @pei-jung, @jpince