### PR TITLE
LPS-77995 Move the Passwords section under the General category

### DIFF
--- a/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/servlet/taglib/ui/navigation/user/entry/UserPasswordScreenNavigationEntry.java
+++ b/modules/apps/foundation/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/servlet/taglib/ui/navigation/user/entry/UserPasswordScreenNavigationEntry.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Pei-Jung Lan
  */
 @Component(
-	property = {"screen.navigation.entry.order:Integer=10"},
+	property = {"screen.navigation.entry.order:Integer=60"},
 	service = ScreenNavigationEntry.class
 )
 public class UserPasswordScreenNavigationEntry
@@ -37,7 +37,7 @@ public class UserPasswordScreenNavigationEntry
 
 	@Override
 	public String getCategoryKey() {
-		return UserFormConstants.CATEGORY_KEY_PREFERENCES;
+		return UserFormConstants.CATEGORY_KEY_GENERAL;
 	}
 
 	@Override


### PR DESCRIPTION
This is an update for [LPS-77995](https://issues.liferay.com/browse/LPS-77995).<br><br>Hey Brian, this just changes the metadata on one of our ScreenNavigatorEntiries in the user form to move the passwords section to a different category.  No logic changes.<br><br>/cc @pei-jung, @jorgeferrer