### PR TITLE
LPS-78071

### DIFF
--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -526,7 +526,6 @@ public class JournalDisplayContext {
 		Group group = themeDisplay.getScopeGroup();
 
 		sb.append(group.getPathFriendlyURL(false, themeDisplay));
-
 		sb.append(group.getFriendlyURL());
 
 		sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
@@ -1327,7 +1326,6 @@ public class JournalDisplayContext {
 		attributes.put("params", params);
 
 		searchContext.setAttributes(attributes);
-
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(end);
 		searchContext.setFolderIds(folderIds);

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionEditorConfigContributor.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionEditorConfigContributor.java
@@ -95,7 +95,6 @@ public class JournalArticleDescriptionEditorConfigContributor
 		jsonArray.put("twitter");
 
 		jsonObject.put("buttons", jsonArray);
-
 		jsonObject.put("name", "text");
 		jsonObject.put("test", "AlloyEditor.SelectionTest.text");
 

--- a/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/util/JournalRSSUtil.java
+++ b/modules/apps/web-experience/journal/journal-web/src/main/java/com/liferay/journal/web/util/JournalRSSUtil.java
@@ -446,7 +446,6 @@ public class JournalRSSUtil {
 				resourceRequest, feed, article, layout, themeDisplay);
 
 			syndEntry.setLink(link);
-
 			syndEntry.setPublishedDate(article.getDisplayDate());
 			syndEntry.setTitle(article.getTitle(languageId));
 			syndEntry.setUpdatedDate(article.getModifiedDate());
@@ -476,7 +475,6 @@ public class JournalRSSUtil {
 		syndLinks.add(selfSyndLink);
 
 		syndFeed.setLinks(syndLinks);
-
 		syndFeed.setPublishedDate(new Date());
 		syndFeed.setTitle(feed.getName());
 		syndFeed.setUri(feedURL.toString());

--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -7,7 +7,7 @@
 
     line.length.excludes=\
         modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checks/PropertiesLanguageKeysCheck.java,\
-        modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java@125
+        modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java@140
 
     source.formatter.excludes=\
         modules/util/source-formatter/src/test/java/com/liferay/source/formatter/JavaSourceProcessorTest.java

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java
@@ -132,17 +132,8 @@ public class MissingEmptyLineCheck extends BaseCheck {
 						nextSibling);
 
 					if ((endLine + 1) == startLineNextExpression) {
-						String newSub = StringUtil.trim(
-							_getFirstLine(nextSibling));
-						String oldSub = StringUtil.trim(
-							_getFirstLine(previousDetailAST));
-
-						String prefix = newSub.replaceAll(
-							"(\\S*\\.set).*", "$1");
-
 						if (!_containsChildToken(
-								previousDetailAST, TokenTypes.ASSIGN) &&
-							(prefix.isEmpty() || !oldSub.startsWith(prefix))) {
+								previousDetailAST, TokenTypes.ASSIGN)) {
 
 							log(
 								startLineNextExpression,

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java
@@ -23,6 +23,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Hugo Huijser
@@ -228,6 +229,59 @@ public class MissingEmptyLineCheck extends BaseCheck {
 
 		if (expressionName.equals(name)) {
 			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isExpressionReferencesNewVariable(
+		DetailAST detailAST, String name) {
+
+		List<DetailAST> identASTList = DetailASTUtil.getAllChildTokens(
+			detailAST, true, TokenTypes.IDENT);
+
+		for (DetailAST identAST : identASTList) {
+			String identName = identAST.getText();
+
+			if (!identName.equals(name)) {
+				continue;
+			}
+
+			DetailAST parentAST = identAST.getParent();
+
+			if (parentAST != null) {
+				parentAST = parentAST.getParent();
+			}
+
+			if (parentAST != null) {
+				parentAST = parentAST.getParent();
+			}
+
+			if ((parentAST == null) ||
+				(parentAST.getType() != TokenTypes.METHOD_CALL)) {
+
+				continue;
+			}
+
+			DetailAST firstChild = parentAST.getFirstChild();
+
+			if ((firstChild != null) &&
+				(firstChild.getType() == TokenTypes.DOT)) {
+
+				firstChild = firstChild.getFirstChild();
+
+				if ((firstChild != null) &&
+					(firstChild.getType() == TokenTypes.IDENT)) {
+
+					String newName = firstChild.getText();
+
+					if (!Character.isUpperCase(newName.charAt(0)) &&
+						!Objects.equals(firstChild.getText(), name)) {
+
+						return true;
+					}
+				}
+			}
 		}
 
 		return false;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/MissingEmptyLineCheck.java
@@ -98,9 +98,32 @@ public class MissingEmptyLineCheck extends BaseCheck {
 			for (DetailAST identAST : identASTList) {
 				String identName = identAST.getText();
 
-				if (identName.equals(name)) {
-					expressionReferencesVariable = true;
+				if (!identName.equals(name)) {
+					continue;
 				}
+
+				if (_isExpressionReferencesNewVariable(nextSibling, name)) {
+					DetailAST nextDetailAST = _getNextDetailAST(nextSibling);
+
+					if (nextDetailAST == null) {
+						continue;
+					}
+
+					String curSub = StringUtil.trim(_getFirstLine(nextSibling));
+					String newSub = StringUtil.trim(
+						_getFirstLine(nextDetailAST));
+
+					String prefix = curSub.replaceAll(
+						"([a-zA-Z0-9_]*\\.).*", "$1");
+
+					if (!prefix.isEmpty() && curSub.startsWith(prefix) &&
+						newSub.startsWith(prefix)) {
+
+						return;
+					}
+				}
+
+				expressionReferencesVariable = true;
 			}
 
 			if (!expressionReferencesVariable) {
@@ -204,6 +227,20 @@ public class MissingEmptyLineCheck extends BaseCheck {
 		}
 
 		return getLine(startLine - 1);
+	}
+
+	private DetailAST _getNextDetailAST(DetailAST detailAST) {
+		DetailAST nextDetailAST = detailAST;
+
+		while (nextDetailAST != null) {
+			nextDetailAST = nextDetailAST.getNextSibling();
+
+			if (nextDetailAST.getType() == TokenTypes.SEMI) {
+				return nextDetailAST.getNextSibling();
+			}
+		};
+
+		return null;
 	}
 
 	private boolean _isExpressionAssignsVariable(


### PR DESCRIPTION
If the `MissingEmptyLineCheck` just checked for a new variable reference it'd no longer complain about a missing new line in the example below

```java
int total = JournalArticleServiceUtil.searchCount(...);

articleSearchContainer.setTotal(total);
List results = null;
```

I added a check that the line after must start with the same substring as the previous line

Examples that are allowed now:
```java
Group group = themeDisplay.getScopeGroup();

sb.append(group.getPathFriendlyURL(false, themeDisplay));
sb.append(group.getFriendlyURL());

...

String classpath = _buildClassPath(classes);

builder.setBootstrapClassPath(classpath);
builder.setProcessLogConsumer(...);
```

@hhuijser