### PR TITLE
[READ DESCRIPTION] LPS-78253 Rename dropdownItems to items

### DIFF
--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/DropdownsDisplayContext.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/DropdownsDisplayContext.java
@@ -100,14 +100,14 @@ public class DropdownsDisplayContext {
 			{
 				addGroup(
 					dropdownGroupItem -> {
-						dropdownGroupItem.setDropdownItems(group1DropdownItems);
+						dropdownGroupItem.setItems(group1DropdownItems);
 						dropdownGroupItem.setLabel("Group 1");
 						dropdownGroupItem.setSeparator(true);
 					});
 
 				addGroup(
 					dropdownGroupItem -> {
-						dropdownGroupItem.setDropdownItems(group2DropdownItems);
+						dropdownGroupItem.setItems(group2DropdownItems);
 						dropdownGroupItem.setLabel("Group 2");
 					});
 			}
@@ -215,7 +215,7 @@ public class DropdownsDisplayContext {
 			{
 				addGroup(
 					dropdownGroupItem -> {
-						dropdownGroupItem.setDropdownItems(group1DropdownItems);
+						dropdownGroupItem.setItems(group1DropdownItems);
 						dropdownGroupItem.setLabel("Group 1");
 						dropdownGroupItem.setSeparator(true);
 					});
@@ -223,7 +223,7 @@ public class DropdownsDisplayContext {
 				addRadioGroup(
 					dropdownRadioGroupItem -> {
 						dropdownRadioGroupItem.setInputName("radiogroup");
-						dropdownRadioGroupItem.setDropdownItems(
+						dropdownRadioGroupItem.setItems(
 							group2DropdownItems);
 						dropdownRadioGroupItem.setLabel("Group 2");
 					});

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/DropdownsDisplayContext.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/DropdownsDisplayContext.java
@@ -223,8 +223,7 @@ public class DropdownsDisplayContext {
 				addRadioGroup(
 					dropdownRadioGroupItem -> {
 						dropdownRadioGroupItem.setInputName("radiogroup");
-						dropdownRadioGroupItem.setItems(
-							group2DropdownItems);
+						dropdownRadioGroupItem.setItems(group2DropdownItems);
 						dropdownRadioGroupItem.setLabel("Group 2");
 					});
 			}

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ManagementToolbarsDisplayContext.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ManagementToolbarsDisplayContext.java
@@ -136,13 +136,13 @@ public class ManagementToolbarsDisplayContext {
 			{
 				addGroup(
 					dropdownGroupItem -> {
-						dropdownGroupItem.setDropdownItems(filterByItems);
+						dropdownGroupItem.setItems(filterByItems);
 						dropdownGroupItem.setLabel("Filter By");
 					});
 
 				addGroup(
 					dropdownGroupItem -> {
-						dropdownGroupItem.setDropdownItems(orderByItems);
+						dropdownGroupItem.setItems(orderByItems);
 						dropdownGroupItem.setLabel("Order By");
 					});
 			}

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownCheckboxItem.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownCheckboxItem.java
@@ -23,16 +23,16 @@ public class DropdownCheckboxItem extends DropdownItem {
 		super("checkbox");
 	}
 
-	public boolean isChecked() {
-		return _checked;
-	}
-
 	public String getInputName() {
 		return _inputName;
 	}
 
 	public String getInputValue() {
 		return _inputValue;
+	}
+
+	public boolean isChecked() {
+		return _checked;
 	}
 
 	public void setChecked(boolean checked) {

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownGroupItem.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownGroupItem.java
@@ -27,14 +27,14 @@ public class DropdownGroupItem extends DropdownItem {
 		super(type);
 	}
 
-	public DropdownItemList getDropdownItems() {
-		return _dropdownItems;
+	public DropdownItemList getItems() {
+		return _items;
 	}
 
-	public void setDropdownItems(DropdownItemList dropdownItems) {
-		_dropdownItems = dropdownItems;
+	public void setItems(DropdownItemList items) {
+		_items = items;
 	}
 
-	private DropdownItemList _dropdownItems;
+	private DropdownItemList _items;
 
 }

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
@@ -31,16 +31,16 @@ public class DropdownItem extends NavigationItem {
 		return _icon;
 	}
 
+	public String getType() {
+		return _type;
+	}
+
 	public boolean isQuickAction() {
 		return _quickAction;
 	}
 
 	public boolean isSeparator() {
 		return _separator;
-	}
-
-	public String getType() {
-		return _type;
 	}
 
 	public void setIcon(String icon) {

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownRadioItem.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownRadioItem.java
@@ -23,12 +23,12 @@ public class DropdownRadioItem extends DropdownItem {
 		super("radio");
 	}
 
-	public boolean isChecked() {
-		return _checked;
-	}
-
 	public String getInputValue() {
 		return _inputValue;
+	}
+
+	public boolean isChecked() {
+		return _checked;
 	}
 
 	public void setChecked(boolean checked) {

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
@@ -23,20 +23,20 @@ import javax.portlet.PortletURL;
  */
 public class NavigationItem implements Serializable {
 
-	public boolean isActive() {
-		return _active;
-	}
-
-	public boolean isDisabled() {
-		return _disabled;
-	}
-
 	public String getHref() {
 		return _href;
 	}
 
 	public String getLabel() {
 		return _label;
+	}
+
+	public boolean isActive() {
+		return _active;
+	}
+
+	public boolean isDisabled() {
+		return _disabled;
 	}
 
 	public void setActive(boolean active) {


### PR DESCRIPTION
Due `DropdownGroupItem` utility is serialized to be passed to `clay` components we need this property to be named `items` to follow with the `clay-dropdown` external API.

```
active: bool,
disabled: bool,
icon: string,
items: list<[
  active: bool,
  disabled: bool,
  icon: string,
  label: string,
  type: string,
],
label: string,
type: string,
```