### PR TITLE
LPS-77880 If notification is not applicable it should have be unread style either

### DIFF
--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/META-INF/resources/notifications/user_notification_entry.jspf
@@ -23,7 +23,9 @@ boolean anonymous = jsonObject.getBoolean("anonymous");
 
 long userNotificationEventUserId = jsonObject.getLong("userId");
 
-boolean notificationUnread = !actionRequired && !userNotificationEvent.isArchived();
+boolean applicable = userNotificationFeedEntry.isApplicable();
+
+boolean notificationUnread = !actionRequired && !userNotificationEvent.isArchived() && applicable;
 
 if (notificationUnread) {
 	row.setCssClass("unread");
@@ -50,7 +52,7 @@ if (notificationUnread) {
 			<liferay-ui:message key="notification-no-longer-applies" />
 		</liferay-ui:search-container-column-text>
 	</c:when>
-	<c:when test="<%= !userNotificationFeedEntry.isApplicable() %>">
+	<c:when test="<%= !applicable %>">
 		<liferay-ui:search-container-column-text colspan="<%= 2 %>">
 			<liferay-ui:message key="<%= userNotificationFeedEntry.getBody() %>" />
 		</liferay-ui:search-container-column-text>


### PR DESCRIPTION
Hi @sergiogonzalez. This is a missing commit that was not included in the first pull request to solve this LPS. This commit makes sure that the no-longer-applies notification doesn't have the unread style (which is not apparent in master except for the value unread in the html class attribute. Tell me if you have any questions. Thanks!