### PR TITLE
LPS-65975 Upgrade themes properly

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_5.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_7_0_5.java
@@ -25,6 +25,7 @@ import com.liferay.portal.upgrade.v7_0_5.UpgradeGroup;
 import com.liferay.portal.upgrade.v7_0_5.UpgradeLayoutPrototype;
 import com.liferay.portal.upgrade.v7_0_5.UpgradeMBMailingList;
 import com.liferay.portal.upgrade.v7_0_5.UpgradePortalPreferences;
+import com.liferay.portal.upgrade.v7_0_5.UpgradeThemeId;
 import com.liferay.portal.upgrade.v7_0_5.UpgradeUser;
 import com.liferay.portal.upgrade.v7_0_5.UpgradeVirtualHost;
 
@@ -50,6 +51,7 @@ public class UpgradeProcess_7_0_5 extends UpgradeProcess {
 		upgrade(UpgradeLayoutPrototype.class);
 		upgrade(UpgradeMBMailingList.class);
 		upgrade(UpgradePortalPreferences.class);
+		upgrade(UpgradeThemeId.class);
 		upgrade(UpgradeUser.class);
 		upgrade(UpgradeVirtualHost.class);
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeThemeId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeThemeId.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_5;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringBundler;
+
+/**
+ * @author Michael Bowerman
+ */
+public class UpgradeThemeId extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		for (String[] themeIds : _RENAMED_THEME_IDS) {
+			String oldThemeId = themeIds[0];
+			String newThemeId = themeIds[1];
+
+			runSQL(
+				StringBundler.concat(
+					"update LayoutSet set themeId = '", newThemeId,
+					"' where themeId = '", oldThemeId, "'"));
+		}
+	}
+
+	private static final String[][] _RENAMED_THEME_IDS = {
+		new String[] {"classic", "classic_WAR_classictheme"},
+		new String[] {"admin", "admin_WAR_admintheme"}
+	};
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeThemeId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeThemeId.java
@@ -37,7 +37,7 @@ public class UpgradeThemeId extends UpgradeProcess {
 
 	private static final String[][] _RENAMED_THEME_IDS = {
 		new String[] {"classic", "classic_WAR_classictheme"},
-		new String[] {"admin", "admin_WAR_admintheme"}
+		new String[] {"controlpanel", "admin_WAR_admintheme"}
 	};
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeThemeId.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_5/UpgradeThemeId.java
@@ -24,20 +24,25 @@ public class UpgradeThemeId extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		for (String[] themeIds : _RENAMED_THEME_IDS) {
+		for (String[] themeIds : _RENAMED_THEMEIDS) {
 			String oldThemeId = themeIds[0];
 			String newThemeId = themeIds[1];
 
-			runSQL(
-				StringBundler.concat(
-					"update LayoutSet set themeId = '", newThemeId,
-					"' where themeId = '", oldThemeId, "'"));
+			for (String themeIdTable : _THEMEID_TABLES) {
+				runSQL(
+					StringBundler.concat(
+						"update ", themeIdTable, " set themeId = '", newThemeId,
+						"' where themeId = '", oldThemeId, "'"));
+			}
 		}
 	}
 
-	private static final String[][] _RENAMED_THEME_IDS = {
+	private static final String[][] _RENAMED_THEMEIDS = {
 		new String[] {"classic", "classic_WAR_classictheme"},
 		new String[] {"controlpanel", "admin_WAR_admintheme"}
 	};
+
+	private static final String[] _THEMEID_TABLES =
+		{"Layout", "LayoutRevision", "LayoutSet", "LayoutSetBranch"};
 
 }


### PR DESCRIPTION
Hi @mbowerman, @SamZiemer,

First of all, thanks for the pull, this a really common issue which has not been solved since long time ago and the fix will be really befinicial for them.

Three things about the pull:
1- I didn't finally add the old theme "admin" as one of the themeIds to upgrade since I was used in a short time period (between LPS-57450 and LPS-65845, just between GA1 and FP1) and I am afraid that some customers/users had "admin" as themeId (custom theme) in 6.2 and below and we upgrade it incorrectly.
2- I also added the rest of the affected tables.
3- It would be great to add this upgrade process in FP40, I think that we are still on time if backport it as soon as possible (if not we will have to wait until FP50). Please take care of it and mention me in the pull just in case we have some issues with EE team.

Thanks again.
Cheers.