### PR TITLE
LPS-75717 Retain only one portlet staging related method to avoid developer confusion

### DIFF
--- a/modules/apps/web-experience/staging/staging-api/bnd.bnd
+++ b/modules/apps/web-experience/staging/staging-api/bnd.bnd
@@ -1,7 +1,7 @@
 Bundle-Name: Liferay Staging API
 Bundle-SymbolicName: com.liferay.staging.api
 Bundle-Version: 2.2.0
-Export-Package:
+Export-Package:\
 	com.liferay.staging,\
 	com.liferay.staging.constants
 Liferay-Releng-Module-Group-Description:

--- a/modules/apps/web-experience/staging/staging-api/src/main/java/com/liferay/staging/StagingGroupHelper.java
+++ b/modules/apps/web-experience/staging/staging-api/src/main/java/com/liferay/staging/StagingGroupHelper.java
@@ -80,8 +80,4 @@ public interface StagingGroupHelper {
 
 	public boolean isStagingOrLiveGroup(long groupId);
 
-	public boolean isStagingPortlet(Group group, String portletId);
-
-	public boolean isStagingPortlet(long groupId, String portletId);
-
 }

--- a/modules/apps/web-experience/staging/staging-impl/src/main/java/com/liferay/staging/internal/StagingGroupHelperImpl.java
+++ b/modules/apps/web-experience/staging/staging-impl/src/main/java/com/liferay/staging/internal/StagingGroupHelperImpl.java
@@ -253,7 +253,7 @@ public class StagingGroupHelperImpl implements StagingGroupHelper {
 
 	@Override
 	public boolean isStagedPortlet(Group group, String portletId) {
-		if (!isLiveGroup(group)) {
+		if (!isStagingGroup(group) && !isLiveGroup(group)) {
 			return false;
 		}
 
@@ -293,22 +293,6 @@ public class StagingGroupHelperImpl implements StagingGroupHelper {
 	@Override
 	public boolean isStagingOrLiveGroup(long groupId) {
 		return isStagingOrLiveGroup(_fetchGroup(groupId));
-	}
-
-	@Override
-	public boolean isStagingPortlet(Group group, String portletId) {
-		if (!isStagingGroup(group)) {
-			return false;
-		}
-
-		return group.isStagedPortlet(portletId);
-	}
-
-	@Override
-	public boolean isStagingPortlet(long groupId, String portletId) {
-		Group group = _fetchGroup(groupId);
-
-		return isStagingPortlet(group, portletId);
 	}
 
 	private Group _fetchGroup(long groupId) {

--- a/modules/apps/web-experience/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGroupHelperTest.java
+++ b/modules/apps/web-experience/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingGroupHelperTest.java
@@ -423,17 +423,17 @@ public class StagingGroupHelperTest {
 
 	@Test
 	public void testIsStagedPortlet() {
-		Assert.assertFalse(
+		Assert.assertTrue(
 			_stagingGroupHelper.isStagedPortlet(
 				_localStagingGroup, _PORTLET_ID_BOOKMARKS));
-		Assert.assertFalse(
+		Assert.assertTrue(
 			_stagingGroupHelper.isStagedPortlet(
 				_localStagingScopeGroup, _PORTLET_ID_BOOKMARKS));
 
-		Assert.assertFalse(
+		Assert.assertTrue(
 			_stagingGroupHelper.isStagedPortlet(
 				_remoteStagingGroup, _PORTLET_ID_BOOKMARKS));
-		Assert.assertFalse(
+		Assert.assertTrue(
 			_stagingGroupHelper.isStagedPortlet(
 				_remoteStagingScopeGroup, _PORTLET_ID_BOOKMARKS));
 
@@ -450,6 +450,10 @@ public class StagingGroupHelperTest {
 		Assert.assertTrue(
 			_stagingGroupHelper.isStagedPortlet(
 				_remoteLiveScopeGroup, _PORTLET_ID_BOOKMARKS));
+
+		Assert.assertFalse(
+			_stagingGroupHelper.isStagedPortlet(
+				_regularGroup, _PORTLET_ID_BOOKMARKS));
 
 		Assert.assertFalse(
 			_stagingGroupHelper.isStagedPortlet(
@@ -478,6 +482,10 @@ public class StagingGroupHelperTest {
 		Assert.assertFalse(
 			_stagingGroupHelper.isStagedPortlet(
 				_remoteLiveScopeGroup, _PORTLET_ID_BLOGS));
+
+		Assert.assertFalse(
+			_stagingGroupHelper.isStagedPortlet(
+				_regularGroup, _PORTLET_ID_BLOGS));
 	}
 
 	@Test
@@ -528,65 +536,6 @@ public class StagingGroupHelperTest {
 
 		Assert.assertFalse(
 			_stagingGroupHelper.isStagingOrLiveGroup(_regularGroup));
-	}
-
-	@Test
-	public void testIsStagingPortlet() {
-		Assert.assertTrue(
-			_stagingGroupHelper.isStagingPortlet(
-				_localStagingGroup, _PORTLET_ID_BOOKMARKS));
-		Assert.assertTrue(
-			_stagingGroupHelper.isStagingPortlet(
-				_localStagingScopeGroup, _PORTLET_ID_BOOKMARKS));
-
-		Assert.assertTrue(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteStagingGroup, _PORTLET_ID_BOOKMARKS));
-		Assert.assertTrue(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteStagingScopeGroup, _PORTLET_ID_BOOKMARKS));
-
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_localLiveGroup, _PORTLET_ID_BOOKMARKS));
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_localLiveScopeGroup, _PORTLET_ID_BOOKMARKS));
-
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteLiveGroup, _PORTLET_ID_BOOKMARKS));
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteLiveScopeGroup, _PORTLET_ID_BOOKMARKS));
-
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_localStagingGroup, _PORTLET_ID_BLOGS));
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_localStagingScopeGroup, _PORTLET_ID_BLOGS));
-
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteStagingGroup, _PORTLET_ID_BLOGS));
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteStagingScopeGroup, _PORTLET_ID_BLOGS));
-
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_localLiveGroup, _PORTLET_ID_BLOGS));
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_localLiveScopeGroup, _PORTLET_ID_BLOGS));
-
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteLiveGroup, _PORTLET_ID_BLOGS));
-		Assert.assertFalse(
-			_stagingGroupHelper.isStagingPortlet(
-				_remoteLiveScopeGroup, _PORTLET_ID_BLOGS));
 	}
 
 	private void _addLocalStagingGroups() throws Exception {


### PR DESCRIPTION
@brianchandotcom we decided to retaing only one portlet staging related method because it's not necessary clear to the consumer what the different methods are exactly doing. the isPortletStaged method will return true whenever the portlet is staged and the developers can use other methods to decide if they are currently on a staging group or live group

cc: @akosthurzo