### PR TITLE
LPS-78259 Provide transaction boundaries to the MVCActionCommands that make multiple service calls

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1112,7 +1112,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		// Group
 
-		addGroup(user);
+		groupLocalService.addGroup(
+			user.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			User.class.getName(), user.getUserId(),
+			GroupConstants.DEFAULT_LIVE_GROUP_ID, (Map<Locale, String>)null,
+			null, 0, true, GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
+			StringPool.SLASH + screenName, false, true, null);
 
 		// Groups
 
@@ -1757,43 +1762,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		if (company.isStrangersVerify()) {
 			sendEmailAddressVerification(
 				user, user.getEmailAddress(), serviceContext);
-		}
-	}
-
-	/**
-	 * Sets the user's status to inactive. This will also deactivate their
-	 * personal site.
-	 *
-	 * @param userId the primary key of the user
-	 * @throws PortalException
-	 */
-	public void deactivateUser(long userId) throws PortalException {
-		deactivateUser(userId, true);
-	}
-
-	/**
-	 * Sets the user's status to inactive. Can also optionally deactivate the
-	 * user's personal site.
-	 *
-	 * @param userId the primary key of the user
-	 * @param deactivateSite whether the user's personal site should be
-	 *                       deactivated
-	 * @throws PortalException
-	 */
-	public void deactivateUser(long userId, boolean deactivateSite)
-		throws PortalException {
-
-		updateStatus(
-			userId, WorkflowConstants.STATUS_INACTIVE, new ServiceContext());
-
-		if (!deactivateSite) {
-			User user = getUser(userId);
-
-			Group group = user.getGroup();
-
-			group.setActive(true);
-
-			groupLocalService.updateGroup(group);
 		}
 	}
 
@@ -3059,26 +3027,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	@Override
 	public User loadGetDefaultUser(long companyId) throws PortalException {
 		return userPersistence.findByC_DU(companyId, true);
-	}
-
-	/**
-	 * Deletes and re-creates the user's group.  This is useful for clearing all
-	 * personal data from the user's personal site, and essentially resets the
-	 * group back to the same state as when the user was first created.
-	 *
-	 * @param userId the primary key of the user
-	 * @throws PortalException
-	 */
-	public void resetUserGroup(long userId) throws PortalException {
-		User user = getUserById(userId);
-
-		if (user.isDefaultUser()) {
-			throw new RequiredUserException();
-		}
-
-		groupLocalService.deleteGroup(user.getGroup());
-
-		addGroup(user);
 	}
 
 	/**
@@ -5723,15 +5671,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			userPersistence.addTeams(userId, userTeamIds);
 		}
-	}
-
-	protected void addGroup(User user) throws PortalException {
-		groupLocalService.addGroup(
-			user.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
-			User.class.getName(), user.getUserId(),
-			GroupConstants.DEFAULT_LIVE_GROUP_ID, (Map<Locale, String>)null,
-			null, 0, true, GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
-			StringPool.SLASH + user.getScreenName(), false, true, null);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -573,27 +573,6 @@ public interface UserLocalService extends BaseLocalService,
 	public User createUser(long userId);
 
 	/**
-	* Sets the user's status to inactive. This will also deactivate their
-	* personal site.
-	*
-	* @param userId the primary key of the user
-	* @throws PortalException
-	*/
-	public void deactivateUser(long userId) throws PortalException;
-
-	/**
-	* Sets the user's status to inactive. Can also optionally deactivate the
-	* user's personal site.
-	*
-	* @param userId the primary key of the user
-	* @param deactivateSite whether the user's personal site should be
-	      deactivated
-	* @throws PortalException
-	*/
-	public void deactivateUser(long userId, boolean deactivateSite)
-		throws PortalException;
-
-	/**
 	* Decrypts the user's primary key and password from their encrypted forms.
 	* Used for decrypting a user's credentials from the values stored in an
 	* automatic login cookie.
@@ -1598,16 +1577,6 @@ public interface UserLocalService extends BaseLocalService,
 	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public User loadGetDefaultUser(long companyId) throws PortalException;
-
-	/**
-	* Deletes and re-creates the user's group.  This is useful for clearing all
-	* personal data from the user's personal site, and essentially resets the
-	* group back to the same state as when the user was first created.
-	*
-	* @param userId the primary key of the user
-	* @throws PortalException
-	*/
-	public void resetUserGroup(long userId) throws PortalException;
 
 	/**
 	* Returns an ordered range of all the users who match the keywords and

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
@@ -685,32 +685,6 @@ public class UserLocalServiceUtil {
 	}
 
 	/**
-	* Sets the user's status to inactive. This will also deactivate their
-	* personal site.
-	*
-	* @param userId the primary key of the user
-	* @throws PortalException
-	*/
-	public static void deactivateUser(long userId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		getService().deactivateUser(userId);
-	}
-
-	/**
-	* Sets the user's status to inactive. Can also optionally deactivate the
-	* user's personal site.
-	*
-	* @param userId the primary key of the user
-	* @param deactivateSite whether the user's personal site should be
-	deactivated
-	* @throws PortalException
-	*/
-	public static void deactivateUser(long userId, boolean deactivateSite)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		getService().deactivateUser(userId, deactivateSite);
-	}
-
-	/**
 	* Decrypts the user's primary key and password from their encrypted forms.
 	* Used for decrypting a user's credentials from the values stored in an
 	* automatic login cookie.
@@ -1968,19 +1942,6 @@ public class UserLocalServiceUtil {
 		long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().loadGetDefaultUser(companyId);
-	}
-
-	/**
-	* Deletes and re-creates the user's group.  This is useful for clearing all
-	* personal data from the user's personal site, and essentially resets the
-	* group back to the same state as when the user was first created.
-	*
-	* @param userId the primary key of the user
-	* @throws PortalException
-	*/
-	public static void resetUserGroup(long userId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		getService().resetUserGroup(userId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
@@ -709,34 +709,6 @@ public class UserLocalServiceWrapper implements UserLocalService,
 	}
 
 	/**
-	* Sets the user's status to inactive. This will also deactivate their
-	* personal site.
-	*
-	* @param userId the primary key of the user
-	* @throws PortalException
-	*/
-	@Override
-	public void deactivateUser(long userId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		_userLocalService.deactivateUser(userId);
-	}
-
-	/**
-	* Sets the user's status to inactive. Can also optionally deactivate the
-	* user's personal site.
-	*
-	* @param userId the primary key of the user
-	* @param deactivateSite whether the user's personal site should be
-	deactivated
-	* @throws PortalException
-	*/
-	@Override
-	public void deactivateUser(long userId, boolean deactivateSite)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		_userLocalService.deactivateUser(userId, deactivateSite);
-	}
-
-	/**
 	* Decrypts the user's primary key and password from their encrypted forms.
 	* Used for decrypting a user's credentials from the values stored in an
 	* automatic login cookie.
@@ -2117,20 +2089,6 @@ public class UserLocalServiceWrapper implements UserLocalService,
 		long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _userLocalService.loadGetDefaultUser(companyId);
-	}
-
-	/**
-	* Deletes and re-creates the user's group.  This is useful for clearing all
-	* personal data from the user's personal site, and essentially resets the
-	* group back to the same state as when the user was first created.
-	*
-	* @param userId the primary key of the user
-	* @throws PortalException
-	*/
-	@Override
-	public void resetUserGroup(long userId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		_userLocalService.resetUserGroup(userId);
 	}
 
 	/**


### PR DESCRIPTION
This is an update for [LPS-78259](https://issues.liferay.com/browse/LPS-78259).<br><br>Hey Brian, this removes the new service methods just added to UserLocalServiceImpl in favor of our MVCActionCommands extending off of BaseTransactionalMVCActionCommand.  This class already existed in our codebase.  I made this choice because these actions are unique to our situation with the UAD portlet and I think they should not be made available as API.<br><br>/cc @pei-jung @willnewbury @noahsherrillwork @JorgeFerrer