### PR TITLE
LPS-70609 The compile.uptodate condition and the download-latest-arti…

### DIFF
--- a/util-taglib/build.xml
+++ b/util-taglib/build.xml
@@ -32,7 +32,7 @@
 		<delete failonerror="false" file="${liferay.home}/osgi/portal/${jar.file}.jar" />
 	</target>
 
-	<target depends="build-common-java.compile" name="compile">
+	<target depends="build-common-java.compile,download-latest-artifact,init-compile" name="compile" unless="${compile.uptodate}">
 		<copy file="classes/META-INF/liferay-portlet_1_0.tld" preservelastmodified="true" tofile="classes/META-INF/liferay-portlet_1_0.tld" />
 
 		<replace file="classes/META-INF/liferay-portlet_1_0.tld">


### PR DESCRIPTION
…fact dependency target should also apply to util-taglib's custom compile target

This prevents the script from running these extra steps even when the artifact is being downloaded from Nexus.