### PR TITLE
LPS-72748 Expando search must honor multiple search class names (as in DLSearcher)

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/expando/ExpandoTest.java
+++ b/modules/apps/foundation/portal-search/portal-search-elasticsearch/src/test/java/com/liferay/portal/search/elasticsearch/internal/expando/ExpandoTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch.internal.expando;
+
+import com.liferay.portal.search.elasticsearch.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch.internal.connection.LiferayIndexCreator;
+import com.liferay.portal.search.elasticsearch.internal.mappings.DescriptionFieldQueryBuilderTest;
+import com.liferay.portal.search.test.util.expando.BaseExpandoTestCase;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Bryan Engler
+ */
+public class ExpandoTest extends BaseExpandoTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
+			DescriptionFieldQueryBuilderTest.class.getSimpleName());
+
+		return new ElasticsearchIndexingFixture(
+			elasticsearchFixture, BaseIndexingTestCase.COMPANY_ID,
+			new LiferayIndexCreator(elasticsearchFixture));
+	}
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test-util/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/build.gradle
@@ -3,13 +3,13 @@ targetCompatibility = "1.8"
 
 dependencies {
 	provided group: "com.liferay", name: "com.liferay.petra.string", version: "1.0.0"
-	provided group: "com.liferay", name: "com.liferay.portal.search", version: "4.0.0"
 	provided group: "com.liferay", name: "com.liferay.registry.api", version: "1.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.53.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.test", version: "1.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.test.integration", version: "2.0.0"
 	provided group: "junit", name: "junit", version: "4.12"
 	provided group: "org.mockito", name: "mockito-core", version: "1.10.8"
+	provided project(":apps:foundation:portal-search:portal-search")
 	provided project(":apps:foundation:portal-search:portal-search-api")
 }
 

--- a/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
+++ b/modules/apps/foundation/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
@@ -1,0 +1,343 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test.util.expando;
+
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.kernel.util.ExpandoBridgeFactory;
+import com.liferay.expando.kernel.util.ExpandoBridgeIndexer;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.search.query.FieldQueryFactory;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.search.analysis.FieldQueryBuilderFactory;
+import com.liferay.portal.search.internal.analysis.SimpleKeywordTokenizer;
+import com.liferay.portal.search.internal.analysis.SubstringFieldQueryBuilder;
+import com.liferay.portal.search.internal.analysis.TitleFieldQueryBuilder;
+import com.liferay.portal.search.internal.expando.ExpandoFieldQueryBuilderFactory;
+import com.liferay.portal.search.internal.expando.ExpandoQueryContributorHelper;
+import com.liferay.portal.search.internal.query.FieldQueryFactoryImpl;
+import com.liferay.portal.search.test.util.DocumentsAssert;
+import com.liferay.portal.search.test.util.IdempotentRetryAssert;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.DocumentCreationHelper;
+import com.liferay.registry.BasicRegistryImpl;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+/**
+ * @author Bryan Engler
+ */
+public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Registry registry = new BasicRegistryImpl();
+
+		registry.registerService(
+			FieldQueryFactory.class,
+			createFieldQueryFactory(createExpandoFieldQueryBuilderFactory()));
+
+		RegistryUtil.setRegistry(registry);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		RegistryUtil.setRegistry(null);
+	}
+
+	@Test
+	public void testMultipleClassNames() throws Exception {
+		List<String> duplicates = Arrays.asList(
+			"alpha", "alpha", "alpha bravo", "charlie", "delta");
+
+		addDocuments(this::addKeyword, duplicates);
+
+		addDocuments(this::addKeyword, Arrays.asList("keyword"));
+
+		addDocuments(this::addText, duplicates);
+
+		addDocuments(this::addText, Arrays.asList("text"));
+
+		assertSearch("alpha", 6);
+		assertSearch("bravo", 2);
+		assertSearch("alpha bravo", 6);
+		assertSearch("rlie", 1);
+		assertSearch("echo", 0);
+		assertSearch("keyword", 1);
+		assertSearch("text", 1);
+	}
+
+	protected static ExpandoFieldQueryBuilderFactory
+		createExpandoFieldQueryBuilderFactory() {
+
+		return new ExpandoFieldQueryBuilderFactory() {
+			{
+				substringQueryBuilder = new SubstringFieldQueryBuilder() {
+					{
+						keywordTokenizer = new SimpleKeywordTokenizer();
+					}
+				};
+			}
+		};
+	}
+
+	protected static FieldQueryFactoryImpl createFieldQueryFactory(
+		FieldQueryBuilderFactory fieldQueryBuilderFactory) {
+
+		return new FieldQueryFactoryImpl() {
+			{
+				titleQueryBuilder = createTitleFieldQueryBuilder();
+
+				addFieldQueryBuilderFactory(fieldQueryBuilderFactory);
+			}
+		};
+	}
+
+	protected static TitleFieldQueryBuilder createTitleFieldQueryBuilder() {
+		return new TitleFieldQueryBuilder() {
+			{
+				keywordTokenizer = new SimpleKeywordTokenizer();
+			}
+		};
+	}
+
+	protected DocumentCreationHelper addKeyword(String value) {
+		return document -> {
+			document.addKeyword(Field.STATUS, _FIELD_KEYWORD + value);
+
+			document.addKeyword(_FIELD_KEYWORD, value);
+		};
+	}
+
+	protected DocumentCreationHelper addText(String value) {
+		return document -> {
+			document.addKeyword(Field.STATUS, _FIELD_TEXT + value);
+
+			document.addText(_FIELD_TEXT, value);
+		};
+	}
+
+	protected void assertSearch(String keywords, int expectedCount)
+		throws Exception {
+
+		IdempotentRetryAssert.retryAssert(
+			3, TimeUnit.SECONDS, () -> doAssertSearch(keywords, expectedCount));
+	}
+
+	protected ExpandoBridge createExpandoBridge(
+		String attributeName, int indexType) {
+
+		ExpandoBridge expandoBridge = Mockito.mock(ExpandoBridge.class);
+
+		Mockito.doReturn(
+			Collections.enumeration(Collections.singletonList(attributeName))
+		).when(
+			expandoBridge
+		).getAttributeNames();
+
+		Mockito.doReturn(
+			createUnicodeProperties(indexType)
+		).when(
+			expandoBridge
+		).getAttributeProperties(
+			Mockito.anyString()
+		);
+
+		return expandoBridge;
+	}
+
+	protected ExpandoBridgeFactory createExpandoBridgeFactory() {
+		ExpandoBridgeFactory expandoBridgeFactory = Mockito.mock(
+			ExpandoBridgeFactory.class);
+
+		Mockito.doReturn(
+			createExpandoBridge(
+				_ATTRIBUTE_KEYWORD, ExpandoColumnConstants.INDEX_TYPE_KEYWORD)
+		).when(
+			expandoBridgeFactory
+		).getExpandoBridge(
+			Mockito.anyLong(), Matchers.eq(_CLASS_NAME_KEYWORD)
+		);
+
+		Mockito.doReturn(
+			createExpandoBridge(
+				_ATTRIBUTE_TEXT, ExpandoColumnConstants.INDEX_TYPE_TEXT)
+		).when(
+			expandoBridgeFactory
+		).getExpandoBridge(
+			Mockito.anyLong(), Matchers.eq(_CLASS_NAME_TEXT)
+		);
+
+		return expandoBridgeFactory;
+	}
+
+	protected ExpandoBridgeIndexer createExpandoBridgeIndexer() {
+		ExpandoBridgeIndexer expandoBridgeIndexer = Mockito.mock(
+			ExpandoBridgeIndexer.class);
+
+		Mockito.doReturn(
+			_FIELD_KEYWORD
+		).when(
+			expandoBridgeIndexer
+		).encodeFieldName(
+			Mockito.anyString(),
+			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_KEYWORD)
+		);
+
+		Mockito.doReturn(
+			_FIELD_TEXT
+		).when(
+			expandoBridgeIndexer
+		).encodeFieldName(
+			Mockito.anyString(),
+			Matchers.eq(ExpandoColumnConstants.INDEX_TYPE_TEXT)
+		);
+
+		return expandoBridgeIndexer;
+	}
+
+	protected ExpandoColumn createExpandoColumn(int indexType) {
+		ExpandoColumn expandoColumn = Mockito.mock(ExpandoColumn.class);
+
+		Mockito.doReturn(
+			createUnicodeProperties(indexType)
+		).when(
+			expandoColumn
+		).getTypeSettingsProperties();
+
+		Mockito.doReturn(
+			ExpandoColumnConstants.STRING
+		).when(
+			expandoColumn
+		).getType();
+
+		return expandoColumn;
+	}
+
+	protected ExpandoColumnLocalService createExpandoColumnLocalService() {
+		ExpandoColumnLocalService expandoColumnLocalService = Mockito.mock(
+			ExpandoColumnLocalService.class);
+
+		Mockito.doReturn(
+			createExpandoColumn(ExpandoColumnConstants.INDEX_TYPE_KEYWORD)
+		).when(
+			expandoColumnLocalService
+		).getDefaultTableColumn(
+			Mockito.anyLong(), Mockito.anyString(),
+			Mockito.eq(_ATTRIBUTE_KEYWORD)
+		);
+
+		Mockito.doReturn(
+			createExpandoColumn(ExpandoColumnConstants.INDEX_TYPE_TEXT)
+		).when(
+			expandoColumnLocalService
+		).getDefaultTableColumn(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.eq(_ATTRIBUTE_TEXT)
+		);
+
+		return expandoColumnLocalService;
+	}
+
+	protected ExpandoQueryContributorHelper
+		createExpandoQueryContributorHelper() {
+
+		return new ExpandoQueryContributorHelper(
+			createExpandoBridgeFactory(), createExpandoBridgeIndexer(),
+			createExpandoColumnLocalService(), null);
+	}
+
+	protected UnicodeProperties createUnicodeProperties(int indexType) {
+		UnicodeProperties unicodeProperties = Mockito.mock(
+			UnicodeProperties.class);
+
+		Mockito.doReturn(
+			String.valueOf(indexType)
+		).when(
+			unicodeProperties
+		).getProperty(
+			ExpandoColumnConstants.INDEX_TYPE
+		);
+
+		return unicodeProperties;
+	}
+
+	protected Void doAssertSearch(String keywords, int expectedCount)
+		throws Exception {
+
+		BooleanQuery booleanQuery = new BooleanQueryImpl();
+
+		SearchContext searchContext = createSearchContext();
+
+		ExpandoQueryContributorHelper expandoQueryContributorHelper =
+			createExpandoQueryContributorHelper();
+
+		expandoQueryContributorHelper.setAndSearch(searchContext.isAndSearch());
+		expandoQueryContributorHelper.setBooleanQuery(booleanQuery);
+		expandoQueryContributorHelper.setClassNamesStream(
+			Stream.of(_CLASS_NAME_KEYWORD, _CLASS_NAME_TEXT));
+		expandoQueryContributorHelper.setCompanyId(
+			searchContext.getCompanyId());
+		expandoQueryContributorHelper.setKeywords(keywords);
+		expandoQueryContributorHelper.setLocale(searchContext.getLocale());
+
+		expandoQueryContributorHelper.contribute();
+
+		Hits hits = search(searchContext, booleanQuery);
+
+		DocumentsAssert.assertCount(
+			(String)searchContext.getAttribute("queryString"), hits.getDocs(),
+			Field.STATUS, expectedCount);
+
+		return null;
+	}
+
+	private static final String _ATTRIBUTE_KEYWORD =
+		RandomTestUtil.randomString();
+
+	private static final String _ATTRIBUTE_TEXT = RandomTestUtil.randomString();
+
+	private static final String _CLASS_NAME_KEYWORD =
+		RandomTestUtil.randomString();
+
+	private static final String _CLASS_NAME_TEXT =
+		RandomTestUtil.randomString();
+
+	private static final String _FIELD_KEYWORD =
+		"expando__keyword__custom_fields__testColumnName";
+
+	private static final String _FIELD_TEXT =
+		"expando__custom_fields__testColumnName";
+
+}

--- a/modules/apps/foundation/portal-search/portal-search-test/build.gradle
+++ b/modules/apps/foundation/portal-search/portal-search-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.journal.service", version: "3.10.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.osgi.util", version: "3.0.0"
 	testIntegrationCompile group: "com.liferay", name: "com.liferay.petra.string", version: "1.0.0"
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
 	testIntegrationCompile project(":apps:collaboration:message-boards:message-boards-api")
 	testIntegrationCompile project(":apps:foundation:portal-search:portal-search-api")
 }

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/BaseIndexerExpandoQueryContributor.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/BaseIndexerExpandoQueryContributor.java
@@ -12,35 +12,33 @@
  * details.
  */
 
-package com.liferay.portal.search.internal.contributor.query;
+package com.liferay.portal.search.internal.expando;
 
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactory;
 import com.liferay.expando.kernel.util.ExpandoBridgeIndexer;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.ExpandoQueryContributor;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.LocalizationUtil;
-import com.liferay.portal.search.internal.expando.ExpandoQueryContributorHelper;
-import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
-import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Michael C. Han
+ * @author André de Oliveira
  */
-@Component(immediate = true, service = KeywordQueryContributor.class)
-public class ExpandoKeywordQueryContributor implements KeywordQueryContributor {
+@Component(immediate = true, service = ExpandoQueryContributor.class)
+public class BaseIndexerExpandoQueryContributor
+	implements ExpandoQueryContributor {
 
 	@Override
 	public void contribute(
-		String keywords, BooleanQuery booleanQuery,
-		KeywordQueryContributorHelper keywordQueryContributorHelper) {
-
-		SearchContext searchContext =
-			keywordQueryContributorHelper.getSearchContext();
+		String keywords, BooleanQuery booleanQuery, String[] classNames,
+		SearchContext searchContext) {
 
 		ExpandoQueryContributorHelper expandoQueryContributorHelper =
 			new ExpandoQueryContributorHelper(
@@ -50,7 +48,7 @@ public class ExpandoKeywordQueryContributor implements KeywordQueryContributor {
 		expandoQueryContributorHelper.setAndSearch(searchContext.isAndSearch());
 		expandoQueryContributorHelper.setBooleanQuery(booleanQuery);
 		expandoQueryContributorHelper.setClassNamesStream(
-			keywordQueryContributorHelper.getSearchClassNamesStream());
+			Stream.of(classNames));
 		expandoQueryContributorHelper.setCompanyId(
 			searchContext.getCompanyId());
 		expandoQueryContributorHelper.setKeywords(keywords);

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/ExpandoQueryContributorHelper.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/expando/ExpandoQueryContributorHelper.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.expando;
+
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.kernel.util.ExpandoBridgeFactory;
+import com.liferay.expando.kernel.util.ExpandoBridgeIndexer;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.ParseException;
+import com.liferay.portal.kernel.search.Query;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * @author André de Oliveira
+ */
+public class ExpandoQueryContributorHelper {
+
+	public ExpandoQueryContributorHelper(
+		ExpandoBridgeFactory expandoBridgeFactory,
+		ExpandoBridgeIndexer expandoBridgeIndexer,
+		ExpandoColumnLocalService expandoColumnLocalService,
+		Localization localization) {
+
+		_expandoBridgeFactory = expandoBridgeFactory;
+		_expandoBridgeIndexer = expandoBridgeIndexer;
+		_expandoColumnLocalService = expandoColumnLocalService;
+		_localization = localization;
+	}
+
+	public void contribute() {
+		if (Validator.isBlank(_keywords)) {
+			return;
+		}
+
+		_classNamesStream.forEach(this::contribute);
+	}
+
+	public void setAndSearch(boolean andSearch) {
+		_andSearch = andSearch;
+	}
+
+	public void setBooleanQuery(BooleanQuery booleanQuery) {
+		_booleanQuery = booleanQuery;
+	}
+
+	public void setClassNamesStream(Stream<String> classNamesStream) {
+		_classNamesStream = classNamesStream;
+	}
+
+	public void setCompanyId(long companyId) {
+		_companyId = companyId;
+	}
+
+	public void setKeywords(String keywords) {
+		_keywords = keywords;
+	}
+
+	public void setLocale(Locale locale) {
+		_locale = locale;
+	}
+
+	protected void contribute(String className) {
+		ExpandoBridge expandoBridge = _expandoBridgeFactory.getExpandoBridge(
+			_companyId, className);
+
+		Set<String> attributeNames = SetUtil.fromEnumeration(
+			expandoBridge.getAttributeNames());
+
+		for (String attributeName : attributeNames) {
+			contribute(attributeName, expandoBridge);
+		}
+	}
+
+	protected void contribute(
+		String attributeName, ExpandoBridge expandoBridge) {
+
+		UnicodeProperties properties = expandoBridge.getAttributeProperties(
+			attributeName);
+
+		int indexType = GetterUtil.getInteger(
+			properties.getProperty(ExpandoColumnConstants.INDEX_TYPE));
+
+		if (indexType == ExpandoColumnConstants.INDEX_TYPE_NONE) {
+			return;
+		}
+
+		String fieldName = getExpandoFieldName(attributeName, expandoBridge);
+
+		boolean like = false;
+
+		if (indexType == ExpandoColumnConstants.INDEX_TYPE_TEXT) {
+			like = true;
+		}
+
+		if (_andSearch) {
+			_booleanQuery.addRequiredTerm(fieldName, _keywords, like);
+		}
+		else {
+			_addTerm(_booleanQuery, fieldName, _keywords, like);
+		}
+	}
+
+	protected String getExpandoFieldName(
+		String attributeName, ExpandoBridge expandoBridge) {
+
+		ExpandoColumn expandoColumn =
+			_expandoColumnLocalService.getDefaultTableColumn(
+				expandoBridge.getCompanyId(), expandoBridge.getClassName(),
+				attributeName);
+
+		UnicodeProperties unicodeProperties =
+			expandoColumn.getTypeSettingsProperties();
+
+		int indexType = GetterUtil.getInteger(
+			unicodeProperties.getProperty(ExpandoColumnConstants.INDEX_TYPE));
+
+		String fieldName = _expandoBridgeIndexer.encodeFieldName(
+			attributeName, indexType);
+
+		if (expandoColumn.getType() ==
+				ExpandoColumnConstants.STRING_LOCALIZED) {
+
+			fieldName = getLocalizedName(fieldName);
+		}
+
+		return fieldName;
+	}
+
+	protected String getLocalizedName(String name) {
+		if (_locale == null) {
+			return name;
+		}
+
+		return _localization.getLocalizedName(
+			name, LocaleUtil.toLanguageId(_locale));
+	}
+
+	private Query _addTerm(
+		BooleanQuery booleanQuery, String fieldName, String keywords,
+		boolean like) {
+
+		try {
+			return booleanQuery.addTerm(fieldName, keywords, like);
+		}
+		catch (ParseException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+
+	private boolean _andSearch;
+	private BooleanQuery _booleanQuery;
+	private Stream<String> _classNamesStream = Stream.empty();
+	private long _companyId;
+	private final ExpandoBridgeFactory _expandoBridgeFactory;
+	private final ExpandoBridgeIndexer _expandoBridgeIndexer;
+	private final ExpandoColumnLocalService _expandoColumnLocalService;
+	private String _keywords;
+	private Locale _locale;
+	private final Localization _localization;
+
+}

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
@@ -14,9 +14,6 @@
 
 package com.liferay.portal.search.internal.searcher;
 
-import com.liferay.expando.kernel.model.ExpandoBridge;
-import com.liferay.expando.kernel.model.ExpandoColumnConstants;
-import com.liferay.expando.kernel.util.ExpandoBridgeFactory;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.BaseSearcher;
 import com.liferay.portal.kernel.search.BooleanClause;
@@ -47,9 +44,8 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.internal.expando.ExpandoQueryContributorHelper;
 import com.liferay.portal.search.permission.SearchPermissionFilterContributor;
 
 import java.util.Collection;
@@ -58,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * @author Raymond Augé
@@ -67,14 +62,14 @@ public class FacetedSearcherImpl
 	extends BaseSearcher implements FacetedSearcher {
 
 	public FacetedSearcherImpl(
-		ExpandoBridgeFactory expandoBridgeFactory,
+		ExpandoQueryContributorHelper expandoQueryContributorHelper,
 		GroupLocalService groupLocalService, IndexerRegistry indexerRegistry,
 		IndexSearcherHelper indexSearcherHelper,
 		SearchEngineHelper searchEngineHelper,
 		Collection<SearchPermissionFilterContributor>
 			searchPermissionFilterContributors) {
 
-		_expandoBridgeFactory = expandoBridgeFactory;
+		_expandoQueryContributorHelper = expandoQueryContributorHelper;
 		_groupLocalService = groupLocalService;
 		_indexerRegistry = indexerRegistry;
 		_indexSearcherHelper = indexSearcherHelper;
@@ -84,35 +79,20 @@ public class FacetedSearcherImpl
 	}
 
 	protected void addSearchExpando(
-			BooleanQuery searchQuery, SearchContext searchContext,
-			String keywords, String className)
+			BooleanQuery booleanQuery, SearchContext searchContext,
+			String keywords, Collection<String> classNames)
 		throws Exception {
 
-		ExpandoBridge expandoBridge = _expandoBridgeFactory.getExpandoBridge(
-			searchContext.getCompanyId(), className);
+		_expandoQueryContributorHelper.setAndSearch(
+			searchContext.isAndSearch());
+		_expandoQueryContributorHelper.setBooleanQuery(booleanQuery);
+		_expandoQueryContributorHelper.setClassNamesStream(classNames.stream());
+		_expandoQueryContributorHelper.setCompanyId(
+			searchContext.getCompanyId());
+		_expandoQueryContributorHelper.setKeywords(keywords);
+		_expandoQueryContributorHelper.setLocale(searchContext.getLocale());
 
-		Set<String> attributeNames = SetUtil.fromEnumeration(
-			expandoBridge.getAttributeNames());
-
-		for (String attributeName : attributeNames) {
-			UnicodeProperties properties = expandoBridge.getAttributeProperties(
-				attributeName);
-
-			int indexType = GetterUtil.getInteger(
-				properties.getProperty(ExpandoColumnConstants.INDEX_TYPE));
-
-			if (indexType != ExpandoColumnConstants.INDEX_TYPE_NONE) {
-				String fieldName = getExpandoFieldName(
-					searchContext, expandoBridge, attributeName);
-
-				if (searchContext.isAndSearch()) {
-					searchQuery.addRequiredTerm(fieldName, keywords);
-				}
-				else {
-					searchQuery.addTerm(fieldName, keywords);
-				}
-			}
-		}
+		_expandoQueryContributorHelper.contribute();
 	}
 
 	protected void addSearchKeywords(
@@ -136,10 +116,9 @@ public class FacetedSearcherImpl
 
 			searchQuery.addTerms(Field.KEYWORDS, keywords);
 
-			for (String entryClassName : entryClassNameIndexerMap.keySet()) {
-				addSearchExpando(
-					searchQuery, searchContext, keywords, entryClassName);
-			}
+			addSearchExpando(
+				searchQuery, searchContext, keywords,
+				entryClassNameIndexerMap.keySet());
 		}
 	}
 
@@ -507,7 +486,7 @@ public class FacetedSearcherImpl
 		};
 	}
 
-	private final ExpandoBridgeFactory _expandoBridgeFactory;
+	private final ExpandoQueryContributorHelper _expandoQueryContributorHelper;
 	private final GroupLocalService _groupLocalService;
 	private final IndexerRegistry _indexerRegistry;
 	private final IndexSearcherHelper _indexSearcherHelper;

--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherManagerImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherManagerImpl.java
@@ -14,13 +14,18 @@
 
 package com.liferay.portal.search.internal.searcher;
 
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactory;
+import com.liferay.expando.kernel.util.ExpandoBridgeIndexer;
 import com.liferay.portal.kernel.search.IndexSearcherHelper;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcher;
 import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcherManager;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.util.Localization;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.search.internal.expando.ExpandoQueryContributorHelper;
 import com.liferay.portal.search.permission.SearchPermissionFilterContributor;
 
 import java.util.Collection;
@@ -41,9 +46,11 @@ public class FacetedSearcherManagerImpl implements FacetedSearcherManager {
 	@Override
 	public FacetedSearcher createFacetedSearcher() {
 		return new FacetedSearcherImpl(
-			expandoBridgeFactory, groupLocalService, indexerRegistry,
-			indexSearcherHelper, searchEngineHelper,
-			_searchPermissionFilterContributors);
+			new ExpandoQueryContributorHelper(
+				expandoBridgeFactory, expandoBridgeIndexer,
+				expandoColumnLocalService, getLocalization()),
+			groupLocalService, indexerRegistry, indexSearcherHelper,
+			searchEngineHelper, _searchPermissionFilterContributors);
 	}
 
 	@Reference(
@@ -59,6 +66,17 @@ public class FacetedSearcherManagerImpl implements FacetedSearcherManager {
 			searchPermissionFilterContributor);
 	}
 
+	protected Localization getLocalization() {
+
+		// See LPS-72507
+
+		if (localization != null) {
+			return localization;
+		}
+
+		return LocalizationUtil.getLocalization();
+	}
+
 	protected void removeSearchPermissionFilterContributor(
 		SearchPermissionFilterContributor searchPermissionFilterContributor) {
 
@@ -70,6 +88,12 @@ public class FacetedSearcherManagerImpl implements FacetedSearcherManager {
 	protected ExpandoBridgeFactory expandoBridgeFactory;
 
 	@Reference
+	protected ExpandoBridgeIndexer expandoBridgeIndexer;
+
+	@Reference
+	protected ExpandoColumnLocalService expandoColumnLocalService;
+
+	@Reference
 	protected GroupLocalService groupLocalService;
 
 	@Reference
@@ -77,6 +101,8 @@ public class FacetedSearcherManagerImpl implements FacetedSearcherManager {
 
 	@Reference
 	protected IndexSearcherHelper indexSearcherHelper;
+
+	protected Localization localization;
 
 	@Reference
 	protected SearchEngineHelper searchEngineHelper;

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/expando/ExpandoTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/expando/ExpandoTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.elasticsearch6.internal.expando;
+
+import com.liferay.portal.search.elasticsearch6.internal.ElasticsearchIndexingFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
+import com.liferay.portal.search.elasticsearch6.internal.connection.LiferayIndexCreator;
+import com.liferay.portal.search.elasticsearch6.internal.mappings.DescriptionFieldQueryBuilderTest;
+import com.liferay.portal.search.test.util.expando.BaseExpandoTestCase;
+import com.liferay.portal.search.test.util.indexing.BaseIndexingTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Bryan Engler
+ */
+public class ExpandoTest extends BaseExpandoTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() throws Exception {
+		ElasticsearchFixture elasticsearchFixture = new ElasticsearchFixture(
+			DescriptionFieldQueryBuilderTest.class.getSimpleName());
+
+		return new ElasticsearchIndexingFixture(
+			elasticsearchFixture, BaseIndexingTestCase.COMPANY_ID,
+			new LiferayIndexCreator(elasticsearchFixture));
+	}
+
+}

--- a/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/expando/ExpandoTest.java
+++ b/modules/apps/portal-search-solr/portal-search-solr/src/test/java/com/liferay/portal/search/solr/internal/expando/ExpandoTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.solr.internal.expando;
+
+import com.liferay.portal.search.solr.internal.SolrIndexingFixture;
+import com.liferay.portal.search.test.util.expando.BaseExpandoTestCase;
+import com.liferay.portal.search.test.util.indexing.IndexingFixture;
+
+/**
+ * @author Bryan Engler
+ */
+public class ExpandoTest extends BaseExpandoTestCase {
+
+	@Override
+	protected IndexingFixture createIndexingFixture() {
+		return new SolrIndexingFixture();
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/BaseIndexer.java
@@ -20,11 +20,6 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.expando.kernel.model.ExpandoBridge;
-import com.liferay.expando.kernel.model.ExpandoColumn;
-import com.liferay.expando.kernel.model.ExpandoColumnConstants;
-import com.liferay.expando.kernel.service.ExpandoColumnLocalServiceUtil;
-import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
-import com.liferay.expando.kernel.util.ExpandoBridgeIndexerUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchCountryException;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
@@ -68,7 +63,6 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.registry.collections.ServiceTrackerCollections;
@@ -1035,49 +1029,14 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 			String keywords)
 		throws Exception {
 
-		Map<String, Query> expandoQueries = new HashMap<>();
+		for (ExpandoQueryContributor expandoQueryContributor :
+				getExpandoQueryContributors()) {
 
-		ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(
-			searchContext.getCompanyId(), getClassName(searchContext));
-
-		Set<String> attributeNames = SetUtil.fromEnumeration(
-			expandoBridge.getAttributeNames());
-
-		for (String attributeName : attributeNames) {
-			UnicodeProperties properties = expandoBridge.getAttributeProperties(
-				attributeName);
-
-			int indexType = GetterUtil.getInteger(
-				properties.getProperty(ExpandoColumnConstants.INDEX_TYPE));
-
-			if ((indexType != ExpandoColumnConstants.INDEX_TYPE_NONE) &&
-				Validator.isNotNull(keywords)) {
-
-				String fieldName = getExpandoFieldName(
-					searchContext, expandoBridge, attributeName);
-
-				boolean like = false;
-
-				if (indexType == ExpandoColumnConstants.INDEX_TYPE_TEXT) {
-					like = true;
-				}
-
-				if (searchContext.isAndSearch()) {
-					Query query = searchQuery.addRequiredTerm(
-						fieldName, keywords, like);
-
-					expandoQueries.put(attributeName, query);
-				}
-				else {
-					Query query = searchQuery.addTerm(
-						fieldName, keywords, like);
-
-					expandoQueries.put(attributeName, query);
-				}
-			}
+			expandoQueryContributor.contribute(
+				keywords, searchQuery, getSearchClassNames(), searchContext);
 		}
 
-		return expandoQueries;
+		return new HashMap<>();
 	}
 
 	protected void addSearchFolderId(
@@ -1567,28 +1526,18 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 		SearchContext searchContext, ExpandoBridge expandoBridge,
 		String attributeName) {
 
-		ExpandoColumn expandoColumn =
-			ExpandoColumnLocalServiceUtil.getDefaultTableColumn(
-				expandoBridge.getCompanyId(), expandoBridge.getClassName(),
-				attributeName);
+		return null;
+	}
 
-		UnicodeProperties unicodeProperties =
-			expandoColumn.getTypeSettingsProperties();
-
-		int indexType = GetterUtil.getInteger(
-			unicodeProperties.getProperty(ExpandoColumnConstants.INDEX_TYPE));
-
-		String fieldName = ExpandoBridgeIndexerUtil.encodeFieldName(
-			attributeName, indexType);
-
-		if (expandoColumn.getType() ==
-				ExpandoColumnConstants.STRING_LOCALIZED) {
-
-			fieldName = Field.getLocalizedName(
-				searchContext.getLocale(), fieldName);
+	protected List<ExpandoQueryContributor> getExpandoQueryContributors() {
+		if (_expandoQueryContributors != null) {
+			return _expandoQueryContributors;
 		}
 
-		return fieldName;
+		_expandoQueryContributors = ServiceTrackerCollections.openList(
+			ExpandoQueryContributor.class);
+
+		return _expandoQueryContributors;
 	}
 
 	protected Locale getLocale(PortletRequest portletRequest) {
@@ -1987,6 +1936,7 @@ public abstract class BaseIndexer<T> implements Indexer<T> {
 	private String[] _defaultSelectedLocalizedFieldNames;
 	private final Document _document = new DocumentImpl();
 	private List<DocumentContributor> _documentContributors;
+	private List<ExpandoQueryContributor> _expandoQueryContributors;
 	private boolean _filterSearch;
 	private Boolean _indexerEnabled;
 	private IndexerPostProcessor[] _indexerPostProcessors =

--- a/portal-kernel/src/com/liferay/portal/kernel/search/ExpandoQueryContributor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/ExpandoQueryContributor.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.search;
+
+/**
+ * @author André de Oliveira
+ */
+public interface ExpandoQueryContributor {
+
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery, String[] classNames,
+		SearchContext searchContext);
+
+}


### PR DESCRIPTION
CI results: only 1 failure "unique to this pull" - seems unrelated.

"Build was aborted" (https://github.com/arboliveira/liferay-portal/pull/430#issuecomment-372544730)
"Caused by: java.io.IOException: Exception in opening zip file: /opt/dev/projects/github/liferay-portal/bundles/osgi/state/org.eclipse.osgi/830/0/.cp/extension/arquillian-install-portlet-in-liferay.jar"
(https://test-1-5.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=3,label_exp=!master/202159//consoleText)

Author: @BryanEngler 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-72748