### PR TITLE
LPS-78665 Apply it for all upgrades in this module. WARN is enough in this case

### DIFF
--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
@@ -18,11 +18,13 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.journal.model.JournalArticleResource;
 import com.liferay.journal.service.JournalArticleResourceLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -76,9 +78,13 @@ public class UpgradeLayoutType extends UpgradeProcess {
 			_CLASS_NAME, resourcePrimKey);
 
 		if (assetEntry == null) {
-			throw new UpgradeException(
-				"Unable to find asset entry for a journal article with " +
-					"classPK " + resourcePrimKey);
+			if ((resourcePrimKey != -1) && _log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to find asset entry for a journal article with " +
+						"classPK " + resourcePrimKey);
+			}
+
+			return -1;
 		}
 
 		return assetEntry.getEntryId();
@@ -119,7 +125,14 @@ public class UpgradeLayoutType extends UpgradeProcess {
 				groupId, articleId);
 
 		if (journalArticleResource == null) {
-			throw new UpgradeException("Unable to get article " + articleId);
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to locate article ", String.valueOf(articleId),
+						" in group ", String.valueOf(groupId)));
+			}
+
+			return -1;
 		}
 
 		return journalArticleResource.getResourcePrimKey();
@@ -179,6 +192,9 @@ public class UpgradeLayoutType extends UpgradeProcess {
 
 	private static final String _PORTLET_ID_JOURNAL_CONTENT =
 		"com_liferay_journal_content_web_portlet_JournalContentPortlet";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradeLayoutType.class);
 
 	private final JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -78,13 +79,9 @@ public class UpgradeLayoutType extends UpgradeProcess {
 			_CLASS_NAME, resourcePrimKey);
 
 		if (assetEntry == null) {
-			if ((resourcePrimKey != -1) && _log.isWarnEnabled()) {
-				_log.warn(
-					"Unable to find asset entry for a journal article with " +
-						"classPK " + resourcePrimKey);
-			}
-
-			return -1;
+			throw new UpgradeException(
+				"Unable to find asset entry for a journal article with " +
+					"classPK " + resourcePrimKey);
 		}
 
 		return assetEntry.getEntryId();
@@ -101,25 +98,6 @@ public class UpgradeLayoutType extends UpgradeProcess {
 			return null;
 		}
 
-		long resourcePrimKey = getResourcePrimKey(groupId, articleId);
-
-		PortletPreferences portletPreferences = new PortletPreferencesImpl();
-
-		portletPreferences.setValue("articleId", articleId);
-
-		long assetEntryId = getAssetEntryId(resourcePrimKey);
-
-		portletPreferences.setValue(
-			"assetEntryId", String.valueOf(assetEntryId));
-
-		portletPreferences.setValue("groupId", String.valueOf(groupId));
-
-		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
-	}
-
-	protected long getResourcePrimKey(long groupId, String articleId)
-		throws Exception {
-
 		JournalArticleResource journalArticleResource =
 			_journalArticleResourceLocalService.fetchArticleResource(
 				groupId, articleId);
@@ -132,10 +110,22 @@ public class UpgradeLayoutType extends UpgradeProcess {
 						" in group ", String.valueOf(groupId)));
 			}
 
-			return -1;
+			return null;
 		}
 
-		return journalArticleResource.getResourcePrimKey();
+		PortletPreferences portletPreferences = new PortletPreferencesImpl();
+
+		portletPreferences.setValue("articleId", articleId);
+
+		long assetEntryId = getAssetEntryId(
+			journalArticleResource.getResourcePrimKey());
+
+		portletPreferences.setValue(
+			"assetEntryId", String.valueOf(assetEntryId));
+
+		portletPreferences.setValue("groupId", String.valueOf(groupId));
+
+		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 	}
 
 	protected String getTypeSettings(String portletId) {

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.layout.admin.web.internal.upgrade.v_1_0_1.UpgradeLayoutType">
+		<priority value="INFO" />
+	</category>
+</log4j:configuration>

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-	<category name="com.liferay.layout.admin.web.internal.upgrade.v_1_0_1.UpgradeLayoutType">
-		<priority value="INFO" />
+	<category name="com.liferay.layout.admin.web.internal.upgrade">
+		<priority value="WARN" />
 	</category>
 </log4j:configuration>


### PR DESCRIPTION
Hi @mbowerman,

Please, take a look at the changes, taking into account your comment in https://issues.liferay.com/browse/LPS-78665:

> What we can do instead of throwing an Exception, is simply configure the Web Content Display Portlet on the page to point to an invalid resourcePrimKey (such as -1). This will cause the Web Content Display portlet to not display any Web Content, which is the same behavior that was occurring in the pre-upgrade environment. Additionally, we can log a warning to let the user know that the Web Content that the page is pointing to could not be found.

What we need is to configure an empty WCD portlet, so it is enough to store empty preferences.

Let me know if you see any drawback to this

Thanks!

cc/@SamZiemer