### PR TITLE
LPS-78834 Adding missing @Component annotation

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/AdminUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/util/AdminUtil.java
@@ -17,11 +17,13 @@ package com.liferay.knowledge.base.web.internal.util;
 import com.liferay.knowledge.base.util.AdminHelper;
 import com.liferay.portal.kernel.diff.DiffVersionsInfo;
 
+import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Lance Ji
  */
+@Component
 public class AdminUtil {
 
 	public static DiffVersionsInfo getDiffVersionsInfo(


### PR DESCRIPTION
/cc @lanceji92674957, @shuyangzhou

@hhuijser, would it make sense to add a formatting rule that complains when a `@Reference` annotation is present inside a class without a `@Component` one?

Thanks!