### PR TITLE
LPS-78665 UpgradeLayoutType: taking into account wrong article ids

### DIFF
--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/upgrade/v_1_0_1/UpgradeLayoutType.java
@@ -18,11 +18,13 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
 import com.liferay.journal.model.JournalArticleResource;
 import com.liferay.journal.service.JournalArticleResourceLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -76,9 +78,13 @@ public class UpgradeLayoutType extends UpgradeProcess {
 			_CLASS_NAME, resourcePrimKey);
 
 		if (assetEntry == null) {
-			throw new UpgradeException(
-				"Unable to find asset entry for a journal article with " +
-					"classPK " + resourcePrimKey);
+			if ((resourcePrimKey != -1) && _log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to find asset entry for a journal article with " +
+						"classPK " + resourcePrimKey);
+			}
+
+			return -1;
 		}
 
 		return assetEntry.getEntryId();
@@ -119,7 +125,14 @@ public class UpgradeLayoutType extends UpgradeProcess {
 				groupId, articleId);
 
 		if (journalArticleResource == null) {
-			throw new UpgradeException("Unable to get article " + articleId);
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to locate article ", String.valueOf(articleId),
+						" in group ", String.valueOf(groupId)));
+			}
+
+			return -1;
 		}
 
 		return journalArticleResource.getResourcePrimKey();
@@ -179,6 +192,9 @@ public class UpgradeLayoutType extends UpgradeProcess {
 
 	private static final String _PORTLET_ID_JOURNAL_CONTENT =
 		"com_liferay_journal_content_web_portlet_JournalContentPortlet";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradeLayoutType.class);
 
 	private final JournalArticleResourceLocalService
 		_journalArticleResourceLocalService;

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.layout.admin.web.internal.upgrade.v_1_0_1.UpgradeLayoutType">
+		<priority value="INFO" />
+	</category>
+</log4j:configuration>

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/resources/META-INF/module-log4j.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-	<category name="com.liferay.layout.admin.web.internal.upgrade.v_1_0_1.UpgradeLayoutType">
-		<priority value="INFO" />
+	<category name="com.liferay.layout.admin.web.internal.upgrade">
+		<priority value="WARN" />
 	</category>
 </log4j:configuration>


### PR DESCRIPTION
Hi @mbowerman,

After thinking more about it, your solution is the proper one. I just avoided to store -1 values in portlet preferences keeping old values, 

I have tested it and the WCD portlet shows the proper message:
![article](https://user-images.githubusercontent.com/861040/37416027-1925ad14-27ad-11e8-82bb-e0e1bdb6f494.png)

Let me know if you see any drawback.

Thanks!
cc/@samziemer