### PR TITLE
LPS-78265 Default log levels for Elasticsearch 6 need updated package names

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -5630,6 +5630,15 @@ osb.lcs.portlet.oauth.consumer.secret=${osb.lcs.portlet.oauth.consumer.secret}</
 	</category>
 </log4j:configuration>]]></echo>
 
+		<echo file="${liferay.home}/osgi/log4j/com.liferay.portal.search.elasticsearch6.impl-log4j-ext.xml"><![CDATA[<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.portal.search.elasticsearch6.internal.connection.EmbeddedElasticsearchConnection">
+		<priority value="ERROR" />
+	</category>
+</log4j:configuration>]]></echo>
+
 		<echo file="${liferay.home}/osgi/log4j/com.liferay.portal.search.elasticsearch-log4j-ext.xml"><![CDATA[<?xml version="1.0"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/META-INF/module-log4j.xml
@@ -2,11 +2,11 @@
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-	<category name="com.liferay.portal.search.elasticsearch">
+	<category name="com.liferay.portal.search.elasticsearch6">
 		<priority value="ERROR" />
 	</category>
 
-	<category name="com.liferay.portal.search.elasticsearch.internal.connection.EmbeddedElasticsearchConnection">
+	<category name="com.liferay.portal.search.elasticsearch6.internal.connection.EmbeddedElasticsearchConnection">
 		<priority value="WARN" />
 	</category>
 </log4j:configuration>

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/log4j2.properties
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/resources/log4j2.properties
@@ -1,0 +1,13 @@
+status = error
+
+# log action execution errors for easier debugging
+logger.action.name = org.elasticsearch.action
+logger.action.level = debug
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
CI results: only 2 "Failures unique to this pull" - apparently, false negatives. https://github.com/arboliveira/liferay-portal/pull/431#issuecomment-372953967

1. Database hiccup: _"SQL5043N  Support for one or more communications protocols specified in the DB2COMM environment variable failed to start successfully."_
2. Duplicate of a failure also found in "Failures in common with acceptance upstream results": _"WAR /tmp/junit8804205156164122421/gradle/portlet-portlet/build/libs/portlet-portlet.war and /tmp/junit8804205156164122421/maven/portlet-portlet/target/portlet-portlet-1.0.0/WEB-INF/lib/spring-beans-4.1.9.RELEASE.jar do not match"_

Authors: @BryanEngler @xbrianlee 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-78265