### PR TITLE
LRQA-39309 Update poshi to v1.0.82 & update default Firefox to v52.0 

### DIFF
--- a/modules/apps/collaboration/social/social-bookmarks-taglib/build.gradle
+++ b/modules/apps/collaboration/social/social-bookmarks-taglib/build.gradle
@@ -2,7 +2,6 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	provided group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.54.0"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
@@ -11,4 +10,5 @@ dependencies {
 	provided group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:collaboration:social:social-bookmarks-api")
+	provided project(":core:osgi-service-tracker-collections")
 }

--- a/portal-web/build-test.gradle
+++ b/portal-web/build-test.gradle
@@ -13,7 +13,7 @@ poshiRunner {
 	}
 
 	openCVVersion = "2.4.10-0.10"
-	version = "1.0.80"
+	version = "1.0.82"
 }
 
 task updateGradleCache

--- a/test.properties
+++ b/test.properties
@@ -118,8 +118,8 @@
 
     #browser.firefox.version=22.0
     #browser.firefox.version=38.0
-    browser.firefox.version=45.0
-    #browser.firefox.version=52.0
+    #browser.firefox.version=45.0
+    browser.firefox.version=52.0
 
     #browser.firefox.bin.file[22.0]=
     #browser.firefox.bin.file[38.0]=


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-39309

We are currently pushing this update to master and 7.0.x only because FF52 support is only needed in those two branches. We will be pushing poshi-runner 1.0.82 to the other branches once we have verified them.

This pull request has been tested here https://github.com/pyoo47/liferay-portal/pull/565 (UNRELATED FAILURES)