### PR TITLE
LPS-78640 Reconnect to remote Elasticsearch when a misconfiguration gets corrected

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/BaseElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/BaseElasticsearchConnection.java
@@ -52,6 +52,8 @@ public abstract class BaseElasticsearchConnection
 
 	@Override
 	public void connect() {
+		settingsBuilder = new SettingsBuilder(Settings.builder());
+
 		loadOptionalDefaultConfigurations();
 
 		loadAdditionalConfigurations();
@@ -162,7 +164,7 @@ public abstract class BaseElasticsearchConnection
 	}
 
 	protected volatile ElasticsearchConfiguration elasticsearchConfiguration;
-	protected final SettingsBuilder settingsBuilder = new SettingsBuilder(
+	protected SettingsBuilder settingsBuilder = new SettingsBuilder(
 		Settings.builder());
 
 	private Client _client;

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnection.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnection.java
@@ -176,6 +176,11 @@ public class RemoteElasticsearchConnection extends BaseElasticsearchConnection {
 
 		if (isConnected()) {
 			close();
+		}
+
+		if (!isConnected() && (elasticsearchConfiguration.operationMode() ==
+				com.liferay.portal.
+					search.elasticsearch6.configuration.OperationMode.REMOTE)) {
 
 			connect();
 		}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
@@ -14,7 +14,11 @@
 
 package com.liferay.portal.search.elasticsearch6.internal.connection;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.search.elasticsearch6.configuration.OperationMode;
 
 import java.net.InetSocketAddress;
 
@@ -49,6 +53,8 @@ public class RemoteElasticsearchConnectionTest {
 	public void testModifyConnected() {
 		HashMap<String, Object> properties = new HashMap<>();
 
+		properties.put("operationMode", OperationMode.REMOTE.name());
+
 		_remoteElasticsearchConnection.activate(properties);
 
 		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
@@ -69,14 +75,49 @@ public class RemoteElasticsearchConnectionTest {
 	}
 
 	@Test
+	public void testModifyConnectedWithInvalidPropertiesThenValidProperties() {
+		HashMap<String, Object> properties = new HashMap<>();
+
+		properties.put("operationMode", OperationMode.REMOTE.name());
+
+		_remoteElasticsearchConnection.activate(properties);
+
+		_remoteElasticsearchConnection.connect();
+
+		properties.put(
+			"additionalConfigurations",
+			StringBundler.concat(
+				StringPool.OPEN_CURLY_BRACE, RandomTestUtil.randomString(),
+				StringPool.CLOSE_CURLY_BRACE));
+
+		try {
+			_remoteElasticsearchConnection.modified(properties);
+
+			Assert.fail();
+		}
+		catch (NullPointerException npe) {
+		}
+
+		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
+
+		properties.replace("additionalConfigurations", StringPool.BLANK);
+
+		_remoteElasticsearchConnection.modified(properties);
+
+		Assert.assertTrue(_remoteElasticsearchConnection.isConnected());
+	}
+
+	@Test
 	public void testModifyUnconnected() {
 		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
 
 		HashMap<String, Object> properties = new HashMap<>();
 
+		properties.put("operationMode", OperationMode.REMOTE.name());
+
 		_remoteElasticsearchConnection.modified(properties);
 
-		Assert.assertFalse(_remoteElasticsearchConnection.isConnected());
+		Assert.assertTrue(_remoteElasticsearchConnection.isConnected());
 	}
 
 	protected void assertTransportAddress(String hostString, int port) {


### PR DESCRIPTION
CI results: there's 2 "Failures unique to this pull", apparently false negatives. https://github.com/arboliveira/liferay-portal/pull/433#issuecomment-373585045

[1:]
This pull changes Java classes only, not bnd or package structure of any kind.
`Split package, multiple jars provide the same package:org/apache/felix/utils/extender`

[2:]
CDN hiccup.
```
A problem occurred evaluating project ':apps:foundation:apio-architect'.
> Could not resolve all dependencies for configuration 'classpath'.
> Could not resolve com.liferay:com.liferay.gradle.plugins.app.docker:1.0.2.
Required by: unspecified:unspecified:unspecified
> Could not resolve com.liferay:com.liferay.gradle.plugins.app.docker:1.0.2.
> Could not get resource 'https://cdn.lfrs.sl/repository.liferay.com/nexus/
content/groups/public/com/liferay/com.liferay.gradle.plugins.app.docker/
1.0.2/com.liferay.gradle.plugins.app.docker-1.0.2.pom'.
 ```

Author: @ericyanLr  
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-78640