### PR TITLE
LPS-78528 Limit Web Proxy to administrators

### DIFF
--- a/modules/apps/foundation/web-proxy/web-proxy-web/src/main/java/com/liferay/web/proxy/web/internal/portlet/WebProxyPortlet.java
+++ b/modules/apps/foundation/web-proxy/web-proxy-web/src/main/java/com/liferay/web/proxy/web/internal/portlet/WebProxyPortlet.java
@@ -83,7 +83,7 @@ import org.portletbridge.portlet.PortletBridgeServlet;
 		"javax.portlet.name=" + WebProxyPortletKeys.WEB_PROXY,
 		"javax.portlet.preferences=classpath:/META-INF/portlet-preferences/default-portlet-preferences.xml",
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=power-user,user"
+		"javax.portlet.security-role-ref=administrator"
 	},
 	service = Portlet.class
 )


### PR DESCRIPTION
Limiting access of web proxy to administrator in the same way we limit access to XSL Content and for the same reason.

@brianchandotcom, please don't backport. We'll need to figure out how to push this out to existing users.

Code has been reviewed by @topolik