### PR TITLE
LRQA-39387 Always deploy the source formatter jar when running "ci:test:sf"

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3150,6 +3150,10 @@ information. Make sure to commit in all build services results.
 			<test-action>
 				<antcall target="compile" />
 
+				<antcall target="install-portal-snapshots" />
+
+				<gradle-execute dir="modules/util/source-formatter" task="deploy" />
+
 				<ant dir="portal-impl" target="format-source-all">
 					<property name="format.current.branch" value="true" />
 					<property name="show.documentation" value="false" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-39387

@hhuijser - After talking to @petershin about this issue we were able to figure out why this was failing.

This should prevent this issue from occurring in the future:
#56269

Thanks!