### PR TITLE
LPS-79248 Upgrade process should use the shared connection field when…

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_0_0/UpgradeRatingsEntry.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_0_0/UpgradeRatingsEntry.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringBundler;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -33,14 +32,11 @@ public class UpgradeRatingsEntry extends UpgradeProcess {
 	}
 
 	protected long getClassNameId(String className) throws Exception {
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select classNameId from ClassName_ where value = ?");
 
 			ps.setString(1, className);
@@ -54,21 +50,18 @@ public class UpgradeRatingsEntry extends UpgradeProcess {
 			return 0;
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 
 	protected void updateRatingsEntries() throws Exception {
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
 			long classNameId = getClassNameId(_ARTICLE_CLASS_NAME);
 
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select entryId, score from RatingsEntry where classNameId = " +
 					classNameId);
 
@@ -89,7 +82,7 @@ public class UpgradeRatingsEntry extends UpgradeProcess {
 			}
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_0_0/UpgradeRatingsStats.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_0_0/UpgradeRatingsStats.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringBundler;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -33,14 +32,11 @@ public class UpgradeRatingsStats extends UpgradeProcess {
 	}
 
 	protected long getClassNameId(String className) throws Exception {
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select classNameId from ClassName_ where value = ?");
 
 			ps.setString(1, className);
@@ -54,21 +50,18 @@ public class UpgradeRatingsStats extends UpgradeProcess {
 			return 0;
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 
 	protected void updateRatingsStats() throws Exception {
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
 			long classNameId = getClassNameId(_ARTICLE_CLASS_NAME);
 
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select statsId, totalScore, averageScore from RatingsStats " +
 					"where classNameId = " + classNameId);
 
@@ -92,7 +85,7 @@ public class UpgradeRatingsStats extends UpgradeProcess {
 			}
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/UpgradeClassName.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/UpgradeClassName.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringBundler;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -41,14 +40,11 @@ public class UpgradeClassName extends UpgradeProcess {
 	}
 
 	protected long getClassNameId(String className) throws Exception {
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select classNameId from ClassName_ where value = ?");
 
 			ps.setString(1, className);
@@ -62,7 +58,7 @@ public class UpgradeClassName extends UpgradeProcess {
 			return 0;
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/UpgradeResourceAction.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/UpgradeResourceAction.java
@@ -17,7 +17,6 @@ package com.liferay.knowledge.base.internal.upgrade.v1_1_0;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -38,14 +37,11 @@ public class UpgradeResourceAction extends UpgradeProcess {
 	}
 
 	protected boolean hasResourceAction(String name) throws Exception {
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select count(*) from ResourceAction where name = ?");
 
 			ps.setString(1, name);
@@ -63,7 +59,7 @@ public class UpgradeResourceAction extends UpgradeProcess {
 			return false;
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/UpgradeResourcePermission.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/UpgradeResourcePermission.java
@@ -17,7 +17,6 @@ package com.liferay.knowledge.base.internal.upgrade.v1_1_0;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -38,14 +37,11 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 	}
 
 	protected boolean hasResourcePermission(String name) throws Exception {
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select count(*) from ResourcePermission where name = ?");
 
 			ps.setString(1, name);
@@ -63,7 +59,7 @@ public class UpgradeResourcePermission extends UpgradeProcess {
 			return false;
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 

--- a/modules/apps/wsrp/wsrp-service/src/main/java/com/liferay/wsrp/internal/upgrade/v1_1_0/UpgradeUuid.java
+++ b/modules/apps/wsrp/wsrp-service/src/main/java/com/liferay/wsrp/internal/upgrade/v1_1_0/UpgradeUuid.java
@@ -25,7 +25,6 @@ import com.liferay.wsrp.internal.consumer.portlet.ConsumerPortlet;
 import com.liferay.wsrp.model.WSRPConsumerPortlet;
 import com.liferay.wsrp.service.WSRPConsumerPortletLocalServiceUtil;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -67,13 +66,10 @@ public class UpgradeUuid extends UpgradeProcess {
 	protected void updateLayout(long plid, String typeSettings)
 		throws Exception {
 
-		Connection con = null;
 		PreparedStatement ps = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"update Layout set typeSettings = ? where plid = " + plid);
 
 			ps.setString(1, typeSettings);
@@ -81,21 +77,18 @@ public class UpgradeUuid extends UpgradeProcess {
 			ps.executeUpdate();
 		}
 		finally {
-			DataAccess.cleanUp(con, ps);
+			DataAccess.cleanUp(ps);
 		}
 	}
 
 	protected void updateLayout(String oldPortletId, String newPortletId)
 		throws Exception {
 
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select plid, typeSettings from Layout where typeSettings " +
 					"like ?");
 
@@ -115,7 +108,7 @@ public class UpgradeUuid extends UpgradeProcess {
 			}
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 
@@ -123,13 +116,10 @@ public class UpgradeUuid extends UpgradeProcess {
 			String oldPortletId, String newPortletId)
 		throws Exception {
 
-		Connection con = null;
 		PreparedStatement ps = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"update ResourceAction set name = ? where name = ? ");
 
 			ps.setString(1, newPortletId);
@@ -138,7 +128,7 @@ public class UpgradeUuid extends UpgradeProcess {
 			ps.executeUpdate();
 		}
 		finally {
-			DataAccess.cleanUp(con, ps);
+			DataAccess.cleanUp(ps);
 		}
 	}
 
@@ -146,13 +136,10 @@ public class UpgradeUuid extends UpgradeProcess {
 			long resourcePermissionId, String name, String primKey)
 		throws Exception {
 
-		Connection con = null;
 		PreparedStatement ps = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"update ResourcePermission set name = ?, primKey = ? where " +
 					"resourcePermissionId = ?");
 
@@ -163,7 +150,7 @@ public class UpgradeUuid extends UpgradeProcess {
 			ps.executeUpdate();
 		}
 		finally {
-			DataAccess.cleanUp(con, ps);
+			DataAccess.cleanUp(ps);
 		}
 	}
 
@@ -171,14 +158,11 @@ public class UpgradeUuid extends UpgradeProcess {
 			String oldPortletId, String newPortletId)
 		throws Exception {
 
-		Connection con = null;
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
-
-			ps = con.prepareStatement(
+			ps = connection.prepareStatement(
 				"select resourcePermissionId, primKey from " +
 					"ResourcePermission where name = ?");
 
@@ -198,7 +182,7 @@ public class UpgradeUuid extends UpgradeProcess {
 			}
 		}
 		finally {
-			DataAccess.cleanUp(con, ps, rs);
+			DataAccess.cleanUp(ps, rs);
 		}
 	}
 


### PR DESCRIPTION
…ever possible

@hhuijser can you SF this? The only exception we have now is com.liferay.portal.upgrade.util.UpgradeCompanyId which uses DataAccess.getUpgradeOptimizedConnection() inside TableUpdater. That one is fine since it runs in different thread.
We need to prevent people from adding in bad usages in the future.