### PR TITLE
Lps 77959

### DIFF
--- a/modules/apps/foundation/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskFinder.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-api/src/main/java/com/liferay/portal/background/task/service/persistence/BackgroundTaskFinder.java
@@ -22,9 +22,6 @@ import aQute.bnd.annotation.ProviderType;
  */
 @ProviderType
 public interface BackgroundTaskFinder {
-	public int countByG_T_C(long[] groupIds,
-		java.lang.String[] taskExecutorClassNames, java.lang.Boolean completed);
-
 	public java.util.List<com.liferay.portal.background.task.model.BackgroundTask> findByG_T_C(
 		long[] groupIds, java.lang.String[] taskExecutorClassNames,
 		java.lang.Boolean completed, int start, int end, boolean orderByType);

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
@@ -598,15 +598,15 @@ public class BackgroundTaskLocalServiceImpl
 	public int getBackgroundTasksCount(
 		long[] groupIds, String[] taskExecutorClassNames) {
 
-		return backgroundTaskFinder.countByG_T_C(
-			groupIds, taskExecutorClassNames, null);
+		return backgroundTaskPersistence.countByG_T(
+			groupIds, taskExecutorClassNames);
 	}
 
 	@Override
 	public int getBackgroundTasksCount(
 		long[] groupIds, String[] taskExecutorClassNames, boolean completed) {
 
-		return backgroundTaskFinder.countByG_T_C(
+		return backgroundTaskPersistence.countByG_T_C(
 			groupIds, taskExecutorClassNames, completed);
 	}
 

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/persistence/impl/BackgroundTaskFinderImpl.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/persistence/impl/BackgroundTaskFinderImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.SQLQuery;
 import com.liferay.portal.kernel.dao.orm.Session;
-import com.liferay.portal.kernel.dao.orm.Type;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -39,63 +37,8 @@ import java.util.List;
 public class BackgroundTaskFinderImpl
 	extends BackgroundTaskFinderBaseImpl implements BackgroundTaskFinder {
 
-	public static final String COUNT_BY_G_T_C =
-		BackgroundTaskFinder.class.getName() + ".countByG_T_C";
-
 	public static final String FIND_BY_G_T_C =
 		BackgroundTaskFinder.class.getName() + ".findByG_T_C";
-
-	@Override
-	public int countByG_T_C(
-		long[] groupIds, String[] taskExecutorClassNames, Boolean completed) {
-
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = CustomSQLUtil.get(getClass(), COUNT_BY_G_T_C);
-
-			sql = _replaceWhereConditions(
-				groupIds, taskExecutorClassNames, sql, completed);
-
-			SQLQuery q = session.createSynchronizedSQLQuery(sql);
-
-			q.addScalar(COUNT_COLUMN_NAME, Type.LONG);
-
-			QueryPos qPos = QueryPos.getInstance(q);
-
-			for (long groupId : groupIds) {
-				qPos.add(groupId);
-			}
-
-			for (String taskExecutorClassName : taskExecutorClassNames) {
-				qPos.add(taskExecutorClassName);
-			}
-
-			if (completed != null) {
-				qPos.add(completed.booleanValue());
-			}
-
-			Iterator<Long> itr = q.iterate();
-
-			if (itr.hasNext()) {
-				Long count = itr.next();
-
-				if (count != null) {
-					return count.intValue();
-				}
-			}
-
-			return 0;
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
 
 	@Override
 	public List<BackgroundTask> findByG_T_C(

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/resources/custom-sql/default.xml
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/resources/custom-sql/default.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0"?>
 
 <custom-sql>
-	<sql id="com.liferay.portal.background.task.service.persistence.BackgroundTaskFinder.countByG_T_C">
-		<![CDATA[
-			SELECT
-				COUNT(*) AS COUNT_VALUE
-			FROM
-				BackgroundTask
-			[$WHERE_CONDITIONS$]
-		]]>
-	</sql>
 	<sql id="com.liferay.portal.background.task.service.persistence.BackgroundTaskFinder.findByG_T_C">
 		<![CDATA[
 			SELECT


### PR DESCRIPTION
@matethurzo this fixes the performance regression caused by LPS-77959, @slnn has verified it here https://github.com/slnn/liferay-portal/pull/270#issuecomment-377444256

In the future, if you feel any of your changes could cause a performance hit, please send your pulls through @slnn, she can validate your pulls before they get merged into master, which will reduce the risk and impact to our daily performance monitoring tests.

@matethurzo for this issue particularly, please be very careful with what query we do by SB, what query we do by finder. All SB generated queries are equipped with cache support, and all finders are cacheless. Which means when possible we always prefer SB generated queries. Finder are normally for queries that are crossing tables, not really for single table queries. I did not touch your FIND_BY_G_T_C finder, as it is not used in our test case, but I doubt the reason why you need it. I am leaving this to you, if it is truly still a single table query, you should switch to use SB generated query for it.