### PR TITLE
Lps 76463

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -19,7 +19,6 @@ import com.liferay.asset.kernel.exception.DuplicateTagException;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -550,7 +549,6 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 	 * @return the asset tags of the entity
 	 */
 	@Override
-	@ThreadLocalCachable
 	public List<AssetTag> getTags(String className, long classPK) {
 		long classNameId = classNameLocalService.getClassNameId(className);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.exception.DuplicateTagException;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -51,6 +52,7 @@ import com.liferay.social.kernel.util.SocialCounterPeriodUtil;
 import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -523,7 +525,14 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 	 */
 	@Override
 	public List<AssetTag> getTags(long classNameId, long classPK) {
-		return assetTagFinder.findByC_C(classNameId, classPK);
+		AssetEntry entry = assetEntryPersistence.fetchByC_C(
+			classNameId, classPK);
+
+		if (entry == null) {
+			return Collections.emptyList();
+		}
+
+		return assetEntryPersistence.getAssetTags(entry.getEntryId());
 	}
 
 	@Override
@@ -549,6 +558,7 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 	 * @return the asset tags of the entity
 	 */
 	@Override
+	@ThreadLocalCachable
 	public List<AssetTag> getTags(String className, long classPK) {
 		long classNameId = classNameLocalService.getClassNameId(className);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -45,9 +45,6 @@ public class AssetTagFinderImpl
 	public static final String COUNT_BY_G_C_N =
 		AssetTagFinder.class.getName() + ".countByG_C_N";
 
-	public static final String FIND_BY_C_C =
-		AssetTagFinder.class.getName() + ".findByC_C";
-
 	public static final String FIND_BY_G_C_N =
 		AssetTagFinder.class.getName() + ".findByG_C_N";
 
@@ -129,36 +126,6 @@ public class AssetTagFinderImpl
 			}
 
 			return 0;
-		}
-		catch (Exception e) {
-			throw new SystemException(e);
-		}
-		finally {
-			closeSession(session);
-		}
-	}
-
-	@Override
-	public List<AssetTag> findByC_C(long classNameId, long classPK) {
-		Session session = null;
-
-		try {
-			session = openSession();
-
-			String sql = CustomSQLUtil.get(FIND_BY_C_C);
-
-			SQLQuery q = session.createSynchronizedSQLQuery(sql);
-
-			q.addEntity("AssetTag", AssetTagImpl.class);
-
-			QueryPos qPos = QueryPos.getInstance(q);
-
-			qPos.add(classNameId);
-			qPos.add(classPK);
-
-			List<AssetTag> tags = q.list();
-
-			return tags;
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagFinderImpl.java
@@ -156,7 +156,9 @@ public class AssetTagFinderImpl
 			qPos.add(classNameId);
 			qPos.add(classPK);
 
-			return q.list(true);
+			List<AssetTag> tags = q.list();
+
+			return tags;
 		}
 		catch (Exception e) {
 			throw new SystemException(e);

--- a/portal-impl/src/custom-sql/asset.xml
+++ b/portal-impl/src/custom-sql/asset.xml
@@ -243,23 +243,6 @@
 				)
 		]]>
 	</sql>
-	<sql id="com.liferay.asset.kernel.service.persistence.AssetTagFinder.findByC_C">
-		<![CDATA[
-			SELECT
-				{AssetTag.*}
-			FROM
-				AssetEntry
-				INNER JOIN
-				AssetEntries_AssetTags ON
-	  				AssetEntries_AssetTags.entryId = AssetEntry.entryId
-				INNER JOIN
-				AssetTag ON
-	  				AssetTag.tagId = AssetEntries_AssetTags.tagId
-			WHERE
-				(AssetEntry.classNameId = ?) AND
-				(AssetEntry.classPK =  ?)
-		]]>
-	</sql>
 	<sql id="com.liferay.asset.kernel.service.persistence.AssetTagFinder.findByG_C_N">
 		<![CDATA[
 			SELECT

--- a/portal-impl/src/custom-sql/asset.xml
+++ b/portal-impl/src/custom-sql/asset.xml
@@ -249,10 +249,10 @@
 				{AssetTag.*}
 			FROM
 				AssetEntry
-			INNER JOIN
+				INNER JOIN
 				AssetEntries_AssetTags ON
 	  				AssetEntries_AssetTags.entryId = AssetEntry.entryId
-			INNER JOIN
+				INNER JOIN
 				AssetTag ON
 	  				AssetTag.tagId = AssetEntries_AssetTags.tagId
 			WHERE

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
@@ -20,6 +20,7 @@ import com.liferay.asset.kernel.model.AssetTag;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 
+import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
@@ -588,6 +589,7 @@ public interface AssetTagLocalService extends BaseLocalService,
 	* @param classPK the primary key of the entity
 	* @return the asset tags of the entity
 	*/
+	@ThreadLocalCachable
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AssetTag> getTags(java.lang.String className, long classPK);
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetTagLocalService.java
@@ -20,7 +20,6 @@ import com.liferay.asset.kernel.model.AssetTag;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 
-import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCachable;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
@@ -589,7 +588,6 @@ public interface AssetTagLocalService extends BaseLocalService,
 	* @param classPK the primary key of the entity
 	* @return the asset tags of the entity
 	*/
-	@ThreadLocalCachable
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AssetTag> getTags(java.lang.String className, long classPK);
 

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagFinder.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagFinder.java
@@ -27,9 +27,6 @@ public interface AssetTagFinder {
 	public int countByG_C_N(long groupId, long classNameId,
 		java.lang.String name);
 
-	public java.util.List<com.liferay.asset.kernel.model.AssetTag> findByC_C(
-		long classNameId, long classPK);
-
 	public java.util.List<com.liferay.asset.kernel.model.AssetTag> findByG_C_N(
 		long groupId, long classNameId, java.lang.String name, int start,
 		int end,

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagFinderUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetTagFinderUtil.java
@@ -34,11 +34,6 @@ public class AssetTagFinderUtil {
 		return getFinder().countByG_C_N(groupId, classNameId, name);
 	}
 
-	public static java.util.List<com.liferay.asset.kernel.model.AssetTag> findByC_C(
-		long classNameId, long classPK) {
-		return getFinder().findByC_C(classNameId, classPK);
-	}
-
 	public static java.util.List<com.liferay.asset.kernel.model.AssetTag> findByG_C_N(
 		long groupId, long classNameId, java.lang.String name, int start,
 		int end,


### PR DESCRIPTION
@marcellustavares this fixes the regression from LPS-75330. It turned out to not be your fault. You just being the first (at least this is the first appearance to our test coverage) to start using a bad change from months ago.

@matethurzo and @zoltancsaszi this was from your change in LPS-76463. And actually this is exactly the same type of issue I fixed yesterday for you in https://github.com/brianchandotcom/liferay-portal/pull/56693 . So I want to highlight this again. When having the same function, we always prefer to use SB generated queries over handcoded finder queries, because of the cache.

What bothers me is, https://issues.liferay.com/browse/LPS-76463 and https://issues.liferay.com/browse/LPS-76462 were filed as performance improvement tickets. And obviously it was not tested properly and it did not go through my team's validation. When dealing with performance issues, without years of experience, what your feelings tell you are most likely contrary to the facts. Next time please make sure you go through our validation for any performance improvement changes. We can eliminate the guessworks for you.

I am not sure whether you have applied this anti-pattern anywhere else, if you have, please make sure to revert them.

CC @slnn