### PR TITLE
LRQA-39439 | master

### DIFF
--- a/build-test-elasticsearch6.xml
+++ b/build-test-elasticsearch6.xml
@@ -3,54 +3,9 @@
 <project basedir="." name="portal-test-elasticsearch" xmlns:antelope="antlib:ise.antelope.tasks">
 	<import file="build-test.xml" />
 
-	<macrodef name="configure-elasticsearch-osgi-bundle-properties">
-		<sequential>
-			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config">${line.separator}operationMode=&quot;REMOTE&quot;</echo>
-		</sequential>
-	</macrodef>
-
 	<macrodef name="configure-elasticsearch-properties">
 		<sequential>
 			<echo append="true" file="${elasticsearch.dir}/config/elasticsearch.yml">${line.separator}cluster.name: LiferayElasticsearchCluster</echo>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="configure-elasticsearch-x-pack-monitoring-osgi-bundle-properties">
-		<sequential>
-			<propertyregex
-				defaultValue="${elastic.xpack.kibana.user.password}"
-				input="${elastic.xpack.kibana.user.password}"
-				override="true"
-				property="osgi.config.kibana.user.password"
-				regexp="="
-				replace="\\\\="
-			/>
-
-			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch6.xpack.monitoring.web.internal.configuration.XPackMonitoringConfiguration.config">kibanaPassword="${osgi.config.kibana.user.password}"
-kibanaURL="https://localhost:5601"
-kibanaUserName="kibana"
-proxyServletLogEnable="true"</echo>
-		</sequential>
-	</macrodef>
-
-	<macrodef name="configure-elasticsearch-x-pack-security-osgi-bundle-properties">
-		<sequential>
-			<propertyregex
-				defaultValue="${elastic.xpack.elastic.user.password}"
-				input="${elastic.xpack.elastic.user.password}"
-				override="true"
-				property="osgi.config.elastic.user.password"
-				regexp="="
-				replace="\\\\="
-			/>
-
-			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch6.xpack.security.internal.configuration.XPackSecurityConfiguration.config">certificateFormat="PEM"
-password="${osgi.config.elastic.user.password}"
-requiresAuthentication="true"
-sslCertificateAuthoritiesPaths="${elasticsearch.dir}-1/config/certs/ca/ca.crt"
-sslCertificatePath="${elasticsearch.dir}-1/config/certs/localhost/localhost.crt"
-sslKeyPath="${elasticsearch.dir}-1/config/certs/localhost/localhost.key"
-transportSSLEnabled="true"</echo>
 		</sequential>
 	</macrodef>
 
@@ -93,7 +48,52 @@ xpack.security.sessionTimeout: 600000</echo>
 		</sequential>
 	</macrodef>
 
-	<macrodef name="configure-x-pack-security-app-server-truststore">
+	<macrodef name="configure-portal-elasticsearch-osgi-properties">
+		<sequential>
+			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch6.configuration.ElasticsearchConfiguration.config">${line.separator}operationMode=&quot;REMOTE&quot;</echo>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="configure-portal-x-pack-monitoring-osgi-properties">
+		<sequential>
+			<propertyregex
+				defaultValue="${elastic.xpack.kibana.user.password}"
+				input="${elastic.xpack.kibana.user.password}"
+				override="true"
+				property="osgi.config.kibana.user.password"
+				regexp="="
+				replace="\\\\="
+			/>
+
+			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch6.xpack.monitoring.web.internal.configuration.XPackMonitoringConfiguration.config">kibanaPassword="${osgi.config.kibana.user.password}"
+kibanaURL="https://localhost:5601"
+kibanaUserName="kibana"
+proxyServletLogEnable="true"</echo>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="configure-portal-x-pack-security-osgi-properties">
+		<sequential>
+			<propertyregex
+				defaultValue="${elastic.xpack.elastic.user.password}"
+				input="${elastic.xpack.elastic.user.password}"
+				override="true"
+				property="osgi.config.elastic.user.password"
+				regexp="="
+				replace="\\\\="
+			/>
+
+			<echo append="true" file="${liferay.home}/osgi/configs/com.liferay.portal.search.elasticsearch6.xpack.security.internal.configuration.XPackSecurityConfiguration.config">certificateFormat="PEM"
+password="${osgi.config.elastic.user.password}"
+requiresAuthentication="true"
+sslCertificateAuthoritiesPaths="${elasticsearch.dir}-1/config/certs/ca/ca.crt"
+sslCertificatePath="${elasticsearch.dir}-1/config/certs/localhost/localhost.crt"
+sslKeyPath="${elasticsearch.dir}-1/config/certs/localhost/localhost.key"
+transportSSLEnabled="true"</echo>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="configure-portal-x-pack-security-truststore">
 		<sequential>
 			<if>
 				<os family="unix" />
@@ -140,7 +140,7 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 		</sequential>
 	</macrodef>
 
-	<macrodef name="generate-elasticsearch-x-pack-security-certificates">
+	<macrodef name="generate-x-pack-security-certificates">
 		<attribute default="liferay" name="certificate.password" />
 
 		<sequential>
@@ -367,7 +367,7 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 		</sequential>
 	</macrodef>
 
-	<macrodef name="set-elasticsearch-x-pack-user-passwords">
+	<macrodef name="set-x-pack-user-passwords">
 		<sequential>
 			<if>
 				<os family="unix" />
@@ -620,13 +620,13 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 
 				<property name="xpack.certificate.password" value="liferay" />
 
-				<generate-elasticsearch-x-pack-security-certificates certificate.password="${xpack.certificate.password}" />
+				<generate-x-pack-security-certificates certificate.password="${xpack.certificate.password}" />
 
 				<configure-elasticsearch-x-pack-security-properties />
 			</then>
 		</if>
 
-		<configure-elasticsearch-osgi-bundle-properties />
+		<configure-portal-elasticsearch-osgi-properties />
 
 		<get-testcase-property property.name="remote.elasticsearch.cluster.size" />
 
@@ -650,13 +650,13 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 			<then>
 				<sleep seconds="30" />
 
-				<set-elasticsearch-x-pack-user-passwords />
+				<set-x-pack-user-passwords />
 
-				<configure-elasticsearch-x-pack-security-osgi-bundle-properties />
+				<configure-portal-x-pack-security-osgi-properties />
 
-				<configure-elasticsearch-x-pack-monitoring-osgi-bundle-properties />
+				<configure-portal-x-pack-monitoring-osgi-properties />
 
-				<configure-x-pack-security-app-server-truststore />
+				<configure-portal-x-pack-security-truststore />
 
 				<antcall target="start-kibana" />
 			</then>
@@ -818,6 +818,15 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 
 			<print-file file.name="${elasticsearch.dir}-${elasticsearch.node.number}/logs/LiferayElasticsearchCluster.log" />
 		</antelope:repeat>
+
+		<if>
+			<equals arg1="${elastic.xpack.enabled}" arg2="true" />
+			<then>
+				<print-file file.name="${elastic.kibana.dir}/bin/kibana.log" />
+
+				<antcall target="stop-kibana" />
+			</then>
+		</if>
 	</target>
 
 	<target name="stop-kibana">

--- a/build-test.xml
+++ b/build-test.xml
@@ -9383,16 +9383,7 @@ module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.pr
 		<if>
 			<equals arg1="${remote.elasticsearch.enabled}" arg2="true" />
 			<then>
-				<ant antfile="build-test-elasticsearch.xml" target="start-elasticsearch" />
-
-				<get-testcase-property property.name="elastic.kibana.enabled" />
-
-				<if>
-					<equals arg1="${elastic.kibana.enabled}" arg2="true" />
-					<then>
-						<ant antfile="build-test-elasticsearch.xml" target="start-kibana" />
-					</then>
-				</if>
+				<ant antfile="build-test-elasticsearch6.xml" target="start-elasticsearch" />
 			</then>
 		</if>
 
@@ -9742,17 +9733,6 @@ module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.pr
 			</then>
 		</if>
 
-		<get-testcase-property property.name="elastic.kibana.enabled" />
-
-		<if>
-			<equals arg1="${elastic.kibana.enabled}" arg2="true" />
-			<then>
-				<print-file file.name="${elastic.kibana.dir}/bin/kibana.log" />
-
-				<ant antfile="build-test-elasticsearch.xml" target="stop-kibana" />
-			</then>
-		</if>
-
 		<get-testcase-property property.name="openam.enabled" />
 
 		<if>
@@ -9767,7 +9747,7 @@ module.framework.properties.blacklist.portal.profile.names=${blacklist.portal.pr
 		<if>
 			<equals arg1="${remote.elasticsearch.enabled}" arg2="true" />
 			<then>
-				<ant antfile="build-test-elasticsearch.xml" target="stop-elasticsearch" />
+				<ant antfile="build-test-elasticsearch6.xml" target="stop-elasticsearch" />
 			</then>
 		</if>
 

--- a/test.properties
+++ b/test.properties
@@ -1235,7 +1235,6 @@
         default.layout.template.id,\
         deploy.latest.marketplace.app.disabled,\
         direct.deploy.enabled,\
-        elastic.kibana.enabled,\
         elastic.xpack.enabled,\
         ext.plugins.includes,\
         extraapps.plugins.includes,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-39439

**Summary of changes:**
1. Rename `build-test-elasticsearch.xml` to `build-test-elasticsearch6.xml` to keep parity with 7.0.x, where we'll have `build-test-elasticsearch.xml` for ES2 and `build-test-elasticsearch6.xml` for ES6. The setup differences for the two versions are so drastic that it necessitates two build scripts. Also these names would also keep parity with the module names.
2. Rename macrodefs as per https://github.com/brianchandotcom/liferay-portal/pull/56714#issuecomment-377729801. The naming scheme now follows this format: `action - affected entity (Portal, ES, Kibana) - affected subentity (X-Pack, OSGi)`.
3. Remove `elastic.kibana.enabled` test property since it's redundant. Whenever we install X-Pack, we also test Kibana, therefore we can simplify this testing logic.