### PR TITLE
 LRQA-39695 Update Chrome/ChromeDriver versions and pass arguments in as a property 

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6576,6 +6576,15 @@ auto.deploy.dest.dir=C:/WINDOWS/system32/config/systemprofile/liferay/websphere-
 		<propertycopy from="browser.firefox.bin.file[${browser.firefox.version}]" name="browser.firefox.bin.file" silent="true" />
 
 		<if>
+			<isset property="browser.chrome.bin.args" />
+			<then>
+				<echo append="true" file="${test.ext.properties.file}">
+					browser.chrome.bin.args=${browser.chrome.bin.args}
+				</echo>
+			</then>
+		</if>
+
+		<if>
 			<isset property="browser.firefox.bin.file" />
 			<then>
 				<echo append="true" file="${test.ext.properties.file}">

--- a/test.properties
+++ b/test.properties
@@ -112,6 +112,8 @@
 
     browser.androidchrome.version=42.0
 
+    #browser.chrome.bin.args=
+
     browser.chrome.version=44.0
 
     browser.edge.version=20.1

--- a/test.properties
+++ b/test.properties
@@ -114,7 +114,8 @@
 
     #browser.chrome.bin.args=
 
-    browser.chrome.version=44.0
+    #browser.chrome.version=44.0
+    browser.chrome.version=65.0
 
     browser.edge.version=20.1
 
@@ -896,7 +897,7 @@
 ##
 
     selenium.chrome.driver.executable=chromedriver${file.suffix.exe}
-    selenium.chrome.driver.version=2.16
+    selenium.chrome.driver.version=2.37
     #selenium.desired.capabilities.platform=
     selenium.executable.dir.name=../tools/selenium/
     selenium.gecko.driver.executable=geckodriver${file.suffix.exe}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-39695

Chrome testing is only currently needed for master / 7.1.x so no back ports are needed.

Pull request tested here https://github.com/pyoo47/liferay-portal/pull/583 (UNRELATED FAILURES)