### PR TITLE
LRQA-39896 BUG - Should be remote name, not remote branch name.

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -470,9 +470,9 @@ public class GitWorkingDirectory {
 			sb.append(" --no-tags ");
 		}
 
-		String remoteBranchName = remoteBranch.getName();
+		sb.append(remote.getName());
 
-		sb.append(remoteBranchName);
+		String remoteBranchName = remoteBranch.getName();
 
 		if ((remoteBranchName != null) && !remoteBranchName.isEmpty()) {
 			sb.append(" ");


### PR DESCRIPTION
My previous pull request introduced a bug in the GitWorkingDirectory logic

Please publish after merging