### PR TITLE
LPS-79593 Disabling pointer events on thumbs children

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_ratings.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_ratings.scss
@@ -15,6 +15,10 @@
 		a svg {
 			margin-right: 8px;
 		}
+
+		.rating-element * {
+			pointer-events: none;
+		}
 	}
 
 	.rating-input-container {


### PR DESCRIPTION
Hi @brianchandotcom,

This might cause conflicts with https://github.com/brianchandotcom/liferay-portal/pull/57085 in a scss file. 

If that is the case, the final result after solving them must be:

```sass
&.like, &.thumbs {
	.rating-element * {
		pointer-events: none;
	}
}
```

Thanks!