### PR TITLE
LPS-79327 Ignore broken tests

### DIFF
--- a/modules/apps/meris/meris-asset-category-demo-test/src/testIntegration/java/com/liferay/meris/asset/category/demo/test/AssetCategoryMerisSegmentManagerTest.java
+++ b/modules/apps/meris/meris-asset-category-demo-test/src/testIntegration/java/com/liferay/meris/asset/category/demo/test/AssetCategoryMerisSegmentManagerTest.java
@@ -46,6 +46,7 @@ import java.util.Locale;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -106,6 +107,7 @@ public class AssetCategoryMerisSegmentManagerTest {
 			_merisSegmentManager.getMerisProfile(_merisProfileId));
 	}
 
+	@Ignore
 	@Test
 	public void testGetMerisProfileMerisSegments() throws Exception {
 		Comparator<MerisSegment> merisSegmentNameComparator =
@@ -121,6 +123,7 @@ public class AssetCategoryMerisSegmentManagerTest {
 			merisSegments.isEmpty());
 	}
 
+	@Ignore
 	@Test
 	public void testGetMerisProfiles() throws Exception {
 		List merisProfiles = _merisSegmentManager.getMerisProfiles(
@@ -163,6 +166,7 @@ public class AssetCategoryMerisSegmentManagerTest {
 			"No meris segments were found", merisSegments.isEmpty());
 	}
 
+	@Ignore
 	@Test
 	public void testMatches() {
 		Assert.assertTrue(


### PR DESCRIPTION
@epgarcia in https://github.com/brianchandotcom/liferay-portal/pull/57095 you added 3 broken tests.
```
java.lang.AssertionError: Meris profile does not contain a meris segment
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertFalse(Assert.java:64)
	at com.liferay.meris.asset.category.demo.test.AssetCategoryMerisSegmentManagerTest.testGetMerisProfileMerisSegments(AssetCategoryMerisSegmentManagerTest.java:119)
```
```
java.lang.AssertionError: Meris segment does not contain a meris profile
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertFalse(Assert.java:64)
	at com.liferay.meris.asset.category.demo.test.AssetCategoryMerisSegmentManagerTest.testGetMerisProfiles(AssetCategoryMerisSegmentManagerTest.java:130)
```
```
java.lang.AssertionError: Meris profile does not match the meris segment
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at com.liferay.meris.asset.category.demo.test.AssetCategoryMerisSegmentManagerTest.testMatches(AssetCategoryMerisSegmentManagerTest.java:168)
```

There is nothing random here, they are stable failures. If you run your tests locally, you will see them. I simply junit ignoring them now to keep CI clean. Please fix them and send @brianchandotcom a pull for them.