### PR TITLE
LPS-79548 Global type variable injected by template context contributor module is not recognized in freemarker portlet

### DIFF
--- a/util-bridges/src/com/liferay/util/bridges/freemarker/FreeMarkerPortlet.java
+++ b/util-bridges/src/com/liferay/util/bridges/freemarker/FreeMarkerPortlet.java
@@ -111,6 +111,9 @@ public class FreeMarkerPortlet extends MVCPortlet {
 					writer = new UnsyncStringWriter();
 				}
 
+				template.prepare(
+					PortalUtil.getHttpServletRequest(portletRequest));
+
 				template.processTemplate(writer);
 			}
 			catch (Exception e) {


### PR DESCRIPTION
Hello @jbalsas 

Based on you comment in [PTR-317](https://issues.liferay.com/browse/PTR-317), I added the `template.prepare()` call to `FreeMarkerPortlet`.

Could you please review this change?

Thank you and best regards,
István