### PR TITLE
LPS-79678 Editing an AnnouncementsEntry from the UAD Portlet does not redirect back to the "View entities" view

### DIFF
--- a/modules/apps/collaboration/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/display/AnnouncementsEntryUADEntityDisplayHelper.java
+++ b/modules/apps/collaboration/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/display/AnnouncementsEntryUADEntityDisplayHelper.java
@@ -54,6 +54,8 @@ public class AnnouncementsEntryUADEntityDisplayHelper {
 		portletURL.setParameter(
 			"mvcRenderCommandName", "/announcements/edit_entry");
 		portletURL.setParameter(
+			"redirect", portal.getCurrentURL(liferayPortletRequest));
+		portletURL.setParameter(
 			"entryId", String.valueOf(announcementsEntry.getEntryId()));
 
 		return portletURL.toString();


### PR DESCRIPTION
This is an update for [LPS-79678](https://issues.liferay.com/browse/LPS-79678).<br><br>/cc @pei-jung @willnewbury