### PR TITLE
LPS-79713 Removes year from theme footer as it does not serve any specific goal

### DIFF
--- a/modules/apps/foundation/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -70,14 +70,10 @@
 	<footer id="footer" role="contentinfo">
 		<div class="container">
 			<div class="row">
-				<div class="col-md-6 text-center text-md-left">
+				<div class="col-md-12 text-center text-md-left">
 					<@liferay.language key="powered-by" />
 
 					<a class="text-white" href="http://www.liferay.com" rel="external">Liferay</a>
-				</div>
-
-				<div class="col-md-6 text-center text-md-right">
-					2018
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Hey @brianchandotcom, 

I checked around and the current year (or whatever that was) was not really meant to show in the Classic footer, so we're simply removing it moving forward.