### PR TITLE
LRQA-40058 Compile only when source-formatter changes

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3430,17 +3430,6 @@ information. Make sure to commit in all build services results.
 	<target name="source-format-current-branch-jdk8">
 		<run-batch-test>
 			<test-action>
-				<antcall target="compile" />
-
-				<antcall target="install-portal-snapshots" />
-
-				<if>
-					<available file="modules/util/source-formatter" />
-					<then>
-						<gradle-execute dir="modules/util/source-formatter" task="deploy" />
-					</then>
-				</if>
-
 				<exec executable="git" failonerror="true" outputproperty="git.diff">
 					<arg value="diff" />
 					<arg value="--name-only" />
@@ -3453,6 +3442,17 @@ information. Make sure to commit in all build services results.
 					<contains string="${git.diff}" substring="modules${file.separator}util${file.separator}source-formatter" />
 					<then>
 						<var name="format.current.branch" value="false" />
+
+						<antcall target="compile" />
+
+						<antcall target="install-portal-snapshots" />
+
+						<if>
+							<available file="modules/util/source-formatter" />
+							<then>
+								<gradle-execute dir="modules/util/source-formatter" task="deploy" />
+							</then>
+						</if>
 					</then>
 				</if>
 

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3454,6 +3454,9 @@ information. Make sure to commit in all build services results.
 							</then>
 						</if>
 					</then>
+					<else>
+						<antcall target="setup-sdk" />
+					</else>
 				</if>
 
 				<ant dir="portal-impl" target="format-source-all">


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40058

Resend of https://github.com/brianchandotcom/liferay-portal/pull/57280

I've removed Peter's Shin's optimizations to simplify the compile logic that is needed to rebuild source-formatter when the pull request contains changes to source-formatter.

CC: @cesar-polanco