### PR TITLE
LRQA-39812 Release poshi runner 1.0.87

### DIFF
--- a/portal-web/build-test.gradle
+++ b/portal-web/build-test.gradle
@@ -13,7 +13,7 @@ poshiRunner {
 	}
 
 	openCVVersion = "2.4.10-0.10"
-	version = "1.0.82"
+	version = "1.0.87"
 }
 
 task updateGradleCache


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-39812

Tested here: 
https://github.com/kenjiheigel/liferay-portal/pull/429#issuecomment-382504210 (master, unrelated failures)
https://github.com/kenjiheigel/liferay-portal-ee/pull/225#issuecomment-382489470
https://github.com/kenjiheigel/liferay-portal-ee/pull/224#issuecomment-382495392 (ee-6.2.x, PASSED)
https://github.com/kenjiheigel/liferay-portal-ee/pull/223#issuecomment-382498435 ((ee-6.1.x, PASSED)

master, ee-6.2.x and ee-6.1.x are all clean in testing. 7.0.x is stuck in traffic so I'll wait a bit before sending the backports 

@jpince, @timpak, this should resolve the Firefox 45 second timeout WebDriverException