### PR TITLE
LPS-79953 Adjust UADDisplay.java interface to accept a Locale

### DIFF
--- a/modules/apps/collaboration/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/display/AnnouncementsEntryUADDisplay.java
+++ b/modules/apps/collaboration/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/display/AnnouncementsEntryUADDisplay.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.user.associated.data.display.UADDisplay;
 
+import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -70,7 +71,7 @@ public class AnnouncementsEntryUADDisplay
 		return "Announcements posted by the user";
 	}
 
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "AnnouncementsEntry";
 	}
 

--- a/modules/apps/collaboration/blogs/blogs-uad/src/main/java/com/liferay/blogs/uad/display/BlogsEntryUADDisplay.java
+++ b/modules/apps/collaboration/blogs/blogs-uad/src/main/java/com/liferay/blogs/uad/display/BlogsEntryUADDisplay.java
@@ -25,6 +25,7 @@ import com.liferay.user.associated.data.display.UADDisplay;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -62,12 +63,7 @@ public class BlogsEntryUADDisplay implements UADDisplay<BlogsEntry> {
 	}
 
 	@Override
-	public String getTypeDescription() {
-		return "A blog post";
-	}
-
-	@Override
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "BlogsEntry";
 	}
 

--- a/modules/apps/collaboration/bookmarks/bookmarks-uad/src/main/java/com/liferay/bookmarks/uad/display/BookmarksEntryUADDisplay.java
+++ b/modules/apps/collaboration/bookmarks/bookmarks-uad/src/main/java/com/liferay/bookmarks/uad/display/BookmarksEntryUADDisplay.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.user.associated.data.display.UADDisplay;
 
+import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -69,7 +70,7 @@ public class BookmarksEntryUADDisplay implements UADDisplay<BookmarksEntry> {
 		return "A link to another page or website";
 	}
 
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "BookmarksEntry";
 	}
 

--- a/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/http/MBMessageServiceSoap.java
+++ b/modules/apps/collaboration/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/http/MBMessageServiceSoap.java
@@ -277,21 +277,6 @@ public class MBMessageServiceSoap {
 		}
 	}
 
-	public static com.liferay.message.boards.model.MBMessageDisplay getMessageDisplay(
-		long messageId, int status) throws RemoteException {
-		try {
-			com.liferay.message.boards.model.MBMessageDisplay returnValue = MBMessageServiceUtil.getMessageDisplay(messageId,
-					status);
-
-			return returnValue;
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-
-			throw new RemoteException(e.getMessage());
-		}
-	}
-
 	public static java.lang.String[] getTempAttachmentNames(long groupId,
 		java.lang.String folderName) throws RemoteException {
 		try {

--- a/modules/apps/collaboration/message-boards/message-boards-uad/src/main/java/com/liferay/message/boards/uad/display/MBCategoryUADDisplay.java
+++ b/modules/apps/collaboration/message-boards/message-boards-uad/src/main/java/com/liferay/message/boards/uad/display/MBCategoryUADDisplay.java
@@ -25,6 +25,7 @@ import com.liferay.user.associated.data.display.UADDisplay;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -62,12 +63,7 @@ public class MBCategoryUADDisplay implements UADDisplay<MBCategory> {
 	}
 
 	@Override
-	public String getTypeDescription() {
-		return "";
-	}
-
-	@Override
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "MBCategory";
 	}
 

--- a/modules/apps/collaboration/message-boards/message-boards-uad/src/main/java/com/liferay/message/boards/uad/display/MBMessageUADDisplay.java
+++ b/modules/apps/collaboration/message-boards/message-boards-uad/src/main/java/com/liferay/message/boards/uad/display/MBMessageUADDisplay.java
@@ -25,6 +25,7 @@ import com.liferay.user.associated.data.display.UADDisplay;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -62,12 +63,7 @@ public class MBMessageUADDisplay implements UADDisplay<MBMessage> {
 	}
 
 	@Override
-	public String getTypeDescription() {
-		return "";
-	}
-
-	@Override
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "MBMessage";
 	}
 

--- a/modules/apps/collaboration/wiki/wiki-uad/src/main/java/com/liferay/wiki/uad/display/WikiNodeUADDisplay.java
+++ b/modules/apps/collaboration/wiki/wiki-uad/src/main/java/com/liferay/wiki/uad/display/WikiNodeUADDisplay.java
@@ -25,6 +25,7 @@ import com.liferay.wiki.uad.constants.WikiUADConstants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -61,12 +62,7 @@ public class WikiNodeUADDisplay implements UADDisplay<WikiNode> {
 	}
 
 	@Override
-	public String getTypeDescription() {
-		return "A wiki node";
-	}
-
-	@Override
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "WikiNode";
 	}
 

--- a/modules/apps/collaboration/wiki/wiki-uad/src/main/java/com/liferay/wiki/uad/display/WikiPageUADDisplay.java
+++ b/modules/apps/collaboration/wiki/wiki-uad/src/main/java/com/liferay/wiki/uad/display/WikiPageUADDisplay.java
@@ -25,6 +25,7 @@ import com.liferay.wiki.uad.constants.WikiUADConstants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -61,12 +62,7 @@ public class WikiPageUADDisplay implements UADDisplay<WikiPage> {
 	}
 
 	@Override
-	public String getTypeDescription() {
-		return "A wiki page";
-	}
-
-	@Override
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "WikiPage";
 	}
 

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/model/upgrade/BaseKaleoUpgradeTableListener.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/model/upgrade/BaseKaleoUpgradeTableListener.java
@@ -44,7 +44,7 @@ public class BaseKaleoUpgradeTableListener extends BaseUpgradeTableListener {
 		ResultSet rs = null;
 
 		try {
-			con = DataAccess.getConnection();
+			con = DataAccess.getUpgradeOptimizedConnection();
 
 			ps = con.prepareStatement(
 				StringBundler.concat(

--- a/modules/apps/foundation/contacts/contacts-uad/src/main/java/com/liferay/contacts/uad/display/EntryUADDisplay.java
+++ b/modules/apps/foundation/contacts/contacts-uad/src/main/java/com/liferay/contacts/uad/display/EntryUADDisplay.java
@@ -25,6 +25,7 @@ import com.liferay.user.associated.data.display.UADDisplay;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -61,12 +62,7 @@ public class EntryUADDisplay implements UADDisplay<Entry> {
 	}
 
 	@Override
-	public String getTypeDescription() {
-		return "";
-	}
-
-	@Override
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "Entry";
 	}
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-api/src/main/java/com/liferay/user/associated/data/display/UADDisplay.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-api/src/main/java/com/liferay/user/associated/data/display/UADDisplay.java
@@ -37,8 +37,6 @@ public interface UADDisplay<T> {
 
 	public Map<String, Object> getNonanonymizableFieldValues(T t);
 
-	public String getTypeDescription();
-
 	public String getTypeName();
 
 }

--- a/modules/apps/foundation/user-associated-data/user-associated-data-api/src/main/java/com/liferay/user/associated/data/display/UADDisplay.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-api/src/main/java/com/liferay/user/associated/data/display/UADDisplay.java
@@ -17,6 +17,7 @@ package com.liferay.user.associated.data.display;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -37,6 +38,6 @@ public interface UADDisplay<T> {
 
 	public Map<String, Object> getNonanonymizableFieldValues(T t);
 
-	public String getTypeName();
+	public String getTypeName(Locale locale);
 
 }

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADDisplayTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADDisplayTestCase.java
@@ -48,12 +48,6 @@ public abstract class BaseUADDisplayTestCase<T> {
 	}
 
 	@Test
-	public void testGetTypeDescription() {
-		Assert.assertEquals(
-			getTypeDescription(), _uadDisplay.getTypeDescription());
-	}
-
-	@Test
 	public void testGetTypeName() throws Exception {
 		BaseModel baseModel = addBaseModel(_user.getUserId());
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADDisplayTestCase.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-test-util/src/main/java/com/liferay/user/associated/data/test/util/BaseUADDisplayTestCase.java
@@ -14,16 +14,16 @@
 
 package com.liferay.user.associated.data.test.util;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.user.associated.data.aggregator.UADAggregator;
 import com.liferay.user.associated.data.display.UADDisplay;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,13 +48,10 @@ public abstract class BaseUADDisplayTestCase<T> {
 	}
 
 	@Test
-	public void testGetTypeName() throws Exception {
-		BaseModel baseModel = addBaseModel(_user.getUserId());
-
-		String simpleClassName = StringUtil.extractLast(
-			baseModel.getModelClassName(), StringPool.PERIOD);
-
-		Assert.assertEquals(simpleClassName, _uadDisplay.getTypeName());
+	public void testGetTypeName() {
+		Assert.assertTrue(
+			"The type name should not be null",
+			Validator.isNotNull(_uadDisplay.getTypeName(Locale.US)));
 	}
 
 	protected abstract BaseModel<?> addBaseModel(long userId) throws Exception;

--- a/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/controller/UADApplicationExportController.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/controller/UADApplicationExportController.java
@@ -147,7 +147,7 @@ public class UADApplicationExportController {
 
 		sb.append(uadDisplay.getApplicationName());
 		sb.append(StringPool.FORWARD_SLASH);
-		sb.append(uadDisplay.getTypeName());
+		sb.append(uadRegistryKey);
 		sb.append(StringPool.FORWARD_SLASH);
 		sb.append(fileName);
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.user.associated.data.aggregator.UADAggregator;
@@ -103,7 +104,9 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 				_getSearchContainer(
 					renderRequest, currentURL, uadRegistryKey, uadDisplay,
 					selectedUser.getUserId(), liferayPortletResponse));
-			viewUADEntitiesDisplay.setTypeName(uadDisplay.getTypeName());
+			viewUADEntitiesDisplay.setTypeName(
+				uadDisplay.getTypeName(
+					LocaleThreadLocal.getThemeDisplayLocale()));
 
 			viewUADEntitiesDisplay.setUADRegistryKey(uadRegistryKey);
 
@@ -168,7 +171,9 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 						uadRegistryKey.equals(uadDisplay.getKey()));
 					navigationItem.setHref(
 						tabPortletURL, "uadRegistryKey", uadDisplay.getKey());
-					navigationItem.setLabel(uadDisplay.getTypeName());
+					navigationItem.setLabel(
+						uadDisplay.getTypeName(
+							LocaleThreadLocal.getThemeDisplayLocale()));
 				});
 		}
 

--- a/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -25,7 +25,7 @@ UADDisplay uadDisplay = (UADDisplay)request.getAttribute(UADWebKeys.INFO_PANEL_U
 	<c:choose>
 		<c:when test="<%= ListUtil.isEmpty(uadEntities) %>">
 			<div class="sidebar-header">
-				<h3 class="sidebar-title"><%= uadDisplay.getTypeName() %></h3>
+				<h3 class="sidebar-title"><%= uadDisplay.getTypeName(locale) %></h3>
 				<h5 class="sidebar-subtitle"><%= uadDisplay.getApplicationName() %></h5>
 			</div>
 		</c:when>
@@ -49,7 +49,7 @@ UADDisplay uadDisplay = (UADDisplay)request.getAttribute(UADWebKeys.INFO_PANEL_U
 
 				<h3 class="sidebar-title"><%= StringUtil.shorten(String.valueOf(displayValues.get(identifierFieldName)), 200) %></h3>
 
-				<h5 class="sidebar-subtitle"><%= uadDisplay.getTypeName() %></h5>
+				<h5 class="sidebar-subtitle"><%= uadDisplay.getTypeName(locale) %></h5>
 			</div>
 
 			<div class="sidebar-body">
@@ -74,7 +74,7 @@ UADDisplay uadDisplay = (UADDisplay)request.getAttribute(UADWebKeys.INFO_PANEL_U
 		</c:when>
 		<c:when test="<%= ListUtil.isNotEmpty(uadEntities) && (uadEntities.size() > 1) %>">
 			<div class="sidebar-header">
-				<h3 class="sidebar-title"><%= uadDisplay.getTypeName() %></h3>
+				<h3 class="sidebar-title"><%= uadDisplay.getTypeName(locale) %></h3>
 				<h5 class="sidebar-subtitle"><liferay-ui:message arguments="<%= uadEntities.size() %>" key="x-items-are-selected" /></h5>
 			</div>
 		</c:when>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/uad_display.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/uad_display.ftl
@@ -7,6 +7,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.user.associated.data.display.UADDisplay;
 
+import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -46,12 +47,7 @@ public class ${entity.name}UADDisplay implements UADDisplay<${entity.name}> {
 	}
 
 	@Override
-	public String getTypeDescription() {
-		return "${entity.UADTypeDescription}";
-	}
-
-	@Override
-	public String getTypeName() {
+	public String getTypeName(Locale locale) {
 		return "${entity.name}";
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyAuditedModel.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyAuditedModel.java
@@ -282,7 +282,7 @@ public class VerifyAuditedModel extends VerifyProcess {
 
 			long previousCompanyId = 0;
 
-			try (Connection con = DataAccess.getConnection();
+			try (Connection con = DataAccess.getUpgradeOptimizedConnection();
 				PreparedStatement ps1 = con.prepareStatement(sb.toString());
 				ResultSet rs = ps1.executeQuery();
 				PreparedStatement ps2 =

--- a/portal-impl/src/com/liferay/portal/verify/VerifyGroupedModel.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyGroupedModel.java
@@ -152,7 +152,7 @@ public class VerifyGroupedModel extends VerifyProcess {
 			sb.append(verifiableGroupedModel.getTableName());
 			sb.append(" where groupId is null");
 
-			try (Connection con = DataAccess.getConnection();
+			try (Connection con = DataAccess.getUpgradeOptimizedConnection();
 				PreparedStatement ps1 = con.prepareStatement(sb.toString());
 				ResultSet rs = ps1.executeQuery()) {
 

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcess.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcess.java
@@ -66,7 +66,7 @@ public abstract class VerifyProcess extends BaseDBProcess {
 			_log.info("Verifying " + ClassUtil.getClassName(this));
 		}
 
-		try (Connection con = DataAccess.getConnection()) {
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection()) {
 			connection = con;
 
 			doVerify();

--- a/portal-impl/src/com/liferay/portal/verify/VerifyResourcePermissions.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyResourcePermissions.java
@@ -231,7 +231,7 @@ public class VerifyResourcePermissions extends VerifyProcess {
 
 		try (LoggingTimer loggingTimer = new LoggingTimer(
 				verifiableResourcedModel.getTableName());
-			Connection con = DataAccess.getConnection();
+			Connection con = DataAccess.getUpgradeOptimizedConnection();
 			PreparedStatement ps = con.prepareStatement(
 				_getVerifyResourcedModelSQL(
 					true, verifiableResourcedModel, role));
@@ -244,7 +244,7 @@ public class VerifyResourcePermissions extends VerifyProcess {
 
 		try (LoggingTimer loggingTimer = new LoggingTimer(
 				verifiableResourcedModel.getTableName());
-			Connection con = DataAccess.getConnection();
+			Connection con = DataAccess.getUpgradeOptimizedConnection();
 			PreparedStatement ps = con.prepareStatement(
 				_getVerifyResourcedModelSQL(
 					false, verifiableResourcedModel, role));

--- a/portal-impl/src/com/liferay/portal/verify/VerifyUUID.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyUUID.java
@@ -87,7 +87,7 @@ public class VerifyUUID extends VerifyProcess {
 
 		try (LoggingTimer loggingTimer = new LoggingTimer(
 				verifiableUUIDModel.getTableName());
-			Connection con = DataAccess.getConnection();
+			Connection con = DataAccess.getUpgradeOptimizedConnection();
 			PreparedStatement ps1 = con.prepareStatement(
 				StringBundler.concat(
 					"select ", verifiableUUIDModel.getPrimaryKeyColumnName(),

--- a/portal-impl/test/integration/com/liferay/portal/kernel/upgrade/BaseUpgradePortletIdTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/kernel/upgrade/BaseUpgradePortletIdTest.java
@@ -92,7 +92,7 @@ public class BaseUpgradePortletIdTest extends BaseUpgradePortletId {
 
 	@After
 	public void tearDown() throws Exception {
-		try (Connection con = DataAccess.getConnection()) {
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection()) {
 			connection = con;
 
 			String[][] renamePortletIdsArray = getRenamePortletIdsArray();

--- a/portal-impl/test/integration/com/liferay/portal/upgrade/v7_0_0/UpgradeKernelPackageTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/upgrade/v7_0_0/UpgradeKernelPackageTest.java
@@ -49,7 +49,7 @@ public class UpgradeKernelPackageTest extends UpgradeKernelPackage {
 
 	@Before
 	public void setUp() throws Exception {
-		connection = DataAccess.getConnection();
+		connection = DataAccess.getUpgradeOptimizedConnection();
 
 		runSQL("insert into Counter values('" + _OLD_CLASS_NAME + "', 10)");
 

--- a/portal-impl/test/integration/com/liferay/portal/upgrade/v7_0_3/UpgradeOracleTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/upgrade/v7_0_3/UpgradeOracleTest.java
@@ -111,7 +111,7 @@ public class UpgradeOracleTest {
 	protected int getCharLength(String tableName, String columnName)
 		throws Exception {
 
-		try (Connection connection = DataAccess.getConnection();
+		try (Connection connection = DataAccess.getUpgradeOptimizedConnection();
 			PreparedStatement ps = connection.prepareStatement(
 				StringBundler.concat(
 					"select char_length from user_tab_columns where ",
@@ -129,7 +129,7 @@ public class UpgradeOracleTest {
 	protected String getCharUsed(String tableName, String columnName)
 		throws Exception {
 
-		try (Connection connection = DataAccess.getConnection();
+		try (Connection connection = DataAccess.getUpgradeOptimizedConnection();
 			PreparedStatement ps = connection.prepareStatement(
 				StringBundler.concat(
 					"select char_used from user_tab_columns where table_name ",

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradeCompanyId.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseUpgradeCompanyId.java
@@ -94,7 +94,8 @@ public abstract class BaseUpgradeCompanyId extends UpgradeProcess {
 		@Override
 		public final Void call() throws Exception {
 			try (LoggingTimer loggingTimer = new LoggingTimer(_tableName);
-				Connection connection = DataAccess.getConnection()) {
+				Connection connection =
+				DataAccess.getUpgradeOptimizedConnection()) {
 
 				if (_createCompanyIdColumn) {
 					if (_log.isInfoEnabled()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeProcess.java
@@ -86,7 +86,7 @@ public abstract class UpgradeProcess
 			_log.info("Upgrading " + ClassUtil.getClassName(this));
 		}
 
-		try (Connection con = DataAccess.getConnection()) {
+		try (Connection con = DataAccess.getUpgradeOptimizedConnection()) {
 			connection = con;
 
 			doUpgrade();


### PR DESCRIPTION
This is an update for [LPS-79953](https://issues.liferay.com/browse/LPS-79953).<br><br>Hey Brian, this updates the UADDisplay API to take in a locale so that each display can return translated entity type names.  It does not actually implement the translation for each module, but just fixes compile errors.<br><br>/cc @pei-jung @willnewbury