### PR TITLE
LPS-79348 additional commits

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/document/AssetEntryDocumentContributor.java
+++ b/modules/apps/foundation/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/contributor/document/AssetEntryDocumentContributor.java
@@ -73,9 +73,7 @@ public class AssetEntryDocumentContributor implements DocumentContributor {
 				Field.EXPIRATION_DATE, assetEntry.getExpirationDate());
 		}
 		else {
-			document.addDate(
-				Field.EXPIRATION_DATE,
-				new Date(System.currentTimeMillis() + (Time.YEAR * 1000)));
+			document.addDate(Field.EXPIRATION_DATE, new Date(Long.MAX_VALUE));
 		}
 
 		if (!document.hasField(Field.MODIFIED_DATE)) {


### PR DESCRIPTION
change back to long.max_val since it's not neccesary because adding to indexin engine with a document will later be handled, so that the date will be truncated to less than 10000 year