### PR TITLE
LPS-79250 Skip stale background tasks (from companies already deleted)

### DIFF
--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskManagerImpl.java
@@ -403,6 +403,7 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 		return translate(backgroundTasks);
 	}
 
+	@Override
 	public List<BackgroundTask> getBackgroundTasks(
 		long[] groupIds, String name, String[] taskExecutorClassNames,
 		int start, int end,
@@ -573,6 +574,7 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 			groupIds, name, taskExecutorClassName, completed);
 	}
 
+	@Override
 	public int getBackgroundTasksCount(
 		long[] groupIds, String name, String[] taskExecutorClassNames) {
 
@@ -608,7 +610,7 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 			new BackgroundTaskMessageListener(
 				_backgroundTaskExecutorRegistry, this,
 				_backgroundTaskStatusRegistry,
-				_backgroundTaskThreadLocalManager, _messageBus);
+				_backgroundTaskThreadLocalManager, _lockManager, _messageBus);
 
 		backgroundTaskDestination.register(backgroundTaskMessageListener);
 
@@ -748,6 +750,9 @@ public class BackgroundTaskManagerImpl implements BackgroundTaskManager {
 
 	@Reference
 	private DestinationFactory _destinationFactory;
+
+	@Reference
+	private LockManager _lockManager;
 
 	@Reference
 	private MessageBus _messageBus;

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/SerialBackgroundTaskExecutor.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/SerialBackgroundTaskExecutor.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal;
+
+import com.liferay.portal.background.task.internal.lock.BackgroundTaskLockHelper;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskLockHelperUtil;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.backgroundtask.DelegatingBackgroundTaskExecutor;
+import com.liferay.portal.kernel.lock.DuplicateLockException;
+import com.liferay.portal.kernel.lock.Lock;
+import com.liferay.portal.kernel.lock.LockManager;
+
+/**
+ * @author Michael C. Han
+ */
+public class SerialBackgroundTaskExecutor
+	extends DelegatingBackgroundTaskExecutor {
+
+	public SerialBackgroundTaskExecutor(
+		BackgroundTaskExecutor backgroundTaskExecutor,
+		LockManager lockManager) {
+
+		super(backgroundTaskExecutor);
+
+		_lockManager = lockManager;
+	}
+
+	@Override
+	public BackgroundTaskExecutor clone() {
+		return new SerialBackgroundTaskExecutor(
+			getBackgroundTaskExecutor(), _lockManager);
+	}
+
+	@Override
+	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
+		throws Exception {
+
+		Lock lock = null;
+
+		try {
+			if (isSerial()) {
+				lock = acquireLock(backgroundTask);
+			}
+
+			BackgroundTaskExecutor backgroundTaskExecutor =
+				getBackgroundTaskExecutor();
+
+			return backgroundTaskExecutor.execute(backgroundTask);
+		}
+		finally {
+			if (lock != null) {
+				BackgroundTaskLockHelperUtil.unlockBackgroundTask(
+					backgroundTask);
+			}
+		}
+	}
+
+	protected Lock acquireLock(BackgroundTask backgroundTask)
+		throws DuplicateLockException {
+
+		BackgroundTaskLockHelper backgroundTaskLockHelper =
+			new BackgroundTaskLockHelper(_lockManager);
+
+		Lock lock = backgroundTaskLockHelper.lockBackgroundTask(backgroundTask);
+
+		if (!lock.isNew()) {
+			throw new DuplicateLockException(lock);
+		}
+
+		return lock;
+	}
+
+	private final LockManager _lockManager;
+
+}

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/StaleBackgroundTaskException.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/StaleBackgroundTaskException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal;
+
+/**
+ * @author André de Oliveira
+ */
+public class StaleBackgroundTaskException extends RuntimeException {
+
+	public StaleBackgroundTaskException(String msg) {
+		super(msg);
+	}
+
+}

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutor.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutor.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal;
+
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocalManager;
+import com.liferay.portal.kernel.backgroundtask.DelegatingBackgroundTaskExecutor;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+/**
+ * @author Michael C. Han
+ */
+public class ThreadLocalAwareBackgroundTaskExecutor
+	extends DelegatingBackgroundTaskExecutor {
+
+	public ThreadLocalAwareBackgroundTaskExecutor(
+		BackgroundTaskExecutor backgroundTaskExecutor,
+		BackgroundTaskThreadLocalManager backgroundTaskThreadLocalManager) {
+
+		super(backgroundTaskExecutor);
+
+		_backgroundTaskThreadLocalManager = backgroundTaskThreadLocalManager;
+	}
+
+	@Override
+	public BackgroundTaskExecutor clone() {
+		BackgroundTaskExecutor backgroundTaskExecutor =
+			new ThreadLocalAwareBackgroundTaskExecutor(
+				getBackgroundTaskExecutor(), _backgroundTaskThreadLocalManager);
+
+		return backgroundTaskExecutor;
+	}
+
+	@Override
+	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
+		throws Exception {
+
+		Map<String, Serializable> threadLocalValues =
+			_backgroundTaskThreadLocalManager.getThreadLocalValues();
+
+		try {
+			try {
+				_backgroundTaskThreadLocalManager.deserializeThreadLocals(
+					backgroundTask.getTaskContextMap());
+			}
+			catch (StaleBackgroundTaskException sbte) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						"Skipped stale background task " + backgroundTask,
+						sbte);
+				}
+
+				return BackgroundTaskResult.SUCCESS;
+			}
+
+			return super.execute(backgroundTask);
+		}
+		finally {
+			_backgroundTaskThreadLocalManager.setThreadLocalValues(
+				threadLocalValues);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ThreadLocalAwareBackgroundTaskExecutor.class);
+
+	private final BackgroundTaskThreadLocalManager
+		_backgroundTaskThreadLocalManager;
+
+}

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/lock/BackgroundTaskLockHelper.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/lock/BackgroundTaskLockHelper.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal.lock;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutorRegistryUtil;
+import com.liferay.portal.kernel.lock.Lock;
+import com.liferay.portal.kernel.lock.LockManager;
+
+/**
+ * @author Daniel Kocsis
+ */
+public class BackgroundTaskLockHelper {
+
+	public BackgroundTaskLockHelper(LockManager lockManager) {
+		_lockManager = lockManager;
+	}
+
+	public boolean isLockedBackgroundTask(BackgroundTask backgroundTask) {
+		return _lockManager.isLocked(
+			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask));
+	}
+
+	public Lock lockBackgroundTask(BackgroundTask backgroundTask) {
+		String owner =
+			backgroundTask.getName() + StringPool.POUND +
+				backgroundTask.getBackgroundTaskId();
+
+		return _lockManager.lock(
+			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask),
+			owner);
+	}
+
+	public void unlockBackgroundTask(BackgroundTask backgroundTask) {
+		String owner =
+			backgroundTask.getName() + StringPool.POUND +
+				backgroundTask.getBackgroundTaskId();
+
+		_lockManager.unlock(
+			BackgroundTaskExecutor.class.getName(), getLockKey(backgroundTask),
+			owner);
+	}
+
+	protected static String getLockKey(BackgroundTask backgroundTask) {
+		BackgroundTaskExecutor backgroundTaskExecutor =
+			BackgroundTaskExecutorRegistryUtil.getBackgroundTaskExecutor(
+				backgroundTask.getTaskExecutorClassName());
+
+		String lockKey = StringPool.BLANK;
+
+		if (backgroundTaskExecutor.getIsolationLevel() ==
+				BackgroundTaskConstants.ISOLATION_LEVEL_CLASS) {
+
+			lockKey = backgroundTask.getTaskExecutorClassName();
+		}
+		else if (backgroundTaskExecutor.getIsolationLevel() ==
+					BackgroundTaskConstants.ISOLATION_LEVEL_COMPANY) {
+
+			lockKey =
+				backgroundTask.getTaskExecutorClassName() + StringPool.POUND +
+					backgroundTask.getCompanyId();
+		}
+		else if (backgroundTaskExecutor.getIsolationLevel() ==
+					BackgroundTaskConstants.ISOLATION_LEVEL_CUSTOM) {
+
+			lockKey = backgroundTaskExecutor.generateLockKey(backgroundTask);
+		}
+		else if (backgroundTaskExecutor.getIsolationLevel() ==
+					BackgroundTaskConstants.ISOLATION_LEVEL_GROUP) {
+
+			lockKey =
+				backgroundTask.getTaskExecutorClassName() + StringPool.POUND +
+					backgroundTask.getGroupId();
+		}
+		else if (backgroundTaskExecutor.getIsolationLevel() ==
+					BackgroundTaskConstants.ISOLATION_LEVEL_TASK_NAME) {
+
+			lockKey =
+				backgroundTask.getTaskExecutorClassName() + StringPool.POUND +
+					backgroundTask.getName();
+		}
+		else {
+			lockKey =
+				backgroundTask.getTaskExecutorClassName() + StringPool.POUND +
+					backgroundTaskExecutor.getIsolationLevel();
+		}
+
+		return lockKey;
+	}
+
+	private final LockManager _lockManager;
+
+}

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.background.task.internal.messaging;
 
+import com.liferay.portal.background.task.internal.SerialBackgroundTaskExecutor;
+import com.liferay.portal.background.task.internal.ThreadLocalAwareBackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
@@ -25,10 +27,9 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskStatusRegistry;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocalManager;
 import com.liferay.portal.kernel.backgroundtask.ClassLoaderAwareBackgroundTaskExecutor;
-import com.liferay.portal.kernel.backgroundtask.SerialBackgroundTaskExecutor;
-import com.liferay.portal.kernel.backgroundtask.ThreadLocalAwareBackgroundTaskExecutor;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.lock.DuplicateLockException;
+import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
@@ -53,12 +54,13 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 		BackgroundTaskManager backgroundTaskManager,
 		BackgroundTaskStatusRegistry backgroundTaskStatusRegistry,
 		BackgroundTaskThreadLocalManager backgroundTaskThreadLocalManager,
-		MessageBus messageBus) {
+		LockManager lockManager, MessageBus messageBus) {
 
 		_backgroundTaskExecutorRegistry = backgroundTaskExecutorRegistry;
 		_backgroundTaskManager = backgroundTaskManager;
 		_backgroundTaskStatusRegistry = backgroundTaskStatusRegistry;
 		_backgroundTaskThreadLocalManager = backgroundTaskThreadLocalManager;
+		_lockManager = lockManager;
 		_messageBus = messageBus;
 	}
 
@@ -278,7 +280,7 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 
 		if (backgroundTaskExecutor.isSerial()) {
 			backgroundTaskExecutor = new SerialBackgroundTaskExecutor(
-				backgroundTaskExecutor);
+				backgroundTaskExecutor, _lockManager);
 		}
 
 		backgroundTaskExecutor = new ThreadLocalAwareBackgroundTaskExecutor(
@@ -296,6 +298,7 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 	private final BackgroundTaskStatusRegistry _backgroundTaskStatusRegistry;
 	private final BackgroundTaskThreadLocalManager
 		_backgroundTaskThreadLocalManager;
+	private final LockManager _lockManager;
 	private final MessageBus _messageBus;
 
 }

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
@@ -18,11 +18,13 @@ import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.cache.thread.local.Lifecycle;
 import com.liferay.portal.kernel.cache.thread.local.ThreadLocalCacheManager;
 import com.liferay.portal.kernel.cluster.ClusterInvokeThreadLocal;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
@@ -49,6 +51,18 @@ public abstract class BaseBackgroundTaskTestCase {
 	public void setUp() throws Exception {
 		backgroundTaskThreadLocalManagerImpl =
 			new BackgroundTaskThreadLocalManagerImpl();
+
+		CompanyLocalService companyLocalService = Mockito.mock(
+			CompanyLocalService.class);
+
+		Mockito.when(
+			companyLocalService.fetchCompany(Mockito.anyLong())
+		).thenReturn(
+			Mockito.mock(Company.class)
+		);
+
+		backgroundTaskThreadLocalManagerImpl.companyLocalService =
+			companyLocalService;
 
 		PermissionCheckerFactory permissionCheckerFactory = Mockito.mock(
 			PermissionCheckerFactory.class);

--- a/modules/apps/foundation/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutorTest.java
+++ b/modules/apps/foundation/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutorTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.background.task.internal;
+
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author André de Oliveira
+ */
+public class ThreadLocalAwareBackgroundTaskExecutorTest
+	extends BaseBackgroundTaskTestCase {
+
+	@Test
+	public void testStaleBackgroundTaskIsSkipped() throws Exception {
+		CompanyLocalService companyLocalService = Mockito.mock(
+			CompanyLocalService.class);
+
+		Mockito.when(
+			companyLocalService.fetchCompany(Mockito.anyLong())
+		).thenReturn(
+			null
+		);
+
+		backgroundTaskThreadLocalManagerImpl.companyLocalService =
+			companyLocalService;
+
+		BackgroundTaskExecutor backgroundTaskExecutor = Mockito.mock(
+			BackgroundTaskExecutor.class);
+
+		ThreadLocalAwareBackgroundTaskExecutor
+			threadLocalAwareBackgroundTaskExecutor =
+				new ThreadLocalAwareBackgroundTaskExecutor(
+					backgroundTaskExecutor,
+					backgroundTaskThreadLocalManagerImpl);
+
+		BackgroundTask backgroundTask = Mockito.mock(BackgroundTask.class);
+
+		Mockito.when(
+			backgroundTask.getTaskContextMap()
+		).thenReturn(
+			Collections.singletonMap(
+				BackgroundTaskThreadLocalManagerImpl.KEY_THREAD_LOCAL_VALUES,
+				(Serializable)new HashMap<>(
+					Collections.singletonMap("companyId", 1)))
+		);
+
+		BackgroundTaskResult backgroundTaskResult =
+			threadLocalAwareBackgroundTaskExecutor.execute(backgroundTask);
+
+		Assert.assertTrue(backgroundTaskResult.isSuccessful());
+
+		Mockito.verifyZeroInteractions(backgroundTaskExecutor);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTaskLockHelperUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTaskLockHelperUtil.java
@@ -22,7 +22,10 @@ import com.liferay.portal.kernel.lock.LockManagerUtil;
 
 /**
  * @author Daniel Kocsis
+ * @deprecated As of 7.0.0, moved to {@link
+ *             com.liferay.portal.background.task.internal.lock.BackgroundTaskLockHelper}
  */
+@Deprecated
 @ProviderType
 public class BackgroundTaskLockHelperUtil {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/SerialBackgroundTaskExecutor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/SerialBackgroundTaskExecutor.java
@@ -19,7 +19,10 @@ import com.liferay.portal.kernel.lock.Lock;
 
 /**
  * @author Michael C. Han
+ * @deprecated As of 7.0.0, moved to {@link
+ *             com.liferay.portal.background.task.internal.SerialBackgroundTaskExecutor}
  */
+@Deprecated
 public class SerialBackgroundTaskExecutor
 	extends DelegatingBackgroundTaskExecutor {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/ThreadLocalAwareBackgroundTaskExecutor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/ThreadLocalAwareBackgroundTaskExecutor.java
@@ -20,7 +20,10 @@ import java.util.Map;
 
 /**
  * @author Michael C. Han
+ * @deprecated As of 7.0.0, moved to {@link
+ *             com.liferay.portal.background.task.internal.ThreadLocalAwareBackgroundTaskExecutor}
  */
+@Deprecated
 public class ThreadLocalAwareBackgroundTaskExecutor
 	extends DelegatingBackgroundTaskExecutor {
 


### PR DESCRIPTION
@mhan810 @BryanEngler I decided for a less aggressive approach, quietly skipping over stale background tasks instead of proactively deleting them. This made the fix much smaller and allowed me to cover it with a unit test.

----

@brianchandotcom  CI results: at least 6 "Failures unique to this pull", however apparently false negatives given present CI circumstances. https://github.com/arboliveira/liferay-portal/pull/465#issuecomment-384441435

[1.]
Several functional test failures due to `LocalFile` errors observed elsewhere, not sure why being reported as "unique to this pull".

[2.]
`source-format-jdk8` failure: `./modules/apps/social-private-messaging/social-private-messaging-api/src/main/resources/com/liferay/social/privatemessaging/configuration/packageinfo expected:<null> but was:<version 2.0.0>`

[3.]
`modules-unit-jdk8`: several compile errors in `analytics-client-impl`. 
```
/opt/dev/projects/github/liferay-portal/modules/apps/foundation/analytics/analytics-client-impl/src/main/java/com/liferay/analytics/client/impl/AnalyticsClientImpl.java:23: error: package com.liferay.portal.kernel.util does not exist
     [exec] import com.liferay.portal.kernel.util.GetterUtil;
```

[4.]
`unit-jdk8`: unrelated failures in `AutoDeleteFileInputStreamTest`, including `com.liferay.portal.kernel.io.AutoDeleteFileInputStream is not fully covered`.

----

https://issues.liferay.com/browse/LPS-79250
