### PR TITLE
OAUTH2-124 Unexpected behaviour in GetterUtil.getString()

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/authorize/AuthorizationCodeGrantServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/authorize/AuthorizationCodeGrantServiceContainerRequestFilter.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.servlet.ProtectedPrincipal;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -86,7 +85,7 @@ public class AuthorizationCodeGrantServiceContainerRequestFilter
 						@Override
 						public Principal getUserPrincipal() {
 							return new ProtectedPrincipal(
-								GetterUtil.getString(user.getUserId()));
+								Long.toString(user.getUserId()));
 						}
 
 						@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -432,7 +432,7 @@ public class LiferayOAuthDataProvider
 
 			extraProperties.put(
 				OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
-				GetterUtil.getString(oAuth2Authorization.getCompanyId()));
+				Long.toString(oAuth2Authorization.getCompanyId()));
 
 			return refreshToken;
 		}
@@ -621,7 +621,7 @@ public class LiferayOAuthDataProvider
 
 		UserSubject userSubject = serverAccessToken.getSubject();
 
-		userSubject.setId(GetterUtil.getString(accessToken.getUserId()));
+		userSubject.setId(Long.toString(accessToken.getUserId()));
 		userSubject.setLogin(accessToken.getUserName());
 
 		return serverAccessToken;
@@ -659,7 +659,7 @@ public class LiferayOAuthDataProvider
 
 		UserSubject userSubject = cxfRefreshToken.getSubject();
 
-		userSubject.setId(GetterUtil.getString(refreshToken.getUserId()));
+		userSubject.setId(Long.toString(refreshToken.getUserId()));
 		userSubject.setLogin(refreshToken.getUserName());
 
 		return cxfRefreshToken;
@@ -705,7 +705,7 @@ public class LiferayOAuthDataProvider
 
 		UserSubject userSubject = serverAccessToken.getSubject();
 
-		userSubject.setId(GetterUtil.getString(accessToken.getUserId()));
+		userSubject.setId(Long.toString(accessToken.getUserId()));
 		userSubject.setLogin(accessToken.getUserName());
 
 		return serverAccessToken;
@@ -768,7 +768,7 @@ public class LiferayOAuthDataProvider
 
 		extraProperties.put(
 			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
-			GetterUtil.getString(oAuth2Authorization.getCompanyId()));
+			Long.toString(oAuth2Authorization.getCompanyId()));
 
 		return serverAccessToken;
 	}
@@ -865,7 +865,7 @@ public class LiferayOAuthDataProvider
 
 		properties.put(
 			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
-			GetterUtil.getString(oAuth2Application.getCompanyId()));
+			Long.toString(oAuth2Application.getCompanyId()));
 		properties.put(
 			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_CLIENT_FEATURES,
 			oAuth2Application.getFeatures());
@@ -885,13 +885,13 @@ public class LiferayOAuthDataProvider
 		long companyId, long userId, String username) {
 
 		UserSubject userSubject = new UserSubject(
-			username, GetterUtil.getString(userId));
+			username, Long.toString(userId));
 
 		Map<String, String> properties = userSubject.getProperties();
 
 		properties.put(
 			OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
-			GetterUtil.getString(companyId));
+			Long.toString(companyId));
 
 		return userSubject;
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayResourceOwnerLoginHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayResourceOwnerLoginHandler.java
@@ -55,13 +55,13 @@ public class LiferayResourceOwnerLoginHandler
 			}
 
 			UserSubject userSubject = new UserSubject(
-				user.getLogin(), GetterUtil.getString(user.getUserId()));
+				user.getLogin(), Long.toString(user.getUserId()));
 
 			Map<String, String> properties = userSubject.getProperties();
 
 			properties.put(
 				OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
-				GetterUtil.getString(user.getCompanyId()));
+				Long.toString(user.getCompanyId()));
 
 			return userSubject;
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferaySubjectCreator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferaySubjectCreator.java
@@ -56,13 +56,13 @@ public class LiferaySubjectCreator implements SubjectCreator {
 				GetterUtil.getLong(userPrincipal.getName()));
 
 			UserSubject userSubject = new UserSubject(
-				user.getLogin(), GetterUtil.getString(user.getUserId()));
+				user.getLogin(), Long.toString(user.getUserId()));
 
 			Map<String, String> properties = userSubject.getProperties();
 
 			properties.put(
 				OAuth2ProviderRestEndpointConstants.PROPERTY_KEY_COMPANY_ID,
-				GetterUtil.getString(user.getCompanyId()));
+				Long.toString(user.getCompanyId()));
 
 			return userSubject;
 		}


### PR DESCRIPTION
Hi Brian. `GetterUtil.getString(Object value)` returns `null` when the argument is not a String object, which is not what is required here, and causes a regression.

Maybe this GetterUtil method needs a review because other methods do type conversion. Even `getStringValues(Object[] values, String[] defaultValue)`.

/cc @topolik @csierra