### PR TITLE
Revert "LPS-79982 use length of encoded URL when shortening URLs"

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -2077,8 +2077,6 @@ public class HttpImpl implements Http {
 
 			String redirect = redirectParam.substring(pos + 1);
 
-			int encodedRedirectLength = redirect.length();
-
 			try {
 				redirect = URLCodec.decodeURL(redirect, StringPool.UTF8);
 			}
@@ -2099,7 +2097,7 @@ public class HttpImpl implements Http {
 			redirect = URLCodec.encodeURL(
 				_shortenURL(redirect, currentLength + newLength));
 
-			newLength += encodedRedirectLength;
+			newLength += redirect.length();
 
 			if ((currentLength + newLength) > URL_MAXIMUM_LENGTH) {
 				sb.setIndex(sb.index() - 2);


### PR DESCRIPTION
This reverts commit 9ce67658cfec798c42e136e630117f8155d11ae4.

@dsanz your change broke HttpImplTest, please fix it and resend.