### PR TITLE
LPS-77819 Search results: Creation Date formatted with current display Locale

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.FastDateFormatFactory;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -312,6 +313,8 @@ public class SearchResultsPortlet
 			assetRendererFactoryLookup);
 		searchResultSummaryDisplayBuilder.setCurrentURL(portletURL.toString());
 		searchResultSummaryDisplayBuilder.setDocument(document);
+		searchResultSummaryDisplayBuilder.setFastDateFormatFactory(
+			fastDateFormatFactory);
 		searchResultSummaryDisplayBuilder.setHighlightEnabled(
 			searchResultsPortletPreferences.isHighlightEnabled());
 		searchResultSummaryDisplayBuilder.setImageRequested(true);
@@ -443,6 +446,9 @@ public class SearchResultsPortlet
 	protected AssetEntryLocalService assetEntryLocalService;
 
 	protected AssetRendererFactoryLookup assetRendererFactoryLookup;
+
+	@Reference
+	protected FastDateFormatFactory fastDateFormatFactory;
 
 	@Reference
 	protected Http http;

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/resources/META-INF/resources/main_search.jspf
@@ -96,6 +96,7 @@ Hits hits = searchDisplayContext.getHits();
 				searchResultSummaryDisplayBuilder.setAssetEntryLocalService(com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil.getService());
 				searchResultSummaryDisplayBuilder.setCurrentURL(currentURL);
 				searchResultSummaryDisplayBuilder.setDocument(document);
+				searchResultSummaryDisplayBuilder.setFastDateFormatFactory(com.liferay.portal.kernel.util.FastDateFormatFactoryUtil.getFastDateFormatFactory());
 				searchResultSummaryDisplayBuilder.setHighlightEnabled(searchDisplayContext.isHighlightEnabled());
 				searchResultSummaryDisplayBuilder.setLanguage(com.liferay.portal.kernel.language.LanguageUtil.getLanguage());
 				searchResultSummaryDisplayBuilder.setLocale(locale);


### PR DESCRIPTION
CI results: 5 "Failures unique to this pull", apparently false negatives. https://github.com/arboliveira/liferay-portal/pull/470#issuecomment-385133335

[1.] 
Nexus hiccup.
```
> Could not GET 'http://repository.liferay.com/nexus/content/groups/public/com/liferay/portal/com.liferay.portal.kernel/maven-metadata.xml'.
     [exec]                > squid.lax.liferay.com: Name or service not known
```

[2, 3.]
`BladeSamplesTest` problems; This pull doesn't deal with Blade Samples at all.
```
Unresolved requirement: Import-Package: com.liferay.blade.samples.servicebuilder.exception; version="[1.0.0,2.0.0)"
```

[4.] 
`project-templates-soy-portlet` problems; This pull doesn't deal with project templates at all.
```
Unused "liferayVersion" required property in ../project-templates-soy-portlet/src/main/resources/META-INF/maven/archetype-metadata.xml
```

[5.]
`HttpImplTest.testShortenURL` problems. This pull doesn't deal with `HttpImpl` at all. (The test failure however looks like a legitimate regression introduced elsewhere, not a hiccup.)

Author: @ling-alan-huang 
Reviewers: @yuhai @hhuijser @arboliveira

https://issues.liferay.com/browse/LPS-77819
