### PR TITLE
LPS-76728 New Search Bar replaces Search Portlet in front page

### DIFF
--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/configuration/SearchWebConfiguration.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/configuration/SearchWebConfiguration.java
@@ -32,14 +32,12 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface SearchWebConfiguration {
 
 	@Meta.AD(
-		deflt = "true",
 		description = "classic-search-portlet-in-front-page-help",
 		name = "classic-search-portlet-in-front-page", required = false
 	)
 	public boolean classicSearchPortletInFrontPage();
 
 	@Meta.AD(
-		deflt = "true",
 		description = "skip-automatic-creation-of-search-page-in-guest-site-help",
 		name = "skip-automatic-creation-of-search-page-in-guest-site",
 		required = false

--- a/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
+++ b/modules/apps/foundation/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/layout/prototype/SearchLayoutFactoryImpl.java
@@ -122,7 +122,8 @@ public class SearchLayoutFactoryImpl implements SearchLayoutFactory {
 
 		ServiceContext serviceContext = new ServiceContext();
 
-		serviceContext.setAttribute("layoutPrototypeLinkEnabled", Boolean.TRUE);
+		serviceContext.setAttribute(
+			"layoutPrototypeLinkEnabled", Boolean.FALSE);
 
 		serviceContext.setAttribute(
 			"layoutPrototypeUuid", layoutPrototype.getUuid());


### PR DESCRIPTION
CI results: 5 "Failures unique to this pull", apparently false negatives. https://github.com/arboliveira/liferay-portal/pull/464#issuecomment-385132487

[1.]
`LocalFile.PGDynamicdatalists#ConfigureSpreadsheetListPG ` problem. There were widespread `LocalFile` errors in the past few days, and this specific problem regards the test not getting past the login screen. Probably unrelated to this pull's changes; in any case this pull is easily reversible if need be. (cc/ @xbrianlee)

[2, 3.]
`BladeSamplesTest` problems; This pull doesn't deal with Blade Samples at all.
```
Unresolved requirement: Import-Package: com.liferay.blade.samples.servicebuilder.exception; version="[1.0.0,2.0.0)"
```

[4.] 
`project-templates-soy-portlet` problems; This pull doesn't deal with project templates at all.
```
Unused "liferayVersion" required property in ../project-templates-soy-portlet/src/main/resources/META-INF/maven/archetype-metadata.xml
```

[5.]
`HttpImplTest.testShortenURL` problems. This pull doesn't deal with `HttpImpl` at all. (The test failure however looks like a legitimate regression introduced elsewhere, not a hiccup. Also, seen in other pulls; not sure why listed as "unique to this pull." cc/ @xbrianlee)


https://issues.liferay.com/browse/LPS-76728