### PR TITLE
LPS-80314 Bundle symbolic name has been changed.

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -6032,7 +6032,7 @@ osb.lcs.portlet.oauth.consumer.secret=${osb.lcs.portlet.oauth.consumer.secret}</
 	</root>
 </log4j:configuration>]]></echo>
 
-		<echo file="${liferay.home}/osgi/log4j/com.liferay.portal.osgi.web.wab.generator-log4j-ext.xml"><![CDATA[<?xml version="1.0"?>
+		<echo file="${liferay.home}/osgi/log4j/com.liferay.portal.osgi.web.wab.generator.impl-log4j-ext.xml"><![CDATA[<?xml version="1.0"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">


### PR DESCRIPTION
@brianchandotcom this fixes the random portal log scan failure about "Waiting on startup required bundles to activate: [/classic-theme]". It is due to CI machine is too slow, causing classic-theme taking more than 1min to load up. We had this issue before, and we suppressed the logging, however due to api-impl separation, the bundle symbolic name has changed, caused this issue to show up again.