### PR TITLE
LRQA-40562 Exclude directories set using build.exclude.dirs

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1404,6 +1404,7 @@ app.server.type=@{app.server.type}]]></echo>
 									>
 										<include name="apps/*" />
 										<include name="private/apps/*" />
+										<exclude name="${build.exclude.dirs}" />
 									</dirset>
 								</path>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40562

This needs to be backported to 7.0.x and 7.1.x