### PR TITLE
LPS-76043 Add TikaSafeRandomizerBumper here too

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-web-test/src/testIntegration/java/com/liferay/adaptive/media/document/library/web/internal/optimizer/test/DLAMImageOptimizerTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.test.randomizerbumpers.TikaSafeRandomizerBumper;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -334,7 +335,8 @@ public class DLAMImageOptimizerTest {
 			_user1.getUserId(), _group1.getGroupId(),
 			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			RandomTestUtil.randomString(),
-			ContentTypes.APPLICATION_OCTET_STREAM, RandomTestUtil.randomBytes(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomBytes(TikaSafeRandomizerBumper.INSTANCE),
 			serviceContext);
 
 		AMImageConfigurationEntry amImageConfigurationEntry1 =


### PR DESCRIPTION
@brianchandotcom the biggest fight between us and CI is not those fatal stable failures, as they reveal themselves and can be reproduced easily.

The real pain is the random failures. We have many sources of randomness, many thanks to the OSGi dynamic nature. For a lot of them, there is really no way to avoid them, but just to take the hit to fix them. 

But this RandomTestUtil is really not a smart thing to do. We are on purposely creating random troubles for ourselves, just because people are not willing to provide their own test data.

We will start to wipe out the usages of RandomTestUtil and eventually get rid of it. Instead we will be providing people a TestDataConstants class to hold those commonly used test data.