### PR TITLE
LRQA-40641 Restore github expected message for semantic-versioning

### DIFF
--- a/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_semantic_versioning_failure/expected-github-message.html
+++ b/modules/test/jenkins-results-parser/src/test/resources/dependencies/GitHubMessageTest/test-portal-acceptance-pullrequest(master)_semantic_versioning_failure/expected-github-message.html
@@ -422,17 +422,17 @@
                     </strong>
                     <pre>
                       <code>     [exec] Download http://repository.liferay.com/nexus/content/groups/public/com/liferay/com.liferay.blogs.api/3.0.1/com.liferay.blogs.api-3.0.1.jar
-     [exec] :apps:blogs:blogs-api:compileJava UP-TO-DATE
-     [exec] :apps:blogs:blogs-api:buildCSS UP-TO-DATE
-     [exec] :apps:blogs:blogs-api:processResources UP-TO-DATE
-     [exec] :apps:blogs:blogs-api:transpileJS SKIPPED
-     [exec] :apps:blogs:blogs-api:configJSModules SKIPPED
-     [exec] :apps:blogs:blogs-api:copyLibs SKIPPED
-     [exec] :apps:blogs:blogs-api:replaceSoyTranslation UP-TO-DATE
-     [exec] :apps:blogs:blogs-api:wrapSoyAlloyTemplate SKIPPED
-     [exec] :apps:blogs:blogs-api:classes UP-TO-DATE
-     [exec] :apps:blogs:blogs-api:jar UP-TO-DATE
-     [exec] :apps:blogs:blogs-api:baseline
+     [exec] :apps:collaboration:blogs:blogs-api:compileJava UP-TO-DATE
+     [exec] :apps:collaboration:blogs:blogs-api:buildCSS UP-TO-DATE
+     [exec] :apps:collaboration:blogs:blogs-api:processResources UP-TO-DATE
+     [exec] :apps:collaboration:blogs:blogs-api:transpileJS SKIPPED
+     [exec] :apps:collaboration:blogs:blogs-api:configJSModules SKIPPED
+     [exec] :apps:collaboration:blogs:blogs-api:copyLibs SKIPPED
+     [exec] :apps:collaboration:blogs:blogs-api:replaceSoyTranslation UP-TO-DATE
+     [exec] :apps:collaboration:blogs:blogs-api:wrapSoyAlloyTemplate SKIPPED
+     [exec] :apps:collaboration:blogs:blogs-api:classes UP-TO-DATE
+     [exec] :apps:collaboration:blogs:blogs-api:jar UP-TO-DATE
+     [exec] :apps:collaboration:blogs:blogs-api:baseline
      [exec]   PACKAGE_NAME                                       DELTA      CUR_VER    BASE_VER   REC_VER    WARNINGS
      [exec] = ================================================== ========== ========== ========== ========== ==========
      [exec] * com.liferay.blogs.configuration                    CHANGED    1.0.1      1.0.1      1.0.2      VERSION INCREASE REQUIRED
@@ -444,8 +444,8 @@
      [exec] 		~   annotated  aQute.bnd.annotation.metatype.Meta$OCD
      [exec] 			+   property   name='blogs-group-service-configuration-name'
      [exec] 			-   property   name='blogs.group.service.configuration.name'
-     [exec] :apps:blogs:blogs-api:baseline FAILED
-     [exec] :apps:blogs:blogs-api:syncVersions
+     [exec] :apps:collaboration:blogs:blogs-api:baseline FAILED
+     [exec] :apps:collaboration:blogs:blogs-api:syncVersions
      [exec]
      [exec] BUILD FAILED
      [exec]
@@ -455,7 +455,7 @@
      [exec] FAILURE: Build failed with an exception.
      [exec]
      [exec] * What went wrong:
-     [exec] Execution failed for task ':apps:blogs:blogs-api:baseline'.
+     [exec] Execution failed for task ':apps:collaboration:blogs:blogs-api:baseline'.
      [exec] &gt; Semantic versioning is incorrect</code>
                     </pre>
                   </p>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-40641

Pull request tested here https://github.com/pyoo47/liferay-portal/pull/631 (PASSED)

This pull request restores the original expected message that was changed in this commit:
https://github.com/liferay/liferay-portal/commit/f1ae2360583511e1c771de3319cc9627864342b5

The developer erroneously assumed that the expected message should change due to a change the build logic. He didn't realize that our expected message is generated using static console log text from our samples repository.