### PR TITLE
LPS-80553 Preserve order of columns from display class to ui

### DIFF
--- a/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
+++ b/modules/apps/foundation/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
@@ -135,7 +135,10 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 		Map<String, Object> columnFieldValues = uadDisplay.getFieldValues(
 			entity, uadDisplay.getColumnFieldNames());
 
-		columnFieldValues.forEach(uadEntity::addColumnEntry);
+		for (String columnFieldName : uadDisplay.getColumnFieldNames()) {
+			uadEntity.addColumnEntry(
+				columnFieldName, columnFieldValues.get(columnFieldName));
+		}
 
 		return uadEntity;
 	}


### PR DESCRIPTION
This is an update for [LPS-80553](https://issues.liferay.com/browse/LPS-80553).<br><br>Hey Brian, this fixes an issue where the table columns in the view entities display section did not display in the correct order.  Changes to the user-associated-data-web module only<br><br>/cc @willnewbury @pei-jung