### PR TITLE
LPS-80665 Use "bundleSymbolicName" to track the domain of each UAD component

### DIFF
--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADApplicationExportDisplay.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADApplicationExportDisplay.java
@@ -22,17 +22,17 @@ import java.util.Date;
 public class UADApplicationExportDisplay {
 
 	public UADApplicationExportDisplay(
-		String applicationName, int dataCount, boolean exportSupported,
+		String applicationKey, int dataCount, boolean exportSupported,
 		Date lastExportDate) {
 
-		_applicationName = applicationName;
+		_applicationKey = applicationKey;
 		_dataCount = dataCount;
 		_exportSupported = exportSupported;
 		_lastExportDate = lastExportDate;
 	}
 
-	public String getApplicationName() {
-		return _applicationName;
+	public String getApplicationKey() {
+		return _applicationKey;
 	}
 
 	public int getDataCount() {
@@ -47,7 +47,7 @@ public class UADApplicationExportDisplay {
 		return _exportSupported;
 	}
 
-	private final String _applicationName;
+	private final String _applicationKey;
 	private final int _dataCount;
 	private final boolean _exportSupported;
 	private final Date _lastExportDate;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADApplicationSummaryDisplay.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADApplicationSummaryDisplay.java
@@ -23,8 +23,8 @@ public class UADApplicationSummaryDisplay {
 		return _count;
 	}
 
-	public String getName() {
-		return _name;
+	public String getKey() {
+		return _key;
 	}
 
 	public String getViewURL() {
@@ -35,8 +35,8 @@ public class UADApplicationSummaryDisplay {
 		_count = count;
 	}
 
-	public void setName(String name) {
-		_name = name;
+	public void setKey(String key) {
+		_key = key;
 	}
 
 	public void setViewURL(String viewURL) {
@@ -44,7 +44,7 @@ public class UADApplicationSummaryDisplay {
 	}
 
 	private int _count;
-	private String _name;
+	private String _key;
 	private String _viewURL;
 
 }

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/ViewUADEntitiesDisplay.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/ViewUADEntitiesDisplay.java
@@ -30,8 +30,8 @@ public class ViewUADEntitiesDisplay {
 		return _actionDropdownItems;
 	}
 
-	public String getApplicationName() {
-		return _applicationName;
+	public String getApplicationKey() {
+		return _applicationKey;
 	}
 
 	public List<NavigationItem> getNavigationItems() {
@@ -56,8 +56,8 @@ public class ViewUADEntitiesDisplay {
 		_actionDropdownItems = getActionDropdownItems;
 	}
 
-	public void setApplicationName(String applicationName) {
-		_applicationName = applicationName;
+	public void setApplicationKey(String applicationKey) {
+		_applicationKey = applicationKey;
 	}
 
 	public void setNavigationItems(List<NavigationItem> navigationItems) {
@@ -77,7 +77,7 @@ public class ViewUADEntitiesDisplay {
 	}
 
 	private List<DropdownItem> _actionDropdownItems;
-	private String _applicationName;
+	private String _applicationKey;
 	private List<NavigationItem> _navigationItems;
 	private SearchContainer<UADEntity> _searchContainer;
 	private String _typeName;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/UADExporter.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/UADExporter.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class UADExporter {
 
 	public static long exportApplicationDataInBackground(
-			String applicationName, long userId, long groupId)
+			String applicationKey, long userId, long groupId)
 		throws PortalException {
 
 		Map<String, Serializable> taskContextMap = new HashMap<>();
@@ -40,7 +40,7 @@ public class UADExporter {
 
 		BackgroundTask backgroundTask =
 			BackgroundTaskManagerUtil.addBackgroundTask(
-				userId, groupId, applicationName,
+				userId, groupId, applicationKey,
 				UADExportBackgroundTaskExecutor.class.getName(), taskContextMap,
 				new ServiceContext());
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/background/task/UADExportBackgroundTaskExecutor.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/background/task/UADExportBackgroundTaskExecutor.java
@@ -51,7 +51,7 @@ public class UADExportBackgroundTaskExecutor
 	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
 		throws Exception {
 
-		String applicationName = backgroundTask.getName();
+		String applicationKey = backgroundTask.getName();
 
 		Map<String, Serializable> taskContextMap =
 			backgroundTask.getTaskContextMap();
@@ -59,7 +59,7 @@ public class UADExportBackgroundTaskExecutor
 		long userId = (long)taskContextMap.get("userId");
 
 		File file = _uadApplicationExportController.export(
-			applicationName, userId);
+			applicationKey, userId);
 
 		_backgroundTaskManager.addBackgroundTaskAttachment(
 			userId, backgroundTask.getBackgroundTaskId(), file.getName(), file);

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/background/task/UADExportBackgroundTaskStatusMessageSender.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/background/task/UADExportBackgroundTaskStatusMessageSender.java
@@ -44,7 +44,7 @@ public class UADExportBackgroundTaskStatusMessageSender {
 	}
 
 	public void sendStatusMessage(
-		String messageType, String applicationName, long total) {
+		String messageType, String applicationKey, long total) {
 
 		Message message = new Message();
 
@@ -52,7 +52,7 @@ public class UADExportBackgroundTaskStatusMessageSender {
 			BackgroundTaskConstants.BACKGROUND_TASK_ID,
 			BackgroundTaskThreadLocal.getBackgroundTaskId());
 		message.put("applicationDataTotal", total);
-		message.put("applicationName", applicationName);
+		message.put("applicationKey", applicationKey);
 		message.put("messageType", messageType);
 
 		_backgroundTaskStatusMessageSender.sendBackgroundTaskStatusMessage(

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/background/task/UADExportBackgroundTaskStatusMessageTranslator.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/export/background/task/UADExportBackgroundTaskStatusMessageTranslator.java
@@ -43,11 +43,11 @@ public class UADExportBackgroundTaskStatusMessageTranslator
 		BackgroundTaskStatus backgroundTaskStatus, Message message) {
 
 		long applicationDataTotal = message.getLong("applicationDataTotal");
-		String applicationName = message.getString("applicationName");
+		String applicationKey = message.getString("applicationKey");
 
 		backgroundTaskStatus.setAttribute(
 			"applicationDataTotal", applicationDataTotal);
-		backgroundTaskStatus.setAttribute("applicationName", applicationName);
+		backgroundTaskStatus.setAttribute("applicationKey", applicationKey);
 	}
 
 	private synchronized void _translateEntityMessage(
@@ -57,15 +57,15 @@ public class UADExportBackgroundTaskStatusMessageTranslator
 			backgroundTaskStatus.getAttribute("applicationDataCounter"));
 		long applicationDataTotal = GetterUtil.getLong(
 			backgroundTaskStatus.getAttribute("applicationDataTotal"));
-		String applicationName = GetterUtil.getString(
-			backgroundTaskStatus.getAttribute("applicationName"));
+		String applicationKey = GetterUtil.getString(
+			backgroundTaskStatus.getAttribute("applicationKey"));
 		String entityName = message.getString("entityName");
 
 		backgroundTaskStatus.setAttribute(
 			"applicationDataCounter", ++applicationDataCounter);
 		backgroundTaskStatus.setAttribute(
 			"applicationDataTotal", applicationDataTotal);
-		backgroundTaskStatus.setAttribute("applicationName", applicationName);
+		backgroundTaskStatus.setAttribute("applicationKey", applicationKey);
 		backgroundTaskStatus.setAttribute("entityName", entityName);
 	}
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/AnonymizeApplicationUADEntitiesMVCActionCommand.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/AnonymizeApplicationUADEntitiesMVCActionCommand.java
@@ -49,12 +49,12 @@ public class AnonymizeApplicationUADEntitiesMVCActionCommand
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		String applicationName = ParamUtil.getString(
-			actionRequest, "applicationName");
+		String applicationKey = ParamUtil.getString(
+			actionRequest, "applicationKey");
 
 		List<UADAnonymizer> uadAnonymizers =
 			_uadApplicationSummaryHelper.getApplicationUADAnonymizers(
-				applicationName);
+				applicationKey);
 
 		for (UADAnonymizer uadAnonymizer : uadAnonymizers) {
 			User selectedUser = getSelectedUser(actionRequest);

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/DeleteApplicationUADEntitiesMVCActionCommand.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/DeleteApplicationUADEntitiesMVCActionCommand.java
@@ -47,12 +47,12 @@ public class DeleteApplicationUADEntitiesMVCActionCommand
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		String applicationName = ParamUtil.getString(
-			actionRequest, "applicationName");
+		String applicationKey = ParamUtil.getString(
+			actionRequest, "applicationKey");
 
 		List<UADAnonymizer> uadAnonymizers =
 			_uadApplicationSummaryHelper.getApplicationUADAnonymizers(
-				applicationName);
+				applicationKey);
 
 		for (UADAnonymizer uadAnonymizer : uadAnonymizers) {
 			long selectedUserId = getSelectedUserId(actionRequest);

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ExportApplicationDataMVCActionCommand.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ExportApplicationDataMVCActionCommand.java
@@ -49,14 +49,14 @@ public class ExportApplicationDataMVCActionCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String[] applicationNames = StringUtil.split(
-			ParamUtil.getString(actionRequest, "applicationNames"));
+		String[] applicationKeys = StringUtil.split(
+			ParamUtil.getString(actionRequest, "applicationKeys"));
 
-		for (String applicationName : applicationNames) {
+		for (String applicationKey : applicationKeys) {
 			long selUserId = getSelectedUserId(actionRequest);
 
 			UADExporter.exportApplicationDataInBackground(
-				applicationName, selUserId, themeDisplay.getScopeGroupId());
+				applicationKey, selUserId, themeDisplay.getScopeGroupId());
 		}
 
 		String redirect = ParamUtil.getString(actionRequest, "redirect");

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
@@ -38,6 +38,7 @@ import com.liferay.user.associated.data.web.internal.registry.UADRegistry;
 import com.liferay.user.associated.data.web.internal.util.SelectedUserHelper;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -74,8 +75,8 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 			User selectedUser = _selectedUserHelper.getSelectedUser(
 				renderRequest);
 
-			String applicationName = ParamUtil.getString(
-				renderRequest, "applicationName");
+			String applicationKey = ParamUtil.getString(
+				renderRequest, "applicationKey");
 			String uadRegistryKey = ParamUtil.getString(
 				renderRequest, "uadRegistryKey");
 
@@ -84,7 +85,7 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 
 			viewUADEntitiesDisplay.setActionDropdownItems(
 				_getActionDropdownItems(renderRequest, renderResponse));
-			viewUADEntitiesDisplay.setApplicationName(applicationName);
+			viewUADEntitiesDisplay.setApplicationName(applicationKey);
 
 			LiferayPortletResponse liferayPortletResponse =
 				_portal.getLiferayPortletResponse(renderResponse);
@@ -94,7 +95,7 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 
 			viewUADEntitiesDisplay.setNavigationItems(
 				_getNavigationItems(
-					applicationName, uadRegistryKey, currentURL,
+					applicationKey, uadRegistryKey, currentURL,
 					liferayPortletResponse));
 
 			UADDisplay uadDisplay = _uadRegistry.getUADDisplay(uadRegistryKey);
@@ -175,8 +176,7 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 	}
 
 	private List<NavigationItem> _getNavigationItems(
-			String applicationName, String uadRegistryKey,
-			PortletURL currentURL,
+			String applicationKey, String uadRegistryKey, PortletURL currentURL,
 			LiferayPortletResponse liferayPortletResponse)
 		throws PortletException {
 
@@ -186,12 +186,11 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 		PortletURL tabPortletURL = PortletURLUtil.clone(
 			currentURL, liferayPortletResponse);
 
-		for (UADDisplay uadDisplay : _uadRegistry.getUADDisplays()) {
-			if (!applicationName.equals(uadDisplay.getApplicationName())) {
-				continue;
-			}
+		Collection<UADDisplay> applicationUADDisplays =
+			_uadRegistry.getApplicationUADDisplays(applicationKey);
 
-			navigationItemList.add(
+		applicationUADDisplays.forEach(
+			uadDisplay -> navigationItemList.add(
 				navigationItem -> {
 					Class<?> uadClass = uadDisplay.getTypeClass();
 
@@ -201,8 +200,7 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 						tabPortletURL, "uadRegistryKey", uadClass.getName());
 
 					navigationItem.setLabel(uadDisplay.getTypeName(locale));
-				});
-		}
+				}));
 
 		return navigationItemList;
 	}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/portlet/action/ViewUADEntitiesMVCRenderCommand.java
@@ -85,7 +85,7 @@ public class ViewUADEntitiesMVCRenderCommand implements MVCRenderCommand {
 
 			viewUADEntitiesDisplay.setActionDropdownItems(
 				_getActionDropdownItems(renderRequest, renderResponse));
-			viewUADEntitiesDisplay.setApplicationName(applicationKey);
+			viewUADEntitiesDisplay.setApplicationKey(applicationKey);
 
 			LiferayPortletResponse liferayPortletResponse =
 				_portal.getLiferayPortletResponse(renderResponse);

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/registry/UADRegistry.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/registry/UADRegistry.java
@@ -69,20 +69,12 @@ public class UADRegistry {
 		return _uadAnonymizerServiceTrackerMap.getService(key);
 	}
 
-	public Set<String> getUADAnonymizerKeySet() {
-		return _uadAnonymizerServiceTrackerMap.keySet();
-	}
-
 	public Collection<UADAnonymizer> getUADAnonymizers() {
 		return _uadAnonymizerServiceTrackerMap.values();
 	}
 
 	public UADDisplay getUADDisplay(String key) {
 		return _uadDisplayServiceTrackerMap.getService(key);
-	}
-
-	public Set<String> getUADDisplayKeySet() {
-		return _uadDisplayServiceTrackerMap.keySet();
 	}
 
 	public Collection<UADDisplay> getUADDisplays() {
@@ -95,14 +87,6 @@ public class UADRegistry {
 
 	public UADExporter getUADExporter(String key) {
 		return _uadExporterServiceTrackerMap.getService(key);
-	}
-
-	public Set<String> getUADExporterKeySet() {
-		return _uadExporterServiceTrackerMap.keySet();
-	}
-
-	public Collection<UADExporter> getUADExporters() {
-		return _uadExporterServiceTrackerMap.values();
 	}
 
 	@Activate

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADApplicationExportHelper.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADApplicationExportHelper.java
@@ -80,10 +80,10 @@ public class UADApplicationExportHelper {
 	public List<UADApplicationExportDisplay> getUADApplicationExportDisplays(
 		long groupId, long userId) {
 
-		Set<String> exporterApplicationNames =
+		Set<String> exporterApplicationKeys =
 			_uadRegistry.getApplicationUADExportersKeySet();
 
-		Iterator<String> iterator = exporterApplicationNames.iterator();
+		Iterator<String> iterator = exporterApplicationKeys.iterator();
 
 		List<UADApplicationExportDisplay> uadApplicationExportDisplays =
 			new ArrayList<>();

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADApplicationSummaryHelper.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADApplicationSummaryHelper.java
@@ -200,7 +200,7 @@ public class UADApplicationSummaryHelper {
 		String orderByColumn, String orderByType) {
 
 		Comparator<UADApplicationSummaryDisplay> comparator =
-			Comparator.comparing(UADApplicationSummaryDisplay::getName);
+			Comparator.comparing(UADApplicationSummaryDisplay::getKey);
 
 		if (orderByColumn.equals("items") || orderByColumn.equals("status")) {
 			comparator = Comparator.comparingInt(
@@ -359,7 +359,7 @@ public class UADApplicationSummaryHelper {
 
 		uadApplicationSummaryDisplay.setCount(count);
 
-		uadApplicationSummaryDisplay.setName(applicationKey);
+		uadApplicationSummaryDisplay.setKey(applicationKey);
 
 		if (count > 0) {
 			uadApplicationSummaryDisplay.setViewURL(
@@ -390,10 +390,10 @@ public class UADApplicationSummaryHelper {
 
 		uadApplicationSummaryDisplays.sort(
 			(uadApplicationSummaryDisplay, uadApplicationSummaryDisplay2) -> {
-				String applicationKey1 = uadApplicationSummaryDisplay.getName();
+				String applicationKey1 = uadApplicationSummaryDisplay.getKey();
 
 				return applicationKey1.compareTo(
-					uadApplicationSummaryDisplay2.getName());
+					uadApplicationSummaryDisplay2.getKey());
 			});
 
 		return uadApplicationSummaryDisplays;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -36,7 +36,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	<aui:form method="post" name="fm" onSubmit='<%= "event.preventDefault(); " + renderResponse.getNamespace() + "exportApplicationData();" %>'>
 		<aui:input name="redirect" type="hidden" value="<%= viewUADExportProcesses.toString() %>" />
 		<aui:input name="p_u_i_d" type="hidden" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
-		<aui:input name="applicationNames" type="hidden" />
+		<aui:input name="applicationKeys" type="hidden" />
 
 		<div class="sheet sheet-lg">
 			<div class="sheet-section">
@@ -64,13 +64,13 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 
 					<liferay-ui:search-container-row
 						className="com.liferay.user.associated.data.web.internal.display.UADApplicationExportDisplay"
-						keyProperty="applicationName"
+						keyProperty="applicationKey"
 						modelVar="uadApplicationExportDisplay"
 					>
 						<liferay-ui:search-container-column-text
 							cssClass="table-cell-expand table-list-title"
 							name="application"
-							property="applicationName"
+							property="applicationKey"
 						/>
 
 						<liferay-ui:search-container-column-text
@@ -112,7 +112,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 	function <portlet:namespace />exportApplicationData() {
 		var form = AUI.$(document.<portlet:namespace />fm);
 
-		form.fm('applicationNames').val(Liferay.Util.listCheckedExcept(form, '<portlet:namespace />allRowIds', '<portlet:namespace />rowIds'));
+		form.fm('applicationKeys').val(Liferay.Util.listCheckedExcept(form, '<portlet:namespace />allRowIds', '<portlet:namespace />rowIds'));
 
 		submitForm(form, '<portlet:actionURL name="/export_application_data" />');
 	}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/applications_summary_action.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/applications_summary_action.jsp
@@ -39,7 +39,7 @@ UADApplicationSummaryDisplay uadApplicationSummaryDisplay = (UADApplicationSumma
 	<portlet:actionURL name="/anonymize_application_uad_entities" var="anonymizeUADEntitiesURL">
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 		<portlet:param name="p_u_i_d" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
-		<portlet:param name="applicationName" value="<%= uadApplicationSummaryDisplay.getName() %>" />
+		<portlet:param name="applicationKey" value="<%= uadApplicationSummaryDisplay.getKey() %>" />
 	</portlet:actionURL>
 
 	<liferay-ui:icon
@@ -50,7 +50,7 @@ UADApplicationSummaryDisplay uadApplicationSummaryDisplay = (UADApplicationSumma
 	<portlet:actionURL name="/delete_application_uad_entities" var="deleteUADEntitiesURL">
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 		<portlet:param name="p_u_i_d" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
-		<portlet:param name="applicationName" value="<%= uadApplicationSummaryDisplay.getName() %>" />
+		<portlet:param name="applicationKey" value="<%= uadApplicationSummaryDisplay.getKey() %>" />
 	</portlet:actionURL>
 
 	<liferay-ui:icon

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_applications_summary.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_applications_summary.jsp
@@ -77,14 +77,14 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 				<liferay-ui:search-container-row
 					className="com.liferay.user.associated.data.web.internal.display.UADApplicationSummaryDisplay"
 					escapedModel="<%= true %>"
-					keyProperty="name"
+					keyProperty="key"
 					modelVar="uadApplicationSummaryDisplay"
 				>
 					<liferay-ui:search-container-column-text
 						cssClass="table-cell-expand table-list-title"
 						href="<%= uadApplicationSummaryDisplay.getViewURL() %>"
 						name="name"
-						property="name"
+						property="key"
 					/>
 
 					<liferay-ui:search-container-column-text


### PR DESCRIPTION
This is an update for [LPS-80665](https://issues.liferay.com/browse/LPS-80665).<br><br>Hey Brian, this removes the usage of 'getApplicationName' as a key for tracking the application domain of each registered UAD component.  It is in preparation for providing support for translating the application names of each app's UAD implementation.<br><br>/cc @pei-jung