### PR TITLE
LPS-80469 New Indexers: migrate Calendar, Document Library indexers

### DIFF
--- a/modules/apps/calendar/calendar-service/build.gradle
+++ b/modules/apps/calendar/calendar-service/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:petra:petra-content")
 	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingBatchReindexer.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingBatchReindexer.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+/**
+ * @author André de Oliveira
+ */
+public interface CalendarBookingBatchReindexer {
+
+	public void reindex(long calendarId, long companyId);
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingBatchReindexerImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingBatchReindexerImpl.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.calendar.service.CalendarBookingLocalService;
+import com.liferay.calendar.workflow.CalendarBookingWorkflowConstants;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.batch.BatchIndexingActionable;
+import com.liferay.portal.search.indexer.IndexerDocumentBuilder;
+import com.liferay.portal.search.indexer.IndexerWriter;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author André de Oliveira
+ */
+@Component(immediate = true, service = CalendarBookingBatchReindexer.class)
+public class CalendarBookingBatchReindexerImpl
+	implements CalendarBookingBatchReindexer {
+
+	@Override
+	public void reindex(long calendarId, long companyId) {
+		BatchIndexingActionable batchIndexingActionable =
+			indexerWriter.getBatchIndexingActionable();
+
+		batchIndexingActionable.setCompanyId(companyId);
+
+		batchIndexingActionable.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property calendarIdPropery = PropertyFactoryUtil.forName(
+					"calendarId");
+
+				dynamicQuery.add(calendarIdPropery.eq(calendarId));
+
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				int[] statuses = {
+					WorkflowConstants.STATUS_APPROVED,
+					CalendarBookingWorkflowConstants.STATUS_MAYBE
+				};
+
+				dynamicQuery.add(statusProperty.in(statuses));
+			});
+
+		batchIndexingActionable.setPerformActionMethod(
+			(CalendarBooking calendarBooking) -> {
+				Document document = indexerDocumentBuilder.getDocument(
+					calendarBooking);
+
+				batchIndexingActionable.addDocuments(document);
+			});
+
+		batchIndexingActionable.performActions();
+	}
+
+	@Reference
+	protected CalendarBookingLocalService calendarBookingLocalService;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.calendar.model.CalendarBooking)"
+	)
+	protected IndexerDocumentBuilder indexerDocumentBuilder;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.calendar.model.CalendarBooking)"
+	)
+	protected IndexerWriter<CalendarBooking> indexerWriter;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingIndexer.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingIndexer.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriterHelper;
-import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchEngineHelperUtil;
 import com.liferay.portal.kernel.search.SearchPermissionChecker;
@@ -55,14 +54,12 @@ import java.util.Locale;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
 /**
+ * @deprecated As of 3.0.0, since 7.1.0
  * @author Adam Victor Brandizzi
  * @author Eduardo Lundgren
  */
-@Component(immediate = true, service = Indexer.class)
+@Deprecated
 public class CalendarBookingIndexer extends BaseIndexer<CalendarBooking> {
 
 	public static final String CLASS_NAME = CalendarBooking.class.getName();
@@ -354,14 +351,12 @@ public class CalendarBookingIndexer extends BaseIndexer<CalendarBooking> {
 		indexableActionableDynamicQuery.performActions();
 	}
 
-	@Reference(unbind = "-")
 	protected void setCalendarBookingLocalService(
 		CalendarBookingLocalService calendarBookingLocalService) {
 
 		_calendarBookingLocalService = calendarBookingLocalService;
 	}
 
-	@Reference(unbind = "-")
 	protected void setClassNameLocalService(
 		ClassNameLocalService classNameLocalService) {
 
@@ -373,11 +368,7 @@ public class CalendarBookingIndexer extends BaseIndexer<CalendarBooking> {
 
 	private CalendarBookingLocalService _calendarBookingLocalService;
 	private ClassNameLocalService _classNameLocalService;
-
-	@Reference
 	private IndexWriterHelper _indexWriterHelper;
-
-	@Reference
 	private TrashHelper _trashHelper;
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingKeywordQueryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingKeywordQueryContributor.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bryan Engler
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.CalendarBooking",
+	service = KeywordQueryContributor.class
+)
+public class CalendarBookingKeywordQueryContributor
+	implements KeywordQueryContributor {
+
+	@Override
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery,
+		KeywordQueryContributorHelper keywordQueryContributorHelper) {
+
+		SearchContext searchContext =
+			keywordQueryContributorHelper.getSearchContext();
+
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.DESCRIPTION, true);
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.TITLE, true);
+	}
+
+	@Reference
+	protected QueryHelper queryHelper;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelDocumentContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelDocumentContributor.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.calendar.constants.CalendarActionKeys;
+import com.liferay.calendar.model.Calendar;
+import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.trash.TrashHelper;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.CalendarBooking",
+	service = ModelDocumentContributor.class
+)
+public class CalendarBookingModelDocumentContributor
+	implements ModelDocumentContributor<CalendarBooking> {
+
+	@Override
+	public void contribute(Document document, CalendarBooking calendarBooking) {
+		document.addKeyword(
+			Field.CLASS_NAME_ID,
+			classNameLocalService.getClassNameId(Calendar.class));
+		document.addKeyword(Field.CLASS_PK, calendarBooking.getCalendarId());
+
+		Locale defaultLocale = LocaleUtil.getSiteDefault();
+
+		String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
+
+		String[] descriptionLanguageIds = getLanguageIds(
+			defaultLanguageId, calendarBooking.getDescription());
+
+		for (String descriptionLanguageId : descriptionLanguageIds) {
+			String description = calendarBooking.getDescription(
+				descriptionLanguageId);
+
+			document.addText(
+				LocalizationUtil.getLocalizedName(
+					Field.DESCRIPTION, descriptionLanguageId),
+				description);
+		}
+
+		document.addKeyword(Field.RELATED_ENTRY, true);
+
+		String[] titleLanguageIds = getLanguageIds(
+			defaultLanguageId, calendarBooking.getTitle());
+
+		for (String titleLanguageId : titleLanguageIds) {
+			String title = calendarBooking.getTitle(titleLanguageId);
+
+			document.addText(
+				LocalizationUtil.getLocalizedName(Field.TITLE, titleLanguageId),
+				title);
+		}
+
+		document.addKeyword(
+			Field.VIEW_ACTION_ID, CalendarActionKeys.VIEW_BOOKING_DETAILS);
+
+		String calendarBookingId = String.valueOf(
+			calendarBooking.getCalendarBookingId());
+
+		if (calendarBooking.isInTrash()) {
+			calendarBookingId = trashHelper.getOriginalTitle(calendarBookingId);
+		}
+
+		document.addKeyword("calendarBookingId", calendarBookingId);
+
+		document.addText("defaultLanguageId", defaultLanguageId);
+		document.addNumber("endTime", calendarBooking.getEndTime());
+		document.addText("location", calendarBooking.getLocation());
+		document.addNumber("startTime", calendarBooking.getStartTime());
+	}
+
+	protected String[] getLanguageIds(
+		String defaultLanguageId, String content) {
+
+		String[] languageIds = LocalizationUtil.getAvailableLanguageIds(
+			content);
+
+		if (languageIds.length == 0) {
+			languageIds = new String[] {defaultLanguageId};
+		}
+
+		return languageIds;
+	}
+
+	@Reference
+	protected ClassNameLocalService classNameLocalService;
+
+	@Reference
+	protected TrashHelper trashHelper;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelIndexerWriterContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelIndexerWriterContributor.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.calendar.service.CalendarBookingLocalService;
+import com.liferay.calendar.workflow.CalendarBookingWorkflowConstants;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.batch.BatchIndexingActionable;
+import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.index.contributor.helper.IndexerWriterMode;
+import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.CalendarBooking",
+	service = ModelIndexerWriterContributor.class
+)
+public class CalendarBookingModelIndexerWriterContributor
+	implements ModelIndexerWriterContributor<CalendarBooking> {
+
+	@Override
+	public void customize(
+		BatchIndexingActionable batchIndexingActionable,
+		ModelIndexerWriterDocumentHelper modelIndexerWriterDocumentHelper) {
+
+		batchIndexingActionable.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property statusProperty = PropertyFactoryUtil.forName("status");
+
+				int[] statuses = {
+					WorkflowConstants.STATUS_APPROVED,
+					CalendarBookingWorkflowConstants.STATUS_MAYBE
+				};
+
+				dynamicQuery.add(statusProperty.in(statuses));
+			});
+
+		batchIndexingActionable.setPerformActionMethod(
+			(CalendarBooking calendarBooking) -> {
+				batchIndexingActionable.addDocuments(
+					modelIndexerWriterDocumentHelper.getDocument(
+						calendarBooking));
+			});
+	}
+
+	@Override
+	public BatchIndexingActionable getBatchIndexingActionable() {
+		return dynamicQueryBatchIndexingActionableFactory.
+			getBatchIndexingActionable(
+				calendarBookingLocalService.
+					getIndexableActionableDynamicQuery());
+	}
+
+	@Override
+	public long getCompanyId(CalendarBooking calendarBooking) {
+		return calendarBooking.getCompanyId();
+	}
+
+	@Override
+	public IndexerWriterMode getIndexerWriterMode(
+		CalendarBooking calendarBooking) {
+
+		int status = calendarBooking.getStatus();
+
+		if ((status == WorkflowConstants.STATUS_APPROVED) ||
+			(status == CalendarBookingWorkflowConstants.STATUS_MAYBE) ||
+			(status == WorkflowConstants.STATUS_IN_TRASH)) {
+
+			return IndexerWriterMode.UPDATE;
+		}
+
+		return IndexerWriterMode.DELETE;
+	}
+
+	@Reference
+	protected CalendarBookingLocalService calendarBookingLocalService;
+
+	@Reference
+	protected DynamicQueryBatchIndexingActionableFactory
+		dynamicQueryBatchIndexingActionableFactory;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelPreFilterContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelPreFilterContributor.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bryan Engler
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.CalendarBooking",
+	service = ModelPreFilterContributor.class
+)
+public class CalendarBookingModelPreFilterContributor
+	implements ModelPreFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		addWorkflowStatusFilter(
+			booleanFilter, modelSearchSettings, searchContext);
+	}
+
+	protected void addWorkflowStatusFilter(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		workflowStatusModelPreFilterContributor.contribute(
+			booleanFilter, modelSearchSettings, searchContext);
+	}
+
+	@Reference(target = "(model.pre.filter.contributor.id=WorkflowStatus)")
+	protected ModelPreFilterContributor workflowStatusModelPreFilterContributor;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingModelSummaryContributor.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+import com.liferay.portal.search.summary.SummaryHelper;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.CalendarBooking",
+	service = ModelSummaryContributor.class
+)
+public class CalendarBookingModelSummaryContributor
+	implements ModelSummaryContributor {
+
+	@Override
+	public Summary getSummary(
+		Document document, Locale locale, String snippet) {
+
+		Locale snippetLocale = summaryHelper.getSnippetLocale(document, locale);
+
+		Locale defaultLocale = LocaleUtil.fromLanguageId(
+			document.get("defaultLanguageId"));
+
+		String localizedTitleName = Field.getLocalizedName(locale, Field.TITLE);
+
+		if ((snippetLocale == null) &&
+			(document.getField(localizedTitleName) == null)) {
+
+			snippetLocale = defaultLocale;
+		}
+		else {
+			snippetLocale = locale;
+		}
+
+		String prefix = Field.SNIPPET + StringPool.UNDERLINE;
+
+		String title = document.get(
+			snippetLocale, prefix + Field.TITLE, Field.TITLE);
+
+		if (Validator.isNull(title) && !snippetLocale.equals(defaultLocale)) {
+			title = document.get(
+				defaultLocale, prefix + Field.TITLE, Field.TITLE);
+		}
+
+		String description = document.get(
+			snippetLocale, prefix + Field.DESCRIPTION, Field.DESCRIPTION);
+
+		if (Validator.isNull(description) &&
+			!snippetLocale.equals(defaultLocale)) {
+
+			description = document.get(
+				defaultLocale, prefix + Field.DESCRIPTION, Field.DESCRIPTION);
+		}
+
+		description = HtmlUtil.extractText(description);
+
+		Summary summary = new Summary(snippetLocale, title, description);
+
+		summary.setMaxContentLength(200);
+
+		return summary;
+	}
+
+	@Reference
+	protected SummaryHelper summaryHelper;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingSearchRegistrar.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarBookingSearchRegistrar.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.calendar.model.CalendarBooking;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(immediate = true)
+public class CalendarBookingSearchRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = modelSearchRegistrarHelper.register(
+			CalendarBooking.class, bundleContext,
+			modelSearchDefinition -> {
+				modelSearchDefinition.setDefaultSelectedFieldNames(
+					Field.COMPANY_ID, Field.ENTRY_CLASS_NAME,
+					Field.ENTRY_CLASS_PK, Field.UID);
+
+				modelSearchDefinition.setDefaultSelectedLocalizedFieldNames(
+					Field.DESCRIPTION, Field.TITLE);
+
+				modelSearchDefinition.setModelIndexWriteContributor(
+					modelIndexWriterContributor);
+
+				modelSearchDefinition.setModelSummaryContributor(
+					modelSummaryContributor);
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.calendar.model.CalendarBooking)"
+	)
+	protected ModelIndexerWriterContributor<CalendarBooking>
+		modelIndexWriterContributor;
+
+	@Reference
+	protected ModelSearchRegistrarHelper modelSearchRegistrarHelper;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.calendar.model.CalendarBooking)"
+	)
+	protected ModelSummaryContributor modelSummaryContributor;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarField.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarField.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+/**
+ * @author Michael C. Han
+ */
+public class CalendarField {
+
+	public static final String RESOURCE_NAME = "resourceName";
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarIndexer.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarIndexer.java
@@ -47,13 +47,11 @@ import java.util.Locale;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
 /**
+ * @deprecated As of 3.0.0, since 7.1.0
  * @author Adam Brandizzi
  */
-@Component(immediate = true, service = Indexer.class)
+@Deprecated
 public class CalendarIndexer extends BaseIndexer<Calendar> {
 
 	public static final String CLASS_NAME = Calendar.class.getName();
@@ -208,21 +206,18 @@ public class CalendarIndexer extends BaseIndexer<Calendar> {
 		indexableActionableDynamicQuery.performActions();
 	}
 
-	@Reference(unbind = "-")
 	protected void setCalendarBookingLocalService(
 		CalendarBookingLocalService calendarBookingLocalService) {
 
 		_calendarBookingLocalService = calendarBookingLocalService;
 	}
 
-	@Reference(unbind = "-")
 	protected void setCalendarLocalService(
 		CalendarLocalService calendarLocalService) {
 
 		_calendarLocalService = calendarLocalService;
 	}
 
-	@Reference(unbind = "-")
 	protected void setIndexerRegistry(IndexerRegistry indexerRegistry) {
 		_indexerRegistry = indexerRegistry;
 	}
@@ -232,15 +227,8 @@ public class CalendarIndexer extends BaseIndexer<Calendar> {
 
 	private CalendarBookingLocalService _calendarBookingLocalService;
 	private CalendarLocalService _calendarLocalService;
-
-	@Reference(
-		target = "(model.class.name=com.liferay.calendar.model.Calendar)"
-	)
 	private ModelResourcePermission<Calendar> _calendarModelResourcePermission;
-
 	private IndexerRegistry _indexerRegistry;
-
-	@Reference
 	private IndexWriterHelper _indexWriterHelper;
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarKeywordQueryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarKeywordQueryContributor.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.Calendar",
+	service = KeywordQueryContributor.class
+)
+public class CalendarKeywordQueryContributor
+	implements KeywordQueryContributor {
+
+	@Override
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery,
+		KeywordQueryContributorHelper keywordQueryContributorHelper) {
+
+		SearchContext searchContext =
+			keywordQueryContributorHelper.getSearchContext();
+
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.DESCRIPTION, true);
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.NAME, true);
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, CalendarField.RESOURCE_NAME, true);
+	}
+
+	@Reference
+	protected QueryHelper queryHelper;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelDocumentContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelDocumentContributor.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.calendar.model.Calendar;
+import com.liferay.calendar.model.CalendarResource;
+import com.liferay.calendar.service.CalendarResourceLocalService;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.Calendar",
+	service = ModelDocumentContributor.class
+)
+public class CalendarModelDocumentContributor
+	implements ModelDocumentContributor<Calendar> {
+
+	@Override
+	public void contribute(Document document, Calendar calendar) {
+		document.addLocalizedKeyword(
+			Field.DESCRIPTION, calendar.getDescriptionMap(), true);
+		document.addLocalizedKeyword(Field.NAME, calendar.getNameMap(), true);
+		document.addKeyword("calendarId", calendar.getCalendarId());
+
+		Locale defaultLocale = LocaleUtil.getSiteDefault();
+
+		String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
+
+		document.addText("defaultLanguageId", defaultLanguageId);
+
+		CalendarResource calendarResource =
+			calendarResourceLocalService.fetchCalendarResource(
+				calendar.getCalendarResourceId());
+
+		if (calendarResource != null) {
+			document.addLocalizedKeyword(
+				CalendarField.RESOURCE_NAME, calendarResource.getNameMap(),
+				true);
+		}
+	}
+
+	@Reference
+	protected CalendarResourceLocalService calendarResourceLocalService;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelIndexerWriterContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelIndexerWriterContributor.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.calendar.model.Calendar;
+import com.liferay.calendar.service.CalendarLocalService;
+import com.liferay.portal.search.batch.BatchIndexingActionable;
+import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.Calendar",
+	service = ModelIndexerWriterContributor.class
+)
+public class CalendarModelIndexerWriterContributor
+	implements ModelIndexerWriterContributor<Calendar> {
+
+	@Override
+	public void customize(
+		BatchIndexingActionable batchIndexingActionable,
+		ModelIndexerWriterDocumentHelper modelIndexerWriterDocumentHelper) {
+
+		batchIndexingActionable.setPerformActionMethod(
+			(Calendar calendar) -> {
+				batchIndexingActionable.addDocuments(
+					modelIndexerWriterDocumentHelper.getDocument(calendar));
+			});
+	}
+
+	@Override
+	public BatchIndexingActionable getBatchIndexingActionable() {
+		return dynamicQueryBatchIndexingActionableFactory.
+			getBatchIndexingActionable(
+				calendarLocalService.getIndexableActionableDynamicQuery());
+	}
+
+	@Override
+	public long getCompanyId(Calendar calendar) {
+		return calendar.getCompanyId();
+	}
+
+	@Override
+	public void modelIndexed(Calendar calendar) {
+		calendarBookingBatchReindexer.reindex(
+			calendar.getCalendarId(), calendar.getCompanyId());
+	}
+
+	@Reference
+	protected CalendarBookingBatchReindexer calendarBookingBatchReindexer;
+
+	@Reference
+	protected CalendarLocalService calendarLocalService;
+
+	@Reference
+	protected DynamicQueryBatchIndexingActionableFactory
+		dynamicQueryBatchIndexingActionableFactory;
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelSummaryContributor.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarModelSummaryContributor.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.calendar.model.Calendar",
+	service = ModelSummaryContributor.class
+)
+public class CalendarModelSummaryContributor
+	implements ModelSummaryContributor {
+
+	@Override
+	public Summary getSummary(
+		Document document, Locale locale, String snippet) {
+
+		String prefix = Field.SNIPPET + StringPool.UNDERLINE;
+
+		String title = document.get(prefix + Field.NAME, Field.NAME);
+		String content = document.get(
+			prefix + Field.DESCRIPTION, Field.DESCRIPTION);
+
+		Summary summary = new Summary(title, content);
+
+		summary.setMaxContentLength(200);
+
+		return summary;
+	}
+
+}

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarSearchRegistrar.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/CalendarSearchRegistrar.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.calendar.internal.search;
+
+import com.liferay.calendar.model.Calendar;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(immediate = true)
+public class CalendarSearchRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = modelSearchRegistrarHelper.register(
+			Calendar.class, bundleContext,
+			modelSearchDefinition -> {
+				modelSearchDefinition.setDefaultSelectedFieldNames(
+					Field.COMPANY_ID, Field.ENTRY_CLASS_NAME,
+					Field.ENTRY_CLASS_PK, Field.UID);
+
+				modelSearchDefinition.setDefaultSelectedLocalizedFieldNames(
+					Field.DESCRIPTION, Field.NAME, CalendarField.RESOURCE_NAME);
+
+				modelSearchDefinition.setSelectAllLocales(true);
+
+				modelSearchDefinition.setModelIndexWriteContributor(
+					modelIndexWriterContributor);
+
+				modelSearchDefinition.setModelSummaryContributor(
+					modelSummaryContributor);
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.calendar.model.Calendar)"
+	)
+	protected ModelIndexerWriterContributor<Calendar>
+		modelIndexWriterContributor;
+
+	@Reference
+	protected ModelSearchRegistrarHelper modelSearchRegistrarHelper;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.calendar.model.Calendar)"
+	)
+	protected ModelSummaryContributor modelSummaryContributor;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+}

--- a/modules/apps/document-library/document-library-service/build.gradle
+++ b/modules/apps/document-library/document-library-service/build.gradle
@@ -19,7 +19,8 @@ dependencies {
 	compileOnly project(":apps:petra:petra-model-adapter")
 	compileOnly project(":apps:portal-configuration:portal-configuration-upgrade-api")
 	compileOnly project(":apps:portal-instances:portal-instances-api")
-	compileOnly project(":apps:portal-search:portal-search")
+	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
@@ -30,6 +31,7 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 
+	testCompile project(":apps:portal-search:portal-search")
 	testCompile project(":core:petra:petra-lang")
 	testCompile project(":core:registry-api")
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryExpandoBridgeRetriever.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryExpandoBridgeRetriever.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.util.ExpandoBridgeFactory;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.search.spi.model.index.contributor.ExpandoBridgeRetriever;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ExpandoBridgeRetriever.class
+)
+public class DLFileEntryExpandoBridgeRetriever
+	implements ExpandoBridgeRetriever {
+
+	@Override
+	public ExpandoBridge getExpandoBridge(BaseModel baseModel) {
+		try {
+			DLFileEntry dlFileEntry = (DLFileEntry)baseModel;
+
+			DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+			ExpandoBridge expandoBridge = expandoBridgeFactory.getExpandoBridge(
+				dlFileEntry.getCompanyId(), DLFileEntry.class.getName(),
+				dlFileVersion.getFileVersionId());
+
+			return expandoBridge;
+		}
+		catch (PortalException pe) {
+			throw new SystemException(pe);
+		}
+	}
+
+	@Reference
+	protected ExpandoBridgeFactory expandoBridgeFactory;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryKeywordQueryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryKeywordQueryContributor.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.query.QueryHelper;
+import com.liferay.portal.search.spi.model.query.contributor.KeywordQueryContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.KeywordQueryContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bryan Engler
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = KeywordQueryContributor.class
+)
+public class DLFileEntryKeywordQueryContributor
+	implements KeywordQueryContributor {
+
+	@Override
+	public void contribute(
+		String keywords, BooleanQuery booleanQuery,
+		KeywordQueryContributorHelper keywordQueryContributorHelper) {
+
+		SearchContext searchContext =
+			keywordQueryContributorHelper.getSearchContext();
+
+		if (Validator.isNull(keywords)) {
+			queryHelper.addSearchTerm(
+				booleanQuery, searchContext, Field.DESCRIPTION, false);
+			queryHelper.addSearchTerm(
+				booleanQuery, searchContext, Field.TITLE, false);
+			queryHelper.addSearchTerm(
+				booleanQuery, searchContext, Field.USER_NAME, false);
+		}
+
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, "ddmContent", false);
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, "extension", false);
+		queryHelper.addSearchTerm(
+			booleanQuery, searchContext, "fileEntryTypeId", false);
+		queryHelper.addSearchTerm(booleanQuery, searchContext, "path", false);
+		queryHelper.addSearchLocalizedTerm(
+			booleanQuery, searchContext, Field.CONTENT, false);
+	}
+
+	@Reference
+	protected QueryHelper queryHelper;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelDocumentContributor.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLFileEntryMetadataLocalService;
+import com.liferay.dynamic.data.mapping.kernel.DDMFormValues;
+import com.liferay.dynamic.data.mapping.kernel.DDMStructureManager;
+import com.liferay.dynamic.data.mapping.kernel.StorageEngineManager;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentHelper;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.RelatedEntryIndexer;
+import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.portal.util.PrefsPropsUtil;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.trash.TrashHelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelDocumentContributor.class
+)
+public class DLFileEntryModelDocumentContributor
+	implements ModelDocumentContributor<DLFileEntry> {
+
+	@Override
+	public void contribute(Document document, DLFileEntry dlFileEntry) {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Indexing document " + dlFileEntry);
+		}
+
+		boolean indexContent = true;
+
+		String[] ignoreExtensions = PrefsPropsUtil.getStringArray(
+			PropsKeys.DL_FILE_INDEXING_IGNORE_EXTENSIONS, StringPool.COMMA);
+
+		if (ArrayUtil.contains(
+				ignoreExtensions,
+				StringPool.PERIOD + dlFileEntry.getExtension())) {
+
+			indexContent = false;
+		}
+
+		InputStream is = null;
+
+		if (indexContent) {
+			try {
+				DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+				is = dlFileVersion.getContentStream(false);
+			}
+			catch (Exception e) {
+				if (_log.isDebugEnabled()) {
+					_log.debug("Unable to retrieve document stream", e);
+				}
+			}
+		}
+
+		try {
+			DLFileVersion dlFileVersion = dlFileEntry.getFileVersion();
+
+			if (indexContent) {
+				if (is != null) {
+					try {
+						Locale defaultLocale = portal.getSiteDefaultLocale(
+							dlFileEntry.getGroupId());
+
+						String localizedField = Field.getLocalizedName(
+							defaultLocale.toString(), Field.CONTENT);
+
+						document.addFile(
+							localizedField, is, dlFileEntry.getTitle(),
+							PropsValues.DL_FILE_INDEXING_MAX_SIZE);
+					}
+					catch (IOException ioe) {
+						if (_log.isWarnEnabled()) {
+							_log.warn("Unable to index content", ioe);
+						}
+					}
+				}
+				else if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Document " + dlFileEntry +
+							" does not have any content");
+				}
+			}
+
+			document.addKeyword(
+				Field.CLASS_TYPE_ID, dlFileEntry.getFileEntryTypeId());
+			document.addText(Field.DESCRIPTION, dlFileEntry.getDescription());
+			document.addKeyword(Field.FOLDER_ID, dlFileEntry.getFolderId());
+			document.addKeyword(Field.HIDDEN, dlFileEntry.isInHiddenFolder());
+			document.addText(
+				Field.PROPERTIES, dlFileEntry.getLuceneProperties());
+			document.addKeyword(Field.STATUS, dlFileVersion.getStatus());
+
+			String title = dlFileEntry.getTitle();
+
+			if (dlFileEntry.isInTrash()) {
+				title = trashHelper.getOriginalTitle(title);
+			}
+
+			document.addText(Field.TITLE, title);
+
+			document.addKeyword(
+				Field.TREE_PATH,
+				StringUtil.split(dlFileEntry.getTreePath(), CharPool.SLASH));
+
+			document.addKeyword(
+				"dataRepositoryId", dlFileEntry.getDataRepositoryId());
+			//todo is this necessary?
+			document.addText(
+				"ddmContent",
+				extractDDMContent(dlFileVersion, LocaleUtil.getSiteDefault()));
+			document.addKeyword("extension", dlFileEntry.getExtension());
+			document.addKeyword(
+				"fileEntryTypeId", dlFileEntry.getFileEntryTypeId());
+			document.addKeyword(
+				"mimeType",
+				StringUtil.replace(
+					dlFileEntry.getMimeType(), CharPool.FORWARD_SLASH,
+					CharPool.UNDERLINE));
+			document.addKeyword("path", dlFileEntry.getTitle());
+			document.addKeyword("readCount", dlFileEntry.getReadCount());
+			document.addKeyword("size", dlFileEntry.getSize());
+
+			//todo is this necessary? duplicates extractDDMContent
+			addFileEntryTypeAttributes(document, dlFileVersion);
+
+			if (dlFileEntry.isInHiddenFolder()) {
+				List<RelatedEntryIndexer> relatedEntryIndexers =
+					relatedEntryIndexerRegistry.getRelatedEntryIndexers(
+						dlFileEntry.getClassName());
+
+				if (ListUtil.isNotEmpty(relatedEntryIndexers)) {
+					for (RelatedEntryIndexer relatedEntryIndexer :
+							relatedEntryIndexers) {
+
+						relatedEntryIndexer.addRelatedEntryFields(
+							document, new LiferayFileEntry(dlFileEntry));
+
+						DocumentHelper documentHelper = new DocumentHelper(
+							document);
+
+						documentHelper.setAttachmentOwnerKey(
+							portal.getClassNameId(dlFileEntry.getClassName()),
+							dlFileEntry.getClassPK());
+
+						document.addKeyword(Field.RELATED_ENTRY, true);
+					}
+				}
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug("Document " + dlFileEntry + " indexed successfully");
+			}
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			if (is != null) {
+				try {
+					is.close();
+				}
+				catch (IOException ioe) {
+				}
+			}
+		}
+	}
+
+	protected void addFileEntryTypeAttributes(
+			Document document, DLFileVersion dlFileVersion)
+		throws PortalException {
+
+		List<DLFileEntryMetadata> dlFileEntryMetadatas =
+			dlFileEntryMetadataLocalService.getFileVersionFileEntryMetadatas(
+				dlFileVersion.getFileVersionId());
+
+		for (DLFileEntryMetadata dlFileEntryMetadata : dlFileEntryMetadatas) {
+			try {
+				DDMFormValues ddmFormValues =
+					storageEngineManager.getDDMFormValues(
+						dlFileEntryMetadata.getDDMStorageId());
+
+				if (ddmFormValues != null) {
+					ddmStructureManager.addAttributes(
+						dlFileEntryMetadata.getDDMStructureId(), document,
+						ddmFormValues);
+				}
+			}
+			catch (Exception e) {
+				if (_log.isDebugEnabled()) {
+					_log.debug("Unable to retrieve metadata values", e);
+				}
+			}
+		}
+	}
+
+	protected String extractDDMContent(
+			DLFileVersion dlFileVersion, Locale locale)
+		throws Exception {
+
+		List<DLFileEntryMetadata> dlFileEntryMetadatas =
+			dlFileEntryMetadataLocalService.getFileVersionFileEntryMetadatas(
+				dlFileVersion.getFileVersionId());
+
+		StringBundler sb = new StringBundler(dlFileEntryMetadatas.size());
+
+		for (DLFileEntryMetadata dlFileEntryMetadata : dlFileEntryMetadatas) {
+			try {
+				DDMFormValues ddmFormValues =
+					storageEngineManager.getDDMFormValues(
+						dlFileEntryMetadata.getDDMStorageId());
+
+				if (ddmFormValues != null) {
+					sb.append(
+						ddmStructureManager.extractAttributes(
+							dlFileEntryMetadata.getDDMStructureId(),
+							ddmFormValues, locale));
+				}
+			}
+			catch (Exception e) {
+				if (_log.isDebugEnabled()) {
+					_log.debug("Unable to retrieve metadata values", e);
+				}
+			}
+		}
+
+		return sb.toString();
+	}
+
+	@Reference
+	protected DDMStructureManager ddmStructureManager;
+
+	@Reference
+	protected DLFileEntryMetadataLocalService dlFileEntryMetadataLocalService;
+
+	@Reference
+	protected Portal portal;
+
+	@Reference
+	protected RelatedEntryIndexerRegistry relatedEntryIndexerRegistry;
+
+	@Reference
+	protected StorageEngineManager storageEngineManager;
+
+	@Reference
+	protected TrashHelper trashHelper;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFileEntryModelDocumentContributor.class);
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelIndexerWriterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelIndexerWriterContributor.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.exception.NoSuchFileVersionException;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileVersion;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.search.batch.BatchIndexingActionable;
+import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.index.contributor.helper.IndexerWriterMode;
+import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelIndexerWriterContributor.class
+)
+public class DLFileEntryModelIndexerWriterContributor
+	implements ModelIndexerWriterContributor<DLFileEntry> {
+
+	@Override
+	public void customize(
+		BatchIndexingActionable batchIndexingActionable,
+		ModelIndexerWriterDocumentHelper modelIndexerWriterDocumentHelper) {
+
+		batchIndexingActionable.setInterval(_dlFileIndexingInterval);
+		batchIndexingActionable.setPerformActionMethod(
+			(DLFileEntry dlFileEntry) -> {
+				batchIndexingActionable.addDocuments(
+					modelIndexerWriterDocumentHelper.getDocument(dlFileEntry));
+			});
+	}
+
+	@Override
+	public BatchIndexingActionable getBatchIndexingActionable() {
+		return dynamicQueryBatchIndexingActionableFactory.
+			getBatchIndexingActionable(
+				dlFileEntryLocalService.getIndexableActionableDynamicQuery());
+	}
+
+	@Override
+	public long getCompanyId(DLFileEntry dlFileEntry) {
+		return dlFileEntry.getCompanyId();
+	}
+
+	@Override
+	public IndexerWriterMode getIndexerWriterMode(DLFileEntry dlFileEntry) {
+		DLFileVersion dlFileVersion = null;
+
+		try {
+			dlFileVersion = dlFileEntry.getFileVersion();
+		}
+		catch (NoSuchFileVersionException nsfve) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to get file version for file entry " +
+						dlFileEntry.getFileEntryId(),
+					nsfve);
+			}
+
+			return IndexerWriterMode.SKIP;
+		}
+		catch (PortalException pe) {
+			throw new SystemException(pe);
+		}
+
+		if (!dlFileVersion.isApproved() && !dlFileEntry.isInTrash()) {
+			return IndexerWriterMode.SKIP;
+		}
+
+		return IndexerWriterMode.UPDATE;
+	}
+
+	@Activate
+	protected void activate() {
+		_dlFileIndexingInterval = GetterUtil.getInteger(
+			props.get(PropsKeys.DL_FILE_INDEXING_INTERVAL), 500);
+	}
+
+	@Reference
+	protected DLFileEntryLocalService dlFileEntryLocalService;
+
+	@Reference
+	protected DynamicQueryBatchIndexingActionableFactory
+		dynamicQueryBatchIndexingActionableFactory;
+
+	@Reference
+	protected Props props;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFileEntryModelIndexerWriterContributor.class);
+
+	private int _dlFileIndexingInterval;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelPreFilterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelPreFilterContributor.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.dynamic.data.mapping.kernel.DDMStructure;
+import com.liferay.dynamic.data.mapping.kernel.DDMStructureManager;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.BaseRelatedEntryIndexer;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.RelatedEntryIndexer;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.QueryFilter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bryan Engler
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelPreFilterContributor.class
+)
+public class DLFileEntryModelPreFilterContributor
+	implements ModelPreFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		addAttachmentFilter(booleanFilter, searchContext);
+		addClassTypeIdsFilter(
+			booleanFilter, modelSearchSettings, searchContext);
+		addDDMFieldFilter(booleanFilter, searchContext);
+		addWorkflowStatusFilter(
+			booleanFilter, modelSearchSettings, searchContext);
+		addHiddenFilter(booleanFilter, searchContext);
+		addMimeTypesFilter(booleanFilter, searchContext);
+	}
+
+	protected void addAttachmentFilter(
+		BooleanFilter booleanFilter, SearchContext searchContext) {
+
+		if (!searchContext.isIncludeAttachments()) {
+			return;
+		}
+
+		try {
+			relatedEntryIndexer.addRelatedClassNames(
+				booleanFilter, searchContext);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	protected void addClassTypeIdsFilter(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		long[] classTypeIds = searchContext.getClassTypeIds();
+
+		if (ArrayUtil.isEmpty(classTypeIds)) {
+			return;
+		}
+
+		TermsFilter termsFilter = new TermsFilter(Field.CLASS_TYPE_ID);
+
+		termsFilter.addValues(ArrayUtil.toStringArray(classTypeIds));
+
+		booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+	}
+
+	protected void addDDMFieldFilter(
+		BooleanFilter booleanFilter, SearchContext searchContext) {
+
+		try {
+			String ddmStructureFieldName = (String)searchContext.getAttribute(
+				"ddmStructureFieldName");
+			Serializable ddmStructureFieldValue = searchContext.getAttribute(
+				"ddmStructureFieldValue");
+
+			if (Validator.isNotNull(ddmStructureFieldName) &&
+				Validator.isNotNull(ddmStructureFieldValue)) {
+
+				String[] ddmStructureFieldNameParts = StringUtil.split(
+					ddmStructureFieldName,
+					DDMStructureManager.STRUCTURE_INDEXER_FIELD_SEPARATOR);
+
+				DDMStructure ddmStructure = ddmStructureManager.getStructure(
+					GetterUtil.getLong(ddmStructureFieldNameParts[2]));
+
+				String fieldName = StringUtil.replaceLast(
+					ddmStructureFieldNameParts[3],
+					StringPool.UNDERLINE.concat(
+						LocaleUtil.toLanguageId(searchContext.getLocale())),
+					StringPool.BLANK);
+
+				try {
+					ddmStructureFieldValue =
+						ddmStructureManager.getIndexedFieldValue(
+							ddmStructureFieldValue,
+							ddmStructure.getFieldType(fieldName));
+				}
+				catch (Exception e) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(e, e);
+					}
+				}
+
+				BooleanQuery booleanQuery = new BooleanQueryImpl();
+
+				booleanQuery.addRequiredTerm(
+					ddmStructureFieldName,
+					StringPool.QUOTE + ddmStructureFieldValue +
+						StringPool.QUOTE);
+
+				booleanFilter.add(
+					new QueryFilter(booleanQuery), BooleanClauseOccur.MUST);
+			}
+		}
+		catch (PortalException pe) {
+			throw new SystemException(pe);
+		}
+	}
+
+	protected void addHiddenFilter(
+		BooleanFilter booleanFilter, SearchContext searchContext) {
+
+		if (ArrayUtil.isEmpty(searchContext.getFolderIds()) ||
+			ArrayUtil.contains(
+				searchContext.getFolderIds(),
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+
+			booleanFilter.addRequiredTerm(
+				Field.HIDDEN, searchContext.isIncludeAttachments());
+		}
+	}
+
+	protected void addMimeTypesFilter(
+		BooleanFilter booleanFilter, SearchContext searchContext) {
+
+		String[] mimeTypes = (String[])searchContext.getAttribute("mimeTypes");
+
+		if (ArrayUtil.isNotEmpty(mimeTypes)) {
+			BooleanFilter mimeTypesBooleanFilter = new BooleanFilter();
+
+			for (String mimeType : mimeTypes) {
+				mimeTypesBooleanFilter.addTerm(
+					"mimeType",
+					StringUtil.replace(
+						mimeType, CharPool.FORWARD_SLASH, CharPool.UNDERLINE));
+			}
+
+			booleanFilter.add(mimeTypesBooleanFilter, BooleanClauseOccur.MUST);
+		}
+	}
+
+	protected void addWorkflowStatusFilter(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		workflowStatusModelPreFilterContributor.contribute(
+			booleanFilter, modelSearchSettings, searchContext);
+	}
+
+	@Reference
+	protected DDMStructureManager ddmStructureManager;
+
+	protected RelatedEntryIndexer relatedEntryIndexer =
+		new BaseRelatedEntryIndexer();
+
+	@Reference(target = "(model.pre.filter.contributor.id=WorkflowStatus)")
+	protected ModelPreFilterContributor workflowStatusModelPreFilterContributor;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFileEntryModelPreFilterContributor.class);
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelSearchContextContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelSearchContextContributor.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.search.spi.model.query.contributor.SearchContextContributor;
+import com.liferay.portal.search.spi.model.query.contributor.helper.SearchContextContributorHelper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = SearchContextContributor.class
+)
+public class DLFileEntryModelSearchContextContributor
+	implements SearchContextContributor {
+
+	@Override
+	public void contribute(
+		SearchContext searchContext,
+		SearchContextContributorHelper searchContextContributorHelper) {
+
+		if (!searchContext.isIncludeAttachments()) {
+			return;
+		}
+
+		searchContext.addFullQueryEntryClassName(DLFileEntry.class.getName());
+	}
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelSummaryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelSummaryContributor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelSummaryContributor.class
+)
+public class DLFileEntryModelSummaryContributor
+	implements ModelSummaryContributor {
+
+	@Override
+	public Summary getSummary(
+		Document document, Locale locale, String snippet) {
+
+		String prefix = Field.SNIPPET + StringPool.UNDERLINE;
+
+		String title = document.get(prefix + Field.TITLE, Field.TITLE);
+		String content = document.get(
+			locale, prefix + Field.CONTENT, Field.CONTENT);
+
+		if (Validator.isNull(content)) {
+			content = document.get(
+				prefix + Field.DESCRIPTION, Field.DESCRIPTION);
+		}
+
+		Summary summary = new Summary(title, content);
+
+		summary.setMaxContentLength(200);
+
+		return summary;
+	}
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelVisibilityContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryModelVisibilityContributor.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.search.spi.model.result.contributor.ModelVisibilityContributor;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelVisibilityContributor.class
+)
+public class DLFileEntryModelVisibilityContributor
+	implements ModelVisibilityContributor {
+
+	@Override
+	public boolean isVisible(long classPK, int status) {
+		FileVersion fileVersion = getFileVersion(classPK);
+
+		if (fileVersion == null) {
+			return false;
+		}
+
+		return isVisible(fileVersion.getStatus(), status);
+	}
+
+	protected FileVersion getFileVersion(long classPK) {
+		try {
+			FileEntry fileEntry = dlAppLocalService.getFileEntry(classPK);
+
+			return fileEntry.getFileVersion();
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+
+			return null;
+		}
+	}
+
+	protected boolean isVisible(int entryStatus, int queryStatus) {
+		if (((queryStatus != WorkflowConstants.STATUS_ANY) &&
+			 (entryStatus == queryStatus)) ||
+			(entryStatus != WorkflowConstants.STATUS_IN_TRASH)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Reference
+	protected DLAppLocalService dlAppLocalService;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFileEntryModelVisibilityContributor.class);
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryRelatedEntryIndexer.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryRelatedEntryIndexer.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.comment.Comment;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.search.BaseRelatedEntryIndexer;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.search.RelatedEntryIndexer;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "related.entry.indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = RelatedEntryIndexer.class
+)
+public class DLFileEntryRelatedEntryIndexer implements RelatedEntryIndexer {
+
+	@Override
+	public void addRelatedClassNames(
+			BooleanFilter contextBooleanFilter, SearchContext searchContext)
+		throws Exception {
+
+		_relatedEntryIndexer.addRelatedClassNames(
+			contextBooleanFilter, searchContext);
+	}
+
+	@Override
+	public void addRelatedEntryFields(Document document, Object obj)
+		throws Exception {
+
+		Comment comment = (Comment)obj;
+
+		FileEntry fileEntry = null;
+
+		try {
+			fileEntry = dlAppLocalService.getFileEntry(comment.getClassPK());
+		}
+		catch (Exception e) {
+			return;
+		}
+
+		if (fileEntry instanceof LiferayFileEntry) {
+			DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
+
+			document.addKeyword(Field.FOLDER_ID, dlFileEntry.getFolderId());
+			document.addKeyword(Field.HIDDEN, dlFileEntry.isInHiddenFolder());
+			document.addKeyword(
+				Field.TREE_PATH,
+				StringUtil.split(dlFileEntry.getTreePath(), CharPool.SLASH));
+		}
+	}
+
+	@Override
+	public boolean isVisibleRelatedEntry(long classPK, int status)
+		throws Exception {
+
+		try {
+			FileEntry fileEntry = dlAppLocalService.getFileEntry(classPK);
+
+			if (fileEntry instanceof LiferayFileEntry) {
+				DLFileEntry dlFileEntry = (DLFileEntry)fileEntry.getModel();
+
+				if (dlFileEntry.isInHiddenFolder()) {
+					Indexer<?> indexer = IndexerRegistryUtil.getIndexer(
+						dlFileEntry.getClassName());
+
+					return indexer.isVisible(dlFileEntry.getClassPK(), status);
+				}
+			}
+		}
+		catch (Exception e) {
+			if (_log.isInfoEnabled()) {
+				_log.info("Unable to get file entry", e);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public void updateFullQuery(SearchContext searchContext) {
+		if (searchContext.isIncludeAttachments()) {
+			searchContext.addFullQueryEntryClassName(
+				DLFileEntry.class.getName());
+		}
+	}
+
+	@Reference
+	protected DLAppLocalService dlAppLocalService;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFileEntryRelatedEntryIndexer.class);
+
+	private final RelatedEntryIndexer _relatedEntryIndexer =
+		new BaseRelatedEntryIndexer();
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryRelatedEntryModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntryRelatedEntryModelDocumentContributor.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentHelper;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.RelatedEntryIndexer;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	service = ModelDocumentContributor.class
+)
+public class DLFileEntryRelatedEntryModelDocumentContributor
+	implements ModelDocumentContributor<DLFileEntry> {
+
+	@Override
+	public void contribute(Document document, DLFileEntry dlFileEntry) {
+		if (!dlFileEntry.isInHiddenFolder()) {
+			return;
+		}
+
+		try {
+			relatedEntryIndexer.addRelatedEntryFields(
+				document, new LiferayFileEntry(dlFileEntry));
+
+			DocumentHelper documentHelper = new DocumentHelper(document);
+
+			documentHelper.setAttachmentOwnerKey(
+				portal.getClassNameId(dlFileEntry.getClassName()),
+				dlFileEntry.getClassPK());
+
+			document.addKeyword(Field.RELATED_ENTRY, true);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+	}
+
+	@Reference
+	protected Portal portal;
+
+	@Reference(
+		target = "(related.entry.indexer.class.name=com.liferay.message.boards.model.MBMessage)"
+	)
+	protected RelatedEntryIndexer relatedEntryIndexer;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntrySearchRegistrar.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFileEntrySearchRegistrar.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+import com.liferay.portal.search.spi.model.result.contributor.ModelVisibilityContributor;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(immediate = true)
+public class DLFileEntrySearchRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = modelSearchRegistrarHelper.register(
+			DLFileEntry.class, bundleContext,
+			modelSearchDefinition -> {
+				modelSearchDefinition.setDefaultSelectedFieldNames(
+					Field.ASSET_TAG_NAMES, Field.COMPANY_ID, Field.CONTENT,
+					Field.ENTRY_CLASS_NAME, Field.ENTRY_CLASS_PK,
+					Field.GROUP_ID, Field.MODIFIED_DATE, Field.SCOPE_GROUP_ID,
+					Field.TITLE, Field.UID);
+
+				modelSearchDefinition.setModelIndexWriteContributor(
+					modelIndexWriterContributor);
+
+				modelSearchDefinition.setModelVisibilityContributor(
+					modelVisibilityContributor);
+
+				modelSearchDefinition.setModelSummaryContributor(
+					modelSummaryContributor);
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry)"
+	)
+	protected ModelIndexerWriterContributor<DLFolder>
+		modelIndexWriterContributor;
+
+	@Reference
+	protected ModelSearchRegistrarHelper modelSearchRegistrarHelper;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry)"
+	)
+	protected ModelSummaryContributor modelSummaryContributor;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry)"
+	)
+	protected ModelVisibilityContributor modelVisibilityContributor;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelDocumentContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelDocumentContributor.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
+import com.liferay.trash.TrashHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFolder",
+	service = ModelDocumentContributor.class
+)
+public class DLFolderModelDocumentContributor
+	implements ModelDocumentContributor<DLFolder> {
+
+	@Override
+	public void contribute(Document document, DLFolder dlFolder) {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Indexing folder " + dlFolder);
+		}
+
+		document.addText(Field.DESCRIPTION, dlFolder.getDescription());
+		document.addKeyword(Field.FOLDER_ID, dlFolder.getParentFolderId());
+		document.addKeyword(
+			Field.HIDDEN, dlFolder.isHidden() || dlFolder.isInHiddenFolder());
+
+		String title = dlFolder.getName();
+
+		if (dlFolder.isInTrash()) {
+			title = trashHelper.getOriginalTitle(title);
+		}
+
+		document.addText(Field.TITLE, title);
+
+		document.addKeyword(Field.TREE_PATH, dlFolder.getTreePath());
+		document.addKeyword(
+			Field.TREE_PATH,
+			StringUtil.split(dlFolder.getTreePath(), CharPool.SLASH));
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Document " + dlFolder + " indexed successfully");
+		}
+	}
+
+	@Reference
+	protected TrashHelper trashHelper;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLFolderModelDocumentContributor.class);
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelIndexerWriterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelIndexerWriterContributor.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.search.batch.BatchIndexingActionable;
+import com.liferay.portal.search.batch.DynamicQueryBatchIndexingActionableFactory;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.index.contributor.helper.ModelIndexerWriterDocumentHelper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFolder",
+	service = ModelIndexerWriterContributor.class
+)
+public class DLFolderModelIndexerWriterContributor
+	implements ModelIndexerWriterContributor<DLFolder> {
+
+	@Override
+	public void customize(
+		BatchIndexingActionable batchIndexingActionable,
+		ModelIndexerWriterDocumentHelper modelIndexerWriterDocumentHelper) {
+
+		batchIndexingActionable.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property property = PropertyFactoryUtil.forName("mountPoint");
+
+				dynamicQuery.add(property.eq(false));
+			});
+
+		batchIndexingActionable.setPerformActionMethod(
+			(DLFolder dlFolder) -> {
+				batchIndexingActionable.addDocuments(
+					modelIndexerWriterDocumentHelper.getDocument(dlFolder));
+			});
+	}
+
+	@Override
+	public BatchIndexingActionable getBatchIndexingActionable() {
+		return dynamicQueryBatchIndexingActionableFactory.
+			getBatchIndexingActionable(
+				dlFolderLocalService.getIndexableActionableDynamicQuery());
+	}
+
+	@Override
+	public long getCompanyId(DLFolder dlFolder) {
+		return dlFolder.getCompanyId();
+	}
+
+	@Reference
+	protected DLFolderLocalService dlFolderLocalService;
+
+	@Reference
+	protected DynamicQueryBatchIndexingActionableFactory
+		dynamicQueryBatchIndexingActionableFactory;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelPreFilterContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelPreFilterContributor.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFolder",
+	service = ModelPreFilterContributor.class
+)
+public class DLFolderModelPreFilterContributor
+	implements ModelPreFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		addHiddenFilter(booleanFilter);
+		addWorkflowStatusFilter(
+			booleanFilter, modelSearchSettings, searchContext);
+	}
+
+	protected void addHiddenFilter(BooleanFilter booleanFilter) {
+		booleanFilter.addRequiredTerm(Field.HIDDEN, false);
+	}
+
+	protected void addWorkflowStatusFilter(
+		BooleanFilter booleanFilter, ModelSearchSettings modelSearchSettings,
+		SearchContext searchContext) {
+
+		workflowStatusModelPreFilterContributor.contribute(
+			booleanFilter, modelSearchSettings, searchContext);
+	}
+
+	@Reference(target = "(model.pre.filter.contributor.id=WorkflowStatus)")
+	protected ModelPreFilterContributor workflowStatusModelPreFilterContributor;
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelSummaryContributor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderModelSummaryContributor.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.document.library.kernel.model.DLFolder",
+	service = ModelSummaryContributor.class
+)
+public class DLFolderModelSummaryContributor
+	implements ModelSummaryContributor {
+
+	@Override
+	public Summary getSummary(
+		Document document, Locale locale, String snippet) {
+
+		String prefix = Field.SNIPPET + StringPool.UNDERLINE;
+
+		String title = document.get(prefix + Field.TITLE, Field.TITLE);
+		String content = document.get(
+			prefix + Field.DESCRIPTION, Field.DESCRIPTION);
+
+		Summary summary = new Summary(title, content);
+
+		summary.setMaxContentLength(200);
+
+		return summary;
+	}
+
+}

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderSearchRegistrar.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/search/DLFolderSearchRegistrar.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.internal.search;
+
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.search.spi.model.index.contributor.ModelIndexerWriterContributor;
+import com.liferay.portal.search.spi.model.registrar.ModelSearchRegistrarHelper;
+import com.liferay.portal.search.spi.model.result.contributor.ModelSummaryContributor;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael C. Han
+ */
+@Component(immediate = true)
+public class DLFolderSearchRegistrar {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = modelSearchRegistrarHelper.register(
+			DLFolder.class, bundleContext,
+			modelSearchDefinition -> {
+				modelSearchDefinition.setDefaultSelectedFieldNames(
+					Field.COMPANY_ID, Field.DESCRIPTION, Field.ENTRY_CLASS_NAME,
+					Field.ENTRY_CLASS_PK, Field.TITLE, Field.UID);
+
+				modelSearchDefinition.setModelIndexWriteContributor(
+					modelIndexWriterContributor);
+
+				modelSearchDefinition.setModelSummaryContributor(
+					modelSummaryContributor);
+			});
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceRegistration.unregister();
+	}
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFolder)"
+	)
+	protected ModelIndexerWriterContributor<DLFolder>
+		modelIndexWriterContributor;
+
+	@Reference
+	protected ModelSearchRegistrarHelper modelSearchRegistrarHelper;
+
+	@Reference(
+		target = "(indexer.class.name=com.liferay.document.library.kernel.model.DLFolder)"
+	)
+	protected ModelSummaryContributor modelSummaryContributor;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+}

--- a/portal-impl/src/META-INF/document-library-spring.xml
+++ b/portal-impl/src/META-INF/document-library-spring.xml
@@ -16,9 +16,7 @@
 	<bean class="com.liferay.portlet.documentlibrary.service.permission.DLFileEntryPermission" id="com.liferay.portlet.documentlibrary.service.permission.DLFileEntryPermission" />
 	<bean class="com.liferay.portlet.documentlibrary.service.permission.DLFolderPermission" id="com.liferay.portlet.documentlibrary.service.permission.DLFolderPermission" />
 	<bean class="com.liferay.portlet.documentlibrary.service.permission.DLPermission" id="com.liferay.portlet.documentlibrary.service.permission.DLPermission" />
-	<bean class="com.liferay.portlet.documentlibrary.util.DLFileEntryIndexer" id="com.liferay.portlet.documentlibrary.util.DLFileEntryIndexer" />
 	<bean class="com.liferay.portlet.documentlibrary.util.DLFileEntryLockListener" id="com.liferay.portlet.documentlibrary.util.DLFileEntryLockListener" />
 	<bean class="com.liferay.portlet.documentlibrary.util.DLFileEntryMetadataIndexer" id="com.liferay.portlet.documentlibrary.util.DLFileEntryMetadataIndexer" />
-	<bean class="com.liferay.portlet.documentlibrary.util.DLFolderIndexer" id="com.liferay.portlet.documentlibrary.util.DLFolderIndexer" />
 	<bean class="com.liferay.portlet.documentlibrary.util.DLOpenSearchImpl" id="com.liferay.portlet.documentlibrary.util.DLOpenSearchImpl" />
 </beans>


### PR DESCRIPTION
This discontinues the classic search indexers in Calendar and DocLib (subclasses of BaseIndexer) and reintroduces them as new indexers with 7.1 architecture. (OSGi components based on composition instead of inheritance.)

cc/ @leoadb @sergiogonzalez

----

CI results: at least 6 "Failures unique to this pull" - apparently, false negatives. https://github.com/arboliveira/liferay-portal/pull/478#issuecomment-387933525

1. Database hiccup. `ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 104`

2. Unrelated to Search. `Could not resolve module: com.liferay.portal.startup.monitor [1]
     [exec]   Unresolved requirement: Import-Package: org.osgi.service.component; version="[1.3.0,2.0.0)"`

3. Same

4. Same

5. Unrelated to Search. `Could not resolve module: com.liferay.util.taglib [2]
     [exec]   Unresolved requirement: Import-Package: javax.el`

Authors: @mhan810 @BryanEngler
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-80470