### PR TITLE
LPS-80666 Require a specific Language key based on the bundle symbolic name when getting a translated Application name

### DIFF
--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADApplicationSummaryDisplay.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/display/UADApplicationSummaryDisplay.java
@@ -19,32 +19,32 @@ package com.liferay.user.associated.data.web.internal.display;
  */
 public class UADApplicationSummaryDisplay {
 
-	public int getCount() {
-		return _count;
+	public String getApplicationKey() {
+		return _applicationKey;
 	}
 
-	public String getKey() {
-		return _key;
+	public int getCount() {
+		return _count;
 	}
 
 	public String getViewURL() {
 		return _viewURL;
 	}
 
-	public void setCount(int count) {
-		_count = count;
+	public void setApplicationKey(String applicationKey) {
+		_applicationKey = applicationKey;
 	}
 
-	public void setKey(String key) {
-		_key = key;
+	public void setCount(int count) {
+		_count = count;
 	}
 
 	public void setViewURL(String viewURL) {
 		_viewURL = viewURL;
 	}
 
+	private String _applicationKey;
 	private int _count;
-	private String _key;
 	private String _viewURL;
 
 }

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADApplicationSummaryHelper.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADApplicationSummaryHelper.java
@@ -200,7 +200,8 @@ public class UADApplicationSummaryHelper {
 		String orderByColumn, String orderByType) {
 
 		Comparator<UADApplicationSummaryDisplay> comparator =
-			Comparator.comparing(UADApplicationSummaryDisplay::getKey);
+			Comparator.comparing(
+				UADApplicationSummaryDisplay::getApplicationKey);
 
 		if (orderByColumn.equals("items") || orderByColumn.equals("status")) {
 			comparator = Comparator.comparingInt(
@@ -359,7 +360,7 @@ public class UADApplicationSummaryHelper {
 
 		uadApplicationSummaryDisplay.setCount(count);
 
-		uadApplicationSummaryDisplay.setKey(applicationKey);
+		uadApplicationSummaryDisplay.setApplicationKey(applicationKey);
 
 		if (count > 0) {
 			uadApplicationSummaryDisplay.setViewURL(
@@ -390,10 +391,11 @@ public class UADApplicationSummaryHelper {
 
 		uadApplicationSummaryDisplays.sort(
 			(uadApplicationSummaryDisplay, uadApplicationSummaryDisplay2) -> {
-				String applicationKey1 = uadApplicationSummaryDisplay.getKey();
+				String applicationKey1 =
+					uadApplicationSummaryDisplay.getApplicationKey();
 
 				return applicationKey1.compareTo(
-					uadApplicationSummaryDisplay2.getKey());
+					uadApplicationSummaryDisplay2.getApplicationKey());
 			});
 
 		return uadApplicationSummaryDisplays;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADLanguageUtil.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADLanguageUtil.java
@@ -17,9 +17,13 @@ package com.liferay.user.associated.data.web.internal.util;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
+import com.liferay.user.associated.data.component.UADComponent;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Drew Brokke
@@ -43,6 +47,14 @@ public class UADLanguageUtil {
 		return LanguageUtil.get(
 			resourceBundle, "application.name." + applicationKey,
 			applicationKey);
+	}
+
+	public static <T extends UADComponent> String getApplicationName(
+		T uadComponent, Locale locale) {
+
+		Bundle bundle = FrameworkUtil.getBundle(uadComponent.getClass());
+
+		return getApplicationName(bundle.getSymbolicName(), locale);
 	}
 
 }

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADLanguageUtil.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/util/UADLanguageUtil.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.user.associated.data.web.internal.util;
+
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+/**
+ * @author Drew Brokke
+ */
+public class UADLanguageUtil {
+
+	public static String getApplicationName(
+		String applicationKey, Locale locale) {
+
+		ResourceBundleLoader resourceBundleLoader =
+			ResourceBundleLoaderUtil.
+				getResourceBundleLoaderByBundleSymbolicName(applicationKey);
+
+		if (resourceBundleLoader == null) {
+			return applicationKey;
+		}
+
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			locale);
+
+		return LanguageUtil.get(
+			resourceBundle, "application.name." + applicationKey,
+			applicationKey);
+	}
+
+}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/add_uad_export_processes.jsp
@@ -70,7 +70,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 						<liferay-ui:search-container-column-text
 							cssClass="table-cell-expand table-list-title"
 							name="application"
-							property="applicationKey"
+							value="<%= UADLanguageUtil.getApplicationName(uadApplicationExportDisplay.getApplicationKey(), locale) %>"
 						/>
 
 						<liferay-ui:search-container-column-text

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/applications_summary_action.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/applications_summary_action.jsp
@@ -39,7 +39,7 @@ UADApplicationSummaryDisplay uadApplicationSummaryDisplay = (UADApplicationSumma
 	<portlet:actionURL name="/anonymize_application_uad_entities" var="anonymizeUADEntitiesURL">
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 		<portlet:param name="p_u_i_d" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
-		<portlet:param name="applicationKey" value="<%= uadApplicationSummaryDisplay.getKey() %>" />
+		<portlet:param name="applicationKey" value="<%= uadApplicationSummaryDisplay.getApplicationKey() %>" />
 	</portlet:actionURL>
 
 	<liferay-ui:icon
@@ -50,7 +50,7 @@ UADApplicationSummaryDisplay uadApplicationSummaryDisplay = (UADApplicationSumma
 	<portlet:actionURL name="/delete_application_uad_entities" var="deleteUADEntitiesURL">
 		<portlet:param name="redirect" value="<%= currentURL %>" />
 		<portlet:param name="p_u_i_d" value="<%= String.valueOf(selectedUser.getUserId()) %>" />
-		<portlet:param name="applicationKey" value="<%= uadApplicationSummaryDisplay.getKey() %>" />
+		<portlet:param name="applicationKey" value="<%= uadApplicationSummaryDisplay.getApplicationKey() %>" />
 	</portlet:actionURL>
 
 	<liferay-ui:icon

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/export_processes.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/export_processes.jsp
@@ -33,7 +33,7 @@ UADExportProcessDisplayContext uadExportProcessDisplayContext = new UADExportPro
 		>
 			<div>
 				<h5>
-					<liferay-ui:message key="<%= backgroundTask.getName() %>" />
+					<liferay-ui:message key="<%= UADLanguageUtil.getApplicationName(backgroundTask.getName(), locale) %>" />
 				</h5>
 
 				<clay:label

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -26,7 +26,7 @@ UADDisplay uadDisplay = (UADDisplay)request.getAttribute(UADWebKeys.INFO_PANEL_U
 		<c:when test="<%= ListUtil.isEmpty(uadEntities) %>">
 			<div class="sidebar-header">
 				<h3 class="sidebar-title"><%= uadDisplay.getTypeName(locale) %></h3>
-				<h5 class="sidebar-subtitle"><%= uadDisplay.getApplicationName() %></h5>
+				<h5 class="sidebar-subtitle"><%= UADLanguageUtil.getApplicationName(uadDisplay, locale) %></h5>
 			</div>
 		</c:when>
 		<c:when test="<%= ListUtil.isNotEmpty(uadEntities) && (uadEntities.size() == 1) %>">

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/init.jsp
@@ -61,6 +61,7 @@ page import="com.liferay.user.associated.data.web.internal.display.context.UADEx
 page import="com.liferay.user.associated.data.web.internal.search.UADApplicationExportDisplayChecker" %><%@
 page import="com.liferay.user.associated.data.web.internal.search.UADExportProcessResultRowSplitter" %><%@
 page import="com.liferay.user.associated.data.web.internal.util.UADExportProcessUtil" %><%@
+page import="com.liferay.user.associated.data.web.internal.util.UADLanguageUtil" %><%@
 page import="com.liferay.users.admin.constants.UsersAdminPortletKeys" %>
 
 <%@ page import="java.io.Serializable" %>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_applications_summary.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_applications_summary.jsp
@@ -84,7 +84,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 						cssClass="table-cell-expand table-list-title"
 						href="<%= uadApplicationSummaryDisplay.getViewURL() %>"
 						name="name"
-						property="key"
+						value="<%= UADLanguageUtil.getApplicationName(uadApplicationSummaryDisplay.getKey(), locale) %>"
 					/>
 
 					<liferay-ui:search-container-column-text

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_applications_summary.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/view_uad_applications_summary.jsp
@@ -84,7 +84,7 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 						cssClass="table-cell-expand table-list-title"
 						href="<%= uadApplicationSummaryDisplay.getViewURL() %>"
 						name="name"
-						value="<%= UADLanguageUtil.getApplicationName(uadApplicationSummaryDisplay.getKey(), locale) %>"
+						value="<%= UADLanguageUtil.getApplicationName(uadApplicationSummaryDisplay.getApplicationKey(), locale) %>"
 					/>
 
 					<liferay-ui:search-container-column-text


### PR DESCRIPTION
This is an update for [LPS-80666](https://issues.liferay.com/browse/LPS-80666).<br><br>Hey Brian, this is the next step in translating application names for each UAD component.  It relies on a special language key being present in each module: `application.name + {bundleSymbolicName}`, similar to how we have langauge key format for java portlet titles.  This contains changes for the web module only.  It also contains the change requested here: https://github.com/brianchandotcom/liferay-portal/pull/58211#issuecomment-388180994.<br><br>/cc @pei-jung