### PR TITLE
LPS-72748 [Fix massive CI semver failures] portal-kernel: semver - new protected methods in BaseIndexer

### DIFF
--- a/modules/test/poshi-runner/.gitrepo
+++ b/modules/test/poshi-runner/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 59e083ed1055abd0d73873ada7d4cc9fafe35cd3
+	commit = 3a84bc820cd3f3d485b4f53ec69903969d0435a6
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = f8329e317cb8b1f68ed437d9861c736701543794
+	parent = adb455ca1f2fa411603fc77200bcb6ec78b9b2b0
 	remote = git@github.com:liferay/com-liferay-poshi-runner.git

--- a/modules/test/poshi-runner/poshi-runner/bnd.bnd
+++ b/modules/test/poshi-runner/poshi-runner/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Poshi Runner
 Bundle-SymbolicName: com.liferay.poshi.runner
-Bundle-Version: 1.0.102
+Bundle-Version: 1.0.103

--- a/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
+++ b/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/PoshiRunnerContext.java
@@ -1292,7 +1292,7 @@ public class PoshiRunnerContext {
 	private static final Map<String, String> _pathLocators = new HashMap<>();
 	private static final Pattern _poshiResourceJarNamePattern = Pattern.compile(
 		"jar:.*\\/(?<namespace>\\w+)\\-(?<branchName>\\w+" +
-			"(\\-\\w+)*)\\-(?<sha>\\w+)\\.jar.*");
+			"([\\-\\.]\\w+)*)\\-(?<timestamp>\\d+)\\-(?<sha>\\w+)\\.jar.*");
 	private static final Map<String, Element> _rootElements = new HashMap<>();
 	private static final Map<String, Integer> _seleniumParameterCounts =
 		new HashMap<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/packageinfo
@@ -1,1 +1,1 @@
-version 7.4.0
+version 7.5.0


### PR DESCRIPTION
CI is experiencing massive semver failures. This should fix it. The version bump is required indeed, should it have been detected when originally introduced?

(cc/ @xbrianlee)