### PR TITLE
Lps 80843

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/messaging/AMMessageListener.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/messaging/AMMessageListener.java
@@ -14,7 +14,6 @@
 
 package com.liferay.adaptive.media.web.internal.messaging;
 
-import com.liferay.adaptive.media.processor.AMAsyncProcessorLocator;
 import com.liferay.adaptive.media.processor.AMProcessor;
 import com.liferay.adaptive.media.web.internal.constants.AMDestinationNames;
 import com.liferay.adaptive.media.web.internal.processor.AMAsyncProcessorImpl;
@@ -32,7 +31,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Adolfo Pérez
@@ -90,9 +88,6 @@ public class AMMessageListener extends BaseMessageListener {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AMMessageListener.class);
-
-	@Reference(unbind = "-")
-	private AMAsyncProcessorLocator _amAsyncProcessorLocator;
 
 	private ServiceTrackerMap<String, List<AMProcessor>> _serviceTrackerMap;
 

--- a/modules/apps/portal-background-task/portal-background-task-service/build.gradle
+++ b/modules/apps/portal-background-task/portal-background-task-service/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portal:portal-spring-extender-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/build.gradle
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/build.gradle
@@ -4,9 +4,11 @@ targetCompatibility = "1.8"
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
-	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:portal-osgi-debug:portal-osgi-debug-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-lang")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/DeclarativeServiceSoftCircularDependencySystemChecker.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/DeclarativeServiceSoftCircularDependencySystemChecker.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.osgi.debug.declarative.service.internal;
+
+import com.liferay.portal.osgi.debug.SystemChecker;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+
+/**
+ * @author Shuyang Zhou
+ */
+@Component(immediate = true)
+public class DeclarativeServiceSoftCircularDependencySystemChecker
+	implements SystemChecker {
+
+	@Override
+	public String check() {
+		return SoftCircularDependencyUtil.listSoftCircularDependencies(
+			_serviceComponentRuntime, _bundleContext);
+	}
+
+	@Override
+	public String getName() {
+		return "Declarative Service Soft Circular Dependency Checker";
+	}
+
+	@Override
+	public String getOSGiCommand() {
+		return "ds:softCircularDependency";
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private ServiceComponentRuntime _serviceComponentRuntime;
+
+}

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/DeclarativeServiceSystemChecker.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/DeclarativeServiceSystemChecker.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.runtime.ServiceComponentRuntime;
 /**
  * @author Tina Tian
  */
-@Component(immediate = true, service = SystemChecker.class)
+@Component(immediate = true)
 public class DeclarativeServiceSystemChecker implements SystemChecker {
 
 	@Override

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/DeclarativeServiceUnsatisfiedComponentSystemChecker.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/DeclarativeServiceUnsatisfiedComponentSystemChecker.java
@@ -26,7 +26,8 @@ import org.osgi.service.component.runtime.ServiceComponentRuntime;
  * @author Tina Tian
  */
 @Component(immediate = true)
-public class DeclarativeServiceSystemChecker implements SystemChecker {
+public class DeclarativeServiceUnsatisfiedComponentSystemChecker
+	implements SystemChecker {
 
 	@Override
 	public String check() {
@@ -36,7 +37,7 @@ public class DeclarativeServiceSystemChecker implements SystemChecker {
 
 	@Override
 	public String getName() {
-		return "Declarative Service Component Checker";
+		return "Declarative Service Unsatisfied Component Checker";
 	}
 
 	@Override

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/SoftCircularDependencyOSGiCommands.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/SoftCircularDependencyOSGiCommands.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.osgi.debug.declarative.service.internal;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+
+/**
+ * @author Shuyang Zhou
+ */
+@Component(
+	immediate = true,
+	property = {
+		"osgi.command.function=softCircularDependency", "osgi.command.scope=ds"
+	},
+	service = SoftCircularDependencyOSGiCommands.class
+)
+public class SoftCircularDependencyOSGiCommands {
+
+	public void softCircularDependency() {
+		System.out.println(
+			SoftCircularDependencyUtil.listSoftCircularDependencies(
+				_serviceComponentRuntime, _bundleContext));
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+	}
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private ServiceComponentRuntime _serviceComponentRuntime;
+
+}

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/SoftCircularDependencyUtil.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-declarative-service/src/main/java/com/liferay/portal/osgi/debug/declarative/service/internal/SoftCircularDependencyUtil.java
@@ -1,0 +1,488 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.osgi.debug.declarative.service.internal;
+
+import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.dto.BundleDTO;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.service.component.runtime.dto.ReferenceDTO;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class SoftCircularDependencyUtil {
+
+	public static String listSoftCircularDependencies(
+		ServiceComponentRuntime serviceComponentRuntime,
+		BundleContext bundleContext) {
+
+		Collection<ComponentDescriptionDTO> componentDescriptionDTOs =
+			serviceComponentRuntime.getComponentDescriptionDTOs(
+				bundleContext.getBundles());
+
+		Map<ComponentDescriptionKey, ComponentDescriptionDTO>
+			componentDescriptionDTOIndexMap = _toIndexMap(
+				componentDescriptionDTOs);
+
+		Map<ComponentDescriptionDTO, List<Dependency>> closureNavigationMap =
+			_createClosureNavigationMap(
+				bundleContext, componentDescriptionDTOs,
+				componentDescriptionDTOIndexMap);
+
+		Set<List<Dependency>> circularDependencies =
+			_findSoftCircularDependencies(closureNavigationMap);
+
+		StringBundler sb = new StringBundler();
+
+		for (List<Dependency> dependencies : circularDependencies) {
+			sb.append(StringPool.OPEN_CURLY_BRACE);
+
+			for (Dependency dependency : dependencies) {
+				dependency.appendToChain(sb);
+			}
+
+			sb.append("(circular reference)}\n");
+		}
+
+		return sb.toString();
+	}
+
+	private static Map<ComponentDescriptionDTO, List<Dependency>>
+		_createClosureNavigationMap(
+			BundleContext bundleContext,
+			Collection<ComponentDescriptionDTO> componentDescriptionDTOs,
+			Map<ComponentDescriptionKey, ComponentDescriptionDTO>
+				componentDescriptionDTOIndexMap) {
+
+		Set<Dependency> fullyVisitedDependencies = new HashSet<>();
+
+		Map<ComponentDescriptionDTO, List<Dependency>> closureNavigationMap =
+			new TreeMap<>(_comparator);
+
+		while (true) {
+			int size = componentDescriptionDTOs.size();
+
+			Iterator<ComponentDescriptionDTO> iterator =
+				componentDescriptionDTOs.iterator();
+
+			while (iterator.hasNext()) {
+				ComponentDescriptionDTO fromComponentDescriptionDTO =
+					iterator.next();
+
+				List<Dependency> dependencies = new LinkedList<>();
+
+				for (ReferenceDTO referenceDTO :
+						fromComponentDescriptionDTO.references) {
+
+					ServiceReference<?>[] serviceReferences = null;
+
+					try {
+						serviceReferences = bundleContext.getServiceReferences(
+							referenceDTO.interfaceName, referenceDTO.target);
+					}
+					catch (InvalidSyntaxException ise) {
+						String reference = referenceDTO.bind;
+
+						if (reference == null) {
+							reference = referenceDTO.field;
+						}
+
+						_log.error(
+							StringBundler.concat(
+								"Invalid filter \"", referenceDTO.target,
+								"\" from",
+								fromComponentDescriptionDTO.implementationClass,
+								"[", reference, "]"),
+							ise);
+
+						continue;
+					}
+
+					if (serviceReferences == null) {
+						continue;
+					}
+
+					for (ServiceReference<?> serviceReference :
+							serviceReferences) {
+
+						Object service = bundleContext.getService(
+							serviceReference);
+
+						if (service == null) {
+							continue;
+						}
+
+						Bundle bundle = serviceReference.getBundle();
+
+						Class<?> clazz = service.getClass();
+
+						bundleContext.ungetService(serviceReference);
+
+						ComponentDescriptionDTO toComponentDescriptionDTO =
+							componentDescriptionDTOIndexMap.get(
+								new ComponentDescriptionKey(
+									bundle.getBundleId(), clazz.getName()));
+
+						if (toComponentDescriptionDTO != null) {
+							dependencies.add(
+								new Dependency(
+									fromComponentDescriptionDTO,
+									toComponentDescriptionDTO, referenceDTO));
+						}
+					}
+				}
+
+				if (fullyVisitedDependencies.containsAll(dependencies)) {
+					fullyVisitedDependencies.add(
+						new Dependency(
+							null, fromComponentDescriptionDTO, null));
+
+					iterator.remove();
+
+					closureNavigationMap.remove(fromComponentDescriptionDTO);
+				}
+				else {
+					closureNavigationMap.put(
+						fromComponentDescriptionDTO, dependencies);
+				}
+			}
+
+			if (size == componentDescriptionDTOs.size()) {
+				break;
+			}
+		}
+
+		for (List<Dependency> dependencies : closureNavigationMap.values()) {
+			Iterator<Dependency> iterator = dependencies.iterator();
+
+			while (iterator.hasNext()) {
+				Dependency dependency = iterator.next();
+
+				if (!closureNavigationMap.containsKey(
+						dependency.getToComponentDescriptionDTO())) {
+
+					iterator.remove();
+				}
+			}
+		}
+
+		return closureNavigationMap;
+	}
+
+	private static Set<List<Dependency>> _findSoftCircularDependencies(
+		Map<ComponentDescriptionDTO, List<Dependency>> closureNavigationMap) {
+
+		Set<List<Dependency>> softCircularDependencies = new LinkedHashSet<>();
+
+		Set<Dependency> excludedDependencies = new HashSet<>();
+
+		for (Entry<ComponentDescriptionDTO, List<Dependency>> entry :
+				closureNavigationMap.entrySet()) {
+
+			Dependency startDependency = new Dependency(
+				null, entry.getKey(), null);
+
+			if (excludedDependencies.contains(startDependency)) {
+				continue;
+			}
+
+			List<Dependency> dependencies = new ArrayList<>();
+
+			dependencies.add(startDependency);
+
+			Deque<List<Dependency>> backTrace = new LinkedList<>();
+
+			backTrace.push(dependencies);
+
+			while (!backTrace.isEmpty()) {
+				LinkedList<Dependency> trace = new LinkedList<>();
+
+				for (List<Dependency> curDependencies : backTrace) {
+					trace.addFirst(curDependencies.get(0));
+				}
+
+				Dependency dependency = trace.getLast();
+
+				List<Dependency> nextDependencies = new ArrayList<>(
+					closureNavigationMap.get(
+						dependency.getToComponentDescriptionDTO()));
+
+				nextDependencies.removeAll(excludedDependencies);
+
+				if (nextDependencies.isEmpty()) {
+					List<Dependency> topDependencies = null;
+
+					while ((topDependencies = backTrace.poll()) != null) {
+						if (topDependencies.size() > 1) {
+							backTrace.push(
+								topDependencies.subList(
+									1, topDependencies.size()));
+
+							break;
+						}
+					}
+				}
+				else {
+					dependency = nextDependencies.get(0);
+
+					int index = trace.indexOf(dependency);
+
+					if (index == -1) {
+						backTrace.push(nextDependencies);
+					}
+					else {
+						if (nextDependencies.size() > 1) {
+							backTrace.push(
+								nextDependencies.subList(
+									1, nextDependencies.size()));
+						}
+						else {
+							List<Dependency> topDependencies = null;
+
+							while ((topDependencies =
+										backTrace.poll()) != null) {
+
+								if (topDependencies.size() > 1) {
+									backTrace.push(
+										topDependencies.subList(
+											1, topDependencies.size()));
+
+									break;
+								}
+							}
+						}
+
+						List<Dependency> newTrace = trace.subList(
+							index + 1, trace.size());
+
+						newTrace.add(dependency);
+
+						excludedDependencies.addAll(newTrace);
+
+						if (newTrace.size() > 1) {
+							softCircularDependencies.add(newTrace);
+						}
+					}
+				}
+			}
+		}
+
+		return softCircularDependencies;
+	}
+
+	private static Map<ComponentDescriptionKey, ComponentDescriptionDTO>
+		_toIndexMap(
+			Collection<ComponentDescriptionDTO> componentDescriptionDTOs) {
+
+		Map<ComponentDescriptionKey, ComponentDescriptionDTO>
+			componentDescriptionDTOIndexMap = new HashMap<>();
+
+		for (ComponentDescriptionDTO componentDescriptionDTO :
+				componentDescriptionDTOs) {
+
+			componentDescriptionDTOIndexMap.put(
+				new ComponentDescriptionKey(componentDescriptionDTO),
+				componentDescriptionDTO);
+		}
+
+		return componentDescriptionDTOIndexMap;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SoftCircularDependencyUtil.class);
+
+	private static final Comparator<ComponentDescriptionDTO> _comparator =
+		(componentDescriptionDTO1, componentDescriptionDTO2) -> {
+			String name = componentDescriptionDTO1.name;
+
+			return name.compareTo(componentDescriptionDTO2.name);
+		};
+
+	private static class ComponentDescriptionKey {
+
+		@Override
+		public boolean equals(Object obj) {
+			ComponentDescriptionKey componentDescriptionKey =
+				(ComponentDescriptionKey)obj;
+
+			if ((_bundleId == componentDescriptionKey._bundleId) &&
+				Objects.equals(
+					_implementationClass,
+					componentDescriptionKey._implementationClass)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		@Override
+		public int hashCode() {
+			int hash = HashUtil.hash(0, _bundleId);
+
+			return HashUtil.hash(hash, _implementationClass);
+		}
+
+		private ComponentDescriptionKey(
+			ComponentDescriptionDTO componentDescriptionDTO) {
+
+			BundleDTO bundleDTO = componentDescriptionDTO.bundle;
+
+			_bundleId = bundleDTO.id;
+
+			_implementationClass = componentDescriptionDTO.implementationClass;
+		}
+
+		private ComponentDescriptionKey(
+			long bundleId, String implementationClass) {
+
+			_bundleId = bundleId;
+			_implementationClass = implementationClass;
+		}
+
+		private final long _bundleId;
+		private final String _implementationClass;
+
+	}
+
+	private static class Dependency implements Comparable<Dependency> {
+
+		public void appendToChain(StringBundler sb) {
+			sb.append(_fromComponentDescriptionDTO.implementationClass);
+
+			sb.append(StringPool.OPEN_BRACKET);
+
+			if (_referenceDTO.bind != null) {
+				sb.append(_referenceDTO.bind);
+			}
+
+			if (_referenceDTO.field != null) {
+				sb.append(_referenceDTO.field);
+			}
+
+			sb.append(StringPool.CLOSE_BRACKET);
+
+			sb.append(" -> ");
+		}
+
+		@Override
+		public int compareTo(Dependency dependency) {
+			return _comparator.compare(
+				_toComponentDescriptionDTO,
+				dependency._toComponentDescriptionDTO);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			Dependency dependency = (Dependency)obj;
+
+			if (_toComponentDescriptionDTO ==
+					dependency._toComponentDescriptionDTO) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		public ComponentDescriptionDTO getFromComponentDescriptionDTO() {
+			return _fromComponentDescriptionDTO;
+		}
+
+		public ReferenceDTO getReferenceDTO() {
+			return _referenceDTO;
+		}
+
+		public ComponentDescriptionDTO getToComponentDescriptionDTO() {
+			return _toComponentDescriptionDTO;
+		}
+
+		@Override
+		public int hashCode() {
+			return _toComponentDescriptionDTO.hashCode();
+		}
+
+		@Override
+		public String toString() {
+			StringBundler sb = new StringBundler(7);
+
+			if (_fromComponentDescriptionDTO != null) {
+				sb.append(_fromComponentDescriptionDTO.implementationClass);
+			}
+
+			if (_referenceDTO != null) {
+				sb.append(StringPool.OPEN_BRACKET);
+
+				if (_referenceDTO.bind != null) {
+					sb.append(_referenceDTO.bind);
+				}
+
+				if (_referenceDTO.field != null) {
+					sb.append(_referenceDTO.field);
+				}
+
+				sb.append(StringPool.CLOSE_BRACKET);
+
+				sb.append(" -> ");
+			}
+
+			sb.append(_toComponentDescriptionDTO.implementationClass);
+
+			return sb.toString();
+		}
+
+		private Dependency(
+			ComponentDescriptionDTO fromComponentDescriptionDTO,
+			ComponentDescriptionDTO toComponentDescriptionDTO,
+			ReferenceDTO referenceDTO) {
+
+			_fromComponentDescriptionDTO = fromComponentDescriptionDTO;
+			_toComponentDescriptionDTO = toComponentDescriptionDTO;
+			_referenceDTO = referenceDTO;
+		}
+
+		private final ComponentDescriptionDTO _fromComponentDescriptionDTO;
+		private final ReferenceDTO _referenceDTO;
+		private final ComponentDescriptionDTO _toComponentDescriptionDTO;
+
+	}
+
+}

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-spring-extender/src/main/java/com/liferay/portal/osgi/debug/spring/extender/internal/SpringExtenderSystemChecker.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-spring-extender/src/main/java/com/liferay/portal/osgi/debug/spring/extender/internal/SpringExtenderSystemChecker.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Tina Tian
  */
-@Component(immediate = true, service = SystemChecker.class)
+@Component(immediate = true)
 public class SpringExtenderSystemChecker implements SystemChecker {
 
 	@Override

--- a/modules/apps/portal-osgi-debug/portal-osgi-debug-spring-extender/src/main/java/com/liferay/portal/osgi/debug/spring/extender/internal/SpringExtenderUnavailableComponentSystemChecker.java
+++ b/modules/apps/portal-osgi-debug/portal-osgi-debug-spring-extender/src/main/java/com/liferay/portal/osgi/debug/spring/extender/internal/SpringExtenderUnavailableComponentSystemChecker.java
@@ -22,7 +22,8 @@ import org.osgi.service.component.annotations.Component;
  * @author Tina Tian
  */
 @Component(immediate = true)
-public class SpringExtenderSystemChecker implements SystemChecker {
+public class SpringExtenderUnavailableComponentSystemChecker
+	implements SystemChecker {
 
 	@Override
 	public String check() {
@@ -31,7 +32,7 @@ public class SpringExtenderSystemChecker implements SystemChecker {
 
 	@Override
 	public String getName() {
-		return "Spring Extender Component Checker";
+		return "Spring Extender Unavailable Component Checker";
 	}
 
 	@Override

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -54,7 +54,6 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.scheduler.internal.configuration.SchedulerEngineHelperConfiguration;
-import com.liferay.portal.scheduler.internal.messaging.config.SchedulerProxyMessagingConfigurator;
 import com.liferay.portal.scheduler.internal.messaging.config.ScriptingMessageListener;
 
 import java.util.ArrayList;
@@ -887,6 +886,13 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 		_destinationFactory = destinationFactory;
 	}
 
+	@Reference(
+		target = "(&(destination.name=" + DestinationNames.SCHEDULER_ENGINE + ")(destination.ready=true))",
+		unbind = "-"
+	)
+	protected void setDestinationReady(Object object) {
+	}
+
 	@Reference(unbind = "-")
 	protected void setJsonFactory(JSONFactory jsonFactory) {
 		_jsonFactory = jsonFactory;
@@ -895,12 +901,6 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 	@Reference(target = "(scheduler.engine.proxy=true)", unbind = "-")
 	protected void setSchedulerEngine(SchedulerEngine schedulerEngine) {
 		_schedulerEngine = schedulerEngine;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSchedulerProxyMessagingConfigurator(
-		SchedulerProxyMessagingConfigurator
-			schedulerProxyMessagingConfigurator) {
 	}
 
 	protected void unsetAuditRouter(AuditRouter auditRouter) {

--- a/modules/apps/portal-search/portal-search-web/build.gradle
+++ b/modules/apps/portal-search/portal-search-web/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortlet.java
@@ -18,10 +18,7 @@ import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetBuilder;
 import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetConfiguration;
 import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetConfigurationImpl;
 import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetFactory;
@@ -29,14 +26,11 @@ import com.liferay.portal.search.web.internal.category.facet.constants.CategoryF
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetCategoriesSearchFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetCategoryPermissionCheckerImpl;
 import com.liferay.portal.search.web.internal.facet.display.context.AssetCategoriesSearchFacetDisplayContext;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
-import java.util.Arrays;
 import java.util.Optional;
 
 import javax.portlet.Portlet;
@@ -73,24 +67,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class CategoryFacetPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		CategoryFacetPortletPreferences categoryFacetPortletPreferences =
-			new CategoryFacetPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		Facet facet = buildFacet(
-			categoryFacetPortletPreferences, portletSharedSearchSettings);
-
-		portletSharedSearchSettings.addFacet(facet);
-	}
+public class CategoryFacetPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -171,34 +150,6 @@ public class CategoryFacetPortlet
 			assetCategoriesSearchFacetDisplayBuilder::setParameterValues);
 
 		return assetCategoriesSearchFacetDisplayBuilder.build();
-	}
-
-	protected Facet buildFacet(
-		CategoryFacetPortletPreferences categoryFacetPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		AssetCategoriesFacetBuilder assetCategoriesFacetBuilder =
-			new AssetCategoriesFacetBuilder(assetCategoriesFacetFactory);
-
-		assetCategoriesFacetBuilder.setFrequencyThreshold(
-			categoryFacetPortletPreferences.getFrequencyThreshold());
-		assetCategoriesFacetBuilder.setMaxTerms(
-			categoryFacetPortletPreferences.getMaxTerms());
-		assetCategoriesFacetBuilder.setSearchContext(
-			portletSharedSearchSettings.getSearchContext());
-
-		Optional<String[]> parameterValuesOptional =
-			portletSharedSearchSettings.getParameterValues(
-				categoryFacetPortletPreferences.getParameterName());
-
-		Optional<long[]> categoryIdsOptional = parameterValuesOptional.map(
-			parameterValues -> ListUtil.toLongArray(
-				Arrays.asList(parameterValues), GetterUtil::getLong));
-
-		categoryIdsOptional.ifPresent(
-			assetCategoriesFacetBuilder::setSelectedCategoryIds);
-
-		return assetCategoriesFacetBuilder.build();
 	}
 
 	protected String getFieldName() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/CategoryFacetPortletSharedSearchContributor.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.category.facet.portlet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetBuilder;
+import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetFactory;
+import com.liferay.portal.search.web.internal.category.facet.constants.CategoryFacetPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lino Alves
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + CategoryFacetPortletKeys.CATEGORY_FACET
+)
+public class CategoryFacetPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		CategoryFacetPortletPreferences categoryFacetPortletPreferences =
+			new CategoryFacetPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		Facet facet = buildFacet(
+			categoryFacetPortletPreferences, portletSharedSearchSettings);
+
+		portletSharedSearchSettings.addFacet(facet);
+	}
+
+	protected Facet buildFacet(
+		CategoryFacetPortletPreferences categoryFacetPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		AssetCategoriesFacetBuilder assetCategoriesFacetBuilder =
+			new AssetCategoriesFacetBuilder(assetCategoriesFacetFactory);
+
+		assetCategoriesFacetBuilder.setFrequencyThreshold(
+			categoryFacetPortletPreferences.getFrequencyThreshold());
+		assetCategoriesFacetBuilder.setMaxTerms(
+			categoryFacetPortletPreferences.getMaxTerms());
+		assetCategoriesFacetBuilder.setSearchContext(
+			portletSharedSearchSettings.getSearchContext());
+
+		Optional<String[]> parameterValuesOptional =
+			portletSharedSearchSettings.getParameterValues(
+				categoryFacetPortletPreferences.getParameterName());
+
+		Optional<long[]> categoryIdsOptional = parameterValuesOptional.map(
+			parameterValues -> ListUtil.toLongArray(
+				Arrays.asList(parameterValues), GetterUtil::getLong));
+
+		categoryIdsOptional.ifPresent(
+			assetCategoriesFacetBuilder::setSelectedCategoryIds);
+
+		return assetCategoriesFacetBuilder.build();
+	}
+
+	protected AssetCategoriesFacetFactory assetCategoriesFacetFactory =
+		new AssetCategoriesFacetFactory();
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortlet.java
@@ -16,18 +16,13 @@ package com.liferay.portal.search.web.internal.custom.facet.portlet;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.search.facet.custom.CustomFacetFactory;
-import com.liferay.portal.search.web.internal.custom.facet.builder.CustomFacetBuilder;
 import com.liferay.portal.search.web.internal.custom.facet.constants.CustomFacetPortletKeys;
 import com.liferay.portal.search.web.internal.custom.facet.display.context.CustomFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.custom.facet.display.context.CustomFacetDisplayContext;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
@@ -72,31 +67,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class CustomFacetPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		CustomFacetPortletPreferences customFacetPortletPreferences =
-			new CustomFacetPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		Optional<String> fieldToAggregateOptional =
-			customFacetPortletPreferences.getAggregationFieldOptional();
-
-		fieldToAggregateOptional.ifPresent(
-			fieldToAggregate -> {
-				Facet facet = buildFacet(
-					fieldToAggregate, customFacetPortletPreferences,
-					portletSharedSearchSettings);
-
-				portletSharedSearchSettings.addFacet(facet);
-			});
-	}
+public class CustomFacetPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -163,30 +136,6 @@ public class CustomFacetPortlet
 		return customFacetDisplayBuilder.build();
 	}
 
-	protected Facet buildFacet(
-		String fieldToAggregate,
-		CustomFacetPortletPreferences customFacetPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		CustomFacetBuilder customFacetBuilder = new CustomFacetBuilder(
-			customFacetFactory);
-
-		customFacetBuilder.setAggregationName(
-			getAggregationName(
-				customFacetPortletPreferences,
-				portletSharedSearchSettings.getPortletId()));
-		customFacetBuilder.setFieldToAggregate(fieldToAggregate);
-		customFacetBuilder.setSearchContext(
-			portletSharedSearchSettings.getSearchContext());
-
-		copy(
-			() -> portletSharedSearchSettings.getParameterValues(
-				getParameterName(customFacetPortletPreferences)),
-			customFacetBuilder::setSelectedFields);
-
-		return customFacetBuilder.build();
-	}
-
 	protected <T> void copy(Supplier<Optional<T>> from, Consumer<T> to) {
 		Optional<T> optional = from.get();
 
@@ -231,9 +180,6 @@ public class CustomFacetPortlet
 	protected String getPortletId(RenderRequest renderRequest) {
 		return _portal.getPortletId(renderRequest);
 	}
-
-	@Reference
-	protected CustomFacetFactory customFacetFactory;
 
 	@Reference
 	protected PortletSharedSearchRequest portletSharedSearchRequest;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/portlet/CustomFacetPortletSharedSearchContributor.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.custom.facet.portlet;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.search.facet.custom.CustomFacetFactory;
+import com.liferay.portal.search.web.internal.custom.facet.builder.CustomFacetBuilder;
+import com.liferay.portal.search.web.internal.custom.facet.constants.CustomFacetPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ *@author Wade Cao
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + CustomFacetPortletKeys.CUSTOM_FACET
+)
+public class CustomFacetPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		CustomFacetPortletPreferences customFacetPortletPreferences =
+			new CustomFacetPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		Optional<String> fieldToAggregateOptional =
+			customFacetPortletPreferences.getAggregationFieldOptional();
+
+		fieldToAggregateOptional.ifPresent(
+			fieldToAggregate -> {
+				Facet facet = buildFacet(
+					fieldToAggregate, customFacetPortletPreferences,
+					portletSharedSearchSettings);
+
+				portletSharedSearchSettings.addFacet(facet);
+			});
+	}
+
+	protected Facet buildFacet(
+		String fieldToAggregate,
+		CustomFacetPortletPreferences customFacetPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		CustomFacetBuilder customFacetBuilder = new CustomFacetBuilder(
+			customFacetFactory);
+
+		customFacetBuilder.setAggregationName(
+			getAggregationName(
+				customFacetPortletPreferences,
+				portletSharedSearchSettings.getPortletId()));
+		customFacetBuilder.setFieldToAggregate(fieldToAggregate);
+		customFacetBuilder.setSearchContext(
+			portletSharedSearchSettings.getSearchContext());
+
+		copy(
+			() -> portletSharedSearchSettings.getParameterValues(
+				getParameterName(customFacetPortletPreferences)),
+			customFacetBuilder::setSelectedFields);
+
+		return customFacetBuilder.build();
+	}
+
+	protected <T> void copy(Supplier<Optional<T>> from, Consumer<T> to) {
+		Optional<T> optional = from.get();
+
+		optional.ifPresent(to);
+	}
+
+	protected String getAggregationName(
+		CustomFacetPortletPreferences customFacetPortletPreferences,
+		String portletId) {
+
+		return customFacetPortletPreferences.getAggregationFieldString() +
+			StringPool.PERIOD + portletId;
+	}
+
+	protected String getParameterName(
+		CustomFacetPortletPreferences customFacetPortletPreferences) {
+
+		Optional<String> optional = Stream.of(
+			customFacetPortletPreferences.getParameterNameOptional(),
+			customFacetPortletPreferences.getAggregationFieldOptional()
+		).filter(
+			Optional::isPresent
+		).map(
+			Optional::get
+		).findFirst();
+
+		return optional.orElse("customfield");
+	}
+
+	@Reference
+	protected CustomFacetFactory customFacetFactory;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortlet.java
@@ -17,8 +17,6 @@ package com.liferay.portal.search.web.internal.folder.facet.portlet;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.internal.facet.display.builder.FolderSearchFacetDisplayBuilder;
@@ -26,14 +24,11 @@ import com.liferay.portal.search.web.internal.facet.display.context.FolderSearch
 import com.liferay.portal.search.web.internal.facet.display.context.FolderTitleLookup;
 import com.liferay.portal.search.web.internal.facet.display.context.FolderTitleLookupImpl;
 import com.liferay.portal.search.web.internal.folder.facet.constants.FolderFacetPortletKeys;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
-import java.util.Arrays;
 import java.util.Optional;
 
 import javax.portlet.Portlet;
@@ -70,24 +65,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class FolderFacetPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		FolderFacetPortletPreferences folderFacetPortletPreferences =
-			new FolderFacetPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		Facet facet = buildFacet(
-			folderFacetPortletPreferences, portletSharedSearchSettings);
-
-		portletSharedSearchSettings.addFacet(facet);
-	}
+public class FolderFacetPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -152,33 +132,6 @@ public class FolderFacetPortlet
 			folderSearchFacetDisplayBuilder::setParameterValues);
 
 		return folderSearchFacetDisplayBuilder.build();
-	}
-
-	protected Facet buildFacet(
-		FolderFacetPortletPreferences folderFacetPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		FolderFacetBuilder folderFacetBuilder = new FolderFacetBuilder(
-			folderFacetFactory);
-
-		folderFacetBuilder.setFrequencyThreshold(
-			folderFacetPortletPreferences.getFrequencyThreshold());
-		folderFacetBuilder.setMaxTerms(
-			folderFacetPortletPreferences.getMaxTerms());
-		folderFacetBuilder.setSearchContext(
-			portletSharedSearchSettings.getSearchContext());
-
-		Optional<String[]> parameterValuesOptional =
-			portletSharedSearchSettings.getParameterValues(
-				folderFacetPortletPreferences.getParameterName());
-
-		Optional<long[]> foldersOptional = parameterValuesOptional.map(
-			parameterValues -> ListUtil.toLongArray(
-				Arrays.asList(parameterValues), GetterUtil::getLong));
-
-		foldersOptional.ifPresent(folderFacetBuilder::setSelectedFolders);
-
-		return folderFacetBuilder.build();
 	}
 
 	protected String getFieldName() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/FolderFacetPortletSharedSearchContributor.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.folder.facet.portlet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.search.web.internal.folder.facet.constants.FolderFacetPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lino Alves
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + FolderFacetPortletKeys.FOLDER_FACET
+)
+public class FolderFacetPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		FolderFacetPortletPreferences folderFacetPortletPreferences =
+			new FolderFacetPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		Facet facet = buildFacet(
+			folderFacetPortletPreferences, portletSharedSearchSettings);
+
+		portletSharedSearchSettings.addFacet(facet);
+	}
+
+	protected Facet buildFacet(
+		FolderFacetPortletPreferences folderFacetPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		FolderFacetBuilder folderFacetBuilder = new FolderFacetBuilder(
+			folderFacetFactory);
+
+		folderFacetBuilder.setFrequencyThreshold(
+			folderFacetPortletPreferences.getFrequencyThreshold());
+		folderFacetBuilder.setMaxTerms(
+			folderFacetPortletPreferences.getMaxTerms());
+		folderFacetBuilder.setSearchContext(
+			portletSharedSearchSettings.getSearchContext());
+
+		Optional<String[]> parameterValuesOptional =
+			portletSharedSearchSettings.getParameterValues(
+				folderFacetPortletPreferences.getParameterName());
+
+		Optional<long[]> foldersOptional = parameterValuesOptional.map(
+			parameterValues -> ListUtil.toLongArray(
+				Arrays.asList(parameterValues), GetterUtil::getLong));
+
+		foldersOptional.ifPresent(folderFacetBuilder::setSelectedFolders);
+
+		return folderFacetBuilder.build();
+	}
+
+	protected FolderFacetFactory folderFacetFactory = new FolderFacetFactory();
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortlet.java
@@ -16,20 +16,13 @@ package com.liferay.portal.search.web.internal.search.bar.portlet;
 
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
-import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.generic.BooleanClauseImpl;
-import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.search.web.internal.display.context.SearchScope;
 import com.liferay.portal.search.web.internal.search.bar.constants.SearchBarPortletKeys;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
@@ -72,24 +65,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class SearchBarPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		SearchBarPortletPreferences searchBarPortletPreferences =
-			new SearchBarPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		setKeywords(searchBarPortletPreferences, portletSharedSearchSettings);
-
-		filterByThisSite(
-			searchBarPortletPreferences, portletSharedSearchSettings);
-	}
+public class SearchBarPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -168,67 +146,11 @@ public class SearchBarPortlet
 		optional.ifPresent(to);
 	}
 
-	protected void filterByThisSite(
-		SearchBarPortletPreferences searchBarPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		Optional<Long> groupIdOptional = getThisSiteGroupId(
-			searchBarPortletPreferences, portletSharedSearchSettings);
-
-		groupIdOptional.ifPresent(
-			groupId -> {
-				portletSharedSearchSettings.addCondition(
-					new BooleanClauseImpl(
-						new TermQueryImpl(
-							Field.GROUP_ID, String.valueOf(groupId)),
-						BooleanClauseOccur.MUST));
-			});
-	}
-
-	protected long getScopeGroupId(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		ThemeDisplay themeDisplay =
-			portletSharedSearchSettings.getThemeDisplay();
-
-		return themeDisplay.getScopeGroupId();
-	}
-
 	protected long getScopeGroupId(RenderRequest renderRequest) {
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
 		return themeDisplay.getScopeGroupId();
-	}
-
-	protected Optional<SearchScope> getSearchScope(
-		SearchBarPortletPreferences searchBarPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		String parameterName =
-			searchBarPortletPreferences.getScopeParameterName();
-
-		Optional<String> parameterValueOptional =
-			portletSharedSearchSettings.getParameter(parameterName);
-
-		Optional<SearchScope> searchScopeOptional = parameterValueOptional.map(
-			SearchScope::getSearchScope);
-
-		return searchScopeOptional;
-	}
-
-	protected Optional<Long> getThisSiteGroupId(
-		SearchBarPortletPreferences searchBarPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		Optional<SearchScope> searchScopeOptional = getSearchScope(
-			searchBarPortletPreferences, portletSharedSearchSettings);
-
-		Optional<SearchScope> thisSiteSearchScopeOptional =
-			searchScopeOptional.filter(SearchScope.THIS_SITE::equals);
-
-		return thisSiteSearchScopeOptional.map(
-			searchScope -> getScopeGroupId(portletSharedSearchSettings));
 	}
 
 	protected boolean isSearchLayoutAvailable(
@@ -249,21 +171,6 @@ public class SearchBarPortlet
 		}
 
 		return false;
-	}
-
-	protected void setKeywords(
-		SearchBarPortletPreferences searchBarPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		Optional<String> parameterValueOptional =
-			portletSharedSearchSettings.getParameter(
-				searchBarPortletPreferences.getKeywordsParameterName());
-
-		parameterValueOptional.ifPresent(
-			portletSharedSearchSettings::setKeywords);
-
-		portletSharedSearchSettings.setKeywordsParameterName(
-			searchBarPortletPreferences.getKeywordsParameterName());
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/SearchBarPortletSharedSearchContributor.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.search.bar.portlet;
+
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.generic.BooleanClauseImpl;
+import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.search.web.internal.display.context.SearchScope;
+import com.liferay.portal.search.web.internal.search.bar.constants.SearchBarPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author André de Oliveira
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + SearchBarPortletKeys.SEARCH_BAR
+)
+public class SearchBarPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		SearchBarPortletPreferences searchBarPortletPreferences =
+			new SearchBarPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		setKeywords(searchBarPortletPreferences, portletSharedSearchSettings);
+
+		filterByThisSite(
+			searchBarPortletPreferences, portletSharedSearchSettings);
+	}
+
+	protected void filterByThisSite(
+		SearchBarPortletPreferences searchBarPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		Optional<Long> groupIdOptional = getThisSiteGroupId(
+			searchBarPortletPreferences, portletSharedSearchSettings);
+
+		groupIdOptional.ifPresent(
+			groupId -> {
+				portletSharedSearchSettings.addCondition(
+					new BooleanClauseImpl(
+						new TermQueryImpl(
+							Field.GROUP_ID, String.valueOf(groupId)),
+						BooleanClauseOccur.MUST));
+			});
+	}
+
+	protected long getScopeGroupId(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		ThemeDisplay themeDisplay =
+			portletSharedSearchSettings.getThemeDisplay();
+
+		return themeDisplay.getScopeGroupId();
+	}
+
+	protected Optional<SearchScope> getSearchScope(
+		SearchBarPortletPreferences searchBarPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		String parameterName =
+			searchBarPortletPreferences.getScopeParameterName();
+
+		Optional<String> parameterValueOptional =
+			portletSharedSearchSettings.getParameter(parameterName);
+
+		Optional<SearchScope> searchScopeOptional = parameterValueOptional.map(
+			SearchScope::getSearchScope);
+
+		return searchScopeOptional;
+	}
+
+	protected Optional<Long> getThisSiteGroupId(
+		SearchBarPortletPreferences searchBarPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		Optional<SearchScope> searchScopeOptional = getSearchScope(
+			searchBarPortletPreferences, portletSharedSearchSettings);
+
+		Optional<SearchScope> thisSiteSearchScopeOptional =
+			searchScopeOptional.filter(SearchScope.THIS_SITE::equals);
+
+		return thisSiteSearchScopeOptional.map(
+			searchScope -> getScopeGroupId(portletSharedSearchSettings));
+	}
+
+	protected void setKeywords(
+		SearchBarPortletPreferences searchBarPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		Optional<String> parameterValueOptional =
+			portletSharedSearchSettings.getParameter(
+				searchBarPortletPreferences.getKeywordsParameterName());
+
+		parameterValueOptional.ifPresent(
+			portletSharedSearchSettings::setKeywords);
+
+		portletSharedSearchSettings.setKeywordsParameterName(
+			searchBarPortletPreferences.getKeywordsParameterName());
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.IndexerRegistry;
-import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FastDateFormatFactory;
@@ -42,10 +41,8 @@ import com.liferay.portal.search.web.internal.result.display.builder.AssetRender
 import com.liferay.portal.search.web.internal.result.display.builder.SearchResultSummaryDisplayBuilder;
 import com.liferay.portal.search.web.internal.result.display.context.SearchResultSummaryDisplayContext;
 import com.liferay.portal.search.web.internal.search.results.constants.SearchResultsPortletKeys;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 import com.liferay.portal.search.web.search.result.SearchResultImageContributor;
 
 import java.io.IOException;
@@ -96,23 +93,9 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class SearchResultsPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		SearchResultsPortletPreferences searchResultsPortletPreferences =
-			new SearchResultsPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		paginate(searchResultsPortletPreferences, portletSharedSearchSettings);
-
-		highlight(searchResultsPortletPreferences, portletSharedSearchSettings);
-	}
+public class SearchResultsPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -386,54 +369,6 @@ public class SearchResultsPortlet
 			urlString, paginationStartParameterName);
 
 		return urlString;
-	}
-
-	protected void highlight(
-		SearchResultsPortletPreferences searchResultsPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		boolean highlightEnabled =
-			searchResultsPortletPreferences.isHighlightEnabled();
-
-		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
-
-		queryConfig.setHighlightEnabled(highlightEnabled);
-	}
-
-	protected void paginate(
-		SearchResultsPortletPreferences searchResultsPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		String paginationStartParameterName =
-			searchResultsPortletPreferences.getPaginationStartParameterName();
-
-		portletSharedSearchSettings.setPaginationStartParameterName(
-			paginationStartParameterName);
-
-		Optional<String> paginationStartParameterValueOptional =
-			portletSharedSearchSettings.getParameter(
-				paginationStartParameterName);
-
-		Optional<Integer> paginationStartOptional =
-			paginationStartParameterValueOptional.map(Integer::valueOf);
-
-		paginationStartOptional.ifPresent(
-			portletSharedSearchSettings::setPaginationStart);
-
-		String paginationDeltaParameterName =
-			searchResultsPortletPreferences.getPaginationDeltaParameterName();
-
-		Optional<String> paginationDeltaParameterValueOptional =
-			portletSharedSearchSettings.getParameter(
-				paginationDeltaParameterName);
-
-		Optional<Integer> paginationDeltaOptional =
-			paginationDeltaParameterValueOptional.map(Integer::valueOf);
-
-		int paginationDelta = paginationDeltaOptional.orElse(
-			searchResultsPortletPreferences.getPaginationDelta());
-
-		portletSharedSearchSettings.setPaginationDelta(paginationDelta);
 	}
 
 	protected void removeSearchResultImageContributor(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortletSharedSearchContributor.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.search.results.portlet;
+
+import com.liferay.portal.kernel.search.QueryConfig;
+import com.liferay.portal.search.web.internal.search.results.constants.SearchResultsPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author André de Oliveira
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + SearchResultsPortletKeys.SEARCH_RESULTS
+)
+public class SearchResultsPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		SearchResultsPortletPreferences searchResultsPortletPreferences =
+			new SearchResultsPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		paginate(searchResultsPortletPreferences, portletSharedSearchSettings);
+
+		highlight(searchResultsPortletPreferences, portletSharedSearchSettings);
+	}
+
+	protected void highlight(
+		SearchResultsPortletPreferences searchResultsPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		boolean highlightEnabled =
+			searchResultsPortletPreferences.isHighlightEnabled();
+
+		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
+
+		queryConfig.setHighlightEnabled(highlightEnabled);
+	}
+
+	protected void paginate(
+		SearchResultsPortletPreferences searchResultsPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		String paginationStartParameterName =
+			searchResultsPortletPreferences.getPaginationStartParameterName();
+
+		portletSharedSearchSettings.setPaginationStartParameterName(
+			paginationStartParameterName);
+
+		Optional<String> paginationStartParameterValueOptional =
+			portletSharedSearchSettings.getParameter(
+				paginationStartParameterName);
+
+		Optional<Integer> paginationStartOptional =
+			paginationStartParameterValueOptional.map(Integer::valueOf);
+
+		paginationStartOptional.ifPresent(
+			portletSharedSearchSettings::setPaginationStart);
+
+		String paginationDeltaParameterName =
+			searchResultsPortletPreferences.getPaginationDeltaParameterName();
+
+		Optional<String> paginationDeltaParameterValueOptional =
+			portletSharedSearchSettings.getParameter(
+				paginationDeltaParameterName);
+
+		Optional<Integer> paginationDeltaOptional =
+			paginationDeltaParameterValueOptional.map(Integer::valueOf);
+
+		int paginationDelta = paginationDeltaOptional.orElse(
+			searchResultsPortletPreferences.getPaginationDelta());
+
+		portletSharedSearchSettings.setPaginationDelta(paginationDelta);
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/SiteFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/SiteFacetPortlet.java
@@ -24,10 +24,8 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.internal.facet.display.builder.ScopeSearchFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.facet.display.context.ScopeSearchFacetDisplayContext;
 import com.liferay.portal.search.web.internal.site.facet.constants.SiteFacetPortletKeys;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
@@ -70,24 +68,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class SiteFacetPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		SiteFacetPortletPreferences siteFacetPortletPreferences =
-			new SiteFacetPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		Facet facet = buildFacet(
-			siteFacetPortletPreferences, portletSharedSearchSettings);
-
-		portletSharedSearchSettings.addFacet(facet);
-	}
+public class SiteFacetPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -150,29 +133,6 @@ public class SiteFacetPortlet
 			scopeSearchFacetDisplayBuilder::setParameterValues);
 
 		return scopeSearchFacetDisplayBuilder.build();
-	}
-
-	protected Facet buildFacet(
-		SiteFacetPortletPreferences siteFacetPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		ScopeFacetBuilder scopeFacetBuilder = new ScopeFacetBuilder(
-			scopeFacetFactory);
-
-		scopeFacetBuilder.setFrequencyThreshold(
-			siteFacetPortletPreferences.getFrequencyThreshold());
-		scopeFacetBuilder.setMaxTerms(
-			siteFacetPortletPreferences.getMaxTerms());
-		scopeFacetBuilder.setSearchContext(
-			portletSharedSearchSettings.getSearchContext());
-
-		Optional<String[]> parameterValuesOptional =
-			portletSharedSearchSettings.getParameterValues(
-				siteFacetPortletPreferences.getParameterName());
-
-		parameterValuesOptional.ifPresent(scopeFacetBuilder::setSelectedSites);
-
-		return scopeFacetBuilder.build();
 	}
 
 	protected String getFieldName() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/SiteFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/SiteFacetPortletSharedSearchContributor.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.site.facet.portlet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.search.facet.ScopeFacetFactory;
+import com.liferay.portal.search.web.internal.site.facet.constants.SiteFacetPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author André de Oliveira
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + SiteFacetPortletKeys.SITE_FACET
+)
+public class SiteFacetPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		SiteFacetPortletPreferences siteFacetPortletPreferences =
+			new SiteFacetPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		Facet facet = buildFacet(
+			siteFacetPortletPreferences, portletSharedSearchSettings);
+
+		portletSharedSearchSettings.addFacet(facet);
+	}
+
+	protected Facet buildFacet(
+		SiteFacetPortletPreferences siteFacetPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		ScopeFacetBuilder scopeFacetBuilder = new ScopeFacetBuilder(
+			scopeFacetFactory);
+
+		scopeFacetBuilder.setFrequencyThreshold(
+			siteFacetPortletPreferences.getFrequencyThreshold());
+		scopeFacetBuilder.setMaxTerms(
+			siteFacetPortletPreferences.getMaxTerms());
+		scopeFacetBuilder.setSearchContext(
+			portletSharedSearchSettings.getSearchContext());
+
+		Optional<String[]> parameterValuesOptional =
+			portletSharedSearchSettings.getParameterValues(
+				siteFacetPortletPreferences.getParameterName());
+
+		parameterValuesOptional.ifPresent(scopeFacetBuilder::setSelectedSites);
+
+		return scopeFacetBuilder.build();
+	}
+
+	@Reference
+	protected ScopeFacetFactory scopeFacetFactory;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/SuggestionsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/SuggestionsPortlet.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.search.web.internal.suggestions.portlet;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
@@ -24,10 +23,8 @@ import com.liferay.portal.search.web.internal.portlet.shared.task.PortletSharedR
 import com.liferay.portal.search.web.internal.suggestions.constants.SuggestionsPortletKeys;
 import com.liferay.portal.search.web.internal.suggestions.display.context.SuggestionsPortletDisplayBuilder;
 import com.liferay.portal.search.web.internal.suggestions.display.context.SuggestionsPortletDisplayContext;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 import com.liferay.portal.search.web.search.request.SearchSettings;
 
 import java.io.IOException;
@@ -71,26 +68,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class SuggestionsPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		SuggestionsPortletPreferences suggestionsPortletPreferences =
-			new SuggestionsPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		setUpQueryIndexing(
-			suggestionsPortletPreferences, portletSharedSearchSettings);
-		setUpRelatedSuggestions(
-			suggestionsPortletPreferences, portletSharedSearchSettings);
-		setUpSpellCheckSuggestion(
-			suggestionsPortletPreferences, portletSharedSearchSettings);
-	}
+public class SuggestionsPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -155,47 +135,6 @@ public class SuggestionsPortlet
 			suggestionsPortletPreferences.isSpellCheckSuggestionEnabled());
 
 		return suggestionsPortletDisplayBuilder.build();
-	}
-
-	protected void setUpQueryIndexing(
-		SuggestionsPortletPreferences suggestionsPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
-
-		queryConfig.setQueryIndexingEnabled(
-			suggestionsPortletPreferences.isQueryIndexingEnabled());
-		queryConfig.setQueryIndexingThreshold(
-			suggestionsPortletPreferences.getQueryIndexingThreshold());
-	}
-
-	protected void setUpRelatedSuggestions(
-		SuggestionsPortletPreferences suggestionsPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
-
-		queryConfig.setQuerySuggestionEnabled(
-			suggestionsPortletPreferences.isRelatedQueriesSuggestionsEnabled());
-		queryConfig.setQuerySuggestionScoresThreshold(
-			suggestionsPortletPreferences.
-				getRelatedQueriesSuggestionsDisplayThreshold());
-		queryConfig.setQuerySuggestionsMax(
-			suggestionsPortletPreferences.getRelatedQueriesSuggestionsMax());
-	}
-
-	protected void setUpSpellCheckSuggestion(
-		SuggestionsPortletPreferences suggestionsPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
-
-		queryConfig.setCollatedSpellCheckResultEnabled(
-			suggestionsPortletPreferences.isSpellCheckSuggestionEnabled());
-
-		queryConfig.setCollatedSpellCheckResultScoresThreshold(
-			suggestionsPortletPreferences.
-				getSpellCheckSuggestionDisplayThreshold());
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/SuggestionsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/SuggestionsPortletSharedSearchContributor.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.suggestions.portlet;
+
+import com.liferay.portal.kernel.search.QueryConfig;
+import com.liferay.portal.search.web.internal.suggestions.constants.SuggestionsPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author André de Oliveira
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + SuggestionsPortletKeys.SUGGESTIONS
+)
+public class SuggestionsPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		SuggestionsPortletPreferences suggestionsPortletPreferences =
+			new SuggestionsPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		setUpQueryIndexing(
+			suggestionsPortletPreferences, portletSharedSearchSettings);
+		setUpRelatedSuggestions(
+			suggestionsPortletPreferences, portletSharedSearchSettings);
+		setUpSpellCheckSuggestion(
+			suggestionsPortletPreferences, portletSharedSearchSettings);
+	}
+
+	protected void setUpQueryIndexing(
+		SuggestionsPortletPreferences suggestionsPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
+
+		queryConfig.setQueryIndexingEnabled(
+			suggestionsPortletPreferences.isQueryIndexingEnabled());
+		queryConfig.setQueryIndexingThreshold(
+			suggestionsPortletPreferences.getQueryIndexingThreshold());
+	}
+
+	protected void setUpRelatedSuggestions(
+		SuggestionsPortletPreferences suggestionsPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
+
+		queryConfig.setQuerySuggestionEnabled(
+			suggestionsPortletPreferences.isRelatedQueriesSuggestionsEnabled());
+		queryConfig.setQuerySuggestionScoresThreshold(
+			suggestionsPortletPreferences.
+				getRelatedQueriesSuggestionsDisplayThreshold());
+		queryConfig.setQuerySuggestionsMax(
+			suggestionsPortletPreferences.getRelatedQueriesSuggestionsMax());
+	}
+
+	protected void setUpSpellCheckSuggestion(
+		SuggestionsPortletPreferences suggestionsPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		QueryConfig queryConfig = portletSharedSearchSettings.getQueryConfig();
+
+		queryConfig.setCollatedSpellCheckResultEnabled(
+			suggestionsPortletPreferences.isSpellCheckSuggestionEnabled());
+
+		queryConfig.setCollatedSpellCheckResultScoresThreshold(
+			suggestionsPortletPreferences.
+				getSpellCheckSuggestionDisplayThreshold());
+	}
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/TagFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/TagFacetPortlet.java
@@ -20,14 +20,11 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetTagsSearchFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFacetDisplayContext;
-import com.liferay.portal.search.web.internal.tag.facet.builder.AssetTagsFacetBuilder;
 import com.liferay.portal.search.web.internal.tag.facet.builder.AssetTagsFacetConfiguration;
 import com.liferay.portal.search.web.internal.tag.facet.builder.AssetTagsFacetConfigurationImpl;
 import com.liferay.portal.search.web.internal.tag.facet.constants.TagFacetPortletKeys;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
@@ -67,24 +64,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class TagFacetPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		TagFacetPortletPreferences tagFacetPortletPreferences =
-			new TagFacetPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		Facet facet = buildFacet(
-			tagFacetPortletPreferences, portletSharedSearchSettings);
-
-		portletSharedSearchSettings.addFacet(facet);
-	}
+public class TagFacetPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -148,30 +130,6 @@ public class TagFacetPortlet
 			assetTagsSearchFacetDisplayBuilder::setParameterValues);
 
 		return assetTagsSearchFacetDisplayBuilder.build();
-	}
-
-	protected Facet buildFacet(
-		TagFacetPortletPreferences tagFacetPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		AssetTagsFacetBuilder assetTagsFacetBuilder = new AssetTagsFacetBuilder(
-			assetTagNamesFacetFactory);
-
-		assetTagsFacetBuilder.setFrequencyThreshold(
-			tagFacetPortletPreferences.getFrequencyThreshold());
-		assetTagsFacetBuilder.setMaxTerms(
-			tagFacetPortletPreferences.getMaxTerms());
-		assetTagsFacetBuilder.setSearchContext(
-			portletSharedSearchSettings.getSearchContext());
-
-		Optional<String[]> parameterValuesOptional =
-			portletSharedSearchSettings.getParameterValues(
-				tagFacetPortletPreferences.getParameterName());
-
-		parameterValuesOptional.ifPresent(
-			assetTagsFacetBuilder::setSelectedTags);
-
-		return assetTagsFacetBuilder.build();
 	}
 
 	protected String getFieldName() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/TagFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/TagFacetPortletSharedSearchContributor.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.tag.facet.portlet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
+import com.liferay.portal.search.web.internal.tag.facet.builder.AssetTagsFacetBuilder;
+import com.liferay.portal.search.web.internal.tag.facet.constants.TagFacetPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lino Alves
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + TagFacetPortletKeys.TAG_FACET
+)
+public class TagFacetPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		TagFacetPortletPreferences tagFacetPortletPreferences =
+			new TagFacetPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		Facet facet = buildFacet(
+			tagFacetPortletPreferences, portletSharedSearchSettings);
+
+		portletSharedSearchSettings.addFacet(facet);
+	}
+
+	protected Facet buildFacet(
+		TagFacetPortletPreferences tagFacetPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		AssetTagsFacetBuilder assetTagsFacetBuilder = new AssetTagsFacetBuilder(
+			assetTagNamesFacetFactory);
+
+		assetTagsFacetBuilder.setFrequencyThreshold(
+			tagFacetPortletPreferences.getFrequencyThreshold());
+		assetTagsFacetBuilder.setMaxTerms(
+			tagFacetPortletPreferences.getMaxTerms());
+		assetTagsFacetBuilder.setSearchContext(
+			portletSharedSearchSettings.getSearchContext());
+
+		Optional<String[]> parameterValuesOptional =
+			portletSharedSearchSettings.getParameterValues(
+				tagFacetPortletPreferences.getParameterName());
+
+		parameterValuesOptional.ifPresent(
+			assetTagsFacetBuilder::setSelectedTags);
+
+		return assetTagsFacetBuilder.build();
+	}
+
+	@Reference
+	protected AssetTagNamesFacetFactory assetTagNamesFacetFactory;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/TypeFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/TypeFacetPortlet.java
@@ -23,10 +23,8 @@ import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetEntriesSearchFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.facet.display.context.AssetEntriesSearchFacetDisplayContext;
 import com.liferay.portal.search.web.internal.type.facet.constants.TypeFacetPortletKeys;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
@@ -67,33 +65,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class TypeFacetPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		TypeFacetPortletPreferences typeFacetPortletPreferences =
-			new TypeFacetPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		Facet facet = buildFacet(
-			typeFacetPortletPreferences, portletSharedSearchSettings);
-
-		portletSharedSearchSettings.addFacet(facet);
-
-		ThemeDisplay themeDisplay =
-			portletSharedSearchSettings.getThemeDisplay();
-
-		SearchContext searchContext =
-			portletSharedSearchSettings.getSearchContext();
-
-		searchContext.setEntryClassNames(
-			getAssetTypesClassNames(typeFacetPortletPreferences, themeDisplay));
-	}
+public class TypeFacetPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -163,28 +137,6 @@ public class TypeFacetPortlet
 			assetEntriesSearchFacetDisplayBuilder::setParameterValues);
 
 		return assetEntriesSearchFacetDisplayBuilder.build();
-	}
-
-	protected Facet buildFacet(
-		TypeFacetPortletPreferences typeFacetPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		AssetEntriesFacetBuilder assetEntriesFacetBuilder =
-			new AssetEntriesFacetBuilder(assetEntriesFacetFactory);
-
-		assetEntriesFacetBuilder.setFrequencyThreshold(
-			typeFacetPortletPreferences.getFrequencyThreshold());
-		assetEntriesFacetBuilder.setSearchContext(
-			portletSharedSearchSettings.getSearchContext());
-
-		Optional<String[]> parameterValuesOptional =
-			portletSharedSearchSettings.getParameterValues(
-				typeFacetPortletPreferences.getParameterName());
-
-		parameterValuesOptional.ifPresent(
-			assetEntriesFacetBuilder::setSelectedTypes);
-
-		return assetEntriesFacetBuilder.build();
 	}
 
 	protected String[] getAssetTypesClassNames(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/TypeFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/TypeFacetPortletSharedSearchContributor.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.type.facet.portlet;
+
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
+import com.liferay.portal.search.web.internal.type.facet.constants.TypeFacetPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lino Alves
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + TypeFacetPortletKeys.TYPE_FACET
+)
+public class TypeFacetPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		TypeFacetPortletPreferences typeFacetPortletPreferences =
+			new TypeFacetPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		Facet facet = buildFacet(
+			typeFacetPortletPreferences, portletSharedSearchSettings);
+
+		portletSharedSearchSettings.addFacet(facet);
+
+		ThemeDisplay themeDisplay =
+			portletSharedSearchSettings.getThemeDisplay();
+
+		SearchContext searchContext =
+			portletSharedSearchSettings.getSearchContext();
+
+		searchContext.setEntryClassNames(
+			getAssetTypesClassNames(typeFacetPortletPreferences, themeDisplay));
+	}
+
+	protected Facet buildFacet(
+		TypeFacetPortletPreferences typeFacetPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		AssetEntriesFacetBuilder assetEntriesFacetBuilder =
+			new AssetEntriesFacetBuilder(assetEntriesFacetFactory);
+
+		assetEntriesFacetBuilder.setFrequencyThreshold(
+			typeFacetPortletPreferences.getFrequencyThreshold());
+		assetEntriesFacetBuilder.setSearchContext(
+			portletSharedSearchSettings.getSearchContext());
+
+		Optional<String[]> parameterValuesOptional =
+			portletSharedSearchSettings.getParameterValues(
+				typeFacetPortletPreferences.getParameterName());
+
+		parameterValuesOptional.ifPresent(
+			assetEntriesFacetBuilder::setSelectedTypes);
+
+		return assetEntriesFacetBuilder.build();
+	}
+
+	protected String[] getAssetTypesClassNames(
+		TypeFacetPortletPreferences typeFacetPortletPreferences,
+		ThemeDisplay themeDisplay) {
+
+		return typeFacetPortletPreferences.getCurrentAssetTypesArray(
+			themeDisplay.getCompanyId());
+	}
+
+	@Reference
+	protected AssetEntriesFacetFactory assetEntriesFacetFactory;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetPortlet.java
@@ -21,10 +21,8 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.search.web.internal.facet.display.builder.UserSearchFacetDisplayBuilder;
 import com.liferay.portal.search.web.internal.facet.display.context.UserSearchFacetDisplayContext;
 import com.liferay.portal.search.web.internal.user.facet.constants.UserFacetPortletKeys;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchRequest;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchResponse;
-import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.io.IOException;
 
@@ -66,24 +64,9 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.security-role-ref=guest,power-user,user",
 		"javax.portlet.supports.mime-type=text/html"
 	},
-	service = {Portlet.class, PortletSharedSearchContributor.class}
+	service = Portlet.class
 )
-public class UserFacetPortlet
-	extends MVCPortlet implements PortletSharedSearchContributor {
-
-	@Override
-	public void contribute(
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		UserFacetPortletPreferences userFacetPortletPreferences =
-			new UserFacetPortletPreferencesImpl(
-				portletSharedSearchSettings.getPortletPreferences());
-
-		Facet facet = buildFacet(
-			userFacetPortletPreferences, portletSharedSearchSettings);
-
-		portletSharedSearchSettings.addFacet(facet);
-	}
+public class UserFacetPortlet extends MVCPortlet {
 
 	@Override
 	public void render(
@@ -142,28 +125,6 @@ public class UserFacetPortlet
 		usersOptional.ifPresent(userSearchFacetDisplayBuilder::setParamValues);
 
 		return userSearchFacetDisplayBuilder.build();
-	}
-
-	protected Facet buildFacet(
-		UserFacetPortletPreferences userFacetPortletPreferences,
-		PortletSharedSearchSettings portletSharedSearchSettings) {
-
-		UserFacetBuilder userFacetBuilder = new UserFacetBuilder(
-			userFacetFactory);
-
-		userFacetBuilder.setFrequencyThreshold(
-			userFacetPortletPreferences.getFrequencyThreshold());
-		userFacetBuilder.setMaxTerms(userFacetPortletPreferences.getMaxTerms());
-		userFacetBuilder.setSearchContext(
-			portletSharedSearchSettings.getSearchContext());
-
-		Optional<String[]> parameterValuesOptional =
-			portletSharedSearchSettings.getParameterValues(
-				userFacetPortletPreferences.getParameterName());
-
-		parameterValuesOptional.ifPresent(userFacetBuilder::setSelectedUsers);
-
-		return userFacetBuilder.build();
 	}
 
 	protected String getFieldName() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/UserFacetPortletSharedSearchContributor.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.web.internal.user.facet.portlet;
+
+import com.liferay.portal.kernel.search.facet.Facet;
+import com.liferay.portal.search.web.internal.user.facet.constants.UserFacetPortletKeys;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
+import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
+
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lino Alves
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + UserFacetPortletKeys.USER_FACET
+)
+public class UserFacetPortletSharedSearchContributor
+	implements PortletSharedSearchContributor {
+
+	@Override
+	public void contribute(
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		UserFacetPortletPreferences userFacetPortletPreferences =
+			new UserFacetPortletPreferencesImpl(
+				portletSharedSearchSettings.getPortletPreferences());
+
+		Facet facet = buildFacet(
+			userFacetPortletPreferences, portletSharedSearchSettings);
+
+		portletSharedSearchSettings.addFacet(facet);
+	}
+
+	protected Facet buildFacet(
+		UserFacetPortletPreferences userFacetPortletPreferences,
+		PortletSharedSearchSettings portletSharedSearchSettings) {
+
+		UserFacetBuilder userFacetBuilder = new UserFacetBuilder(
+			userFacetFactory);
+
+		userFacetBuilder.setFrequencyThreshold(
+			userFacetPortletPreferences.getFrequencyThreshold());
+		userFacetBuilder.setMaxTerms(userFacetPortletPreferences.getMaxTerms());
+		userFacetBuilder.setSearchContext(
+			portletSharedSearchSettings.getSearchContext());
+
+		Optional<String[]> parameterValuesOptional =
+			portletSharedSearchSettings.getParameterValues(
+				userFacetPortletPreferences.getParameterName());
+
+		parameterValuesOptional.ifPresent(userFacetBuilder::setSelectedUsers);
+
+		return userFacetBuilder.build();
+	}
+
+	protected UserFacetFactory userFacetFactory = new UserFacetFactory();
+
+}

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BaseIndexerRequestBufferExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BaseIndexerRequestBufferExecutor.java
@@ -24,11 +24,6 @@ import com.liferay.portal.search.buffer.IndexerRequestBufferExecutor;
 
 import java.util.Set;
 
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
-
 /**
  * @author Michael C. Han
  */
@@ -41,6 +36,8 @@ public abstract class BaseIndexerRequestBufferExecutor
 	}
 
 	protected void commit(Set<String> searchEngineIds) {
+		IndexWriterHelper indexWriterHelper = getIndexWriterHelper();
+
 		if (indexWriterHelper == null) {
 			if (_log.isWarnEnabled()) {
 				_log.warn("Index writer helper is null");
@@ -77,12 +74,7 @@ public abstract class BaseIndexerRequestBufferExecutor
 		}
 	}
 
-	@Reference(
-		cardinality = ReferenceCardinality.OPTIONAL,
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	protected volatile IndexWriterHelper indexWriterHelper;
+	protected abstract IndexWriterHelper getIndexWriterHelper();
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseIndexerRequestBufferExecutor.class);

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/DefaultIndexerRequestBufferExecutor.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/DefaultIndexerRequestBufferExecutor.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.internal.buffer;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.search.buffer.IndexerRequest;
 import com.liferay.portal.search.buffer.IndexerRequestBuffer;
@@ -26,7 +27,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author Michael C. Han
@@ -88,7 +93,28 @@ public class DefaultIndexerRequestBufferExecutor
 		}
 	}
 
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_indexWriterHelperServiceTracker = new ServiceTracker<>(
+			bundleContext, IndexWriterHelper.class, null);
+
+		_indexWriterHelperServiceTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_indexWriterHelperServiceTracker.close();
+	}
+
+	@Override
+	protected IndexWriterHelper getIndexWriterHelper() {
+		return _indexWriterHelperServiceTracker.getService();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultIndexerRequestBufferExecutor.class);
+
+	private ServiceTracker<IndexWriterHelper, IndexWriterHelper>
+		_indexWriterHelperServiceTracker;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/build.gradle
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/build.gradle
@@ -15,5 +15,6 @@ dependencies {
 	compileOnly project(":apps:portal:portal-spring-extender-api")
 	compileOnly project(":apps:push-notifications:push-notifications-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
+	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/jmx/MessageBusManager.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/jmx/MessageBusManager.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.management.DynamicMBean;
-import javax.management.MBeanServer;
 import javax.management.NotCompliantMBeanException;
 import javax.management.StandardMBean;
 
@@ -140,10 +139,6 @@ public class MessageBusManager
 		if (mbeanServiceRegistration != null) {
 			mbeanServiceRegistration.unregister();
 		}
-	}
-
-	@Reference(unbind = "-")
-	protected void setMBeanServer(MBeanServer mBeanServer) {
 	}
 
 	@Reference(unbind = "-")

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -1515,6 +1515,29 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 	private void _startDynamicBundles(Set<Bundle> installedBundles)
 		throws Exception {
 
+		Bundle fileInstallBundle = null;
+
+		for (Bundle bundle : installedBundles) {
+			if ("org.apache.felix.fileinstall".equals(
+					bundle.getSymbolicName())) {
+
+				fileInstallBundle = bundle;
+
+				break;
+			}
+		}
+
+		if (fileInstallBundle == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to find FileInstall bundle to synchronize " +
+						"dynamic bundles starting.");
+			}
+		}
+		else {
+			fileInstallBundle.stop(Bundle.STOP_TRANSIENT);
+		}
+
 		FrameworkStartLevel frameworkStartLevel = _framework.adapt(
 			FrameworkStartLevel.class);
 
@@ -1571,6 +1594,10 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 						be);
 				}
 			}
+		}
+
+		if (fileInstallBundle != null) {
+			fileInstallBundle.start(Bundle.START_TRANSIENT);
 		}
 	}
 


### PR DESCRIPTION
@brianchandotcom this eliminates the annoying startup time deadlock. We see it on CI roughly about 3~5 times out of 1000 tomcat startups.

The actual reason of the deadlock is fairly complex (I have put a more detailed explanation on the ticket https://issues.liferay.com/browse/LPS-80843). To make it simple, it is a combination effect of:
1) SCR "soft circular dependencies" 
2) concurrent bundle starting
3) poor osgi core thread safety handling. (very deeply nested synchronized blocks)
We need all these 3 factors to work together plus a bad luck timing to see the deadlock, that's why it is so hard to see or reproduce it.

This fix attacks both 1) and 2), as we can not really fix 3).
And more importantly, this fix creates a defense scanning, we can catch and reject addition of new "soft circular dependencies" by CI.

@jhinkey this will need some documentation updates.

@sergiogonzalez please see https://github.com/brianchandotcom/liferay-portal/commit/f1218e6f3e2bd908a6613818cd0d2ce32b45edde

@arboliveira  please see https://github.com/brianchandotcom/liferay-portal/commit/7781216e023f7604b4de3e44054ceeb02123358c , let me know if you have any objection on that. I did not change any logic, only the way how they are wired up.

And @brianchandotcom you may find https://github.com/brianchandotcom/liferay-portal/commit/4e5f193296245061ccc19b859a7da62a80c85ab5 a bit confusing. It is the cheapest workaround solution I can get. We have 2 real major design issues in scheduler engine dependencies wiring. Fixing them requires a lot of refactor with API changes, I don't think it is a wise thing to do that before release. So let's settle down to this simple workaround for now. I already talked to @tinatian, some real refactor/fix will come later after release.

CC @mhan810 @david-truong