### PR TITLE
LPS-80848 New Search Portlets: rename packages following portlet.shared.search convention

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/shared/search/CategoryFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/category/facet/portlet/shared/search/CategoryFacetPortletSharedSearchContributor.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.category.facet.portlet;
+package com.liferay.portal.search.web.internal.category.facet.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetBuilder;
 import com.liferay.portal.search.web.internal.category.facet.builder.AssetCategoriesFacetFactory;
 import com.liferay.portal.search.web.internal.category.facet.constants.CategoryFacetPortletKeys;
+import com.liferay.portal.search.web.internal.category.facet.portlet.CategoryFacetPortletPreferences;
+import com.liferay.portal.search.web.internal.category.facet.portlet.CategoryFacetPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/portlet/shared/search/CustomFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/custom/facet/portlet/shared/search/CustomFacetPortletSharedSearchContributor.java
@@ -12,13 +12,15 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.custom.facet.portlet;
+package com.liferay.portal.search.web.internal.custom.facet.portlet.shared.search;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.search.facet.custom.CustomFacetFactory;
 import com.liferay.portal.search.web.internal.custom.facet.builder.CustomFacetBuilder;
 import com.liferay.portal.search.web.internal.custom.facet.constants.CustomFacetPortletKeys;
+import com.liferay.portal.search.web.internal.custom.facet.portlet.CustomFacetPortletPreferences;
+import com.liferay.portal.search.web.internal.custom.facet.portlet.CustomFacetPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/shared/search/FolderFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/folder/facet/portlet/shared/search/FolderFacetPortletSharedSearchContributor.java
@@ -12,12 +12,16 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.folder.facet.portlet;
+package com.liferay.portal.search.web.internal.folder.facet.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.web.internal.folder.facet.constants.FolderFacetPortletKeys;
+import com.liferay.portal.search.web.internal.folder.facet.portlet.FolderFacetBuilder;
+import com.liferay.portal.search.web.internal.folder.facet.portlet.FolderFacetFactory;
+import com.liferay.portal.search.web.internal.folder.facet.portlet.FolderFacetPortletPreferences;
+import com.liferay.portal.search.web.internal.folder.facet.portlet.FolderFacetPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/bar/portlet/shared/search/SearchBarPortletSharedSearchContributor.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.search.bar.portlet;
+package com.liferay.portal.search.web.internal.search.bar.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.search.web.internal.display.context.SearchScope;
 import com.liferay.portal.search.web.internal.search.bar.constants.SearchBarPortletKeys;
+import com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortletPreferences;
+import com.liferay.portal.search.web.internal.search.bar.portlet.SearchBarPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/shared/search/SearchResultsPortletSharedSearchContributor.java
@@ -12,10 +12,12 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.search.results.portlet;
+package com.liferay.portal.search.web.internal.search.results.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.search.web.internal.search.results.constants.SearchResultsPortletKeys;
+import com.liferay.portal.search.web.internal.search.results.portlet.SearchResultsPortletPreferences;
+import com.liferay.portal.search.web.internal.search.results.portlet.SearchResultsPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/shared/search/SiteFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/site/facet/portlet/shared/search/SiteFacetPortletSharedSearchContributor.java
@@ -12,11 +12,14 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.site.facet.portlet;
+package com.liferay.portal.search.web.internal.site.facet.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.ScopeFacetFactory;
 import com.liferay.portal.search.web.internal.site.facet.constants.SiteFacetPortletKeys;
+import com.liferay.portal.search.web.internal.site.facet.portlet.ScopeFacetBuilder;
+import com.liferay.portal.search.web.internal.site.facet.portlet.SiteFacetPortletPreferences;
+import com.liferay.portal.search.web.internal.site.facet.portlet.SiteFacetPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/shared/search/SuggestionsPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/suggestions/portlet/shared/search/SuggestionsPortletSharedSearchContributor.java
@@ -12,10 +12,12 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.suggestions.portlet;
+package com.liferay.portal.search.web.internal.suggestions.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.search.web.internal.suggestions.constants.SuggestionsPortletKeys;
+import com.liferay.portal.search.web.internal.suggestions.portlet.SuggestionsPortletPreferences;
+import com.liferay.portal.search.web.internal.suggestions.portlet.SuggestionsPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/shared/search/TagFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/tag/facet/portlet/shared/search/TagFacetPortletSharedSearchContributor.java
@@ -12,63 +12,71 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.user.facet.portlet;
+package com.liferay.portal.search.web.internal.tag.facet.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.facet.Facet;
-import com.liferay.portal.search.web.internal.user.facet.constants.UserFacetPortletKeys;
+import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
+import com.liferay.portal.search.web.internal.tag.facet.builder.AssetTagsFacetBuilder;
+import com.liferay.portal.search.web.internal.tag.facet.constants.TagFacetPortletKeys;
+import com.liferay.portal.search.web.internal.tag.facet.portlet.TagFacetPortletPreferences;
+import com.liferay.portal.search.web.internal.tag.facet.portlet.TagFacetPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.util.Optional;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Lino Alves
  */
 @Component(
 	immediate = true,
-	property = "javax.portlet.name=" + UserFacetPortletKeys.USER_FACET
+	property = "javax.portlet.name=" + TagFacetPortletKeys.TAG_FACET
 )
-public class UserFacetPortletSharedSearchContributor
+public class TagFacetPortletSharedSearchContributor
 	implements PortletSharedSearchContributor {
 
 	@Override
 	public void contribute(
 		PortletSharedSearchSettings portletSharedSearchSettings) {
 
-		UserFacetPortletPreferences userFacetPortletPreferences =
-			new UserFacetPortletPreferencesImpl(
+		TagFacetPortletPreferences tagFacetPortletPreferences =
+			new TagFacetPortletPreferencesImpl(
 				portletSharedSearchSettings.getPortletPreferences());
 
 		Facet facet = buildFacet(
-			userFacetPortletPreferences, portletSharedSearchSettings);
+			tagFacetPortletPreferences, portletSharedSearchSettings);
 
 		portletSharedSearchSettings.addFacet(facet);
 	}
 
 	protected Facet buildFacet(
-		UserFacetPortletPreferences userFacetPortletPreferences,
+		TagFacetPortletPreferences tagFacetPortletPreferences,
 		PortletSharedSearchSettings portletSharedSearchSettings) {
 
-		UserFacetBuilder userFacetBuilder = new UserFacetBuilder(
-			userFacetFactory);
+		AssetTagsFacetBuilder assetTagsFacetBuilder = new AssetTagsFacetBuilder(
+			assetTagNamesFacetFactory);
 
-		userFacetBuilder.setFrequencyThreshold(
-			userFacetPortletPreferences.getFrequencyThreshold());
-		userFacetBuilder.setMaxTerms(userFacetPortletPreferences.getMaxTerms());
-		userFacetBuilder.setSearchContext(
+		assetTagsFacetBuilder.setFrequencyThreshold(
+			tagFacetPortletPreferences.getFrequencyThreshold());
+		assetTagsFacetBuilder.setMaxTerms(
+			tagFacetPortletPreferences.getMaxTerms());
+		assetTagsFacetBuilder.setSearchContext(
 			portletSharedSearchSettings.getSearchContext());
 
 		Optional<String[]> parameterValuesOptional =
 			portletSharedSearchSettings.getParameterValues(
-				userFacetPortletPreferences.getParameterName());
+				tagFacetPortletPreferences.getParameterName());
 
-		parameterValuesOptional.ifPresent(userFacetBuilder::setSelectedUsers);
+		parameterValuesOptional.ifPresent(
+			assetTagsFacetBuilder::setSelectedTags);
 
-		return userFacetBuilder.build();
+		return assetTagsFacetBuilder.build();
 	}
 
-	protected UserFacetFactory userFacetFactory = new UserFacetFactory();
+	@Reference
+	protected AssetTagNamesFacetFactory assetTagNamesFacetFactory;
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/shared/search/TypeFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/type/facet/portlet/shared/search/TypeFacetPortletSharedSearchContributor.java
@@ -12,13 +12,16 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.type.facet.portlet;
+package com.liferay.portal.search.web.internal.type.facet.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.search.facet.type.AssetEntriesFacetFactory;
 import com.liferay.portal.search.web.internal.type.facet.constants.TypeFacetPortletKeys;
+import com.liferay.portal.search.web.internal.type.facet.portlet.AssetEntriesFacetBuilder;
+import com.liferay.portal.search.web.internal.type.facet.portlet.TypeFacetPortletPreferences;
+import com.liferay.portal.search.web.internal.type.facet.portlet.TypeFacetPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/shared/search/UserFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/user/facet/portlet/shared/search/UserFacetPortletSharedSearchContributor.java
@@ -12,69 +12,67 @@
  * details.
  */
 
-package com.liferay.portal.search.web.internal.tag.facet.portlet;
+package com.liferay.portal.search.web.internal.user.facet.portlet.shared.search;
 
 import com.liferay.portal.kernel.search.facet.Facet;
-import com.liferay.portal.search.facet.tag.AssetTagNamesFacetFactory;
-import com.liferay.portal.search.web.internal.tag.facet.builder.AssetTagsFacetBuilder;
-import com.liferay.portal.search.web.internal.tag.facet.constants.TagFacetPortletKeys;
+import com.liferay.portal.search.web.internal.user.facet.constants.UserFacetPortletKeys;
+import com.liferay.portal.search.web.internal.user.facet.portlet.UserFacetBuilder;
+import com.liferay.portal.search.web.internal.user.facet.portlet.UserFacetFactory;
+import com.liferay.portal.search.web.internal.user.facet.portlet.UserFacetPortletPreferences;
+import com.liferay.portal.search.web.internal.user.facet.portlet.UserFacetPortletPreferencesImpl;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchContributor;
 import com.liferay.portal.search.web.portlet.shared.search.PortletSharedSearchSettings;
 
 import java.util.Optional;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Lino Alves
  */
 @Component(
 	immediate = true,
-	property = "javax.portlet.name=" + TagFacetPortletKeys.TAG_FACET
+	property = "javax.portlet.name=" + UserFacetPortletKeys.USER_FACET
 )
-public class TagFacetPortletSharedSearchContributor
+public class UserFacetPortletSharedSearchContributor
 	implements PortletSharedSearchContributor {
 
 	@Override
 	public void contribute(
 		PortletSharedSearchSettings portletSharedSearchSettings) {
 
-		TagFacetPortletPreferences tagFacetPortletPreferences =
-			new TagFacetPortletPreferencesImpl(
+		UserFacetPortletPreferences userFacetPortletPreferences =
+			new UserFacetPortletPreferencesImpl(
 				portletSharedSearchSettings.getPortletPreferences());
 
 		Facet facet = buildFacet(
-			tagFacetPortletPreferences, portletSharedSearchSettings);
+			userFacetPortletPreferences, portletSharedSearchSettings);
 
 		portletSharedSearchSettings.addFacet(facet);
 	}
 
 	protected Facet buildFacet(
-		TagFacetPortletPreferences tagFacetPortletPreferences,
+		UserFacetPortletPreferences userFacetPortletPreferences,
 		PortletSharedSearchSettings portletSharedSearchSettings) {
 
-		AssetTagsFacetBuilder assetTagsFacetBuilder = new AssetTagsFacetBuilder(
-			assetTagNamesFacetFactory);
+		UserFacetBuilder userFacetBuilder = new UserFacetBuilder(
+			userFacetFactory);
 
-		assetTagsFacetBuilder.setFrequencyThreshold(
-			tagFacetPortletPreferences.getFrequencyThreshold());
-		assetTagsFacetBuilder.setMaxTerms(
-			tagFacetPortletPreferences.getMaxTerms());
-		assetTagsFacetBuilder.setSearchContext(
+		userFacetBuilder.setFrequencyThreshold(
+			userFacetPortletPreferences.getFrequencyThreshold());
+		userFacetBuilder.setMaxTerms(userFacetPortletPreferences.getMaxTerms());
+		userFacetBuilder.setSearchContext(
 			portletSharedSearchSettings.getSearchContext());
 
 		Optional<String[]> parameterValuesOptional =
 			portletSharedSearchSettings.getParameterValues(
-				tagFacetPortletPreferences.getParameterName());
+				userFacetPortletPreferences.getParameterName());
 
-		parameterValuesOptional.ifPresent(
-			assetTagsFacetBuilder::setSelectedTags);
+		parameterValuesOptional.ifPresent(userFacetBuilder::setSelectedUsers);
 
-		return assetTagsFacetBuilder.build();
+		return userFacetBuilder.build();
 	}
 
-	@Reference
-	protected AssetTagNamesFacetFactory assetTagNamesFacetFactory;
+	protected UserFacetFactory userFacetFactory = new UserFacetFactory();
 
 }


### PR DESCRIPTION
Renamed internal packages to `com.liferay.portal.search.web.internal.*.facet.portlet.shared.search` , following newly defined convention: https://github.com/brianchandotcom/liferay-portal/pull/58362#issuecomment-388583267

Changes are minimal and internal, and portlets still work normally after manual tests, so skipping a full CI run. Single commit can easily be reverted if needed.

https://issues.liferay.com/browse/LPS-80848