### PR TITLE
Revert "LPS-80388 Upgrade Equinox framework to R7 compatible release …

### DIFF
--- a/modules/core/portal-equinox-log-bridge/build.gradle
+++ b/modules/core/portal-equinox-log-bridge/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.13.0.v20180409-1500-LIFERAY-CACHED"
+	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
 	compileOnly group: "org.slf4j", name: "slf4j-api", version: "1.7.2"
 }
 


### PR DESCRIPTION
…(equinox M7)"

This reverts commit 280c10c3c06ff4d75c7bd13ea827a3af9c9dfb52.

@rotty3000 sorry, I have to revert this, since this is not really doing what you think it is doing.
The osgi core is actually deployed by https://github.com/liferay/liferay-portal/blob/master/modules/core/registry-impl/build.gradle#L5 . Not by portal-equinox-log-bridge. So your change to this module is only just compile time dependency, after deploy we are still using the old one, so we did not really change anything.

And we have many references to this jar, here is the fully list:
```
modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler-test/build.gradle:	testIntegrationCompile group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/build.gradle:	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/apps/static/portal-osgi-web/portal-osgi-web-wab-spring-bridge-api/build.gradle:	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support/build.gradle:	compileOnly group: "org.eclipse.tycho", name: "org.eclipse.osgi", version: "3.10.101.v20150820-1432"
modules/core/portal-equinox-log-bridge/build.gradle:	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/core/portal-bootstrap-test/build.gradle:	testCompile group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/core/portal-security-pacl/build.gradle:	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/core/registry-impl/build.gradle:	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/core/portal-app-license-resolver-hook/build.gradle:	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1.LIFERAY-PATCHED-1"
modules/third-party/org-eclipse-osgi/build.gradle:	compileOnly group: "com.liferay", name: "org.eclipse.osgi", version: "3.10.200-20150904.172142-1-LIFERAY-CACHED"

```
Please update them all so that we have all the tests both unit and integration are running against the last version,