### PR TITLE
LPS-73059 (CI FIX) Fix tests breaking due to renamed config post language keys review

### DIFF
--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/batch/BatchIndexingHelperImplBulkSizesTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/batch/BatchIndexingHelperImplBulkSizesTest.java
@@ -69,11 +69,10 @@ public class BatchIndexingHelperImplBulkSizesTest {
 		assertBulkSize(10000, entryClassName2);
 	}
 
-	protected void activate(String... batchIndexingBulkSizes) {
+	protected void activate(String... indexingBatchSizes) {
 		_batchIndexingHelperImpl.activate(
 			Collections.singletonMap(
-				"batchIndexingBulkSizes",
-				Arrays.asList(batchIndexingBulkSizes)));
+				"indexingBatchSizes", Arrays.asList(indexingBatchSizes)));
 	}
 
 	protected void activateWithoutConfiguration() {


### PR DESCRIPTION
This will fix:

`com.liferay.portal.search.internal.batch.BatchIndexingHelperImplBulkSizesTest.testConfiguration`

`java.lang.AssertionError: expected:<200> but was:<10000>`

cc/ @xbrianlee