### PR TITLE
LPS-80972 New Search Portlets: Selected entries in facets should be visually distinct from unselected ones

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/display/context/ModifiedFacetTermDisplayContext.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/display/context/ModifiedFacetTermDisplayContext.java
@@ -37,14 +37,6 @@ public class ModifiedFacetTermDisplayContext implements Serializable {
 		return _rangeURL;
 	}
 
-	public boolean isActive() {
-		if (_frequency == 0) {
-			return false;
-		}
-
-		return _selected;
-	}
-
 	public boolean isSelected() {
 		return _selected;
 	}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
@@ -33,6 +33,14 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
@@ -76,7 +84,7 @@ AssetCategoriesSearchFacetDisplayContext assetCategoriesSearchFacetDisplayContex
 									<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 										<input class="facet-term" data-term-id="<%= assetCategoriesSearchFacetTermDisplayContext.getAssetCategoryId() %>" id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= assetCategoriesSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
 
-										<span class="term-name">
+										<span class="term-name <%= assetCategoriesSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 											<%= HtmlUtil.escape(assetCategoriesSearchFacetTermDisplayContext.getDisplayName()) %>
 										</span>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -33,6 +33,14 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
@@ -76,7 +84,7 @@ CustomFacetDisplayContext customFacetDisplayContext = (CustomFacetDisplayContext
 									<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 										<input class="facet-term" data-term-id="<%= customFacetTermDisplayContext.getFieldName() %>" id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= customFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
 
-										<span class="term-name">
+										<span class="term-name <%= customFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 											<%= HtmlUtil.escape(customFacetTermDisplayContext.getFieldName()) %>
 										</span>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
@@ -33,6 +33,14 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
@@ -76,7 +84,7 @@ FolderSearchFacetDisplayContext folderSearchFacetDisplayContext = (FolderSearchF
 									<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 										<input class="facet-term" data-term-id="<%= folderSearchFacetTermDisplayContext.getFolderId() %>" id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= folderSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
 
-										<span class="term-name">
+										<span class="term-name <%= folderSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 											<%= HtmlUtil.escape(folderSearchFacetTermDisplayContext.getDisplayName()) %>
 										</span>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/modified/facet/view.jsp
@@ -34,12 +34,20 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
 ModifiedFacetDisplayContext modifiedFacetDisplayContext = (ModifiedFacetDisplayContext)java.util.Objects.requireNonNull(request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT));
 
-ModifiedFacetTermDisplayContext customRangeTermDisplayContext = modifiedFacetDisplayContext.getCustomRangeModifiedFacetTermDisplayContext();
+ModifiedFacetTermDisplayContext customRangeModifiedFacetTermDisplayContext = modifiedFacetDisplayContext.getCustomRangeModifiedFacetTermDisplayContext();
 
 ModifiedFacetCalendarDisplayContext modifiedFacetCalendarDisplayContext = modifiedFacetDisplayContext.getModifiedFacetCalendarDisplayContext();
 %>
@@ -71,15 +79,14 @@ ModifiedFacetCalendarDisplayContext modifiedFacetCalendarDisplayContext = modifi
 						%>
 
 							<li class="facet-value" name="<%= renderResponse.getNamespace() + "range_" + modifiedFacetTermDisplayContext.getLabel() %>">
-								<a class="<%= modifiedFacetTermDisplayContext.isActive() ? "active" : StringPool.BLANK %>" href="<%= modifiedFacetTermDisplayContext.getRangeURL() %>">
+								<a href="<%= modifiedFacetTermDisplayContext.getRangeURL() %>">
+									<span class="term-name <%= modifiedFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
+										<liferay-ui:message key="<%= modifiedFacetTermDisplayContext.getLabel() %>" />
+									</span>
 
-								<span class="term-name">
-									<liferay-ui:message key="<%= modifiedFacetTermDisplayContext.getLabel() %>" />
-								</span>
-
-								<small class="term-count">
-									<span class="badge badge-info frequency"><%= modifiedFacetTermDisplayContext.getFrequency() %></span>
-								</small>
+									<small class="term-count">
+										(<%= modifiedFacetTermDisplayContext.getFrequency() %>)
+									</small>
 								</a>
 							</li>
 
@@ -87,13 +94,13 @@ ModifiedFacetCalendarDisplayContext modifiedFacetCalendarDisplayContext = modifi
 						}
 						%>
 
-						<li class="facet-value nav-item" name="<%= renderResponse.getNamespace() + "range_" + customRangeTermDisplayContext.getLabel() %>">
-							<a class="<%= customRangeTermDisplayContext.isActive() ? "active" : StringPool.BLANK %> nav-link" href="<%= customRangeTermDisplayContext.getRangeURL() %>" id="<portlet:namespace /><%= customRangeTermDisplayContext.getLabel() + "-toggleLink" %>">
-								<span class="term-name"><liferay-ui:message key="<%= customRangeTermDisplayContext.getLabel() %>" />&hellip;</span>
+						<li class="facet-value nav-item" name="<%= renderResponse.getNamespace() + "range_" + customRangeModifiedFacetTermDisplayContext.getLabel() %>">
+							<a class="nav-link" href="<%= customRangeModifiedFacetTermDisplayContext.getRangeURL() %>" id="<portlet:namespace /><%= customRangeModifiedFacetTermDisplayContext.getLabel() + "-toggleLink" %>">
+								<span class="term-name <%= customRangeModifiedFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>"><liferay-ui:message key="<%= customRangeModifiedFacetTermDisplayContext.getLabel() %>" />&hellip;</span>
 
-								<c:if test="<%= customRangeTermDisplayContext.isSelected() %>">
+								<c:if test="<%= customRangeModifiedFacetTermDisplayContext.isSelected() %>">
 									<small class="term-count">
-										<span class="badge badge-info frequency"><%= customRangeTermDisplayContext.getFrequency() %></span>
+										(<%= customRangeModifiedFacetTermDisplayContext.getFrequency() %>)
 									</small>
 								</c:if>
 							</a>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
@@ -33,6 +33,14 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
@@ -76,7 +84,7 @@ ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext = (ScopeSearchFace
 									<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 										<input class="facet-term" data-term-id="<%= scopeSearchFacetTermDisplayContext.getGroupId() %>" id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= scopeSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
 
-										<span class="term-name">
+										<span class="term-name <%= scopeSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 											<%= HtmlUtil.escape(scopeSearchFacetTermDisplayContext.getDescriptiveName()) %>
 										</span>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
@@ -33,6 +33,14 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
@@ -76,7 +84,7 @@ AssetTagsSearchFacetDisplayContext assetTagsSearchFacetDisplayContext = (AssetTa
 									<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 										<input class="facet-term" data-term-id="<%= assetTagsSearchFacetTermDisplayContext.getValue() %>" id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= assetTagsSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
 
-										<span class="term-name">
+										<span class="term-name <%= assetTagsSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 											<%= HtmlUtil.escape(assetTagsSearchFacetTermDisplayContext.getDisplayName()) %>
 										</span>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
@@ -33,6 +33,14 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
@@ -76,7 +84,7 @@ AssetEntriesSearchFacetDisplayContext assetEntriesSearchFacetDisplayContext = (A
 									<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 										<input class="facet-term" data-term-id="<%= assetEntriesSearchFacetTermDisplayContext.getAssetType() %>" id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= assetEntriesSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
 
-										<span class="term-name">
+										<span class="term-name <%= assetEntriesSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 											<%= HtmlUtil.escape(assetEntriesSearchFacetTermDisplayContext.getTypeName()) %>
 										</span>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
@@ -33,6 +33,14 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 	.facet-checkbox-label {
 		display: block;
 	}
+
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
 </style>
 
 <%
@@ -76,7 +84,7 @@ UserSearchFacetDisplayContext userSearchFacetDisplayContext = (UserSearchFacetDi
 									<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
 										<input class="facet-term" data-term-id="<%= userSearchFacetTermDisplayContext.getUserName() %>" id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= userSearchFacetTermDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
 
-										<span class="term-name">
+										<span class="term-name <%= userSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 											<%= HtmlUtil.escape(userSearchFacetTermDisplayContext.getUserName()) %>
 										</span>
 


### PR DESCRIPTION
CI missing: `master` was in an unstable state at the time the first self pull ran, so CI was unable to give reliable test results (https://github.com/arboliveira/liferay-portal/pull/494#issuecomment-390813747)  and this pull's relevant set is unstable as well.  (https://github.com/brianchandotcom/liferay-portal/pull/58783#issuecomment-390831072)

cc/ @xbrianlee This is one of our high profile fixes in New Search.

Author: @wcao20170619 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-80972