### PR TITLE
LPS-80945 Classic Search Portlet: Selected entries in facets should be visually distinct from unselected ones

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/init.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/init.jsp
@@ -20,17 +20,23 @@
 page import="com.liferay.portal.search.web.internal.facet.display.builder.AssetCategoriesSearchFacetDisplayBuilder" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.builder.AssetCategoryPermissionCheckerImpl" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.builder.AssetEntriesSearchFacetDisplayBuilder" %><%@
+page import="com.liferay.portal.search.web.internal.facet.display.builder.AssetTagsSearchFacetDisplayBuilder" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.builder.FolderSearchFacetDisplayBuilder" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.builder.ScopeSearchFacetDisplayBuilder" %><%@
+page import="com.liferay.portal.search.web.internal.facet.display.builder.UserSearchFacetDisplayBuilder" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.AssetCategoriesSearchFacetDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.AssetCategoriesSearchFacetTermDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.AssetEntriesSearchFacetDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.AssetEntriesSearchFacetTermDisplayContext" %><%@
+page import="com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFacetDisplayContext" %><%@
+page import="com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFacetTermDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.FolderSearchFacetDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.FolderSearchFacetTermDisplayContext" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.FolderTitleLookupImpl" %><%@
 page import="com.liferay.portal.search.web.internal.facet.display.context.ScopeSearchFacetDisplayContext" %><%@
-page import="com.liferay.portal.search.web.internal.facet.display.context.ScopeSearchFacetTermDisplayContext" %>
+page import="com.liferay.portal.search.web.internal.facet.display.context.ScopeSearchFacetTermDisplayContext" %><%@
+page import="com.liferay.portal.search.web.internal.facet.display.context.UserSearchFacetDisplayContext" %><%@
+page import="com.liferay.portal.search.web.internal.facet.display.context.UserSearchFacetTermDisplayContext" %>
 
 <%
 String randomNamespace = PortalUtil.generateRandomKey(request, _RANDOM_KEY_INPUT) + StringPool.UNDERLINE;
@@ -51,3 +57,13 @@ String cssClass = "search-facet search-".concat(HtmlUtil.escapeAttribute(facetCo
 <%!
 private static final String _RANDOM_KEY_INPUT = "portlet_search_facets_" + StringUtil.randomString();
 %>
+
+<style>
+	.facet-term-selected {
+		font-weight: 600;
+	}
+
+	.facet-term-unselected {
+		font-weight: 400;
+	}
+</style>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_categories.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_categories.jsp
@@ -51,7 +51,7 @@ AssetCategoriesSearchFacetDisplayContext assetCategoriesSearchFacetDisplayContex
 
 					<ul class="<%= assetCategoriesSearchFacetDisplayContext.isCloud() ? "tag-cloud" : "tag-list" %> list-unstyled">
 						<li class="default facet-value">
-							<a class="<%= assetCategoriesSearchFacetDisplayContext.isNothingSelected() ? "text-primary" : "text-default" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
+							<a class="<%= assetCategoriesSearchFacetDisplayContext.isNothingSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
 						</li>
 
 						<%
@@ -59,7 +59,7 @@ AssetCategoriesSearchFacetDisplayContext assetCategoriesSearchFacetDisplayContex
 						%>
 
 							<li class="facet-value tag-popularity-<%= assetCategoriesSearchFacetTermDisplayContext.getPopularity() %>">
-								<a class="<%= assetCategoriesSearchFacetTermDisplayContext.isSelected() ? "text-primary" : "text-default" %>" data-value="<%= HtmlUtil.escapeAttribute(String.valueOf(assetCategoriesSearchFacetTermDisplayContext.getAssetCategoryId())) %>" href="javascript:;">
+								<a class="<%= assetCategoriesSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="<%= HtmlUtil.escapeAttribute(String.valueOf(assetCategoriesSearchFacetTermDisplayContext.getAssetCategoryId())) %>" href="javascript:;">
 									<%= HtmlUtil.escape(assetCategoriesSearchFacetTermDisplayContext.getDisplayName()) %>
 
 									<c:if test="<%= assetCategoriesSearchFacetTermDisplayContext.isFrequencyVisible() %>">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_entries.jsp
@@ -58,7 +58,7 @@ AssetEntriesSearchFacetDisplayContext assetEntriesSearchFacetDisplayContext = as
 
 			<ul class="asset-type list-unstyled">
 				<li class="default facet-value">
-					<a class="<%= Validator.isNull(fieldParam) ? "text-primary" : "text-default" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
+					<a class="<%= assetEntriesSearchFacetDisplayContext.isNothingSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
 				</li>
 
 				<%
@@ -66,7 +66,7 @@ AssetEntriesSearchFacetDisplayContext assetEntriesSearchFacetDisplayContext = as
 				%>
 
 					<li class="facet-value">
-						<a class="<%= assetEntriesSearchFacetTermDisplayContext.isSelected() ? "text-primary" : "text-default" %>" data-value="<%= HtmlUtil.escapeAttribute(assetEntriesSearchFacetTermDisplayContext.getAssetType()) %>" href="javascript:;">
+						<a class="<%= assetEntriesSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="<%= HtmlUtil.escapeAttribute(assetEntriesSearchFacetTermDisplayContext.getAssetType()) %>" href="javascript:;">
 							<%= assetEntriesSearchFacetTermDisplayContext.getTypeName() %>
 
 							<c:if test="<%= assetEntriesSearchFacetTermDisplayContext.isFrequencyVisible() %>">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_tags.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/asset_tags.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/facets/init.jsp" %>
 
 <%
-com.liferay.portal.search.web.internal.facet.display.builder.AssetTagsSearchFacetDisplayBuilder assetTagsSearchFacetDisplayBuilder = new com.liferay.portal.search.web.internal.facet.display.builder.AssetTagsSearchFacetDisplayBuilder();
+AssetTagsSearchFacetDisplayBuilder assetTagsSearchFacetDisplayBuilder = new AssetTagsSearchFacetDisplayBuilder();
 
 assetTagsSearchFacetDisplayBuilder.setDisplayStyle(dataJSONObject.getString("displayStyle", "cloud"));
 assetTagsSearchFacetDisplayBuilder.setFacet(facet);
@@ -27,7 +27,7 @@ assetTagsSearchFacetDisplayBuilder.setMaxTerms(dataJSONObject.getInt("maxTerms",
 assetTagsSearchFacetDisplayBuilder.setParameterName(facet.getFieldId());
 assetTagsSearchFacetDisplayBuilder.setParameterValue(fieldParam);
 
-com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFacetDisplayContext assetTagsSearchFacetDisplayContext = assetTagsSearchFacetDisplayBuilder.build();
+AssetTagsSearchFacetDisplayContext assetTagsSearchFacetDisplayContext = assetTagsSearchFacetDisplayBuilder.build();
 %>
 
 <c:choose>
@@ -48,17 +48,17 @@ com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFace
 
 					<ul class="<%= assetTagsSearchFacetDisplayContext.isCloudWithCount() ? "tag-cloud" : "tag-list" %> list-unstyled">
 						<li class="default facet-value">
-							<a class="<%= assetTagsSearchFacetDisplayContext.isNothingSelected() ? "text-primary" : "text-default" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
+							<a class="<%= assetTagsSearchFacetDisplayContext.isNothingSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
 						</li>
 
 						<%
-						java.util.List<com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFacetTermDisplayContext> assetTagsSearchFacetTermDisplayContexts = assetTagsSearchFacetDisplayContext.getTermDisplayContexts();
+						java.util.List<AssetTagsSearchFacetTermDisplayContext> assetTagsSearchFacetTermDisplayContexts = assetTagsSearchFacetDisplayContext.getTermDisplayContexts();
 
-						for (com.liferay.portal.search.web.internal.facet.display.context.AssetTagsSearchFacetTermDisplayContext assetTagsSearchFacetTermDisplayContext : assetTagsSearchFacetTermDisplayContexts) {
+						for (AssetTagsSearchFacetTermDisplayContext assetTagsSearchFacetTermDisplayContext : assetTagsSearchFacetTermDisplayContexts) {
 						%>
 
 							<li class="facet-value tag-popularity-<%= assetTagsSearchFacetTermDisplayContext.getPopularity() %>">
-								<a class="<%= assetTagsSearchFacetTermDisplayContext.isSelected() ? "text-primary" : "text-default" %>" data-value="<%= HtmlUtil.escapeAttribute(assetTagsSearchFacetTermDisplayContext.getValue()) %>" href="javascript:;">
+								<a class="<%= assetTagsSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="<%= HtmlUtil.escapeAttribute(assetTagsSearchFacetTermDisplayContext.getValue()) %>" href="javascript:;">
 									<%= HtmlUtil.escape(assetTagsSearchFacetTermDisplayContext.getDisplayName()) %>
 
 									<c:if test="<%= assetTagsSearchFacetTermDisplayContext.isFrequencyVisible() %>">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/folders.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/folders.jsp
@@ -50,7 +50,7 @@ FolderSearchFacetDisplayContext folderSearchFacetDisplayContext = folderSearchFa
 
 					<ul class="folders list-unstyled">
 						<li class="default facet-value">
-							<a class="<%= folderSearchFacetDisplayContext.isNothingSelected() ? "text-primary" : "text-default" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
+							<a class="<%= folderSearchFacetDisplayContext.isNothingSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
 						</li>
 
 						<%
@@ -60,7 +60,7 @@ FolderSearchFacetDisplayContext folderSearchFacetDisplayContext = folderSearchFa
 						%>
 
 							<li class="facet-value">
-								<a class="<%= folderSearchFacetTermDisplayContext.isSelected() ? "text-primary" : "text-default" %>" data-value="<%= folderSearchFacetTermDisplayContext.getFolderId() %>" href="javascript:;">
+								<a class="<%= folderSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="<%= folderSearchFacetTermDisplayContext.getFolderId() %>" href="javascript:;">
 									<%= HtmlUtil.escape(folderSearchFacetTermDisplayContext.getDisplayName()) %>
 
 									<c:if test="<%= folderSearchFacetTermDisplayContext.isFrequencyVisible() %>">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/modified.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/modified.jsp
@@ -53,19 +53,13 @@ int index = 0;
 					<li class="default facet-value">
 
 						<%
-						String defaultRangeCssClass = "text-default";
-
-						if (fieldParamSelection.equals("0")) {
-							defaultRangeCssClass = "text-primary";
-						}
-
 						Map<String, Object> data = new HashMap<>();
 
 						data.put("selection", 0);
 						data.put("value", StringPool.BLANK);
 						%>
 
-						<aui:a cssClass="<%= defaultRangeCssClass %>" href="javascript:;">
+						<aui:a cssClass='<%= (Validator.isNull(fieldParamSelection) || fieldParamSelection.equals("0")) ? "facet-term-selected" : "facet-term-unselected" %>' href="javascript:;">
 							<liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" />
 						</aui:a>
 					</li>
@@ -83,10 +77,10 @@ int index = 0;
 						<li class="facet-value">
 
 							<%
-							String rangeCssClass = "text-default";
+							String rangeCssClass = "facet-term-unselected";
 
 							if (fieldParamSelection.equals(String.valueOf(index))) {
-								rangeCssClass = "text-primary";
+								rangeCssClass = "facet-term-selected";
 							}
 
 							data = new HashMap<>();
@@ -118,10 +112,10 @@ int index = 0;
 						String customRangeCssClass = randomNamespace + "custom-range-toggle";
 
 						if (fieldParamSelection.equals(String.valueOf(index + 1))) {
-							customRangeCssClass += " text-primary";
+							customRangeCssClass += " facet-term-selected";
 						}
 						else {
-							customRangeCssClass += " text-default";
+							customRangeCssClass += " facet-term-unselected";
 						}
 
 						TermCollector termCollector = null;

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/scopes.jsp
@@ -53,7 +53,7 @@ ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext = scopeSearchFacet
 
 					<ul class="list-unstyled scopes">
 						<li class="default facet-value">
-							<a class="<%= scopeSearchFacetDisplayContext.isNothingSelected() ? "text-primary" : "text-default" %>" data-value="0" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
+							<a class="<%= scopeSearchFacetDisplayContext.isNothingSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="0" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
 						</li>
 
 						<%
@@ -63,7 +63,7 @@ ScopeSearchFacetDisplayContext scopeSearchFacetDisplayContext = scopeSearchFacet
 						%>
 
 							<li class="facet-value">
-								<a class="<%= scopeSearchFacetTermDisplayContext.isSelected() ? "text-primary" : "text-default" %>" data-value="<%= scopeSearchFacetTermDisplayContext.getGroupId() %>" href="javascript:;">
+								<a class="<%= scopeSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="<%= scopeSearchFacetTermDisplayContext.getGroupId() %>" href="javascript:;">
 									<%= HtmlUtil.escape(scopeSearchFacetTermDisplayContext.getDescriptiveName()) %>
 
 									<c:if test="<%= scopeSearchFacetTermDisplayContext.isShowCount() %>">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/users.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/users.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/facets/init.jsp" %>
 
 <%
-com.liferay.portal.search.web.internal.facet.display.builder.UserSearchFacetDisplayBuilder userSearchFacetDisplayBuilder = new com.liferay.portal.search.web.internal.facet.display.builder.UserSearchFacetDisplayBuilder();
+UserSearchFacetDisplayBuilder userSearchFacetDisplayBuilder = new UserSearchFacetDisplayBuilder();
 
 userSearchFacetDisplayBuilder.setFacet(facet);
 userSearchFacetDisplayBuilder.setFrequenciesVisible(dataJSONObject.getBoolean("showAssetCount", true));
@@ -26,7 +26,7 @@ userSearchFacetDisplayBuilder.setMaxTerms(dataJSONObject.getInt("maxTerms", 10))
 userSearchFacetDisplayBuilder.setParamName(facet.getFieldId());
 userSearchFacetDisplayBuilder.setParamValue(fieldParam);
 
-com.liferay.portal.search.web.internal.facet.display.context.UserSearchFacetDisplayContext userSearchFacetDisplayContext = userSearchFacetDisplayBuilder.build();
+UserSearchFacetDisplayContext userSearchFacetDisplayContext = userSearchFacetDisplayBuilder.build();
 %>
 
 <c:choose>
@@ -47,18 +47,18 @@ com.liferay.portal.search.web.internal.facet.display.context.UserSearchFacetDisp
 
 					<ul class="list-unstyled users">
 						<li class="default facet-value">
-							<a class="<%= userSearchFacetDisplayContext.isNothingSelected() ? "text-primary" : "text-default" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
+							<a class="<%= userSearchFacetDisplayContext.isNothingSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="" href="javascript:;"><liferay-ui:message key="<%= HtmlUtil.escape(facetConfiguration.getLabel()) %>" /></a>
 						</li>
 
 						<%
-						java.util.List<com.liferay.portal.search.web.internal.facet.display.context.UserSearchFacetTermDisplayContext> userSearchFacetTermDisplayContexts =
+						java.util.List<UserSearchFacetTermDisplayContext> userSearchFacetTermDisplayContexts =
 							userSearchFacetDisplayContext.getTermDisplayContexts();
 
-						for (com.liferay.portal.search.web.internal.facet.display.context.UserSearchFacetTermDisplayContext userSearchFacetTermDisplayContext : userSearchFacetTermDisplayContexts) {
+						for (UserSearchFacetTermDisplayContext userSearchFacetTermDisplayContext : userSearchFacetTermDisplayContexts) {
 						%>
 
 							<li class="facet-value">
-								<a class="<%= userSearchFacetTermDisplayContext.isSelected() ? "text-primary" : "text-default" %>" data-value="<%= HtmlUtil.escapeAttribute(userSearchFacetTermDisplayContext.getUserName()) %>" href="javascript:;">
+								<a class="<%= userSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>" data-value="<%= HtmlUtil.escapeAttribute(userSearchFacetTermDisplayContext.getUserName()) %>" href="javascript:;">
 									<%= HtmlUtil.escape(userSearchFacetTermDisplayContext.getUserName()) %>
 
 									<c:if test="<%= userSearchFacetTermDisplayContext.isFrequencyVisible() %>">


### PR DESCRIPTION
CI missing: `master` was in an unstable state at the time the first self pull ran, so CI was unable to give reliable test results. (https://github.com/arboliveira/liferay-portal/pull/492#issuecomment-390829174)  Monitoring this pull's relevant set now.

Author: @wcao20170619 
Reviewer: @arboliveira

https://issues.liferay.com/browse/LPS-80945