### PR TITLE
LPS-80517 This was added as GREEDY by LPS-71476, because back then we…

### DIFF
--- a/modules/apps/portal-mobile-device-detection-fiftyonedegrees/portal-mobile-device-detection-fiftyonedegrees/src/main/java/com/liferay/portal/mobile/device/detection/fiftyonedegrees/internal/FiftyOneDegreesEngineProxy.java
+++ b/modules/apps/portal-mobile-device-detection-fiftyonedegrees/portal-mobile-device-detection-fiftyonedegrees/src/main/java/com/liferay/portal/mobile/device/detection/fiftyonedegrees/internal/FiftyOneDegreesEngineProxy.java
@@ -41,8 +41,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Brian Greenwald
@@ -112,11 +110,8 @@ public class FiftyOneDegreesEngineProxy {
 	private static final Log _log = LogFactoryUtil.getLog(
 		FiftyOneDegreesEngineProxy.class);
 
-	@Reference(
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY
-	)
-	private volatile DataFileProvider _dataFileProvider;
+	@Reference
+	private DataFileProvider _dataFileProvider;
 
 	private Dataset _dataset;
 	private volatile FiftyOneDegreesConfiguration _fiftyOneDegreesConfiguration;


### PR DESCRIPTION
… did not have portal profile enabled for those CE and EE data providers. Now we have them both enabled portal profile, we know we will only see one DataFileProvider, there is no need of GREEDY anymore.

C @mhan810