### PR TITLE
Lps 80517 6

### DIFF
--- a/modules/core/petra/petra-string/src/main/java/com/liferay/petra/string/StringBundler.java
+++ b/modules/core/petra/petra-string/src/main/java/com/liferay/petra/string/StringBundler.java
@@ -38,12 +38,7 @@ public class StringBundler implements Serializable {
 		String[] strings = new String[objects.length];
 
 		for (int i = 0; i < objects.length; i++) {
-			if (objects[i] == null) {
-				strings[i] = StringPool.NULL;
-			}
-			else {
-				strings[i] = String.valueOf(objects[i]);
-			}
+			strings[i] = String.valueOf(objects[i]);
 		}
 
 		return _toString(strings, strings.length);

--- a/modules/core/petra/petra-string/src/test/java/com/liferay/petra/string/StringBundlerTest.java
+++ b/modules/core/petra/petra-string/src/test/java/com/liferay/petra/string/StringBundlerTest.java
@@ -426,7 +426,22 @@ public class StringBundlerTest {
 	}
 
 	@Test
-	public void testConcat() {
+	public void testConcatObjects() {
+		Assert.assertSame("test1", StringBundler.concat((Object)"test1"));
+		Assert.assertSame(
+			StringPool.NULL, StringBundler.concat(new Object[] {null}));
+		Assert.assertEquals(
+			"test1test2", StringBundler.concat((Object)"test1", "test2"));
+		Assert.assertEquals(
+			"test1test2test3",
+			StringBundler.concat("test1", (Object)"test2", "test3"));
+		Assert.assertEquals(
+			"test1test2test3test4",
+			StringBundler.concat("test1", "test2", "test3", (Object)"test4"));
+	}
+
+	@Test
+	public void testConcatStrings() {
 		Assert.assertSame("test1", StringBundler.concat("test1"));
 		Assert.assertSame(
 			StringPool.NULL, StringBundler.concat(new String[] {null}));


### PR DESCRIPTION
@Ithildir I noticed an issue while fixing this.
When running the petra StringBundlerTest, the classpath is like this:
```
some jars/folders
${liferay.home}/tomcat-9.0.6/lib/ext/com.liferay.petra.string.jar
some jars/folders
${repository.root}/modules/core/petra/petra-string/classes
some jars/folders
```
See the tomcat com.liferay.petra.string.jar is before real module classes, that means unless I deploy the module first, running the gw test will not really see any changes. We need to make some adjustment to the classpath building for modules unit tests. Let's talk about this tomorrow, thanks!