### PR TITLE
LPS-80276 Removes unneeded suffix. Cache name already takes language into account, and rtl servlet takes care of figuring out the right file to load, so this is no longer necessary

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
@@ -378,16 +378,6 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 			resourcePath = resourcePath.substring(contextPath.length());
 		}
 
-		if (resourcePath.endsWith(_CSS_EXTENSION) &&
-			PortalUtil.isRightToLeft(request)) {
-
-			int pos = resourcePath.lastIndexOf(StringPool.PERIOD);
-
-			resourcePath =
-				resourcePath.substring(0, pos) + "_rtl" +
-					resourcePath.substring(pos);
-		}
-
 		URL resourceURL = ResourceUtil.getResourceURL(
 			resourcePath, request.getRequestURI(), _servletContext);
 


### PR DESCRIPTION
/cc @csierra, @alee8888