### PR TITLE
LPS-81106 Override jalopy header text

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/ToolsUtil.java
+++ b/portal-impl/src/com/liferay/portal/tools/ToolsUtil.java
@@ -371,11 +371,23 @@ public class ToolsUtil {
 		throws IOException {
 
 		writeFile(
-			file, content, author, jalopySettings, modifiedFileNames, null);
+			file, content, null, author, jalopySettings, modifiedFileNames,
+			null);
 	}
 
 	public static void writeFile(
 			File file, String content, String author,
+			Map<String, Object> jalopySettings, Set<String> modifiedFileNames,
+			String packagePath)
+		throws IOException {
+
+		writeFile(
+			file, content, null, author, jalopySettings, modifiedFileNames,
+			packagePath);
+	}
+
+	public static void writeFile(
+			File file, String content, String header, String author,
 			Map<String, Object> jalopySettings, Set<String> modifiedFileNames,
 			String packagePath)
 		throws IOException {
@@ -457,6 +469,10 @@ public class ToolsUtil {
 		env.set("fileName", file.getName());
 
 		Convention convention = Convention.getInstance();
+
+		if (Validator.isNotNull(header)) {
+			convention.put(ConventionKeys.HEADER_TEXT, header);
+		}
 
 		String classMask = "/**\n * @author $author$\n*/";
 

--- a/portal-impl/src/com/liferay/portal/tools/ToolsUtil.java
+++ b/portal-impl/src/com/liferay/portal/tools/ToolsUtil.java
@@ -387,6 +387,14 @@ public class ToolsUtil {
 	}
 
 	public static void writeFile(
+			File file, String content, String author,
+			Set<String> modifiedFileNames)
+		throws IOException {
+
+		writeFile(file, content, author, null, modifiedFileNames);
+	}
+
+	public static void writeFile(
 			File file, String content, String header, String author,
 			Map<String, Object> jalopySettings, Set<String> modifiedFileNames,
 			String packagePath)
@@ -516,14 +524,6 @@ public class ToolsUtil {
 		if (failOnFormatError && !formatSuccess) {
 			throw new IOException("Unable to beautify " + file);
 		}
-	}
-
-	public static void writeFile(
-			File file, String content, String author,
-			Set<String> modifiedFileNames)
-		throws IOException {
-
-		writeFile(file, content, author, null, modifiedFileNames);
 	}
 
 	public static void writeFileRaw(


### PR DESCRIPTION
Hi Brian,

This change is needed so SB can override the license for private apps.  Would it be possible to publish a new version of `com.liferay.portal.impl` so I can use it in `portal-tools-service-builder`?