### PR TITLE
LPS-81484 Portlet 2.0 did not have this javax.portlet.automaticResour…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -150,7 +150,12 @@ public class LiferayPortlet extends GenericPortlet {
 			return;
 		}
 
-		super.serveResource(resourceRequest, resourceResponse);
+		boolean autoForward = GetterUtil.getBoolean(
+			getInitParameter("javax.portlet.automaticResourceDispatching"));
+
+		if (autoForward) {
+			super.serveResource(resourceRequest, resourceResponse);
+		}
 	}
 
 	protected void addSuccessMessage(


### PR DESCRIPTION
…ceDispatching feature, portlet 2.1 added it, then portlet 3.0 removed. Great backward compatibility! We have a bug in most of our MVCResourceCommand.serveResource() return value. For example DownloadEntriesMVCResourceCommand.serveResource() should really return false, but it returns true. Causing we hit the super.serveResource() for static resource serving. On portlet 2.1, since we don't have javax.portlet.automaticResourceDispatching enabled, it actually saves us by not doing anything. After upgrading to portlet 3.0, with the the protection of javax.portlet.automaticResourceDispatching, we are actually trying to serve the resource again, and it calls resetBuffer() on the response which is basically throwing away the first serve's output, therefore we get 0 content length. Although the correct fix should be done by fixing all MVCResourceCommand.serveResource() return values. I want to fix it in a backward compatible way, since we are going to release soon, stabilty is the most important thing now.

@rotty3000 @mhan810 @ngriffin7a @sergiogonzalez @drewbrokke @jbalsas @4lejandrito @jrao @david-truong @austinchiang @preston-crary @mtambara 

This fixes:
https://issues.liferay.com/browse/LPS-80953
https://issues.liferay.com/browse/LPS-81282
https://issues.liferay.com/browse/LPS-81018
https://issues.liferay.com/browse/LPS-81274

And @sergiogonzalez I am leaving the issue in DownloadEntriesMVCResourceCommand.serveResource() for you, and I am sure there are other places need to be fixed too, please take care of them if you can, thanks!