### PR TITLE
LPS-79837 Makes validatorTagsMap attribute shared

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/EditFormTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/EditFormTag.java
@@ -173,9 +173,9 @@ public class EditFormTag extends IncludeTag {
 			"liferay-frontend:edit-form:validateOnBlur",
 			String.valueOf(_validateOnBlur));
 		request.setAttribute(
-			"liferay-frontend:edit-form:validatorTagsMap", _validatorTagsMap);
-		request.setAttribute(
 			"LIFERAY_SHARED_aui:form:checkboxNames", _checkboxNames);
+		request.setAttribute(
+			"LIFERAY_SHARED_aui:form:validatorTagsMap", _validatorTagsMap);
 	}
 
 	private String _getAction(HttpServletRequest request) {

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/init.jsp
@@ -34,5 +34,5 @@ String portletNamespace = GetterUtil.getString((java.lang.String)request.getAttr
 boolean useNamespace = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-frontend:edit-form:useNamespace")));
 boolean validateOnBlur = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-frontend:edit-form:validateOnBlur")));
 Map<String, Object> dynamicAttributes = (Map<String, Object>)request.getAttribute("liferay-frontend:edit-form:dynamicAttributes");
-Map<String, List<ValidatorTag>> validatorTagsMap = (Map<String, List<ValidatorTag>>)request.getAttribute("liferay-frontend:edit-form:validatorTagsMap");
+Map<String, List<ValidatorTag>> validatorTagsMap = (Map<String, List<ValidatorTag>>)request.getAttribute("LIFERAY_SHARED_aui:form:validatorTagsMap");
 %>

--- a/portal-web/docroot/html/taglib/aui/form/init-ext.jspf
+++ b/portal-web/docroot/html/taglib/aui/form/init-ext.jspf
@@ -22,5 +22,5 @@ if (themeDisplay.isAddSessionIdToURL()) {
 }
 
 List<String> checkboxNames = (List<String>)request.getAttribute("LIFERAY_SHARED_aui:form:checkboxNames");
-Map<String, List<ValidatorTag>> validatorTagsMap = (Map<String, List<ValidatorTag>>)request.getAttribute("aui:form:validatorTagsMap");
+Map<String, List<ValidatorTag>> validatorTagsMap = (Map<String, List<ValidatorTag>>)request.getAttribute("LIFERAY_SHARED_aui:form:validatorTagsMap");
 %>

--- a/util-taglib/src/com/liferay/taglib/BaseValidatorTagSupport.java
+++ b/util-taglib/src/com/liferay/taglib/BaseValidatorTagSupport.java
@@ -80,7 +80,7 @@ public abstract class BaseValidatorTagSupport extends IncludeTag {
 
 		Map<String, List<ValidatorTag>> validatorTagsMap =
 			(Map<String, List<ValidatorTag>>)request.getAttribute(
-				"aui:form:validatorTagsMap");
+				"LIFERAY_SHARED_aui:form:validatorTagsMap");
 
 		if (validatorTagsMap != null) {
 			List<ValidatorTag> validatorTags = ListUtil.fromMapValues(

--- a/util-taglib/src/com/liferay/taglib/aui/FormTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/FormTag.java
@@ -72,9 +72,10 @@ public class FormTag extends BaseFormTag {
 	protected void setAttributes(HttpServletRequest request) {
 		super.setAttributes(request);
 
-		request.setAttribute("aui:form:validatorTagsMap", _validatorTagsMap);
 		request.setAttribute(
 			"LIFERAY_SHARED_aui:form:checkboxNames", _checkboxNames);
+		request.setAttribute(
+			"LIFERAY_SHARED_aui:form:validatorTagsMap", _validatorTagsMap);
 	}
 
 	private static final boolean _CLEAN_UP_SET_ATTRIBUTES = true;


### PR DESCRIPTION
Hey @brianchandotcom, I'm not sure if this is the correct usage of `LIFERAY_SHARED`, we're already using it in this same tag and we need this to share attributes to maintain compatibility...

See tests in https://github.com/jbalsas/liferay-portal/pull/1287#issuecomment-394161442

Thanks!