### PR TITLE
LPS-81769 As a Liferay administrator I want to import blogpost entries from my current system

### DIFF
--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -86,6 +86,31 @@ public interface BlogsEntryService extends BaseService {
 		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	* Creates a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public BlogsEntry addEntry(String title, String subtitle, String urlTitle,
+		String description, String content, Date displayDate,
+		String coverImageCaption, ImageSelector coverImageImageSelector,
+		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
+		throws PortalException;
+
 	public BlogsEntry addEntry(String title, String subtitle, String urlTitle,
 		String description, String content, int displayDateMonth,
 		int displayDateDay, int displayDateYear, int displayDateHour,
@@ -214,6 +239,32 @@ public interface BlogsEntryService extends BaseService {
 		int displayDateMinute, boolean allowPingbacks, boolean allowTrackbacks,
 		String[] trackbacks, String coverImageCaption,
 		ImageSelector coverImageImageSelector,
+		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	public BlogsEntry updateEntry(long entryId, String title, String subtitle,
+		String urlTitle, String description, String content, Date displayDate,
+		String coverImageCaption, ImageSelector coverImageImageSelector,
 		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
 		throws PortalException;
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -21,6 +21,7 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
+import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceMode;
 import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.service.BaseService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -61,32 +62,6 @@ public interface BlogsEntryService extends BaseService {
 	 *
 	 * Never modify or reference this interface directly. Always use {@link BlogsEntryServiceUtil} to access the blogs entry remote service. Add custom service methods to {@link com.liferay.blogs.service.impl.BlogsEntryServiceImpl} and rerun ServiceBuilder to automatically copy the method declarations to this interface.
 	 */
-
-	/**
-	* Creates a new blogs entry
-	*
-	* @param userId the blogs entry's author id
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the created blogs entry
-	* @review
-	*/
-	public BlogsEntry addEntry(long userId, String title, String subtitle,
-		String urlTitle, String description, String content, Date displayDate,
-		String coverImageCaption, ImageSelector coverImageImageSelector,
-		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
-		throws PortalException;
 
 	/**
 	* @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
@@ -211,6 +186,33 @@ public interface BlogsEntryService extends BaseService {
 	*/
 	public String getOSGiServiceIdentifier();
 
+	/**
+	* Imports a blogs entry
+	*
+	* @param userId the blogs entry's author ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
+	public BlogsEntry importEntry(long userId, String title, String subtitle,
+		String urlTitle, String description, String content, Date displayDate,
+		String coverImageCaption, ImageSelector coverImageImageSelector,
+		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
+		throws PortalException;
+
 	public BlogsEntry moveEntryToTrash(long entryId) throws PortalException;
 
 	public void restoreEntryFromTrash(long entryId) throws PortalException;
@@ -223,7 +225,7 @@ public interface BlogsEntryService extends BaseService {
 	* Updates a blogs entry
 	*
 	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author id
+	* @param userId the blogs entry's author ID
 	* @param title the blogs entry's title
 	* @param subtitle the blogs entry's subtitle
 	* @param urlTitle the blogs entry's urlTitle

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -87,6 +87,31 @@ public interface BlogsEntryService extends BaseService {
 		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	* Adds a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public BlogsEntry addEntry(String title, String subtitle, String urlTitle,
+		String description, String content, Date displayDate,
+		String coverImageCaption, ImageSelector coverImageImageSelector,
+		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
+		throws PortalException;
+
 	public BlogsEntry addEntry(String title, String subtitle, String urlTitle,
 		String description, String content, int displayDateMonth,
 		int displayDateDay, int displayDateYear, int displayDateHour,

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -222,34 +222,6 @@ public interface BlogsEntryService extends BaseService {
 	public void unsubscribe(long groupId) throws PortalException;
 
 	/**
-	* Updates a blogs entry
-	*
-	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author ID
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the updated blogs entry
-	* @review
-	*/
-	public BlogsEntry updateEntry(long entryId, long userId, String title,
-		String subtitle, String urlTitle, String description, String content,
-		Date displayDate, String coverImageCaption,
-		ImageSelector coverImageImageSelector,
-		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
 	* @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	String, String, String, int, int, int, int, int, boolean,
 	boolean, String[], String, ImageSelector, ImageSelector,
@@ -270,6 +242,32 @@ public interface BlogsEntryService extends BaseService {
 		int displayDateMinute, boolean allowPingbacks, boolean allowTrackbacks,
 		String[] trackbacks, String coverImageCaption,
 		ImageSelector coverImageImageSelector,
+		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	public BlogsEntry updateEntry(long entryId, String title, String subtitle,
+		String urlTitle, String description, String content, Date displayDate,
+		String coverImageCaption, ImageSelector coverImageImageSelector,
 		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
 		throws PortalException;
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -63,6 +63,32 @@ public interface BlogsEntryService extends BaseService {
 	 */
 
 	/**
+	* Creates a new blogs entry
+	*
+	* @param userId the blogs entry's author id
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public BlogsEntry addEntry(long userId, String title, String subtitle,
+		String urlTitle, String description, String content, Date displayDate,
+		String coverImageCaption, ImageSelector coverImageImageSelector,
+		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
 	* @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
 	String, String, int, int, int, int, int, boolean, boolean,
 	String[], String, ImageSelector, ImageSelector,
@@ -83,31 +109,6 @@ public interface BlogsEntryService extends BaseService {
 		int displayDateMinute, boolean allowPingbacks, boolean allowTrackbacks,
 		String[] trackbacks, String coverImageCaption,
 		ImageSelector coverImageImageSelector,
-		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
-	* Creates a new blogs entry
-	*
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the created blogs entry
-	* @review
-	*/
-	public BlogsEntry addEntry(String title, String subtitle, String urlTitle,
-		String description, String content, Date displayDate,
-		String coverImageCaption, ImageSelector coverImageImageSelector,
 		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
 		throws PortalException;
 
@@ -219,6 +220,34 @@ public interface BlogsEntryService extends BaseService {
 	public void unsubscribe(long groupId) throws PortalException;
 
 	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param userId the blogs entry's author id
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	public BlogsEntry updateEntry(long entryId, long userId, String title,
+		String subtitle, String urlTitle, String description, String content,
+		Date displayDate, String coverImageCaption,
+		ImageSelector coverImageImageSelector,
+		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
 	* @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	String, String, String, int, int, int, int, int, boolean,
 	boolean, String[], String, ImageSelector, ImageSelector,
@@ -239,32 +268,6 @@ public interface BlogsEntryService extends BaseService {
 		int displayDateMinute, boolean allowPingbacks, boolean allowTrackbacks,
 		String[] trackbacks, String coverImageCaption,
 		ImageSelector coverImageImageSelector,
-		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
-		throws PortalException;
-
-	/**
-	* Updates a blogs entry
-	*
-	* @param entryId the blogs entry's ID
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the updated blogs entry
-	* @review
-	*/
-	public BlogsEntry updateEntry(long entryId, String title, String subtitle,
-		String urlTitle, String description, String content, Date displayDate,
-		String coverImageCaption, ImageSelector coverImageImageSelector,
 		ImageSelector smallImageImageSelector, ServiceContext serviceContext)
 		throws PortalException;
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -44,39 +44,6 @@ public class BlogsEntryServiceUtil {
 	 */
 
 	/**
-	* Creates a new blogs entry
-	*
-	* @param userId the blogs entry's author id
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the created blogs entry
-	* @review
-	*/
-	public static com.liferay.blogs.model.BlogsEntry addEntry(long userId,
-		String title, String subtitle, String urlTitle, String description,
-		String content, java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .addEntry(userId, title, subtitle, urlTitle, description,
-			content, displayDate, coverImageCaption, coverImageImageSelector,
-			smallImageImageSelector, serviceContext);
-	}
-
-	/**
 	* @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
 	String, String, int, int, int, int, int, boolean, boolean,
 	String[], String, ImageSelector, ImageSelector,
@@ -279,6 +246,39 @@ public class BlogsEntryServiceUtil {
 		return getService().getOSGiServiceIdentifier();
 	}
 
+	/**
+	* Imports a blogs entry
+	*
+	* @param userId the blogs entry's author ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntry importEntry(long userId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .importEntry(userId, title, subtitle, urlTitle, description,
+			content, displayDate, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
+	}
+
 	public static com.liferay.blogs.model.BlogsEntry moveEntryToTrash(
 		long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -304,7 +304,7 @@ public class BlogsEntryServiceUtil {
 	* Updates a blogs entry
 	*
 	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author id
+	* @param userId the blogs entry's author ID
 	* @param title the blogs entry's title
 	* @param subtitle the blogs entry's subtitle
 	* @param urlTitle the blogs entry's urlTitle

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -83,6 +83,38 @@ public class BlogsEntryServiceUtil {
 			smallImageImageSelector, serviceContext);
 	}
 
+	/**
+	* Adds a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntry addEntry(String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .addEntry(title, subtitle, urlTitle, description, content,
+			displayDate, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
+	}
+
 	public static com.liferay.blogs.model.BlogsEntry addEntry(String title,
 		String subtitle, String urlTitle, String description, String content,
 		int displayDateMonth, int displayDateDay, int displayDateYear,

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -301,41 +301,6 @@ public class BlogsEntryServiceUtil {
 	}
 
 	/**
-	* Updates a blogs entry
-	*
-	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author ID
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the updated blogs entry
-	* @review
-	*/
-	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
-		long userId, String title, String subtitle, String urlTitle,
-		String description, String content, java.util.Date displayDate,
-		String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .updateEntry(entryId, userId, title, subtitle, urlTitle,
-			description, content, displayDate, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
-	}
-
-	/**
 	* @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	String, String, String, int, int, int, int, int, boolean,
 	boolean, String[], String, ImageSelector, ImageSelector,
@@ -373,6 +338,39 @@ public class BlogsEntryServiceUtil {
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector,
 			smallImageImageSelector, serviceContext);
+	}
+
+	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .updateEntry(entryId, title, subtitle, urlTitle,
+			description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -44,6 +44,39 @@ public class BlogsEntryServiceUtil {
 	 */
 
 	/**
+	* Creates a new blogs entry
+	*
+	* @param userId the blogs entry's author id
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntry addEntry(long userId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .addEntry(userId, title, subtitle, urlTitle, description,
+			content, displayDate, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
+	}
+
+	/**
 	* @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
 	String, String, int, int, int, int, int, boolean, boolean,
 	String[], String, ImageSelector, ImageSelector,
@@ -80,38 +113,6 @@ public class BlogsEntryServiceUtil {
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector,
-			smallImageImageSelector, serviceContext);
-	}
-
-	/**
-	* Creates a new blogs entry
-	*
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the created blogs entry
-	* @review
-	*/
-	public static com.liferay.blogs.model.BlogsEntry addEntry(String title,
-		String subtitle, String urlTitle, String description, String content,
-		java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .addEntry(title, subtitle, urlTitle, description, content,
-			displayDate, coverImageCaption, coverImageImageSelector,
 			smallImageImageSelector, serviceContext);
 	}
 
@@ -300,6 +301,41 @@ public class BlogsEntryServiceUtil {
 	}
 
 	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param userId the blogs entry's author id
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
+		long userId, String title, String subtitle, String urlTitle,
+		String description, String content, java.util.Date displayDate,
+		String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .updateEntry(entryId, userId, title, subtitle, urlTitle,
+			description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	/**
 	* @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	String, String, String, int, int, int, int, int, boolean,
 	boolean, String[], String, ImageSelector, ImageSelector,
@@ -337,39 +373,6 @@ public class BlogsEntryServiceUtil {
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector,
 			smallImageImageSelector, serviceContext);
-	}
-
-	/**
-	* Updates a blogs entry
-	*
-	* @param entryId the blogs entry's ID
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the updated blogs entry
-	* @review
-	*/
-	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
-		String title, String subtitle, String urlTitle, String description,
-		String content, java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return getService()
-				   .updateEntry(entryId, title, subtitle, urlTitle,
-			description, content, displayDate, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -83,6 +83,38 @@ public class BlogsEntryServiceUtil {
 			smallImageImageSelector, serviceContext);
 	}
 
+	/**
+	* Creates a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntry addEntry(String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .addEntry(title, subtitle, urlTitle, description, content,
+			displayDate, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
+	}
+
 	public static com.liferay.blogs.model.BlogsEntry addEntry(String title,
 		String subtitle, String urlTitle, String description, String content,
 		int displayDateMonth, int displayDateDay, int displayDateYear,
@@ -305,6 +337,39 @@ public class BlogsEntryServiceUtil {
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector,
 			smallImageImageSelector, serviceContext);
+	}
+
+	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .updateEntry(entryId, title, subtitle, urlTitle,
+			description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -72,6 +72,38 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
+	/**
+	* Creates a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	@Override
+	public com.liferay.blogs.model.BlogsEntry addEntry(String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _blogsEntryService.addEntry(title, subtitle, urlTitle,
+			description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
 	@Override
 	public com.liferay.blogs.model.BlogsEntry addEntry(String title,
 		String subtitle, String urlTitle, String description, String content,
@@ -318,6 +350,39 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 			description, content, displayDateMonth, displayDateDay,
 			displayDateYear, displayDateHour, displayDateMinute,
 			allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	@Override
+	public com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _blogsEntryService.updateEntry(entryId, title, subtitle,
+			urlTitle, description, content, displayDate, coverImageCaption,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -33,39 +33,6 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 	}
 
 	/**
-	* Creates a new blogs entry
-	*
-	* @param userId the blogs entry's author id
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the created blogs entry
-	* @review
-	*/
-	@Override
-	public com.liferay.blogs.model.BlogsEntry addEntry(long userId,
-		String title, String subtitle, String urlTitle, String description,
-		String content, java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _blogsEntryService.addEntry(userId, title, subtitle, urlTitle,
-			description, content, displayDate, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
-	}
-
-	/**
 	* @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
 	String, String, int, int, int, int, int, boolean, boolean,
 	String[], String, ImageSelector, ImageSelector,
@@ -290,6 +257,39 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 		return _blogsEntryService.getOSGiServiceIdentifier();
 	}
 
+	/**
+	* Imports a blogs entry
+	*
+	* @param userId the blogs entry's author ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	@Override
+	public com.liferay.blogs.model.BlogsEntry importEntry(long userId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _blogsEntryService.importEntry(userId, title, subtitle,
+			urlTitle, description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
 	@Override
 	public com.liferay.blogs.model.BlogsEntry moveEntryToTrash(long entryId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -318,7 +318,7 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 	* Updates a blogs entry
 	*
 	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author id
+	* @param userId the blogs entry's author ID
 	* @param title the blogs entry's title
 	* @param subtitle the blogs entry's subtitle
 	* @param urlTitle the blogs entry's urlTitle

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -72,6 +72,38 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
+	/**
+	* Adds a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	@Override
+	public com.liferay.blogs.model.BlogsEntry addEntry(String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _blogsEntryService.addEntry(title, subtitle, urlTitle,
+			description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
 	@Override
 	public com.liferay.blogs.model.BlogsEntry addEntry(String title,
 		String subtitle, String urlTitle, String description, String content,

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -315,41 +315,6 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 	}
 
 	/**
-	* Updates a blogs entry
-	*
-	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author ID
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the updated blogs entry
-	* @review
-	*/
-	@Override
-	public com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
-		long userId, String title, String subtitle, String urlTitle,
-		String description, String content, java.util.Date displayDate,
-		String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _blogsEntryService.updateEntry(entryId, userId, title, subtitle,
-			urlTitle, description, content, displayDate, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
-	}
-
-	/**
 	* @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	String, String, String, int, int, int, int, int, boolean,
 	boolean, String[], String, ImageSelector, ImageSelector,
@@ -386,6 +351,39 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 			description, content, displayDateMonth, displayDateDay,
 			displayDateYear, displayDateHour, displayDateMinute,
 			allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	@Override
+	public com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _blogsEntryService.updateEntry(entryId, title, subtitle,
+			urlTitle, description, content, displayDate, coverImageCaption,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -33,6 +33,39 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 	}
 
 	/**
+	* Creates a new blogs entry
+	*
+	* @param userId the blogs entry's author id
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	@Override
+	public com.liferay.blogs.model.BlogsEntry addEntry(long userId,
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _blogsEntryService.addEntry(userId, title, subtitle, urlTitle,
+			description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	/**
 	* @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
 	String, String, int, int, int, int, int, boolean, boolean,
 	String[], String, ImageSelector, ImageSelector,
@@ -69,38 +102,6 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 			content, displayDateMonth, displayDateDay, displayDateYear,
 			displayDateHour, displayDateMinute, allowPingbacks,
 			allowTrackbacks, trackbacks, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
-	}
-
-	/**
-	* Creates a new blogs entry
-	*
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the created blogs entry
-	* @review
-	*/
-	@Override
-	public com.liferay.blogs.model.BlogsEntry addEntry(String title,
-		String subtitle, String urlTitle, String description, String content,
-		java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _blogsEntryService.addEntry(title, subtitle, urlTitle,
-			description, content, displayDate, coverImageCaption,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
@@ -314,6 +315,41 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 	}
 
 	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param userId the blogs entry's author id
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	@Override
+	public com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
+		long userId, String title, String subtitle, String urlTitle,
+		String description, String content, java.util.Date displayDate,
+		String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _blogsEntryService.updateEntry(entryId, userId, title, subtitle,
+			urlTitle, description, content, displayDate, coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	/**
 	* @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	String, String, String, int, int, int, int, int, boolean,
 	boolean, String[], String, ImageSelector, ImageSelector,
@@ -350,39 +386,6 @@ public class BlogsEntryServiceWrapper implements BlogsEntryService,
 			description, content, displayDateMonth, displayDateDay,
 			displayDateYear, displayDateHour, displayDateMinute,
 			allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
-	}
-
-	/**
-	* Updates a blogs entry
-	*
-	* @param entryId the blogs entry's ID
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the updated blogs entry
-	* @review
-	*/
-	@Override
-	public com.liferay.blogs.model.BlogsEntry updateEntry(long entryId,
-		String title, String subtitle, String urlTitle, String description,
-		String content, java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		return _blogsEntryService.updateEntry(entryId, title, subtitle,
-			urlTitle, description, content, displayDate, coverImageCaption,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -141,45 +141,6 @@ public class BlogsEntryServiceHttp {
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry addEntry(
-		HttpPrincipal httpPrincipal, long userId, String title,
-		String subtitle, String urlTitle, String description, String content,
-		java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		try {
-			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"addEntry", _addEntryParameterTypes2);
-
-			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
-					title, subtitle, urlTitle, description, content,
-					displayDate, coverImageCaption, coverImageImageSelector,
-					smallImageImageSelector, serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception e) {
-				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
-					throw (com.liferay.portal.kernel.exception.PortalException)e;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(e);
-			}
-
-			return (com.liferay.blogs.model.BlogsEntry)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
-
-			throw se;
-		}
-	}
-
-	public static com.liferay.blogs.model.BlogsEntry addEntry(
 		HttpPrincipal httpPrincipal, String title, String subtitle,
 		String urlTitle, String description, String content,
 		int displayDateMonth, int displayDateDay, int displayDateYear,
@@ -191,7 +152,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"addEntry", _addEntryParameterTypes3);
+					"addEntry", _addEntryParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, title,
 					subtitle, urlTitle, description, content, displayDateMonth,
@@ -226,7 +187,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"deleteEntry", _deleteEntryParameterTypes4);
+					"deleteEntry", _deleteEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -254,7 +215,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getCompanyEntries", _getCompanyEntriesParameterTypes5);
+					"getCompanyEntries", _getCompanyEntriesParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, displayDate, status, max);
@@ -289,7 +250,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getCompanyEntriesRSS", _getCompanyEntriesRSSParameterTypes6);
+					"getCompanyEntriesRSS", _getCompanyEntriesRSSParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, displayDate, status, max, type, version,
@@ -323,7 +284,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getEntriesPrevAndNext",
-					_getEntriesPrevAndNextParameterTypes7);
+					_getEntriesPrevAndNextParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -354,7 +315,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getEntry", _getEntryParameterTypes8);
+					"getEntry", _getEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -385,7 +346,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getEntry", _getEntryParameterTypes9);
+					"getEntry", _getEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					urlTitle);
@@ -417,7 +378,7 @@ public class BlogsEntryServiceHttp {
 		int status, int max) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes10);
+					"getGroupEntries", _getGroupEntriesParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, max);
@@ -445,7 +406,7 @@ public class BlogsEntryServiceHttp {
 		int status, int start, int end) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes11);
+					"getGroupEntries", _getGroupEntriesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, start, end);
@@ -472,7 +433,7 @@ public class BlogsEntryServiceHttp {
 		HttpPrincipal httpPrincipal, long groupId, int status, int max) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes12);
+					"getGroupEntries", _getGroupEntriesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, max);
@@ -500,7 +461,7 @@ public class BlogsEntryServiceHttp {
 		int end) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes13);
+					"getGroupEntries", _getGroupEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, start, end);
@@ -529,7 +490,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes14);
+					"getGroupEntries", _getGroupEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, start, end, obc);
@@ -557,7 +518,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupEntriesCount",
-					_getGroupEntriesCountParameterTypes15);
+					_getGroupEntriesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status);
@@ -585,7 +546,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupEntriesCount",
-					_getGroupEntriesCountParameterTypes16);
+					_getGroupEntriesCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status);
@@ -616,7 +577,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntriesRSS", _getGroupEntriesRSSParameterTypes17);
+					"getGroupEntriesRSS", _getGroupEntriesRSSParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, max, type, version, displayStyle,
@@ -650,7 +611,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupsEntries", _getGroupsEntriesParameterTypes18);
+					"getGroupsEntries", _getGroupsEntriesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, displayDate, status, max);
@@ -683,7 +644,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupUserEntries", _getGroupUserEntriesParameterTypes19);
+					"getGroupUserEntries", _getGroupUserEntriesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status, start, end, obc);
@@ -712,7 +673,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupUserEntries", _getGroupUserEntriesParameterTypes20);
+					"getGroupUserEntries", _getGroupUserEntriesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, statuses, start, end, obc);
@@ -740,7 +701,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupUserEntriesCount",
-					_getGroupUserEntriesCountParameterTypes21);
+					_getGroupUserEntriesCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status);
@@ -768,7 +729,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupUserEntriesCount",
-					_getGroupUserEntriesCountParameterTypes22);
+					_getGroupUserEntriesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, statuses);
@@ -798,7 +759,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntries",
-					_getOrganizationEntriesParameterTypes23);
+					_getOrganizationEntriesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max);
@@ -834,7 +795,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntriesRSS",
-					_getOrganizationEntriesRSSParameterTypes24);
+					_getOrganizationEntriesRSSParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max, type, version,
@@ -854,6 +815,45 @@ public class BlogsEntryServiceHttp {
 			}
 
 			return (String)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry importEntry(
+		HttpPrincipal httpPrincipal, long userId, String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"importEntry", _importEntryParameterTypes24);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
 		}
 		catch (com.liferay.portal.kernel.exception.SystemException se) {
 			_log.error(se, se);
@@ -974,6 +974,45 @@ public class BlogsEntryServiceHttp {
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry updateEntry(
+		HttpPrincipal httpPrincipal, long entryId, long userId, String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"updateEntry", _updateEntryParameterTypes29);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
+					userId, title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry updateEntry(
 		HttpPrincipal httpPrincipal, long entryId, String title,
 		String description, String content, int displayDateMonth,
 		int displayDateDay, int displayDateYear, int displayDateHour,
@@ -984,7 +1023,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes29);
+					"updateEntry", _updateEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, description, content, displayDateMonth,
@@ -1027,52 +1066,13 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes30);
+					"updateEntry", _updateEntryParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, description, content, displayDateMonth,
 					displayDateDay, displayDateYear, displayDateHour,
 					displayDateMinute, allowPingbacks, allowTrackbacks,
 					trackbacks, coverImageCaption, coverImageImageSelector,
-					smallImageImageSelector, serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception e) {
-				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
-					throw (com.liferay.portal.kernel.exception.PortalException)e;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(e);
-			}
-
-			return (com.liferay.blogs.model.BlogsEntry)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
-
-			throw se;
-		}
-	}
-
-	public static com.liferay.blogs.model.BlogsEntry updateEntry(
-		HttpPrincipal httpPrincipal, long entryId, long userId, String title,
-		String subtitle, String urlTitle, String description, String content,
-		java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		try {
-			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes31);
-
-			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
-					userId, title, subtitle, urlTitle, description, content,
-					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			Object returnObj = null;
@@ -1158,13 +1158,6 @@ public class BlogsEntryServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
-			long.class, String.class, String.class, String.class, String.class,
-			String.class, java.util.Date.class, String.class,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _addEntryParameterTypes3 = new Class[] {
 			String.class, String.class, String.class, String.class, String.class,
 			int.class, int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, String.class,
@@ -1172,77 +1165,84 @@ public class BlogsEntryServiceHttp {
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteEntryParameterTypes4 = new Class[] {
+	private static final Class<?>[] _deleteEntryParameterTypes3 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getCompanyEntriesParameterTypes5 = new Class[] {
+	private static final Class<?>[] _getCompanyEntriesParameterTypes4 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes6 = new Class[] {
+	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes5 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes7 = new Class[] {
+	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes6 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _getEntryParameterTypes7 = new Class[] {
 			long.class
 		};
 	private static final Class<?>[] _getEntryParameterTypes8 = new Class[] {
-			long.class
-		};
-	private static final Class<?>[] _getEntryParameterTypes9 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes9 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes10 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes11 = new Class[] {
 			long.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes12 = new Class[] {
 			long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes13 = new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes14 = new Class[] {
 			long.class, java.util.Date.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes15 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesRSSParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesRSSParameterTypes16 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupsEntriesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getGroupsEntriesParameterTypes17 = new Class[] {
 			long.class, long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes18 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes19 = new Class[] {
 			long.class, long.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes20 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes21 = new Class[] {
 			long.class, long.class, int[].class
 		};
-	private static final Class<?>[] _getOrganizationEntriesParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getOrganizationEntriesParameterTypes22 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes24 = new Class[] {
+	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes23 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
+		};
+	private static final Class<?>[] _importEntryParameterTypes24 = new Class[] {
+			long.class, String.class, String.class, String.class, String.class,
+			String.class, java.util.Date.class, String.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _moveEntryToTrashParameterTypes25 = new Class[] {
 			long.class
@@ -1257,23 +1257,23 @@ public class BlogsEntryServiceHttp {
 			long.class
 		};
 	private static final Class<?>[] _updateEntryParameterTypes29 = new Class[] {
+			long.class, long.class, String.class, String.class, String.class,
+			String.class, String.class, java.util.Date.class, String.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
 			long.class, String.class, String.class, String.class, int.class,
 			int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, boolean.class, String.class,
 			String.class, java.io.InputStream.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			int.class, int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, String.class,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
-			long.class, long.class, String.class, String.class, String.class,
-			String.class, String.class, java.util.Date.class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -141,8 +141,8 @@ public class BlogsEntryServiceHttp {
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry addEntry(
-		HttpPrincipal httpPrincipal, String title, String subtitle,
-		String urlTitle, String description, String content,
+		HttpPrincipal httpPrincipal, long userId, String title,
+		String subtitle, String urlTitle, String description, String content,
 		java.util.Date displayDate, String coverImageCaption,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
@@ -152,9 +152,9 @@ public class BlogsEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"addEntry", _addEntryParameterTypes2);
 
-			MethodHandler methodHandler = new MethodHandler(methodKey, title,
-					subtitle, urlTitle, description, content, displayDate,
-					coverImageCaption, coverImageImageSelector,
+			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			Object returnObj = null;
@@ -1059,7 +1059,7 @@ public class BlogsEntryServiceHttp {
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry updateEntry(
-		HttpPrincipal httpPrincipal, long entryId, String title,
+		HttpPrincipal httpPrincipal, long entryId, long userId, String title,
 		String subtitle, String urlTitle, String description, String content,
 		java.util.Date displayDate, String coverImageCaption,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
@@ -1071,7 +1071,7 @@ public class BlogsEntryServiceHttp {
 					"updateEntry", _updateEntryParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
-					title, subtitle, urlTitle, description, content,
+					userId, title, subtitle, urlTitle, description, content,
 					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
@@ -1158,8 +1158,8 @@ public class BlogsEntryServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
-			String.class, String.class, String.class, String.class, String.class,
-			java.util.Date.class, String.class,
+			long.class, String.class, String.class, String.class, String.class,
+			String.class, java.util.Date.class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
@@ -1272,8 +1272,8 @@ public class BlogsEntryServiceHttp {
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
-			long.class, String.class, String.class, String.class, String.class,
-			String.class, java.util.Date.class, String.class,
+			long.class, long.class, String.class, String.class, String.class,
+			String.class, String.class, java.util.Date.class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -974,45 +974,6 @@ public class BlogsEntryServiceHttp {
 	}
 
 	public static com.liferay.blogs.model.BlogsEntry updateEntry(
-		HttpPrincipal httpPrincipal, long entryId, long userId, String title,
-		String subtitle, String urlTitle, String description, String content,
-		java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-		try {
-			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes29);
-
-			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
-					userId, title, subtitle, urlTitle, description, content,
-					displayDate, coverImageCaption, coverImageImageSelector,
-					smallImageImageSelector, serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception e) {
-				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
-					throw (com.liferay.portal.kernel.exception.PortalException)e;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(e);
-			}
-
-			return (com.liferay.blogs.model.BlogsEntry)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
-
-			throw se;
-		}
-	}
-
-	public static com.liferay.blogs.model.BlogsEntry updateEntry(
 		HttpPrincipal httpPrincipal, long entryId, String title,
 		String description, String content, int displayDateMonth,
 		int displayDateDay, int displayDateYear, int displayDateHour,
@@ -1023,7 +984,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes30);
+					"updateEntry", _updateEntryParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, description, content, displayDateMonth,
@@ -1066,13 +1027,52 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes31);
+					"updateEntry", _updateEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, description, content, displayDateMonth,
 					displayDateDay, displayDateYear, displayDateHour,
 					displayDateMinute, allowPingbacks, allowTrackbacks,
 					trackbacks, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry updateEntry(
+		HttpPrincipal httpPrincipal, long entryId, String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"updateEntry", _updateEntryParameterTypes31);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			Object returnObj = null;
@@ -1257,23 +1257,23 @@ public class BlogsEntryServiceHttp {
 			long.class
 		};
 	private static final Class<?>[] _updateEntryParameterTypes29 = new Class[] {
-			long.class, long.class, String.class, String.class, String.class,
-			String.class, String.class, java.util.Date.class, String.class,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
-			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
 			long.class, String.class, String.class, String.class, int.class,
 			int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, boolean.class, String.class,
 			String.class, java.io.InputStream.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			int.class, int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, String.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
+			long.class, String.class, String.class, String.class, String.class,
+			String.class, java.util.Date.class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -143,6 +143,45 @@ public class BlogsEntryServiceHttp {
 	public static com.liferay.blogs.model.BlogsEntry addEntry(
 		HttpPrincipal httpPrincipal, String title, String subtitle,
 		String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"addEntry", _addEntryParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, title,
+					subtitle, urlTitle, description, content, displayDate,
+					coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry addEntry(
+		HttpPrincipal httpPrincipal, String title, String subtitle,
+		String urlTitle, String description, String content,
 		int displayDateMonth, int displayDateDay, int displayDateYear,
 		int displayDateHour, int displayDateMinute, boolean allowPingbacks,
 		boolean allowTrackbacks, String[] trackbacks, String coverImageCaption,
@@ -152,7 +191,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"addEntry", _addEntryParameterTypes2);
+					"addEntry", _addEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, title,
 					subtitle, urlTitle, description, content, displayDateMonth,
@@ -187,7 +226,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"deleteEntry", _deleteEntryParameterTypes3);
+					"deleteEntry", _deleteEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -215,7 +254,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getCompanyEntries", _getCompanyEntriesParameterTypes4);
+					"getCompanyEntries", _getCompanyEntriesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, displayDate, status, max);
@@ -250,7 +289,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getCompanyEntriesRSS", _getCompanyEntriesRSSParameterTypes5);
+					"getCompanyEntriesRSS", _getCompanyEntriesRSSParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, displayDate, status, max, type, version,
@@ -284,7 +323,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getEntriesPrevAndNext",
-					_getEntriesPrevAndNextParameterTypes6);
+					_getEntriesPrevAndNextParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -315,7 +354,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getEntry", _getEntryParameterTypes7);
+					"getEntry", _getEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -346,7 +385,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getEntry", _getEntryParameterTypes8);
+					"getEntry", _getEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					urlTitle);
@@ -378,7 +417,7 @@ public class BlogsEntryServiceHttp {
 		int status, int max) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes9);
+					"getGroupEntries", _getGroupEntriesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, max);
@@ -406,7 +445,7 @@ public class BlogsEntryServiceHttp {
 		int status, int start, int end) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes10);
+					"getGroupEntries", _getGroupEntriesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, start, end);
@@ -433,7 +472,7 @@ public class BlogsEntryServiceHttp {
 		HttpPrincipal httpPrincipal, long groupId, int status, int max) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes11);
+					"getGroupEntries", _getGroupEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, max);
@@ -461,7 +500,7 @@ public class BlogsEntryServiceHttp {
 		int end) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes12);
+					"getGroupEntries", _getGroupEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, start, end);
@@ -490,7 +529,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes13);
+					"getGroupEntries", _getGroupEntriesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, start, end, obc);
@@ -518,7 +557,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupEntriesCount",
-					_getGroupEntriesCountParameterTypes14);
+					_getGroupEntriesCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status);
@@ -546,7 +585,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupEntriesCount",
-					_getGroupEntriesCountParameterTypes15);
+					_getGroupEntriesCountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status);
@@ -577,7 +616,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntriesRSS", _getGroupEntriesRSSParameterTypes16);
+					"getGroupEntriesRSS", _getGroupEntriesRSSParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, max, type, version, displayStyle,
@@ -611,7 +650,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupsEntries", _getGroupsEntriesParameterTypes17);
+					"getGroupsEntries", _getGroupsEntriesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, displayDate, status, max);
@@ -644,7 +683,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupUserEntries", _getGroupUserEntriesParameterTypes18);
+					"getGroupUserEntries", _getGroupUserEntriesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status, start, end, obc);
@@ -673,7 +712,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupUserEntries", _getGroupUserEntriesParameterTypes19);
+					"getGroupUserEntries", _getGroupUserEntriesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, statuses, start, end, obc);
@@ -701,7 +740,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupUserEntriesCount",
-					_getGroupUserEntriesCountParameterTypes20);
+					_getGroupUserEntriesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status);
@@ -729,7 +768,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupUserEntriesCount",
-					_getGroupUserEntriesCountParameterTypes21);
+					_getGroupUserEntriesCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, statuses);
@@ -759,7 +798,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntries",
-					_getOrganizationEntriesParameterTypes22);
+					_getOrganizationEntriesParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max);
@@ -795,7 +834,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntriesRSS",
-					_getOrganizationEntriesRSSParameterTypes23);
+					_getOrganizationEntriesRSSParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max, type, version,
@@ -833,7 +872,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"importEntry", _importEntryParameterTypes24);
+					"importEntry", _importEntryParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
 					title, subtitle, urlTitle, description, content,
@@ -867,7 +906,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"moveEntryToTrash", _moveEntryToTrashParameterTypes25);
+					"moveEntryToTrash", _moveEntryToTrashParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -899,7 +938,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"restoreEntryFromTrash",
-					_restoreEntryFromTrashParameterTypes26);
+					_restoreEntryFromTrashParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -925,7 +964,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"subscribe", _subscribeParameterTypes27);
+					"subscribe", _subscribeParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -951,7 +990,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"unsubscribe", _unsubscribeParameterTypes28);
+					"unsubscribe", _unsubscribeParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -984,7 +1023,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes29);
+					"updateEntry", _updateEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, description, content, displayDateMonth,
@@ -1027,7 +1066,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes30);
+					"updateEntry", _updateEntryParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, description, content, displayDateMonth,
@@ -1068,7 +1107,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes31);
+					"updateEntry", _updateEntryParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, urlTitle, description, content,
@@ -1109,7 +1148,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes32);
+					"updateEntry", _updateEntryParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, urlTitle, description, content,
@@ -1159,111 +1198,118 @@ public class BlogsEntryServiceHttp {
 		};
 	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
 			String.class, String.class, String.class, String.class, String.class,
+			java.util.Date.class, String.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _addEntryParameterTypes3 = new Class[] {
+			String.class, String.class, String.class, String.class, String.class,
 			int.class, int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteEntryParameterTypes3 = new Class[] {
+	private static final Class<?>[] _deleteEntryParameterTypes4 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getCompanyEntriesParameterTypes4 = new Class[] {
+	private static final Class<?>[] _getCompanyEntriesParameterTypes5 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes5 = new Class[] {
+	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes6 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes6 = new Class[] {
-			long.class
-		};
-	private static final Class<?>[] _getEntryParameterTypes7 = new Class[] {
+	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes7 = new Class[] {
 			long.class
 		};
 	private static final Class<?>[] _getEntryParameterTypes8 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _getEntryParameterTypes9 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes10 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes11 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes12 = new Class[] {
 			long.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes13 = new Class[] {
 			long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes14 = new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes15 = new Class[] {
 			long.class, java.util.Date.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes16 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesRSSParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesRSSParameterTypes17 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupsEntriesParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getGroupsEntriesParameterTypes18 = new Class[] {
 			long.class, long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes19 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes20 = new Class[] {
 			long.class, long.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes21 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes22 = new Class[] {
 			long.class, long.class, int[].class
 		};
-	private static final Class<?>[] _getOrganizationEntriesParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getOrganizationEntriesParameterTypes23 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes24 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _importEntryParameterTypes24 = new Class[] {
+	private static final Class<?>[] _importEntryParameterTypes25 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, java.util.Date.class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveEntryToTrashParameterTypes25 = new Class[] {
+	private static final Class<?>[] _moveEntryToTrashParameterTypes26 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _restoreEntryFromTrashParameterTypes26 = new Class[] {
+	private static final Class<?>[] _restoreEntryFromTrashParameterTypes27 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _subscribeParameterTypes27 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes28 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _unsubscribeParameterTypes28 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes29 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes29 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
 			long.class, String.class, String.class, String.class, int.class,
 			int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, boolean.class, String.class,
 			String.class, java.io.InputStream.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			int.class, int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, String.class,
@@ -1271,14 +1317,14 @@ public class BlogsEntryServiceHttp {
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes32 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, java.util.Date.class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes32 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes33 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, int.class, int.class, int.class, int.class, int.class,
 			boolean.class, boolean.class, String[].class, String.class,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -143,6 +143,45 @@ public class BlogsEntryServiceHttp {
 	public static com.liferay.blogs.model.BlogsEntry addEntry(
 		HttpPrincipal httpPrincipal, String title, String subtitle,
 		String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"addEntry", _addEntryParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, title,
+					subtitle, urlTitle, description, content, displayDate,
+					coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry addEntry(
+		HttpPrincipal httpPrincipal, String title, String subtitle,
+		String urlTitle, String description, String content,
 		int displayDateMonth, int displayDateDay, int displayDateYear,
 		int displayDateHour, int displayDateMinute, boolean allowPingbacks,
 		boolean allowTrackbacks, String[] trackbacks, String coverImageCaption,
@@ -152,7 +191,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"addEntry", _addEntryParameterTypes2);
+					"addEntry", _addEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, title,
 					subtitle, urlTitle, description, content, displayDateMonth,
@@ -187,7 +226,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"deleteEntry", _deleteEntryParameterTypes3);
+					"deleteEntry", _deleteEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -215,7 +254,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getCompanyEntries", _getCompanyEntriesParameterTypes4);
+					"getCompanyEntries", _getCompanyEntriesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, displayDate, status, max);
@@ -250,7 +289,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getCompanyEntriesRSS", _getCompanyEntriesRSSParameterTypes5);
+					"getCompanyEntriesRSS", _getCompanyEntriesRSSParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, displayDate, status, max, type, version,
@@ -284,7 +323,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getEntriesPrevAndNext",
-					_getEntriesPrevAndNextParameterTypes6);
+					_getEntriesPrevAndNextParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -315,7 +354,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getEntry", _getEntryParameterTypes7);
+					"getEntry", _getEntryParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -346,7 +385,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getEntry", _getEntryParameterTypes8);
+					"getEntry", _getEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					urlTitle);
@@ -378,7 +417,7 @@ public class BlogsEntryServiceHttp {
 		int status, int max) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes9);
+					"getGroupEntries", _getGroupEntriesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, max);
@@ -406,7 +445,7 @@ public class BlogsEntryServiceHttp {
 		int status, int start, int end) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes10);
+					"getGroupEntries", _getGroupEntriesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, start, end);
@@ -433,7 +472,7 @@ public class BlogsEntryServiceHttp {
 		HttpPrincipal httpPrincipal, long groupId, int status, int max) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes11);
+					"getGroupEntries", _getGroupEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, max);
@@ -461,7 +500,7 @@ public class BlogsEntryServiceHttp {
 		int end) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes12);
+					"getGroupEntries", _getGroupEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, start, end);
@@ -490,7 +529,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntries", _getGroupEntriesParameterTypes13);
+					"getGroupEntries", _getGroupEntriesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, start, end, obc);
@@ -518,7 +557,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupEntriesCount",
-					_getGroupEntriesCountParameterTypes14);
+					_getGroupEntriesCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status);
@@ -546,7 +585,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupEntriesCount",
-					_getGroupEntriesCountParameterTypes15);
+					_getGroupEntriesCountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status);
@@ -577,7 +616,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupEntriesRSS", _getGroupEntriesRSSParameterTypes16);
+					"getGroupEntriesRSS", _getGroupEntriesRSSParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					displayDate, status, max, type, version, displayStyle,
@@ -611,7 +650,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupsEntries", _getGroupsEntriesParameterTypes17);
+					"getGroupsEntries", _getGroupsEntriesParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, displayDate, status, max);
@@ -644,7 +683,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupUserEntries", _getGroupUserEntriesParameterTypes18);
+					"getGroupUserEntries", _getGroupUserEntriesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status, start, end, obc);
@@ -673,7 +712,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.blogs.model.BlogsEntry> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"getGroupUserEntries", _getGroupUserEntriesParameterTypes19);
+					"getGroupUserEntries", _getGroupUserEntriesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, statuses, start, end, obc);
@@ -701,7 +740,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupUserEntriesCount",
-					_getGroupUserEntriesCountParameterTypes20);
+					_getGroupUserEntriesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status);
@@ -729,7 +768,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getGroupUserEntriesCount",
-					_getGroupUserEntriesCountParameterTypes21);
+					_getGroupUserEntriesCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, statuses);
@@ -759,7 +798,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntries",
-					_getOrganizationEntriesParameterTypes22);
+					_getOrganizationEntriesParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max);
@@ -795,7 +834,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"getOrganizationEntriesRSS",
-					_getOrganizationEntriesRSSParameterTypes23);
+					_getOrganizationEntriesRSSParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					organizationId, displayDate, status, max, type, version,
@@ -828,7 +867,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"moveEntryToTrash", _moveEntryToTrashParameterTypes24);
+					"moveEntryToTrash", _moveEntryToTrashParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -860,7 +899,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
 					"restoreEntryFromTrash",
-					_restoreEntryFromTrashParameterTypes25);
+					_restoreEntryFromTrashParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -886,7 +925,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"subscribe", _subscribeParameterTypes26);
+					"subscribe", _subscribeParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -912,7 +951,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"unsubscribe", _unsubscribeParameterTypes27);
+					"unsubscribe", _unsubscribeParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -945,7 +984,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes28);
+					"updateEntry", _updateEntryParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, description, content, displayDateMonth,
@@ -988,13 +1027,52 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes29);
+					"updateEntry", _updateEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, description, content, displayDateMonth,
 					displayDateDay, displayDateYear, displayDateHour,
 					displayDateMinute, allowPingbacks, allowTrackbacks,
 					trackbacks, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry updateEntry(
+		HttpPrincipal httpPrincipal, long entryId, String title,
+		String subtitle, String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
+					"updateEntry", _updateEntryParameterTypes31);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			Object returnObj = null;
@@ -1031,7 +1109,7 @@ public class BlogsEntryServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(BlogsEntryServiceUtil.class,
-					"updateEntry", _updateEntryParameterTypes30);
+					"updateEntry", _updateEntryParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId,
 					title, subtitle, urlTitle, description, content,
@@ -1081,104 +1159,111 @@ public class BlogsEntryServiceHttp {
 		};
 	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
 			String.class, String.class, String.class, String.class, String.class,
+			java.util.Date.class, String.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _addEntryParameterTypes3 = new Class[] {
+			String.class, String.class, String.class, String.class, String.class,
 			int.class, int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, String.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteEntryParameterTypes3 = new Class[] {
+	private static final Class<?>[] _deleteEntryParameterTypes4 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getCompanyEntriesParameterTypes4 = new Class[] {
+	private static final Class<?>[] _getCompanyEntriesParameterTypes5 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes5 = new Class[] {
+	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes6 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes6 = new Class[] {
-			long.class
-		};
-	private static final Class<?>[] _getEntryParameterTypes7 = new Class[] {
+	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes7 = new Class[] {
 			long.class
 		};
 	private static final Class<?>[] _getEntryParameterTypes8 = new Class[] {
+			long.class
+		};
+	private static final Class<?>[] _getEntryParameterTypes9 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes10 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes11 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes12 = new Class[] {
 			long.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes13 = new Class[] {
 			long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesParameterTypes14 = new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes15 = new Class[] {
 			long.class, java.util.Date.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes16 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesRSSParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getGroupEntriesRSSParameterTypes17 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupsEntriesParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getGroupsEntriesParameterTypes18 = new Class[] {
 			long.class, long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes19 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes20 = new Class[] {
 			long.class, long.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes21 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes22 = new Class[] {
 			long.class, long.class, int[].class
 		};
-	private static final Class<?>[] _getOrganizationEntriesParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getOrganizationEntriesParameterTypes23 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes24 = new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, String.class,
 			double.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _moveEntryToTrashParameterTypes24 = new Class[] {
+	private static final Class<?>[] _moveEntryToTrashParameterTypes25 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _restoreEntryFromTrashParameterTypes25 = new Class[] {
+	private static final Class<?>[] _restoreEntryFromTrashParameterTypes26 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _subscribeParameterTypes26 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes27 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _unsubscribeParameterTypes27 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes28 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes28 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes29 = new Class[] {
 			long.class, String.class, String.class, String.class, int.class,
 			int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, boolean.class, String.class,
 			String.class, java.io.InputStream.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes29 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			int.class, int.class, int.class, int.class, int.class, boolean.class,
 			boolean.class, String[].class, String.class,
@@ -1186,7 +1271,14 @@ public class BlogsEntryServiceHttp {
 			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
+			long.class, String.class, String.class, String.class, String.class,
+			String.class, java.util.Date.class, String.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _updateEntryParameterTypes32 = new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, int.class, int.class, int.class, int.class, int.class,
 			boolean.class, boolean.class, String[].class, String.class,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
@@ -91,6 +91,47 @@ public class BlogsEntryServiceSoap {
 		}
 	}
 
+	/**
+	* Adds a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.addEntry(title,
+					subtitle, urlTitle, description, content, displayDate,
+					coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(
 		String title, String subtitle, String urlTitle, String description,
 		String content, int displayDateMonth, int displayDateDay,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
@@ -91,6 +91,47 @@ public class BlogsEntryServiceSoap {
 		}
 	}
 
+	/**
+	* Creates a new blogs entry
+	*
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(
+		String title, String subtitle, String urlTitle, String description,
+		String content, java.util.Date displayDate, String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.addEntry(title,
+					subtitle, urlTitle, description, content, displayDate,
+					coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(
 		String title, String subtitle, String urlTitle, String description,
 		String content, int displayDateMonth, int displayDateDay,
@@ -457,6 +498,49 @@ public class BlogsEntryServiceSoap {
 					displayDateDay, displayDateYear, displayDateHour,
 					displayDateMinute, allowPingbacks, allowTrackbacks,
 					trackbacks, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	/**
+	* Updates a blogs entry
+	*
+	* @param entryId the blogs entry's ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the updated blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntrySoap updateEntry(
+		long entryId, String title, String subtitle, String urlTitle,
+		String description, String content, java.util.Date displayDate,
+		String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
@@ -484,11 +484,37 @@ public class BlogsEntryServiceSoap {
 		}
 	}
 
+	public static com.liferay.blogs.model.BlogsEntrySoap updateEntry(
+		long entryId, String title, String subtitle, String description,
+		String content, int displayDateMonth, int displayDateDay,
+		int displayDateYear, int displayDateHour, int displayDateMinute,
+		boolean allowPingbacks, boolean allowTrackbacks, String[] trackbacks,
+		String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
+					title, subtitle, description, content, displayDateMonth,
+					displayDateDay, displayDateYear, displayDateHour,
+					displayDateMinute, allowPingbacks, allowTrackbacks,
+					trackbacks, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	/**
 	* Updates a blogs entry
 	*
 	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author ID
 	* @param title the blogs entry's title
 	* @param subtitle the blogs entry's subtitle
 	* @param urlTitle the blogs entry's urlTitle
@@ -506,33 +532,8 @@ public class BlogsEntryServiceSoap {
 	* @review
 	*/
 	public static com.liferay.blogs.model.BlogsEntrySoap updateEntry(
-		long entryId, long userId, String title, String subtitle,
-		String urlTitle, String description, String content,
-		java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws RemoteException {
-		try {
-			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
-					userId, title, subtitle, urlTitle, description, content,
-					displayDate, coverImageCaption, coverImageImageSelector,
-					smallImageImageSelector, serviceContext);
-
-			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-
-			throw new RemoteException(e.getMessage());
-		}
-	}
-
-	public static com.liferay.blogs.model.BlogsEntrySoap updateEntry(
-		long entryId, String title, String subtitle, String description,
-		String content, int displayDateMonth, int displayDateDay,
-		int displayDateYear, int displayDateHour, int displayDateMinute,
-		boolean allowPingbacks, boolean allowTrackbacks, String[] trackbacks,
+		long entryId, String title, String subtitle, String urlTitle,
+		String description, String content, java.util.Date displayDate,
 		String coverImageCaption,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
@@ -540,10 +541,8 @@ public class BlogsEntryServiceSoap {
 		throws RemoteException {
 		try {
 			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
-					title, subtitle, description, content, displayDateMonth,
-					displayDateDay, displayDateYear, displayDateHour,
-					displayDateMinute, allowPingbacks, allowTrackbacks,
-					trackbacks, coverImageCaption, coverImageImageSelector,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
@@ -91,48 +91,6 @@ public class BlogsEntryServiceSoap {
 		}
 	}
 
-	/**
-	* Creates a new blogs entry
-	*
-	* @param userId the blogs entry's author id
-	* @param title the blogs entry's title
-	* @param subtitle the blogs entry's subtitle
-	* @param urlTitle the blogs entry's urlTitle
-	* @param description the blogs entry's description
-	* @param content the blogs entry's content
-	* @param displayDate the blogs entry's displayDate
-	* @param coverImageCaption the blogs entry's cover image caption
-	* @param coverImageImageSelector an object containing the data of the
-	blogs's entry cover image, can be {@code null}
-	* @param smallImageImageSelector an object containing the data of the
-	blogs's entry small cover image, can be {@code null}
-	* @param serviceContext the blogs entry's serviceContext; at least it must
-	contain the {@code groupId}
-	* @return the created blogs entry
-	* @review
-	*/
-	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(long userId,
-		String title, String subtitle, String urlTitle, String description,
-		String content, java.util.Date displayDate, String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws RemoteException {
-		try {
-			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.addEntry(userId,
-					title, subtitle, urlTitle, description, content,
-					displayDate, coverImageCaption, coverImageImageSelector,
-					smallImageImageSelector, serviceContext);
-
-			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-
-			throw new RemoteException(e.getMessage());
-		}
-	}
-
 	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(
 		String title, String subtitle, String urlTitle, String description,
 		String content, int displayDateMonth, int displayDateDay,
@@ -435,6 +393,49 @@ public class BlogsEntryServiceSoap {
 		}
 	}
 
+	/**
+	* Imports a blogs entry
+	*
+	* @param userId the blogs entry's author ID
+	* @param title the blogs entry's title
+	* @param subtitle the blogs entry's subtitle
+	* @param urlTitle the blogs entry's urlTitle
+	* @param description the blogs entry's description
+	* @param content the blogs entry's content
+	* @param displayDate the blogs entry's displayDate
+	* @param coverImageCaption the blogs entry's cover image caption
+	* @param coverImageImageSelector an object containing the data of the
+	blogs's entry cover image, can be {@code null}
+	* @param smallImageImageSelector an object containing the data of the
+	blogs's entry small cover image, can be {@code null}
+	* @param serviceContext the blogs entry's serviceContext; at least it must
+	contain the {@code groupId}
+	* @return the created blogs entry
+	* @review
+	*/
+	public static com.liferay.blogs.model.BlogsEntrySoap importEntry(
+		long userId, String title, String subtitle, String urlTitle,
+		String description, String content, java.util.Date displayDate,
+		String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.importEntry(userId,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.blogs.model.BlogsEntrySoap moveEntryToTrash(
 		long entryId) throws RemoteException {
 		try {
@@ -483,38 +484,11 @@ public class BlogsEntryServiceSoap {
 		}
 	}
 
-	public static com.liferay.blogs.model.BlogsEntrySoap updateEntry(
-		long entryId, String title, String subtitle, String description,
-		String content, int displayDateMonth, int displayDateDay,
-		int displayDateYear, int displayDateHour, int displayDateMinute,
-		boolean allowPingbacks, boolean allowTrackbacks, String[] trackbacks,
-		String coverImageCaption,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
-		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
-		com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws RemoteException {
-		try {
-			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
-					title, subtitle, description, content, displayDateMonth,
-					displayDateDay, displayDateYear, displayDateHour,
-					displayDateMinute, allowPingbacks, allowTrackbacks,
-					trackbacks, coverImageCaption, coverImageImageSelector,
-					smallImageImageSelector, serviceContext);
-
-			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
-		}
-		catch (Exception e) {
-			_log.error(e, e);
-
-			throw new RemoteException(e.getMessage());
-		}
-	}
-
 	/**
 	* Updates a blogs entry
 	*
 	* @param entryId the blogs entry's ID
-	* @param userId the blogs entry's author id
+	* @param userId the blogs entry's author ID
 	* @param title the blogs entry's title
 	* @param subtitle the blogs entry's subtitle
 	* @param urlTitle the blogs entry's urlTitle
@@ -543,6 +517,33 @@ public class BlogsEntryServiceSoap {
 			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
 					userId, title, subtitle, urlTitle, description, content,
 					displayDate, coverImageCaption, coverImageImageSelector,
+					smallImageImageSelector, serviceContext);
+
+			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntrySoap updateEntry(
+		long entryId, String title, String subtitle, String description,
+		String content, int displayDateMonth, int displayDateDay,
+		int displayDateYear, int displayDateHour, int displayDateMinute,
+		boolean allowPingbacks, boolean allowTrackbacks, String[] trackbacks,
+		String coverImageCaption,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws RemoteException {
+		try {
+			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
+					title, subtitle, description, content, displayDateMonth,
+					displayDateDay, displayDateYear, displayDateHour,
+					displayDateMinute, allowPingbacks, allowTrackbacks,
+					trackbacks, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceSoap.java
@@ -94,6 +94,7 @@ public class BlogsEntryServiceSoap {
 	/**
 	* Creates a new blogs entry
 	*
+	* @param userId the blogs entry's author id
 	* @param title the blogs entry's title
 	* @param subtitle the blogs entry's subtitle
 	* @param urlTitle the blogs entry's urlTitle
@@ -110,7 +111,7 @@ public class BlogsEntryServiceSoap {
 	* @return the created blogs entry
 	* @review
 	*/
-	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(
+	public static com.liferay.blogs.model.BlogsEntrySoap addEntry(long userId,
 		String title, String subtitle, String urlTitle, String description,
 		String content, java.util.Date displayDate, String coverImageCaption,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
@@ -118,9 +119,9 @@ public class BlogsEntryServiceSoap {
 		com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws RemoteException {
 		try {
-			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.addEntry(title,
-					subtitle, urlTitle, description, content, displayDate,
-					coverImageCaption, coverImageImageSelector,
+			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.addEntry(userId,
+					title, subtitle, urlTitle, description, content,
+					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 
 			return com.liferay.blogs.model.BlogsEntrySoap.toSoapModel(returnValue);
@@ -513,6 +514,7 @@ public class BlogsEntryServiceSoap {
 	* Updates a blogs entry
 	*
 	* @param entryId the blogs entry's ID
+	* @param userId the blogs entry's author id
 	* @param title the blogs entry's title
 	* @param subtitle the blogs entry's subtitle
 	* @param urlTitle the blogs entry's urlTitle
@@ -530,16 +532,16 @@ public class BlogsEntryServiceSoap {
 	* @review
 	*/
 	public static com.liferay.blogs.model.BlogsEntrySoap updateEntry(
-		long entryId, String title, String subtitle, String urlTitle,
-		String description, String content, java.util.Date displayDate,
-		String coverImageCaption,
+		long entryId, long userId, String title, String subtitle,
+		String urlTitle, String description, String content,
+		java.util.Date displayDate, String coverImageCaption,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector coverImageImageSelector,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector smallImageImageSelector,
 		com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws RemoteException {
 		try {
 			com.liferay.blogs.model.BlogsEntry returnValue = BlogsEntryServiceUtil.updateEntry(entryId,
-					title, subtitle, urlTitle, description, content,
+					userId, title, subtitle, urlTitle, description, content,
 					displayDate, coverImageCaption, coverImageImageSelector,
 					smallImageImageSelector, serviceContext);
 

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -72,6 +72,45 @@ import java.util.List;
 public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 
 	/**
+	 * Creates a new blogs entry
+	 *
+	 * @param  userId the blogs entry's author ID
+	 * @param  title the blogs entry's title
+	 * @param  subtitle the blogs entry's subtitle
+	 * @param  urlTitle the blogs entry's urlTitle
+	 * @param  description the blogs entry's description
+	 * @param  content the blogs entry's content
+	 * @param  displayDate the blogs entry's displayDate
+	 * @param  coverImageCaption the blogs entry's cover image caption
+	 * @param  coverImageImageSelector an object containing the data of the
+	 *         blogs's entry cover image, can be {@code null}
+	 * @param  smallImageImageSelector an object containing the data of the
+	 *         blogs's entry small cover image, can be {@code null}
+	 * @param  serviceContext the blogs entry's serviceContext; at least it must
+	 *         contain the {@code groupId}
+	 * @return the created blogs entry
+	 * @review
+	 */
+	@Override
+	public BlogsEntry addEntry(
+			long userId, String title, String subtitle, String urlTitle,
+			String description, String content, Date displayDate,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), serviceContext.getScopeGroupId(),
+			ActionKeys.ADD_ENTRY);
+
+		return blogsEntryLocalService.addEntry(
+			userId, title, subtitle, urlTitle, description, content,
+			displayDate, true, true, new String[0], coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	/**
 	 * @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
 	 *             String, String, int, int, int, int, int, boolean, boolean,
 	 *             String[], String, ImageSelector, ImageSelector,
@@ -143,44 +182,6 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
 			serviceContext);
-	}
-
-	/**
-	 * Creates a new blogs entry
-	 *
-	 * @param  title the blogs entry's title
-	 * @param  subtitle the blogs entry's subtitle
-	 * @param  urlTitle the blogs entry's urlTitle
-	 * @param  description the blogs entry's description
-	 * @param  content the blogs entry's content
-	 * @param  displayDate the blogs entry's displayDate
-	 * @param  coverImageCaption the blogs entry's cover image caption
-	 * @param  coverImageImageSelector an object containing the data of the
-	 *         blogs's entry cover image, can be {@code null}
-	 * @param  smallImageImageSelector an object containing the data of the
-	 *         blogs's entry small cover image, can be {@code null}
-	 * @param  serviceContext the blogs entry's serviceContext; at least it must
-	 *         contain the {@code groupId}
-	 * @return the created blogs entry
-	 * @review
-	 */
-	@Override
-	public BlogsEntry addEntry(
-			String title, String subtitle, String urlTitle, String description,
-			String content, Date displayDate, String coverImageCaption,
-			ImageSelector coverImageImageSelector,
-			ImageSelector smallImageImageSelector,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_portletResourcePermission.check(
-			getPermissionChecker(), serviceContext.getScopeGroupId(),
-			ActionKeys.ADD_ENTRY);
-
-		return blogsEntryLocalService.addEntry(
-			getUserId(), title, subtitle, urlTitle, description, content,
-			displayDate, true, true, new String[0], coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	@Override
@@ -627,6 +628,46 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	}
 
 	/**
+	 * Updates a blogs entry
+	 *
+	 * @param  entryId the blogs entry's ID
+	 * @param  userId the blogs entry's author ID
+	 * @param  title the blogs entry's title
+	 * @param  subtitle the blogs entry's subtitle
+	 * @param  urlTitle the blogs entry's urlTitle
+	 * @param  description the blogs entry's description
+	 * @param  content the blogs entry's content
+	 * @param  displayDate the blogs entry's displayDate
+	 * @param  coverImageCaption the blogs entry's cover image caption
+	 * @param  coverImageImageSelector an object containing the data of the
+	 *         blogs's entry cover image, can be {@code null}
+	 * @param  smallImageImageSelector an object containing the data of the
+	 *         blogs's entry small cover image, can be {@code null}
+	 * @param  serviceContext the blogs entry's serviceContext; at least it must
+	 *         contain the {@code groupId}
+	 * @return the updated blogs entry
+	 * @review
+	 */
+	@Override
+	public BlogsEntry updateEntry(
+			long entryId, long userId, String title, String subtitle,
+			String urlTitle, String description, String content,
+			Date displayDate, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_blogsEntryFolderModelResourcePermission.check(
+			getPermissionChecker(), entryId, ActionKeys.UPDATE);
+
+		return blogsEntryLocalService.updateEntry(
+			userId, entryId, title, subtitle, urlTitle, description, content,
+			displayDate, true, true, new String[0], coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	/**
 	 * @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	 *             String, String, String, int, int, int, int, int, boolean,
 	 *             boolean, String[], String, ImageSelector, ImageSelector,
@@ -699,44 +740,6 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
 			serviceContext);
-	}
-
-	/**
-	 * Updates a blogs entry
-	 *
-	 * @param  entryId the blogs entry's ID
-	 * @param  title the blogs entry's title
-	 * @param  subtitle the blogs entry's subtitle
-	 * @param  urlTitle the blogs entry's urlTitle
-	 * @param  description the blogs entry's description
-	 * @param  content the blogs entry's content
-	 * @param  displayDate the blogs entry's displayDate
-	 * @param  coverImageCaption the blogs entry's cover image caption
-	 * @param  coverImageImageSelector an object containing the data of the
-	 *         blogs's entry cover image, can be {@code null}
-	 * @param  smallImageImageSelector an object containing the data of the
-	 *         blogs's entry small cover image, can be {@code null}
-	 * @param  serviceContext the blogs entry's serviceContext; at least it must
-	 *         contain the {@code groupId}
-	 * @return the updated blogs entry
-	 * @review
-	 */
-	@Override
-	public BlogsEntry updateEntry(
-			long entryId, String title, String subtitle, String urlTitle,
-			String description, String content, Date displayDate,
-			String coverImageCaption, ImageSelector coverImageImageSelector,
-			ImageSelector smallImageImageSelector,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_blogsEntryFolderModelResourcePermission.check(
-			getPermissionChecker(), entryId, ActionKeys.UPDATE);
-
-		return blogsEntryLocalService.updateEntry(
-			getUserId(), entryId, title, subtitle, urlTitle, description,
-			content, displayDate, true, true, new String[0], coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -22,6 +22,8 @@ import com.liferay.blogs.util.comparator.EntryIdComparator;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
+import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceMode;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -70,45 +72,6 @@ import java.util.List;
  * @author Mate Thurzo
  */
 public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
-
-	/**
-	 * Creates a new blogs entry
-	 *
-	 * @param  userId the blogs entry's author ID
-	 * @param  title the blogs entry's title
-	 * @param  subtitle the blogs entry's subtitle
-	 * @param  urlTitle the blogs entry's urlTitle
-	 * @param  description the blogs entry's description
-	 * @param  content the blogs entry's content
-	 * @param  displayDate the blogs entry's displayDate
-	 * @param  coverImageCaption the blogs entry's cover image caption
-	 * @param  coverImageImageSelector an object containing the data of the
-	 *         blogs's entry cover image, can be {@code null}
-	 * @param  smallImageImageSelector an object containing the data of the
-	 *         blogs's entry small cover image, can be {@code null}
-	 * @param  serviceContext the blogs entry's serviceContext; at least it must
-	 *         contain the {@code groupId}
-	 * @return the created blogs entry
-	 * @review
-	 */
-	@Override
-	public BlogsEntry addEntry(
-			long userId, String title, String subtitle, String urlTitle,
-			String description, String content, Date displayDate,
-			String coverImageCaption, ImageSelector coverImageImageSelector,
-			ImageSelector smallImageImageSelector,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_portletResourcePermission.check(
-			getPermissionChecker(), serviceContext.getScopeGroupId(),
-			ActionKeys.ADD_ENTRY);
-
-		return blogsEntryLocalService.addEntry(
-			userId, title, subtitle, urlTitle, description, content,
-			displayDate, true, true, new String[0], coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
-	}
 
 	/**
 	 * @deprecated As of 1.1.0, replaced by {@link #addEntry(String, String,
@@ -593,6 +556,46 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 		return exportToRSS(
 			name, name, type, version, displayStyle, feedURL, entryURL,
 			blogsEntries, themeDisplay);
+	}
+
+	/**
+	 * Imports a blogs entry
+	 *
+	 * @param  userId the blogs entry's author ID
+	 * @param  title the blogs entry's title
+	 * @param  subtitle the blogs entry's subtitle
+	 * @param  urlTitle the blogs entry's urlTitle
+	 * @param  description the blogs entry's description
+	 * @param  content the blogs entry's content
+	 * @param  displayDate the blogs entry's displayDate
+	 * @param  coverImageCaption the blogs entry's cover image caption
+	 * @param  coverImageImageSelector an object containing the data of the
+	 *         blogs's entry cover image, can be {@code null}
+	 * @param  smallImageImageSelector an object containing the data of the
+	 *         blogs's entry small cover image, can be {@code null}
+	 * @param  serviceContext the blogs entry's serviceContext; at least it must
+	 *         contain the {@code groupId}
+	 * @return the created blogs entry
+	 * @review
+	 */
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
+	@Override
+	public BlogsEntry importEntry(
+			long userId, String title, String subtitle, String urlTitle,
+			String description, String content, Date displayDate,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), serviceContext.getScopeGroupId(),
+			ActionKeys.EXPORT_IMPORT_PORTLET_INFO);
+
+		return blogsEntryLocalService.addEntry(
+			userId, title, subtitle, urlTitle, description, content,
+			displayDate, true, true, new String[0], coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -147,6 +147,44 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			serviceContext);
 	}
 
+	/**
+	 * Adds a new blogs entry
+	 *
+	 * @param  title the blogs entry's title
+	 * @param  subtitle the blogs entry's subtitle
+	 * @param  urlTitle the blogs entry's urlTitle
+	 * @param  description the blogs entry's description
+	 * @param  content the blogs entry's content
+	 * @param  displayDate the blogs entry's displayDate
+	 * @param  coverImageCaption the blogs entry's cover image caption
+	 * @param  coverImageImageSelector an object containing the data of the
+	 *         blogs's entry cover image, can be {@code null}
+	 * @param  smallImageImageSelector an object containing the data of the
+	 *         blogs's entry small cover image, can be {@code null}
+	 * @param  serviceContext the blogs entry's serviceContext; at least it must
+	 *         contain the {@code groupId}
+	 * @return the created blogs entry
+	 * @review
+	 */
+	@Override
+	public BlogsEntry addEntry(
+			String title, String subtitle, String urlTitle, String description,
+			String content, Date displayDate, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), serviceContext.getScopeGroupId(),
+			ActionKeys.ADD_ENTRY);
+
+		return blogsEntryLocalService.addEntry(
+			getUserId(), title, subtitle, urlTitle, description, content,
+			displayDate, true, true, new String[0], coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
 	@Override
 	public BlogsEntry addEntry(
 			String title, String subtitle, String urlTitle, String description,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -145,6 +145,44 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			serviceContext);
 	}
 
+	/**
+	 * Creates a new blogs entry
+	 *
+	 * @param  title the blogs entry's title
+	 * @param  subtitle the blogs entry's subtitle
+	 * @param  urlTitle the blogs entry's urlTitle
+	 * @param  description the blogs entry's description
+	 * @param  content the blogs entry's content
+	 * @param  displayDate the blogs entry's displayDate
+	 * @param  coverImageCaption the blogs entry's cover image caption
+	 * @param  coverImageImageSelector an object containing the data of the
+	 *         blogs's entry cover image, can be {@code null}
+	 * @param  smallImageImageSelector an object containing the data of the
+	 *         blogs's entry small cover image, can be {@code null}
+	 * @param  serviceContext the blogs entry's serviceContext; at least it must
+	 *         contain the {@code groupId}
+	 * @return the created blogs entry
+	 * @review
+	 */
+	@Override
+	public BlogsEntry addEntry(
+			String title, String subtitle, String urlTitle, String description,
+			String content, Date displayDate, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), serviceContext.getScopeGroupId(),
+			ActionKeys.ADD_ENTRY);
+
+		return blogsEntryLocalService.addEntry(
+			getUserId(), title, subtitle, urlTitle, description, content,
+			displayDate, true, true, new String[0], coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
 	@Override
 	public BlogsEntry addEntry(
 			String title, String subtitle, String urlTitle, String description,
@@ -661,6 +699,44 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
 			serviceContext);
+	}
+
+	/**
+	 * Updates a blogs entry
+	 *
+	 * @param  entryId the blogs entry's ID
+	 * @param  title the blogs entry's title
+	 * @param  subtitle the blogs entry's subtitle
+	 * @param  urlTitle the blogs entry's urlTitle
+	 * @param  description the blogs entry's description
+	 * @param  content the blogs entry's content
+	 * @param  displayDate the blogs entry's displayDate
+	 * @param  coverImageCaption the blogs entry's cover image caption
+	 * @param  coverImageImageSelector an object containing the data of the
+	 *         blogs's entry cover image, can be {@code null}
+	 * @param  smallImageImageSelector an object containing the data of the
+	 *         blogs's entry small cover image, can be {@code null}
+	 * @param  serviceContext the blogs entry's serviceContext; at least it must
+	 *         contain the {@code groupId}
+	 * @return the updated blogs entry
+	 * @review
+	 */
+	@Override
+	public BlogsEntry updateEntry(
+			long entryId, String title, String subtitle, String urlTitle,
+			String description, String content, Date displayDate,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_blogsEntryFolderModelResourcePermission.check(
+			getPermissionChecker(), entryId, ActionKeys.UPDATE);
+
+		return blogsEntryLocalService.updateEntry(
+			getUserId(), entryId, title, subtitle, urlTitle, description,
+			content, displayDate, true, true, new String[0], coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -631,46 +631,6 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	}
 
 	/**
-	 * Updates a blogs entry
-	 *
-	 * @param  entryId the blogs entry's ID
-	 * @param  userId the blogs entry's author ID
-	 * @param  title the blogs entry's title
-	 * @param  subtitle the blogs entry's subtitle
-	 * @param  urlTitle the blogs entry's urlTitle
-	 * @param  description the blogs entry's description
-	 * @param  content the blogs entry's content
-	 * @param  displayDate the blogs entry's displayDate
-	 * @param  coverImageCaption the blogs entry's cover image caption
-	 * @param  coverImageImageSelector an object containing the data of the
-	 *         blogs's entry cover image, can be {@code null}
-	 * @param  smallImageImageSelector an object containing the data of the
-	 *         blogs's entry small cover image, can be {@code null}
-	 * @param  serviceContext the blogs entry's serviceContext; at least it must
-	 *         contain the {@code groupId}
-	 * @return the updated blogs entry
-	 * @review
-	 */
-	@Override
-	public BlogsEntry updateEntry(
-			long entryId, long userId, String title, String subtitle,
-			String urlTitle, String description, String content,
-			Date displayDate, String coverImageCaption,
-			ImageSelector coverImageImageSelector,
-			ImageSelector smallImageImageSelector,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_blogsEntryFolderModelResourcePermission.check(
-			getPermissionChecker(), entryId, ActionKeys.UPDATE);
-
-		return blogsEntryLocalService.updateEntry(
-			userId, entryId, title, subtitle, urlTitle, description, content,
-			displayDate, true, true, new String[0], coverImageCaption,
-			coverImageImageSelector, smallImageImageSelector, serviceContext);
-	}
-
-	/**
 	 * @deprecated As of 1.1.0, replaced by {@link #updateEntry(long, String,
 	 *             String, String, String, int, int, int, int, int, boolean,
 	 *             boolean, String[], String, ImageSelector, ImageSelector,
@@ -743,6 +703,44 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
 			serviceContext);
+	}
+
+	/**
+	 * Updates a blogs entry
+	 *
+	 * @param  entryId the blogs entry's ID
+	 * @param  title the blogs entry's title
+	 * @param  subtitle the blogs entry's subtitle
+	 * @param  urlTitle the blogs entry's urlTitle
+	 * @param  description the blogs entry's description
+	 * @param  content the blogs entry's content
+	 * @param  displayDate the blogs entry's displayDate
+	 * @param  coverImageCaption the blogs entry's cover image caption
+	 * @param  coverImageImageSelector an object containing the data of the
+	 *         blogs's entry cover image, can be {@code null}
+	 * @param  smallImageImageSelector an object containing the data of the
+	 *         blogs's entry small cover image, can be {@code null}
+	 * @param  serviceContext the blogs entry's serviceContext; at least it must
+	 *         contain the {@code groupId}
+	 * @return the updated blogs entry
+	 * @review
+	 */
+	@Override
+	public BlogsEntry updateEntry(
+			long entryId, String title, String subtitle, String urlTitle,
+			String description, String content, Date displayDate,
+			String coverImageCaption, ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_blogsEntryFolderModelResourcePermission.check(
+			getPermissionChecker(), entryId, ActionKeys.UPDATE);
+
+		return blogsEntryLocalService.updateEntry(
+			getUserId(), entryId, title, subtitle, urlTitle, description,
+			content, displayDate, true, true, new String[0], coverImageCaption,
+			coverImageImageSelector, smallImageImageSelector, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/headless-apio/blog/blog-apio-impl/build.gradle
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/build.gradle
@@ -3,6 +3,7 @@ targetCompatibility = "1.8"
 
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:apio-architect:apio-architect-api")
 	compileOnly project(":apps:blogs:blogs-api")

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -70,9 +70,11 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's alternative headline
+	 * Returns the blog posting's alternative headline if present. Returns an
+	 * empty {@code String} otherwise.
 	 *
-	 * @return the blog posting's alternative headline
+	 * @return the blog posting's alternative headline if present; an empty
+	 *         {@code String} otherwise
 	 * @review
 	 */
 	public String getAlternativeHeadline() {
@@ -94,8 +96,8 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's author ID, if present on the form. Returns the
-	 * {@link CurrentUser} ID otherwise.
+	 * Returns the blog posting's author ID if present. Returns the {@link
+	 * CurrentUser} ID otherwise.
 	 *
 	 * @param  currentUser the current authenticated user
 	 * @return the blog posting's author ID, if present; the {@link CurrentUser}
@@ -110,9 +112,11 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's description
+	 * Returns the blog posting's description if present. Returns an empty
+	 * {@code String} otherwise.
 	 *
-	 * @return the blog posting's description
+	 * @return the blog posting's description if present; an empty {@code
+	 *         String} otherwise
 	 * @review
 	 */
 	public String getDescription() {
@@ -124,9 +128,11 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's display date
+	 * Returns the blog posting's display date if present. Returns today's date
+	 * otherwise.
 	 *
-	 * @return the blog posting's display date
+	 * @return the blog posting's display date if present; today's date
+	 *         otherwise.
 	 * @review
 	 */
 	public Date getDisplayDate() {
@@ -148,9 +154,11 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's semantic URL
+	 * Returns the blog posting's semantic URL if present. Returns an empty
+	 * {@code String} otherwise.
 	 *
-	 * @return the blog posting's semantic URL
+	 * @return the blog posting's semantic URL if present; an empty {@code
+	 *         String} otherwise
 	 * @review
 	 */
 	public String getSemanticUrl() {

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -53,12 +53,12 @@ public class BlogPostingForm {
 			"dateCreated", BlogPostingForm::_setCreateDate
 		).addOptionalDate(
 			"dateModified", BlogPostingForm::_setModifiedDate
-		).addRequiredString(
+		).addOptionalString(
 			"alternativeHeadline", BlogPostingForm::_setAlternativeHeadline
+		).addOptionalString(
+			"description", BlogPostingForm::_setDescription
 		).addRequiredString(
 			"articleBody", BlogPostingForm::_setArticleBody
-		).addRequiredString(
-			"description", BlogPostingForm::_setDescription
 		).addRequiredString(
 			"headline", BlogPostingForm::_setHeadline
 		).build();
@@ -71,7 +71,11 @@ public class BlogPostingForm {
 	 * @review
 	 */
 	public String getAlternativeHeadline() {
-		return _alternativeHeadline;
+		return Optional.ofNullable(
+			_alternativeHeadline
+		).orElse(
+			""
+		);
 	}
 
 	/**
@@ -91,7 +95,11 @@ public class BlogPostingForm {
 	 * @review
 	 */
 	public String getDescription() {
-		return _description;
+		return Optional.ofNullable(
+			_description
+		).orElse(
+			""
+		);
 	}
 
 	/**

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -18,8 +18,8 @@ import com.liferay.apio.architect.form.Form;
 import com.liferay.apio.architect.form.Form.Builder;
 import com.liferay.portal.kernel.service.ServiceContext;
 
-import java.util.Calendar;
 import java.util.Date;
+import java.util.Optional;
 
 /**
  * Instances of this class represent the values extracted from a blog posting
@@ -48,11 +48,11 @@ public class BlogPostingForm {
 		).constructor(
 			BlogPostingForm::new
 		).addOptionalDate(
+			"dateDisplayed", BlogPostingForm::_setDisplayDate
+		).addOptionalDate(
 			"dateCreated", BlogPostingForm::_setCreateDate
 		).addOptionalDate(
 			"dateModified", BlogPostingForm::_setModifiedDate
-		).addRequiredDate(
-			"dateDisplayed", BlogPostingForm::_setDisplayDate
 		).addRequiredString(
 			"alternativeHeadline", BlogPostingForm::_setAlternativeHeadline
 		).addRequiredString(
@@ -95,53 +95,17 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's display date day
+	 * Returns the blog posting's display date
 	 *
-	 * @return the blog posting's display date day
+	 * @return the blog posting's display date
 	 * @review
 	 */
-	public int getDisplayDateDay() {
-		return _displayDateDay;
-	}
-
-	/**
-	 * Returns the blog posting's display date hour
-	 *
-	 * @return the blog posting's display date hour
-	 * @review
-	 */
-	public int getDisplayDateHour() {
-		return _displayDateHour;
-	}
-
-	/**
-	 * Returns the blog posting's display date minute
-	 *
-	 * @return the blog posting's display date minute
-	 * @review
-	 */
-	public int getDisplayDateMinute() {
-		return _displayDateMinute;
-	}
-
-	/**
-	 * Returns the blog posting's display date month
-	 *
-	 * @return the blog posting's display date month
-	 * @review
-	 */
-	public int getDisplayDateMonth() {
-		return _displayDateMonth;
-	}
-
-	/**
-	 * Returns the blog posting's display date year
-	 *
-	 * @return the blog posting's display date year
-	 * @review
-	 */
-	public int getDisplayDateYear() {
-		return _displayDateYear;
+	public Date getDisplayDate() {
+		return Optional.ofNullable(
+			_displayDate
+		).orElseGet(
+			Date::new
+		);
 	}
 
 	/**
@@ -157,7 +121,7 @@ public class BlogPostingForm {
 	/**
 	 * Returns the service context related with this form
 	 *
-	 * @param groupId the group ID
+	 * @param  groupId the group ID
 	 * @return the service context
 	 * @review
 	 */
@@ -196,15 +160,7 @@ public class BlogPostingForm {
 	}
 
 	private void _setDisplayDate(Date displayDate) {
-		Calendar calendar = Calendar.getInstance();
-
-		calendar.setTime(displayDate);
-
-		_displayDateMonth = calendar.get(Calendar.MONTH);
-		_displayDateDay = calendar.get(Calendar.DATE);
-		_displayDateYear = calendar.get(Calendar.YEAR);
-		_displayDateHour = calendar.get(Calendar.HOUR);
-		_displayDateMinute = calendar.get(Calendar.MINUTE);
+		_displayDate = displayDate;
 	}
 
 	private void _setHeadline(String headline) {
@@ -219,11 +175,7 @@ public class BlogPostingForm {
 	private String _articleBody;
 	private Date _createDate;
 	private String _description;
-	private int _displayDateDay;
-	private int _displayDateHour;
-	private int _displayDateMinute;
-	private int _displayDateMonth;
-	private int _displayDateYear;
+	private Date _displayDate;
 	private String _headline;
 	private Date _modifiedDate;
 

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -14,8 +14,6 @@
 
 package com.liferay.blog.apio.internal.architect.form;
 
-import static com.liferay.portal.kernel.util.Validator.isNotNull;
-
 import com.liferay.apio.architect.form.Form;
 import com.liferay.apio.architect.form.Form.Builder;
 import com.liferay.apio.architect.function.throwable.ThrowableFunction;
@@ -120,6 +118,7 @@ public class BlogPostingForm {
 	 * @param  currentUser the current authenticated user
 	 * @return the blog posting's author ID, if present; the {@link CurrentUser}
 	 *         ID otherwise.
+	 * @review
 	 */
 	public long getAuthorId(CurrentUser currentUser) {
 		return Optional.ofNullable(
@@ -172,19 +171,19 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's image caption if both caption and image are
-	 * present. Returns {@code null} otherwise.
+	 * Returns the blog posting's image caption if present. Returns empty {@code
+	 * String} otherwise.
 	 *
-	 * @return the blog posting's image caption if both caption and image are
-	 *         present; {@code null} otherwise
+	 * @return the blog posting's image caption if present; empty {@code String}
+	 *         otherwise
 	 * @review
 	 */
 	public String getImageCaption() {
-		if (isNotNull(_imageCaption) && isNotNull(_imageId)) {
-			return _imageCaption;
-		}
-
-		return null;
+		return Optional.ofNullable(
+			_imageCaption
+		).orElse(
+			""
+		);
 	}
 
 	/**

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -18,8 +18,11 @@ import com.liferay.apio.architect.form.Form;
 import com.liferay.apio.architect.form.Form.Builder;
 import com.liferay.portal.apio.user.CurrentUser;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -62,6 +65,8 @@ public class BlogPostingForm {
 			"description", BlogPostingForm::_setDescription
 		).addOptionalString(
 			"semanticUrl", BlogPostingForm::_setSemanticUrl
+		).addOptionalStringList(
+			"keywords", BlogPostingForm::_setKeywords
 		).addRequiredString(
 			"articleBody", BlogPostingForm::_setArticleBody
 		).addRequiredString(
@@ -191,6 +196,10 @@ public class BlogPostingForm {
 			serviceContext.setModifiedDate(_modifiedDate);
 		}
 
+		if (ListUtil.isNotEmpty(_keywords)) {
+			serviceContext.setAssetTagNames(ArrayUtil.toStringArray(_keywords));
+		}
+
 		return serviceContext;
 	}
 
@@ -222,6 +231,10 @@ public class BlogPostingForm {
 		_headline = headline;
 	}
 
+	private void _setKeywords(List<String> keywords) {
+		_keywords = keywords;
+	}
+
 	private void _setModifiedDate(Date modifiedDate) {
 		_modifiedDate = modifiedDate;
 	}
@@ -237,6 +250,7 @@ public class BlogPostingForm {
 	private String _description;
 	private Date _displayDate;
 	private String _headline;
+	private List<String> _keywords;
 	private Date _modifiedDate;
 	private String _semanticUrl;
 

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -47,6 +47,10 @@ public class BlogPostingForm {
 			__ -> "This form can be used to create or update a blog posting"
 		).constructor(
 			BlogPostingForm::new
+		).addOptionalDate(
+			"dateCreated", BlogPostingForm::_setCreateDate
+		).addOptionalDate(
+			"dateModified", BlogPostingForm::_setModifiedDate
 		).addRequiredDate(
 			"dateDisplayed", BlogPostingForm::_setDisplayDate
 		).addRequiredString(
@@ -164,6 +168,14 @@ public class BlogPostingForm {
 		serviceContext.setAddGuestPermissions(true);
 		serviceContext.setScopeGroupId(groupId);
 
+		if (_createDate != null) {
+			serviceContext.setCreateDate(_createDate);
+		}
+
+		if (_modifiedDate != null) {
+			serviceContext.setModifiedDate(_modifiedDate);
+		}
+
 		return serviceContext;
 	}
 
@@ -173,6 +185,10 @@ public class BlogPostingForm {
 
 	private void _setArticleBody(String articleBody) {
 		_articleBody = articleBody;
+	}
+
+	private void _setCreateDate(Date createDate) {
+		_createDate = createDate;
 	}
 
 	private void _setDescription(String description) {
@@ -195,8 +211,13 @@ public class BlogPostingForm {
 		_headline = headline;
 	}
 
+	private void _setModifiedDate(Date modifiedDate) {
+		_modifiedDate = modifiedDate;
+	}
+
 	private String _alternativeHeadline;
 	private String _articleBody;
+	private Date _createDate;
 	private String _description;
 	private int _displayDateDay;
 	private int _displayDateHour;
@@ -204,5 +225,6 @@ public class BlogPostingForm {
 	private int _displayDateMonth;
 	private int _displayDateYear;
 	private String _headline;
+	private Date _modifiedDate;
 
 }

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -16,6 +16,7 @@ package com.liferay.blog.apio.internal.architect.form;
 
 import com.liferay.apio.architect.form.Form;
 import com.liferay.apio.architect.form.Form.Builder;
+import com.liferay.portal.apio.user.CurrentUser;
 import com.liferay.portal.kernel.service.ServiceContext;
 
 import java.util.Date;
@@ -53,10 +54,14 @@ public class BlogPostingForm {
 			"dateCreated", BlogPostingForm::_setCreateDate
 		).addOptionalDate(
 			"dateModified", BlogPostingForm::_setModifiedDate
+		).addOptionalLong(
+			"author", BlogPostingForm::_setAuthorId
 		).addOptionalString(
 			"alternativeHeadline", BlogPostingForm::_setAlternativeHeadline
 		).addOptionalString(
 			"description", BlogPostingForm::_setDescription
+		).addOptionalString(
+			"semanticUrl", BlogPostingForm::_setSemanticUrl
 		).addRequiredString(
 			"articleBody", BlogPostingForm::_setArticleBody
 		).addRequiredString(
@@ -86,6 +91,22 @@ public class BlogPostingForm {
 	 */
 	public String getArticleBody() {
 		return _articleBody;
+	}
+
+	/**
+	 * Returns the blog posting's author ID, if present on the form. Returns the
+	 * {@link CurrentUser} ID otherwise.
+	 *
+	 * @param  currentUser the current authenticated user
+	 * @return the blog posting's author ID, if present; the {@link CurrentUser}
+	 *         ID otherwise.
+	 */
+	public long getAuthorId(CurrentUser currentUser) {
+		return Optional.ofNullable(
+			_authorId
+		).orElseGet(
+			currentUser::getUserId
+		);
 	}
 
 	/**
@@ -127,6 +148,20 @@ public class BlogPostingForm {
 	}
 
 	/**
+	 * Returns the blog posting's semantic URL
+	 *
+	 * @return the blog posting's semantic URL
+	 * @review
+	 */
+	public String getSemanticUrl() {
+		return Optional.ofNullable(
+			_semanticUrl
+		).orElse(
+			""
+		);
+	}
+
+	/**
 	 * Returns the service context related with this form
 	 *
 	 * @param  groupId the group ID
@@ -159,6 +194,10 @@ public class BlogPostingForm {
 		_articleBody = articleBody;
 	}
 
+	private void _setAuthorId(long authorId) {
+		_authorId = authorId;
+	}
+
 	private void _setCreateDate(Date createDate) {
 		_createDate = createDate;
 	}
@@ -179,12 +218,18 @@ public class BlogPostingForm {
 		_modifiedDate = modifiedDate;
 	}
 
+	private void _setSemanticUrl(String semanticUrl) {
+		_semanticUrl = semanticUrl;
+	}
+
 	private String _alternativeHeadline;
 	private String _articleBody;
+	private Long _authorId;
 	private Date _createDate;
 	private String _description;
 	private Date _displayDate;
 	private String _headline;
 	private Date _modifiedDate;
+	private String _semanticUrl;
 
 }

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -16,6 +16,7 @@ package com.liferay.blog.apio.internal.architect.form;
 
 import com.liferay.apio.architect.form.Form;
 import com.liferay.apio.architect.form.Form.Builder;
+import com.liferay.portal.kernel.service.ServiceContext;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -147,6 +148,23 @@ public class BlogPostingForm {
 	 */
 	public String getHeadline() {
 		return _headline;
+	}
+
+	/**
+	 * Returns the service context related with this form
+	 *
+	 * @param groupId the group ID
+	 * @return the service context
+	 * @review
+	 */
+	public ServiceContext getServiceContext(long groupId) {
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+		serviceContext.setScopeGroupId(groupId);
+
+		return serviceContext;
 	}
 
 	private void _setAlternativeHeadline(String alternativeHeadline) {

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/form/BlogPostingForm.java
@@ -18,7 +18,6 @@ import com.liferay.apio.architect.form.Form;
 import com.liferay.apio.architect.form.Form.Builder;
 import com.liferay.apio.architect.function.throwable.ThrowableFunction;
 import com.liferay.apio.architect.functional.Try;
-import com.liferay.portal.apio.user.CurrentUser;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
@@ -112,20 +111,15 @@ public class BlogPostingForm {
 	}
 
 	/**
-	 * Returns the blog posting's author ID if present. Returns the {@link
-	 * CurrentUser} ID otherwise.
+	 * Returns the blog posting's author ID if present. Returns {@code
+	 * Optional#empty()} otherwise.
 	 *
-	 * @param  currentUser the current authenticated user
-	 * @return the blog posting's author ID, if present; the {@link CurrentUser}
-	 *         ID otherwise.
+	 * @return the blog posting's author ID, if present; {@code Optional#empty()}
+	 *         otherwise.
 	 * @review
 	 */
-	public long getAuthorId(CurrentUser currentUser) {
-		return Optional.ofNullable(
-			_authorId
-		).orElseGet(
-			currentUser::getUserId
-		);
+	public Optional<Long> getAuthorIdOptional() {
+		return Optional.ofNullable(_authorId);
 	}
 
 	/**

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
@@ -139,12 +139,6 @@ public class BlogPostingNestedCollectionResource
 			long groupId, BlogPostingForm blogPostingForm)
 		throws PortalException {
 
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setAddGroupPermissions(true);
-		serviceContext.setAddGuestPermissions(true);
-		serviceContext.setScopeGroupId(groupId);
-
 		return _blogsService.addEntry(
 			blogPostingForm.getHeadline(),
 			blogPostingForm.getAlternativeHeadline(),
@@ -154,7 +148,7 @@ public class BlogPostingNestedCollectionResource
 			blogPostingForm.getDisplayDateYear(),
 			blogPostingForm.getDisplayDateHour(),
 			blogPostingForm.getDisplayDateMinute(), false, false, null, null,
-			null, null, serviceContext);
+			null, null, blogPostingForm.getServiceContext(groupId));
 	}
 
 	private PageItems<BlogsEntry> _getPageItems(
@@ -173,14 +167,10 @@ public class BlogPostingNestedCollectionResource
 			long blogsEntryId, BlogPostingForm blogPostingForm)
 		throws PortalException {
 
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setAddGroupPermissions(true);
-		serviceContext.setAddGuestPermissions(true);
-
 		BlogsEntry blogsEntry = _blogsService.getEntry(blogsEntryId);
 
-		serviceContext.setScopeGroupId(blogsEntry.getGroupId());
+		ServiceContext serviceContext = blogPostingForm.getServiceContext(
+			blogsEntry.getGroupId());
 
 		return _blogsService.updateEntry(
 			blogsEntryId, blogPostingForm.getHeadline(),

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
@@ -33,6 +33,7 @@ import com.liferay.media.object.apio.architect.identifier.MediaObjectIdentifier;
 import com.liferay.person.apio.architect.identifier.PersonIdentifier;
 import com.liferay.portal.apio.identifier.ClassNameClassPK;
 import com.liferay.portal.apio.permission.HasPermission;
+import com.liferay.portal.apio.user.CurrentUser;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -64,7 +65,7 @@ public class BlogPostingNestedCollectionResource
 		return builder.addGetter(
 			this::_getPageItems
 		).addCreator(
-			this::_addBlogsEntry,
+			this::_addBlogsEntry, CurrentUser.class,
 			_hasPermission.forAddingIn(WebSiteIdentifier.class),
 			BlogPostingForm::buildForm
 		).build();
@@ -85,8 +86,8 @@ public class BlogPostingNestedCollectionResource
 			idempotent(_blogsEntryService::deleteEntry),
 			_hasPermission::forDeleting
 		).addUpdater(
-			this::_updateBlogsEntry, _hasPermission::forUpdating,
-			BlogPostingForm::buildForm
+			this::_updateBlogsEntry, CurrentUser.class,
+			_hasPermission::forUpdating, BlogPostingForm::buildForm
 		).build();
 	}
 
@@ -137,17 +138,17 @@ public class BlogPostingNestedCollectionResource
 	}
 
 	private BlogsEntry _addBlogsEntry(
-			long groupId, BlogPostingForm blogPostingForm)
+			long groupId, BlogPostingForm blogPostingForm,
+			CurrentUser currentUser)
 		throws PortalException {
 
-		String urlTitle = "";
-
 		return _blogsEntryService.addEntry(
+			blogPostingForm.getAuthorId(currentUser),
 			blogPostingForm.getHeadline(),
-			blogPostingForm.getAlternativeHeadline(), urlTitle,
-			blogPostingForm.getDescription(), blogPostingForm.getArticleBody(),
-			blogPostingForm.getDisplayDate(), null, null, null,
-			blogPostingForm.getServiceContext(groupId));
+			blogPostingForm.getAlternativeHeadline(),
+			blogPostingForm.getSemanticUrl(), blogPostingForm.getDescription(),
+			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),
+			null, null, null, blogPostingForm.getServiceContext(groupId));
 	}
 
 	private PageItems<BlogsEntry> _getPageItems(
@@ -163,10 +164,9 @@ public class BlogPostingNestedCollectionResource
 	}
 
 	private BlogsEntry _updateBlogsEntry(
-			long blogsEntryId, BlogPostingForm blogPostingForm)
+			long blogsEntryId, BlogPostingForm blogPostingForm,
+			CurrentUser currentUser)
 		throws PortalException {
-
-		String urlTitle = "";
 
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogsEntryId);
 
@@ -174,10 +174,12 @@ public class BlogPostingNestedCollectionResource
 			blogsEntry.getGroupId());
 
 		return _blogsEntryService.updateEntry(
-			blogsEntryId, blogPostingForm.getHeadline(),
-			blogPostingForm.getAlternativeHeadline(), urlTitle,
-			blogPostingForm.getDescription(), blogPostingForm.getArticleBody(),
-			blogPostingForm.getDisplayDate(), null, null, null, serviceContext);
+			blogsEntryId, blogPostingForm.getAuthorId(currentUser),
+			blogPostingForm.getHeadline(),
+			blogPostingForm.getAlternativeHeadline(),
+			blogPostingForm.getSemanticUrl(), blogPostingForm.getDescription(),
+			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),
+			null, null, null, serviceContext);
 	}
 
 	@Reference

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
@@ -32,13 +32,13 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryService;
 import com.liferay.category.apio.architect.identifier.CategoryIdentifier;
 import com.liferay.comment.apio.architect.identifier.CommentIdentifier;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.media.object.apio.architect.identifier.MediaObjectIdentifier;
 import com.liferay.person.apio.architect.identifier.PersonIdentifier;
 import com.liferay.portal.apio.identifier.ClassNameClassPK;
 import com.liferay.portal.apio.permission.HasPermission;
 import com.liferay.portal.apio.user.CurrentUser;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.site.apio.architect.identifier.WebSiteIdentifier;
@@ -154,7 +154,9 @@ public class BlogPostingNestedCollectionResource
 			blogPostingForm.getAlternativeHeadline(),
 			blogPostingForm.getSemanticUrl(), blogPostingForm.getDescription(),
 			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),
-			null, null, null, blogPostingForm.getServiceContext(groupId));
+			blogPostingForm.getImageCaption(),
+			blogPostingForm.getImageSelector(_dlAppLocalService::getFileEntry),
+			null, blogPostingForm.getServiceContext(groupId));
 	}
 
 	private List<String> _getBlogsEntryTags(BlogsEntry blogsEntry) {
@@ -183,16 +185,15 @@ public class BlogPostingNestedCollectionResource
 
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogsEntryId);
 
-		ServiceContext serviceContext = blogPostingForm.getServiceContext(
-			blogsEntry.getGroupId());
-
 		return _blogsEntryService.updateEntry(
 			blogsEntryId, blogPostingForm.getAuthorId(currentUser),
 			blogPostingForm.getHeadline(),
 			blogPostingForm.getAlternativeHeadline(),
 			blogPostingForm.getSemanticUrl(), blogPostingForm.getDescription(),
 			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),
-			null, null, null, serviceContext);
+			blogPostingForm.getImageCaption(),
+			blogPostingForm.getImageSelector(_dlAppLocalService::getFileEntry),
+			null, blogPostingForm.getServiceContext(blogsEntry.getGroupId()));
 	}
 
 	@Reference
@@ -200,6 +201,9 @@ public class BlogPostingNestedCollectionResource
 
 	@Reference
 	private BlogsEntryService _blogsEntryService;
+
+	@Reference
+	private DLAppLocalService _dlAppLocalService;
 
 	@Reference(target = "(model.class.name=com.liferay.blogs.model.BlogsEntry)")
 	private HasPermission<Long> _hasPermission;

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
@@ -37,13 +37,15 @@ import com.liferay.media.object.apio.architect.identifier.MediaObjectIdentifier;
 import com.liferay.person.apio.architect.identifier.PersonIdentifier;
 import com.liferay.portal.apio.identifier.ClassNameClassPK;
 import com.liferay.portal.apio.permission.HasPermission;
-import com.liferay.portal.apio.user.CurrentUser;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.site.apio.architect.identifier.WebSiteIdentifier;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,7 +71,7 @@ public class BlogPostingNestedCollectionResource
 		return builder.addGetter(
 			this::_getPageItems
 		).addCreator(
-			this::_addBlogsEntry, CurrentUser.class,
+			this::_addBlogsEntry,
 			_hasPermission.forAddingIn(WebSiteIdentifier.class),
 			BlogPostingForm::buildForm
 		).build();
@@ -90,8 +92,8 @@ public class BlogPostingNestedCollectionResource
 			idempotent(_blogsEntryService::deleteEntry),
 			_hasPermission::forDeleting
 		).addUpdater(
-			this::_updateBlogsEntry, CurrentUser.class,
-			_hasPermission::forUpdating, BlogPostingForm::buildForm
+			this::_updateBlogsEntry, _hasPermission::forUpdating,
+			BlogPostingForm::buildForm
 		).build();
 	}
 
@@ -144,19 +146,36 @@ public class BlogPostingNestedCollectionResource
 	}
 
 	private BlogsEntry _addBlogsEntry(
-			long groupId, BlogPostingForm blogPostingForm,
-			CurrentUser currentUser)
+			long groupId, BlogPostingForm blogPostingForm)
 		throws PortalException {
 
+		Optional<Long> optional = blogPostingForm.getAuthorIdOptional();
+
+		ImageSelector imageSelector = blogPostingForm.getImageSelector(
+			_dlAppLocalService::getFileEntry);
+
+		ServiceContext serviceContext = blogPostingForm.getServiceContext(
+			groupId);
+
+		if (optional.isPresent()) {
+			return _blogsEntryService.importEntry(
+				optional.get(), blogPostingForm.getHeadline(),
+				blogPostingForm.getAlternativeHeadline(),
+				blogPostingForm.getSemanticUrl(),
+				blogPostingForm.getDescription(),
+				blogPostingForm.getArticleBody(),
+				blogPostingForm.getDisplayDate(),
+				blogPostingForm.getImageCaption(), imageSelector, null,
+				serviceContext);
+		}
+
 		return _blogsEntryService.addEntry(
-			blogPostingForm.getAuthorId(currentUser),
 			blogPostingForm.getHeadline(),
 			blogPostingForm.getAlternativeHeadline(),
 			blogPostingForm.getSemanticUrl(), blogPostingForm.getDescription(),
 			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),
-			blogPostingForm.getImageCaption(),
-			blogPostingForm.getImageSelector(_dlAppLocalService::getFileEntry),
-			null, blogPostingForm.getServiceContext(groupId));
+			blogPostingForm.getImageCaption(), imageSelector, null,
+			serviceContext);
 	}
 
 	private List<String> _getBlogsEntryTags(BlogsEntry blogsEntry) {
@@ -179,15 +198,13 @@ public class BlogPostingNestedCollectionResource
 	}
 
 	private BlogsEntry _updateBlogsEntry(
-			long blogsEntryId, BlogPostingForm blogPostingForm,
-			CurrentUser currentUser)
+			long blogsEntryId, BlogPostingForm blogPostingForm)
 		throws PortalException {
 
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogsEntryId);
 
 		return _blogsEntryService.updateEntry(
-			blogsEntryId, blogPostingForm.getAuthorId(currentUser),
-			blogPostingForm.getHeadline(),
+			blogsEntryId, blogPostingForm.getHeadline(),
 			blogPostingForm.getAlternativeHeadline(),
 			blogPostingForm.getSemanticUrl(), blogPostingForm.getDescription(),
 			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
@@ -23,6 +23,9 @@ import com.liferay.apio.architect.representor.Representor;
 import com.liferay.apio.architect.resource.NestedCollectionResource;
 import com.liferay.apio.architect.routes.ItemRoutes;
 import com.liferay.apio.architect.routes.NestedCollectionRoutes;
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.model.AssetTagModel;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.blog.apio.architect.identifier.BlogPostingIdentifier;
 import com.liferay.blog.apio.internal.architect.form.BlogPostingForm;
 import com.liferay.blogs.model.BlogsEntry;
@@ -36,6 +39,7 @@ import com.liferay.portal.apio.permission.HasPermission;
 import com.liferay.portal.apio.user.CurrentUser;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.site.apio.architect.identifier.WebSiteIdentifier;
 
@@ -134,6 +138,8 @@ public class BlogPostingNestedCollectionResource
 			"fileFormat", blogsEntry -> "text/html"
 		).addString(
 			"headline", BlogsEntry::getTitle
+		).addStringList(
+			"keywords", this::_getBlogsEntryTags
 		).build();
 	}
 
@@ -149,6 +155,13 @@ public class BlogPostingNestedCollectionResource
 			blogPostingForm.getSemanticUrl(), blogPostingForm.getDescription(),
 			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),
 			null, null, null, blogPostingForm.getServiceContext(groupId));
+	}
+
+	private List<String> _getBlogsEntryTags(BlogsEntry blogsEntry) {
+		List<AssetTag> tags = _assetTagLocalService.getTags(
+			BlogsEntry.class.getName(), blogsEntry.getEntryId());
+
+		return ListUtil.toList(tags, AssetTagModel::getName);
 	}
 
 	private PageItems<BlogsEntry> _getPageItems(
@@ -181,6 +194,9 @@ public class BlogPostingNestedCollectionResource
 			blogPostingForm.getArticleBody(), blogPostingForm.getDisplayDate(),
 			null, null, null, serviceContext);
 	}
+
+	@Reference
+	private AssetTagLocalService _assetTagLocalService;
 
 	@Reference
 	private BlogsEntryService _blogsEntryService;

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
@@ -80,9 +80,10 @@ public class BlogPostingNestedCollectionResource
 		ItemRoutes.Builder<BlogsEntry, Long> builder) {
 
 		return builder.addGetter(
-			_blogsService::getEntry
+			_blogsEntryService::getEntry
 		).addRemover(
-			idempotent(_blogsService::deleteEntry), _hasPermission::forDeleting
+			idempotent(_blogsEntryService::deleteEntry),
+			_hasPermission::forDeleting
 		).addUpdater(
 			this::_updateBlogsEntry, _hasPermission::forUpdating,
 			BlogPostingForm::buildForm
@@ -141,7 +142,7 @@ public class BlogPostingNestedCollectionResource
 
 		String urlTitle = "";
 
-		return _blogsService.addEntry(
+		return _blogsEntryService.addEntry(
 			blogPostingForm.getHeadline(),
 			blogPostingForm.getAlternativeHeadline(), urlTitle,
 			blogPostingForm.getDescription(), blogPostingForm.getArticleBody(),
@@ -152,10 +153,10 @@ public class BlogPostingNestedCollectionResource
 	private PageItems<BlogsEntry> _getPageItems(
 		Pagination pagination, long groupId) {
 
-		List<BlogsEntry> blogsEntries = _blogsService.getGroupEntries(
+		List<BlogsEntry> blogsEntries = _blogsEntryService.getGroupEntries(
 			groupId, WorkflowConstants.STATUS_APPROVED,
 			pagination.getStartPosition(), pagination.getEndPosition());
-		int count = _blogsService.getGroupEntriesCount(
+		int count = _blogsEntryService.getGroupEntriesCount(
 			groupId, WorkflowConstants.STATUS_APPROVED);
 
 		return new PageItems<>(blogsEntries, count);
@@ -167,12 +168,12 @@ public class BlogPostingNestedCollectionResource
 
 		String urlTitle = "";
 
-		BlogsEntry blogsEntry = _blogsService.getEntry(blogsEntryId);
+		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogsEntryId);
 
 		ServiceContext serviceContext = blogPostingForm.getServiceContext(
 			blogsEntry.getGroupId());
 
-		return _blogsService.updateEntry(
+		return _blogsEntryService.updateEntry(
 			blogsEntryId, blogPostingForm.getHeadline(),
 			blogPostingForm.getAlternativeHeadline(), urlTitle,
 			blogPostingForm.getDescription(), blogPostingForm.getArticleBody(),
@@ -180,7 +181,7 @@ public class BlogPostingNestedCollectionResource
 	}
 
 	@Reference
-	private BlogsEntryService _blogsService;
+	private BlogsEntryService _blogsEntryService;
 
 	@Reference(target = "(model.class.name=com.liferay.blogs.model.BlogsEntry)")
 	private HasPermission<Long> _hasPermission;

--- a/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
+++ b/modules/apps/headless-apio/blog/blog-apio-impl/src/main/java/com/liferay/blog/apio/internal/architect/resource/BlogPostingNestedCollectionResource.java
@@ -139,16 +139,14 @@ public class BlogPostingNestedCollectionResource
 			long groupId, BlogPostingForm blogPostingForm)
 		throws PortalException {
 
+		String urlTitle = "";
+
 		return _blogsService.addEntry(
 			blogPostingForm.getHeadline(),
-			blogPostingForm.getAlternativeHeadline(),
+			blogPostingForm.getAlternativeHeadline(), urlTitle,
 			blogPostingForm.getDescription(), blogPostingForm.getArticleBody(),
-			blogPostingForm.getDisplayDateMonth(),
-			blogPostingForm.getDisplayDateDay(),
-			blogPostingForm.getDisplayDateYear(),
-			blogPostingForm.getDisplayDateHour(),
-			blogPostingForm.getDisplayDateMinute(), false, false, null, null,
-			null, null, blogPostingForm.getServiceContext(groupId));
+			blogPostingForm.getDisplayDate(), null, null, null,
+			blogPostingForm.getServiceContext(groupId));
 	}
 
 	private PageItems<BlogsEntry> _getPageItems(
@@ -167,6 +165,8 @@ public class BlogPostingNestedCollectionResource
 			long blogsEntryId, BlogPostingForm blogPostingForm)
 		throws PortalException {
 
+		String urlTitle = "";
+
 		BlogsEntry blogsEntry = _blogsService.getEntry(blogsEntryId);
 
 		ServiceContext serviceContext = blogPostingForm.getServiceContext(
@@ -174,14 +174,9 @@ public class BlogPostingNestedCollectionResource
 
 		return _blogsService.updateEntry(
 			blogsEntryId, blogPostingForm.getHeadline(),
-			blogPostingForm.getAlternativeHeadline(),
+			blogPostingForm.getAlternativeHeadline(), urlTitle,
 			blogPostingForm.getDescription(), blogPostingForm.getArticleBody(),
-			blogPostingForm.getDisplayDateMonth(),
-			blogPostingForm.getDisplayDateDay(),
-			blogPostingForm.getDisplayDateYear(),
-			blogPostingForm.getDisplayDateHour(),
-			blogPostingForm.getDisplayDateMinute(), false, false, null, null,
-			null, null, serviceContext);
+			blogPostingForm.getDisplayDate(), null, null, null, serviceContext);
 	}
 
 	@Reference


### PR DESCRIPTION
Hey @brianchandotcom, I discussed with @JorgeFerrer this morning about how to deal with the "exposing the `userId`" situation and we came up with this proposal. For methods that are intended to be used for importing data into Liferay from our APIs, name them `import*` and don't expose them on JSON-WS. Then check the same permission we are using right now for the LAR export/import. What do you think?