### PR TITLE
LRQA-41272 Remove implicit usage of getFirstPropertyValue in getPathMatchers

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/notifications/test/JournalUserNotificationTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/notifications/test/JournalUserNotificationTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.portlet.notifications.test.BaseUserNotificationTestCase;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -35,6 +36,7 @@ import org.junit.runner.RunWith;
  * @author Roberto Díaz
  * @author Sergio González
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class JournalUserNotificationTest extends BaseUserNotificationTestCase {
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionClassTypeTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionClassTypeTest.java
@@ -38,6 +38,7 @@ import com.liferay.portlet.subscriptions.test.BaseSubscriptionClassTypeTestCase;
 import java.util.List;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -45,6 +46,7 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  * @author Roberto Díaz
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class JournalSubscriptionClassTypeTest
 	extends BaseSubscriptionClassTypeTestCase {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionContainerModelTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionContainerModelTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.portlet.subscriptions.test.BaseSubscriptionContainerModelTestCase;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -34,6 +35,7 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  * @author Roberto Díaz
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class JournalSubscriptionContainerModelTest
 	extends BaseSubscriptionContainerModelTestCase {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionLocalizedContentTest.java
@@ -36,6 +36,7 @@ import javax.portlet.PortletPreferences;
 
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -43,6 +44,7 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  * @author Roberto Díaz
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class JournalSubscriptionLocalizedContentTest
 	extends BaseSubscriptionLocalizedContentTestCase {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionRootContainerModelTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/subscriptions/test/JournalSubscriptionRootContainerModelTest.java
@@ -29,6 +29,7 @@ import com.liferay.portlet.subscriptions.test.BaseSubscriptionRootContainerModel
 
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -36,6 +37,7 @@ import org.junit.runner.RunWith;
  * @author Zsolt Berentey
  * @author Roberto Díaz
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class JournalSubscriptionRootContainerModelTest
 	extends BaseSubscriptionRootContainerModelTestCase {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/BatchTestClassGroup.java
@@ -138,6 +138,11 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 	protected String getFirstMatchingPropertyName(
 		String basePropertyName, Properties properties, String testSuiteName) {
 
+		if (basePropertyName.contains("[") || basePropertyName.contains("]")) {
+			throw new RuntimeException(
+				"Invalid base property name " + basePropertyName);
+		}
+
 		Pattern pattern = Pattern.compile(
 			JenkinsResultsParserUtil.combine(
 				basePropertyName, "\\[(?<batchName>[^\\]]+)\\]",
@@ -173,6 +178,11 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 	}
 
 	protected String getFirstPropertyValue(String basePropertyName) {
+		if (basePropertyName.contains("[") || basePropertyName.contains("]")) {
+			throw new RuntimeException(
+				"Invalid base property name " + basePropertyName);
+		}
+
 		List<String> propertyNames = new ArrayList<>();
 
 		if (testSuiteName != null) {
@@ -218,28 +228,22 @@ public abstract class BatchTestClassGroup extends BaseTestClassGroup {
 	}
 
 	protected List<PathMatcher> getPathMatchers(
-		String propertyName, File workingDirectory) {
-
-		String pluginNamesRelativeGlobs = getFirstPropertyValue(propertyName);
-
-		if ((pluginNamesRelativeGlobs == null) ||
-			pluginNamesRelativeGlobs.isEmpty()) {
-
-			return new ArrayList<>();
-		}
+		String relativeGlobs, File workingDirectory) {
 
 		List<PathMatcher> pathMatchers = new ArrayList<>();
 
-		for (String pluginNamesRelativeGlob :
-				pluginNamesRelativeGlobs.split(",")) {
+		if ((relativeGlobs == null) || relativeGlobs.isEmpty()) {
+			return pathMatchers;
+		}
 
+		for (String relativeGlob : relativeGlobs.split(",")) {
 			FileSystem fileSystem = FileSystems.getDefault();
 
 			pathMatchers.add(
 				fileSystem.getPathMatcher(
 					JenkinsResultsParserUtil.combine(
 						"glob:", workingDirectory.getAbsolutePath(), "/",
-						pluginNamesRelativeGlob)));
+						relativeGlob)));
 		}
 
 		return pathMatchers;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ModulesCompileBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ModulesCompileBatchTestClassGroup.java
@@ -55,14 +55,12 @@ public class ModulesCompileBatchTestClassGroup extends BatchTestClassGroup {
 		try {
 			excludesPathMatchers.addAll(
 				getPathMatchers(
-					JenkinsResultsParserUtil.combine(
-						"modules.excludes[", batchName, "]"),
+					getFirstPropertyValue("modules.excludes"),
 					portalGitWorkingDirectory.getWorkingDirectory()));
 
 			includesPathMatchers.addAll(
 				getPathMatchers(
-					JenkinsResultsParserUtil.combine(
-						"modules.includes[", batchName, "]"),
+					getFirstPropertyValue("modules.includes"),
 					portalGitWorkingDirectory.getWorkingDirectory()));
 
 			setTestClasses();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PluginsBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/PluginsBatchTestClassGroup.java
@@ -72,12 +72,12 @@ public class PluginsBatchTestClassGroup extends BatchTestClassGroup {
 
 			excludesPathMatchers.addAll(
 				getPathMatchers(
-					"test.batch.plugin.names.excludes",
+					getFirstPropertyValue("test.batch.plugin.names.excludes"),
 					_pluginsGitWorkingDirectory.getWorkingDirectory()));
 
 			includesPathMatchers.addAll(
 				getPathMatchers(
-					"test.batch.plugin.names.includes",
+					getFirstPropertyValue("test.batch.plugin.names.includes"),
 					_pluginsGitWorkingDirectory.getWorkingDirectory()));
 
 			setTestClasses();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/SemVerBaselineBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/SemVerBaselineBatchTestClassGroup.java
@@ -54,14 +54,12 @@ public class SemVerBaselineBatchTestClassGroup extends BatchTestClassGroup {
 		try {
 			excludesPathMatchers.addAll(
 				getPathMatchers(
-					JenkinsResultsParserUtil.combine(
-						"modules.excludes[", batchName, "]"),
+					getFirstPropertyValue("modules.excludes"),
 					portalGitWorkingDirectory.getWorkingDirectory()));
 
 			includesPathMatchers.addAll(
 				getPathMatchers(
-					JenkinsResultsParserUtil.combine(
-						"modules.includes[", batchName, "]"),
+					getFirstPropertyValue("modules.includes"),
 					portalGitWorkingDirectory.getWorkingDirectory()));
 
 			setTestClasses();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/TCKJunitBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/TCKJunitBatchTestClassGroup.java
@@ -70,11 +70,13 @@ public class TCKJunitBatchTestClassGroup extends BatchTestClassGroup {
 
 		excludesPathMatchers.addAll(
 			getPathMatchers(
-				"test.batch.class.names.excludes", _tckHomeDirectory));
+				getFirstPropertyValue("test.batch.class.names.excludes"),
+				_tckHomeDirectory));
 
 		includesPathMatchers.addAll(
 			getPathMatchers(
-				"test.batch.class.names.includes", _tckHomeDirectory));
+				getFirstPropertyValue("test.batch.class.names.includes"),
+				_tckHomeDirectory));
 
 		setTestClasses();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-41272

Please publish after merging