### PR TITLE
LPS-80927 Apply the language key transformation plugin to the appropriate *-uad modules

### DIFF
--- a/modules/apps/announcements/announcements-uad/build.gradle
+++ b/modules/apps/announcements/announcements-uad/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "com.liferay.lang.merger"
+
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
@@ -10,4 +12,12 @@ dependencies {
 	compileOnly project(":apps:user-associated-data:user-associated-data-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
+}
+
+mergeLang {
+	setting("../announcements-web/src/main/resources/content") {
+		transformKey "javax.portlet.title.com_liferay_announcements_web_portlet_AnnouncementsPortlet", "application.name.com.liferay.announcements.uad"
+	}
+
+	sourceDirs = ["../announcements-web/src/main/resources/content"]
 }

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Announcements

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=إعلانات

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Съобщения

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Anuncis

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Oznámení

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Meddelelser

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Ankündigungen

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Ανακοινώσεις

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Announcements

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Avisos

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Teated

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Jakinarazpenak

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=اطلاعیه‌ها

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Tiedotteet

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Annonces

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Avisos

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=घोषणाएँ

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Objave

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Bejelentések

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Pengumuman

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Annunci

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=הכרזות

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=お知らせ

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=공고

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=ປະກາດ

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Announcements (Automatic Copy)

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Kunngjøringer

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Aankondigingen

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Berichten

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Komunikaty

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Avisos

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Anúncios

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Anunțuri

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Объявления

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Oznámenia

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Sporočila

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Обавештења

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Obaveštenja

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Notiser

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Announcements (Automatic Copy)

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Duyurular

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Об'яви

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=Thông báo

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=通知

--- a/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/announcements/announcements-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.announcements.uad=公告

--- a/modules/apps/bookmarks/bookmarks-uad/build.gradle
+++ b/modules/apps/bookmarks/bookmarks-uad/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "com.liferay.lang.merger"
+
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
@@ -9,4 +11,12 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:user-associated-data:user-associated-data-api")
 	compileOnly project(":core:petra:petra-string")
+}
+
+mergeLang {
+	setting("../bookmarks-web/src/main/resources/content") {
+		transformKey "javax.portlet.title.com_liferay_bookmarks_web_portlet_BookmarksPortlet", "application.name.com.liferay.bookmarks.uad"
+	}
+
+	sourceDirs = ["../bookmarks-web/src/main/resources/content"]
 }

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bookmarks

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=المفضلة

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Буукмарки

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Adreces d'interès

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Záložky

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bogmærker

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Lesezeichen

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Σελιδοδείκτες

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bookmarks

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Enlaces

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Järjehoidjad

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Laster marka

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=یادآوری

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Kirjanmerkit

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Signets

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Enlaces

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=बुकमार्क्स

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Oznake

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Könyvjelzők

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bookmark

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Segnalibri

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=סימניות

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=ブックマーク

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=갈피표

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=ບູ໋ກມາກ

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Mėgstamiausios nuorodos

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bokmerker

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bladwijzers

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bladwijzers

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Zakładki

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Favoritos

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Favoritos

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Marcaje

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Закладки

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Záložky

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Zaznamki

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Маркери

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Markeri

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bokmärken

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Bookmarks (Automatic Copy)

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Yer İmleri

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Закладки

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=Đánh dấu

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=书签

--- a/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/bookmarks/bookmarks-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.bookmarks.uad=書籤

--- a/modules/apps/contacts/contacts-uad/build.gradle
+++ b/modules/apps/contacts/contacts-uad/build.gradle
@@ -1,6 +1,16 @@
+apply plugin: "com.liferay.lang.merger"
+
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:contacts:contacts-api")
 	compileOnly project(":apps:user-associated-data:user-associated-data-api")
+}
+
+mergeLang {
+	setting("../contacts-web/src/main/resources/content") {
+		transformKey "javax.portlet.title.com_liferay_contacts_web_portlet_ContactsCenterPortlet", "application.name.com.liferay.contacts.uad"
+	}
+
+	sourceDirs = ["../contacts-web/src/main/resources/content"]
 }

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contactes

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Správa kontaktů

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Kontaktverwaltung

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Κέντρο επαφών (Automatic Translation)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contactos

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Kontaktuen Gunea

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=مرکز مخاطبین

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Yhteystietokeskus

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Centre de contacts

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Centro de Contactos

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=संपर्क केंद्र (Automatic Translation)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Kontakt centar

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Kapcsolat Központ

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Kontak Center

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Centro contatti

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=מרכז אנשי קשר

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=コンタクトセンター

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=연락처 센터 (Automatic Translation)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Kontaktsenter

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contactcentrum

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contactpersonen Center (Automatic Translation)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Centrum kontaktów

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Central de Contatos

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Centro de Contactos

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Центh контактов

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Správa kontaktov

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Контакт Центар

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=Contacts Center (Automatic Copy)

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=联络中心

--- a/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/contacts/contacts-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.contacts.uad=聯絡人中心

--- a/modules/apps/document-library/document-library-uad/build.gradle
+++ b/modules/apps/document-library/document-library-uad/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "com.liferay.lang.merger"
+
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
@@ -7,4 +9,12 @@ dependencies {
 	compileOnly project(":apps:user-associated-data:user-associated-data-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
+}
+
+mergeLang {
+	setting("../document-library-web/src/main/resources/content") {
+		transformKey "javax.portlet.title.com_liferay_document_library_web_portlet_DLPortlet", "application.name.com.liferay.document.library.uad"
+	}
+
+	sourceDirs = ["../document-library-web/src/main/resources/content"]
 }

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=مكتبة المستندات

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents i fitxers multimèdia

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumenter og media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumente & Medien

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Έγγραφα και Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documentos y multimedia

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumendihoidla

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumentuak eta Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=مستندات و چندرسانه‌ای‌ها

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Asiakirjat ja Mediatiedostot

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents et Média

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documentos e multimedia

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumenti i mediji

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumentumok és médiafájlok

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documenti e Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=מסמכים ומדיה

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=ドキュメントとメディア

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=ເອກະສານ ແລະມີເດຍ

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumentai ir media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumenter og media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documenten en Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documenten en Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumenty i media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documentos e Mídias

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documentos e Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documente și Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Документы и Медиа файлы

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumenty a média

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Документи и Медија

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokumenti i Medija

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Dokument och media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=เอกสารและสื่อ (Automatic Translation)

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Documents and Media

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=Tài liệu và Đa phương tiện

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=文档媒体库

--- a/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/document-library/document-library-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.document.library.uad=文件與媒體

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=صفحات الموقع

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Pàgines del lloc web

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Stránky

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Webstedssider

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Seiten der Site

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Σελίδες του site

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Páginas del sitio web

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Saidi leheküljed (Automatic Translation)

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Guneko Orriak

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=صفحه‌های سایت

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Sivuston sivut

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Pages de site

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Páxinas do sitio

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Stranice web sjedišta

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Webhely oldalak

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Pagine del sito

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=דפי אתר

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=サイトページ

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=ໄຊທ໌ເພ໋ກຕ່າງໆ

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Svetainės puslapiai (Automatic Translation)

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Nettstedssider

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Sitepagina's

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Sitepagina's

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Strony witryny

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Páginas do Site

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Páginas do Site

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Pagini site-uri

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Страницы сайта

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Stránky sídla

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Сајт Странице

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Sajt Stranice

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Platsens sidor

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=หน้าเว็บไซต์ (Automatic Translation)

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Site Pages

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=Trang của Trang thông tin

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=站点页面

--- a/modules/apps/layout/layout-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/layout/layout-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.layout.uad=站台頁面

--- a/modules/apps/message-boards/message-boards-uad/build.gradle
+++ b/modules/apps/message-boards/message-boards-uad/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "com.liferay.lang.merger"
+
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
@@ -7,4 +9,12 @@ dependencies {
 	compileOnly project(":apps:user-associated-data:user-associated-data-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
+}
+
+mergeLang {
+	setting("../message-boards-web/src/main/resources/content") {
+		transformKey "javax.portlet.title.com_liferay_message_boards_web_portlet_MBPortlet", "application.name.com.liferay.message.boards.uad"
+	}
+
+	sourceDirs = ["../message-boards-web/src/main/resources/content"]
 }

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Message Boards

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=المنتديات

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Дъски със съобщения

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Fòrums de discussió

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Diskusní fórum

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Diskussionsfora

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Foren

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Πίνακες Μηνυμάτων

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Message Boards

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Foros de discusión

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Foorumid

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Iragarki taula

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=تالار گفتگو

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Keskustelualueet

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Forum

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Foro de discusión

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=संदेश बोर्ड्स

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Oglasne ploče

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Fórumok

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Message Board

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Forum

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=לוחות מודעות

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=掲示板

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=메시지는 난입한다

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=ການດານຂໍ້ຄວາມ

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Pranešimų lentos

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Diskusjonsfora

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Forums

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Forums

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Fora dyskusyjne

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Fórum

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Fóruns

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Forumuri

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Форумы

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Diskusné fórum

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Table s sporočili

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Форум

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Forum

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Forum

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=กระดานข้อความ (Automatic Translation)

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Mesaj Tahtası

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Дошки оголошень

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=Diễn đàn

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=留言板

--- a/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/message-boards/message-boards-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.message.boards.uad=討論板

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notificacions

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Benachrichtigungen

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notificaciones

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Ilmoitukset

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifiche

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=お知らせ

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notificaties

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notificações

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=通知

--- a/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/notifications/notifications-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.notifications.uad=Notifications (Automatic Copy)

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Password Policies

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=نهج كلمة السر

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Политики на паролите

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Polítiques de contrasenyes

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Politiky hesel

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Adganskodepolitikker

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Kennwortrichtlinien

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Πολιτικές Κωδικών Πρόσβασης

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Password Policies

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Política de contraseñas

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Salasõna reeglid

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Pasahitzaren politikak

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=سیاست‌های رمز عبور

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Salasanakäytännöt

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Politiques de mot de passe

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Políticas da contraseña

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=पासवर्ड नीतियाँ

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Pravila za lozinke

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Jelszókezelés

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Kebijakan Password

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Criteri password

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=מדיניות סיסמאות

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=パスワードポリシー

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=암호 정책

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=ນະໂຍບາຍລະຫັດຜ່ານ

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Password Policies (Automatic Copy)

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Passordinnstillinger

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Wachtwoordbeleid

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Wachtwoordbeleid

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Zasady haseł

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Políticas de Senha

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Políticas de Senha

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Politici de setare a parolei

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Политики паролей

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Pravidlá hesiel

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Pravila za gesla

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Политике Лозинке

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Politike Lozinke

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Lösenordsregler

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Password Policies (Automatic Copy)

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Şifre Politikaları

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Тактика паролів

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=Chính sách đặt mật khẩu

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=密码政策

--- a/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/password-policies-admin/password-policies-admin-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.password.policies.admin.uad=密碼政策

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=سير العمل (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Работен поток (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Flux de treball

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Pracovní postup (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Ροή εργασίας (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Flujo de trabajo (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Töövoo (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=گردش کار (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Työnkulku

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Flux de Travail

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=वर्कफ़्लो (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Munkafolyamat (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Alur kerja (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=זרימת עבודה (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=ワークフロー

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=워크플로 (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Darbo eiga (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Arbeidsflyt (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Przepływ pracy (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Fluxo de Trabalho

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Flux de lucru (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Рабочий процесс (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Pracovný postup (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Potek dela (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Workflow (Automatic Copy)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=ลำดับงาน (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=İş akışı (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Робочий процес (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=Quy trình làm việc (Automatic Translation)

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=工作流

--- a/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-workflow/portal-workflow-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.portal.workflow.uad=工作流 (Automatic Translation)

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roles

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=الأدوار

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Роли

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rols

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Role

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roller

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rollen

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Ρόλοι

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roles

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rol

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rollid

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rolak

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=نقش ها

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roolit

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rôles

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rol

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=रोल्स

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Uloge

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Szerepkörök

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Peran

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Ruoli

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=תפקידים

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=ロール

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=역할

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=ລະບຽບການ

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roles (Automatic Copy)

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roller

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rollen

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Rollen

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Role

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Papéis

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Perfís

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roluri

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Роли

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Role

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Vloge

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Улоге

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Uloge

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roller

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=บทบาท (Automatic Translation)

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Roller

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Ролі

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=Vai trò

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=角色

--- a/modules/apps/roles/roles-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/roles/roles-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.roles.uad=角色

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=فرق الموقع

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Equips del lloc

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Týmy webů

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Teams

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site ομάδες (Automatic Translation)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Equipos del sitio

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=تیم‌های سایت

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Sivuston tiimit

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Équipes du site

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=साइट टीमों (Automatic Translation)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Timovi web sjedišta

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Webhely csapatok

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Team del sito

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=צוותי אתר

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=サイトのチーム

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=사이트 팀 (Automatic Translation)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Nettstedsbrukergrupper

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Siteteams

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Translation)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Zespoły witryny

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Equipes do Site

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Equipas do Site

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Echipe site

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Команды сайта

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Tímy sídla

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Сајт Тимови

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Plats-team

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Site Teams (Automatic Copy)

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=Nhóm của Trang

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=站点团队

--- a/modules/apps/site/site-teams-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/site/site-teams-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.site.teams.uad=站台團隊

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=User Groups

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=مجموعات المستخدم

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Потребителски групи

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grups d'usuari

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Skupiny uživatelů

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Brugergrupper

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Benutzergruppen

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Ομάδες Χρηστών

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=User Groups

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grupos de Usuarios

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Kasutajagrupid

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Erabiltzaile Multzoak

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=گروه‌های کاربری

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Käyttäjäryhmät

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Groupes d'utilisateurs

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grupos de usuarios

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=यूज़र ग्रूप्स

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Korisničke grupe

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Felhasználói csoportok

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grup Pengguna

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Gruppi di utenti

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=קבוצות משתמשים

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=ユーザーグループ

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=사용자 그룹

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=ກຸ່ມຜູ້ໃຊ້

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=User Groups (Automatic Copy)

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Brukergrupper

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Gebruikersgroepen

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Groepen

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grupy użytkownika

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grupos de Usuários

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grupos de Utilizador

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Grupuri utilizatori

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Группы пользователй

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Používateľské skupiny

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Skupine uporabnikov.

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Корисничке Групе

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Korisničke Grupe

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Användargrupper

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=User Groups (Automatic Copy)

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Kullanıcı Grupları

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Групи користувачів

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=Nhóm người dùng

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=用户群组

--- a/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/user-groups-admin/user-groups-admin-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.user.groups.admin.uad=使用者群組

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=Administrador d'usuaris

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=Amministrazione Utenti

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin

--- a/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/users-admin/users-admin-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.users.admin.uad=UsersAdmin (Automatic Copy)

--- a/modules/apps/wiki/wiki-uad/build.gradle
+++ b/modules/apps/wiki/wiki-uad/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "com.liferay.lang.merger"
+
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
@@ -7,4 +9,12 @@ dependencies {
 	compileOnly project(":apps:wiki:wiki-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
+}
+
+mergeLang {
+	setting("../wiki-web/src/main/resources/content") {
+		transformKey "javax.portlet.title.com_liferay_wiki_web_portlet_WikiPortlet", "application.name.com.liferay.wiki.uad"
+	}
+
+	sourceDirs = ["../wiki-web/src/main/resources/content"]
 }

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ar.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=الويكي

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_bg.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ca.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_cs.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_da.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_da.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (Kontrolpanel)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_de.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_de.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_el.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_el.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (πίνακας ελέγχου)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_en.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_en.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_es.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_es.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_et.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_et.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikid

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_eu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikia

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_fa.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=ویکی

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_fi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikit

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_fr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (Panneau de Configuration)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_gl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (Automatic Copy)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_hi_IN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=विकी

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_hr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikiji

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_hu.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikik

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_in.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_in.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (Control Panel)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_it.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_it.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_iw.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=ויקי

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ja.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ko.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=위 키 (Automatic Translation)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_lo.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=ວີກີ

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_lt.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (Automatic Translation)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_nb.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikier

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_nl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki's

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_nl_BE.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki’s

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_pl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (Panel Sterowania)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_pt_PT.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ro.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki-uri

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_ru.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sl.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikiji

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sr_RS.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Вики

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Viki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_sv.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_th.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_th.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki (Automatic Translation)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_tr.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wikiler

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_uk.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Вікі

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_vi.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Từ điển bách khoa (Wiki)

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_zh_CN.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki

--- a/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/wiki/wiki-uad/src/main/resources/content/Language_zh_TW.properties
@@ -1,1 +1,0 @@
-application.name.com.liferay.wiki.uad=Wiki


### PR DESCRIPTION
This is an update for [LPS-80927](https://issues.liferay.com/browse/LPS-80927).<br><br>Hey Brian, this applies the new language transformation to the appropriate UAD moduees.  It also removes language files from any modules that do not have displays in the UI.<br><br>/cc @pei-jung @Ithildir