### PR TITLE
LPS-81975 Move ManagementToolbarTag defaults into a separate class (single source of truth)

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
@@ -14,7 +14,9 @@
 
 package com.liferay.frontend.taglib.clay.internal.servlet.taglib;
 
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.portal.kernel.dao.search.DisplayTerms;
+import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Drew Brokke
@@ -31,6 +33,10 @@ public class ManagementToolbarDefaults {
 
 	public static String getSearchInputName() {
 		return DisplayTerms.KEYWORDS;
+	}
+
+	public static Boolean isShowCreationMenu(CreationMenu creationMenu) {
+		return Validator.isNotNull(creationMenu);
 	}
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
@@ -21,6 +21,10 @@ import com.liferay.portal.kernel.dao.search.DisplayTerms;
  */
 public class ManagementToolbarDefaults {
 
+	public static String getContentRenderer() {
+		return "hiddenInputsForm";
+	}
+
 	public static String getSearchFormMethod() {
 		return "GET";
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
@@ -39,4 +39,8 @@ public class ManagementToolbarDefaults {
 		return Validator.isNotNull(creationMenu);
 	}
 
+	public static Boolean isShowInfoButton(String infoPanelId) {
+		return Validator.isNotNull(infoPanelId);
+	}
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
@@ -14,6 +14,8 @@
 
 package com.liferay.frontend.taglib.clay.internal.servlet.taglib;
 
+import com.liferay.portal.kernel.dao.search.DisplayTerms;
+
 /**
  * @author Drew Brokke
  */
@@ -21,6 +23,10 @@ public class ManagementToolbarDefaults {
 
 	public static String getSearchFormMethod() {
 		return "GET";
+	}
+
+	public static String getSearchInputName() {
+		return DisplayTerms.KEYWORDS;
 	}
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/ManagementToolbarDefaults.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.internal.servlet.taglib;
+
+/**
+ * @author Drew Brokke
+ */
+public class ManagementToolbarDefaults {
+
+	public static String getSearchFormMethod() {
+		return "GET";
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
@@ -72,7 +72,8 @@ public class ManagementToolbarTag extends BaseClayTag {
 			putValue("searchData", searchData);
 
 			String contentRenderer = GetterUtil.getString(
-				context.get("contentRenderer"), "hiddenInputsForm");
+				context.get("contentRenderer"),
+				ManagementToolbarDefaults.getContentRenderer());
 
 			setContentRenderer(contentRenderer);
 		}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
@@ -107,7 +107,8 @@ public class ManagementToolbarTag extends BaseClayTag {
 		String infoPanelId = (String)context.get("infoPanelId");
 
 		boolean showInfoButton = GetterUtil.getBoolean(
-			context.get("showInfoButton"), Validator.isNotNull(infoPanelId));
+			context.get("showInfoButton"),
+			ManagementToolbarDefaults.isShowInfoButton(infoPanelId));
 
 		setShowInfoButton(showInfoButton);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
@@ -23,7 +23,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.ViewTypeItem;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
@@ -52,7 +51,7 @@ public class ManagementToolbarTag extends BaseClayTag {
 		String searchInputName = (String)context.get("searchInputName");
 
 		if (Validator.isNull(searchInputName)) {
-			searchInputName = DisplayTerms.KEYWORDS;
+			searchInputName = ManagementToolbarDefaults.getSearchInputName();
 
 			setSearchInputName(searchInputName);
 		}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib.soy;
 
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.frontend.taglib.clay.internal.js.loader.modules.extender.npm.NPMResolverProvider;
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.ManagementToolbarDefaults;
 import com.liferay.frontend.taglib.clay.servlet.taglib.soy.base.BaseClayTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
@@ -57,7 +58,8 @@ public class ManagementToolbarTag extends BaseClayTag {
 		}
 
 		String searchFormMethod = GetterUtil.getString(
-			context.get("searchFormMethod"), "GET");
+			context.get("searchFormMethod"),
+			ManagementToolbarDefaults.getSearchFormMethod());
 
 		setSearchFormMethod(searchFormMethod);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/ManagementToolbarTag.java
@@ -94,7 +94,8 @@ public class ManagementToolbarTag extends BaseClayTag {
 		CreationMenu creationMenu = (CreationMenu)context.get("creationMenu");
 
 		boolean showCreationMenu = GetterUtil.getBoolean(
-			context.get("showCreationMenu"), Validator.isNotNull(creationMenu));
+			context.get("showCreationMenu"),
+			ManagementToolbarDefaults.isShowCreationMenu(creationMenu));
 
 		setShowCreationMenu(showCreationMenu);
 


### PR DESCRIPTION
This is an update for [LPS-81975](https://issues.liferay.com/browse/LPS-81975).<br><br>Hey Brian, this just moves the default values into a new class in the taglib module.<br><br>/cc @pei-jung @4lejandrito