### PR TITLE
LPS-81869

### DIFF
--- a/modules/apps/headless-apio/app.bnd
+++ b/modules/apps/headless-apio/app.bnd
@@ -1,0 +1,14 @@
+Liferay-Releng-App-Description: Liferay Headless Apio is a suite of APIs built with the Apio Architect framework
+Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix}
+Liferay-Releng-Bundle: false
+Liferay-Releng-Category: Utility
+Liferay-Releng-Demo-Url:
+Liferay-Releng-Deprecated: false
+Liferay-Releng-Labs: true
+Liferay-Releng-Marketplace: true
+Liferay-Releng-Portal-Required: false
+Liferay-Releng-Public: ${liferay.releng.public}
+Liferay-Releng-Restart-Required: false
+Liferay-Releng-Suite:
+Liferay-Releng-Support-Url: http://www.liferay.com
+Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/apps/headless-apio/app.bnd
+++ b/modules/apps/headless-apio/app.bnd
@@ -1,4 +1,4 @@
-Liferay-Releng-App-Description: Liferay Headless Apio is a suite of APIs built with the Apio Architect framework
+Liferay-Releng-App-Description:
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix}
 Liferay-Releng-Bundle: false
 Liferay-Releng-Category: Utility

--- a/modules/apps/headless-apio/build.gradle
+++ b/modules/apps/headless-apio/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: "com.liferay.app.defaults.plugin"

--- a/modules/apps/screens/app.bnd
+++ b/modules/apps/screens/app.bnd
@@ -9,6 +9,6 @@ Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: true
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true
-Liferay-Releng-Suite:
+Liferay-Releng-Suite: foundation
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}

--- a/modules/apps/screens/app.bnd
+++ b/modules/apps/screens/app.bnd
@@ -1,12 +1,12 @@
 Liferay-Releng-App-Description: Liferay Screens is a framework consisting of native Android and iOS components called Screenlets. Screenlets simplify development by implementing common use cases in mobile apps that connect to Liferay instances. The Liferay Screens Compatibility app exposes additional classes and methods that aren’t present in Liferay’s out-of-the-box API. These classes and methods are required for Screenlets to work correctly in your mobile apps. Installing this app automatically exposes these classes and methods; the app doesn’t provide or require a UI.
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Screens Compatibility
-Liferay-Releng-Bundle: false
+Liferay-Releng-Bundle: true
 Liferay-Releng-Category: Utility
 Liferay-Releng-Demo-Url:
 Liferay-Releng-Deprecated: false
 Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
-Liferay-Releng-Portal-Required: false
+Liferay-Releng-Portal-Required: true
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true
 Liferay-Releng-Suite:

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -179,6 +179,7 @@
         modules/apps/ip-geocoder/app.bnd,\
         modules/apps/marketplace/app.bnd,\
         modules/apps/portal-search-elasticsearch6/app.bnd,\
+        modules/apps/screens/app.bnd,\
         modules/apps/static/app.bnd,\
         modules/apps/sync/app.bnd
 


### PR DESCRIPTION
I've added the suite to the screens app.bnd but headless-apio doesn't need it if it's just a marketplace app (as it is agreed with Jorge) and not a bundle.

I've removed the App-Description while docs reviews it (I've sent a PR here https://github.com/ngaskill/liferay-portal/pull/4). Frontend-editor or journal doesn't have descriptions either.