### PR TITLE
LPS-81667 Apply multi threading moving JournalArticleImages to DL during the journal upgrade

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
@@ -136,8 +136,8 @@ public class UpgradeImageTypeContent extends UpgradeProcess {
 		sb.append("JournalArticleImage.groupId, ");
 		sb.append("JournalArticle.resourcePrimKey, JournalArticle.userId ");
 		sb.append("from JournalArticleImage left join JournalArticle on ");
-		sb.append("(JournalArticle.groupId=JournalArticleImage.groupId) and ");
-		sb.append("(JournalArticle.articleId=JournalArticleImage.articleId)");
+		sb.append("(JournalArticle.groupId=JournalArticleImage.groupId and ");
+		sb.append("JournalArticle.articleId=JournalArticleImage.articleId)");
 
 		List<SaveImageFileEntryCallable> saveImageFileEntryCallables =
 			new ArrayList<>();

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
@@ -130,14 +130,15 @@ public class UpgradeImageTypeContent extends UpgradeProcess {
 	protected void copyJournalArticleImagesToJournalRepository()
 		throws Exception {
 
-		StringBundler sb = new StringBundler(6);
+		StringBundler sb = new StringBundler(7);
 
 		sb.append("select JournalArticleImage.articleImageId, ");
 		sb.append("JournalArticleImage.groupId, ");
 		sb.append("JournalArticle.resourcePrimKey, JournalArticle.userId ");
-		sb.append("from JournalArticleImage left join JournalArticle on ");
+		sb.append("from JournalArticleImage inner join JournalArticle on ");
 		sb.append("(JournalArticle.groupId=JournalArticleImage.groupId and ");
-		sb.append("JournalArticle.articleId=JournalArticleImage.articleId)");
+		sb.append("JournalArticle.articleId=JournalArticleImage.articleId ");
+		sb.append(" and JournalArticle.version=JournalArticleImage.version)");
 
 		List<SaveImageFileEntryCallable> saveImageFileEntryCallables =
 			new ArrayList<>();


### PR DESCRIPTION
Hey @shuyangzhou, we have applied multithreading in this upgrade because the logic allows it. The improvement has been huge, from almost one week to 6 hours and 20 minutes. I think we can apply it in other parts of the upgrade process, I will send you a pull if we can build like a framework for this.

Thanks.

cc/ @pavel-savinov @jorgediaz-lr