### PR TITLE
LPS-82051 When deploy a Configuration Category from a different module than configuration-admin-web , the category label will be not localized

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
@@ -15,6 +15,12 @@
 package com.liferay.configuration.admin.web.internal.display;
 
 import com.liferay.configuration.admin.category.ConfigurationCategory;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.ResourceBundleLoaderUtil;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 /**
  * @author Jorge Ferrer
@@ -25,6 +31,20 @@ public class ConfigurationCategoryDisplay {
 		ConfigurationCategory configurationCategory) {
 
 		_configurationCategory = configurationCategory;
+	}
+
+	public String getCategoryLabel(Locale locale) {
+		ResourceBundleLoader resourceBundleLoader =
+			ResourceBundleLoaderUtil.
+				getResourceBundleLoaderByBundleSymbolicName(
+					_configurationCategory.getBundleSymbolicName());
+
+		ResourceBundle resourceBundle = resourceBundleLoader.loadResourceBundle(
+			locale);
+
+		return LanguageUtil.get(
+			resourceBundle,
+			"category." + _configurationCategory.getCategoryKey());
 	}
 
 	public String getCategoryIcon() {

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryDisplay.java
@@ -33,6 +33,14 @@ public class ConfigurationCategoryDisplay {
 		_configurationCategory = configurationCategory;
 	}
 
+	public String getCategoryIcon() {
+		return _configurationCategory.getCategoryIcon();
+	}
+
+	public String getCategoryKey() {
+		return _configurationCategory.getCategoryKey();
+	}
+
 	public String getCategoryLabel(Locale locale) {
 		ResourceBundleLoader resourceBundleLoader =
 			ResourceBundleLoaderUtil.
@@ -45,14 +53,6 @@ public class ConfigurationCategoryDisplay {
 		return LanguageUtil.get(
 			resourceBundle,
 			"category." + _configurationCategory.getCategoryKey());
-	}
-
-	public String getCategoryIcon() {
-		return _configurationCategory.getCategoryIcon();
-	}
-
-	public String getCategoryKey() {
-		return _configurationCategory.getCategoryKey();
 	}
 
 	public String getCategorySection() {

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -41,7 +41,11 @@ if (configurationModel.isFactory()) {
 
 PortalUtil.addPortletBreadcrumbEntry(request, portletDisplay.getPortletDisplayName(), String.valueOf(renderResponse.createRenderURL()));
 
-String categoryDisplayName = LanguageUtil.get(request, "category." + configurationModel.getCategory());
+ConfigurationCategoryMenuDisplay configurationCategoryMenuDisplay = (ConfigurationCategoryMenuDisplay)request.getAttribute(ConfigurationAdminWebKeys.CONFIGURATION_CATEGORY_MENU_DISPLAY);
+
+ConfigurationCategoryDisplay configurationCategoryDisplay = configurationCategoryMenuDisplay.getConfigurationCategoryDisplay();
+
+String categoryDisplayName = HtmlUtil.escape(configurationCategoryDisplay.getCategoryLabel(locale));
 
 PortletURL viewCategoryURL = renderResponse.createRenderURL();
 

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,4 +1,4 @@
-HtmlUtil<%--
+<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,4 +1,4 @@
-<%--
+HtmlUtil<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -41,6 +41,7 @@ page import="com.liferay.configuration.admin.web.internal.util.ResourceBundleLoa
 page import="com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition" %><%@
 page import="com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.ResourceBundleLoader" %><%@

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
@@ -112,7 +112,12 @@ renderResponse.setTitle(LanguageUtil.get(request, "search-results"));
 
 				if (configurationCategory != null) {
 					categorySection = LanguageUtil.get(request, "category-section." + configurationCategory.getCategorySection());
-					category = LanguageUtil.get(request, "category." + configurationCategory.getCategoryKey());
+
+					ConfigurationCategoryMenuDisplay configurationCategoryMenuDisplay = configurationEntryRetriever.getConfigurationCategoryMenuDisplay(configurationCategory.getCategoryKey(), themeDisplay.getLanguageId());
+
+					ConfigurationCategoryDisplay configurationCategoryDisplay = configurationCategoryMenuDisplay.getConfigurationCategoryDisplay();
+
+					category = HtmlUtil.escape(configurationCategoryDisplay.getCategoryLabel(locale));
 				}
 				else {
 					categorySection = LanguageUtil.get(request, "other");

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -65,7 +65,7 @@ List<ConfigurationCategorySectionDisplay> configurationCategorySectionDisplays =
 								/>
 
 								<span class="list-group-card-item-text">
-									<liferay-ui:message key='<%= "category." + configurationCategoryDisplay.getCategoryKey() %>' />
+									<%= HtmlUtil.escape(configurationCategoryDisplay.getCategoryLabel(locale)) %>
 								</span>
 							</a>
 						</li>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_configuration_screen.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_configuration_screen.jsp
@@ -34,7 +34,11 @@ PortletURL viewCategoryURL = renderResponse.createRenderURL();
 viewCategoryURL.setParameter("mvcRenderCommandName", "/view_category");
 viewCategoryURL.setParameter("configurationCategory", configurationScreen.getCategoryKey());
 
-String categoryDisplayName = LanguageUtil.get(request, "category." + configurationScreen.getCategoryKey());
+ConfigurationCategoryMenuDisplay configurationCategoryMenuDisplay = (ConfigurationCategoryMenuDisplay)request.getAttribute(ConfigurationAdminWebKeys.CONFIGURATION_CATEGORY_MENU_DISPLAY);
+
+ConfigurationCategoryDisplay configurationCategoryDisplay = configurationCategoryMenuDisplay.getConfigurationCategoryDisplay();
+
+String categoryDisplayName = HtmlUtil.escape(configurationCategoryDisplay.getCategoryLabel(locale));
 
 PortalUtil.addPortletBreadcrumbEntry(request, categoryDisplayName, viewCategoryURL.toString());
 

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
@@ -56,7 +56,7 @@ PortalUtil.addPortletBreadcrumbEntry(request, factoryConfigurationModelName, nul
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(portletURL.toString());
 
-renderResponse.setTitle(LanguageUtil.get(request, "category." + configurationModel.getCategory()));
+renderResponse.setTitle(categoryDisplayName);
 %>
 
 <div class="container-fluid container-fluid-max-xl">

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
@@ -30,7 +30,11 @@ ConfigurationModelIterator configurationModelIterator = (ConfigurationModelItera
 
 PortalUtil.addPortletBreadcrumbEntry(request, portletDisplay.getPortletDisplayName(), String.valueOf(renderResponse.createRenderURL()));
 
-String categoryDisplayName = LanguageUtil.get(request, "category." + configurationModel.getCategory());
+ConfigurationCategoryMenuDisplay configurationCategoryMenuDisplay = (ConfigurationCategoryMenuDisplay)request.getAttribute(ConfigurationAdminWebKeys.CONFIGURATION_CATEGORY_MENU_DISPLAY);
+
+ConfigurationCategoryDisplay configurationCategoryDisplay = configurationCategoryMenuDisplay.getConfigurationCategoryDisplay();
+
+String categoryDisplayName = HtmlUtil.escape(configurationCategoryDisplay.getCategoryLabel(locale));
 
 PortletURL viewCategoryURL = renderResponse.createRenderURL();
 


### PR DESCRIPTION
This is an update for [LPS-82051](https://issues.liferay.com/browse/LPS-82051).<br><br>/cc @JorgeFerrer @pei-jung @marco-leo @Commando18