### PR TITLE
LPS-81854 FIX CI Failures and Performance Regression, caused by Search Options Portlet and Empty Search

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/display/context/SearchDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/display/context/SearchDisplayContextTest.java
@@ -78,7 +78,7 @@ public class SearchDisplayContextTest {
 
 	@Test
 	public void testSearchKeywordsBlank() throws Exception {
-		assertSearchSkipped(StringPool.BLANK, StringPool.BLANK);
+		assertSearchKeywords(StringPool.BLANK, StringPool.BLANK);
 	}
 
 	@Test
@@ -88,32 +88,10 @@ public class SearchDisplayContextTest {
 
 	@Test
 	public void testSearchKeywordsSpaces() throws Exception {
-		assertSearchSkipped(StringPool.DOUBLE_SPACE, StringPool.BLANK);
+		assertSearchKeywords(StringPool.DOUBLE_SPACE, StringPool.BLANK);
 	}
 
 	protected void assertSearchKeywords(
-			String requestKeywords, String searchDisplayContextKeywords)
-		throws Exception {
-
-		SearchDisplayContext searchDisplayContext = createSearchDisplayContext(
-			requestKeywords, renderRequest);
-
-		Assert.assertEquals(
-			searchDisplayContextKeywords, searchDisplayContext.getKeywords());
-
-		SearchContext searchContext = searchDisplayContext.getSearchContext();
-
-		Mockito.verify(
-			facetedSearcher
-		).search(
-			searchContext
-		);
-
-		Assert.assertEquals(
-			searchDisplayContextKeywords, searchContext.getKeywords());
-	}
-
-	protected void assertSearchSkipped(
 			String requestKeywords, String searchDisplayContextKeywords)
 		throws Exception {
 
@@ -127,7 +105,16 @@ public class SearchDisplayContextTest {
 		Assert.assertNotNull(searchDisplayContext.getSearchContainer());
 		Assert.assertNotNull(searchDisplayContext.getSearchContext());
 
-		Mockito.verifyZeroInteractions(facetedSearcher);
+		SearchContext searchContext = searchDisplayContext.getSearchContext();
+
+		Mockito.verify(
+			facetedSearcher
+		).search(
+			searchContext
+		);
+
+		Assert.assertEquals(
+			searchDisplayContextKeywords, searchContext.getKeywords());
 	}
 
 	protected void assertSearchSkippedAndNullResults(

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.HitsImpl;
 import com.liferay.portal.kernel.search.IndexSearcherHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerPostProcessor;
@@ -38,6 +39,7 @@ import com.liferay.portal.kernel.search.generic.MatchAllQuery;
 import com.liferay.portal.kernel.search.generic.StringQuery;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.constants.SearchContextAttributes;
 import com.liferay.portal.search.internal.expando.ExpandoQueryContributorHelper;
@@ -85,16 +87,14 @@ public class FacetedSearcherImpl
 	}
 
 	protected void addSearchKeywords(
-			BooleanQuery searchQuery, String keywords, boolean luceneSyntax,
+			BooleanQuery searchQuery, boolean luceneSyntax,
 			Map<String, Indexer<?>> entryClassNameIndexerMap,
 			SearchContext searchContext)
 		throws Exception {
 
-		if (Validator.isBlank(keywords) &&
-			!GetterUtil.getBoolean(
-				searchContext.getAttribute(
-					SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH))) {
+		String keywords = searchContext.getKeywords();
 
+		if (Validator.isBlank(keywords)) {
 			return;
 		}
 
@@ -124,8 +124,6 @@ public class FacetedSearcherImpl
 
 		BooleanQuery searchQuery = new BooleanQueryImpl();
 
-		String keywords = searchContext.getKeywords();
-
 		boolean luceneSyntax = GetterUtil.getBoolean(
 			searchContext.getAttribute(
 				SearchContextAttributes.ATTRIBUTE_KEY_LUCENE_SYNTAX));
@@ -136,8 +134,7 @@ public class FacetedSearcherImpl
 				searchContext.getSearchEngineId());
 
 		addSearchKeywords(
-			searchQuery, keywords, luceneSyntax, entryClassNameIndexerMap,
-			searchContext);
+			searchQuery, luceneSyntax, entryClassNameIndexerMap, searchContext);
 
 		_addSearchTerms(
 			searchQuery, fullQueryBooleanFilter, luceneSyntax,
@@ -195,6 +192,16 @@ public class FacetedSearcherImpl
 	@Override
 	protected Hits doSearch(SearchContext searchContext)
 		throws SearchException {
+
+		String keywords = StringUtil.trim(searchContext.getKeywords());
+
+		if (Validator.isBlank(keywords) &&
+			!GetterUtil.getBoolean(
+				searchContext.getAttribute(
+					SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH))) {
+
+			return new HitsImpl();
+		}
 
 		try {
 			searchContext.setSearchEngineId(getSearchEngineId());

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImplTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.searcher;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.IndexSearcherHelper;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngineHelper;
+import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.search.facet.faceted.searcher.FacetedSearcher;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.search.constants.SearchContextAttributes;
+import com.liferay.portal.search.internal.expando.ExpandoQueryContributorHelper;
+import com.liferay.portal.search.internal.indexer.PreFilterContributorHelper;
+import com.liferay.portal.search.internal.test.util.DocumentFixture;
+import com.liferay.registry.BasicRegistryImpl;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author André de Oliveira
+ */
+public class FacetedSearcherImplTest {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Registry registry = new BasicRegistryImpl();
+
+		RegistryUtil.setRegistry(registry);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		RegistryUtil.setRegistry(null);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		_documentFixture = new DocumentFixture();
+
+		_documentFixture.setUp();
+
+		facetedSearcher = createFacetedSearcher();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_documentFixture.tearDown();
+	}
+
+	@Test
+	public void testEmptySearchDisabledBlank() throws Exception {
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setKeywords(StringPool.BLANK);
+
+		assertSearchSkipped(searchContext);
+	}
+
+	@Test
+	public void testEmptySearchDisabledByDefault() throws Exception {
+		SearchContext searchContext = new SearchContext();
+
+		assertSearchSkipped(searchContext);
+	}
+
+	@Test
+	public void testEmptySearchDisabledSpaces() throws Exception {
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setKeywords(StringPool.FOUR_SPACES);
+
+		assertSearchSkipped(searchContext);
+	}
+
+	@Test
+	public void testEmptySearchEnabled() throws Exception {
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setAttribute(
+			SearchContextAttributes.ATTRIBUTE_KEY_EMPTY_SEARCH, Boolean.TRUE);
+		searchContext.setEntryClassNames(
+			new String[] {RandomTestUtil.randomString()});
+
+		Hits hits = facetedSearcher.search(searchContext);
+
+		Assert.assertNull(hits);
+
+		Mockito.verify(
+			indexSearcherHelper
+		).search(
+			Mockito.same(searchContext), Mockito.any()
+		);
+	}
+
+	protected void assertSearchSkipped(SearchContext searchContext)
+		throws SearchException {
+
+		Hits hits = facetedSearcher.search(searchContext);
+
+		Assert.assertEquals(hits.toString(), 0, hits.getLength());
+
+		Mockito.verifyZeroInteractions(indexSearcherHelper);
+	}
+
+	protected FacetedSearcherImpl createFacetedSearcher() {
+		return new FacetedSearcherImpl(
+			expandoQueryContributorHelper, indexerRegistry, indexSearcherHelper,
+			preFilterContributorHelper, searchEngineHelper);
+	}
+
+	@Mock
+	protected ExpandoQueryContributorHelper expandoQueryContributorHelper;
+
+	protected FacetedSearcher facetedSearcher;
+
+	@Mock
+	protected IndexerRegistry indexerRegistry;
+
+	@Mock
+	protected IndexSearcherHelper indexSearcherHelper;
+
+	@Mock
+	protected PreFilterContributorHelper preFilterContributorHelper;
+
+	@Mock
+	protected SearchEngineHelper searchEngineHelper;
+
+	private DocumentFixture _documentFixture;
+
+}

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/test/util/DocumentFixture.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/test/util/DocumentFixture.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.internal.test.util;
+
+import com.liferay.portal.kernel.util.FastDateFormatFactory;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+
+import java.text.SimpleDateFormat;
+
+import org.mockito.Mockito;
+
+/**
+ * @author André de Oliveira
+ */
+public class DocumentFixture {
+
+	public void mockProperty(String property, String value) {
+		Mockito.when(
+			props.get(property)
+		).thenReturn(
+			value
+		);
+	}
+
+	public void setUp() {
+		setUpFastDateFormatFactoryUtil();
+		setUpPropsUtil();
+	}
+
+	public void tearDown() {
+		tearDownFastDateFormatFactoryUtil();
+		tearDownPropsUtil();
+	}
+
+	protected void setUpFastDateFormatFactoryUtil() {
+		_fastDateFormatFactory =
+			FastDateFormatFactoryUtil.getFastDateFormatFactory();
+
+		FastDateFormatFactoryUtil fastDateFormatFactoryUtil =
+			new FastDateFormatFactoryUtil();
+
+		FastDateFormatFactory fastDateFormatFactory = Mockito.mock(
+			FastDateFormatFactory.class);
+
+		Mockito.when(
+			fastDateFormatFactory.getSimpleDateFormat("yyyyMMddHHmmss")
+		).thenReturn(
+			new SimpleDateFormat("yyyyMMddHHmmss")
+		);
+
+		fastDateFormatFactoryUtil.setFastDateFormatFactory(
+			fastDateFormatFactory);
+	}
+
+	protected void setUpPropsUtil() {
+		_props = PropsUtil.getProps();
+
+		props = Mockito.mock(Props.class);
+
+		mockProperty(PropsKeys.INDEX_DATE_FORMAT_PATTERN, "yyyyMMddHHmmss");
+		mockProperty(
+			PropsKeys.INDEX_SEARCH_COLLATED_SPELL_CHECK_RESULT_ENABLED, "true");
+		mockProperty(
+			PropsKeys.INDEX_SEARCH_COLLATED_SPELL_CHECK_RESULT_SCORES_THRESHOLD,
+			"50");
+		mockProperty(PropsKeys.INDEX_SEARCH_HIGHLIGHT_FRAGMENT_SIZE, "80");
+		mockProperty(
+			PropsKeys.INDEX_SEARCH_HIGHLIGHT_REQUIRE_FIELD_MATCH, "true");
+		mockProperty(PropsKeys.INDEX_SEARCH_HIGHLIGHT_SNIPPET_SIZE, "3");
+		mockProperty(PropsKeys.INDEX_SEARCH_QUERY_INDEXING_ENABLED, "true");
+		mockProperty(PropsKeys.INDEX_SEARCH_QUERY_INDEXING_THRESHOLD, "50");
+		mockProperty(PropsKeys.INDEX_SEARCH_QUERY_SUGGESTION_ENABLED, "true");
+		mockProperty(
+			PropsKeys.INDEX_SEARCH_QUERY_SUGGESTION_MAX, "yyyyMMddHHmmss");
+		mockProperty(
+			PropsKeys.INDEX_SEARCH_QUERY_SUGGESTION_SCORES_THRESHOLD, "0");
+		mockProperty(PropsKeys.INDEX_SEARCH_SCORING_ENABLED, "true");
+		mockProperty(
+			PropsKeys.INDEX_SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH, "255");
+
+		PropsUtil.setProps(props);
+	}
+
+	protected void tearDownFastDateFormatFactoryUtil() {
+		FastDateFormatFactoryUtil fastDateFormatFactoryUtil =
+			new FastDateFormatFactoryUtil();
+
+		fastDateFormatFactoryUtil.setFastDateFormatFactory(
+			_fastDateFormatFactory);
+
+		_fastDateFormatFactory = null;
+	}
+
+	protected void tearDownPropsUtil() {
+		PropsUtil.setProps(_props);
+
+		_props = null;
+
+		props = null;
+	}
+
+	protected Props props;
+
+	private FastDateFormatFactory _fastDateFormatFactory;
+	private Props _props;
+
+}


### PR DESCRIPTION
This pull fixes several problems caused by the recent addition of LPS-81854 and LPS-80940:

- A 7.9% performance regression: fix tested and confirmed by @slnn - Thanks again! (https://github.com/slnn/liferay-portal/pull/303#issuecomment-395312878)
- CI failures: `SearchDisplayContextTest` `testSearchKeywordsBlank`, `testSearchKeywordsSpaces` "org.mockito.exceptions.verification.NoInteractionsWanted"
- CI failures: `WikiPageUADAnonymizerTest`, `WikiNodeUADExporterTest` "com.liferay.portal.kernel.exception.NoSuchGroupException: No Group exists with the primary key 0"

Added new unit tests covering the root cause, to prevent new regressions.  cc/ @jpince

CI passed, false negatives only. (https://github.com/arboliveira/liferay-portal/pull/518#issuecomment-395311531)

- 1 database hiccup: `ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 104`
- several startup failures with error: `com.liferay.portal.lpkg.deployer.LPKGVerifyException: LPKG validation failed with {[missing requirement com.liferay.aggregate.rating.apio.api; version=1.0.0; type=osgi.bundle [caused by: Unable to resolve com.liferay.aggregate.rating.apio.api version=1.0.0:`

https://issues.liferay.com/browse/LPS-81854
https://issues.liferay.com/browse/LPS-80940
