### PR TITLE
LPS-81869 Rename app.bnd to Hypermedia REST APIs

### DIFF
--- a/modules/apps/headless-apio/app.bnd
+++ b/modules/apps/headless-apio/app.bnd
@@ -1,5 +1,5 @@
 Liferay-Releng-App-Description:
-Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Headless Apio
+Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Hypermedia REST APIs
 Liferay-Releng-Bundle: false
 Liferay-Releng-Category: Utility
 Liferay-Releng-Demo-Url:

--- a/modules/sdk/gradle-plugins-lang-builder/src/main/java/com/liferay/gradle/plugins/lang/builder/BuildLangTask.java
+++ b/modules/sdk/gradle-plugins-lang-builder/src/main/java/com/liferay/gradle/plugins/lang/builder/BuildLangTask.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.Optional;
 import org.gradle.util.GUtil;


### PR DESCRIPTION
We've had a meeting to discuss the best name for the project (Jorge, JM, Alex and I) and come up with  "Hypermedia REST APIs".

We think that headless is a misleading public name because the APIs can be used for other purpouses and we are not only porting headless related services.