### PR TITLE
LPS-82313 Rendering portlet_header in barebone mode too. If it is empty dont render the wrappers

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portlet.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portlet.ftl
@@ -52,18 +52,35 @@
 			</a>
 		</#if>
 
+		<@liferay_util["buffer"] var="portlet_header">
+			<@liferay_util["dynamic-include"] key="portlet_header_${portlet_display_root_portlet_id}" />
+		</@>
+
+		<@liferay_util["buffer"] var="portlet_header_wrapper">
+			<#if portlet_header?has_content>
+				<div class="autofit-col autofit-col-end">
+					<div class="autofit-section">
+						${portlet_header}
+					</div>
+				</div>
+			</#if>
+		</@>
+
 		<#if validator.isNotNull(portlet_display.getPortletDecoratorId()) && !stringUtil.equals(portlet_display.getPortletDecoratorId(), "barebone")>
 			<div class="autofit-float autofit-row portlet-header">
 				<div class="autofit-col autofit-col-expand">
 						<h2 class="portlet-title-text">${portlet_title}</h2>
 				</div>
 
-				<div class="autofit-col autofit-col-end">
-					<div class="autofit-section">
-						<@liferay_util["dynamic-include"] key="portlet_header_${portlet_display_root_portlet_id}" />
-					</div>
-				</div>
+				${portlet_header_wrapper}
+
 			</div>
+		<#else>
+			<#if portlet_header_wrapper?has_content>
+				<div class="autofit-float autofit-row portlet-header">
+					${portlet_header_wrapper}
+				</div>
+			</#if>
 		</#if>
 
 		${portlet_display.writeContent(writer)}


### PR DESCRIPTION
Hey @slnn, I've cleared this out initially with @shuyangzhou, but just to be sure, could you schedule a performance testing with this as soon as possible?

Current affected tests would be Blogs, Wiki, MessageBoards and WebContentDisplay (plus login). Feel free to decide which ones to run based on your bandwidth. 

Thanks!