### PR TITLE
Lps 82420

### DIFF
--- a/modules/apps/apio-architect/.gitrepo
+++ b/modules/apps/apio-architect/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 62bc393e5d617259fda431491c904c7045827e2c
+	commit = 7ccd2526eefb3248e06806219040ae9c267a5bbd
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 9c42f611be456a9eb5d375b496a4dae4d1b45ab4
+	parent = d65cca20ee6941869da25c2e40cc91edeb0a6cb6
 	remote = git@github.com:liferay/com-liferay-apio-architect.git

--- a/modules/apps/apio-architect/apio-architect-test-util/bnd.bnd
+++ b/modules/apps/apio-architect/apio-architect-test-util/bnd.bnd
@@ -9,3 +9,23 @@ Import-Package:\
 	!org.skyscreamer.jsonassert.*,\
 	\
 	*
+-conditionalpackage:\
+	com.liferay.apio.architect.impl.internal.alias,\
+	com.liferay.apio.architect.impl.internal.alias.form,\
+	com.liferay.apio.architect.impl.internal.date,\
+	com.liferay.apio.architect.impl.internal.documentation,\
+	com.liferay.apio.architect.impl.internal.form,\
+	com.liferay.apio.architect.impl.internal.list,\
+	com.liferay.apio.architect.impl.internal.message.json,\
+	com.liferay.apio.architect.impl.internal.operation,\
+	com.liferay.apio.architect.impl.internal.pagination,\
+	com.liferay.apio.architect.impl.internal.related,\
+	com.liferay.apio.architect.impl.internal.representor,\
+	com.liferay.apio.architect.impl.internal.request,\
+	com.liferay.apio.architect.impl.internal.response.control,\
+	com.liferay.apio.architect.impl.internal.routes,\
+	com.liferay.apio.architect.impl.internal.single.model,\
+	com.liferay.apio.architect.impl.internal.unsafe,\
+	com.liferay.apio.architect.impl.internal.url,\
+	com.liferay.apio.architect.impl.internal.writer,\
+	com.liferay.apio.architect.impl.internal.writer.util

--- a/modules/apps/apio-architect/apio-architect-test-util/build.gradle
+++ b/modules/apps/apio-architect/apio-architect-test-util/build.gradle
@@ -2,17 +2,17 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	compile group: "com.google.code.gson", name: "gson", version: "2.8.1"
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compile group: "org.hamcrest", name: "java-hamcrest", version: "2.0.0.0"
 	compile group: "org.json", name: "json", version: "20180130"
 	compile group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"
 	compile project(":apps:apio-architect:apio-architect-api")
+	compile project(":apps:apio-architect:apio-architect-impl")
 
-	compileOnly project(":apps:apio-architect:apio-architect-impl")
+	compileInclude group: "com.google.code.gson", name: "gson", version: "2.8.1"
 }
 
-deploy {
-	enabled = false
+liferay {
+	deployDir = file("${liferayHome}/osgi/test")
 }

--- a/modules/apps/frontend-js/frontend-js-bundle-config-extender/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-bundle-config-extender/build.gradle
@@ -7,4 +7,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.3.0"
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":core:osgi-felix-util")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/frontend-js/frontend-js-bundle-config-extender/src/main/java/com/liferay/frontend/js/bundle/config/extender/internal/JSBundleConfigTracker.java
+++ b/modules/apps/frontend-js/frontend-js-bundle-config-extender/src/main/java/com/liferay/frontend/js/bundle/config/extender/internal/JSBundleConfigTracker.java
@@ -15,6 +15,7 @@
 package com.liferay.frontend.js.bundle.config.extender.internal;
 
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.petra.string.StringPool;
 
 import java.net.URL;
 
@@ -68,7 +69,8 @@ public class JSBundleConfigTracker
 
 		Bundle bundle = serviceReference.getBundle();
 
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String jsConfig = headers.get("Liferay-JS-Config");
 

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/JSLoaderModule.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/JSLoaderModule.java
@@ -293,7 +293,8 @@ public class JSLoaderModule {
 			_versionedConfiguration = normalize(
 				generateConfiguration(jsonObject, bundleWiring, true));
 
-			Dictionary<String, String> headers = _bundle.getHeaders();
+			Dictionary<String, String> headers = _bundle.getHeaders(
+				StringPool.BLANK);
 
 			String jsSubmodulesExport = GetterUtil.getString(
 				headers.get("Liferay-JS-Submodules-Export"));

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryImpl.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/NPMRegistryImpl.java
@@ -284,7 +284,8 @@ public class NPMRegistryImpl implements NPMRegistry {
 	}
 
 	private void _processLegacyBridges(Bundle bundle) {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String jsSubmodulesBridge = GetterUtil.getString(
 			headers.get("Liferay-JS-Submodules-Bridge"));

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/test/java/com/liferay/frontend/js/loader/modules/extender/internal/JSLoaderModulesServletTest.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/test/java/com/liferay/frontend/js/loader/modules/extender/internal/JSLoaderModulesServletTest.java
@@ -503,7 +503,7 @@ public class JSLoaderModulesServletTest extends PowerMockito {
 			new Hashtable<String, String>()
 		).when(
 			bundle
-		).getHeaders();
+		).getHeaders(StringPool.BLANK);
 
 		doReturn(
 			bsn

--- a/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/TopHeadExtender.java
+++ b/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/TopHeadExtender.java
@@ -59,7 +59,8 @@ public class TopHeadExtender extends AbstractExtender {
 
 	@Override
 	protected Extension doCreateExtension(Bundle bundle) throws Exception {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String liferayJsResourcesTopHead = headers.get(
 			"Liferay-JS-Resources-Top-Head");

--- a/modules/apps/frontend-theme/frontend-theme-contributor-extender/src/main/java/com/liferay/frontend/theme/contributor/extender/internal/ThemeContributorExtender.java
+++ b/modules/apps/frontend-theme/frontend-theme-contributor-extender/src/main/java/com/liferay/frontend/theme/contributor/extender/internal/ThemeContributorExtender.java
@@ -106,7 +106,8 @@ public class ThemeContributorExtender extends AbstractExtender {
 	private String _getProperty(
 		Bundle bundle, String headerName, String jsonName) {
 
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String type = headers.get(headerName);
 

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/AppDisplayFactoryUtil.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/AppDisplayFactoryUtil.java
@@ -83,7 +83,8 @@ public class AppDisplayFactoryUtil {
 		}
 
 		for (Bundle bundle : bundles) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String curAppTitle = GetterUtil.getString(
 				headers.get(BundleConstants.LIFERAY_RELENG_APP_TITLE));
@@ -190,7 +191,8 @@ public class AppDisplayFactoryUtil {
 		Collection<Bundle> bundles = bundlesMap.values();
 
 		for (Bundle bundle : bundles) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			if (Validator.isNotNull(category)) {
 				String[] categories = StringUtil.split(

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/BundleUtil.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/BundleUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.marketplace.app.manager.web.internal.util;
 
 import com.liferay.marketplace.app.manager.web.internal.constants.BundleConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -41,7 +42,8 @@ public class BundleUtil {
 				continue;
 			}
 
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String bundleType = GetterUtil.getString(
 				headers.get("Liferay-Releng-Bundle-Type"));
@@ -53,7 +55,8 @@ public class BundleUtil {
 	}
 
 	public static boolean isFragment(Bundle bundle) {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String fragmentHost = headers.get(BundleConstants.FRAGMENT_HOST);
 

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/MarketplaceAppManagerSearchUtil.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/MarketplaceAppManagerSearchUtil.java
@@ -124,7 +124,8 @@ public class MarketplaceAppManagerSearchUtil {
 			return true;
 		}
 
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String bundleDescription = headers.get(
 			BundleConstants.BUNDLE_DESCRIPTION);

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/MarketplaceAppManagerUtil.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/MarketplaceAppManagerUtil.java
@@ -81,7 +81,8 @@ public class MarketplaceAppManagerUtil {
 				moduleGroupDisplay.getDisplayURL(renderResponse));
 		}
 
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String bundleName = GetterUtil.getString(
 			headers.get(BundleConstants.BUNDLE_NAME));
@@ -159,7 +160,8 @@ public class MarketplaceAppManagerUtil {
 		List<String> categories = new ArrayList<>();
 
 		for (Bundle bundle : bundles) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String[] categoriesArray = StringUtil.split(
 				headers.get(BundleConstants.LIFERAY_RELENG_CATEGORY));

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/ModuleGroupDisplayFactoryUtil.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/ModuleGroupDisplayFactoryUtil.java
@@ -47,7 +47,8 @@ public class ModuleGroupDisplayFactoryUtil {
 		List<Bundle> bundles = appDisplay.getBundles();
 
 		for (Bundle bundle : bundles) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String curModuleGroupTitle = GetterUtil.getString(
 				headers.get(BundleConstants.LIFERAY_RELENG_MODULE_GROUP_TITLE));
@@ -83,7 +84,8 @@ public class ModuleGroupDisplayFactoryUtil {
 			new HashMap<>();
 
 		for (Bundle bundle : bundles) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String moduleGroupTitle = headers.get(
 				BundleConstants.LIFERAY_RELENG_MODULE_GROUP_TITLE);

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/comparator/BundleComparator.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/comparator/BundleComparator.java
@@ -15,6 +15,7 @@
 package com.liferay.marketplace.app.manager.web.internal.util.comparator;
 
 import com.liferay.marketplace.app.manager.web.internal.constants.BundleConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Comparator;
@@ -52,7 +53,8 @@ public class BundleComparator implements Comparator<Bundle> {
 	}
 
 	protected String getBundleName(Bundle bundle) {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		return GetterUtil.getString(headers.get(BundleConstants.BUNDLE_NAME));
 	}

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/comparator/MarketplaceAppManagerComparator.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/util/comparator/MarketplaceAppManagerComparator.java
@@ -110,7 +110,8 @@ public class MarketplaceAppManagerComparator implements Comparator {
 		else if (object instanceof Bundle) {
 			Bundle bundle = (Bundle)object;
 
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			return GetterUtil.getString(
 				headers.get(BundleConstants.BUNDLE_NAME));

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/bundle_columns.jspf
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/bundle_columns.jspf
@@ -25,7 +25,7 @@
 >
 
 	<%
-	Dictionary<String, String> headers = bundle.getHeaders();
+	Dictionary<String, String> headers = bundle.getHeaders(StringPool.BLANK);
 	%>
 
 	<h5 class="text-default">

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
@@ -42,7 +42,7 @@ SearchContainer searchContainer = viewModuleManagementToolbarDisplayContext.getS
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(backURL.toString());
 
-Dictionary<String, String> headers = bundle.getHeaders();
+Dictionary<String, String> headers = bundle.getHeaders(StringPool.BLANK);
 
 String bundleName = GetterUtil.getString(headers.get(BundleConstants.BUNDLE_NAME));
 

--- a/modules/apps/marketplace/marketplace-deployer/build.gradle
+++ b/modules/apps/marketplace/marketplace-deployer/build.gradle
@@ -6,4 +6,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:marketplace:marketplace-api")
 	compileOnly project(":apps:static:portal-lpkg-deployer:portal-lpkg-deployer-api")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/marketplace/marketplace-deployer/src/main/java/com/liferay/marketplace/deployer/internal/LPKGArtifactInstaller.java
+++ b/modules/apps/marketplace/marketplace-deployer/src/main/java/com/liferay/marketplace/deployer/internal/LPKGArtifactInstaller.java
@@ -14,6 +14,7 @@
 
 package com.liferay.marketplace.deployer.internal;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.concurrent.DefaultNoticeableFuture;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -122,7 +123,8 @@ public class LPKGArtifactInstaller implements ArtifactInstaller {
 		}
 
 		for (Bundle bundle : _lpkgDeployer.deploy(_bundleContext, file)) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String fragmentHost = headers.get(Constants.FRAGMENT_HOST);
 
@@ -181,7 +183,8 @@ public class LPKGArtifactInstaller implements ArtifactInstaller {
 				Set<Bundle> wrapperBundles = new HashSet<>();
 
 				for (Bundle installedBundle : installedBundles) {
-					Dictionary<String, String> headers = bundle.getHeaders();
+					Dictionary<String, String> headers = bundle.getHeaders(
+						StringPool.BLANK);
 
 					if (Boolean.getBoolean(headers.get("Wrapper-Bundle"))) {
 						wrapperBundles.add(installedBundle);

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/internal/lpkg/deployer/LPKGDeployerRegistrar.java
@@ -105,7 +105,8 @@ public class LPKGDeployerRegistrar {
 
 		if ((bundles != null) && !bundles.isEmpty()) {
 			for (Bundle bundle : bundles) {
-				Dictionary<String, String> headers = bundle.getHeaders();
+				Dictionary<String, String> headers = bundle.getHeaders(
+					StringPool.BLANK);
 
 				String contextName = ContextUtil.getContextName(
 					GetterUtil.getString(headers.get("Web-ContextPath")));

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/service/impl/AppLocalServiceImpl.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/service/impl/AppLocalServiceImpl.java
@@ -221,7 +221,8 @@ public class AppLocalServiceImpl extends AppLocalServiceBaseImpl {
 		List<Bundle> bundles = BundleManagerUtil.getInstalledBundles();
 
 		for (Bundle bundle : bundles) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			boolean liferayRelengBundle = GetterUtil.getBoolean(
 				headers.get("Liferay-Releng-Bundle"));

--- a/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/ConfiguratorExtender.java
+++ b/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/ConfiguratorExtender.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.configuration.extender.internal;
 
 import com.liferay.osgi.felix.util.AbstractExtender;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringBundler;
 
 import java.io.IOException;
@@ -193,7 +194,7 @@ public class ConfiguratorExtender extends AbstractExtender {
 
 		@Override
 		public Dictionary<String, String> getHeaders() {
-			return _bundle.getHeaders();
+			return _bundle.getHeaders(StringPool.BLANK);
 		}
 
 		@Override

--- a/modules/apps/portal-remote/portal-remote-http-tunnel-extender/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-http-tunnel-extender/build.gradle
@@ -8,4 +8,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.http.whiteboard", version: "1.0.0"
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-felix-util")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-remote/portal-remote-http-tunnel-extender/src/main/java/com/liferay/portal/remote/http/tunnel/extender/internal/HttpTunnelExtender.java
+++ b/modules/apps/portal-remote/portal-remote-http-tunnel-extender/src/main/java/com/liferay/portal/remote/http/tunnel/extender/internal/HttpTunnelExtender.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.remote.http.tunnel.extender.internal;
 
 import com.liferay.osgi.felix.util.AbstractExtender;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -80,7 +81,8 @@ public class HttpTunnelExtender extends AbstractExtender {
 
 	@Override
 	protected Extension doCreateExtension(Bundle bundle) throws Exception {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		if (headers.get("Http-Tunnel") == null) {
 			return null;

--- a/modules/apps/portal-scripting/portal-scripting-executor/build.gradle
+++ b/modules/apps/portal-scripting/portal-scripting-executor/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:portal-scripting:portal-scripting-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-scripting/portal-scripting-executor/src/main/java/com/liferay/portal/scripting/executor/internal/extender/ScriptingExecutorExtender.java
+++ b/modules/apps/portal-scripting/portal-scripting-executor/src/main/java/com/liferay/portal/scripting/executor/internal/extender/ScriptingExecutorExtender.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.scripting.executor.internal.extender;
 
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cluster.ClusterMasterExecutor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -142,7 +143,8 @@ public class ScriptingExecutorExtender {
 
 			Bundle bundle = scriptBundleProvider.getBundle();
 
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			if (GetterUtil.getBoolean(
 					headers.get(

--- a/modules/apps/portal/portal-split-packages-test/src/testIntegration/java/com/liferay/portal/split/packages/test/SplitPackagesTest.java
+++ b/modules/apps/portal/portal-split-packages-test/src/testIntegration/java/com/liferay/portal/split/packages/test/SplitPackagesTest.java
@@ -107,7 +107,8 @@ public class SplitPackagesTest {
 	}
 
 	private Set<ExportPackage> _getExportPackages(Bundle bundle) {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String exportPackageName = headers.get(Constants.EXPORT_PACKAGE);
 

--- a/modules/apps/portal/portal-spring-extender-impl/src/main/java/com/liferay/portal/spring/extender/internal/context/ModuleApplicationContextExtender.java
+++ b/modules/apps/portal/portal-spring-extender-impl/src/main/java/com/liferay/portal/spring/extender/internal/context/ModuleApplicationContextExtender.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.spring.extender.internal.context;
 
 import com.liferay.osgi.felix.util.AbstractExtender;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -85,7 +86,8 @@ public class ModuleApplicationContextExtender extends AbstractExtender {
 
 	@Override
 	protected Extension doCreateExtension(Bundle bundle) throws Exception {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		if (headers.get("Liferay-Spring-Context") == null) {
 			return null;
@@ -216,7 +218,8 @@ public class ModuleApplicationContextExtender extends AbstractExtender {
 				_component.add(serviceDependency);
 			}
 
-			Dictionary<String, String> headers = _bundle.getHeaders();
+			Dictionary<String, String> headers = _bundle.getHeaders(
+				StringPool.BLANK);
 
 			String requireSchemaVersion = headers.get(
 				"Liferay-Require-SchemaVersion");
@@ -250,7 +253,8 @@ public class ModuleApplicationContextExtender extends AbstractExtender {
 		private ServiceRegistration<UpgradeStep> _processInitialUpgrade(
 			ClassLoader classLoader) {
 
-			Dictionary<String, String> headers = _bundle.getHeaders();
+			Dictionary<String, String> headers = _bundle.getHeaders(
+				StringPool.BLANK);
 
 			String upgradeToSchemaVersion = GetterUtil.getString(
 				headers.get("Liferay-Require-SchemaVersion"),

--- a/modules/apps/portal/portal-spring-extender-impl/src/main/java/com/liferay/portal/spring/extender/internal/context/SpringContextHeaderParser.java
+++ b/modules/apps/portal/portal-spring-extender-impl/src/main/java/com/liferay/portal/spring/extender/internal/context/SpringContextHeaderParser.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.spring.extender.internal.context;
 
+import com.liferay.petra.string.StringPool;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
@@ -33,7 +35,8 @@ public class SpringContextHeaderParser {
 	public String[] getBeanDefinitionFileNames() {
 		List<String> beanDefinitionFileNames = new ArrayList<>();
 
-		Dictionary<String, String> headers = _bundle.getHeaders();
+		Dictionary<String, String> headers = _bundle.getHeaders(
+			StringPool.BLANK);
 
 		String liferayService = headers.get("Liferay-Service");
 

--- a/modules/apps/static/osgi/osgi-util/src/main/java/com/liferay/osgi/util/bundle/BundleStartLevelUtil.java
+++ b/modules/apps/static/osgi/osgi-util/src/main/java/com/liferay/osgi/util/bundle/BundleStartLevelUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.osgi.util.bundle;
 
 import com.liferay.petra.concurrent.DefaultNoticeableFuture;
+import com.liferay.petra.string.StringPool;
 
 import java.util.Collections;
 import java.util.Dictionary;
@@ -60,7 +61,8 @@ public class BundleStartLevelUtil {
 	private static void _startBundle(Bundle bundle, BundleContext bundleContext)
 		throws Exception {
 
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String fragmentHost = headers.get(Constants.FRAGMENT_HOST);
 

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleUtil.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-impl/src/main/java/com/liferay/portal/bundle/blacklist/internal/BundleUtil.java
@@ -16,6 +16,7 @@ package com.liferay.portal.bundle.blacklist.internal;
 
 import com.liferay.osgi.util.bundle.BundleStartLevelUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.concurrent.DefaultNoticeableFuture;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.lpkg.deployer.LPKGDeployer;
@@ -101,8 +102,8 @@ public class BundleUtil {
 			String contextName = webContextPath[0].substring(1);
 
 			for (Bundle installedBundle : bundleContext.getBundles()) {
-				Dictionary<String, String> headers =
-					installedBundle.getHeaders();
+				Dictionary<String, String> headers = installedBundle.getHeaders(
+					StringPool.BLANK);
 
 				if (contextName.equals(
 						headers.get("Liferay-WAB-Context-Name"))) {

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBundleTrackerCustomizer.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBundleTrackerCustomizer.java
@@ -617,7 +617,8 @@ public class LPKGBundleTrackerCustomizer
 
 		Set<Bundle> uninstalledBundles = new HashSet<>();
 
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		if (symbolicName.startsWith(prefix) &&
 			Boolean.valueOf(headers.get("Wrapper-Bundle"))) {

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/WABWrapperBundleTrackerCustomizer.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/WABWrapperBundleTrackerCustomizer.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.lpkg.deployer.internal;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 
@@ -39,7 +40,8 @@ public class WABWrapperBundleTrackerCustomizer
 
 	@Override
 	public Bundle addingBundle(Bundle bundle, BundleEvent event) {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		if (Boolean.valueOf(headers.get("Wrapper-Bundle"))) {
 			return bundle;
@@ -84,7 +86,8 @@ public class WABWrapperBundleTrackerCustomizer
 	}
 
 	private Bundle _getWABBundle(Bundle bundle) throws MalformedURLException {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		URL lpkgURL = new URL(headers.get("Liferay-WAB-LPKG-URL"));
 

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/wrapper/bundle/WARBundleWrapperBundleActivator.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/wrapper/bundle/WARBundleWrapperBundleActivator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.lpkg.deployer.internal.wrapper.bundle;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 
@@ -37,7 +38,8 @@ public class WARBundleWrapperBundleActivator implements BundleActivator {
 	public void start(final BundleContext bundleContext) throws Exception {
 		Bundle bundle = bundleContext.getBundle();
 
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String contextName = headers.get("Liferay-WAB-Context-Name");
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/BundlePluginPackage.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/BundlePluginPackage.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.osgi.web.portlet.tracker.internal;
 
 import com.liferay.osgi.util.StringPlus;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.PortletApp;
 import com.liferay.portal.kernel.plugin.License;
 import com.liferay.portal.kernel.plugin.PluginPackage;
@@ -39,7 +40,7 @@ public class BundlePluginPackage implements PluginPackage {
 		_bundle = bundle;
 		_portletApp = portletApp;
 
-		_headers = _bundle.getHeaders();
+		_headers = _bundle.getHeaders(StringPool.BLANK);
 		_version = Version.getInstance(getVersion());
 	}
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper-impl/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-context-helper-impl/src/main/java/com/liferay/portal/osgi/web/servlet/context/helper/internal/ServletContextHelperRegistrationImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.osgi.web.servlet.context.helper.internal;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
@@ -309,7 +310,8 @@ public class ServletContextHelperRegistrationImpl
 	}
 
 	protected String getContextPath() {
-		Dictionary<String, String> headers = _bundle.getHeaders();
+		Dictionary<String, String> headers = _bundle.getHeaders(
+			StringPool.BLANK);
 
 		String contextPath = headers.get("Web-ContextPath");
 
@@ -321,7 +323,8 @@ public class ServletContextHelperRegistrationImpl
 	}
 
 	protected String getServletContextName(String contextPath) {
-		Dictionary<String, String> headers = _bundle.getHeaders();
+		Dictionary<String, String> headers = _bundle.getHeaders(
+			StringPool.BLANK);
 
 		String header = headers.get("Web-ContextName");
 
@@ -339,7 +342,8 @@ public class ServletContextHelperRegistrationImpl
 			return GetterUtil.getBoolean(rtlRequired);
 		}
 
-		Dictionary<String, String> headers = _bundle.getHeaders();
+		Dictionary<String, String> headers = _bundle.getHeaders(
+			StringPool.BLANK);
 
 		rtlRequired = headers.get("Liferay-RTL-Support-Required");
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspServlet.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspServlet.java
@@ -544,7 +544,8 @@ public class JspServlet extends HttpServlet {
 		public List<Path> addingBundle(Bundle bundle, BundleEvent bundleEvent) {
 			List<Path> paths = new ArrayList<>();
 
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String fragmentHost = headers.get("Fragment-Host");
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabUtil.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WabUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.osgi.web.wab.extender.internal;
 
+import com.liferay.petra.string.StringPool;
+
 import java.util.Dictionary;
 
 import org.osgi.framework.Bundle;
@@ -24,7 +26,8 @@ import org.osgi.framework.Bundle;
 public class WabUtil {
 
 	public static String getWebContextPath(Bundle bundle) {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		return headers.get("Web-ContextPath");
 	}

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -1025,7 +1025,8 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 	}
 
 	private boolean _hasLazyActivationPolicy(Bundle bundle) {
-		Dictionary<String, String> headers = bundle.getHeaders();
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
 
 		String fragmentHost = headers.get(Constants.FRAGMENT_HOST);
 
@@ -1462,7 +1463,8 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		List<String> hostBundleSymbolicNames = new ArrayList<>();
 
 		for (Bundle bundle : installedBundles) {
-			Dictionary<String, String> headers = bundle.getHeaders();
+			Dictionary<String, String> headers = bundle.getHeaders(
+				StringPool.BLANK);
 
 			String fragmentHost = headers.get(Constants.FRAGMENT_HOST);
 


### PR DESCRIPTION
@hhuijser we need to SF this. Basically we want to force people to use Bundle.getHeaders(String) rather than Bundle.getHeaders().

Bundle.getHeaders() is logically the same as Bundle.getHeaders(java.util.Locale.getDefault().toString()), which will try to look up current locale's localization. In all of our cases, we don't use bundle header localization, so this is very much a waste. When using Bundle.getHeaders(StringPool.BLANK), we will skip the localization lookup.

If by any chance later we actually need to do header localization, people can still explicitly do Bundle.getHeaders(java.util.Locale.getDefault().toString()) to lookup by default locale, or passing in explicit Locale.toString() with the one they need. Either way we should not use Bundle.getHeaders() anymore.