### PR TITLE
LPS-81963 Sign in Icon is not a Lexicon icon

### DIFF
--- a/modules/apps/apio-architect/.gitrepo
+++ b/modules/apps/apio-architect/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 62bc393e5d617259fda431491c904c7045827e2c
+	commit = 7ccd2526eefb3248e06806219040ae9c267a5bbd
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 9c42f611be456a9eb5d375b496a4dae4d1b45ab4
+	parent = d65cca20ee6941869da25c2e40cc91edeb0a6cb6
 	remote = git@github.com:liferay/com-liferay-apio-architect.git

--- a/modules/apps/apio-architect/apio-architect-test-util/bnd.bnd
+++ b/modules/apps/apio-architect/apio-architect-test-util/bnd.bnd
@@ -9,3 +9,23 @@ Import-Package:\
 	!org.skyscreamer.jsonassert.*,\
 	\
 	*
+-conditionalpackage:\
+	com.liferay.apio.architect.impl.internal.alias,\
+	com.liferay.apio.architect.impl.internal.alias.form,\
+	com.liferay.apio.architect.impl.internal.date,\
+	com.liferay.apio.architect.impl.internal.documentation,\
+	com.liferay.apio.architect.impl.internal.form,\
+	com.liferay.apio.architect.impl.internal.list,\
+	com.liferay.apio.architect.impl.internal.message.json,\
+	com.liferay.apio.architect.impl.internal.operation,\
+	com.liferay.apio.architect.impl.internal.pagination,\
+	com.liferay.apio.architect.impl.internal.related,\
+	com.liferay.apio.architect.impl.internal.representor,\
+	com.liferay.apio.architect.impl.internal.request,\
+	com.liferay.apio.architect.impl.internal.response.control,\
+	com.liferay.apio.architect.impl.internal.routes,\
+	com.liferay.apio.architect.impl.internal.single.model,\
+	com.liferay.apio.architect.impl.internal.unsafe,\
+	com.liferay.apio.architect.impl.internal.url,\
+	com.liferay.apio.architect.impl.internal.writer,\
+	com.liferay.apio.architect.impl.internal.writer.util

--- a/modules/apps/apio-architect/apio-architect-test-util/build.gradle
+++ b/modules/apps/apio-architect/apio-architect-test-util/build.gradle
@@ -2,17 +2,17 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	compile group: "com.google.code.gson", name: "gson", version: "2.8.1"
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compile group: "org.hamcrest", name: "java-hamcrest", version: "2.0.0.0"
 	compile group: "org.json", name: "json", version: "20180130"
 	compile group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"
 	compile project(":apps:apio-architect:apio-architect-api")
+	compile project(":apps:apio-architect:apio-architect-impl")
 
-	compileOnly project(":apps:apio-architect:apio-architect-impl")
+	compileInclude group: "com.google.code.gson", name: "gson", version: "2.8.1"
 }
 
-deploy {
-	enabled = false
+liferay {
+	deployDir = file("${liferayHome}/osgi/test")
 }

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -70,7 +70,7 @@
 		%>
 
 		<span class="sign-in text-default" role="presentation">
-			<aui:a cssClass="sign-in text-default" data="<%= anchorData %>" href="<%= themeDisplay.getURLSignIn() %>" iconCssClass="icon-user" label="sign-in" />
+			<aui:icon cssClass="sign-in text-default" data="<%= anchorData %>" image="user" label="sign-in" markupView="lexicon" url="<%= themeDisplay.getURLSignIn() %>" />
 		</span>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
This is an update for [LPS-81963](https://issues.liferay.com/browse/LPS-81963).<br><br>Hey Brian, this updates the user icon in the sign-in link to use a Lexicon icon.<br><br>/cc @pei-jung @susanavr

---
**Before**
<img width="380" alt="screen shot 2018-06-14 at 5 02 03 pm" src="https://user-images.githubusercontent.com/6403097/41443951-b8d13fce-6ff4-11e8-8242-2a1479fd3faa.png">

---
**After**
<img width="372" alt="screen shot 2018-06-14 at 5 01 28 pm" src="https://user-images.githubusercontent.com/6403097/41443952-b8e5dcf4-6ff4-11e8-9f12-e98d63a57f49.png">