### PR TITLE
[7.1] LPS-81713 Close workers

### DIFF
--- a/modules/apps/apio-architect/.gitrepo
+++ b/modules/apps/apio-architect/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 62bc393e5d617259fda431491c904c7045827e2c
+	commit = 7ccd2526eefb3248e06806219040ae9c267a5bbd
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 9c42f611be456a9eb5d375b496a4dae4d1b45ab4
+	parent = d65cca20ee6941869da25c2e40cc91edeb0a6cb6
 	remote = git@github.com:liferay/com-liferay-apio-architect.git

--- a/modules/apps/apio-architect/apio-architect-test-util/bnd.bnd
+++ b/modules/apps/apio-architect/apio-architect-test-util/bnd.bnd
@@ -9,3 +9,23 @@ Import-Package:\
 	!org.skyscreamer.jsonassert.*,\
 	\
 	*
+-conditionalpackage:\
+	com.liferay.apio.architect.impl.internal.alias,\
+	com.liferay.apio.architect.impl.internal.alias.form,\
+	com.liferay.apio.architect.impl.internal.date,\
+	com.liferay.apio.architect.impl.internal.documentation,\
+	com.liferay.apio.architect.impl.internal.form,\
+	com.liferay.apio.architect.impl.internal.list,\
+	com.liferay.apio.architect.impl.internal.message.json,\
+	com.liferay.apio.architect.impl.internal.operation,\
+	com.liferay.apio.architect.impl.internal.pagination,\
+	com.liferay.apio.architect.impl.internal.related,\
+	com.liferay.apio.architect.impl.internal.representor,\
+	com.liferay.apio.architect.impl.internal.request,\
+	com.liferay.apio.architect.impl.internal.response.control,\
+	com.liferay.apio.architect.impl.internal.routes,\
+	com.liferay.apio.architect.impl.internal.single.model,\
+	com.liferay.apio.architect.impl.internal.unsafe,\
+	com.liferay.apio.architect.impl.internal.url,\
+	com.liferay.apio.architect.impl.internal.writer,\
+	com.liferay.apio.architect.impl.internal.writer.util

--- a/modules/apps/apio-architect/apio-architect-test-util/build.gradle
+++ b/modules/apps/apio-architect/apio-architect-test-util/build.gradle
@@ -2,17 +2,17 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 dependencies {
-	compile group: "com.google.code.gson", name: "gson", version: "2.8.1"
 	compile group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compile group: "org.hamcrest", name: "java-hamcrest", version: "2.0.0.0"
 	compile group: "org.json", name: "json", version: "20180130"
 	compile group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"
 	compile project(":apps:apio-architect:apio-architect-api")
+	compile project(":apps:apio-architect:apio-architect-impl")
 
-	compileOnly project(":apps:apio-architect:apio-architect-impl")
+	compileInclude group: "com.google.code.gson", name: "gson", version: "2.8.1"
 }
 
-deploy {
-	enabled = false
+liferay {
+	deployDir = file("${liferayHome}/osgi/test")
 }

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessWorker.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-brightness/src/main/resources/META-INF/resources/BrightnessWorker.js
@@ -37,4 +37,6 @@ onmessage = function(event) {
 	}
 
 	postMessage(imageData);
+
+	close();
 };

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastWorker.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-contrast/src/main/resources/META-INF/resources/ContrastWorker.js
@@ -39,4 +39,6 @@ onmessage = function(event) {
 	}
 
 	postMessage(imageData);
+
+	close();
 };

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsWorker.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsWorker.js
@@ -47,6 +47,8 @@ onmessage = function(event) {
 	}
 
 	postMessage(imageData);
+
+	close();
 };
 
 /**

--- a/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationWorker.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-capability-saturation/src/main/resources/META-INF/resources/SaturationWorker.js
@@ -41,4 +41,6 @@ onmessage = function(event) {
 	}
 
 	postMessage(imageData);
+
+	close();
 };


### PR DESCRIPTION
Hey @brianchandotcom, this fixes an out-of-memory error when using the ImageEditor in certain conditions. It affects both 7.0 and master, so we'd like this fixed for release as it affects all major linux distros.

Thanks!