### PR TITLE
OAUTH2-169 Make portlet title end-user friendly

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications
 last-access=Last Access
 missing-application-name=The application name is missing.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ar.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=عملاء مع "سر العميل" القديمة لم تعد إذا تغيرت، يمكن طلب المميزة الجديدة بعد أن قمت بحفظ تفاصيل التطبيق. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=يأذن لتطبيقات الطرف الثالث تأمين الوصول إلى الموارد المستخدم دون إعطائهم كلمات المرور. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=إدارة OAuth2 (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 تأذن للمدخل (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 توصيل الطلبات (Automatic Translation)
 last-access=آخر وصول (Automatic Translation)
 missing-application-name=اسم التطبيق غير موجود. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_bg.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Ако промяна, клиенти със стария клиент тайната вече може да поиска нови символи след запишете подробности за приложението. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Разрешава трети приложения страна сигурен достъп до потребителски ресурси без да им давате пароли. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 администрация (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 разрешава портлета (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 от свързани приложения (Automatic Translation)
 last-access=Последен достъп (Automatic Translation)
 missing-application-name=Липсва името на приложението. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ca.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Si els canvieu, els clients amb el secret de client anterior no podran sol·licitar testimonis nous quan hàgiu desat els detalls de l'aplicació.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Autoritza l'accés segur de les aplicacions de tercers als recursos d'usuari sense donar-los les contrasenyes.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Administració OAuth2
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Portlet d'autorització d'OAuth2
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=Aplicacions connectades mitjançant OAuth2
 last-access=Últim accés
 missing-application-name=Falta el nom de l'aplicació.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_cs.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Je-li změněn, klienti s starý tajný klíč klienta již požadovat nové tokeny, po uložení podrobností aplikace. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Povoluje aplikace třetích stran zabezpečený přístup k prostředkům uživatelského aniž by jim hesla. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administrativa (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 autorizovat portletu (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 propojených aplikací (Automatic Translation)
 last-access=Poslední přístup (Automatic Translation)
 missing-application-name=Chybí název aplikace. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_da.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_de.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_el.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Αν αλλάξει, τους πελάτες με το παλιό μυστικό πρόγραμμα-πελάτης μπορεί να ζητήσει πλέον νέες μάρκες μετά μπορείτε να αποθηκεύσετε τις λεπτομέρειες της εφαρμογής. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Εξουσιοδοτεί τρίτος-όμαδα εφαρμογές ασφαλούς πρόσβασης σε πόρους χρήστη χωρίς να τους δίνει τους κωδικούς πρόσβασης. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Διοίκηση OAuth2 (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 εξουσιοδοτεί Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 συνδεδεμένες εφαρμογές (Automatic Translation)
 last-access=Τελευταία πρόσβαση (Automatic Translation)
 missing-application-name=Λείπει το όνομα της εφαρμογής. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_en.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications
 last-access=Last Access
 missing-application-name=The application name is missing.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_es.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Si se modifica, los clientes con el secreto de cliente anterior ya no podrán solicitar nuevos tokens después de guardar los detalles de la aplicación.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Autoriza a las aplicaciones de terceros a obtener acceso seguro a recursos de usuario sin proporcionar las contraseñas.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Administración de OAuth2
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Portlet de autorización de OAuth2
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=Aplicaciones conectadas mediante OAuth2
 last-access=Último acceso
 missing-application-name=Falta el nombre de la aplicación.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_et.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Kui muutunud, vana klient saladus klientidele enam taotleda uute märkide taotluse andmeid salvestanud. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Lubab õigusi turvaline juurdepääs kasutaja ressursse, ilma et annaksite neile paroolid. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 haldus (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 lubavad portleti (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 omavahel seotud taotlused (Automatic Translation)
 last-access=Viimase vaatamise (Automatic Translation)
 missing-application-name=Rakenduse nimi on puudu. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_eu.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_fa.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=پس از شما ذخيره برنامه اگر تغییر، مشتریان با راز مشتری قدیمی دیگر نشانه های جدید درخواست. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=برنامه های شخص ثالث امن دسترسی به منابع کاربر را بدون کلمه عبور به آنها اجازه می دهد. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=دولت OAuth2 (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 اجازه پورتلت (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 برنامه های کاربردی متصل (Automatic Translation)
 last-access=آخرین دسترسی (Automatic Translation)
 missing-application-name=نام برنامه کاربردی ندارد. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_fi.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Jos muutetaan, asiakkaat, joilla on vanha Asiakkaan Salainen, eivät enää voi pyytää uusia tokeneita, kun tallennat sovelluksen tiedot.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Valtuuttaa kolmannen osapuolen sovelluksille turvallisen pääsyn käyttäjän resursseihin antamatta niille salasanoja.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2-ylläpito
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Valtuuta Portlet
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2-kytketyt Sovellukset
 last-access=Viimeksi Käytetty
 missing-application-name=Sovelluksen nimi puuttuu.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_fr.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Si modifiés, les clients dotés de l’ancien secret de client ne peuvent plus demander de nouveaux jetons une fois les détails d'application enregistrés.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Accorde à des applications tierces un accès sécurisé aux ressources utilisateurs sans leur donner les mots de passe.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Administration OAuth2
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Portlet OAuth2 autorisée
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=Applications OAuth2 connectées
 last-access=Dernier accès
 missing-application-name=Le nom de l'application est manquant.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_gl.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_hi_IN.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=यदि बदल गया, पुराने ग्राहक गुप्त के साथ ग्राहकों को अब आप आवेदन विवरण को बचाने के बाद नए टोकन अनुरोध कर सकते हैं । (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=तृतीय-पक्ष अनुप्रयोगों को पासवर्ड दिए बिना उपयोगकर्ता संसाधनों तक सुरक्षित पहुंच को प्राधिकृत करते हैं । (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 व्यवस्थापन (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 अधिकृत पोर्टलेट (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 कनेक्टेड अनुप्रयोग (Automatic Translation)
 last-access=अंतिम पहुंच (Automatic Translation)
 missing-application-name=अनुप्रयोग का नाम अनुपलब्ध है । (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_hr.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_hu.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Ha megváltozik, a régi ügyfél-titkot használó ügyfelek az alkalmazás részleteinek mentése után nem kérhetnek új tokeneket.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Hitelesíti a felhasználói források biztonságos elérését harmadik felek alkalmazásai részére anélkül, hogy jelszót kéne nekik adni.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 adminisztráció
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 hitelesítési portlet
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 csatlakoztatott Applications
 last-access=Utolsó hozzáférés
 missing-application-name=Az alkalmazás neve hiányzik.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_in.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Jika mengubah, klien dengan rahasia klien lama dapat tidak lagi meminta bukti baru setelah Anda menyimpan rincian aplikasi. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Mengotorisasi aplikasi pihak ketiga akses ke sumber daya pengguna tanpa memberi mereka password. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administrasi (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 otorisasi Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 terhubung aplikasi (Automatic Translation)
 last-access=Akses terakhir (Automatic Translation)
 missing-application-name=Nama aplikasi hilang. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_it.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Se modificato, i client con il vecchio segreto Client non possono richiedere non più nuovi token dopo aver salvato i dettagli di applicazione. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Autorizza l'applicazioni di terze parti accesso sicuro alle risorse dell'utente senza dare loro le password. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 amministrazione (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 autorizzazione Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 applicazioni connesse (Automatic Translation)
 last-access=Ultimo accesso (Automatic Translation)
 missing-application-name=Il nome dell'applicazione è manca. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_iw.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=אם שונה, לקוחות עם סוד הלקוח הישן לא יוכלו עוד לבקש אסימונים חדשים לאחר שתשמור את פרטי היישום.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=מרשה ליישומי צד שלישי גישב בטוחה למשאבי הלקוח מבלי לגלות להם את הסיסמאות.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=ניהול OAuth2
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=פורטלט הרשאות OAuth2
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=יישומי OAuth2 מחוברים
 last-access=גישה אחרונה
 missing-application-name=שם היישום חסר.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ja.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=変更すると、アプリケーションの詳細を保存した後、古いクライアント・シークレットを持つクライアントが今後新しいトークンをリクエストできなくなります。
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=サードパーティー製のアプリケーションにパスワードを付与することなくユーザーのリソースに安全にアクセスできるようにします。
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 管理
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 認証ポートレット
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 接続アプリケーション
 last-access=最終アクセス
 missing-application-name=アプリケーション名が入力されていません。

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ko.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=변경 하는 경우 응용 프로그램 세부 정보를 저장 한 후 이전 클라이언트 비밀 클라이언트 새로운 토큰 요청 이상 수 없습니다. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=그들에 게 암호를 제공 하지 않고 사용자 리소스에 대 한 제 3-파티 응용 프로그램 보안 액세스 권한을 부여 합니다. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 관리 (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 허가 포틀릿 (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 응용 프로그램 연결 (Automatic Translation)
 last-access=마지막 액세스 (Automatic Translation)
 missing-application-name=응용 프로그램 이름은 없습니다. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_lo.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_lt.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Pakeitus senas klientas paslaptis klientams jau gali prašyti naujų žetonų įrašę paraiškos duomenis. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Leidžia programas saugią prieigą prie vartotojo išteklių nesuteikiant jiems slaptažodžius. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administracija (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 leisti portalo įskiepį (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 prijungtas paraiškos (Automatic Translation)
 last-access=Paskutinė prieiga (Automatic Translation)
 missing-application-name=Programos pavadinimas nėra. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_nb.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Hvis endret, kan klienter med gamle klienten hemmeligheten lenger be nye symboler etter du lagre programmet. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Autoriserer tredjepartsprogrammer sikker tilgang til brukerressurser uten å gi dem passord. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administrasjon (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 godkjenne portleten (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 tilkoblede applikasjoner (Automatic Translation)
 last-access=Siste logginn (Automatic Translation)
 missing-application-name=Programnavnet mangler. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_nl.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Bij wijziging kunnen clients met het oude clientgeheim geen nieuwe tokens aanvragen nadat u de applicatiedetails opslaat.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Geeft applicaties van derden toepassingen veilige toegang tot gebruikersbronnen zonder de wachtwoorden te geven.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2-beheer
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Autorisatieportlet OAuth2
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=Verbonden applicaties OAuth2
 last-access=Laatste aanmelding
 missing-application-name=De naam van de applicatie ontbreekt.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_nl_BE.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_pl.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Jeśli zmienione, klienci z stary klucz tajny klienta nie mogą żądać nowe tokeny po zapisaniu danych aplikacji. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Zezwala aplikacji innych firm, bezpieczny dostęp do zasobów użytkownika bez podawania ich hasła. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administracji (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 autoryzować portletu (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 połączone aplikacje (Automatic Translation)
 last-access=Ostatni dostęp (Automatic Translation)
 missing-application-name=Brakuje nazwy aplikacji. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_pt_BR.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Se alterado, os clientes com o Segredo de Cliente antigo não solicitam novos tokens depois de salvar os detalhes do aplicativo.
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Autoriza que aplicativos de terceiros acessem com segurança; ca os recursos do usuário sem dar a eles as senhas.
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Administração de OAuth2
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Autoriza Portlet
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=Aplicativos Conectados do OAuth2
 last-access=Último Acesso
 missing-application-name=O nome da aplicação está faltando.

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_pt_PT.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Se mudou, os clientes com o velho segredo de cliente já não podem solicitar novos tokens depois de salvar os detalhes da aplicação. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Autoriza o acesso seguro de aplicativos de terceiros aos recursos de usuário sem lhes dar as senhas. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administração (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 autorizar Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 conectado aplicativos (Automatic Translation)
 last-access=Último acesso (Automatic Translation)
 missing-application-name=O nome do aplicativo está faltando. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ro.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=În cazul în care s-a schimbat, clientii cu secretul Client vechi nu mai pot solicita token-uri noi după ce salvaţi detaliile de aplicare. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Autorizează aplicaţii terţe părţi accesul securizat la utilizator resurse fără a le da parolele. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administrare (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 autoriza Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 conectat aplicaţii (Automatic Translation)
 last-access=Ultimul acces (Automatic Translation)
 missing-application-name=Lipsește numele de cerere. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_ru.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Если изменилась, клиенты с Секрет старого клиента больше не могут запрашивать новые маркеры, после того, как вы сохранить сведения приложения. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Уполномочивает сторонних приложений безопасный доступ к ресурсам пользователей не давая им пароли. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 администрация (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 санкционировать портлета (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 подключенных приложений (Automatic Translation)
 last-access=Последний доступ (Automatic Translation)
 missing-application-name=Отсутствует имя приложения. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sk.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Ak zmenil, klienti s staré tajomstvo klienta po uložení žiadosti Podrobnosti už požiadať nové tokeny. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Oprávňuje aplikácie tretích bezpečný prístup k užívateľovi zdrojov bez toho, aby ich heslá. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 administratíva (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 povoliť portletu (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 pripojených aplikácií (Automatic Translation)
 last-access=Posledný prístup (Automatic Translation)
 missing-application-name=Chýba názov aplikácie. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sl.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Če spremenila, lahko stranke s staro odjemalec skrivnost ni več zahteva nove žetone, ko shranite podrobnosti uporabe. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Dovoljuje tretji-stranka uporaba varnega dostopa do uporabnik virov brez jim gesla. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 uprava (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 dovoli portalne gradnike (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 povezanih vlog (Automatic Translation)
 last-access=Zadnji dostop (Automatic Translation)
 missing-application-name=Manjka ime aplikacije. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sr_RS.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_sv.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=If changed, clients with the old Client Secret can no longer request new tokens after you save the application details. (Automatic Copy)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Authorizes third-party applications secure access to user resources without giving them the passwords. (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 Administration (Automatic Copy)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 Authorize Portlet (Automatic Copy)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 Connected Applications (Automatic Copy)
 last-access=Last Access (Automatic Copy)
 missing-application-name=The application name is missing. (Automatic Copy)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_th.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=ถ้าเปลี่ยน ลูกค้าที่ มีความลับลูกค้าเก่าสามารถร้องขอโทเค็นใหม่ไม่หลังจากคุณบันทึกรายละเอียดใบสมัคร (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=อนุญาตโปรแกรมประยุกต์ของบริษัทอื่นการเข้าถึงทรัพยากรของผู้ใช้โดยไม่ต้องให้รหัสผ่าน (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=บริหาร OAuth2 (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 อนุญาตพอร์ตเล็ต (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 เชื่อมต่อโปรแกรมประยุกต์ (Automatic Translation)
 last-access=เข้าครั้งสุดท้าย (Automatic Translation)
 missing-application-name=ชื่อโปรแกรมประยุกต์ขาดหายไป (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_tr.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Uygulama detayları kaydettikten sonra değiştirdiyseniz, eski istemci sırrı müşterilerle artık yeni belirteçleri talep edebilirsiniz. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Üçüncü taraf uygulamalar Kullanıcı kaynaklarına güvenli erişim parolaları vermeden yetki verir. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 yönetim (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 yetki Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 bağlı uygulamaların (Automatic Translation)
 last-access=Son giris (Automatic Translation)
 missing-application-name=Uygulama adı eksik. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_uk.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Якщо змінено, замовники з старий клієнт секрет може вже не вимагають нових жетонів після збереження застосування деталі. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Уповноважує сторін захищений доступ до користувача ресурсів не даючи їм паролі. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 адміністрації (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 авторизувати портлету (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 підключено додатків (Automatic Translation)
 last-access=Останній доступ (Automatic Translation)
 missing-application-name=Відсутнє ім'я застосунку. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_vi.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=Nếu thay đổi, khách hàng với những bí mật khách hàng cũ có thể không còn yêu cầu thẻ mới sau khi bạn lưu các chi tiết của ứng dụng. (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Cho phép các ứng dụng của bên thứ ba truy nhập an toàn cho người sử dụng tài nguyên mà không cho họ mật khẩu. (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=Quản trị OAuth2 (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 cho phép Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 kết nối các ứng dụng (Automatic Translation)
 last-access=Truy nhập cuối (Automatic Translation)
 missing-application-name=Tên ứng dụng bị thiếu. (Automatic Translation)

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_zh_CN.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=如果更改，具有旧客户端密钥的客户端在您保存应用程序详细信息后无法再请求新令牌。
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=授权第三方应用程序安全访问用户资源，无需向它们提供密码。
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 管理
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 授权 Portlet
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 连接的应用程序
 last-access=上次访问
 missing-application-name=缺少应用程序名称。

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/content/Language_zh_TW.properties
@@ -54,7 +54,7 @@ if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-
 if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details=如果更改, 則在保存應用程式詳細資訊後, 具有舊用戶端金鑰的用戶端將不再請求新的標記。 (Automatic Translation)
 javax.portlet.description.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=授權協力廠商應用程式安全地訪問使用者資源而不給他們密碼。 (Automatic Translation)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet=OAuth2 管理 (Automatic Translation)
-javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=OAuth2 授權 Portlet (Automatic Translation)
+javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2AuthorizePortlet=Application Authorization Request (Automatic Copy)
 javax.portlet.title.com_liferay_oauth2_provider_web_internal_portlet_OAuth2ConnectedApplicationsPortlet=OAuth2 連接的應用程式 (Automatic Translation)
 last-access=上次訪問 (Automatic Translation)
 missing-application-name=缺少應用程式名稱。 (Automatic Translation)


### PR DESCRIPTION
Because OAuth2 Authorize portlet is now a runtime portlet and shown maximized, it's portlet title should be end-user friendly.

Reviewed by @topolik https://github.com/liferay/liferay-portal/pull/2914#issuecomment-398857320