### PR TITLE
LPS-82252 re-add quotes because .config format needs it

### DIFF
--- a/modules/apps/headless-apio/portal/portal-apio-impl/configs/com.liferay.apio.architect.impl.internal.application.ApioApplication-default.config
+++ b/modules/apps/headless-apio/portal/portal-apio-impl/configs/com.liferay.apio.architect.impl.internal.application.ApioApplication-default.config
@@ -1,4 +1,4 @@
-auth.verifier.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes=*
-auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes=*
-auth.verifier.guest.allowed=true
-oauth2.scopechecker.type=none
+auth.verifier.auth.verifier.BasicAuthHeaderAuthVerifier.urls.includes="*"
+auth.verifier.auth.verifier.OAuth2RestAuthVerifier.urls.includes="*"
+auth.verifier.guest.allowed="true"
+oauth2.scopechecker.type="none"


### PR DESCRIPTION
I've talked with @csierra about the comments in https://github.com/brianchandotcom/liferay-portal/pull/60590 (rename .config to .cfg and remove quotes) and the .config files are different to .cfg 

The .config format is newer and more powerful than the .cfg because it allows types (http://blogs.adobe.com/contentmanagement/2016/06/09/config-vs-cfg-battle-royale/) and easier multivalues, it's the recommended format against .cfg that should be deprecated. 

The .config format needs the double quotes (right now the CI is failing because of it: https://test-1-2.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/244493/testReport/com.liferay.portal.log.assertor/PortalLogAssertorTest/testScanOSGiLog/)

// @hhuijser