### PR TITLE
LPS-79117 portal-search-elasticsearch6: app.bnd: remove reference to discontinued Elasticsearch 2

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/app.bnd
+++ b/modules/apps/portal-search-elasticsearch6/app.bnd
@@ -1,4 +1,4 @@
-Liferay-Releng-App-Description: ${liferay.releng.app.title.prefix} to Elasticsearch 6 connects Liferay Portal or Liferay DXP to the Elasticsearch 6.1.x search engine. This client application is a drop-in replacement for the default Elasticsearch 2.x connector that ships with the Foundation app suite.
+Liferay-Releng-App-Description: ${liferay.releng.app.title.prefix} to Elasticsearch 6 connects Liferay Portal or Liferay DXP to the Elasticsearch 6.1.x search engine.
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Connector to Elasticsearch 6
 Liferay-Releng-Bundle: true
 Liferay-Releng-Category: Utility


### PR DESCRIPTION
cc/ @rbohl @david-truong