### PR TITLE
LPS-82822 We no longer need to update the in memory cache after LPS-2…

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -1036,11 +1036,6 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		portletPersistence.update(portlet);
 
-		portlet = getPortletById(companyId, portletId);
-
-		portlet.setRoles(roles);
-		portlet.setActive(active);
-
 		portletLocalService.removeCompanyPortletsPool(companyId);
 
 		return portlet;


### PR DESCRIPTION
…0468 since we clear it right after. Removing this reduces the times we reload the portlets by about half during startup.