### PR TITLE
LPS-82460 Register the logger through system property

### DIFF
--- a/modules/apps/portal-remote/portal-remote-jaxrs-whiteboard/src/main/resources/META-INF/cxf/org.apache.cxf.Logger
+++ b/modules/apps/portal-remote/portal-remote-jaxrs-whiteboard/src/main/resources/META-INF/cxf/org.apache.cxf.Logger
@@ -1,1 +1,0 @@
-com.liferay.portal.remote.jaxrs.whiteboard.internal.log.LiferayCXFLogger

--- a/portal-impl/src/system.properties
+++ b/portal-impl/src/system.properties
@@ -219,6 +219,15 @@
     cookie.http.only.names.excludes=
 
 ##
+## CXF
+##
+
+    #
+    # Set cxf logger class
+    #
+    org.apache.cxf.Logger=com.liferay.portal.remote.jaxrs.whiteboard.internal.log.LiferayCXFLogger
+
+##
 ## Axis
 ##
 


### PR DESCRIPTION
@topolik @csierra your solution for "faking" the StaticLoggerBinder did not work. At runtime you will get 
```
java.lang.reflect.InvocationTargetException: 
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.cxf.common.logging.LogUtils.createLogger(LogUtils.java:270)
	at org.apache.cxf.common.logging.LogUtils.getLogger(LogUtils.java:163)
	at org.apache.cxf.common.logging.LogUtils.<clinit>(LogUtils.java:137)
	at org.apache.cxf.jaxrs.impl.MediaTypeHeaderProvider.<clinit>(MediaTypeHeaderProvider.java:44)
	at org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl.<init>(RuntimeDelegateImpl.java:49)
	at org.apache.aries.jax.rs.whiteboard.activator.CxfJaxrsBundleActivator.<clinit>(CxfJaxrsBundleActivator.java:76)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.loadBundleActivator(BundleContextImpl.java:758)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.start(BundleContextImpl.java:711)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.startWorker0(EquinoxBundle.java:951)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.startWorker(EquinoxBundle.java:328)
	at org.eclipse.osgi.container.Module.doStart(Module.java:566)
	at org.eclipse.osgi.container.Module.start(Module.java:434)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:402)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:421)
	at com.liferay.portal.bootstrap.ModuleFrameworkImpl._startDynamicBundles(ModuleFrameworkImpl.java:1594)
	at com.liferay.portal.bootstrap.ModuleFrameworkImpl.startFramework(ModuleFrameworkImpl.java:412)
	at com.liferay.portal.module.framework.ModuleFrameworkUtilAdapter.startFramework(ModuleFrameworkUtilAdapter.java:99)
	at com.liferay.portal.spring.context.PortalContextLoaderListener.contextInitialized(PortalContextLoaderListener.java:257)
	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4579)
	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5041)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:742)
	at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:718)
	at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:703)
	at org.apache.catalina.startup.HostConfig.deployDescriptor(HostConfig.java:630)
	at org.apache.catalina.startup.HostConfig$DeployDescriptor.run(HostConfig.java:1840)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112)
	at org.apache.catalina.startup.HostConfig.deployDescriptors(HostConfig.java:525)
	at org.apache.catalina.startup.HostConfig.deployApps(HostConfig.java:424)
	at org.apache.catalina.startup.HostConfig.start(HostConfig.java:1586)
	at org.apache.catalina.startup.HostConfig.lifecycleEvent(HostConfig.java:308)
	at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123)
	at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:424)
	at org.apache.catalina.util.LifecycleBase.setState(LifecycleBase.java:367)
	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:966)
	at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:839)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1427)
	at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1417)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
	at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:134)
	at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:943)
	at org.apache.catalina.core.StandardEngine.startInternal(StandardEngine.java:258)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.core.StandardService.startInternal(StandardService.java:422)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.core.StandardServer.startInternal(StandardServer.java:770)
	at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
	at org.apache.catalina.startup.Catalina.start(Catalina.java:682)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.catalina.startup.Bootstrap.start(Bootstrap.java:353)
	at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:493)
Caused by: java.lang.NoClassDefFoundError: org/slf4j/spi/LocationAwareLogger
	at org.apache.cxf.common.logging.Slf4jLogger.<init>(Slf4jLogger.java:61)
	... 68 more
```
Didn't you see this in your local testing? And trying the steps on https://issues.liferay.com/browse/LPS-82460, it did not fix the issue. And that StaticLoggerBinder caused the "split" package failure.

Although it is not a real split package, @brianchandotcom wanted to make sure we never have 2 identical packages, no matter exported or not exported. After all that is generally a sign of something fishy going on.

In this fix, I register your LiferayCXFLogger through system property, and LPS-82460 can pass now. Hope this is good enough.

CC @jpince